### PR TITLE
feat(doc integrations): Create DocIntegrationAvatar endpoints + serializer

### DIFF
--- a/src/sentry/api/bases/doc_integrations.py
+++ b/src/sentry/api/bases/doc_integrations.py
@@ -15,6 +15,7 @@ class DocIntegrationsPermission(SentryPermission):
     scope_map = {"GET": PARANOID_GET}
 
     def has_permission(self, request: Request, view: Endpoint):
+        return True
         if not super().has_permission(request, view):
             return False
 
@@ -26,6 +27,7 @@ class DocIntegrationsPermission(SentryPermission):
     def has_object_permission(
         self, request: Request, view: Endpoint, doc_integration: DocIntegration
     ):
+        return True
         if not hasattr(request, "user") or not request.user:
             return False
 

--- a/src/sentry/api/bases/doc_integrations.py
+++ b/src/sentry/api/bases/doc_integrations.py
@@ -15,7 +15,6 @@ class DocIntegrationsPermission(SentryPermission):
     scope_map = {"GET": PARANOID_GET}
 
     def has_permission(self, request: Request, view: Endpoint):
-        return True
         if not super().has_permission(request, view):
             return False
 
@@ -27,7 +26,6 @@ class DocIntegrationsPermission(SentryPermission):
     def has_object_permission(
         self, request: Request, view: Endpoint, doc_integration: DocIntegration
     ):
-        return True
         if not hasattr(request, "user") or not request.user:
             return False
 

--- a/src/sentry/api/endpoints/doc_integration_avatar.py
+++ b/src/sentry/api/endpoints/doc_integration_avatar.py
@@ -1,11 +1,13 @@
 from sentry.api.bases.avatar import AvatarMixin
 from sentry.api.bases.doc_integrations import DocIntegrationBaseEndpoint
+from sentry.api.serializers.rest_framework.doc_integration import DocIntegrationAvatarSerializer
 from sentry.models import DocIntegrationAvatar
 
 
 class DocIntegrationAvatarEndpoint(AvatarMixin, DocIntegrationBaseEndpoint):
     object_type = "doc_integration"
     model = DocIntegrationAvatar
+    serializer_cls = DocIntegrationAvatarSerializer
 
     def get_avatar_filename(self, obj):
         return f"{obj.slug}.png"

--- a/src/sentry/api/endpoints/doc_integration_avatar.py
+++ b/src/sentry/api/endpoints/doc_integration_avatar.py
@@ -1,0 +1,11 @@
+from sentry.api.bases.avatar import AvatarMixin
+from sentry.api.bases.doc_integrations import DocIntegrationBaseEndpoint
+from sentry.models import DocIntegrationAvatar
+
+
+class DocIntegrationAvatarEndpoint(AvatarMixin, DocIntegrationBaseEndpoint):
+    object_type = "doc_integration"
+    model = DocIntegrationAvatar
+
+    def get_avatar_filename(self, obj):
+        return f"{obj.slug}.png"

--- a/src/sentry/api/endpoints/sentry_app_avatar.py
+++ b/src/sentry/api/endpoints/sentry_app_avatar.py
@@ -1,11 +1,13 @@
 from sentry.api.bases import SentryAppBaseEndpoint
 from sentry.api.bases.avatar import AvatarMixin
+from sentry.api.serializers.rest_framework.sentry_app import SentryAppAvatarSerializer
 from sentry.models import SentryAppAvatar
 
 
 class SentryAppAvatarEndpoint(AvatarMixin, SentryAppBaseEndpoint):
     object_type = "sentry_app"
     model = SentryAppAvatar
+    serializer_cls = SentryAppAvatarSerializer
 
     def get(self, request, **kwargs):
         return super().get(request, access=request.access, **kwargs)

--- a/src/sentry/api/serializers/models/doc_integration.py
+++ b/src/sentry/api/serializers/models/doc_integration.py
@@ -12,10 +12,9 @@ from sentry.utils.json import JSONData
 @register(DocIntegration)
 class DocIntegrationSerializer(Serializer):
     def get_attrs(self, item_list: List[DocIntegration], user: User, **kwargs: Any):
-        doc_ids = {item.id for item in item_list}
         # Get associated IntegrationFeatures
-        doc_feature_attrs = IntegrationFeature.objects.get_by_target_ids(
-            target_ids=doc_ids, target_type=IntegrationTypes.DOC_INTEGRATION
+        doc_feature_attrs = IntegrationFeature.objects.get_by_targets_as_dict(
+            targets=item_list, target_type=IntegrationTypes.DOC_INTEGRATION
         )
 
         # Get associated DocIntegrationAvatar

--- a/src/sentry/api/serializers/models/doc_integration.py
+++ b/src/sentry/api/serializers/models/doc_integration.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from typing import Any, List, Mapping
 
 from sentry.api.serializers import Serializer, register, serialize
@@ -13,20 +12,15 @@ from sentry.utils.json import JSONData
 @register(DocIntegration)
 class DocIntegrationSerializer(Serializer):
     def get_attrs(self, item_list: List[DocIntegration], user: User, **kwargs: Any):
-        # Get associated IntegrationFeatures
         doc_ids = {item.id for item in item_list}
-        features = IntegrationFeature.objects.filter(
-            target_type=IntegrationTypes.DOC_INTEGRATION.value, target_id__in=doc_ids
+        # Get associated IntegrationFeatures
+        doc_feature_attrs = IntegrationFeature.objects.get_by_target_ids(
+            target_ids=doc_ids, target_type=IntegrationTypes.DOC_INTEGRATION
         )
-        doc_feature_attrs = defaultdict(set)
-        for feature in features:
-            doc_feature_attrs[feature.target_id].add(feature)
 
         # Get associated DocIntegrationAvatar
         avatars = DocIntegrationAvatar.objects.filter(doc_integration__in=item_list)
-        doc_avatar_attrs = defaultdict(DocIntegrationAvatar)
-        for avatar in avatars:
-            doc_avatar_attrs[avatar.doc_integration_id] = avatar
+        doc_avatar_attrs = {avatar.doc_integration_id: avatar for avatar in avatars}
 
         # Attach both as attrs
         return {

--- a/src/sentry/api/serializers/models/doc_integration_avatar.py
+++ b/src/sentry/api/serializers/models/doc_integration_avatar.py
@@ -1,0 +1,16 @@
+from typing import MutableMapping
+
+from sentry.api.serializers import Serializer, register
+from sentry.models import DocIntegrationAvatar
+from sentry.utils.json import JSONData
+
+
+@register(DocIntegrationAvatar)
+class DocIntegrationAvatarSerializer(Serializer):
+    def serialize(
+        self, obj: DocIntegrationAvatar, attrs, user, **kwargs
+    ) -> MutableMapping[str, JSONData]:
+        return {
+            "avatarType": obj.get_avatar_type_display(),
+            "avatarUuid": obj.ident,
+        }

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -1,3 +1,5 @@
+from typing import Any, List
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.app import env
 from sentry.auth.superuser import is_active_superuser
@@ -5,11 +7,21 @@ from sentry.constants import SentryAppStatus
 from sentry.models import IntegrationFeature, SentryApp
 from sentry.models.integrationfeature import IntegrationTypes
 from sentry.models.sentryapp import MASKED_VALUE
+from sentry.models.user import User
 from sentry.utils.compat import map
 
 
 @register(SentryApp)
 class SentryAppSerializer(Serializer):
+    def get_attrs(self, item_list: List[SentryApp], user: User, **kwargs: Any):
+        sentry_app_ids = {item.id for item in item_list}
+        features_by_sentry_app_id = IntegrationFeature.objects.get_by_target_ids(
+            target_ids=sentry_app_ids, target_type=IntegrationTypes.DOC_INTEGRATION
+        )
+        return {
+            item: {"features": features_by_sentry_app_id.get(item.id, set())} for item in item_list
+        }
+
     def serialize(self, obj, attrs, user, access):
         from sentry.mediators.service_hooks.creator import consolidate_events
 
@@ -34,10 +46,7 @@ class SentryAppSerializer(Serializer):
         data["featureData"] = []
 
         if obj.status != SentryAppStatus.INTERNAL:
-            features = IntegrationFeature.objects.filter(
-                target_id=obj.id, target_type=IntegrationTypes.SENTRY_APP.value
-            )
-            data["featureData"] = map(lambda x: serialize(x, user), features)
+            data["featureData"] = map(lambda x: serialize(x, user), attrs.get("features"))
 
         if obj.status == SentryAppStatus.PUBLISHED and obj.date_published:
             data.update({"datePublished": obj.date_published})

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -14,9 +14,8 @@ from sentry.utils.compat import map
 @register(SentryApp)
 class SentryAppSerializer(Serializer):
     def get_attrs(self, item_list: List[SentryApp], user: User, **kwargs: Any):
-        sentry_app_ids = {item.id for item in item_list}
-        features_by_sentry_app_id = IntegrationFeature.objects.get_by_target_ids(
-            target_ids=sentry_app_ids, target_type=IntegrationTypes.DOC_INTEGRATION
+        features_by_sentry_app_id = IntegrationFeature.objects.get_by_targets_as_dict(
+            targets=item_list, target_type=IntegrationTypes.SENTRY_APP
         )
         return {
             item: {"features": features_by_sentry_app_id.get(item.id, set())} for item in item_list

--- a/src/sentry/api/serializers/rest_framework/doc_integration.py
+++ b/src/sentry/api/serializers/rest_framework/doc_integration.py
@@ -6,6 +6,7 @@ from jsonschema.exceptions import ValidationError as SchemaValidationError
 from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
 
+from sentry.api.fields.avatar import AvatarField
 from sentry.api.serializers.rest_framework.sentry_app import URLField
 from sentry.api.validators.doc_integration import validate_metadata_schema
 from sentry.models.integration import DocIntegration
@@ -95,3 +96,16 @@ class DocIntegrationSerializer(Serializer):
             setattr(doc_integration, key, value)
         doc_integration.save()
         return doc_integration
+
+
+class DocIntegrationAvatarSerializer(Serializer):
+    avatar_photo = AvatarField(required=True)
+    avatar_type = serializers.ChoiceField(choices=(("upload", "upload")))
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+
+        if not attrs.get("avatar_photo"):
+            raise serializers.ValidationError({"avatar_photo": "A logo is required."})
+
+        return attrs

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -79,6 +79,7 @@ from .endpoints.debug_files import (
     SourceMapsEndpoint,
     UnknownDebugFilesEndpoint,
 )
+from .endpoints.doc_integration_avatar import DocIntegrationAvatarEndpoint
 from .endpoints.doc_integration_details import DocIntegrationDetailsEndpoint
 from .endpoints.doc_integrations import DocIntegrationsEndpoint
 from .endpoints.event_apple_crash_report import EventAppleCrashReportEndpoint
@@ -2122,6 +2123,11 @@ urlpatterns = [
         r"^doc-integrations/(?P<doc_integration_slug>[^\/]+)/$",
         DocIntegrationDetailsEndpoint.as_view(),
         name="sentry-api-0-doc-integration-details",
+    ),
+    url(
+        r"^doc-integrations/(?P<doc_integration_slug>[^\/]+)/avatar/$",
+        DocIntegrationAvatarEndpoint.as_view(),
+        name="sentry-api-0-doc-integration-avatar",
     ),
     # Grouping configs
     url(

--- a/src/sentry/models/docintegrationavatar.py
+++ b/src/sentry/models/docintegrationavatar.py
@@ -11,6 +11,8 @@ class DocIntegrationAvatar(AvatarBase):
     A DocIntegrationAvatar associates a DocIntegration with a logo photo File.
     """
 
+    AVATAR_TYPES = ((0, "upload"),)
+
     FILE_TYPE = "avatar.file"
 
     doc_integration = FlexibleForeignKey("sentry.DocIntegration", related_name="avatar")

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -6,7 +6,7 @@ from binascii import hexlify
 from datetime import datetime
 from hashlib import sha1
 from importlib import import_module
-from typing import Any, Optional, Sequence
+from typing import Any, List, Optional, Sequence
 from uuid import uuid4
 
 import petname
@@ -82,6 +82,7 @@ from sentry.models import (
     UserPermission,
     UserReport,
 )
+from sentry.models.docintegrationavatar import DocIntegrationAvatar
 from sentry.models.integration import DocIntegration
 from sentry.models.integrationfeature import Feature, IntegrationFeature, IntegrationTypes
 from sentry.models.releasefile import update_artifact_index
@@ -889,14 +890,18 @@ class Factories:
         return _kwargs
 
     @staticmethod
-    def create_doc_integration(features=None, **kwargs):
+    def create_doc_integration(features=None, has_avatar: bool = True, **kwargs) -> DocIntegration:
         doc = DocIntegration.objects.create(**Factories._doc_integration_kwargs(**kwargs))
         if features:
             Factories.create_doc_integration_features(features=features, doc_integration=doc)
+        if has_avatar:
+            Factories.create_doc_integration_avatar(doc_integration=doc)
         return doc
 
     @staticmethod
-    def create_doc_integration_features(features=None, doc_integration=None):
+    def create_doc_integration_features(
+        features=None, doc_integration=None
+    ) -> List[IntegrationFeature]:
         if not features:
             features = [Feature.API]
         if not doc_integration:
@@ -910,6 +915,16 @@ class Factories:
                 )
                 for feature in features
             ]
+        )
+
+    @staticmethod
+    def create_doc_integration_avatar(doc_integration=None, **kwargs) -> DocIntegrationAvatar:
+        if not doc_integration:
+            doc_integration = Factories.create_doc_integration()
+        photo = File.objects.create(name="test.png", type="avatar.file")
+        photo.putfile(io.BytesIO(b"imaginethiswasphotobytes"))
+        return DocIntegrationAvatar.objects.create(
+            doc_integration=doc_integration, avatar_type=0, file_id=photo.id
         )
 
     @staticmethod

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -890,7 +890,7 @@ class Factories:
         return _kwargs
 
     @staticmethod
-    def create_doc_integration(features=None, has_avatar: bool = True, **kwargs) -> DocIntegration:
+    def create_doc_integration(features=None, has_avatar: bool = False, **kwargs) -> DocIntegration:
         doc = DocIntegration.objects.create(**Factories._doc_integration_kwargs(**kwargs))
         if features:
             Factories.create_doc_integration_features(features=features, doc_integration=doc)

--- a/src/sentry/web/frontend/doc_integration_avatar.py
+++ b/src/sentry/web/frontend/doc_integration_avatar.py
@@ -1,0 +1,6 @@
+from sentry.models import DocIntegrationAvatar
+from sentry.web.frontend.base import AvatarPhotoView
+
+
+class DocIntegrationAvatarPhotoView(AvatarPhotoView):
+    model = DocIntegrationAvatar

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -16,6 +16,7 @@ from sentry.web.frontend.auth_logout import AuthLogoutView
 from sentry.web.frontend.auth_organization_login import AuthOrganizationLoginView
 from sentry.web.frontend.auth_provider_login import AuthProviderLoginView
 from sentry.web.frontend.disabled_member_view import DisabledMemberView
+from sentry.web.frontend.doc_integration_avatar import DocIntegrationAvatarPhotoView
 from sentry.web.frontend.error_page_embed import ErrorPageEmbedView
 from sentry.web.frontend.group_event_json import GroupEventJsonView
 from sentry.web.frontend.group_plugin_action import GroupPluginActionView
@@ -588,6 +589,11 @@ urlpatterns += [
         r"^sentry-app-avatar/(?P<avatar_id>[^\/]+)/$",
         SentryAppAvatarPhotoView.as_view(),
         name="sentry-app-avatar-url",
+    ),
+    url(
+        r"^doc-integration-avatar/(?P<avatar_id>[^\/]+)/$",
+        DocIntegrationAvatarPhotoView.as_view(),
+        name="sentry-doc-integration-avatar-url",
     ),
     # Serve chartcuterie configuration module
     url(

--- a/tests/sentry/api/endpoints/test_doc_integration_avatar.py
+++ b/tests/sentry/api/endpoints/test_doc_integration_avatar.py
@@ -1,0 +1,104 @@
+from base64 import b64encode
+
+from rest_framework import status
+
+from sentry.api.serializers.base import serialize
+from sentry.testutils import APITestCase
+
+
+class DocIntegrationAvatarTest(APITestCase):
+    endpoint = "sentry-api-0-doc-integration-avatar"
+
+    def setUp(self):
+        self.user = self.create_user(email="peter@marvel.com", is_superuser=True)
+        self.superuser = self.create_user(email="gwen@marvel.com", is_superuser=True)
+        self.draft_doc = self.create_doc_integration(
+            name="spiderman", is_draft=True, has_avatar=True
+        )
+        self.published_doc = self.create_doc_integration(
+            name="spiderwoman", is_draft=False, has_avatar=True
+        )
+        self.avatar_payload = {
+            "avatar_photo": b64encode(self.load_fixture("rookout-color.png")),
+            "avatar_type": "upload",
+        }
+
+
+class GetDocIntegrationAvatarTest(DocIntegrationAvatarTest):
+    method = "GET"
+
+    def test_view_avatar_for_user(self):
+        """
+        Tests that regular users can see only published doc integration avatars
+        """
+        self.login_as(user=self.user)
+        response = self.get_success_response(
+            self.published_doc.slug, status_code=status.HTTP_200_OK
+        )
+        assert serialize(self.published_doc) == response.data
+        assert serialize(self.published_doc.avatar.get()) == response.data["avatar"]
+        response = self.get_error_response(
+            self.draft_doc.slug, status_code=status.HTTP_403_FORBIDDEN
+        )
+
+    def test_view_avatar_for_superuser(self):
+        """
+        Tests that superusers can see all doc integration avatars
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        for doc in [self.published_doc, self.draft_doc]:
+            response = self.get_success_response(doc.slug, status_code=status.HTTP_200_OK)
+            assert serialize(doc) == response.data
+            assert serialize(doc.avatar.get()) == response.data["avatar"]
+
+
+class PutDocIntegrationAvatarTest(DocIntegrationAvatarTest):
+    method = "PUT"
+
+    def test_upload_avatar_for_user(self):
+        """
+        Tests that regular users cannot upload doc integration avatars
+        """
+        self.login_as(user=self.user)
+        self.get_error_response(self.published_doc.slug, status_code=status.HTTP_403_FORBIDDEN)
+        self.get_error_response(self.draft_doc.slug, status_code=status.HTTP_403_FORBIDDEN)
+
+    def test_upload_avatar_for_superuser(self):
+        """
+        Tests that superusers can upload avatars
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        for doc in [self.published_doc, self.draft_doc]:
+            prev_avatar = doc.avatar.get()
+            response = self.get_success_response(
+                doc.slug, status_code=status.HTTP_200_OK, **self.avatar_payload
+            )
+            assert serialize(doc) == response.data
+            assert serialize(doc.avatar.get()) == response.data["avatar"]
+            assert serialize(prev_avatar) != response.data["avatar"]
+            assert prev_avatar.file_id != doc.avatar.get().file_id
+
+    def test_upload_avatar_payload_structure(self):
+        """
+        Tests that errors are thrown on malformed upload payloads
+        """
+        self.login_as(user=self.superuser, superuser=True)
+        # Structured as 'error-description' : (malformed-payload, erroring-fields)
+        invalid_payloads = {
+            "empty_payload": ({}, ["avatar_photo", "avatar_type"]),
+            "missing_avatar_photo": (
+                {"avatar_type": self.avatar_payload["avatar_type"]},
+                ["avatar_photo"],
+            ),
+            "missing_avatar_type": (
+                {"avatar_photo": self.avatar_payload["avatar_photo"]},
+                ["avatar_type"],
+            ),
+            "invalid_avatar_type": ({**self.avatar_payload, "avatar_type": 1}, ["avatar_type"]),
+        }
+        for payload, fields in invalid_payloads.values():
+            response = self.get_error_response(
+                self.draft_doc.slug, status_code=status.HTTP_400_BAD_REQUEST, **payload
+            )
+            for field in fields:
+                assert field in response.data.keys()

--- a/tests/sentry/api/endpoints/test_doc_integration_details.py
+++ b/tests/sentry/api/endpoints/test_doc_integration_details.py
@@ -12,15 +12,16 @@ class DocIntegrationDetailsTest(APITestCase):
     def setUp(self):
         self.user = self.create_user(email="jinx@lol.com")
         self.superuser = self.create_user(email="vi@lol.com", is_superuser=True)
-        self.doc_1 = self.create_doc_integration(name="test_1", is_draft=True)
+        self.doc_1 = self.create_doc_integration(name="test_1", is_draft=True, has_avatar=False)
         self.doc_2 = self.create_doc_integration(
             name="test_2",
             is_draft=False,
             metadata={"resources": [{"title": "Documentation", "url": "https://docs.sentry.io/"}]},
             features=[2, 3, 4],
+            has_avatar=True,
         )
         self.doc_delete = self.create_doc_integration(
-            name="test_3", is_draft=True, features=[1, 2, 3, 4, 5, 6, 7]
+            name="test_3", is_draft=True, features=[1, 2, 3, 4, 5, 6, 7], has_avatar=True
         )
 
 
@@ -33,17 +34,19 @@ class GetDocIntegrationDetailsTest(DocIntegrationDetailsTest):
         for those with superuser permissions
         """
         self.login_as(user=self.superuser, superuser=True)
-        # Non-draft DocIntegration, with features
+        # Non-draft DocIntegration, with features and an avatar
         response = self.get_success_response(self.doc_2.slug, status_code=status.HTTP_200_OK)
         assert serialize(self.doc_2) == response.data
         features = IntegrationFeature.objects.filter(
             target_id=self.doc_2.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
         )
         for feature in features:
-            assert serialize(feature) in serialize(self.doc_2)["features"]
-        # Draft DocIntegration, without features
+            assert serialize(feature) in response.data["features"]
+        assert serialize(self.doc_2.avatar.get()) == response.data["avatar"]
+        # Draft DocIntegration, without features or an avatar
         response = self.get_success_response(self.doc_1.slug, status_code=status.HTTP_200_OK)
         assert serialize(self.doc_1) == response.data
+        assert not response.data["avatar"]
 
     def test_read_doc_for_public(self):
         """
@@ -51,7 +54,7 @@ class GetDocIntegrationDetailsTest(DocIntegrationDetailsTest):
         are visible for those without superuser permissions
         """
         self.login_as(user=self.user)
-        # Non-draft DocIntegration, with features
+        # Non-draft DocIntegration, with features and an avatar
         response = self.get_success_response(self.doc_2.slug, status_code=status.HTTP_200_OK)
         assert serialize(self.doc_2) == response.data
         features = IntegrationFeature.objects.filter(
@@ -59,7 +62,8 @@ class GetDocIntegrationDetailsTest(DocIntegrationDetailsTest):
         )
         for feature in features:
             assert serialize(feature) in serialize(self.doc_2)["features"]
-        # Draft DocIntegration, without features
+        assert serialize(self.doc_2.avatar.get()) == response.data["avatar"]
+        # Draft DocIntegration, without features or an avatar
         self.get_error_response(self.doc_1.slug, status_code=status.HTTP_403_FORBIDDEN)
 
 
@@ -212,16 +216,20 @@ class DeleteDocIntegrationDetailsTest(DocIntegrationDetailsTest):
     def test_delete_valid_for_superuser(self):
         """
         Tests that the delete method works for those with superuser
-        permissions, deleting the DocIntegration and associated IntegrationFeatures
+        permissions, deleting the DocIntegration and associated
+        IntegrationFeatures and DocIntegrationAvatar
         """
         self.login_as(user=self.superuser, superuser=True)
-        self.get_success_response(self.doc_delete.slug, status_code=status.HTTP_204_NO_CONTENT)
-        with self.assertRaises(DocIntegration.DoesNotExist):
-            DocIntegration.objects.get(id=self.doc_delete.id)
         features = IntegrationFeature.objects.filter(
             target_id=self.doc_delete.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
         )
+        assert features.exists()
+        assert self.doc_delete.avatar.exists()
+        self.get_success_response(self.doc_delete.slug, status_code=status.HTTP_204_NO_CONTENT)
+        with self.assertRaises(DocIntegration.DoesNotExist):
+            DocIntegration.objects.get(id=self.doc_delete.id)
         assert not features.exists()
+        assert not self.doc_delete.avatar.exists()
 
     def test_delete_invalid_for_public(self):
         """
@@ -236,3 +244,4 @@ class DeleteDocIntegrationDetailsTest(DocIntegrationDetailsTest):
         )
         assert features.exists()
         assert len(features) == 7
+        assert self.doc_delete.avatar.exists()

--- a/tests/sentry/api/endpoints/test_doc_integrations.py
+++ b/tests/sentry/api/endpoints/test_doc_integrations.py
@@ -1,9 +1,13 @@
+from typing import List
+
 from rest_framework import status
+from rest_framework.response import Response
 
 from sentry.api.serializers.base import serialize
 from sentry.models.integration import DocIntegration
 from sentry.models.integrationfeature import IntegrationFeature, IntegrationTypes
 from sentry.testutils import APITestCase
+from sentry.utils.json import JSONData
 
 
 class DocIntegrationsTest(APITestCase):
@@ -21,8 +25,8 @@ class DocIntegrationsTest(APITestCase):
             features=[2, 3, 4],
         )
 
-    def get_avatars(self, resp):
-        return [doc.get("avatar") for doc in resp.data]
+    def get_avatars(self, response: Response) -> List[JSONData]:
+        return [doc.get("avatar") for doc in response.data]
 
 
 class GetDocIntegrationsTest(DocIntegrationsTest):

--- a/tests/sentry/web/frontend/test_doc_integration_avatar.py
+++ b/tests/sentry/web/frontend/test_doc_integration_avatar.py
@@ -1,0 +1,15 @@
+from rest_framework import status
+
+from sentry.testutils.cases import APITestCase
+from sentry.web.frontend.generic import FOREVER_CACHE
+
+
+class DocIntegrationAvatartest(APITestCase):
+    endpoint = "sentry-doc-integration-avatar-url"
+
+    def test_headers(self):
+        doc = self.create_doc_integration(name="spiderman", has_avatar=True)
+        response = self.get_success_response(doc.avatar.get().ident, status_code=status.HTTP_200_OK)
+        assert response["Cache-Control"] == FOREVER_CACHE
+        assert response.get("Vary") == "Accept-Language, Cookie"
+        assert response.get("Set-Cookie") is None


### PR DESCRIPTION
See [API-2320](https://getsentry.atlassian.net/browse/API-2320)

This PR adds the endpoints and serializer for DocIntegrationAvatar. It also makes some changes to the existing BaseAvatar to make it a bit cleaner with the use of different serializer classes.