### PR TITLE
ref(alerts): Mark legacy plugins clearly

### DIFF
--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -21,6 +21,7 @@ from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 
 logger = logging.getLogger("sentry.integrations.sentry_app")
+PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS = ["PagerDuty", "Slack"]
 
 
 def build_incident_attachment(action, incident, metric_value=None, method=None):
@@ -142,9 +143,14 @@ class NotifyEventServiceAction(EventAction):
         self.form_fields = {
             "service": {
                 "type": "choice",
-                "choices": [[i.slug, i.title] for i in self.get_services()],
+                "choices": [[i.slug, self.transform_title(i.title)] for i in self.get_services()],
             }
         }
+
+    def transform_title(self, title):
+        if title not in PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS:
+            return title
+        return "(Legacy) " + title
 
     def after(self, event, state):
         service = self.get_option("service")

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -148,9 +148,9 @@ class NotifyEventServiceAction(EventAction):
         }
 
     def transform_title(self, title):
-        if title not in PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS:
-            return title
-        return "(Legacy) " + title
+        if title in PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS:
+            return f"(Legacy) {title}"
+        return title
 
     def after(self, event, state):
         service = self.get_option("service")


### PR DESCRIPTION
If a user has both a plugin and a first party integration installed of the same service, it can be pretty confusing when they create an alert as it's not clear which is which. This PR prepends "(Legacy)" before the plugin name to reduce confusion.

**Before**
<img width="972" alt="Screen Shot 2021-12-13 at 4 46 38 PM" src="https://user-images.githubusercontent.com/29959063/145912521-5fa20671-d657-4c2c-97cf-8579d2806d6c.png">
**After**
<img width="978" alt="Screen Shot 2021-12-13 at 4 46 19 PM" src="https://user-images.githubusercontent.com/29959063/145912516-9f904694-f658-44b0-9ed3-d546900f0060.png">
