### PR TITLE
fix(metrics): Add granularity to release health overview queries

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -670,7 +670,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
     @staticmethod
     def _get_session_duration_data_for_overview(
-        where: List[Condition], org_id: int
+        where: List[Condition],
+        org_id: int,
+        rollup: int,
     ) -> Mapping[Tuple[int, str], Any]:
         """
         Percentiles of session duration
@@ -705,6 +707,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                     ),
                 ],
                 groupby=aggregates,
+                granularity=Granularity(rollup),
             ),
             referrer="release_health.metrics.get_session_duration_data_for_overview",
         )["data"]:
@@ -719,7 +722,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
     @staticmethod
     def _get_errored_sessions_for_overview(
-        where: List[Condition], org_id: int
+        where: List[Condition],
+        org_id: int,
+        rollup: int,
     ) -> Mapping[Tuple[int, str], int]:
         """
         Count of errored sessions, incl fatal (abnormal, crashed) sessions,
@@ -743,6 +748,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                     Condition(Column("metric_id"), Op.EQ, metric_id(org_id, "session.error")),
                 ],
                 groupby=aggregates,
+                granularity=Granularity(rollup),
             ),
             referrer="release_health.metrics.get_errored_sessions_for_overview",
         )["data"]:
@@ -753,7 +759,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
     @staticmethod
     def _get_session_by_status_for_overview(
-        where: List[Condition], org_id: int
+        where: List[Condition], org_id: int, rollup: int
     ) -> Mapping[Tuple[int, str, str], int]:
         """
         Counts of init, abnormal and crashed sessions, purpose-built for overview
@@ -786,6 +792,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                     ),
                 ],
                 groupby=aggregates,
+                granularity=Granularity(rollup),
             ),
             referrer="release_health.metrics.get_abnormal_and_crashed_sessions_for_overview",
         )["data"]:
@@ -800,7 +807,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
     @staticmethod
     def _get_users_and_crashed_users_for_overview(
-        where: List[Condition], org_id: int
+        where: List[Condition], org_id: int, rollup: int
     ) -> Mapping[Tuple[int, str, str], int]:
         release_column_name = tag_key(org_id, "release")
         session_status_column_name = tag_key(org_id, "session.status")
@@ -832,6 +839,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 select=select,
                 where=where,
                 groupby=aggregates,
+                granularity=Granularity(rollup),
             ),
             referrer="release_health.metrics.get_users_and_crashed_users_for_overview",
         )["data"]:
@@ -924,7 +932,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             stat = "sessions"
         assert stat in ("sessions", "users")
         now = datetime.now(pytz.utc)
-        _, summary_start, _ = get_rollup_starts_and_buckets(summary_stats_period or "24h")
+        rollup, summary_start, _ = get_rollup_starts_and_buckets(summary_stats_period or "24h")
 
         org_id = self._get_org_id([x for x, _ in project_releases])
 
@@ -951,10 +959,10 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         else:
             health_stats_data = {}
 
-        rv_durations = self._get_session_duration_data_for_overview(where, org_id)
-        rv_errored_sessions = self._get_errored_sessions_for_overview(where, org_id)
-        rv_sessions = self._get_session_by_status_for_overview(where, org_id)
-        rv_users = self._get_users_and_crashed_users_for_overview(where, org_id)
+        rv_durations = self._get_session_duration_data_for_overview(where, org_id, rollup)
+        rv_errored_sessions = self._get_errored_sessions_for_overview(where, org_id, rollup)
+        rv_sessions = self._get_session_by_status_for_overview(where, org_id, rollup)
+        rv_users = self._get_users_and_crashed_users_for_overview(where, org_id, rollup)
 
         # XXX: In order to be able to dual-read and compare results from both
         # old and new backend, this should really go back through the


### PR DESCRIPTION
These queries were lacking a `granularity` argument, which can be provided `get_rollup_starts_and_buckets`.﻿
