### PR TITLE
feat(suspect-spans): Add new endpoint for span examples

### DIFF
--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -313,12 +313,12 @@ class Span:
 
     @staticmethod
     def from_str(s: str) -> Span:
-        parts = s.split(":", 1)
+        parts = s.rsplit(":", 1)
         if len(parts) != 2:
             raise ValueError(f"{s} is not a valid span.")
-        if not is_span_id(parts[0]):
-            raise ValueError(f"{parts[0]} is not a valid span group.")
-        return Span(op=parts[1], group=parts[0])
+        if not is_span_id(parts[1]):
+            raise ValueError(f"{parts[1]} is not a valid span group.")
+        return Span(op=parts[0], group=parts[1])
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import dataclasses
 from itertools import chain
 from typing import Any, Dict, List, Optional, Tuple
 
+from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,6 +16,7 @@ from snuba_sdk.orderby import LimitBy
 from sentry import eventstore, features
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.serializers.rest_framework import ListField
 from sentry.models import Organization
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.types import ParamsType
@@ -53,7 +57,7 @@ SPAN_PERFORMANCE_COLUMNS: Dict[str, SpanPerformanceColumn] = {
 }
 
 
-class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsEndpointBase):  # type: ignore
+class OrganizationEventsSpansEndpointBase(OrganizationEventsEndpointBase):  # type: ignore
     def has_feature(self, request: Request, organization: Organization) -> bool:
         return bool(
             features.has(
@@ -63,6 +67,26 @@ class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsEndpointBase)
             )
         )
 
+    def get_orderby_column(self, request: Request) -> Tuple[str, str]:
+        orderbys = super().get_orderby(request)
+
+        if orderbys is None:
+            direction = "-"
+            orderby = "sumExclusiveTime"
+        elif len(orderbys) != 1:
+            raise ParseError(detail="Can only order by one column.")
+        else:
+            direction = "-" if orderbys[0].startswith("-") else ""
+            orderby = orderbys[0].lstrip("-")
+
+        if orderby not in SPAN_PERFORMANCE_COLUMNS:
+            options = ", ".join(SPAN_PERFORMANCE_COLUMNS.keys())
+            raise ParseError(detail=f"Can only order by one of {options}")
+
+        return direction, orderby
+
+
+class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsSpansEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(request, organization):
             return Response(status=404)
@@ -97,30 +121,26 @@ class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsEndpointBase)
                 params, query, span_ops, span_groups, orderbys, limit, offset
             )
 
-            orderbys = [
-                direction + column
-                for column in SPAN_PERFORMANCE_COLUMNS[orderby_column].suspect_example_columns
-            ]
-
             # Because we want to support pagination, the limit is 1 more than will be
             # returned and displayed. Since this extra result is only used for
             # pagination, we do not need to get any example transactions for it.
-            suspects_requiring_examples = suspects[: limit - 1]
+            suspects_requiring_examples = [
+                Span(suspect.op, suspect.group) for suspect in suspects[: limit - 1]
+            ]
 
-            transaction_ids = query_example_transactions(
-                params, query, orderbys, suspects_requiring_examples, per_suspect
+            example_transactions = query_example_transactions(
+                params, query, direction, orderby_column, suspects_requiring_examples, per_suspect
             )
 
             return [
                 SuspectSpanWithExamples(
                     examples=[
                         get_example_transaction(
-                            suspect.project_id,
-                            transaction_id,
+                            event,
                             suspect.op,
                             suspect.group,
                         )
-                        for transaction_id in transaction_ids.get((suspect.op, suspect.group), [])
+                        for event in example_transactions.get(Span(suspect.op, suspect.group), [])
                     ],
                     **dataclasses.asdict(suspect),
                 ).serialize()
@@ -135,23 +155,69 @@ class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsEndpointBase)
                 max_per_page=4,
             )
 
-    def get_orderby_column(self, request: Request) -> Tuple[str, str]:
-        orderbys = super().get_orderby(request)
 
-        if orderbys is None:
-            direction = "-"
-            orderby = "sumExclusiveTime"
-        elif len(orderbys) != 1:
-            raise ParseError(detail="Can only order by one column.")
-        else:
-            direction = "-" if orderbys[0].startswith("-") else ""
-            orderby = orderbys[0].lstrip("-")
+class SpansExamplesSerializer(serializers.Serializer):  # type: ignore
+    query = serializers.CharField(required=False, allow_null=True)
+    span = ListField(child=serializers.CharField(), required=True, allow_null=False, max_length=10)
 
-        if orderby not in SPAN_PERFORMANCE_COLUMNS:
-            options = ", ".join(SPAN_PERFORMANCE_COLUMNS.keys())
-            raise ParseError(detail=f"Can only order by one of {options}")
+    def validate_span(self, spans: List[str]) -> List[Span]:
+        try:
+            return [Span.from_str(span) for span in spans]
+        except ValueError as e:
+            raise serializers.ValidationError(str(e))
 
-        return direction, orderby
+
+class OrganizationEventsSpansEndpoint(OrganizationEventsSpansEndpointBase):
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not self.has_feature(request, organization):
+            return Response(status=404)
+
+        try:
+            params = self.get_snuba_params(request, organization)
+        except NoProjects:
+            return Response(status=404)
+
+        serializer = SpansExamplesSerializer(data=request.GET)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+        serialized = serializer.validated_data
+
+        query = serialized.get("query")
+        spans = serialized["span"]
+
+        direction, orderby_column = self.get_orderby_column(request)
+
+        def data_fn(offset: int, limit: int) -> Any:
+            if len(spans) > 1 and offset > 0:
+                raise ParseError(detail="Can only specify offset with one span.")
+
+            example_transactions = query_example_transactions(
+                params, query, direction, orderby_column, spans, limit, offset
+            )
+
+            return [
+                {
+                    "op": span.op,
+                    "group": span.group,
+                    "examples": [
+                        get_example_transaction(
+                            event,
+                            span.op,
+                            span.group,
+                        ).serialize()
+                        for event in example_transactions.get(span, [])
+                    ],
+                }
+                for span in sorted(spans, key=lambda span: (span.op, span.group))
+            ]
+
+        with self.handle_query_errors():
+            return self.paginate(
+                request,
+                paginator=GenericOffsetPaginator(data_fn=data_fn),
+                default_per_page=3,
+                max_per_page=10,
+            )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -173,6 +239,8 @@ class ExampleSpan:
 @dataclasses.dataclass(frozen=True)
 class ExampleTransaction:
     id: str
+    project_id: int
+    project: str
     description: Optional[str]
     start_timestamp: float
     finish_timestamp: float
@@ -182,6 +250,8 @@ class ExampleTransaction:
     def serialize(self) -> Any:
         return {
             "id": self.id,
+            "projectId": self.project_id,
+            "project": self.project,
             "description": self.description,
             "startTimestamp": self.start_timestamp,
             "finishTimestamp": self.finish_timestamp,
@@ -234,6 +304,28 @@ class SuspectSpanWithExamples(SuspectSpan):
             [] if self.examples is None else [ex.serialize() for ex in self.examples]
         )
         return serialized
+
+
+@dataclasses.dataclass(frozen=True)
+class Span:
+    op: str
+    group: str
+
+    @staticmethod
+    def from_str(s: str) -> Span:
+        parts = s.split(":", 1)
+        if len(parts) != 2:
+            raise ValueError(f"{s} is not a valid span.")
+        if not is_span_id(parts[0]):
+            raise ValueError(f"{parts[0]} is not a valid span group.")
+        return Span(op=parts[1], group=parts[0])
+
+
+@dataclasses.dataclass(frozen=True)
+class EventID:
+    project_id: int
+    project_slug: str
+    event_id: str
 
 
 def query_suspect_span_groups(
@@ -325,32 +417,36 @@ def query_suspect_span_groups(
 def query_example_transactions(
     params: ParamsType,
     query: Optional[str],
-    order_columns: List[str],
-    suspects: List[SuspectSpan],
+    direction: str,
+    orderby: str,
+    spans: List[Span],
     per_suspect: int = 5,
-) -> Dict[Tuple[str, str], List[str]]:
+    offset: Optional[int] = None,
+) -> Dict[Span, List[EventID]]:
     # there aren't any suspects, early return to save an empty query
-    if not suspects or per_suspect == 0:
+    if not spans or per_suspect == 0:
         return {}
+
+    orderby_columns = SPAN_PERFORMANCE_COLUMNS[orderby].suspect_example_columns
 
     selected_columns: List[str] = [
         "id",
+        "project.id",
+        "project",
         "array_join(spans_op)",
         "array_join(spans_group)",
+        *orderby_columns,
     ]
-
-    for column in SPAN_PERFORMANCE_COLUMNS.values():
-        for col in column.suspect_example_columns:
-            selected_columns.append(col)
 
     builder = QueryBuilder(
         dataset=Dataset.Discover,
         params=params,
         selected_columns=selected_columns,
         query=query,
-        orderby=order_columns,
+        orderby=[direction + column for column in orderby_columns],
         # we want only `per_suspect` examples for each suspect
-        limit=len(suspects) * per_suspect,
+        limit=len(spans) * per_suspect,
+        offset=offset,
         functions_acl=["array_join", "sumArray", "percentileArray", "maxArray"],
     )
 
@@ -368,42 +464,41 @@ def query_example_transactions(
                 Op.IN,
                 Function(
                     "tuple",
-                    [Function("tuple", [suspect.op, suspect.group]) for suspect in suspects],
+                    [Function("tuple", [suspect.op, suspect.group]) for suspect in spans],
                 ),
             ),
         ]
     )
 
-    # Hack: the limit by clause only allows columns but here we want to
-    # do a limitby on the two array joins. For the time being, directly
-    # do the limitby on the internal snuba name for the span group column
-    # but this should not be relied upon in production, and if two spans
-    # differ only by the span op, this will result in a incorrect query
-    builder.limitby = LimitBy(Column("_snuba_array_join_spans_group"), per_suspect)
+    if len(spans) > 1:
+        # Hack: the limit by clause only allows columns but here we want to
+        # do a limitby on the two array joins. For the time being, directly
+        # do the limitby on the internal snuba name for the span group column
+        # but this should not be relied upon in production, and if two spans
+        # differ only by the span op, this will result in a incorrect query
+        builder.limitby = LimitBy(Column("_snuba_array_join_spans_group"), per_suspect)
 
     snql_query = builder.get_snql_query()
     results = raw_snql_query(snql_query, "api.organization-events-spans-performance-examples")
 
-    examples: Dict[Tuple[str, str], List[str]] = {
-        (suspect.op, suspect.group): [] for suspect in suspects
-    }
+    examples: Dict[Span, List[EventID]] = {Span(suspect.op, suspect.group): [] for suspect in spans}
 
     for example in results["data"]:
-        key = example["array_join_spans_op"], example["array_join_spans_group"]
-        examples[key].append(example["id"])
+        key = Span(example["array_join_spans_op"], example["array_join_spans_group"])
+        value = EventID(example["project.id"], example["project"], example["id"])
+        examples[key].append(value)
 
     return examples
 
 
 def get_example_transaction(
-    project_id: int,
-    transaction_id: str,
+    event: EventID,
     span_op: str,
     span_group: str,
 ) -> ExampleTransaction:
     span_group_id = int(span_group, 16)
-    event = eventstore.get_event_by_id(project_id, transaction_id)
-    data = event.data
+    nodestore_event = eventstore.get_event_by_id(event.project_id, event.event_id)
+    data = nodestore_event.data
 
     # the transaction itself is a span as well but we need to reconstruct
     # it from the event as it's not present in the spans array
@@ -456,7 +551,9 @@ def get_example_transaction(
     )
 
     return ExampleTransaction(
-        id=transaction_id,
+        id=event.event_id,
+        project_id=event.project_id,
+        project=event.project_slug,
         description=description,
         start_timestamp=data["start_timestamp"],
         finish_timestamp=data["timestamp"],

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -183,6 +183,7 @@ from .endpoints.organization_events_meta import (
 )
 from .endpoints.organization_events_span_ops import OrganizationEventsSpanOpsEndpoint
 from .endpoints.organization_events_spans_performance import (
+    OrganizationEventsSpansEndpoint,
     OrganizationEventsSpansPerformanceEndpoint,
 )
 from .endpoints.organization_events_stats import OrganizationEventsStatsEndpoint
@@ -1035,6 +1036,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/events-span-ops/$",
                     OrganizationEventsSpanOpsEndpoint.as_view(),
                     name="sentry-api-0-organization-events-span-ops",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/events-spans/$",
+                    OrganizationEventsSpansEndpoint.as_view(),
+                    name="sentry-api-0-organization-events-spans",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/events-spans-performance/$",

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -1176,7 +1176,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsSpansEndpointTestBas
                 self.url,
                 data={
                     "project": self.project.id,
-                    "span": [f"{'ab' * 8}:http.server", f"{'cd' * 8}:django.middleware"],
+                    "span": [f"http.server:{'ab' * 8}", f"django.middleware:{'cd' * 8}"],
                     "cursor": "0:10:0",
                 },
                 format="json",
@@ -1198,7 +1198,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsSpansEndpointTestBas
         with self.feature(self.FEATURES):
             response = self.client.get(
                 self.url,
-                data={"project": self.project.id, "span": f"{'ab' * 8}:http.server"},
+                data={"project": self.project.id, "span": f"http.server:{'ab' * 8}"},
                 format="json",
             )
 
@@ -1225,7 +1225,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsSpansEndpointTestBas
                 self.url,
                 data={
                     "project": self.project.id,
-                    "span": [f"{'ab' * 8}:http.server", f"{'cd' * 8}:django.middleware"],
+                    "span": [f"http.server:{'ab' * 8}", f"django.middleware:{'cd' * 8}"],
                 },
                 format="json",
             )

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.urls import reverse
+from rest_framework.exceptions import ErrorDetail
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.expressions import Limit
@@ -16,7 +17,7 @@ from sentry.utils import json
 from sentry.utils.samples import load_data
 
 
-class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase):
+class OrganizationEventsSpansEndpointTestBase(APITestCase, SnubaTestCase):
     FEATURES = ["organizations:performance-suspect-spans-view"]
 
     def setUp(self):
@@ -24,7 +25,7 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
         self.login_as(user=self.user)
 
         self.url = reverse(
-            "sentry-api-0-organization-events-spans-performance",
+            self.URL,
             kwargs={"organization_slug": self.organization.slug},
         )
 
@@ -104,6 +105,98 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
 
         return self.store_event(data, project_id=self.project.id)
 
+    def suspect_span_examples_snuba_results(self, op, event):
+        results = {
+            "project.id": self.project.id,
+            "project": self.project.slug,
+            "id": event.event_id,
+            "array_join_spans_op": op,
+        }
+
+        if op == "http.server":
+            results.update(
+                {
+                    "array_join_spans_group": "ab" * 8,
+                    "count": 1,
+                    "sumArray_spans_exclusive_time": 4.0,
+                    "maxArray_spans_exclusive_time": 4.0,
+                }
+            )
+        elif op == "django.middleware":
+            results.update(
+                {
+                    "array_join_spans_group": "cd" * 8,
+                    "count": 2,
+                    "sumArray_spans_exclusive_time": 6.0,
+                    "maxArray_spans_exclusive_time": 3.0,
+                }
+            )
+        elif op == "django.view":
+            results.update(
+                {
+                    "array_join_spans_group": "ef" * 8,
+                    "count": 3,
+                    "sumArray_spans_exclusive_time": 3.0,
+                    "maxArray_spans_exclusive_time": 1.0,
+                }
+            )
+        else:
+            assert False, f"Unexpected Op: {op}"
+
+        return results
+
+    def assert_span_results(self, result, expected_result, keys):
+        assert len(result) == len(expected_result)
+        for suspect, expected_suspect in zip(result, expected_result):
+            for key in keys:
+                assert suspect[key] == expected_suspect[key], key
+
+            assert len(suspect["examples"]) == len(expected_suspect["examples"])
+
+            for example, expected_example in zip(suspect["examples"], expected_suspect["examples"]):
+                for key in [
+                    "id",
+                    "description",
+                    "startTimestamp",
+                    "finishTimestamp",
+                    "nonOverlappingExclusiveTime",
+                ]:
+                    assert example[key] == expected_example[key], key
+
+                assert len(example["spans"]) == len(expected_example["spans"])
+
+                for span, expected_span in zip(example["spans"], expected_example["spans"]):
+                    for key in [
+                        "id",
+                        "startTimestamp",
+                        "finishTimestamp",
+                        "exclusiveTime",
+                    ]:
+                        assert span[key] == expected_span[key], key
+
+    def assert_suspect_span(self, result, expected_result):
+        self.assert_span_results(
+            result,
+            expected_result,
+            [
+                "projectId",
+                "project",
+                "transaction",
+                "op",
+                "group",
+                "frequency",
+                "count",
+                "sumExclusiveTime",
+                "p50ExclusiveTime",
+                "p75ExclusiveTime",
+                "p95ExclusiveTime",
+                "p99ExclusiveTime",
+            ],
+        )
+
+    def assert_span_examples(self, result, expected_result):
+        self.assert_span_results(result, expected_result, ["op", "group"])
+
     def suspect_span_group_snuba_results(self, op, event):
         results = {
             "project.id": self.project.id,
@@ -159,59 +252,11 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
 
         return results
 
-    def suspect_span_examples_snuba_results(self, op, event):
-        results = {
-            "id": event.event_id,
-            "array_join_spans_op": op,
-        }
-
-        if op == "http.server":
-            results.update(
-                {
-                    "array_join_spans_group": "ab" * 8,
-                    "count": 1,
-                    "sumArray_spans_exclusive_time": 4.0,
-                    "maxArray_spans_exclusive_time": 4.0,
-                }
-            )
-        elif op == "django.middleware":
-            results.update(
-                {
-                    "array_join_spans_group": "cd" * 8,
-                    "count": 2,
-                    "sumArray_spans_exclusive_time": 6.0,
-                    "maxArray_spans_exclusive_time": 3.0,
-                }
-            )
-        elif op == "django.view":
-            results.update(
-                {
-                    "array_join_spans_group": "ef" * 8,
-                    "count": 3,
-                    "sumArray_spans_exclusive_time": 3.0,
-                    "maxArray_spans_exclusive_time": 1.0,
-                }
-            )
-        else:
-            assert False, f"Unexpected Op: {op}"
-
-        return results
-
-    def suspect_span_results(self, op, event):
+    def span_example_results(self, op, event):
         if op == "http.server":
             return {
-                "projectId": self.project.id,
-                "project": self.project.slug,
-                "transaction": event.transaction,
                 "op": op,
                 "group": "ab" * 8,
-                "frequency": 1,
-                "count": 1,
-                "sumExclusiveTime": 4.0,
-                "p50ExclusiveTime": 4.0,
-                "p75ExclusiveTime": 4.0,
-                "p95ExclusiveTime": 4.0,
-                "p99ExclusiveTime": 4.0,
                 "examples": [
                     {
                         "id": event.event_id,
@@ -233,20 +278,10 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
                 ],
             }
 
-        if op == "django.middleware":
+        elif op == "django.middleware":
             return {
-                "projectId": self.project.id,
-                "project": self.project.slug,
-                "transaction": event.transaction,
                 "op": op,
                 "group": "cd" * 8,
-                "frequency": 1,
-                "count": 2,
-                "sumExclusiveTime": 6.0,
-                "p50ExclusiveTime": 3.0,
-                "p75ExclusiveTime": 3.0,
-                "p95ExclusiveTime": 3.0,
-                "p99ExclusiveTime": 3.0,
                 "examples": [
                     {
                         "id": event.event_id,
@@ -269,7 +304,7 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
                 ],
             }
 
-        if op == "django.view":
+        elif op == "django.view":
             return {
                 "projectId": self.project.id,
                 "project": self.project.slug,
@@ -305,49 +340,70 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
                 ],
             }
 
-        assert False, f"Unexpected Op: {op}"
+        else:
+            assert False, f"Unexpected Op: {op}"
 
-    def assert_suspect_span(self, result, expected_result):
-        assert len(result) == len(expected_result)
-        for suspect, expected_suspect in zip(result, expected_result):
-            for key in [
-                "projectId",
-                "project",
-                "transaction",
-                "op",
-                "group",
-                "frequency",
-                "count",
-                "sumExclusiveTime",
-                "p50ExclusiveTime",
-                "p75ExclusiveTime",
-                "p95ExclusiveTime",
-                "p99ExclusiveTime",
-            ]:
-                assert suspect[key] == expected_suspect[key], key
+    def suspect_span_results(self, op, event):
+        results = self.span_example_results(op, event)
 
-            assert len(suspect["examples"]) == len(expected_suspect["examples"])
+        if op == "http.server":
+            results.update(
+                {
+                    "projectId": self.project.id,
+                    "project": self.project.slug,
+                    "transaction": event.transaction,
+                    "op": op,
+                    "group": "ab" * 8,
+                    "frequency": 1,
+                    "count": 1,
+                    "sumExclusiveTime": 4.0,
+                    "p50ExclusiveTime": 4.0,
+                    "p75ExclusiveTime": 4.0,
+                    "p95ExclusiveTime": 4.0,
+                    "p99ExclusiveTime": 4.0,
+                }
+            )
 
-            for example, expected_example in zip(suspect["examples"], expected_suspect["examples"]):
-                for key in [
-                    "id",
-                    "description",
-                    "startTimestamp",
-                    "finishTimestamp",
-                    "nonOverlappingExclusiveTime",
-                ]:
-                    assert example[key] == expected_example[key], key
+        elif op == "django.middleware":
+            results.update(
+                {
+                    "projectId": self.project.id,
+                    "project": self.project.slug,
+                    "transaction": event.transaction,
+                    "frequency": 1,
+                    "count": 2,
+                    "sumExclusiveTime": 6.0,
+                    "p50ExclusiveTime": 3.0,
+                    "p75ExclusiveTime": 3.0,
+                    "p95ExclusiveTime": 3.0,
+                    "p99ExclusiveTime": 3.0,
+                }
+            )
 
-                assert len(example["spans"]) == len(expected_example["spans"])
+        elif op == "django.view":
+            results.update(
+                {
+                    "projectId": self.project.id,
+                    "project": self.project.slug,
+                    "transaction": event.transaction,
+                    "frequency": 1,
+                    "count": 3,
+                    "sumExclusiveTime": 3.0,
+                    "p50ExclusiveTime": 1.0,
+                    "p75ExclusiveTime": 1.0,
+                    "p95ExclusiveTime": 1.0,
+                    "p99ExclusiveTime": 1.0,
+                }
+            )
 
-                for span, expected_span in zip(example["spans"], expected_example["spans"]):
-                    for key in [
-                        "id",
-                        "startTimestamp",
-                        "finishTimestamp",
-                        "exclusiveTime",
-                    ]:
-                        assert span[key] == expected_span[key], key
+        else:
+            assert False, f"Unexpected Op: {op}"
+
+        return results
+
+
+class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndpointTestBase):
+    URL = "sentry-api-0-organization-events-spans-performance"
 
     def test_no_feature(self):
         response = self.client.get(self.url, format="json")
@@ -359,7 +415,7 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
         self.login_as(user=user)
 
         url = reverse(
-            "sentry-api-0-organization-events-spans-performance",
+            self.URL,
             kwargs={"organization_slug": org.slug},
         )
 
@@ -1080,3 +1136,107 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
         results = self.suspect_span_results("http.server", event)
         results["group"] = "00" + "ab" * 7
         self.assert_suspect_span(response.data, [results])
+
+
+class OrganizationEventsSpansEndpointTest(OrganizationEventsSpansEndpointTestBase):
+    URL = "sentry-api-0-organization-events-spans"
+
+    def test_no_feature(self):
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == 404, response.content
+
+    def test_no_projects(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        self.login_as(user=user)
+
+        url = reverse(
+            self.URL,
+            kwargs={"organization_slug": org.slug},
+        )
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(url, format="json")
+        assert response.status_code == 404, response.content
+
+    def test_require_span_param(self):
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={"project": self.project.id},
+                format="json",
+            )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {"span": [ErrorDetail("This field is required.", code="required")]}
+
+    def test_illegal_offset_with_multiple_spans(self):
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={
+                    "project": self.project.id,
+                    "span": [f"{'ab' * 8}:http.server", f"{'cd' * 8}:django.middleware"],
+                    "cursor": "0:10:0",
+                },
+                format="json",
+            )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {"detail": "Can only specify offset with one span."}
+
+    @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
+    def test_one_span(self, mock_raw_snql_query):
+        event = self.create_event()
+
+        mock_raw_snql_query.side_effect = [
+            {
+                "data": [self.suspect_span_examples_snuba_results("http.server", event)],
+            },
+        ]
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={"project": self.project.id, "span": f"{'ab' * 8}:http.server"},
+                format="json",
+            )
+
+        assert response.status_code == 200, response.content
+        assert mock_raw_snql_query.call_count == 1
+
+        self.assert_span_examples(response.data, [self.span_example_results("http.server", event)])
+
+    @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
+    def test_multiple_spans(self, mock_raw_snql_query):
+        event = self.create_event()
+
+        mock_raw_snql_query.side_effect = [
+            {
+                "data": [
+                    self.suspect_span_examples_snuba_results("django.middleware", event),
+                    self.suspect_span_examples_snuba_results("http.server", event),
+                ],
+            },
+        ]
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={
+                    "project": self.project.id,
+                    "span": [f"{'ab' * 8}:http.server", f"{'cd' * 8}:django.middleware"],
+                },
+                format="json",
+            )
+
+        assert response.status_code == 200, response.content
+        assert mock_raw_snql_query.call_count == 1
+
+        self.assert_span_examples(
+            response.data,
+            [
+                self.span_example_results("django.middleware", event),
+                self.span_example_results("http.server", event),
+            ],
+        )


### PR DESCRIPTION
In preparation for the new span details page, split the span examples query from
the suspect spans query.