### PR TITLE
feat(codeoowner): adds growth as codeowner to notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -188,7 +188,7 @@ build-utils/        @getsentry/owners-js-build
 /src/sentry/integrations/                     @getsentry/ecosystem
 /src/sentry/mail/                             @getsentry/ecosystem
 /src/sentry/mediators/                        @getsentry/ecosystem
-/src/sentry/notifications/                    @getsentry/ecosystem
+/src/sentry/notifications/                    @getsentry/ecosystem @getsentry/growth
 /src/sentry/plugins/                          @getsentry/ecosystem
 /src/sentry/ratelimits/                       @getsentry/ecosystem
 /src/sentry/shared_integrations/              @getsentry/ecosystem


### PR DESCRIPTION
The growth team has a dependency on notifications so we need to add the team as a codeowner 