### PR TITLE
feat(metrics): Add transaction.duration to project config [INGEST-680]

### DIFF
--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -382,6 +382,7 @@ def get_transaction_metrics_settings(
     custom_tags = []
 
     if features.has("organizations:transaction-metrics-extraction", project.organization):
+        metrics.append("sentry.transactions.transaction.duration")
         # TODO: for now let's extract all known measurements. we might want to
         # be more fine-grained in the future once we know which measurements we
         # really need (or how that can be dynamically determined)

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/with_metrics.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-12-09T11:50:35.599561Z'
+created: '2021-12-15T15:04:19.291385Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -14,6 +14,7 @@ breakdownsV2:
 transactionMetrics:
   extractCustomTags: []
   extractMetrics:
+  - sentry.transactions.transaction.duration
   - sentry.transactions.measurements.app_start_cold
   - sentry.transactions.measurements.app_start_warm
   - sentry.transactions.measurements.cls


### PR DESCRIPTION
Relay is now able to extract `transaction.duration` as metric. Add this metric to the allow list in project config.

See also https://github.com/getsentry/relay/pull/1148.