### PR TITLE
feat(dashboard-templates): Add UI for new templates

### DIFF
--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -18,6 +18,14 @@ export type DashboardsEventParameters = {
   };
   'dashboards_views.add_widget_modal.confirm': {};
   'dashboards_views.edit_widget_modal.confirm': {};
+  'dashboards_manage.search': {};
+  'dashboards_manage.change_sort': {
+    sort: string;
+  };
+  'dashboards_manage.create.start': {};
+  'dashboards_manage.templates.toggle': {
+    show_templates: boolean;
+  };
 };
 
 export type DashboardsEventKey = keyof DashboardsEventParameters;
@@ -36,4 +44,8 @@ export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
     'Dashboards2: Add Widget to Dashboard modal form submitted',
   'dashboards_views.edit_widget_modal.confirm':
     'Dashboards2: Edit Dashboard Widget modal form submitted',
+  'dashboards_manage.search': 'Dashboards Manager: Search',
+  'dashboards_manage.change_sort': 'Dashboards Manager: Sort By Changed',
+  'dashboards_manage.create.start': 'Dashboards Manager: Dashboard Create Started',
+  'dashboards_manage.templates.toggle': 'Dashboards Manager: Template Toggle Changed',
 };

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -11,6 +11,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import Switch from 'sentry/components/switchButton';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
@@ -25,6 +26,8 @@ import AsyncView from 'sentry/views/asyncView';
 import {DashboardListItem} from '../types';
 
 import DashboardList from './dashboardList';
+import TemplateCard from './templateCard';
+import {setShowTemplates, shouldShowTemplates} from './utils';
 
 const SORT_OPTIONS: SelectValue<string>[] = [
   {label: t('My Dashboards'), value: 'mydashboards'},
@@ -45,9 +48,23 @@ type Props = {
 type State = {
   dashboards: DashboardListItem[] | null;
   dashboardsPageLinks: string;
+  showTemplates: boolean;
 } & AsyncView['state'];
 
 class ManageDashboards extends AsyncView<Props, State> {
+  state: State = {
+    // AsyncComponent state
+    loading: true,
+    reloading: false,
+    error: false,
+    errors: {},
+
+    // local component state
+    dashboards: null,
+    dashboardsPageLinks: '',
+    showTemplates: shouldShowTemplates(),
+  };
+
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {organization, location} = this.props;
     return [
@@ -108,10 +125,40 @@ class ManageDashboards extends AsyncView<Props, State> {
     });
   };
 
+  toggleTemplates = () => {
+    const {showTemplates} = this.state;
+    const {organization} = this.props;
+
+    trackAnalyticsEvent({
+      eventKey: 'dashboards_manage.templates.toggle',
+      eventName: 'Dashboards Manager: Template Toggle Changed',
+      organization_id: parseInt(organization.id, 10),
+      show_templates: !showTemplates,
+    });
+
+    this.setState({showTemplates: !showTemplates}, () => {
+      setShowTemplates(!showTemplates);
+    });
+  };
+
   getQuery() {
     const {query} = this.props.location.query;
 
     return typeof query === 'string' ? query : undefined;
+  }
+
+  renderTemplates() {
+    const {organization} = this.props;
+    return (
+      <Feature organization={organization} features={['dashboards-edit']}>
+        <TemplateContainer>
+          <TemplateCard title="Default" widgetCount={10} />
+          <TemplateCard title="Frontend" widgetCount={9} />
+          <TemplateCard title="Backend" widgetCount={13} />
+          <TemplateCard title="Mobile" widgetCount={4} />
+        </TemplateContainer>
+      </Feature>
+    );
   }
 
   renderActions() {
@@ -190,6 +237,7 @@ class ManageDashboards extends AsyncView<Props, State> {
   }
 
   renderBody() {
+    const {showTemplates} = this.state;
     const {organization} = this.props;
 
     return (
@@ -204,18 +252,34 @@ class ManageDashboards extends AsyncView<Props, State> {
               <PageContent>
                 <StyledPageHeader>
                   {t('Dashboards')}
-                  <Button
-                    data-test-id="dashboard-create"
-                    onClick={event => {
-                      event.preventDefault();
-                      this.onCreate();
-                    }}
-                    priority="primary"
-                    icon={<IconAdd size="xs" isCircled />}
-                  >
-                    {t('Create Dashboard')}
-                  </Button>
+                  <ButtonContainer>
+                    <Feature
+                      organization={organization}
+                      features={['dashboards-edit']}
+                    >
+                      <SwitchContainer>
+                        Show Templates
+                        <TemplateSwitch
+                          isActive={showTemplates}
+                          size="lg"
+                          toggle={this.toggleTemplates}
+                        />
+                      </SwitchContainer>
+                    </Feature>
+                    <Button
+                      data-test-id="dashboard-create"
+                      onClick={event => {
+                        event.preventDefault();
+                        this.onCreate();
+                      }}
+                      priority="primary"
+                      icon={<IconAdd size="xs" isCircled />}
+                    >
+                      {t('Create Dashboard')}
+                    </Button>
+                  </ButtonContainer>
                 </StyledPageHeader>
+                {showTemplates && this.renderTemplates()}
                 {this.renderActions()}
                 {this.renderDashboards()}
               </PageContent>
@@ -249,6 +313,29 @@ const StyledActions = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: auto;
   }
+`;
+
+const SwitchContainer = styled('div')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  display: inline;
+  padding-right: ${space(2)};
+`;
+
+const TemplateSwitch = styled(Switch)`
+  vertical-align: middle;
+  display: inline;
+  margin-left: ${space(1)};
+`;
+
+const ButtonContainer = styled('div')`
+  display: inline;
+`;
+
+const TemplateContainer = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-gap: ${space(2)};
+  padding-bottom: ${space(4)};
 `;
 
 export default withApi(withOrganization(ManageDashboards));

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -253,10 +253,7 @@ class ManageDashboards extends AsyncView<Props, State> {
                 <StyledPageHeader>
                   {t('Dashboards')}
                   <ButtonContainer>
-                    <Feature
-                      organization={organization}
-                      features={['dashboards-edit']}
-                    >
+                    <Feature organization={organization} features={['dashboards-edit']}>
                       <SwitchContainer>
                         Show Templates
                         <TemplateSwitch

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -245,7 +245,7 @@ class ManageDashboards extends AsyncView<Props, State> {
                       features={['dashboards-template']}
                     >
                       <SwitchContainer>
-                        Show Templates
+                        {t('Show Templates')}
                         <TemplateSwitch
                           isActive={showTemplates}
                           size="lg"
@@ -321,7 +321,7 @@ const ButtonContainer = styled('div')`
 const TemplateContainer = styled('div')`
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  @media (max-width: ${p => p.theme.breakpoints[2]}) {
+  @media (max-width: ${p => p.theme.breakpoints[3]}) {
     grid-template-columns: repeat(2, 1fr);
   }
   grid-gap: ${space(2)};

--- a/static/app/views/dashboardsV2/manage/templateCard.tsx
+++ b/static/app/views/dashboardsV2/manage/templateCard.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+
+import Button from 'sentry/components/button';
+import Card from 'sentry/components/card';
+import {IconAdd, IconGeneric} from 'sentry/icons';
+import overflowEllipsis from 'sentry/styles/overflowEllipsis';
+import space from 'sentry/styles/space';
+
+type Props = {
+  title: string;
+  widgetCount: number;
+};
+
+function TemplateCard({title, widgetCount}: Props) {
+  return (
+    <StyledCard>
+      <Header>
+        <IconGeneric size="48" />
+        <CardText>
+          <Title>{title}</Title>
+          <Detail>{widgetCount} Starter Widgets</Detail>
+        </CardText>
+      </Header>
+      <ButtonContainer>
+        <StyledButton priority="default">Preview</StyledButton>
+        <StyledButton priority="primary" icon={<IconAdd size="xs" isCircled />}>
+          Add Dash
+        </StyledButton>
+      </ButtonContainer>
+    </StyledCard>
+  );
+}
+
+const StyledCard = styled(Card)`
+  padding: ${space(2)};
+  display: inline;
+`;
+
+const Title = styled('div')`
+  color: ${p => p.theme.textColor};
+  ${overflowEllipsis};
+`;
+
+const Detail = styled('div')`
+  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.gray300};
+  ${overflowEllipsis};
+  line-height: 1.5;
+`;
+
+const Header = styled('div')`
+  display: flex;
+  padding-bottom: ${space(2)};
+`;
+
+const CardText = styled('div')`
+  padding-left: ${space(2)};
+`;
+
+const ButtonContainer = styled('div')`
+  display: flex;
+  width: 100%;
+`;
+
+const StyledButton = styled(Button)`
+  display: block;
+  margin: 0 auto;
+  width: 100%;
+`;
+
+export default TemplateCard;

--- a/static/app/views/dashboardsV2/manage/templateCard.tsx
+++ b/static/app/views/dashboardsV2/manage/templateCard.tsx
@@ -21,7 +21,7 @@ function TemplateCard({title, widgetCount}: Props) {
         <CardText>
           <Title>{title}</Title>
           <Detail>
-            {widgetCount} {t('Starter Widgets')}
+            {t('%s Starter Widgets', widgetCount)}
           </Detail>
         </CardText>
       </Header>

--- a/static/app/views/dashboardsV2/manage/templateCard.tsx
+++ b/static/app/views/dashboardsV2/manage/templateCard.tsx
@@ -64,20 +64,17 @@ const CardText = styled('div')`
 
 const ButtonContainer = styled('div')`
   display: flex;
-  width: 100%;
 `;
 
 const StyledButton = styled(Button)<{priority: string}>`
   display: block;
-  margin: 0 auto;
-  width: 100%;
+  width: auto;
   ${overflowEllipsis};
 
   ${p =>
     p.priority === 'default' &&
-    `width: auto;
-    margin-right: ${space(2)};
-    padding: 0 ${space(2)};`};
+    `width: 50%;
+    margin-right: ${space(2)};`};
 `;
 
 export default TemplateCard;

--- a/static/app/views/dashboardsV2/manage/templateCard.tsx
+++ b/static/app/views/dashboardsV2/manage/templateCard.tsx
@@ -20,9 +20,7 @@ function TemplateCard({title, widgetCount}: Props) {
         <IconGeneric size="48" />
         <CardText>
           <Title>{title}</Title>
-          <Detail>
-            {t('%s Starter Widgets', widgetCount)}
-          </Detail>
+          <Detail>{t('%s Starter Widgets', widgetCount)}</Detail>
         </CardText>
       </Header>
       <ButtonContainer>

--- a/static/app/views/dashboardsV2/manage/templateCard.tsx
+++ b/static/app/views/dashboardsV2/manage/templateCard.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import Button from 'sentry/components/button';
 import Card from 'sentry/components/card';
 import {IconAdd, IconGeneric} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
 
@@ -19,13 +20,15 @@ function TemplateCard({title, widgetCount}: Props) {
         <IconGeneric size="48" />
         <CardText>
           <Title>{title}</Title>
-          <Detail>{widgetCount} Starter Widgets</Detail>
+          <Detail>
+            {widgetCount} {t('Starter Widgets')}
+          </Detail>
         </CardText>
       </Header>
       <ButtonContainer>
-        <StyledButton priority="default">Preview</StyledButton>
+        <StyledButton priority="default">{t('Preview')}</StyledButton>
         <StyledButton priority="primary" icon={<IconAdd size="xs" isCircled />}>
-          Add Dash
+          {t('Add Dashboard')}
         </StyledButton>
       </ButtonContainer>
     </StyledCard>
@@ -64,10 +67,17 @@ const ButtonContainer = styled('div')`
   width: 100%;
 `;
 
-const StyledButton = styled(Button)`
+const StyledButton = styled(Button)<{priority: string}>`
   display: block;
   margin: 0 auto;
   width: 100%;
+  ${overflowEllipsis};
+
+  ${p =>
+    p.priority === 'default' &&
+    `width: auto;
+    margin-right: ${space(2)};
+    padding: 0 ${space(2)};`};
 `;
 
 export default TemplateCard;

--- a/static/app/views/dashboardsV2/manage/utils.tsx
+++ b/static/app/views/dashboardsV2/manage/utils.tsx
@@ -1,0 +1,9 @@
+const SHOW_TEMPLATES_KEY = 'dashboards-show-templates';
+
+export function shouldShowTemplates(): boolean {
+  const shouldShow = localStorage.getItem(SHOW_TEMPLATES_KEY);
+  return shouldShow === 'true' || shouldShow === null;
+}
+export function setShowTemplates(value: boolean) {
+  localStorage.setItem(SHOW_TEMPLATES_KEY, value ? 'true' : 'false');
+}


### PR DESCRIPTION
- Not yet functional, first piece of adding the ability to create dashboards from templates.
- Everything behind a new feature flag (Will add in follow up PR)

# Preview: 
<img src="https://user-images.githubusercontent.com/4205004/146214995-e0e82ef2-13c7-4da0-a9ea-c1f83de20580.png">
<img src="https://user-images.githubusercontent.com/4205004/146214884-d5f99b86-33d2-4cc8-851b-f3b85dfe2dc1.png">
