### PR TITLE
ref(cra-alerts): Removes entity regex parse

### DIFF
--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -300,8 +300,8 @@ class QuerySubscriptionConsumer:
                         contents["subscription_id"],
                         EntityKey(entity_key),
                     )
-                except KeyError:
-                    logger.exception("Message payload does not contain an entity key")
+                except InvalidMessageError as e:
+                    logger.exception(e)
                 except Exception:
                     logger.exception("Failed to delete unused subscription from snuba.")
                 return

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -139,16 +139,18 @@ class ParseMessageValueTest(BaseQuerySubscriptionTest, unittest.TestCase):
                 payload.pop(field)
         if update_fields:
             payload.update(update_fields)
-        self.run_invalid_schema_test({"version": 2, "payload": payload})
+        self.run_invalid_schema_test({"version": 3, "payload": payload})
 
     def test_invalid_payload(self):
         self.run_invalid_payload_test(remove_fields=["subscription_id"])
         self.run_invalid_payload_test(remove_fields=["result"])
         self.run_invalid_payload_test(remove_fields=["timestamp"])
+        self.run_invalid_payload_test(remove_fields=["entity"])
         self.run_invalid_payload_test(update_fields={"subscription_id": ""})
         self.run_invalid_payload_test(update_fields={"result": {}})
         self.run_invalid_payload_test(update_fields={"result": {"hello": "hi"}})
         self.run_invalid_payload_test(update_fields={"timestamp": -1})
+        self.run_invalid_payload_test(update_fields={"entity": -1})
 
     def test_invalid_version(self):
         with self.assertRaises(InvalidMessageError) as cm:


### PR DESCRIPTION
This PR:
- Removes the logic that relies on regex parsing the query string in the subscription update sent from snuba when a subscription has already been deleted in sentry but not in snuba. 

The following has to be merged first https://github.com/getsentry/snuba/pull/2291 before merging this