### PR TITLE
ref(ratelimit): Set rate limit properties

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -23,6 +23,7 @@ from sentry.models import Activity, Group, GroupSeen, GroupSubscriptionManager, 
 from sentry.models.groupinbox import get_inbox_details
 from sentry.plugins.base import plugins
 from sentry.plugins.bases import IssueTrackingPlugin2
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 
@@ -30,6 +31,25 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 
 
 class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(5, 1),
+            RateLimitCategory.USER: RateLimit(5, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+        },
+        "PUT": {
+            RateLimitCategory.IP: RateLimit(5, 1),
+            RateLimitCategory.USER: RateLimit(5, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+        },
+        "DELETE": {
+            RateLimitCategory.IP: RateLimit(5, 5),
+            RateLimitCategory.USER: RateLimit(5, 5),
+            RateLimitCategory.ORGANIZATION: RateLimit(5, 5),
+        },
+    }
+
     def _get_activity(self, request, group, num):
         return Activity.objects.get_activities_for_group(group, num)
 

--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -4,9 +4,18 @@ from sentry.api import client
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.group_index import rate_limit_endpoint
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class GroupEventsLatestEndpoint(GroupEndpoint):
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(15, 1),
+            RateLimitCategory.USER: RateLimit(15, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(15, 1),
+        }
+    }
+
     @rate_limit_endpoint(limit=15, window=1)
     def get(self, request, group):
         """

--- a/src/sentry/api/endpoints/group_first_last_release.py
+++ b/src/sentry/api/endpoints/group_first_last_release.py
@@ -3,9 +3,18 @@ from rest_framework.response import Response
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
 from sentry.api.helpers.group_index import get_first_last_release, rate_limit_endpoint
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class GroupFirstLastReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(5, 1),
+            RateLimitCategory.USER: RateLimit(5, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+        }
+    }
+
     @rate_limit_endpoint(limit=5, window=1)
     def get(self, request, group):
         """Get the first and last release for a group.

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -6,10 +6,20 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import serialize
 from sentry.models import Project
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
 
 
 class EventIdLookupEndpoint(OrganizationEndpoint):
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(1, 1),
+            RateLimitCategory.USER: RateLimit(1, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(1, 1),
+        }
+    }
+
     @rate_limit_endpoint(limit=1, window=1)
     def get(self, request, organization, event_id):
         """

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -38,6 +38,7 @@ from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.search.snuba.backend import assigned_or_suggested_filter
 from sentry.search.snuba.executors import get_search_filter
 from sentry.snuba import discover
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.compat import map
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.validators import normalize_event_id
@@ -136,6 +137,24 @@ def inbox_search(
 
 class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
     permission_classes = (OrganizationEventPermission,)
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(10, 1),
+            RateLimitCategory.USER: RateLimit(10, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(10, 1),
+        },
+        "PUT": {
+            RateLimitCategory.IP: RateLimit(5, 5),
+            RateLimitCategory.USER: RateLimit(5, 5),
+            RateLimitCategory.ORGANIZATION: RateLimit(5, 5),
+        },
+        "DELETE": {
+            RateLimitCategory.IP: RateLimit(5, 5),
+            RateLimitCategory.USER: RateLimit(5, 5),
+            RateLimitCategory.ORGANIZATION: RateLimit(5, 5),
+        },
+    }
 
     def _search(self, request, organization, projects, environments, extra_query_kwargs=None):
         query_kwargs = build_query_params_from_request(

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -12,11 +12,20 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.models import Group
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.compat import map
 
 
 class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
     permission_classes = (OrganizationEventPermission,)
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(10, 1),
+            RateLimitCategory.USER: RateLimit(10, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(10, 1),
+        }
+    }
 
     @rate_limit_endpoint(limit=10, window=1)
     def get(self, request, organization):

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -11,6 +11,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.issue_search import convert_query_values, parse_search_query
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.snuba import discover
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
 
@@ -19,6 +20,15 @@ ISSUES_COUNT_MAX_HITS_LIMIT = 100
 
 
 class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(10, 1),
+            RateLimitCategory.USER: RateLimit(10, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(10, 1),
+        }
+    }
+
     def _count(self, request, query, organization, projects, environments, extra_query_kwargs=None):
         query_kwargs = {"projects": projects}
 

--- a/src/sentry/api/endpoints/organization_join_request.py
+++ b/src/sentry/api/endpoints/organization_join_request.py
@@ -11,6 +11,7 @@ from sentry.app import ratelimiter
 from sentry.models import AuthProvider, InviteStatus, OrganizationMember
 from sentry.notifications.notifications.organization_request import JoinRequestNotification
 from sentry.signals import join_request_created
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,14 @@ def create_organization_join_request(organization, email, ip_address=None):
 class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
     # Disable authentication and permission requirements.
     permission_classes = []
+
+    rate_limits = {
+        "POST": {
+            RateLimitCategory.IP: RateLimit(5, 86400),
+            RateLimitCategory.USER: RateLimit(5, 86400),
+            RateLimitCategory.ORGANIZATION: RateLimit(5, 86400),
+        }
+    }
 
     def post(self, request, organization):
         if organization.get_option("sentry:join_requests") is False:

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -15,9 +15,19 @@ from sentry.snuba.outcomes import (
     run_outcomes_query_totals,
 )
 from sentry.snuba.sessions_v2 import InvalidField, InvalidParams
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(20, 1),
+            RateLimitCategory.USER: RateLimit(20, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
+        }
+    }
+
     @rate_limit_endpoint(limit=20, window=1)
     def get(self, request, organization):
         with self.handle_query_errors():

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -7,9 +7,19 @@ from sentry import eventstore, features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectEventsEndpoint(ProjectEndpoint):
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(5, 1),
+            RateLimitCategory.USER: RateLimit(5, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+        }
+    }
+
     @rate_limit_endpoint(limit=5, window=1)
     def get(self, request, project):
         """

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -19,6 +19,7 @@ from sentry.api.serializers.models.group import StreamGroupSerializer
 from sentry.models import QUERY_STATUS_LOOKUP, Environment, Group, GroupStatus
 from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.signals import advanced_search
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.validators import normalize_event_id
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
@@ -26,6 +27,14 @@ ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', a
 
 class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
     permission_classes = (ProjectEventPermission,)
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(3, 1),
+            RateLimitCategory.USER: RateLimit(3, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(3, 1),
+        }
+    }
 
     @track_slo_response("workflow")
     @rate_limit_endpoint(limit=3, window=1)

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -6,9 +6,19 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.app import tsdb
 from sentry.models import Environment, Group
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(20, 1),
+            RateLimitCategory.USER: RateLimit(20, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
+        }
+    }
+
     @rate_limit_endpoint(limit=20, window=1)
     def get(self, request, project):
         try:

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -9,9 +9,19 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.models import ProjectKey
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(20, 1),
+            RateLimitCategory.USER: RateLimit(20, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
+        }
+    }
+
     @rate_limit_endpoint(limit=20, window=1)
     def get(self, request, project, key_id):
         try:

--- a/src/sentry/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/api/endpoints/user_emails_confirm.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.validators import AllowedEmailField
 from sentry.models import UserEmail
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger("sentry.accounts")
 
@@ -31,6 +32,14 @@ class EmailSerializer(serializers.Serializer):
 
 
 class UserEmailsConfirmEndpoint(UserEndpoint):
+
+    rate_limits = {
+        "POST": {
+            RateLimitCategory.USER: RateLimit(10, 60),
+            RateLimitCategory.ORGANIZATION: RateLimit(10, 60),
+        }
+    }
+
     def post(self, request, user):
         """
         Sends a confirmation email to user

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -11,6 +11,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.group_index.index import rate_limit_endpoint
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.discover.utils import transform_aliases_and_query
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import snuba
 from sentry.utils.compat import map
 
@@ -25,6 +26,14 @@ class DiscoverQueryPermission(OrganizationPermission):
 
 class DiscoverQueryEndpoint(OrganizationEndpoint):
     permission_classes = (DiscoverQueryPermission,)
+
+    rate_limits = {
+        "POST": {
+            RateLimitCategory.IP: RateLimit(4, 1),
+            RateLimitCategory.USER: RateLimit(4, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(4, 1),
+        }
+    }
 
     def has_feature(self, request, organization):
         return features.has(

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -44,12 +44,9 @@ class RatelimitMiddleware(MiddlewareMixin):
             request.will_be_rate_limited = True
             enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
             if enforce_rate_limit:
-                error_message = getattr(
-                    view_func.view_class, "rate_limit_error_message", DEFAULT_ERROR_MESSAGE
-                )
                 return HttpResponse(
                     {
-                        "detail": error_message.format(
+                        "detail": DEFAULT_ERROR_MESSAGE.format(
                             limit=rate_limit_check_dict["limit"],
                             window=rate_limit_check_dict["window"],
                         )


### PR DESCRIPTION
Part 1 of moving existing rate limits to the new middleware. Set the custom rate limit properties to the existing rate limited endpoints. The middleware won't 429 yet, so the old decorator is still there to maintain behavior. The old rate limit only rate limited by IP, while the new one categorizes the request by authentication type. So to ensure same functionality, the rate limit is duplicated across all three properties

There are some functions that use the redis rate limiter for purposes outside of endpoint rate limiting (like login attempts). In this situation, we can't cleanly convert to the middleware (it's sometimes used outside of endpoints).