### PR TITLE
chore(chart-unfurls): Remove the chart-unfurls flag

### DIFF
--- a/src/sentry/integrations/slack/endpoints/event.py
+++ b/src/sentry/integrations/slack/endpoints/event.py
@@ -135,7 +135,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
                 organization
                 and link_type == LinkType.DISCOVER
                 and not slack_request.has_identity
-                and features.has("organizations:chart-unfurls", organization, actor=request.user)
+                and features.has("organizations:discover-basic", organization, actor=request.user)
             ):
                 analytics.record(
                     "integrations.slack.chart_unfurl",

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -103,7 +103,7 @@ def unfurl_discover(
         # If the link shared is an org w/o the slack integration do not unfurl
         if not org:
             continue
-        if not features.has("organizations:chart-unfurls", org):
+        if not features.has("organizations:discover-basic", org):
             continue
 
         params = link.args["query"]

--- a/tests/sentry/integrations/slack/endpoints/test_event.py
+++ b/tests/sentry/integrations/slack/endpoints/test_event.py
@@ -219,7 +219,7 @@ class DiscoverLinkSharedEvent(BaseEventTest):
 
     def test_share_discover_links_unlinked_user(self):
         IdentityProvider.objects.create(type="slack", external_id="TXXXXXXX1", config={})
-        with self.feature("organizations:chart-unfurls"):
+        with self.feature("organizations:discover-basic"):
             data = self.share_discover_links()
 
         blocks = json.loads(data["blocks"])

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -116,12 +116,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(
-            [
-                "organizations:discover-basic",
-                "organizations:chart-unfurls",
-            ]
-        ):
+        with self.feature(["organizations:discover-basic"]):
             unfurls = link_handlers[link_type].fn(self.request, self.integration, links, self.user)
 
         assert (
@@ -155,12 +150,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(
-            [
-                "organizations:discover-basic",
-                "organizations:chart-unfurls",
-            ]
-        ):
+        with self.feature(["organizations:discover-basic"]):
             unfurls = link_handlers[link_type].fn(self.request, self.integration, links, self.user)
 
         assert (
@@ -195,12 +185,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(
-            [
-                "organizations:discover-basic",
-                "organizations:chart-unfurls",
-            ]
-        ):
+        with self.feature(["organizations:discover-basic"]):
             unfurls = link_handlers[link_type].fn(self.request, self.integration, links, self.user)
 
         assert (
@@ -235,12 +220,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(
-            [
-                "organizations:discover-basic",
-                "organizations:chart-unfurls",
-            ]
-        ):
+        with self.feature(["organizations:discover-basic"]):
             unfurls = link_handlers[link_type].fn(self.request, self.integration, links, self.user)
 
         assert (
@@ -296,7 +276,6 @@ class UnfurlTest(TestCase):
             [
                 "organizations:discover",
                 "organizations:discover-basic",
-                "organizations:chart-unfurls",
                 "organizations:discover-top-events",
             ]
         ):
@@ -363,7 +342,6 @@ class UnfurlTest(TestCase):
             [
                 "organizations:discover",
                 "organizations:discover-basic",
-                "organizations:chart-unfurls",
                 "organizations:discover-top-events",
             ]
         ):
@@ -408,7 +386,6 @@ class UnfurlTest(TestCase):
             [
                 "organizations:discover",
                 "organizations:discover-basic",
-                "organizations:chart-unfurls",
                 "organizations:discover-top-events",
             ]
         ):
@@ -455,7 +432,6 @@ class UnfurlTest(TestCase):
             [
                 "organizations:discover",
                 "organizations:discover-basic",
-                "organizations:chart-unfurls",
                 "organizations:discover-top-events",
             ]
         ):
@@ -515,7 +491,6 @@ class UnfurlTest(TestCase):
             [
                 "organizations:discover",
                 "organizations:discover-basic",
-                "organizations:chart-unfurls",
             ]
         ):
             unfurls = link_handlers[link_type].fn(self.request, self.integration, links, self.user)
@@ -557,7 +532,6 @@ class UnfurlTest(TestCase):
             [
                 "organizations:discover",
                 "organizations:discover-basic",
-                "organizations:chart-unfurls",
             ]
         ):
             unfurls = link_handlers[link_type].fn(self.request, self.integration, links, self.user)
@@ -603,12 +577,7 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature(
-            [
-                "organizations:discover-basic",
-                "organizations:chart-unfurls",
-            ]
-        ):
+        with self.feature(["organizations:discover-basic"]):
             unfurls = link_handlers[link_type].fn(self.request, self.integration, links, self.user)
 
         assert (


### PR DESCRIPTION
Remove the chart unfurl flag and replace with
the discover-basic flag since the feature has
been in GA for a couple months now.