### PR TITLE
fix(dashboard): Fixed dashboard widget modal search bar not autocompleting properly

### DIFF
--- a/static/app/components/dashboards/widgetQueriesForm.tsx
+++ b/static/app/components/dashboards/widgetQueriesForm.tsx
@@ -50,7 +50,7 @@ type Props = {
  * callback. This component's state should live in the parent.
  */
 class WidgetQueriesForm extends React.Component<Props> {
-  blurTimeout: ReturnType<typeof setTimeout> | undefined = undefined;
+  blurTimeout: number | null = null;
 
   // Handle scalar field values changing.
   handleFieldChange = (queryIndex: number, field: string) => {
@@ -117,8 +117,8 @@ class WidgetQueriesForm extends React.Component<Props> {
                     // this, we set a timer in our onSearch handler to block our onBlur
                     // handler from firing if it is within 200ms, ie from clicking an
                     // autocomplete value.
-                    this.blurTimeout = setTimeout(() => {
-                      this.blurTimeout = undefined;
+                    this.blurTimeout = window.setTimeout(() => {
+                      this.blurTimeout = null;
                     }, 200);
                     return this.handleFieldChange(queryIndex, 'conditions')(field);
                   }}

--- a/static/app/components/dashboards/widgetQueriesForm.tsx
+++ b/static/app/components/dashboards/widgetQueriesForm.tsx
@@ -54,12 +54,10 @@ type State = {
  * callback. This component's state should live in the parent.
  */
 class WidgetQueriesForm extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      blurTimeout: undefined,
-    };
-  }
+  state: State = {
+    blurTimeout: undefined,
+  };
+
   // Handle scalar field values changing.
   handleFieldChange = (queryIndex: number, field: string) => {
     const {queries, onChange} = this.props;

--- a/static/app/components/dashboards/widgetQueriesForm.tsx
+++ b/static/app/components/dashboards/widgetQueriesForm.tsx
@@ -45,18 +45,12 @@ type Props = {
   fieldOptions: ReturnType<typeof generateFieldOptions>;
 };
 
-type State = {
-  blurTimeout?: ReturnType<typeof setTimeout>;
-};
-
 /**
  * Contain widget queries interactions and signal changes via the onChange
  * callback. This component's state should live in the parent.
  */
-class WidgetQueriesForm extends React.Component<Props, State> {
-  state: State = {
-    blurTimeout: undefined,
-  };
+class WidgetQueriesForm extends React.Component<Props> {
+  blurTimeout: ReturnType<typeof setTimeout> | undefined = undefined;
 
   // Handle scalar field values changing.
   handleFieldChange = (queryIndex: number, field: string) => {
@@ -92,7 +86,6 @@ class WidgetQueriesForm extends React.Component<Props, State> {
       fieldOptions,
       onChange,
     } = this.props;
-    const {blurTimeout} = this.state;
 
     const hideLegendAlias = ['table', 'world_map', 'big_number'].includes(displayType);
     const explodedFields = queries[0].fields.map(field => explodeField({field}));
@@ -124,15 +117,13 @@ class WidgetQueriesForm extends React.Component<Props, State> {
                     // this, we set a timer in our onSearch handler to block our onBlur
                     // handler from firing if it is within 200ms, ie from clicking an
                     // autocomplete value.
-                    this.setState({
-                      blurTimeout: setTimeout(() => {
-                        this.setState({blurTimeout: undefined});
-                      }, 200),
-                    });
+                    this.blurTimeout = setTimeout(() => {
+                      this.blurTimeout = undefined;
+                    }, 200);
                     return this.handleFieldChange(queryIndex, 'conditions')(field);
                   }}
                   onBlur={field => {
-                    if (!blurTimeout) {
+                    if (!this.blurTimeout) {
                       this.handleFieldChange(queryIndex, 'conditions')(field);
                     }
                   }}

--- a/tests/js/spec/components/dashboards/widgetQueriesForm.spec.tsx
+++ b/tests/js/spec/components/dashboards/widgetQueriesForm.spec.tsx
@@ -1,0 +1,80 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import WidgetQueriesForm from 'sentry/components/dashboards/widgetQueriesForm';
+import {DisplayType} from 'sentry/views/dashboardsV2/types';
+import {generateFieldOptions} from 'sentry/views/eventsV2/utils';
+
+describe('WidgetQueriesForm', function () {
+  const {organization, routerContext} = initializeOrg({
+    router: {orgId: 'orgId'},
+  } as Parameters<typeof initializeOrg>[0]);
+  let onChangeHandler;
+
+  beforeEach(() => {
+    onChangeHandler = jest.fn();
+    MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [
+        {
+          id: '5718466',
+          organizationId: '1',
+          type: 0,
+          query: 'event.type:transaction',
+          lastSeen: '2021-12-01T20:46:36.972966Z',
+          dateCreated: '2021-12-01T20:46:36.975384Z',
+        },
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      method: 'POST',
+    });
+
+    const fieldOptions = {};
+
+    mountWithTheme(
+      <WidgetQueriesForm
+        displayType={DisplayType.TABLE}
+        organization={organization}
+        selection={{
+          projects: [1],
+          environments: ['prod'],
+          datetime: {
+            period: '14d',
+            start: null,
+            end: null,
+            utc: false,
+          },
+        }}
+        queries={[
+          {
+            conditions: 'event.type:',
+            fields: ['count()'],
+            name: '',
+            orderby: '',
+          },
+        ]}
+        onChange={onChangeHandler}
+        fieldOptions={fieldOptions as ReturnType<typeof generateFieldOptions>}
+        canAddSearchConditions
+        handleAddSearchConditions={() => undefined}
+        handleDeleteQuery={() => undefined}
+      />,
+      {context: routerContext}
+    );
+  });
+
+  it('only calls onChange once when selecting a value from the autocomplete dropdown', async function () {
+    userEvent.click(screen.getAllByText('event.type:')[1]);
+    await tick();
+    expect(screen.getByText('Recent Searches')).toBeInTheDocument();
+    expect(screen.getByText(':transaction')).toBeInTheDocument();
+    userEvent.click(screen.getByText(':transaction'));
+    await tick();
+    expect(onChangeHandler).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes widget condition search bar not autocompleting properly when selecting an option from the dropdown.
onSearch and onBlur actions would both fire at the same time which causes the search bar the change and unchange, effectively not working. This fix ensures only onSearch or onBlur fires at a time.

![image](https://user-images.githubusercontent.com/83961295/145900745-f0e0af49-2ccd-4cd5-b93f-08d3f6ef62c4.png)
