### PR TITLE
ref(integrationfeature): Remove uses of sentry_app

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_features.py
+++ b/src/sentry/api/endpoints/sentry_app_features.py
@@ -2,7 +2,7 @@ from sentry.api.bases.sentryapps import SentryAppBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import IntegrationFeature
-from sentry.models.integration_feature import IntegrationTypes
+from sentry.models.integrationfeature import IntegrationTypes
 
 
 class SentryAppFeaturesEndpoint(SentryAppBaseEndpoint):

--- a/src/sentry/api/endpoints/sentry_app_features.py
+++ b/src/sentry/api/endpoints/sentry_app_features.py
@@ -2,11 +2,14 @@ from sentry.api.bases.sentryapps import SentryAppBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import IntegrationFeature
+from sentry.models.integration_feature import IntegrationTypes
 
 
 class SentryAppFeaturesEndpoint(SentryAppBaseEndpoint):
     def get(self, request, sentry_app):
-        features = IntegrationFeature.objects.filter(sentry_app_id=sentry_app.id)
+        features = IntegrationFeature.objects.filter(
+            target_id=sentry_app.id, target_type=IntegrationTypes.SENTRY_APP.value
+        )
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -3,7 +3,7 @@ from sentry.app import env
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
 from sentry.models import IntegrationFeature, SentryApp
-from sentry.models.integration_feature import IntegrationTypes
+from sentry.models.integrationfeature import IntegrationTypes
 from sentry.models.sentryapp import MASKED_VALUE
 from sentry.utils.compat import map
 

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -3,6 +3,7 @@ from sentry.app import env
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
 from sentry.models import IntegrationFeature, SentryApp
+from sentry.models.integration_feature import IntegrationTypes
 from sentry.models.sentryapp import MASKED_VALUE
 from sentry.utils.compat import map
 
@@ -33,7 +34,9 @@ class SentryAppSerializer(Serializer):
         data["featureData"] = []
 
         if obj.status != SentryAppStatus.INTERNAL:
-            features = IntegrationFeature.objects.filter(sentry_app_id=obj.id)
+            features = IntegrationFeature.objects.filter(
+                target_id=obj.id, target_type=IntegrationTypes.SENTRY_APP.value
+            )
             data["featureData"] = map(lambda x: serialize(x, user), features)
 
         if obj.status == SentryAppStatus.PUBLISHED and obj.date_published:

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -114,7 +114,6 @@ class Creator(Mediator, SentryAppMixin):
         try:
             with transaction.atomic():
                 IntegrationFeature.objects.create(
-                    sentry_app=self.sentry_app,
                     target_id=self.sentry_app.id,
                     target_type=IntegrationTypes.SENTRY_APP.value,
                 )

--- a/src/sentry/models/integrationfeature.py
+++ b/src/sentry/models/integrationfeature.py
@@ -113,7 +113,7 @@ class IntegrationFeature(Model):
 
         if self.user_description:
             return self.user_description
-        integration = None
+
         if self.target_type == IntegrationTypes.SENTRY_APP.value:
             integration = SentryApp.objects.get(id=self.target_id)
         else:

--- a/src/sentry/models/integrationfeature.py
+++ b/src/sentry/models/integrationfeature.py
@@ -109,6 +109,13 @@ class IntegrationFeature(Model):
 
     @property
     def description(self):
+        from sentry.models import DocIntegration, SentryApp
+
         if self.user_description:
             return self.user_description
-        return Feature.description(self.feature, self.sentry_app.name)
+        integration = None
+        if self.target_type == IntegrationTypes.SENTRY_APP.value:
+            integration = SentryApp.objects.get(id=self.target_id)
+        else:
+            integration = DocIntegration.objects.get(id=self.target_id)
+        return Feature.description(self.feature, integration.name)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -862,7 +862,6 @@ class Factories:
             sentry_app = Factories.create_sentry_app()
 
         integration_feature = IntegrationFeature.objects.create(
-            sentry_app=sentry_app,
             target_id=sentry_app.id,
             target_type=IntegrationTypes.SENTRY_APP.value,
             feature=feature or Feature.API,

--- a/tests/sentry/api/endpoints/test_sentry_app_features.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_features.py
@@ -12,7 +12,9 @@ class SentryAppFeaturesTest(APITestCase):
         self.sentry_app = self.create_sentry_app(
             name="Test", organization=self.create_organization(owner=self.user)
         )
-        self.api_feature = IntegrationFeature.objects.get(sentry_app=self.sentry_app)
+        self.api_feature = IntegrationFeature.objects.get(
+            target_id=self.sentry_app.id, target_type=IntegrationTypes.SENTRY_APP.value
+        )
         self.issue_link_feature = self.create_sentry_app_feature(
             sentry_app=self.sentry_app, feature=Feature.ISSUE_LINK
         )

--- a/tests/sentry/mediators/sentry_apps/test_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_creator.py
@@ -12,6 +12,7 @@ from sentry.models import (
     SentryAppComponent,
     User,
 )
+from sentry.models.integration_feature import IntegrationTypes
 from sentry.testutils import TestCase
 
 
@@ -102,7 +103,9 @@ class TestCreator(TestCase):
 
     def test_creates_integration_feature(self):
         app = self.creator.call()
-        assert IntegrationFeature.objects.filter(sentry_app=app).exists()
+        assert IntegrationFeature.objects.filter(
+            target_id=app.id, target_type=IntegrationTypes.SENTRY_APP.value
+        ).exists()
 
     @patch("sentry.mediators.sentry_apps.creator.Creator.log")
     @patch("sentry.models.integrationfeature.IntegrationFeature.objects.create")

--- a/tests/sentry/mediators/sentry_apps/test_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_creator.py
@@ -12,7 +12,7 @@ from sentry.models import (
     SentryAppComponent,
     User,
 )
-from sentry.models.integration_feature import IntegrationTypes
+from sentry.models.integrationfeature import IntegrationTypes
 from sentry.testutils import TestCase
 
 

--- a/tests/sentry/models/test_integrationfeature.py
+++ b/tests/sentry/models/test_integrationfeature.py
@@ -1,5 +1,5 @@
 from sentry.models import IntegrationFeature
-from sentry.models.integration_feature import IntegrationTypes
+from sentry.models.integrationfeature import IntegrationTypes
 from sentry.testutils import TestCase
 
 

--- a/tests/sentry/models/test_integrationfeature.py
+++ b/tests/sentry/models/test_integrationfeature.py
@@ -1,11 +1,14 @@
 from sentry.models import IntegrationFeature
+from sentry.models.integration_feature import IntegrationTypes
 from sentry.testutils import TestCase
 
 
 class IntegrationFeatureTest(TestCase):
     def setUp(self):
         self.sentry_app = self.create_sentry_app()
-        self.integration_feature = IntegrationFeature.objects.get(sentry_app=self.sentry_app)
+        self.integration_feature = IntegrationFeature.objects.get(
+            target_id=self.sentry_app.id, target_type=IntegrationTypes.SENTRY_APP.value
+        )
 
     def test_feature_str(self):
         assert self.integration_feature.feature_str() == "integrations-api"


### PR DESCRIPTION
This is step 4 of a migration plan to update `IntegrationFeature` as outlined [here](https://github.com/getsentry/sentry/pull/30521). This step stops writing to the `sentry_app` column as we prepare to remove it. 

Do not merge until https://github.com/getsentry/sentry/pull/30563 has been merged