### PR TITLE
fix(async-csv): Separate transaction for separate dbs in exports

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -354,24 +354,19 @@ def merge_export_blobs(data_export_id, **kwargs):
                 file.checksum = file_checksum.hexdigest()
                 file.save()
 
-            # This is in a separate atomic transaction because in prod, files exist
-            # outside of the primary database which means that the transaction to
-            # the primary database is idle the entire time the writes the the files
-            # database is happening. In the event the writes to the files database
-            # takes longer than the idle timeout, the connection to the primary
-            # database can timeout causing a failure.
-            with atomic_transaction(
-                using=(
-                    router.db_for_write(ExportedData),
-                    router.db_for_write(File),
-                )
-            ):
-                data_export.finalize_upload(file=file)
+                # This is in a separate atomic transaction because in prod, files exist
+                # outside of the primary database which means that the transaction to
+                # the primary database is idle the entire time the writes the the files
+                # database is happening. In the event the writes to the files database
+                # takes longer than the idle timeout, the connection to the primary
+                # database can timeout causing a failure.
+                with atomic_transaction(using=router.db_for_write(ExportedData)):
+                    data_export.finalize_upload(file=file)
 
-            time_elapsed = (timezone.now() - data_export.date_added).total_seconds()
-            metrics.timing("dataexport.duration", time_elapsed, sample_rate=1.0)
-            logger.info("dataexport.end", extra={"data_export_id": data_export_id})
-            metrics.incr("dataexport.end", tags={"success": True}, sample_rate=1.0)
+                time_elapsed = (timezone.now() - data_export.date_added).total_seconds()
+                metrics.timing("dataexport.duration", time_elapsed, sample_rate=1.0)
+                logger.info("dataexport.end", extra={"data_export_id": data_export_id})
+                metrics.incr("dataexport.end", tags={"success": True}, sample_rate=1.0)
         except Exception as error:
             metrics.incr("dataexport.error", tags={"error": str(error)}, sample_rate=1.0)
             metrics.incr(

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -360,7 +360,12 @@ def merge_export_blobs(data_export_id, **kwargs):
             # database is happening. In the event the writes to the files database
             # takes longer than the idle timeout, the connection to the primary
             # database can timeout causing a failure.
-            with atomic_transaction(using=router.db_for_write(ExportedData)):
+            with atomic_transaction(
+                using=(
+                    router.db_for_write(ExportedData),
+                    router.db_for_write(File),
+                )
+            ):
                 data_export.finalize_upload(file=file)
 
             time_elapsed = (timezone.now() - data_export.date_added).total_seconds()


### PR DESCRIPTION
This is a hypothesis but because the transaction to the primary db is idle the
entire time the task is writing all the FileBlobIndex to the files db, the
connection to the primary db can time out and errors when it is used.