### PR TITLE
feat(gsh): Standalone project selector

### DIFF
--- a/static/app/components/organizations/multipleProjectSelector.tsx
+++ b/static/app/components/organizations/multipleProjectSelector.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import Button from 'sentry/components/button';
+import {GetActorPropsFn} from 'sentry/components/dropdownMenu';
 import Link from 'sentry/components/links/link';
 import HeaderItem from 'sentry/components/organizations/headerItem';
 import PlatformList from 'sentry/components/platformList';
@@ -35,6 +36,11 @@ type Props = WithRouterProps & {
   showProjectSettingsLink?: boolean;
   lockedMessageSubject?: React.ReactNode;
   footerMessage?: React.ReactNode;
+  customDropdownButton?: (config: {
+    getActorProps: GetActorPropsFn;
+    selectedProjects: Project[];
+    isOpen: boolean;
+  }) => React.ReactElement;
 };
 
 type State = {
@@ -195,6 +201,7 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
       forceProject,
       showProjectSettingsLink,
       footerMessage,
+      customDropdownButton,
     } = this.props;
     const selectedProjectIds = new Set(value);
     const multi = this.multi;
@@ -271,6 +278,9 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
             )}
           >
             {({getActorProps, selectedProjects, isOpen}) => {
+              if (customDropdownButton) {
+                return customDropdownButton({getActorProps, selectedProjects, isOpen});
+              }
               const hasSelected = !!selectedProjects.length;
               const title = hasSelected
                 ? selectedProjects.map(({slug}) => slug).join(', ')

--- a/static/app/components/organizations/multipleProjectSelector.tsx
+++ b/static/app/components/organizations/multipleProjectSelector.tsx
@@ -41,6 +41,7 @@ type Props = WithRouterProps & {
     selectedProjects: Project[];
     isOpen: boolean;
   }) => React.ReactElement;
+  customLoadingIndicator?: React.ReactNode;
 };
 
 type State = {
@@ -202,6 +203,7 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
       showProjectSettingsLink,
       footerMessage,
       customDropdownButton,
+      customLoadingIndicator,
     } = this.props;
     const selectedProjectIds = new Set(value);
     const multi = this.multi;
@@ -237,13 +239,15 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
         {this.renderProjectName()}
       </StyledHeaderItem>
     ) : !isGlobalSelectionReady ? (
-      <StyledHeaderItem
-        data-test-id="global-header-project-selector-loading"
-        icon={<IconProject />}
-        loading
-      >
-        {t('Loading\u2026')}
-      </StyledHeaderItem>
+      customLoadingIndicator ?? (
+        <StyledHeaderItem
+          data-test-id="global-header-project-selector-loading"
+          icon={<IconProject />}
+          loading
+        >
+          {t('Loading\u2026')}
+        </StyledHeaderItem>
+      )
     ) : (
       <ClassNames>
         {({css}) => (

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -120,6 +120,15 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
     );
   };
 
+  const customLoadingIndicator = (
+    <StyledDropdownButton showChevron={false} disabled>
+      <DropdownTitle>
+        <IconProject />
+        {t('Loading\u2026')}
+      </DropdownTitle>
+    </StyledDropdownButton>
+  );
+
   return (
     <MultipleProjectSelector
       organization={organization}
@@ -130,6 +139,7 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
       onChange={handleChangeProjects}
       onUpdate={handleUpdateProjects}
       customDropdownButton={customProjectDropdown}
+      customLoadingIndicator={customLoadingIndicator}
       {...otherProps}
     />
   );

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -1,0 +1,151 @@
+import {useState} from 'react';
+import {withRouter, WithRouterProps} from 'react-router';
+import styled from '@emotion/styled';
+import partition from 'lodash/partition';
+
+import {updateProjects} from 'sentry/actionCreators/globalSelection';
+import DropdownButton from 'sentry/components/dropdownButton';
+import MultipleProjectSelector from 'sentry/components/organizations/multipleProjectSelector';
+import PlatformList from 'sentry/components/platformList';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
+import {IconProject} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import GlobalSelectionStore from 'sentry/stores/globalSelectionStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import space from 'sentry/styles/space';
+import {MinimalProject} from 'sentry/types';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+
+type Props = {
+  router: WithRouterProps['router'];
+
+  /**
+   * Message to display at the bottom of project list
+   */
+  footerMessage?: React.ReactNode;
+
+  /**
+   * Subject that will be used in a tooltip that is shown on a lock icon hover
+   * E.g. This 'issue' is unique to a project
+   */
+  lockedMessageSubject?: string;
+
+  /**
+   * If true, there will be a back to issues stream icon link
+   */
+  showIssueStreamLink?: boolean;
+
+  /**
+   * If true, there will be a project settings icon link
+   * (forceProject prop needs to be present to know the right project slug)
+   */
+  showProjectSettingsLink?: boolean;
+
+  /**
+   * Slugs of projects to restrict the project selector to
+   */
+  specificProjectSlugs?: string[];
+
+  /**
+   * A project will be forced from parent component (selection is disabled, and if user
+   * does not have multi-project support enabled, it will not try to auto select a project).
+   *
+   * Project will be specified in the prop `forceProject` (since its data is async)
+   */
+  shouldForceProject?: boolean;
+
+  /**
+   * If a forced project is passed, selection is disabled
+   */
+  forceProject?: MinimalProject | null;
+};
+
+export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}: Props) {
+  const [currentSelectedProjects, setCurrentSelectedProjects] = useState<number[] | null>(
+    null
+  );
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+  const organization = useOrganization();
+  const {selection, isReady} = useLegacyStore(GlobalSelectionStore);
+
+  const handleChangeProjects = (newProjects: number[] | null) => {
+    setCurrentSelectedProjects(newProjects);
+  };
+
+  const handleUpdateProjects = () => {
+    // Clear environments when switching projects
+    updateProjects(currentSelectedProjects || [], router, {
+      save: true,
+      resetParams: [],
+      environments: [],
+    });
+    setCurrentSelectedProjects(null);
+  };
+
+  const specifiedProjects = specificProjectSlugs
+    ? projects.filter(project => specificProjectSlugs.includes(project.slug))
+    : projects;
+
+  const [_, otherProjects] = partition(specifiedProjects, project => project.isMember);
+
+  const isSuperuser = isActiveSuperuser();
+  const isOrgAdmin = organization.access.includes('org:admin');
+  const nonMemberProjects = isSuperuser || isOrgAdmin ? otherProjects : [];
+
+  const customProjectDropdown = ({getActorProps, selectedProjects, isOpen}) => {
+    const selectedProjectIds = new Set(selection.projects);
+    const hasSelected = !!selectedProjects.length;
+    const title = hasSelected
+      ? selectedProjects.map(({slug}) => slug).join(', ')
+      : selectedProjectIds.has(ALL_ACCESS_PROJECTS)
+      ? t('All Projects')
+      : t('My Projects');
+    const icon = hasSelected ? (
+      <PlatformList
+        platforms={selectedProjects.map(p => p.platform ?? 'other').reverse()}
+        max={5}
+      />
+    ) : (
+      <IconProject />
+    );
+    return (
+      <StyledDropdownButton isOpen={isOpen} {...getActorProps()}>
+        <DropdownTitle>
+          {icon}
+          {title}
+        </DropdownTitle>
+      </StyledDropdownButton>
+    );
+  };
+
+  return (
+    <MultipleProjectSelector
+      organization={organization}
+      projects={projects}
+      isGlobalSelectionReady={projectsLoaded && isReady}
+      nonMemberProjects={nonMemberProjects}
+      value={currentSelectedProjects || selection.projects}
+      onChange={handleChangeProjects}
+      onUpdate={handleUpdateProjects}
+      customDropdownButton={customProjectDropdown}
+      {...otherProps}
+    />
+  );
+}
+
+const StyledDropdownButton = styled(DropdownButton)`
+  width: 100%;
+  height: 40px;
+`;
+
+const DropdownTitle = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: ${space(1)};
+  align-items: center;
+  white-space: nowrap;
+`;
+
+export default withRouter(ProjectPageFilter);

--- a/tests/js/spec/components/projectPageFilter.spec.tsx
+++ b/tests/js/spec/components/projectPageFilter.spec.tsx
@@ -1,0 +1,62 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import ProjectPageFilter from 'sentry/components/projectPageFilter';
+import GlobalSelectionStore from 'sentry/stores/globalSelectionStore';
+import OrganizationStore from 'sentry/stores/organizationStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+describe('ProjectPageFilter', function () {
+  const {organization, router, routerContext} = initializeOrg({
+    organization: {features: ['global-views']},
+    project: undefined,
+    projects: [
+      {
+        id: 2,
+        slug: 'project-2',
+      },
+    ],
+    router: {
+      location: {query: {}},
+      params: {orgId: 'org-slug'},
+    },
+  });
+  OrganizationStore.onUpdate(organization, {replace: true});
+  ProjectsStore.loadInitialData(organization.projects);
+  GlobalSelectionStore.onInitializeUrlState({
+    projects: [],
+    environments: [],
+    datetime: {start: null, end: null, period: '14d', utc: null},
+  });
+
+  it('can pick project', function () {
+    mountWithTheme(
+      <OrganizationContext.Provider value={organization}>
+        <ProjectPageFilter />
+      </OrganizationContext.Provider>,
+      {
+        context: routerContext,
+      }
+    );
+
+    // Open the project dropdown
+    expect(screen.getByText('My Projects')).toBeInTheDocument();
+    userEvent.click(screen.getByText('My Projects'));
+
+    // Click the first project's checkbox
+    const projectOptions = screen.getAllByTestId('checkbox-fancy');
+    userEvent.click(projectOptions[0]);
+
+    // Confirm the selection changed the visible text
+    expect(screen.queryByText('My Projects')).not.toBeInTheDocument();
+
+    // Close the dropdown
+    userEvent.click(screen.getAllByText('project-2')[0]);
+
+    // Verify we were redirected
+    expect(router.push).toHaveBeenCalledWith(
+      expect.objectContaining({query: {environment: [], project: [2]}})
+    );
+  });
+});


### PR DESCRIPTION
Reusing the multiple project selector from the GSH and using it in a standalone `ProjectPageFilter`. Accepts similar parameters that were accepted by the GSH regarding project selection for consistency purposes.

Many props/functionalities will be subject to change as we implement optional pinning and find out how it might change form on different pages.

This is an example of how it could look on the issues page (just an example, not a final placement)
![image](https://user-images.githubusercontent.com/9372512/146266539-a709a67e-991a-436c-a3ee-17831fd5a3ef.png)

Loading state:
![image](https://user-images.githubusercontent.com/9372512/146451375-89bf72ea-03ed-4c67-a7b8-e5342e6fcd0d.png)
