### PR TITLE
feat(notifications): adds secondary analytics event optionally

### DIFF
--- a/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Sequence
 
 from django.urls import reverse
 
-from sentry import analytics
 from sentry.models import OrganizationMember
 from sentry.notifications.notifications.organization_request import OrganizationRequestNotification
 from sentry.notifications.notifications.strategies.member_write_role_recipient_strategy import (
@@ -78,12 +77,10 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification):
     def get_callback_data(self) -> Mapping[str, Any]:
         return {"member_id": self.pending_member.id, "member_email": self.pending_member.email}
 
-    def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
-        analytics.record(
-            self.analytics_event,
-            organization_id=self.organization.id,
-            user_id=self.pending_member.inviter.id if self.pending_member.inviter else None,
-            target_user_id=recipient.id,
-            invited_member_id=self.pending_member.id,
-            providers=provider.name.lower(),
-        )
+    def get_log_params(self, recipient: Team | User) -> MutableMapping[str, Any]:
+        # TODO: figure out who the user should be when pending_member.inviter is None
+        return {
+            **super().get_log_params(recipient),
+            "user_id": self.pending_member.inviter.id if self.pending_member.inviter else None,
+            "invited_member_id": self.pending_member.id,
+        }


### PR DESCRIPTION
This PR is part of a greater effort to increase standardization of notifications by adding support for two different analytics events for sending a notification. Now we will always record the `integrations.{provider.name}.notification_sent` event for every notification in addition to an optional one based on `analytics_event`. The purpose of this is to make it easier to do different types of analysis (e.g: looking at a specific notification funnel vs tracking how many times we send any type of Slack notification).