### PR TITLE
feat(suspect-spans): Add new span details page

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1246,13 +1246,23 @@ function buildRoutes() {
           }
           component={SafeLazyLoad}
         />
-        <Route
-          path="spans/"
-          componentPromise={() =>
-            import('sentry/views/performance/transactionSummary/transactionSpans')
-          }
-          component={SafeLazyLoad}
-        />
+        <Route path="spans/">
+          <IndexRoute
+            componentPromise={() =>
+              import('sentry/views/performance/transactionSummary/transactionSpans')
+            }
+            component={SafeLazyLoad}
+          />
+          <Route
+            path=":spanSlug/"
+            componentPromise={() =>
+              import(
+                'sentry/views/performance/transactionSummary/transactionSpans/spanDetails'
+              )
+            }
+            component={SafeLazyLoad}
+          />
+        </Route>
       </Route>
       <Route
         path="vitaldetail/"

--- a/static/app/views/performance/breadcrumb.tsx
+++ b/static/app/views/performance/breadcrumb.tsx
@@ -8,6 +8,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 
 import Tab from './transactionSummary/tabs';
 import {eventsRouteWithQuery} from './transactionSummary/transactionEvents/utils';
+import {spansRouteWithQuery} from './transactionSummary/transactionSpans/utils';
 import {tagsRouteWithQuery} from './transactionSummary/transactionTags/utils';
 import {vitalsRouteWithQuery} from './transactionSummary/transactionVitals/utils';
 import {transactionSummaryRouteWithQuery} from './transactionSummary/utils';
@@ -101,6 +102,15 @@ class Breadcrumb extends Component<Props> {
           crumbs.push({
             to: webVitalsTarget,
             label: t('Web Vitals'),
+            preserveGlobalSelection: true,
+          });
+          break;
+        }
+        case Tab.Spans: {
+          const spansTarget = spansRouteWithQuery(routeQuery);
+          crumbs.push({
+            to: spansTarget,
+            label: t('Spans'),
             preserveGlobalSelection: true,
           });
           break;

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -168,7 +168,7 @@ function PageLayout(props: Props) {
   );
 }
 
-function NoAccess() {
+export function NoAccess() {
   return <Alert type="warning">{t("You don't have access to this feature")}</Alert>;
 }
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -16,10 +16,8 @@ import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
-import {isAggregateField} from 'sentry/utils/discover/fields';
 import SuspectSpansQuery from 'sentry/utils/performance/suspectSpans/suspectSpansQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
 import {SetStateAction} from '../types';
 import {generateTransactionLink} from '../utils';
@@ -28,7 +26,7 @@ import OpsFilter from './opsFilter';
 import {Actions} from './styles';
 import SuspectSpanCard from './suspectSpanCard';
 import {SpansTotalValues} from './types';
-import {getSuspectSpanSortFromEventView, SPAN_SORT_OPTIONS} from './utils';
+import {getSuspectSpanSortFromEventView, getTotalsView, SPAN_SORT_OPTIONS} from './utils';
 
 const ANALYTICS_VALUES = {
   spanOp: (organization: Organization, value: string | undefined) =>
@@ -178,31 +176,6 @@ function SpansContent(props: Props) {
       </DiscoverQuery>
     </Layout.Main>
   );
-}
-
-/**
- * For the totals view, we want to get some transaction level stats like
- * the number of transactions and the sum of the transaction duration.
- * This requires the removal of any aggregate conditions as they can result
- * in unexpected empty responses.
- */
-function getTotalsView(eventView: EventView): EventView {
-  const totalsView = eventView.withColumns([
-    {kind: 'function', function: ['count', '', undefined, undefined]},
-    {kind: 'function', function: ['sum', 'transaction.duration', undefined, undefined]},
-  ]);
-
-  const conditions = new MutableSearch(eventView.query);
-
-  // filter out any aggregate conditions
-  Object.keys(conditions.filters).forEach(field => {
-    if (isAggregateField(field)) {
-      conditions.removeFilter(field);
-    }
-  });
-
-  totalsView.query = conditions.formatString();
-  return totalsView;
 }
 
 export default SpansContent;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -1,0 +1,214 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import {SectionHeading as _SectionHeading} from 'sentry/components/charts/styles';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t, tn} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
+import EventView from 'sentry/utils/discover/eventView';
+import {formatPercentage} from 'sentry/utils/formatters';
+import SuspectSpansQuery from 'sentry/utils/performance/suspectSpans/suspectSpansQuery';
+import {SuspectSpan} from 'sentry/utils/performance/suspectSpans/types';
+import Breadcrumb from 'sentry/views/performance/breadcrumb';
+
+import {PerformanceDuration} from '../../../utils';
+import Tab from '../../tabs';
+import {SpanSlug} from '../types';
+import {getTotalsView} from '../utils';
+
+type Props = {
+  location: Location;
+  organization: Organization;
+  eventView: EventView;
+  projectId: string;
+  transactionName: string;
+  spanSlug: SpanSlug;
+};
+
+export default function SpanDetailsContent(props: Props) {
+  const {location, organization, eventView, projectId, transactionName, spanSlug} = props;
+  return (
+    <Fragment>
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Breadcrumb
+            organization={organization}
+            location={location}
+            transaction={{
+              project: projectId,
+              name: transactionName,
+            }}
+            tab={Tab.Spans}
+          />
+          <Layout.Title>{transactionName}</Layout.Title>
+        </Layout.HeaderContent>
+      </Layout.Header>
+      <Layout.Body>
+        <Layout.Main fullWidth>
+          <DiscoverQuery
+            eventView={getTotalsView(eventView)}
+            orgSlug={organization.slug}
+            location={location}
+            referrer="api.performance.transaction-spans"
+            cursor="0:0:1"
+            noPagination
+          >
+            {({tableData}) => {
+              const totalCount: number = tableData?.data?.[0]?.count ?? null;
+
+              return (
+                <SuspectSpansQuery
+                  location={location}
+                  orgSlug={organization.slug}
+                  eventView={eventView}
+                  perSuspect={0}
+                  spanOps={[spanSlug.op]}
+                  spanGroups={[spanSlug.group]}
+                >
+                  {({suspectSpans, isLoading}) => {
+                    if (isLoading) {
+                      return <LoadingIndicator />;
+                    }
+
+                    if (!suspectSpans?.length) {
+                      return (
+                        <EmptyStateWarning>
+                          <p>{t('No span data found')}</p>
+                        </EmptyStateWarning>
+                      );
+                    }
+
+                    // There should always be exactly 1 result
+                    const suspectSpan = suspectSpans[0];
+
+                    return (
+                      <Fragment>
+                        <SpanDetailsHeader
+                          spanSlug={spanSlug}
+                          suspectSpan={suspectSpan}
+                          totalCount={totalCount}
+                        />
+                      </Fragment>
+                    );
+                  }}
+                </SuspectSpansQuery>
+              );
+            }}
+          </DiscoverQuery>
+        </Layout.Main>
+      </Layout.Body>
+    </Fragment>
+  );
+}
+
+type HeaderProps = {
+  spanSlug: SpanSlug;
+  suspectSpan: SuspectSpan;
+  totalCount: number | null;
+};
+
+function SpanDetailsHeader(props: HeaderProps) {
+  const {spanSlug, suspectSpan, totalCount} = props;
+
+  const frequency = totalCount
+    ? Math.min(suspectSpan.frequency, totalCount)
+    : suspectSpan.frequency;
+
+  return (
+    <ContentHeader>
+      <HeaderInfo data-test-id="header-operation-name">
+        <SectionHeading>{t('Span Operation')}</SectionHeading>
+        <SectionBody>Span Description Placeholder</SectionBody>
+        <SectionSubtext data-test-id="operation-name">{spanSlug.op}</SectionSubtext>
+      </HeaderInfo>
+      <HeaderInfo data-test-id="header-percentiles">
+        <SectionHeading>{t('Exclusive Time Percentiles')}</SectionHeading>
+        <PercentileHeaderBodyWrapper>
+          <div data-test-id="section-p75">
+            <SectionBody>
+              <PerformanceDuration
+                abbreviation
+                milliseconds={suspectSpan.p75ExclusiveTime}
+              />
+            </SectionBody>
+            <SectionSubtext>{t('p75')}</SectionSubtext>
+          </div>
+          <div data-test-id="section-p95">
+            <SectionBody>
+              <PerformanceDuration
+                abbreviation
+                milliseconds={suspectSpan.p95ExclusiveTime}
+              />
+            </SectionBody>
+            <SectionSubtext>{t('p95')}</SectionSubtext>
+          </div>
+          <div data-test-id="section-p99">
+            <SectionBody>
+              <PerformanceDuration
+                abbreviation
+                milliseconds={suspectSpan.p99ExclusiveTime}
+              />
+            </SectionBody>
+            <SectionSubtext>{t('p99')}</SectionSubtext>
+          </div>
+        </PercentileHeaderBodyWrapper>
+      </HeaderInfo>
+      <HeaderInfo data-test-id="header-frequency">
+        <SectionHeading>{t('Frequency')}</SectionHeading>
+        <SectionBody>
+          {totalCount ? formatPercentage(frequency / totalCount) : '\u2014'}
+        </SectionBody>
+        <SectionSubtext>{tn('%s event', '%s events', frequency)}</SectionSubtext>
+      </HeaderInfo>
+      <HeaderInfo data-test-id="header-total-exclusive-time">
+        <SectionHeading>{t('Total Exclusive Time')}</SectionHeading>
+        <SectionBody>
+          <PerformanceDuration abbreviation milliseconds={suspectSpan.sumExclusiveTime} />
+        </SectionBody>
+        <SectionSubtext>TBD</SectionSubtext>
+      </HeaderInfo>
+    </ContentHeader>
+  );
+}
+
+const ContentHeader = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-gap: ${space(4)};
+  margin-bottom: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    grid-template-columns: auto max-content max-content max-content;
+    grid-row-gap: 0;
+  }
+`;
+
+const HeaderInfo = styled('div')`
+  height: 78px;
+`;
+
+const SectionHeading = styled(_SectionHeading)`
+  margin: 0;
+`;
+
+const SectionBody = styled('div')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  padding: ${space(0.5)} 0;
+  max-height: 32px;
+`;
+
+const SectionSubtext = styled('div')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const PercentileHeaderBodyWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: max-content max-content max-content;
+  grid-gap: ${space(3)};
+`;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
@@ -1,0 +1,89 @@
+import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
+
+import Feature from 'sentry/components/acl/feature';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import GlobalSelectionHeader from 'sentry/components/organizations/globalSelectionHeader';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import {PageContent} from 'sentry/styles/organization';
+import {defined} from 'sentry/utils';
+import {decodeScalar} from 'sentry/utils/queryString';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+
+import {getTransactionName} from '../../../utils';
+import {NoAccess} from '../../pageLayout';
+import {generateSpansEventView, parseSpanSlug} from '../utils';
+
+import SpanDetailsContent from './content';
+
+type Props = Pick<RouteComponentProps<{spanSlug: string}, {}>, 'location' | 'params'>;
+
+export default function SpanDetails(props: Props) {
+  const {location, params} = props;
+  const transactionName = getTransactionName(location);
+  const spanSlug = parseSpanSlug(params.spanSlug);
+
+  const projectId = decodeScalar(location.query.project);
+  if (!defined(projectId) || !defined(transactionName) || !defined(spanSlug)) {
+    return null;
+  }
+
+  const organization = useOrganization();
+  const {projects} = useProjects();
+
+  const project = projects.find(p => p.id === projectId);
+  const eventView = generateSpansEventView(location, transactionName);
+
+  return (
+    <SentryDocumentTitle
+      title={getDocumentTitle(transactionName)}
+      orgSlug={organization.slug}
+      projectSlug={project?.slug}
+    >
+      <Feature
+        features={['performance-view', 'performance-suspect-spans-view']}
+        organization={organization}
+        renderDisabled={NoAccess}
+      >
+        <GlobalSelectionHeader
+          lockedMessageSubject={t('transaction')}
+          shouldForceProject={defined(project)}
+          forceProject={project}
+          specificProjectSlugs={defined(project) ? [project.slug] : []}
+          disableMultipleProjectSelection
+          showProjectSettingsLink
+        >
+          <StyledPageContent>
+            <NoProjectMessage organization={organization}>
+              <SpanDetailsContent
+                location={location}
+                organization={organization}
+                eventView={eventView}
+                projectId={projectId}
+                transactionName={transactionName}
+                spanSlug={spanSlug}
+              />
+            </NoProjectMessage>
+          </StyledPageContent>
+        </GlobalSelectionHeader>
+      </Feature>
+    </SentryDocumentTitle>
+  );
+}
+
+function getDocumentTitle(transactionName: string): string {
+  const hasTransactionName =
+    typeof transactionName === 'string' && String(transactionName).trim().length > 0;
+
+  if (hasTransactionName) {
+    return [String(transactionName).trim(), t('Performance')].join(' - ');
+  }
+
+  return [t('Summary'), t('Performance')].join(' - ');
+}
+
+const StyledPageContent = styled(PageContent)`
+  padding: 0;
+`;

--- a/static/app/views/performance/transactionSummary/transactionSpans/types.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/types.tsx
@@ -38,3 +38,8 @@ export type SpansTotalValues = {
   count: number;
   sum_transaction_duration: number;
 };
+
+export type SpanSlug = {
+  op: string;
+  group: string;
+};

--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -1,10 +1,13 @@
 import {Location, Query} from 'history';
 
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
+import {isAggregateField} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
-import {SpanSortOption, SpanSortOthers, SpanSortPercentiles} from './types';
+import {SpanSlug, SpanSortOption, SpanSortOthers, SpanSortPercentiles} from './types';
 
 export function generateSpansRoute({orgSlug}: {orgSlug: String}): string {
   return `/organizations/${orgSlug}/performance/summary/spans/`;
@@ -98,4 +101,71 @@ export function getSuspectSpanSortFromLocation(
 export function getSuspectSpanSortFromEventView(eventView: EventView): SpanSortOption {
   const sort = eventView.sorts.length ? eventView.sorts[0].field : DEFAULT_SORT;
   return getSuspectSpanSort(sort);
+}
+
+export function parseSpanSlug(spanSlug: string | undefined): SpanSlug | undefined {
+  if (!defined(spanSlug)) {
+    return undefined;
+  }
+
+  const delimiterPos = spanSlug.lastIndexOf(':');
+  if (delimiterPos < 0) {
+    return undefined;
+  }
+
+  const op = spanSlug.slice(0, delimiterPos);
+  const group = spanSlug.slice(delimiterPos + 1);
+
+  return {op, group};
+}
+
+export function generateSpansEventView(
+  location: Location,
+  transactionName: string
+): EventView {
+  const query = decodeScalar(location.query.query, '');
+  const conditions = new MutableSearch(query);
+  conditions
+    .setFilterValues('event.type', ['transaction'])
+    .setFilterValues('transaction', [transactionName]);
+
+  const eventView = EventView.fromNewQueryWithLocation(
+    {
+      id: undefined,
+      version: 2,
+      name: transactionName,
+      fields: [...Object.values(SpanSortOthers), ...Object.values(SpanSortPercentiles)],
+      query: conditions.formatString(),
+      projects: [],
+    },
+    location
+  );
+
+  const sort = getSuspectSpanSortFromLocation(location);
+  return eventView.withSorts([{field: sort.field, kind: 'desc'}]);
+}
+
+/**
+ * For the totals view, we want to get some transaction level stats like
+ * the number of transactions and the sum of the transaction duration.
+ * This requires the removal of any aggregate conditions as they can result
+ * in unexpected empty responses.
+ */
+export function getTotalsView(eventView: EventView): EventView {
+  const totalsView = eventView.withColumns([
+    {kind: 'function', function: ['count', '', undefined, undefined]},
+    {kind: 'function', function: ['sum', 'transaction.duration', undefined, undefined]},
+  ]);
+
+  const conditions = new MutableSearch(eventView.query);
+
+  // filter out any aggregate conditions
+  Object.keys(conditions.filters).forEach(field => {
+    if (isAggregateField(field)) {
+      conditions.removeFilter(field);
+    }
+  });
+
+  totalsView.query = conditions.formatString();
+  return totalsView;
 }

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -141,11 +141,11 @@ function makeSuspectSpan(opt: SuspectOpt): SuspectSpan {
     frequency: 1,
     count: 1,
     avgOccurrences: 1,
-    sumExclusiveTime: 1,
+    sumExclusiveTime: 5,
     p50ExclusiveTime: 1,
-    p75ExclusiveTime: 1,
-    p95ExclusiveTime: 1,
-    p99ExclusiveTime: 1,
+    p75ExclusiveTime: 2,
+    p95ExclusiveTime: 3,
+    p99ExclusiveTime: 4,
     examples: examples.map(makeExample),
   };
 }

--- a/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
@@ -64,7 +64,7 @@ describe('Performance > Transaction Spans', function () {
     });
     eventsV2Mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/eventsv2/',
-      body: 100,
+      body: [{count: 100}],
     });
     eventsSpanOpsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-span-ops/',

--- a/tests/js/spec/views/performance/transactionSpans/spanDetails.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/spanDetails.spec.tsx
@@ -1,0 +1,134 @@
+import {
+  generateSuspectSpansResponse,
+  initializeData as _initializeData,
+} from 'sentry-test/performance/initializePerformanceData';
+import {act, mountWithTheme, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import SpanDetails from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails';
+
+function initializeData(settings) {
+  const data = _initializeData(settings);
+  act(() => void ProjectsStore.loadInitialData(data.organization.projects));
+  return data;
+}
+
+describe('Performance > Transaction Spans > Span Details', function () {
+  beforeEach(function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {data: [{count: 1}]},
+    });
+  });
+
+  afterEach(function () {
+    MockApiClient.clearMockResponses();
+    ProjectsStore.reset();
+  });
+
+  describe('Without Span Data', function () {
+    beforeEach(function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-spans-performance/',
+        body: [],
+      });
+    });
+
+    it(`renders empty when missing project`, async function () {
+      const data = initializeData({query: {transaction: 'transaction'}});
+
+      const {container} = mountWithTheme(
+        <SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />,
+        {context: data.routerContext, organization: data.organization}
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it(`renders empty when missing transaction`, async function () {
+      const data = initializeData({query: {project: '1'}});
+
+      const {container} = mountWithTheme(
+        <SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />,
+        {context: data.routerContext, organization: data.organization}
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it(`renders no data when empty response`, async function () {
+      const data = initializeData({
+        features: ['performance-view', 'performance-suspect-spans-view'],
+        query: {project: '1', transaction: 'transaction'},
+      });
+
+      mountWithTheme(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
+        context: data.routerContext,
+        organization: data.organization,
+      });
+
+      expect(await screen.findByText('No span data found')).toBeInTheDocument();
+    });
+  });
+
+  describe('With Span Data', function () {
+    beforeEach(function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-spans-performance/',
+        body: generateSuspectSpansResponse(),
+      });
+    });
+
+    it('renders header elements', async function () {
+      const data = initializeData({
+        features: ['performance-view', 'performance-suspect-spans-view'],
+        query: {project: '1', transaction: 'transaction'},
+      });
+
+      mountWithTheme(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
+        context: data.routerContext,
+        organization: data.organization,
+      });
+
+      const operationNameHeader = await screen.findByTestId('header-operation-name');
+      expect(
+        await within(operationNameHeader).findByText('Span Operation')
+      ).toBeInTheDocument();
+      // TODO: add an expect for the span description here
+      expect(
+        await within(operationNameHeader).findByTestId('operation-name')
+      ).toHaveTextContent('op');
+
+      const percentilesHeader = await screen.findByTestId('header-percentiles');
+      expect(
+        await within(percentilesHeader).findByText('Exclusive Time Percentiles')
+      ).toBeInTheDocument();
+      const p75Section = await within(percentilesHeader).findByTestId('section-p75');
+      expect(await within(p75Section).findByText('2.00ms')).toBeInTheDocument();
+      expect(await within(p75Section).findByText('p75')).toBeInTheDocument();
+      const p95Section = await within(percentilesHeader).findByTestId('section-p95');
+      expect(await within(p95Section).findByText('3.00ms')).toBeInTheDocument();
+      expect(await within(p95Section).findByText('p95')).toBeInTheDocument();
+      const p99Section = await within(percentilesHeader).findByTestId('section-p99');
+      expect(await within(p99Section).findByText('4.00ms')).toBeInTheDocument();
+      expect(await within(p99Section).findByText('p99')).toBeInTheDocument();
+
+      const frequencyHeader = await screen.findByTestId('header-frequency');
+      expect(await within(frequencyHeader).findByText('100%')).toBeInTheDocument();
+      expect(await within(frequencyHeader).findByText('1 event')).toBeInTheDocument();
+
+      const totalExclusiveTimeHeader = await screen.findByTestId(
+        'header-total-exclusive-time'
+      );
+      expect(
+        await within(totalExclusiveTimeHeader).findByText('5.00ms')
+      ).toBeInTheDocument();
+      // TODO: add an expect for the TBD
+    });
+  });
+});


### PR DESCRIPTION
This adds a new span details page that will display a span specific information
in a transaction. This just adds the top header section.

![image](https://user-images.githubusercontent.com/10239353/146076783-d3ee8739-6b55-4a0e-a841-0da282fce3f5.png)
