### PR TITLE
fix(teams): Keep hasMore consistent with TeamStore state

### DIFF
--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -344,7 +344,7 @@ function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
     fetching: state.fetching || store.loading,
     initiallyLoaded: state.initiallyLoaded,
     fetchError: state.fetchError,
-    hasMore: state.hasMore,
+    hasMore: state.hasMore ?? store.hasMore,
     onSearch: handleSearch,
     loadMore: handleFetchAdditionalTeams,
   };

--- a/tests/js/spec/utils/useTeams.spec.tsx
+++ b/tests/js/spec/utils/useTeams.spec.tsx
@@ -137,4 +137,18 @@ describe('useTeams', function () {
     expect(initiallyLoaded).toBe(true);
     expect(teams).toEqual(expect.arrayContaining(mockTeams));
   });
+
+  it('correctly returns hasMore before and after store update', async function () {
+    TeamStore.reset();
+    const {result, waitFor} = renderHook(() => useTeams());
+
+    const {teams, hasMore} = result.current;
+    expect(hasMore).toBe(null);
+    expect(teams).toEqual(expect.arrayContaining([]));
+
+    act(() => TeamStore.loadInitialData(mockTeams, false, null));
+    await waitFor(() => expect(result.current.teams.length).toBe(1));
+
+    expect(result.current.hasMore).toBe(false);
+  });
 });


### PR DESCRIPTION
After merging https://github.com/getsentry/sentry/pull/30395 I noticed there was a race condition that can occur on the organization teams settings page where the 'Show more' button would not show due to the follow conditions happening

1. User does a fresh pageload transaction on the organization teams setting page
2. Page renders while teams/projects are being loaded
3. useTeams hook is initialized with the current state of the TeamStore which has `hasMore` set to `null`
4. Teams/Projects are loaded causing the TeamStore to set `hasMore` to `true` if there are more than 100 teams
5. useTeams hook does not use this new data or consume the update from the store so the 'Show more' button is not shown.