### PR TITLE
fix(data-scrubber): Find transactions in scrubbing rules preview [INGEST-693]

### DIFF
--- a/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
+++ b/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
@@ -1,8 +1,9 @@
 from rest_framework.response import Response
 from sentry_relay import pii_selector_suggestions_from_event
 
-from sentry import eventstore
+from sentry import nodestore
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.eventstore.models import Event
 
 
 class DataScrubbingSelectorSuggestionsEndpoint(OrganizationEndpoint):
@@ -31,11 +32,13 @@ class DataScrubbingSelectorSuggestionsEndpoint(OrganizationEndpoint):
         suggestions = {}
 
         if event_id:
-            for event in eventstore.get_events(
-                filter=eventstore.Filter(event_ids=[event_id], project_ids=project_ids),
-                referrer="api.data_scrubbing_selector_suggestions",
-            ):
-                for selector in pii_selector_suggestions_from_event(dict(event.data)):
+            # go to nodestore directly instead of eventstore.get_events, which
+            # would not return transaction events
+            node_ids = [Event.generate_node_id(p, event_id) for p in project_ids]
+            all_data = nodestore.get_multi(node_ids)
+
+            for data in filter(None, all_data.values()):
+                for selector in pii_selector_suggestions_from_event(data):
                     examples_ = suggestions.setdefault(selector["path"], [])
                     if selector["value"]:
                         examples_.append(selector["value"])


### PR DESCRIPTION
Bypasses eventstore and goes to nodestore directly to resolve every event type
when fetching suggestions for data scrubbing rules. Computing the suggestions
merely requires the event payload, but not an updated group_id or any other
information that would reside in Snuba.

Fixes https://github.com/getsentry/sentry/issues/30235
