### PR TITLE
fix(releasehealth-duplex): Capture entire error in message [INGEST-776]

### DIFF
--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -537,9 +537,8 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
             )
 
             if errors:
-                with push_scope() as scope:
-                    scope.fingerprint = ["release-health-errors", fn_name]
-                    capture_message(f"{fn_name} - Release health metrics mismatch")
+                # We heavily rely on Sentry's message sanitization to properly deduplicate this
+                capture_message(f"{fn_name} - Release health metrics mismatch: {errors[0]}")
         except Exception:
             capture_exception()
             should_compare = False


### PR DESCRIPTION
We have seen that the created issues in Sentry are too large, and not a
lot. When we add the first error into the message, we can rely on
message grouping to strip common values such as integers.