### PR TITLE
fix(ui): dark theme for code chunk in instrumentation docs

### DIFF
--- a/static/app/components/events/interfaces/spans/inlineDocs.tsx
+++ b/static/app/components/events/interfaces/spans/inlineDocs.tsx
@@ -1,3 +1,5 @@
+import 'prism-sentry/index.css';
+
 import {Component} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';


### PR DESCRIPTION
[JIRA ref.](https://getsentry.atlassian.net/browse/VIS-1249)
In the "Requires Manual Instrumentation" doc, in dark mode the code chunks appear white. That's because we haven't imported our Prism theme yet.

Before:
<img width="935" alt="Screen Shot 2021-12-13 at 10 24 11 AM" src="https://user-images.githubusercontent.com/44172267/145868253-c2b270ec-b066-4cdd-a01a-729ac7d276c8.png">

After:
<img width="935" alt="Screen Shot 2021-12-13 at 10 31 58 AM" src="https://user-images.githubusercontent.com/44172267/145868377-7523f6ba-6033-4215-9a1a-3d9d1336ebfc.png">

<img width="935" alt="Screen Shot 2021-12-13 at 10 25 04 AM" src="https://user-images.githubusercontent.com/44172267/145868296-bc73eac8-c989-4588-80b5-e9b16b76977a.png">


