### PR TITLE
feat(notifications): debug views use notification logic

### DIFF
--- a/src/sentry/web/frontend/debug/debug_organization_invite_request.py
+++ b/src/sentry/web/frontend/debug/debug_organization_invite_request.py
@@ -1,27 +1,23 @@
-from django.urls import reverse
 from django.views.generic import View
 
-from sentry.models import Organization, User
-from sentry.utils.http import absolute_uri
+from sentry.models import Organization, OrganizationMember, User
+from sentry.notifications.notifications.organization_request import InviteRequestNotification
 
-from .mail import MailPreview
+from .mail import render_preview_email_for_notification
 
 
 class DebugOrganizationInviteRequestEmailView(View):
     def get(self, request):
         org = Organization(id=1, slug="default", name="Default")
-        user = User(name="Rick Swan")
+        requester = User(name="Rick Swan")
+        pending_member = OrganizationMember(
+            email="test@gmail.com", organization=org, inviter=requester
+        )
+        recipient = User(name="James Bond")
+        recipient_member = OrganizationMember(user=recipient, organization=org)
 
-        context = {
-            "organization_name": org.name,
-            "inviter_name": user.get_salutation_name,
-            "email": "test@gmail.com",
-            "pending_requests_link": absolute_uri(
-                reverse("sentry-organization-members", args=[org.slug])
-            ),
-        }
-        return MailPreview(
-            html_template="sentry/emails/organization-invite-request.html",
-            text_template="sentry/emails/organization-invite-request.txt",
-            context=context,
-        ).render(request)
+        notification = InviteRequestNotification(pending_member, requester)
+
+        # hack to avoid a query
+        notification.role_based_recipient_strategy.set_member_in_cache(recipient_member)
+        return render_preview_email_for_notification(notification, recipient)

--- a/src/sentry/web/frontend/debug/debug_organization_join_request.py
+++ b/src/sentry/web/frontend/debug/debug_organization_join_request.py
@@ -1,25 +1,26 @@
-from django.urls import reverse
 from django.views.generic import View
 
-from sentry.models import Organization
-from sentry.utils.http import absolute_uri
+from sentry.models import InviteStatus, Organization, OrganizationMember, User
+from sentry.notifications.notifications.organization_request import JoinRequestNotification
 
-from .mail import MailPreview
+from .mail import render_preview_email_for_notification
 
 
 class DebugOrganizationJoinRequestEmailView(View):
     def get(self, request):
         org = Organization(id=1, slug="default", name="Default")
-        context = {
-            "organization_name": org.name,
-            "email": "test@gmail.com",
-            "pending_requests_link": absolute_uri(
-                reverse("sentry-organization-members", args=[org.slug])
-            ),
-            "settings_link": absolute_uri(reverse("sentry-organization-settings", args=[org.slug])),
-        }
-        return MailPreview(
-            html_template="sentry/emails/organization-join-request.html",
-            text_template="sentry/emails/organization-join-request.txt",
-            context=context,
-        ).render(request)
+        user_to_join = User(name="Rick Swan")
+        pending_member = OrganizationMember(
+            email="test@gmail.com",
+            organization=org,
+            user=user_to_join,
+            invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
+        )
+        recipient = User(name="James Bond")
+        recipient_member = OrganizationMember(user=recipient, organization=org)
+
+        notification = JoinRequestNotification(pending_member, user_to_join)
+
+        # hack to avoid a query
+        notification.role_based_recipient_strategy.set_member_in_cache(recipient_member)
+        return render_preview_email_for_notification(notification, recipient)

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import logging
 import time
@@ -5,6 +7,7 @@ import traceback
 import uuid
 from datetime import datetime, timedelta
 from random import Random
+from typing import Any, MutableMapping
 
 import pytz
 from django.template.defaultfilters import slugify
@@ -21,6 +24,7 @@ from sentry.digests.notifications import Notification, build_digest
 from sentry.digests.utils import get_digest_metadata
 from sentry.event_manager import EventManager, get_event_type
 from sentry.http import get_server_hostname
+from sentry.mail.notifications import get_builder_args
 from sentry.models import (
     Activity,
     Group,
@@ -31,8 +35,10 @@ from sentry.models import (
     Release,
     Rule,
     Team,
+    User,
 )
 from sentry.notifications.notifications.activity import EMAIL_CLASSES_BY_TYPE
+from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.utils import loremipsum
 from sentry.utils.dates import to_datetime, to_timestamp
@@ -661,3 +667,22 @@ def org_delete_confirm(request):
             "url": absolute_uri(reverse("sentry-restore-organization", args=[org.slug])),
         },
     ).render(request)
+
+
+# Used to generate debug email views from a notification
+def render_preview_email_for_notification(
+    notification: BaseNotification, recipient: User | Team
+) -> MutableMapping[str, Any]:
+    # remove unneeded fields
+    basic_args = get_builder_args(notification, recipient)
+    args = {
+        k: v
+        for k, v in basic_args.items()
+        if k not in ["headers", "reference", "reply_reference", "subject"]
+    }
+    # convert subject back to a string
+    args["subject"] = basic_args["subject"].decode("utf-8")
+
+    preview = MailPreviewAdapter(**args)
+
+    return render_to_response("sentry/debug/mail/preview.html", {"preview": preview})


### PR DESCRIPTION
This PR changes the debug emails for organization join and invite requests to use the actual notification to generate the email views. The purpose of this is so we have a single source of truth for the logic between debug views and the notification. Otherwise, we'd be in danger of the debug views not working after someone updates a notification but forgets to update those views. It also makes it easier to test changes notifications without having to actually trigger the email.

One thing that's kind of annoying with debug email views is that while we generate instances of models in memory, we don't save them so we can't query them. This is a problem where we need to query the DB which currently happens with the `OrganizationMember` of the user getting the email. To get around this, I am just pre-populating the cache with `set_member_in_cache`. A long-term solution might involve saving some dummy data in these debug views to the DB so we can query it but I'm not quite sure how that would work. So I am sticking with this hack (for now).