### PR TITLE
ref(alerts): Switch `AlertsContainer` to useOrganization

### DIFF
--- a/static/app/views/alerts/index.tsx
+++ b/static/app/views/alerts/index.tsx
@@ -1,14 +1,13 @@
 import {cloneElement, Fragment, isValidElement} from 'react';
 
-import {Organization} from 'sentry/types';
-import withOrganization from 'sentry/utils/withOrganization';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
-  organization: Organization;
   children: React.ReactNode;
 };
 
-function AlertsContainer({organization, children}: Props) {
+function AlertsContainer({children}: Props) {
+  const organization = useOrganization();
   const hasMetricAlerts = organization.features.includes('incidents');
 
   const content =
@@ -22,4 +21,4 @@ function AlertsContainer({organization, children}: Props) {
   return <Fragment>{content}</Fragment>;
 }
 
-export default withOrganization(AlertsContainer);
+export default AlertsContainer;

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -128,7 +128,7 @@ describe('ProjectAlertsCreate', function () {
     ProjectsStore.loadInitialData([project]);
     const params = {orgId: organization.slug, projectId: project.slug};
     const wrapper = mountWithTheme(
-      <AlertsContainer organization={organization} params={params}>
+      <AlertsContainer>
         <AlertBuilderProjectProvider params={params}>
           <ProjectAlertsCreate
             params={params}
@@ -142,7 +142,7 @@ describe('ProjectAlertsCreate', function () {
           />
         </AlertBuilderProjectProvider>
       </AlertsContainer>,
-      {context: routerContext}
+      {context: routerContext, organization}
     );
     mockRouterPush(wrapper, router);
 

--- a/tests/js/spec/views/alerts/index.spec.jsx
+++ b/tests/js/spec/views/alerts/index.spec.jsx
@@ -8,6 +8,7 @@ describe('AlertsContainer', function () {
       const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
       const {container} = mountWithTheme(<AlertsContainer />, {
         context: TestStubs.routerContext([{organization}]),
+        organization,
       });
       expect(container).toBeEmptyDOMElement();
     });


### PR DESCRIPTION
This component wraps all the alerts views via the router