### PR TITLE
ref(ui): Separate hover color from focus color

### DIFF
--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -355,7 +355,7 @@ const DropdownMenuItem = styled('li')`
     }
   }
   &:hover > span {
-    background: ${p => p.theme.focus};
+    background: ${p => p.theme.hover};
   }
 `;
 

--- a/static/app/components/dropdownAutoComplete/row.tsx
+++ b/static/app/components/dropdownAutoComplete/row.tsx
@@ -94,7 +94,7 @@ const AutoCompleteItem = styled('div')<{
   justify-content: center;
 
   font-size: 0.9em;
-  background-color: ${p => (p.isHighlighted ? p.theme.focus : 'transparent')};
+  background-color: ${p => (p.isHighlighted ? p.theme.hover : 'transparent')};
   color: ${p => (p.isHighlighted ? p.theme.textColor : 'inherit')};
   padding: ${p => getItemPaddingForSize(p.itemSize)};
   cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
@@ -106,6 +106,6 @@ const AutoCompleteItem = styled('div')<{
 
   :hover {
     color: ${p => p.theme.textColor};
-    background-color: ${p => p.theme.focus};
+    background-color: ${p => p.theme.hover};
   }
 `;

--- a/static/app/components/dropdownLink.tsx
+++ b/static/app/components/dropdownLink.tsx
@@ -14,7 +14,7 @@ const getRootCss = (theme: Theme) => css`
       &:hover,
       &:focus {
         color: inherit;
-        background-color: ${theme.focus};
+        background-color: ${theme.hover};
       }
     }
 
@@ -29,7 +29,7 @@ const getRootCss = (theme: Theme) => css`
 
   .dropdown-submenu:hover > span {
     color: ${theme.textColor};
-    background: ${theme.focus};
+    background: ${theme.hover};
   }
 `;
 

--- a/static/app/components/forms/selectControl.tsx
+++ b/static/app/components/forms/selectControl.tsx
@@ -185,7 +185,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
         ? theme.background
         : theme.textColor,
       backgroundColor: state.isFocused
-        ? theme.focus
+        ? theme.hover
         : state.isSelected
         ? theme.active
         : 'transparent',

--- a/static/app/components/menuItem.tsx
+++ b/static/app/components/menuItem.tsx
@@ -211,7 +211,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
     ${common}
 
     &:hover {
-      background: ${props.theme.focus};
+      background: ${props.theme.hover};
     }
   `;
 }

--- a/static/app/components/organizations/timeRangeSelector/dateRange/dateRangeWrapper.tsx
+++ b/static/app/components/organizations/timeRangeSelector/dateRange/dateRangeWrapper.tsx
@@ -51,7 +51,7 @@ const DateRangePicker = styled(BaseDateRangePicker)`
   }
 
   .rdrDayInPreview {
-    background: ${p => p.theme.focus};
+    background: ${p => p.theme.hover};
   }
 
   .rdrMonth {

--- a/static/app/components/organizations/timeRangeSelector/dateRange/selectorItem.tsx
+++ b/static/app/components/organizations/timeRangeSelector/dateRange/selectorItem.tsx
@@ -32,7 +32,7 @@ const SelectorItem = styled(BaseSelectorItem)`
 
   &:hover {
     color: ${p => p.theme.textColor};
-    background: ${p => p.theme.focus};
+    background: ${p => p.theme.hover};
   }
 `;
 

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -177,7 +177,7 @@ const SearchListItem = styled(ListItem)`
 
   &:hover,
   &.active {
-    background: ${p => p.theme.focus};
+    background: ${p => p.theme.hover};
   }
 `;
 

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -16,6 +16,7 @@ export const lightColors = {
   surface100: '#FAF9FB',
   surface200: '#FFFFFF',
   surface300: '#FFFFFF',
+  surface400: '#F5F3F7',
 
   gray500: '#2B2233',
   gray400: '#4D4158',
@@ -65,6 +66,7 @@ export const darkColors = {
   surface100: '#1A141F',
   surface200: '#241D2A',
   surface300: '#2C2433',
+  surface400: '#362E3E',
 
   gray500: '#EBE6EF',
   gray400: '#D6D0DC',
@@ -189,6 +191,11 @@ const generateAliases = (colors: BaseColors) => ({
    */
   disabled: colors.gray300,
   disabledBorder: colors.gray200,
+
+  /**
+   * Indicates a "hover" state, to suggest that an interactive element is clickable
+   */
+  hover: colors.surface400,
 
   /**
    * Indicates that something is "active" or "selected"

--- a/static/app/views/eventsV2/table/arithmeticInput.tsx
+++ b/static/app/views/eventsV2/table/arithmeticInput.tsx
@@ -451,7 +451,7 @@ const DropdownListItem = styled(ListItem)`
 
   &:hover,
   &.active {
-    background: ${p => p.theme.focus};
+    background: ${p => p.theme.hover};
   }
 `;
 


### PR DESCRIPTION
Add `surface400` and its corresponding alias, `hover`, to `theme.tsx`.

Why: we currently use the same color (`theme.focus`) for both focus and hover states. However, these are different states that should have different colors. Having a separate, customized color (`surface400`) for hover state allows us to implement better hover state designs.

Example with select hover, before:
<img width="465" alt="Screen Shot 2021-12-14 at 4 13 55 PM" src="https://user-images.githubusercontent.com/44172267/146099441-949a559c-7fc8-486f-bcaa-a545b16945d8.png">
<img width="465" alt="Screen Shot 2021-12-14 at 4 15 50 PM" src="https://user-images.githubusercontent.com/44172267/146099622-079b73bc-7499-4f8c-b9c9-6e32152d756a.png">

After:
<img width="465" alt="Screen Shot 2021-12-14 at 4 14 25 PM" src="https://user-images.githubusercontent.com/44172267/146099483-89e8a4c7-4650-426e-98ab-a7ce2d09d785.png">
<img width="465" alt="Screen Shot 2021-12-14 at 4 16 08 PM" src="https://user-images.githubusercontent.com/44172267/146099663-a935ac7d-0cbd-472e-9838-0148ce7660b7.png">

