### PR TITLE
fix(snql): Dedupe selected columns in snql builder

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2839,7 +2839,7 @@ class QueryFields(QueryBase):
             return []
 
         resolved_columns = []
-        stripped_columns = [column.strip() for column in selected_columns]
+        stripped_columns = [column.strip() for column in set(selected_columns)]
 
         if equations:
             _, _, parsed_equations = resolve_equation_list(


### PR DESCRIPTION
The snql builder can receive duplicate columns but the duplicates do not add
anything. Remove them in the final select clause.