### PR TITLE
fix(snql): Bug with sdk update endpoint where there wasn't project.id

### DIFF
--- a/src/sentry/api/endpoints/organization_has_mobile_app_events.py
+++ b/src/sentry/api/endpoints/organization_has_mobile_app_events.py
@@ -53,7 +53,7 @@ class OrganizationHasMobileAppEvents(OrganizationEventsEndpointBase):
                 },
                 referrer="api.organization-has-mobile-app-events",
                 use_snql=features.has(
-                    "organizations:performance-view", organization, actor=request.user
+                    "organizations:performance-use-snql", organization, actor=request.user
                 ),
             )
             data = result["data"]

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -75,7 +75,13 @@ class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
         with self.handle_query_errors():
             result = discover.query(
                 query="has:sdk.version",
-                selected_columns=["project", "sdk.name", "sdk.version", "last_seen()"],
+                selected_columns=[
+                    "project",
+                    "project.id",
+                    "sdk.name",
+                    "sdk.version",
+                    "last_seen()",
+                ],
                 orderby="-project",
                 params={
                     "start": timezone.now() - timedelta(days=1),
@@ -85,7 +91,7 @@ class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
                 },
                 referrer="api.organization-sdk-updates",
                 use_snql=features.has(
-                    "organizations:performance-view", organization, actor=request.user
+                    "organizations:performance-use-snql", organization, actor=request.user
                 ),
             )
 


### PR DESCRIPTION
- This changes the query so it explicitly asks for project.id
- Also updates the feature flag cause its currently the wrong one