### PR TITLE
Rename to self-hosted in (most of) frontend

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -153,7 +153,8 @@ def get_client_config(request=None):
         "statuspage": _get_statuspage(),
         "messages": [{"message": msg.message, "level": msg.tags} for msg in messages],
         "apmSampling": float(settings.SENTRY_FRONTEND_APM_SAMPLING or 0),
-        "isOnPremise": settings.SENTRY_SELF_HOSTED,
+        "isOnPremise": settings.SENTRY_SELF_HOSTED,  # deprecated, use ...
+        "isSelfHosted": settings.SENTRY_SELF_HOSTED,  # ... this instead
         "invitesEnabled": settings.SENTRY_ENABLE_INVITES,
         "gravatarBaseUrl": settings.SENTRY_GRAVATAR_BASE_URL,
         "termsUrl": settings.TERMS_URL,

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -20,7 +20,8 @@ def get_default_context(request, existing_context=None, team=None):
         "URL_PREFIX": options.get("system.url-prefix"),
         "SINGLE_ORGANIZATION": settings.SENTRY_SINGLE_ORGANIZATION,
         "PLUGINS": plugins,
-        "ONPREMISE": settings.SENTRY_SELF_HOSTED,
+        "ONPREMISE": settings.SENTRY_SELF_HOSTED,  # deprecated, use ...
+        "SELF_HOSTED": settings.SENTRY_SELF_HOSTED,  # ... this instead
     }
 
     if existing_context:

--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -18,7 +18,7 @@ function BaseFooter({className}: Props) {
   return (
     <footer className={className}>
       <LeftLinks>
-        {config.isOnPremise && (
+        {config.isSelfHosted && (
           <Fragment>
             {'Sentry '}
             {getDynamicText({
@@ -47,7 +47,7 @@ function BaseFooter({className}: Props) {
         <FooterLink href="https://github.com/getsentry/sentry">
           {t('Contribute')}
         </FooterLink>
-        {config.isOnPremise && !config.demoMode && (
+        {config.isSelfHosted && !config.demoMode && (
           <FooterLink href="/out/">{t('Migrate to SaaS')}</FooterLink>
         )}
       </RightLinks>

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -121,7 +121,8 @@ export interface Config {
   invitesEnabled: boolean;
   privacyUrl: string | null;
   termsUrl: string | null;
-  isOnPremise: boolean;
+  isOnPremise: boolean; // deprecated, use ...
+  isSelfHosted: boolean; // ... this instead
   lastOrganization: string | null;
   gravatarBaseUrl: string;
 

--- a/static/app/views/alerts/issueRuleEditor/setupAlertIntegrationButton.tsx
+++ b/static/app/views/alerts/issueRuleEditor/setupAlertIntegrationButton.tsx
@@ -55,7 +55,7 @@ export default class SetupAlertIntegrationButton extends AsyncComponent<Props, S
     const config = ConfigStore.getConfig();
     // link to docs to set up Slack for on-prem folks
     const referrerQuery = '?referrer=issue-alert-builder';
-    const buttonProps = config.isOnPremise
+    const buttonProps = config.isSelfHosted
       ? {
           href: `https://develop.sentry.dev/integrations/slack/${referrerQuery}`,
         }

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -67,17 +67,17 @@ class SettingsIndex extends React.Component<Props> {
   render() {
     const {organization} = this.props;
     const user = ConfigStore.get('user');
-    const isOnPremise = ConfigStore.get('isOnPremise');
+    const isSelfHosted = ConfigStore.get('isSelfHosted');
 
     const organizationSettingsUrl =
       (organization && `/settings/${organization.slug}/`) || '';
 
     const supportLinkProps = {
-      isOnPremise,
+      isSelfHosted,
       href: LINKS.FORUM,
       to: `${organizationSettingsUrl}support`,
     };
-    const supportText = isOnPremise ? t('Community Forums') : t('Contact Support');
+    const supportText = isSelfHosted ? t('Community Forums') : t('Contact Support');
 
     return (
       <SentryDocumentTitle
@@ -340,7 +340,7 @@ const ExternalHomeLink = styled(
 `;
 
 type SupportLinkProps<T extends boolean> = {
-  isOnPremise: T;
+  isSelfHosted: T;
   href: string;
   to: string;
   isCentered?: boolean;
@@ -350,12 +350,12 @@ type SupportLinkProps<T extends boolean> = {
 
 const SupportLinkComponent = <T extends boolean>({
   isCentered,
-  isOnPremise,
+  isSelfHosted,
   href,
   to,
   ...props
 }: SupportLinkProps<T>) =>
-  isOnPremise ? (
+  isSelfHosted ? (
     <ExternalHomeLink isCentered={isCentered} href={href} {...props} />
   ) : (
     <HomeLink to={to} {...props} />

--- a/tests/fixtures/js-stubs/config.js
+++ b/tests/fixtures/js-stubs/config.js
@@ -15,7 +15,8 @@ export function Config(params = {}) {
     invitesEnabled: false,
     privacyUrl: null,
     termsUrl: null,
-    isOnPremise: false,
+    isOnPremise: false, // deprecated, use ...
+    isSelfHosted: false, // ... this instead
     lastOrganization: null,
     gravatarBaseUrl: 'https://gravatar.com',
     dsn: 'test-dsn',

--- a/tests/js/spec/views/settings/settingsIndex.spec.jsx
+++ b/tests/js/spec/views/settings/settingsIndex.spec.jsx
@@ -25,8 +25,8 @@ describe('SettingsIndex', function () {
     expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
   });
 
-  it('has different links for on premise users', function () {
-    ConfigStore.set('isOnPremise', true);
+  it('has different links for self-hosted users', function () {
+    ConfigStore.set('isSelfHosted', true);
 
     wrapper = mountWithTheme(
       <SettingsIndex
@@ -62,7 +62,7 @@ describe('SettingsIndex', function () {
       api = MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/`,
       });
-      ConfigStore.config.isOnPremise = false;
+      ConfigStore.config.isSelfHosted = false;
       wrapper = mountWithTheme(
         <SettingsIndex router={TestStubs.router()} params={{}} />,
         TestStubs.routerContext()


### PR DESCRIPTION
Part of https://github.com/getsentry/self-hosted/issues/796, split out from #30528 by [request](https://github.com/getsentry/sentry/pull/30528#pullrequestreview-828146212), follow-up to #30556.

Follow up is #30559 for frontend for an old plugin.