### PR TITLE
ref(metrics-request): Update base query params logic

### DIFF
--- a/static/app/utils/metrics/metricsRequest.tsx
+++ b/static/app/utils/metrics/metricsRequest.tsx
@@ -93,19 +93,14 @@ class MetricsRequest extends React.Component<Props, State> {
   }
 
   baseQueryParams({previousPeriod = false} = {}) {
-    const {
-      project,
-      environment,
-      field,
-      statsPeriod,
-      start,
-      end,
-      query,
-      groupBy,
-      orderBy,
-      limit,
-      interval,
-    } = this.props;
+    const {project, environment, field, query, groupBy, orderBy, limit, interval} =
+      this.props;
+
+    const {start, end, statsPeriod} = getPeriod({
+      period: this.props.statsPeriod,
+      start: this.props.start,
+      end: this.props.end,
+    });
 
     const commonQuery = {
       project,
@@ -123,8 +118,8 @@ class MetricsRequest extends React.Component<Props, State> {
       return {
         ...commonQuery,
         statsPeriod,
-        start: start ?? undefined,
-        end: end ?? undefined,
+        start,
+        end,
       };
     }
 

--- a/tests/js/spec/utils/metrics/metricsRequest.spec.tsx
+++ b/tests/js/spec/utils/metrics/metricsRequest.spec.tsx
@@ -189,7 +189,7 @@ describe('MetricsRequest', () => {
     );
   });
 
-  it('make one request with absolute date', async () => {
+  it('make one request with absolute date', () => {
     mountWithTheme(
       <MetricsRequest
         {...props}

--- a/tests/js/spec/utils/metrics/metricsRequest.spec.tsx
+++ b/tests/js/spec/utils/metrics/metricsRequest.spec.tsx
@@ -188,4 +188,48 @@ describe('MetricsRequest', () => {
       })
     );
   });
+
+  it('make one request with absolute date', async () => {
+    mountWithTheme(
+      <MetricsRequest
+        {...props}
+        statsPeriod=""
+        start="Wed Dec 01 2021 01:00:00 GMT+0100 (Central European Standard Time)"
+        end="Fri Dec 17 2021 00:59:59 GMT+0100 (Central European Standard Time)"
+        includePrevious
+      >
+        {childrenMock}
+      </MetricsRequest>
+    );
+
+    expect(childrenMock).toHaveBeenNthCalledWith(1, {
+      errored: false,
+      loading: true,
+      reloading: false,
+      response: null,
+      responsePrevious: null,
+    });
+
+    // if start and end are provided, it will not perform a request to fetch previous data
+    expect(metricsMock).toHaveBeenCalledTimes(1);
+
+    expect(metricsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {
+          end: '2021-12-17T00:59:59',
+          environment: ['prod'],
+          field: ['fieldA'],
+          groupBy: ['status'],
+          interval: '1h',
+          limit: 3,
+          orderBy: 'fieldA',
+          project: ['2'],
+          query: 'abc',
+          start: '2021-12-01T01:00:00',
+          statsPeriod: undefined,
+        },
+      })
+    );
+  });
 });


### PR DESCRIPTION
When an absolute date is set, `statsPeriod` becomes `undefined` and this + invalid date format was causing an error when performing a request.

This PR introduces one more use of the `getPeriod` function in the MetricsRequest component, solving the issue