### PR TITLE
fix(performance-metrics): Handle null serie values [INGEST-753]

### DIFF
--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -5,7 +5,7 @@ export type MetricsApiResponse = {
   groups: {
     by: Record<string, string>;
     totals: Record<string, number>;
-    series: Record<string, number[]>;
+    series: Record<string, Array<number | null>>;
   }[];
   start: DateString;
   end: DateString;

--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -4,7 +4,7 @@ export type MetricsApiResponse = {
   intervals: string[];
   groups: {
     by: Record<string, string>;
-    totals: Record<string, number>;
+    totals: Record<string, number | null>;
     series: Record<string, Array<number | null>>;
   }[];
   start: DateString;

--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {
   DAY,
@@ -12,9 +13,13 @@ import {
 } from 'sentry/utils/formatters';
 
 /**
- * Formatter for chart tooltips that handle a variety of discover result values
+ * Formatter for chart tooltips that handle a variety of discover and metrics result values.
+ * If the result is metric values, the value can be of type number or null
  */
-export function tooltipFormatter(value: number, seriesName: string = ''): string {
+export function tooltipFormatter(value: number | null, seriesName: string = ''): string {
+  if (!defined(value)) {
+    return '\u2014';
+  }
   switch (aggregateOutputType(seriesName)) {
     case 'integer':
     case 'number':

--- a/static/app/views/performance/landing/widgets/transforms/transformMetricsToArea.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformMetricsToArea.tsx
@@ -119,7 +119,7 @@ export function transformMetricsToArea<T extends WidgetDataConstraint>(
     return {
       mean: meanData,
       outputType: aggregateOutputType(seriesName),
-      label: meanData ? axisLabelFormatter(meanData, seriesName) : undefined,
+      label: defined(meanData) ? axisLabelFormatter(meanData, seriesName) : undefined,
     };
   });
 

--- a/static/app/views/performance/landing/widgets/transforms/transformMetricsToArea.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformMetricsToArea.tsx
@@ -145,7 +145,7 @@ export function transformMetricsToArea<T extends WidgetDataConstraint>(
       stack: 'previous',
       data: series.some(serie => defined(serie.value)) ? series : [],
     };
-  }) as undefined | Series[];
+  }) as null | Series[];
 
   return {
     ...commonChildData,

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidgetMetrics.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidgetMetrics.tsx
@@ -5,6 +5,7 @@ import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import Count from 'sentry/components/count';
 import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import MetricsRequest from 'sentry/utils/metrics/metricsRequest';
 import {decodeList} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -174,17 +175,23 @@ export function LineChartListWidgetMetrics(props: PerformanceWidgetProps) {
                   query: props.eventView.getGlobalSelectionQuery(),
                 });
 
+                const countValue = listItem[field];
+
                 return (
                   <Fragment>
                     <GrowLink to={transactionTarget} className="truncate">
                       <Truncate value={transaction} maxLength={40} />
                     </GrowLink>
                     <RightAlignedCell>
-                      <Count value={listItem[field]} />
+                      {defined(countValue) && <Count value={countValue} />}
                     </RightAlignedCell>
                     <ListClose
                       setSelectListIndex={setSelectListIndex}
-                      onClick={() => excludeTransaction(listItem.transaction, props)}
+                      onClick={() =>
+                        defined(listItem.transaction)
+                          ? excludeTransaction(listItem.transaction, props)
+                          : undefined
+                      }
                     />
                   </Fragment>
                 );

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidgetMetrics.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidgetMetrics.tsx
@@ -166,7 +166,12 @@ export function LineChartListWidgetMetrics(props: PerformanceWidgetProps) {
               selectedIndex={selectedListIndex}
               setSelectedIndex={setSelectListIndex}
               items={provided.widgetData.list.data.map(listItem => () => {
-                const transaction = listItem.transaction as string;
+                const transaction = listItem.transaction as string | null;
+                const countValue = listItem[field];
+
+                if (!transaction) {
+                  return null;
+                }
 
                 const transactionTarget = transactionSummaryRouteWithQuery({
                   orgSlug: organization.slug,
@@ -175,23 +180,17 @@ export function LineChartListWidgetMetrics(props: PerformanceWidgetProps) {
                   query: props.eventView.getGlobalSelectionQuery(),
                 });
 
-                const countValue = listItem[field];
-
                 return (
                   <Fragment>
                     <GrowLink to={transactionTarget} className="truncate">
                       <Truncate value={transaction} maxLength={40} />
                     </GrowLink>
                     <RightAlignedCell>
-                      {defined(countValue) && <Count value={countValue} />}
+                      {defined(countValue) ? <Count value={countValue} /> : '\u2014'}
                     </RightAlignedCell>
                     <ListClose
                       setSelectListIndex={setSelectListIndex}
-                      onClick={() =>
-                        defined(listItem.transaction)
-                          ? excludeTransaction(listItem.transaction, props)
-                          : undefined
-                      }
+                      onClick={() => excludeTransaction(transaction, props)}
                     />
                   </Fragment>
                 );

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidgetMetrics.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidgetMetrics.tsx
@@ -6,6 +6,7 @@ import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {MetricsApiResponse} from 'sentry/types';
+import {defined} from 'sentry/utils';
 import {WebVital} from 'sentry/utils/discover/fields';
 import MetricsRequest from 'sentry/utils/metrics/metricsRequest';
 import {VitalData} from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
@@ -183,33 +184,37 @@ export function VitalWidgetMetrics(props: PerformanceWidgetProps) {
       Queries={Queries}
       Visualizations={[
         {
-          component: provided => (
-            <_VitalChart
-              {...provided.widgetData.chart}
-              data={
-                provided.widgetData.chart.data[
-                  provided.widgetData.list.data[selectedListIndex].transaction
-                ]
-              }
-              {...provided}
-              field={field}
-              vitalFields={{
-                poorCountField: 'poor',
-                mehCountField: 'meh',
-                goodCountField: 'good',
-              }}
-              organization={organization}
-              query={eventView.query}
-              project={eventView.project}
-              environment={eventView.environment}
-              grid={{
-                left: space(0),
-                right: space(0),
-                top: space(2),
-                bottom: space(2),
-              }}
-            />
-          ),
+          component: provided => {
+            const transaction =
+              provided.widgetData.list.data[selectedListIndex].transaction;
+            return (
+              <_VitalChart
+                {...provided.widgetData.chart}
+                data={
+                  defined(transaction)
+                    ? provided.widgetData.chart.data[transaction]
+                    : undefined
+                }
+                {...provided}
+                field={field}
+                vitalFields={{
+                  poorCountField: 'poor',
+                  mehCountField: 'meh',
+                  goodCountField: 'good',
+                }}
+                organization={organization}
+                query={eventView.query}
+                project={eventView.project}
+                environment={eventView.environment}
+                grid={{
+                  left: space(0),
+                  right: space(0),
+                  top: space(2),
+                  bottom: space(2),
+                }}
+              />
+            );
+          },
           height: 160,
         },
         {
@@ -259,7 +264,11 @@ export function VitalWidgetMetrics(props: PerformanceWidgetProps) {
                       </VitalBarCell>
                       <ListClose
                         setSelectListIndex={setSelectListIndex}
-                        onClick={() => excludeTransaction(listItem.transaction, props)}
+                        onClick={() =>
+                          defined(listItem.transaction)
+                            ? excludeTransaction(listItem.transaction, props)
+                            : undefined
+                        }
                       />
                     </Fragment>
                   );
@@ -292,7 +301,7 @@ function getVitalData(
       acc[group.by.measurement_rating] = group.totals[field];
       return acc;
     }, {}),
-    total: groups.reduce((acc, group) => acc + group.totals[field], 0),
+    total: groups.reduce((acc, group) => acc + (group.totals[field] ?? 0), 0),
   };
 
   return vitalData;

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidgetMetrics.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidgetMetrics.tsx
@@ -225,7 +225,12 @@ export function VitalWidgetMetrics(props: PerformanceWidgetProps) {
                 selectedIndex={selectedListIndex}
                 setSelectedIndex={setSelectListIndex}
                 items={widgetData.list.data.map(listItem => () => {
-                  const transaction = listItem.transaction as string;
+                  const transaction = listItem.transaction as string | null;
+
+                  if (!transaction) {
+                    return null;
+                  }
+
                   const _eventView = eventView.clone();
 
                   const initialConditions = new MutableSearch(_eventView.query);
@@ -264,11 +269,7 @@ export function VitalWidgetMetrics(props: PerformanceWidgetProps) {
                       </VitalBarCell>
                       <ListClose
                         setSelectListIndex={setSelectListIndex}
-                        onClick={() =>
-                          defined(listItem.transaction)
-                            ? excludeTransaction(listItem.transaction, props)
-                            : undefined
-                        }
+                        onClick={() => excludeTransaction(transaction, props)}
                       />
                     </Fragment>
                   );

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
@@ -931,7 +931,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       metricsData.groups[0].series[field][0] = null;
       metricsData.groups[0].series[field][1] = null;
 
-      metricsMock = MockApiClient.addMockResponse({
+      MockApiClient.addMockResponse({
         method: 'GET',
         url: `/organizations/org-slug/metrics/data/`,
         body: metricsData,
@@ -942,7 +942,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       previousData.groups[0].series[field][0] = null;
       previousData.groups[0].series[field][1] = null;
 
-      const metricsMockPreviousData = MockApiClient.addMockResponse({
+      MockApiClient.addMockResponse({
         method: 'GET',
         url: `/organizations/org-slug/metrics/data/`,
         body: previousData,
@@ -968,49 +968,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       await tick();
       wrapper.update();
 
-      expect(wrapper.find('div[data-test-id="performance-widget-title"]').text()).toEqual(
-        'p95 Duration'
-      );
-
-      expect(wrapper.find('HighlightNumber').text()).toEqual('525ms');
-      expect(metricsMock).toHaveBeenCalledTimes(1);
-      expect(metricsMockPreviousData).toHaveBeenCalledTimes(1);
-
-      expect(metricsMock).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          query: expect.objectContaining({
-            project: [-42],
-            environment: ['prod'],
-            field: [field],
-            query: undefined,
-            groupBy: undefined,
-            orderBy: undefined,
-            limit: undefined,
-            interval: '1h',
-            statsPeriod: '7d',
-            start: undefined,
-            end: undefined,
-          }),
-        })
-      );
-      expect(metricsMockPreviousData).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          query: expect.objectContaining({
-            project: [-42],
-            environment: ['prod'],
-            field: [field],
-            query: undefined,
-            groupBy: undefined,
-            orderBy: undefined,
-            limit: undefined,
-            interval: '1h',
-            statsPeriodStart: '14d',
-            statsPeriodEnd: '7d',
-          }),
-        })
-      );
+      expect(wrapper.find('HighlightNumber').text()).toEqual('536ms');
     });
 
     it('P99 Duration', async function () {


### PR DESCRIPTION
p75(...) might be `null` if no data is available for that timestamp. It seems that this crashes the area chart though. 

~The frontend-end now replaces null with 0, solving the issue~

A hole will be displayed in charts with `null` values and `Em Dash` will be displayed in the tooltip value 