### PR TITLE
feat(suspect-spans): Allow specifying certain columns

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -145,11 +145,11 @@ class OrganizationEventsSpansEndpointTestBase(APITestCase, SnubaTestCase):
 
         return results
 
-    def assert_span_results(self, result, expected_result, keys, none_keys):
+    def assert_span_results(self, result, expected_result, keys, none_keys=None):
         assert len(result) == len(expected_result)
         for suspect, expected_suspect in zip(result, expected_result):
             for key in keys:
-                if key in none_keys:
+                if none_keys and key in none_keys:
                     assert suspect[key] is None, key
                 else:
                     assert suspect[key] == expected_suspect[key], key


### PR DESCRIPTION
Querying additional unused columns can get expensive on the suspect spans query.
This change allows specifying exactly the necessary columns to be rendered.