### PR TITLE
doc(eventstore): Clarify event types returned by methods

### DIFF
--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -146,6 +146,9 @@ class EventStorage(Service):
         """
         Fetches a list of events given a set of criteria.
 
+        Searches for error events, including security and default messages, but not for
+        transaction events. Returns an empty list if no events match the filter.
+
         Arguments:
         snuba_filter (Filter): Filter
         orderby (Sequence[str]): List of fields to order by - default ['-time', '-event_id']
@@ -183,7 +186,7 @@ class EventStorage(Service):
 
     def get_event_by_id(self, project_id, event_id, group_id=None):
         """
-        Gets a single event given a project_id and event_id.
+        Gets a single event of any event type given a project_id and event_id.
         Returns None if an event cannot be found.
 
         Arguments:


### PR DESCRIPTION
Originally, `eventstore.get_events` and `eventstore.get_event_by_id` would
return all events including transactions. When splitting the datasets in Snuba,
this behavior changed. In practice, we only had a single use in the product that
would require transaction events (see #30718), which is why this went unnoticed.

Unfortunately, the contract of the two methods has now differed. Until this gets
addressed, this PR aims to clarify which event types are returned by the two
functions.
