### PR TITLE
ref(ui): Hover & focus states for buttons

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -151,15 +151,15 @@ type StyledButtonProps = ButtonProps & {theme: Theme};
 
 const getFontSize = ({size, priority, theme}: StyledButtonProps) => {
   if (priority === 'link') {
-    return 'inherit';
+    return 'font-size: inherit';
   }
 
   switch (size) {
     case 'xsmall':
     case 'small':
-      return theme.fontSizeSmall;
+      return `font-size: ${theme.fontSizeSmall}`;
     default:
-      return theme.fontSizeMedium;
+      return `font-size: ${theme.fontSizeMedium}`;
   }
 };
 
@@ -167,13 +167,18 @@ const getFontWeight = ({priority, borderless}: StyledButtonProps) =>
   `font-weight: ${priority === 'link' || borderless ? 'inherit' : 600};`;
 
 const getBoxShadow =
-  (theme: Theme, active: boolean) =>
+  (theme: Theme) =>
   ({priority, borderless, disabled}: StyledButtonProps) => {
     if (disabled || borderless || priority === 'link') {
       return 'box-shadow: none';
     }
 
-    return `box-shadow: ${active ? 'inset' : ''} ${theme.dropShadowLight}`;
+    return `
+      box-shadow: ${theme.dropShadowLight};
+      &:active {
+        box-shadow: inset ${theme.dropShadowLight};
+      }
+    `;
   };
 
 const getColors = ({priority, disabled, borderless, theme}: StyledButtonProps) => {
@@ -185,14 +190,14 @@ const getColors = ({priority, disabled, borderless, theme}: StyledButtonProps) =
     backgroundActive,
     border,
     borderActive,
+    focusBorder,
     focusShadow,
   } = theme.button[themeName];
 
   return css`
     color: ${color};
     background-color: ${background};
-    border: 1px solid
-      ${priority !== 'link' && !borderless && !!border ? border : 'transparent'};
+    border: 1px solid ${borderless ? 'transparent' : border};
 
     &:hover {
       color: ${color};
@@ -203,13 +208,12 @@ const getColors = ({priority, disabled, borderless, theme}: StyledButtonProps) =
     &:active {
       color: ${colorActive || color};
       background: ${backgroundActive};
-      border-color: ${priority !== 'link' && !borderless && (borderActive || border)
-        ? borderActive || border
-        : 'transparent'};
+      border-color: ${borderless ? 'transparent' : borderActive};
     }
 
     &.focus-visible {
-      ${focusShadow && `box-shadow: ${focusShadow} 0 0 0 3px;`}
+      border: 1px solid ${focusBorder};
+      box-shadow: ${focusBorder} 0 0 0 1px, ${focusShadow} 0 0 0 4px;
     }
   `;
 };
@@ -261,20 +265,15 @@ const StyledButton = styled(
   padding: 0;
   text-transform: none;
   ${getFontWeight};
-  font-size: ${getFontSize};
+  ${getFontSize};
   ${getColors};
-  ${p => getBoxShadow(p.theme, false)};
+  ${p => getBoxShadow(p.theme)};
   cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
   opacity: ${p => (p.busy || p.disabled) && '0.65'};
 
-  &:active {
-    ${p => getBoxShadow(p.theme, true)};
-  }
   &:focus {
     outline: none;
   }
-
-  ${p => (p.borderless || p.priority === 'link') && 'border-color: transparent'};
 `;
 
 /**

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -199,7 +199,8 @@ const generateAliases = (colors: BaseColors) => ({
    * Indicates that something has "focus", which is different than "active" state as it is more temporal
    * and should be a bit subtler than active
    */
-  focus: colors.surface100,
+  focus: colors.purple200,
+  focusBorder: colors.purple300,
 
   /**
    * Inactive
@@ -211,19 +212,6 @@ const generateAliases = (colors: BaseColors) => ({
    */
   linkColor: colors.blue300,
   linkHoverColor: colors.blue300,
-
-  /**
-   * Secondary button colors
-   */
-  secondaryButtonBorder: colors.gray200,
-
-  secondaryButtonText: colors.gray500,
-
-  /**
-   * Primary button colors
-   */
-  primaryButtonBorder: colors.purple200,
-  primaryButtonBorderActive: colors.purple300,
 
   /**
    * Form placeholder text color
@@ -447,67 +435,74 @@ const generateButtonTheme = (colors: BaseColors, alias: Aliases) => ({
   borderRadius: '3px',
 
   default: {
-    color: alias.secondaryButtonText,
-    colorActive: alias.secondaryButtonText,
+    color: alias.textColor,
+    colorActive: alias.textColor,
     background: alias.background,
-    backgroundActive: alias.background,
-    border: alias.secondaryButtonBorder,
-    borderActive: alias.secondaryButtonBorder,
-    focusShadow: color(colors.gray200).alpha(0.5).string(),
+    backgroundActive: alias.backgroundSecondary,
+    border: alias.border,
+    borderActive: alias.border,
+    focusBorder: alias.focusBorder,
+    focusShadow: alias.focus,
   },
   primary: {
     color: colors.white,
     colorActive: colors.white,
     background: colors.purple300,
-    backgroundActive: '#4e3fb4',
-    border: alias.primaryButtonBorder,
-    borderActive: alias.primaryButtonBorderActive,
-    focusShadow: colors.purple200,
+    backgroundActive: colors.purple400,
+    border: colors.purple300,
+    borderActive: colors.purple300,
+    focusBorder: alias.focusBorder,
+    focusShadow: alias.focus,
   },
   success: {
     color: colors.white,
     colorActive: colors.white,
-    background: '#3fa372',
-    backgroundActive: colors.green300,
-    border: '#7ccca5',
-    borderActive: '#7ccca5',
+    background: colors.green300,
+    backgroundActive: colors.green400,
+    border: colors.green300,
+    borderActive: colors.green300,
+    focusBorder: colors.green300,
     focusShadow: colors.green200,
   },
   danger: {
     color: colors.white,
     colorActive: colors.white,
     background: colors.red300,
-    backgroundActive: '#bf2a1d',
-    border: '#bf2a1d',
-    borderActive: '#7d1c13',
+    backgroundActive: colors.red400,
+    border: colors.red300,
+    borderActive: colors.red300,
+    focusBorder: colors.red300,
     focusShadow: colors.red200,
   },
   link: {
     color: colors.blue300,
     colorActive: colors.blue300,
     background: 'transparent',
-    border: false,
-    borderActive: false,
     backgroundActive: 'transparent',
-    focusShadow: false,
+    border: 'transparent',
+    borderActive: 'transparent',
+    focusBorder: alias.focusBorder,
+    focusShadow: alias.focus,
   },
   disabled: {
     color: alias.disabled,
     colorActive: alias.disabled,
-    border: alias.disabledBorder,
-    borderActive: alias.disabledBorder,
     background: alias.background,
     backgroundActive: alias.background,
-    focusShadow: false,
+    border: alias.disabledBorder,
+    borderActive: alias.disabledBorder,
+    focusBorder: 'transparent',
+    focusShadow: 'transparent',
   },
   form: {
     color: alias.textColor,
     colorActive: alias.textColor,
     background: alias.background,
-    backgroundActive: alias.background,
+    backgroundActive: alias.backgroundSecondary,
     border: alias.formInputBorder,
     borderActive: alias.formInputBorder,
-    focusShadow: false,
+    focusBorder: alias.focusBorder,
+    focusShadow: alias.focus,
   },
 });
 


### PR DESCRIPTION
Some small style adjustments for buttons:
 - **Default buttons**: 
   - On hover, use `backgroundSecondary` as the background color, instead of just white
   - On focus, use purple box shadows instead of the current gray (see screenshots below)
 - **Link buttons** (second from right in screenshots): add a focus ring, also in purple
 - **In `theme.tsx`**: use the new 400-series accent colors (e.g. `purple400`) for hover, focus & active states instead of the current hard-coded values
 - **In `button.tsx`**: general cleanup, mostly to make the code more readable

Focus states, before & after:
<img width="922" alt="Screen Shot 2021-12-14 at 2 39 25 PM" src="https://user-images.githubusercontent.com/44172267/146090749-3cbc2fb8-3dcf-4f55-ba1f-da6057ff7d5a.png">
<img width="922" alt="Screen Shot 2021-12-14 at 2 40 12 PM" src="https://user-images.githubusercontent.com/44172267/146090728-e6dd71c8-e93d-4b98-8fad-1d7d20e50015.png">

Here're some [samples on Storybook](https://storybook-q8uzn1fi6.sentry.dev/?path=/story/components-buttons--overview) - click on the canvas, then press `tab` a few times to see focus states.

