### PR TITLE
feat(cra-metrics): Adds support for crash free users over metrics

### DIFF
--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -705,19 +705,11 @@ class MetricsCrashRateAlertCreationTest(AlertRuleCreateEndpointTestCrashRateAler
     def setUp(self):
         super().setUp()
         self.valid_alert_rule["dataset"] = Dataset.Metrics.value
-        for tag in [SessionMetricKey.SESSION.value, "session.status", "init", "crashed"]:
+        for tag in [
+            SessionMetricKey.SESSION.value,
+            SessionMetricKey.USER.value,
+            "session.status",
+            "init",
+            "crashed",
+        ]:
             indexer.record(tag)
-
-    def test_simple_crash_rate_alerts_for_users(self):
-        self.valid_alert_rule.update(
-            {
-                "aggregate": "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
-            }
-        )
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(
-                self.organization.slug, self.project.slug, status_code=400, **self.valid_alert_rule
-            )
-        assert (
-            resp.data["nonFieldErrors"][0] == "Crash Free Users subscriptions are not supported yet"
-        )


### PR DESCRIPTION
Adds ability to create users crash free rate
alerts over metrics. Introduces
MetricsSetsEntitySubscription class that now
along with MetricsCountersEntitySubscription
inherit from the newly added abstract class
BaseMetricsEntitySubscription. This class
basically encompasses the shared behaviour
among both kinds of crash free rate alerts