### PR TITLE
chore: Add workflow as the codeowner of team insights

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -258,9 +258,12 @@ build-utils/        @getsentry/owners-js-build
 
 ### Workflow ###
 
-/src/sentry/api/endpoints/organization_activity.py  @getsentry/workflow
-/src/sentry/api/endpoints/organization_searches.py  @getsentry/workflow
-/src/sentry/tasks/releasemonitor.py                 @getsentry/workflow
+/src/sentry/api/endpoints/organization_activity.py    @getsentry/workflow
+/src/sentry/api/endpoints/organization_searches.py    @getsentry/workflow
+/src/sentry/tasks/releasemonitor.py                   @getsentry/workflow
+
+/static/app/views/organizationStats/teamInsights      @getsentry/workflow
+/tests/js/spec/views/organizationStats/teamInsights/  @getsentry/workflow
 
 ## End of Workflow ##
 


### PR DESCRIPTION
Team insights is inside `organizationStats` folder belonging to enterprise team, would like them to stop being tagged on our PRs