### PR TITLE
fix(discover): Updates Discover widget modal to propagate global header selection to the dashboard view when submitting

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -242,7 +242,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     errors: FlatValidationError,
     widgetData: Widget
   ) => {
-    const {closeModal, organization} = this.props;
+    const {closeModal, organization, selection} = this.props;
     const {selectedDashboard, dashboards} = this.state;
     // Validate that a dashboard was selected since api call to /dashboards/widgets/ does not check for dashboard
     if (
@@ -283,6 +283,13 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
 
       trackAdvancedAnalyticsEvent('discover_views.add_to_dashboard.confirm', {
         organization,
+      });
+
+      // Propagate global header selection
+      Object.assign(pathQuery, {
+        ...selection.datetime,
+        project: selection.projects,
+        environment: selection.environments,
       });
 
       if (selectedDashboard.value === 'new') {

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -279,17 +279,14 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
         interval: widgetData.interval,
         title: widgetData.title,
         ...queryData,
+        // Propagate global header selection
+        ...selection.datetime,
+        project: selection.projects,
+        environment: selection.environments,
       };
 
       trackAdvancedAnalyticsEvent('discover_views.add_to_dashboard.confirm', {
         organization,
-      });
-
-      // Propagate global header selection
-      Object.assign(pathQuery, {
-        ...selection.datetime,
-        project: selection.projects,
-        environment: selection.environments,
       });
 
       if (selectedDashboard.value === 'new') {

--- a/static/app/views/dashboardsV2/view.tsx
+++ b/static/app/views/dashboardsV2/view.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
+import pick from 'lodash/pick';
 
 import {updateDashboardVisit} from 'sentry/actionCreators/dashboards';
 import Feature from 'sentry/components/acl/feature';
@@ -43,13 +44,7 @@ function ViewEditDashboard(props: Props) {
     if (constructedWidget) {
       browserHistory.replace({
         pathname: location.pathname,
-        query: {
-          ...Object.keys(location.query)
-            .filter(key => ALLOWED_PARAMS.includes(key))
-            .reduce((acc, key) => {
-              return {...acc, [key]: location.query[key]};
-            }, {}),
-        },
+        query: pick(location.query, ALLOWED_PARAMS),
       });
     }
   }, [api, orgSlug, dashboardId]);

--- a/static/app/views/dashboardsV2/view.tsx
+++ b/static/app/views/dashboardsV2/view.tsx
@@ -17,6 +17,8 @@ import OrgDashboards from './orgDashboards';
 import {DashboardState, Widget} from './types';
 import {constructWidgetFromQuery} from './utils';
 
+const ALLOWED_PARAMS = ['start', 'end', 'utc', 'period', 'project', 'environment'];
+
 type Props = RouteComponentProps<{orgId: string; dashboardId: string}, {}> & {
   organization: Organization;
   children: React.ReactNode;
@@ -37,9 +39,18 @@ function ViewEditDashboard(props: Props) {
 
     const constructedWidget = constructWidgetFromQuery(location.query);
     setNewWidget(constructedWidget);
-    // Clean up url after constructing widget from query string
+    // Clean up url after constructing widget from query string, only allow GHS params
     if (constructedWidget) {
-      browserHistory.replace(location.pathname);
+      browserHistory.replace({
+        pathname: location.pathname,
+        query: {
+          ...Object.keys(location.query)
+            .filter(key => ALLOWED_PARAMS.includes(key))
+            .reduce((acc, key) => {
+              return {...acc, [key]: location.query[key]};
+            }, {}),
+        },
+      });
     }
   }, [api, orgSlug, dashboardId]);
 

--- a/tests/js/spec/views/dashboardsV2/view.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/view.spec.tsx
@@ -8,7 +8,7 @@ import ViewEditDashboard from 'sentry/views/dashboardsV2/view';
 describe('Dashboards > ViewEditDashboard', function () {
   const initialData = initializeOrg();
 
-  it('removes widget params from url and preserves selection params', async function () {
+  it('removes widget params from url and preserves selection params', function () {
     const location = {
       pathname: '/',
       query: {
@@ -44,8 +44,7 @@ describe('Dashboards > ViewEditDashboard', function () {
       </ViewEditDashboard>
     );
 
-    expect(browserHistory.replace).toHaveBeenNthCalledWith(
-      1,
+    expect(browserHistory.replace).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/',
         query: {

--- a/tests/js/spec/views/dashboardsV2/view.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/view.spec.tsx
@@ -1,0 +1,62 @@
+import {browserHistory} from 'react-router';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountWithTheme} from 'sentry-test/reactTestingLibrary';
+
+import ViewEditDashboard from 'sentry/views/dashboardsV2/view';
+
+describe('Dashboards > ViewEditDashboard', function () {
+  const initialData = initializeOrg();
+
+  it('removes widget params from url and preserves selection params', async function () {
+    const location = {
+      pathname: '/',
+      query: {
+        environment: 'canary',
+        period: '7d',
+        project: '11111',
+        start: null,
+        end: null,
+        utc: null,
+        displayType: 'line',
+        interval: '5m',
+        queryConditions: '',
+        queryFields: 'count()',
+        queryNames: '',
+        queryOrderby: '',
+        title: 'test',
+      },
+    };
+    mountWithTheme(
+      <ViewEditDashboard
+        location={TestStubs.location(location)}
+        organization={initialData.organization}
+        router={initialData.router}
+        params={{
+          orgId: initialData.organization.slug,
+          dashboardId: '1',
+        }}
+        route={{}}
+        routes={[]}
+        routeParams={{}}
+      >
+        {() => undefined}
+      </ViewEditDashboard>
+    );
+
+    expect(browserHistory.replace).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        pathname: '/',
+        query: {
+          end: null,
+          environment: 'canary',
+          period: '7d',
+          project: '11111',
+          start: null,
+          utc: null,
+        },
+      })
+    );
+  });
+});


### PR DESCRIPTION
Updates Discover widget modal to propagate global header selection to the dashboard view when clicking the save button. Previously we would lose the global header selection when redirecting from discover to dashboards.