### PR TITLE
feat(doc integrations): Add DocIntegrationDetails endpoint

### DIFF
--- a/src/sentry/api/bases/doc_integrations.py
+++ b/src/sentry/api/bases/doc_integrations.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from rest_framework.request import Request
 
 from sentry.api.base import Endpoint
@@ -5,7 +6,9 @@ from sentry.api.bases.integration import PARANOID_GET
 from sentry.api.permissions import SentryPermission
 from sentry.api.validators.doc_integration import METADATA_PROPERTIES
 from sentry.auth.superuser import is_active_superuser
+from sentry.models.integration import DocIntegration
 from sentry.utils.json import JSONData
+from sentry.utils.sdk import configure_scope
 
 
 class DocIntegrationsPermission(SentryPermission):
@@ -20,9 +23,39 @@ class DocIntegrationsPermission(SentryPermission):
 
         return False
 
+    def has_object_permission(
+        self, request: Request, view: Endpoint, doc_integration: DocIntegration
+    ):
+        if not hasattr(request, "user") or not request.user:
+            return False
+
+        if is_active_superuser(request):
+            return True
+
+        if not doc_integration.is_draft and request.method == "GET":
+            return True
+
+        return False
+
 
 class DocIntegrationsBaseEndpoint(Endpoint):
     permission_classes = (DocIntegrationsPermission,)
 
     def generate_incoming_metadata(self, request: Request) -> JSONData:
         return {k: v for k, v in request.json_body.items() if k in METADATA_PROPERTIES}
+
+
+class DocIntegrationBaseEndpoint(DocIntegrationsBaseEndpoint):
+    def convert_args(self, request: Request, doc_integration_slug: str, *args, **kwargs):
+        try:
+            doc_integration = DocIntegration.objects.get(slug=doc_integration_slug)
+        except DocIntegration.DoesNotExist:
+            raise Http404
+
+        self.check_object_permissions(request, doc_integration)
+
+        with configure_scope() as scope:
+            scope.set_tag("doc_integration", doc_integration.slug)
+
+        kwargs["doc_integration"] = doc_integration
+        return (args, kwargs)

--- a/src/sentry/api/endpoints/doc_integration_details.py
+++ b/src/sentry/api/endpoints/doc_integration_details.py
@@ -1,0 +1,33 @@
+import logging
+
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.bases.doc_integrations import DocIntegrationBaseEndpoint
+from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework import DocIntegrationSerializer
+from sentry.models.integration import DocIntegration
+
+logger = logging.getLogger(__name__)
+
+
+class DocIntegrationDetailsEndpoint(DocIntegrationBaseEndpoint):
+    def get(self, request: Request, doc_integration: DocIntegration) -> Response:
+        return self.respond(serialize(doc_integration, request.user), status=status.HTTP_200_OK)
+
+    def put(self, request: Request, doc_integration: DocIntegration) -> Response:
+        data = request.json_body
+        data["metadata"] = self.generate_incoming_metadata(request)
+
+        serializer = DocIntegrationSerializer(doc_integration, data=data)
+        if serializer.is_valid():
+            doc_integration = serializer.save()
+            return Response(
+                serialize(doc_integration, request.user),
+                status=status.HTTP_200_OK,
+            )
+        return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request: Request, doc_integration: DocIntegration) -> Response:
+        return self.respond(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/doc_integration_details.py
+++ b/src/sentry/api/endpoints/doc_integration_details.py
@@ -8,6 +8,7 @@ from sentry.api.bases.doc_integrations import DocIntegrationBaseEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import DocIntegrationSerializer
 from sentry.models.integration import DocIntegration
+from sentry.models.integrationfeature import IntegrationFeature, IntegrationTypes
 
 logger = logging.getLogger(__name__)
 
@@ -30,4 +31,8 @@ class DocIntegrationDetailsEndpoint(DocIntegrationBaseEndpoint):
         return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request: Request, doc_integration: DocIntegration) -> Response:
+        IntegrationFeature.objects.filter(
+            target_id=doc_integration.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        ).delete()
+        doc_integration.delete()
         return self.respond(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/doc_integrations.py
+++ b/src/sentry/api/endpoints/doc_integrations.py
@@ -37,7 +37,7 @@ class DocIntegrationsEndpoint(DocIntegrationsBaseEndpoint):
         if serializer.is_valid():
             doc_integration = serializer.save()
             return Response(
-                serialize(doc_integration, request.user, access=request.access),
+                serialize(doc_integration, request.user),
                 status=status.HTTP_201_CREATED,
             )
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/serializers/rest_framework/doc_integration.py
+++ b/src/sentry/api/serializers/rest_framework/doc_integration.py
@@ -49,9 +49,11 @@ class DocIntegrationSerializer(Serializer):
             raise ValidationError(
                 f"Generated slug '{slug}' is too long, please use a shorter name."
             )
-        queryset = DocIntegration.objects.filter(slug=slug)
-        if queryset.exists():
-            raise ValidationError(f"Name '{value}' is already taken, please use another.")
+        # Only check this for validating creation, not updates
+        if self.instance is None:
+            queryset = DocIntegration.objects.filter(slug=slug)
+            if queryset.exists():
+                raise ValidationError(f"Name '{value}' is already taken, please use another.")
         return value
 
     def create(self, validated_data: MutableMapping[str, Any]) -> DocIntegration:
@@ -92,3 +94,4 @@ class DocIntegrationSerializer(Serializer):
         for key, value in validated_data.items():
             setattr(doc_integration, key, value)
         doc_integration.save()
+        return doc_integration

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -79,6 +79,7 @@ from .endpoints.debug_files import (
     SourceMapsEndpoint,
     UnknownDebugFilesEndpoint,
 )
+from .endpoints.doc_integration_details import DocIntegrationDetailsEndpoint
 from .endpoints.doc_integrations import DocIntegrationsEndpoint
 from .endpoints.event_apple_crash_report import EventAppleCrashReportEndpoint
 from .endpoints.event_attachment_details import EventAttachmentDetailsEndpoint
@@ -2116,6 +2117,11 @@ urlpatterns = [
         r"^doc-integrations/$",
         DocIntegrationsEndpoint.as_view(),
         name="sentry-api-0-doc-integrations",
+    ),
+    url(
+        r"^doc-integrations/(?P<doc_integration_slug>[^\/]+)/$",
+        DocIntegrationDetailsEndpoint.as_view(),
+        name="sentry-api-0-doc-integration-details",
     ),
     # Grouping configs
     url(

--- a/tests/sentry/api/endpoints/test_doc_integration_details.py
+++ b/tests/sentry/api/endpoints/test_doc_integration_details.py
@@ -1,0 +1,201 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from sentry.api.serializers.base import serialize
+from sentry.models.integration import DocIntegration
+from sentry.models.integrationfeature import IntegrationFeature, IntegrationTypes
+from sentry.testutils import APITestCase
+
+
+class DocIntegrationDetailsTest(APITestCase):
+    def url(self, doc_integration: DocIntegration):
+        return reverse("sentry-api-0-doc-integration-details", args=[doc_integration.slug])
+
+    def setUp(self):
+        self.user = self.create_user(email="jinx@lol.com")
+        self.superuser = self.create_user(email="vi@lol.com", is_superuser=True)
+        self.doc_1 = self.create_doc_integration(name="test_1", is_draft=False)
+        self.doc_2 = self.create_doc_integration(name="test_2", is_draft=True)
+        self.doc_3 = self.create_doc_integration(
+            name="test_3",
+            is_draft=False,
+            metadata={"resources": [{"title": "Documentation", "url": "https://docs.sentry.io/"}]},
+            features=[2, 3, 4],
+        )
+        self.doc_delete = self.create_doc_integration(
+            name="test_4", is_draft=True, features=[1, 2, 3, 4, 5, 6, 7]
+        )
+
+
+class GetDocIntegrationDetailsTest(DocIntegrationDetailsTest):
+    def test_read_doc_for_superuser(self):
+        """
+        Tests that any DocIntegration is visible (with all the expected data)
+        for those with superuser permissions
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        # Non-draft DocIntegration, with features
+        response = self.client.get(self.url(self.doc_3), format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert serialize(self.doc_3) == response.data
+        features = IntegrationFeature.objects.filter(
+            target_id=self.doc_3.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        )
+        for feature in features:
+            assert serialize(feature) in serialize(self.doc_3)["features"]
+        # Draft DocIntegration, without features
+        response = self.client.get(self.url(self.doc_2), format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert serialize(self.doc_2) == response.data
+
+    def test_read_doc_for_public(self):
+        """
+        Tests that only non-draft DocIntegrations (with all the expected data)
+        are visible for those without superuser permissions
+        """
+        self.login_as(user=self.user)
+        # Non-draft DocIntegration, with features
+        response = self.client.get(self.url(self.doc_3), format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert serialize(self.doc_3) == response.data
+        features = IntegrationFeature.objects.filter(
+            target_id=self.doc_3.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        )
+        for feature in features:
+            assert serialize(feature) in serialize(self.doc_3)["features"]
+        # Draft DocIntegration, without features
+        response = self.client.get(self.url(self.doc_2), format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+class PostDocIntegrationDetailsTest(DocIntegrationDetailsTest):
+    payload = {
+        "name": "Enemy",
+        "author": "Imagine Dragons",
+        "description": "An opening theme song 👀",
+        "url": "https://github.com/getsentry/sentry/",
+        "popularity": 5,
+        "resources": [{"title": "Docs", "url": "https://github.com/getsentry/sentry/"}],
+        "features": [1, 2, 3],
+    }
+    ignored_keys = ["is_draft", "metadata"]
+
+    @pytest.mark.skip
+    def test_create_doc_for_superuser(self):
+        """
+        Tests that a draft DocIntegration is created for superuser requests along
+        with all the appropriate IntegrationFeatures
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.client.post(self.url, self.payload, format="json")
+        doc = DocIntegration.objects.get(name=self.payload["name"], author=self.payload["author"])
+        assert response.status_code == status.HTTP_201_CREATED
+        assert serialize(doc) == response.data
+        assert doc.is_draft
+        features = IntegrationFeature.objects.filter(
+            target_id=doc.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        )
+        assert features.exists()
+        assert len(features) == 3
+        for feature in features:
+            assert serialize(feature) in response.data["features"]
+
+    @pytest.mark.skip
+    def test_create_invalid_auth(self):
+        """
+        Tests that the POST endpoint is only accessible for superusers
+        """
+        self.login_as(user=self.user)
+        response = self.client.post(self.url, self.payload, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.skip
+    def test_create_repeated_slug(self):
+        """
+        Tests that repeated names throw errors when generating slugs
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        payload = {**self.payload, "name": self.doc_1.name}
+        response = self.client.post(self.url, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "name" in response.data.keys()
+
+    @pytest.mark.skip
+    def test_create_invalid_metadata(self):
+        """
+        Tests that incorrectly structured metadata throws an error
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        invalid_resources = {
+            "not_an_array": {},
+            "extra_keys": [{**self.payload["resources"][0], "extra": "key"}],
+            "missing_keys": [{"title": "Missing URL field"}],
+        }
+        for resources in invalid_resources.values():
+            response = self.client.post(
+                self.url, {**self.payload, "resources": resources}, format="json"
+            )
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
+            assert "metadata" in response.data.keys()
+
+    @pytest.mark.skip
+    def test_create_empty_metadata(self):
+        """
+        Tests that sending no metadata keys does not trigger errors
+        and resolves to an appropriate default
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        payload = {**self.payload}
+        del payload["resources"]
+        response = self.client.post(self.url, payload, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        assert "resources" in response.data.keys()
+        assert len(response.data["resources"]) == 0
+
+    @pytest.mark.skip
+    def test_create_ignore_keys(self):
+        """
+        Test that certain reserved keys cannot be overridden by the
+        request payload. They must be created by the API.
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        payload = {**self.payload, "is_draft": False, "metadata": {"should": "not override"}}
+        response = self.client.post(self.url, payload, format="json")
+        doc = DocIntegration.objects.get(name=self.payload["name"], author=self.payload["author"])
+        assert response.status_code == status.HTTP_201_CREATED
+        for key in self.ignored_keys:
+            assert key not in response.data.keys()
+            assert getattr(doc, key) is not payload[key]
+
+
+class DeleteDocIntegrationDetailsTest(DocIntegrationDetailsTest):
+    def test_delete_invalid_for_public(self):
+        """
+        Tests that the delete method is not accessible by those with regular member
+        permissions, and no changes occur in the database.
+        """
+        self.login_as(user=self.user)
+        response = self.client.delete(self.url(self.doc_delete))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert DocIntegration.objects.get(id=self.doc_delete.id)
+        features = IntegrationFeature.objects.filter(
+            target_id=self.doc_delete.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        )
+        assert features.exists()
+        assert len(features) == 7
+
+    def test_delete_valid_for_superuser(self):
+        """
+        Tests that the delete method works for those with superuser
+        permissions, deleting the DocIntegration and associated IntegrationFeatures
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.client.delete(self.url(self.doc_delete))
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        with self.assertRaises(DocIntegration.DoesNotExist):
+            DocIntegration.objects.get(id=self.doc_delete.id)
+        features = IntegrationFeature.objects.filter(
+            target_id=self.doc_delete.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        )
+        assert not features.exists()

--- a/tests/sentry/api/endpoints/test_doc_integration_details.py
+++ b/tests/sentry/api/endpoints/test_doc_integration_details.py
@@ -1,4 +1,3 @@
-import pytest
 from rest_framework import status
 
 from sentry.api.serializers.base import serialize
@@ -13,16 +12,15 @@ class DocIntegrationDetailsTest(APITestCase):
     def setUp(self):
         self.user = self.create_user(email="jinx@lol.com")
         self.superuser = self.create_user(email="vi@lol.com", is_superuser=True)
-        self.doc_1 = self.create_doc_integration(name="test_1", is_draft=False)
-        self.doc_2 = self.create_doc_integration(name="test_2", is_draft=True)
-        self.doc_3 = self.create_doc_integration(
-            name="test_3",
+        self.doc_1 = self.create_doc_integration(name="test_1", is_draft=True)
+        self.doc_2 = self.create_doc_integration(
+            name="test_2",
             is_draft=False,
             metadata={"resources": [{"title": "Documentation", "url": "https://docs.sentry.io/"}]},
             features=[2, 3, 4],
         )
         self.doc_delete = self.create_doc_integration(
-            name="test_4", is_draft=True, features=[1, 2, 3, 4, 5, 6, 7]
+            name="test_3", is_draft=True, features=[1, 2, 3, 4, 5, 6, 7]
         )
 
 
@@ -36,16 +34,16 @@ class GetDocIntegrationDetailsTest(DocIntegrationDetailsTest):
         """
         self.login_as(user=self.superuser, superuser=True)
         # Non-draft DocIntegration, with features
-        response = self.get_success_response(self.doc_3.slug, status_code=status.HTTP_200_OK)
-        assert serialize(self.doc_3) == response.data
-        features = IntegrationFeature.objects.filter(
-            target_id=self.doc_3.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
-        )
-        for feature in features:
-            assert serialize(feature) in serialize(self.doc_3)["features"]
-        # Draft DocIntegration, without features
         response = self.get_success_response(self.doc_2.slug, status_code=status.HTTP_200_OK)
         assert serialize(self.doc_2) == response.data
+        features = IntegrationFeature.objects.filter(
+            target_id=self.doc_2.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        )
+        for feature in features:
+            assert serialize(feature) in serialize(self.doc_2)["features"]
+        # Draft DocIntegration, without features
+        response = self.get_success_response(self.doc_1.slug, status_code=status.HTTP_200_OK)
+        assert serialize(self.doc_1) == response.data
 
     def test_read_doc_for_public(self):
         """
@@ -54,15 +52,15 @@ class GetDocIntegrationDetailsTest(DocIntegrationDetailsTest):
         """
         self.login_as(user=self.user)
         # Non-draft DocIntegration, with features
-        response = self.get_success_response(self.doc_3.slug, status_code=status.HTTP_200_OK)
-        assert serialize(self.doc_3) == response.data
+        response = self.get_success_response(self.doc_2.slug, status_code=status.HTTP_200_OK)
+        assert serialize(self.doc_2) == response.data
         features = IntegrationFeature.objects.filter(
-            target_id=self.doc_3.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+            target_id=self.doc_2.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
         )
         for feature in features:
-            assert serialize(feature) in serialize(self.doc_3)["features"]
+            assert serialize(feature) in serialize(self.doc_2)["features"]
         # Draft DocIntegration, without features
-        self.get_error_response(self.doc_2.slug, status_code=status.HTTP_403_FORBIDDEN)
+        self.get_error_response(self.doc_1.slug, status_code=status.HTTP_403_FORBIDDEN)
 
 
 class PutDocIntegrationDetailsTest(DocIntegrationDetailsTest):
@@ -74,75 +72,95 @@ class PutDocIntegrationDetailsTest(DocIntegrationDetailsTest):
         "url": "https://github.com/getsentry/sentry/",
         "popularity": 5,
         "resources": [{"title": "Docs", "url": "https://github.com/getsentry/sentry/"}],
-        "features": [1, 2, 3],
+        "features": [4, 5, 6],
+        "is_draft": False,
     }
+    ignored_keys = ["metadata"]
 
     def test_update_doc_for_superuser(self):
-        pass
-
-    def test_update_invalid_auth(self):
-        pass
-
-    def test_update_removes_unused_features(self):
-        pass
-
-    def test_update_retains_carryover_features(self):
-        pass
-
-    def test_update_does_not_change_slug(self):
-        pass
-
-    def test_update_invalid_metadata(self):
-        pass
-
-    def test_update_empty_metadata(self):
-        pass
-
-    def test_update_ignore_keys(self):
-        pass
-
-    @pytest.mark.skip
-    def test_create_doc_for_superuser(self):
         """
-        Tests that a draft DocIntegration is created for superuser requests along
-        with all the appropriate IntegrationFeatures
+        Tests that a DocIntegration can be updated by superuser requests
         """
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.post(self.url, self.payload, format="json")
-        doc = DocIntegration.objects.get(name=self.payload["name"], author=self.payload["author"])
-        assert response.status_code == status.HTTP_201_CREATED
-        assert serialize(doc) == response.data
-        assert doc.is_draft
+        response = self.get_success_response(
+            self.doc_1.slug, status_code=status.HTTP_200_OK, **self.payload
+        )
+        self.doc_1.refresh_from_db()
+        assert serialize(self.doc_1) == response.data
         features = IntegrationFeature.objects.filter(
-            target_id=doc.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+            target_id=self.doc_1.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
         )
         assert features.exists()
         assert len(features) == 3
         for feature in features:
+            # Ensure payload features are in the database
+            assert feature.feature in self.payload["features"]
+            # Ensure they are also serialized in the response
             assert serialize(feature) in response.data["features"]
 
-    @pytest.mark.skip
-    def test_create_invalid_auth(self):
+    def test_update_invalid_auth(self):
         """
-        Tests that the POST endpoint is only accessible for superusers
+        Tests that non-superuser PUT requests to the endpoint are ignored and
+        have no side-effects on the database records
         """
         self.login_as(user=self.user)
-        response = self.client.post(self.url, self.payload, format="json")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        self.get_error_response(
+            self.doc_1.slug, status_code=status.HTTP_403_FORBIDDEN, **self.payload
+        )
 
-    @pytest.mark.skip
-    def test_create_repeated_slug(self):
+    def test_update_removes_unused_features(self):
         """
-        Tests that repeated names throw errors when generating slugs
+        Tests that DocIntegration updates remove any unused and no longer
+        necessary features from the database
         """
         self.login_as(user=self.superuser, superuser=True)
-        payload = {**self.payload, "name": self.doc_1.name}
-        response = self.client.post(self.url, payload, format="json")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "name" in response.data.keys()
+        self.get_success_response(self.doc_2.slug, status_code=status.HTTP_200_OK, **self.payload)
+        unused_features = IntegrationFeature.objects.filter(
+            target_id=self.doc_2.id,
+            target_type=IntegrationTypes.DOC_INTEGRATION.value,
+        ).exclude(feature__in=self.payload["features"])
+        assert not unused_features.exists()
 
-    @pytest.mark.skip
-    def test_create_invalid_metadata(self):
+    def test_update_retains_carryover_features(self):
+        """
+        Tests that DocIntegration updates retain any existing features if
+        applicable to avoid pointless database transactions
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        unaffected_feature = IntegrationFeature.objects.get(
+            target_id=self.doc_2.id, target_type=IntegrationTypes.DOC_INTEGRATION.value, feature=4
+        )
+        initial_date_added = unaffected_feature.date_added
+        self.get_success_response(self.doc_2.slug, status_code=status.HTTP_200_OK, **self.payload)
+        unaffected_feature.refresh_from_db()
+        assert initial_date_added == unaffected_feature.date_added
+
+    def test_update_duplicate_features(self):
+        """
+        Tests that providing duplicate keys do not result in a server
+        error; instead, the excess are ignored.
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        payload = {**self.payload, "features": [0, 0, 0, 0, 1, 1, 1, 2]}
+        self.get_success_response(self.doc_1.slug, status_code=status.HTTP_200_OK, **payload)
+        features = IntegrationFeature.objects.filter(
+            target_id=self.doc_1.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        )
+        assert features.exists()
+        assert len(features) == 3
+
+    def test_update_does_not_change_slug(self):
+        """
+        Tests that a name alteration is permitted and does not have an
+        effect on the slug of the DocIntegration
+        """
+        previous_slug = self.doc_1.slug
+        self.login_as(user=self.superuser, superuser=True)
+        self.get_success_response(self.doc_1.slug, status_code=status.HTTP_200_OK, **self.payload)
+        self.doc_1.refresh_from_db()
+        assert self.doc_1.slug == previous_slug
+
+    def test_update_invalid_metadata(self):
         """
         Tests that incorrectly structured metadata throws an error
         """
@@ -153,58 +171,43 @@ class PutDocIntegrationDetailsTest(DocIntegrationDetailsTest):
             "missing_keys": [{"title": "Missing URL field"}],
         }
         for resources in invalid_resources.values():
-            response = self.client.post(
-                self.url, {**self.payload, "resources": resources}, format="json"
+            payload = {**self.payload, "resources": resources}
+            response = self.get_error_response(
+                self.doc_1.slug, status_code=status.HTTP_400_BAD_REQUEST, **payload
             )
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
             assert "metadata" in response.data.keys()
 
-    @pytest.mark.skip
-    def test_create_empty_metadata(self):
+    def test_update_empty_metadata(self):
         """
-        Tests that sending no metadata keys does not trigger errors
-        and resolves to an appropriate default
+        Tests that sending no metadata keys should erase any existing
+        metadata contained on the record
         """
+        previous_metadata = self.doc_2.metadata
         self.login_as(user=self.superuser, superuser=True)
         payload = {**self.payload}
         del payload["resources"]
-        response = self.client.post(self.url, payload, format="json")
-        assert response.status_code == status.HTTP_201_CREATED
-        assert "resources" in response.data.keys()
-        assert len(response.data["resources"]) == 0
+        response = self.get_success_response(
+            self.doc_2.slug, status_code=status.HTTP_200_OK, **payload
+        )
+        assert "resources" not in response.data.keys()
+        self.doc_2.refresh_from_db()
+        assert self.doc_2.metadata != previous_metadata
 
-    @pytest.mark.skip
-    def test_create_ignore_keys(self):
+    def test_update_ignore_keys(self):
         """
         Test that certain reserved keys cannot be overridden by the
         request payload. They must be created by the API.
         """
         self.login_as(user=self.superuser, superuser=True)
-        payload = {**self.payload, "is_draft": False, "metadata": {"should": "not override"}}
-        response = self.client.post(self.url, payload, format="json")
-        doc = DocIntegration.objects.get(name=self.payload["name"], author=self.payload["author"])
-        assert response.status_code == status.HTTP_201_CREATED
+        payload = {**self.payload, "metadata": {"should": "not override"}}
+        self.get_success_response(self.doc_1.slug, status_code=status.HTTP_200_OK, **payload)
+        # Ensure the DocIntegration was not created with the ignored keys' values
         for key in self.ignored_keys:
-            assert key not in response.data.keys()
-            assert getattr(doc, key) is not payload[key]
+            assert getattr(self.doc_1, key) is not payload[key]
 
 
 class DeleteDocIntegrationDetailsTest(DocIntegrationDetailsTest):
     method = "DELETE"
-
-    def test_delete_invalid_for_public(self):
-        """
-        Tests that the delete method is not accessible by those with regular member
-        permissions, and no changes occur in the database.
-        """
-        self.login_as(user=self.user)
-        self.get_error_response(self.doc_delete.slug, status_code=status.HTTP_403_FORBIDDEN)
-        assert DocIntegration.objects.get(id=self.doc_delete.id)
-        features = IntegrationFeature.objects.filter(
-            target_id=self.doc_delete.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
-        )
-        assert features.exists()
-        assert len(features) == 7
 
     def test_delete_valid_for_superuser(self):
         """
@@ -219,3 +222,17 @@ class DeleteDocIntegrationDetailsTest(DocIntegrationDetailsTest):
             target_id=self.doc_delete.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
         )
         assert not features.exists()
+
+    def test_delete_invalid_for_public(self):
+        """
+        Tests that the delete method is not accessible by those with regular member
+        permissions, and no changes occur in the database.
+        """
+        self.login_as(user=self.user)
+        self.get_error_response(self.doc_delete.slug, status_code=status.HTTP_403_FORBIDDEN)
+        assert DocIntegration.objects.get(id=self.doc_delete.id)
+        features = IntegrationFeature.objects.filter(
+            target_id=self.doc_delete.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        )
+        assert features.exists()
+        assert len(features) == 7

--- a/tests/sentry/api/endpoints/test_doc_integrations.py
+++ b/tests/sentry/api/endpoints/test_doc_integrations.py
@@ -89,6 +89,9 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         assert features.exists()
         assert len(features) == 3
         for feature in features:
+            # Ensure payload features are in the database
+            assert feature.feature in self.payload["features"]
+            # Ensure they are also serialized in the response
             assert serialize(feature) in response.data["features"]
 
     def test_create_invalid_auth(self):


### PR DESCRIPTION
See [API-2319](https://getsentry.atlassian.net/browse/API-2319)

This PR adds the details endpoint for DocIntegrations. It lends a lot of the logic from the existing endpoints with a few changes for security when accessing individual DocIntegrations and a few small changes to the tests.

