### PR TITLE
ref(projectconfig_cache): Delete redis-blaster implementation, execute deletes faster [ISSUE-1306]

### DIFF
--- a/src/sentry/relay/projectconfig_cache/base.py
+++ b/src/sentry/relay/projectconfig_cache/base.py
@@ -10,8 +10,8 @@ class ProjectConfigCache(Service):
     def set_many(self, configs):
         pass
 
-    def delete_many(self, project_ids):
+    def delete_many(self, public_keys):
         pass
 
-    def get(self, project_id):
+    def get(self, public_key):
         raise NotImplementedError()


### PR DESCRIPTION
Add pipelining to projectconfig key deletes. In the same PR, get rid of
support for redis blaster, as we don't support it on the Relay side
anyway.