### PR TITLE
ref(integationfeature): Write to new columns

### DIFF
--- a/src/sentry/api/serializers/models/integration_feature.py
+++ b/src/sentry/api/serializers/models/integration_feature.py
@@ -9,4 +9,6 @@ class IntegrationFeatureSerializer(Serializer):
             "description": obj.description.strip(),
             # feature gating work done in getsentry expects the format 'featureGate'
             "featureGate": obj.feature_str(),
+            "targetId": obj.target_id,
+            "targetType": obj.target_type,
         }

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -14,6 +14,7 @@ from sentry.models import (
     SentryAppComponent,
     User,
 )
+from sentry.models.integrationfeature import IntegrationTypes
 from sentry.models.sentryapp import default_uuid, generate_slug
 
 from .mixin import SentryAppMixin
@@ -112,7 +113,11 @@ class Creator(Mediator, SentryAppMixin):
         # defaults to 'integrations-api'
         try:
             with transaction.atomic():
-                IntegrationFeature.objects.create(sentry_app=self.sentry_app)
+                IntegrationFeature.objects.create(
+                    sentry_app=self.sentry_app,
+                    target_id=self.sentry_app.id,
+                    target_type=IntegrationTypes.SENTRY_APP.value,
+                )
         except IntegrityError as e:
             self.log(sentry_app=self.sentry_app.slug, error_message=str(e))
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -82,7 +82,7 @@ from sentry.models import (
     UserPermission,
     UserReport,
 )
-from sentry.models.integrationfeature import Feature, IntegrationFeature
+from sentry.models.integrationfeature import Feature, IntegrationFeature, IntegrationTypes
 from sentry.models.releasefile import update_artifact_index
 from sentry.signals import project_created
 from sentry.snuba.models import QueryDatasets
@@ -862,7 +862,10 @@ class Factories:
             sentry_app = Factories.create_sentry_app()
 
         integration_feature = IntegrationFeature.objects.create(
-            sentry_app=sentry_app, feature=feature or Feature.API
+            sentry_app=sentry_app,
+            target_id=sentry_app.id,
+            target_type=IntegrationTypes.SENTRY_APP.value,
+            feature=feature or Feature.API,
         )
 
         if description:

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from sentry.models import SentryApp
+from sentry.models.integrationfeature import IntegrationTypes
 from sentry.testutils import APITestCase
 from sentry.utils import json
 
@@ -57,6 +58,8 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
                         {
                             "featureGate": "integrations-api",
                             "description": "Testin can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                            "targetId": self.unpublished_app.id,
+                            "targetType": IntegrationTypes.SENTRY_APP.value,
                         }
                     ],
                     "popularity": SentryApp._meta.get_field("popularity").default,

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 from sentry.constants import SentryAppStatus
 from sentry.models import OrganizationMember, SentryApp
+from sentry.models.integrationfeature import IntegrationTypes
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
 from sentry.utils import json
@@ -135,6 +136,8 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
                 {
                     "description": "Test can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
                     "featureGate": "integrations-api",
+                    "targetId": self.published_app.id,
+                    "targetType": IntegrationTypes.SENTRY_APP.value,
                 }
             ],
             "popularity": self.popularity,

--- a/tests/sentry/api/endpoints/test_sentry_app_features.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_features.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 
 from sentry.models import IntegrationFeature
-from sentry.models.integrationfeature import Feature
+from sentry.models.integrationfeature import Feature, IntegrationTypes
 from sentry.testutils import APITestCase
 
 
@@ -26,9 +26,13 @@ class SentryAppFeaturesTest(APITestCase):
         assert {
             "description": self.api_feature.description,
             "featureGate": self.api_feature.feature_str(),
+            "targetId": self.sentry_app.id,
+            "targetType": IntegrationTypes.SENTRY_APP.value,
         } in response.data
 
         assert {
             "description": self.issue_link_feature.description,
             "featureGate": self.issue_link_feature.feature_str(),
+            "targetId": self.sentry_app.id,
+            "targetType": IntegrationTypes.SENTRY_APP.value,
         } in response.data

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -12,6 +12,7 @@ from sentry.models import (
     SentryAppInstallation,
     SentryAppInstallationToken,
 )
+from sentry.models.integrationfeature import IntegrationTypes
 from sentry.models.sentryapp import MASKED_VALUE
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
@@ -88,6 +89,8 @@ class GetSentryAppsTest(SentryAppsTest):
                 {
                     "featureGate": "integrations-api",
                     "description": "Test can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                    "targetId": self.published_app.id,
+                    "targetType": IntegrationTypes.SENTRY_APP.value,
                 }
             ],
             "popularity": self.default_popularity,
@@ -196,6 +199,8 @@ class GetSentryAppsTest(SentryAppsTest):
                 {
                     "featureGate": "integrations-api",
                     "description": "Test can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                    "targetId": self.published_app.id,
+                    "targetType": IntegrationTypes.SENTRY_APP.value,
                 }
             ],
             "popularity": self.default_popularity,
@@ -245,6 +250,8 @@ class GetSentryAppsTest(SentryAppsTest):
                 {
                     "featureGate": "integrations-api",
                     "description": "Testin can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                    "targetId": self.unpublished_app.id,
+                    "targetType": IntegrationTypes.SENTRY_APP.value,
                 }
             ],
             "popularity": self.default_popularity,
@@ -298,6 +305,8 @@ class GetSentryAppsTest(SentryAppsTest):
                 {
                     "featureGate": "integrations-api",
                     "description": "Boo Far can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                    "targetId": sentry_app.id,
+                    "targetType": IntegrationTypes.SENTRY_APP.value,
                 }
             ],
             "popularity": self.default_popularity,

--- a/tests/sentry/api/serializers/test_sentry_app.py
+++ b/tests/sentry/api/serializers/test_sentry_app.py
@@ -1,5 +1,6 @@
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.sentry_app import SentryAppSerializer
+from sentry.models.integrationfeature import IntegrationTypes
 from sentry.testutils import TestCase
 
 # from sentry.constants import SentryAppStatus
@@ -22,6 +23,8 @@ class SentryAppSerializerTest(TestCase):
             {
                 "description": "Tesla App can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
                 "featureGate": "integrations-api",
+                "targetId": sentry_app.id,
+                "targetType": IntegrationTypes.SENTRY_APP.value,
             }
         ]
         assert result["scopes"] == ["org:write", "team:admin"]


### PR DESCRIPTION
This is step 2 of a migration process outlined [here](https://github.com/getsentry/sentry/pull/30521) in which we'll write to the new `target_id` and `target_type` columns before backfilling and ultimately removing the `sentry_app` column.