### PR TITLE
fix(chartcuterie): Import default from worldMap geoJson

### DIFF
--- a/static/app/chartcuterie/config.tsx
+++ b/static/app/chartcuterie/config.tsx
@@ -8,7 +8,8 @@
  * into the configuration file loaded by the service.
  */
 
-import * as worldMap from 'sentry/data/world.json';
+// eslint-disable-next-line import/no-named-default
+import {default as worldMap} from 'sentry/data/world.json';
 
 import {discoverCharts} from './discover';
 import {ChartcuterieConfig, ChartType, RenderConfig, RenderDescriptor} from './types';


### PR DESCRIPTION
Before this change, upgrading chartcuterie to
echarts v5 would result in the following error:

```
info: Server listening for render requests on port 7901
Error: Invalid geoJson format
Cannot set property UTF8Encoding of [object Module] which has only a getter
    at GeoJSONResource._parseToRegions (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:29300:17)
    at GeoJSONResource.load (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:29265:33)
    at Object.load (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:29433:25)
    at MapSeries.getInitialData (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:52007:42)
    at MapSeries.SeriesModel.init (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:23835:25)
    at GlobalModel.<anonymous> (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:18387:32)
    at Array.forEach (<anonymous>)
    at each (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:368:17)
    at GlobalModel.visitComponent (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:18330:11)
    at Function.entity.topologicalTravel (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:15913:22)
info: [requestId:6072bfe8df8046a28ed6e810401348dd] rendered in 243ms {"requestId":"6072bfe8df8046a28ed6e810401348dd","status":500,"time":243}
Error: Invalid geoJson format
coordinate.charCodeAt is not a function
    at GeoJSONResource._parseToRegions (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:29300:17)
    at GeoJSONResource.load (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:29265:33)
    at Object.load (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:29433:25)
    at MapSeries.getInitialData (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:52007:42)
    at MapSeries.SeriesModel.init (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:23835:25)
    at GlobalModel.<anonymous> (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:18387:32)
    at Array.forEach (<anonymous>)
    at each (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:368:17)
    at GlobalModel.visitComponent (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:18330:11)
    at Function.entity.topologicalTravel (/Users/shruthilayajaganathan/code/chartcuterie/node_modules/echarts/dist/echarts.js:15913:22)
info: [requestId:42e5a7a2c8c044469a1d63e7360209ed] rendered in 4ms {"requestId":"42e5a7a2c8c044469a1d63e7360209ed","status":500,"time":4}
```

This change fixes it.

Corresponding echarts v5 update on chartcuterie: https://github.com/getsentry/chartcuterie/pull/75