### PR TITLE
feat(metric-alerts): Add extra tags to subscription metric logger

### DIFF
--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -118,7 +118,11 @@ def handle_subscription_metrics_logger(subscription_update, subscription):
         aggregation_value = int(processor.get_aggregation_value(subscription_update))
         processor.alert_rule.comparison_delta = int(timedelta(days=7).total_seconds())
         comparison_value = processor.get_aggregation_value(subscription_update)
-        tags = {"project_id": subscription.project_id, "subscription_id": subscription.id}
+        tags = {
+            "project_id": subscription.project_id,
+            "subscription_id": subscription.id,
+            "time_window": subscription.snuba_query.time_window,
+        }
         metrics.incr("subscriptions.result.value", aggregation_value, tags=tags, sample_rate=1.0)
         if comparison_value is not None:
             metrics.incr(

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -120,6 +120,7 @@ def handle_subscription_metrics_logger(subscription_update, subscription):
         comparison_value = processor.get_aggregation_value(subscription_update)
         tags = {
             "project_id": subscription.project_id,
+            "project_slug": subscription.project.slug,
             "subscription_id": subscription.id,
             "time_window": subscription.snuba_query.time_window,
         }

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -223,6 +223,7 @@ class TestHandleSubscriptionMetricsLogger(TestCase):
                     100,
                     tags={
                         "project_id": self.project.id,
+                        "project_slug": self.project.slug,
                         "subscription_id": self.subscription.id,
                         "time_window": 600,
                     },

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -221,7 +221,11 @@ class TestHandleSubscriptionMetricsLogger(TestCase):
                 call(
                     "subscriptions.result.value",
                     100,
-                    tags={"project_id": self.project.id, "subscription_id": self.subscription.id},
+                    tags={
+                        "project_id": self.project.id,
+                        "subscription_id": self.subscription.id,
+                        "time_window": 600,
+                    },
                     sample_rate=1.0,
                 )
             ]


### PR DESCRIPTION
This adds `time_window` to the subscription metric logger to make it easier to differentiate between
values.