### PR TITLE
build(js): Bump jest-sentry-environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "jest-circus": "27.0.6",
     "jest-fetch-mock": "^3.0.3",
     "jest-junit": "^9.0.0",
-    "jest-sentry-environment": "1.1.4",
+    "jest-sentry-environment": "1.2.0",
     "prettier": "2.3.2",
     "react-refresh": "^0.8.3",
     "react-select-event": "5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9514,10 +9514,10 @@ jest-runtime@^27.0.6:
     strip-bom "^4.0.0"
     yargs "^16.0.3"
 
-jest-sentry-environment@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/jest-sentry-environment/-/jest-sentry-environment-1.1.4.tgz#72fa4c60562b12ee6747b37e156cd0c4358961ff"
-  integrity sha512-buk7le+9LoiL94iFmMlxa++gGYpmM/qczefZiWlFTL+77uqvgYQgWV9FR4V1DyB7lJKpBfJlmVfz6k8KMmY6RQ==
+jest-sentry-environment@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/jest-sentry-environment/-/jest-sentry-environment-1.2.0.tgz#ccc0537cbf48e788b08eabb859ed2bf26a911fea"
+  integrity sha512-QeZ7FHpBJHMZngaiqHoFL3ddbEuZXzgAcc0auRBBkKk/4MLIcI/3wxLLx4w8pKVnmrvTBmmctZlkvuBxurjObA==
 
 jest-serializer@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
### Summary
Gives us access to the outer transaction being run.