### PR TITLE
fix(post_process): Prevent auto assignments from ping-ponging between teams.

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -123,7 +123,7 @@ def handle_owner_assignment(project, group, event):
 
         with sentry_sdk.start_span(op="post_process.handle_owner_assignment.analytics_record"):
             if auto_assignment and owners and not assignees_exists:
-                assignment = GroupAssignee.objects.assign(group, owners[0])
+                assignment = GroupAssignee.objects.assign(group, owners[0], create_only=True)
                 if assignment["new_assignment"] or assignment["updated_assignment"]:
                     analytics.record(
                         "codeowners.assignment"


### PR DESCRIPTION
In rare cases auto assignments can ping-pong between teams. This happens when multiple events with
different stack traces arrive within a minute window. Since we cache the result of the check for an
assignee existing for 60 seconds when one doesn't exist, the problem is that every subsequent event
sees a stale value and attempts to perform assignment again.

This could happen without the caching though - if two events were being processed simultaneously
then we would likely see this same problem.

To fix this, I have added `create_only` to the `assign` method. This causes assignment to halt if we
find that the group already has an assignee, and since it's protected by constraints in the database
we can rely on this working correctly.