### PR TITLE
fix(discover): Fix cell action container css

### DIFF
--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -449,7 +449,8 @@ const Container = styled('div')`
   width: 100%;
   height: 100%;
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  justify-content: center;
 `;
 
 const MenuRoot = styled('div')`


### PR DESCRIPTION
Fix regression from https://github.com/getsentry/sentry/pull/30496.

This properly emulates `display: block` without resorting to having to add `width: 100%` to every children like in https://github.com/getsentry/sentry/pull/30721

### Before
<img width="1301" alt="Screen Shot 2021-12-16 at 11 55 38 AM" src="https://user-images.githubusercontent.com/139499/146414814-848f1197-64cd-4d4d-9bbf-a9c8fa8fb309.png">

### After

<img width="1303" alt="Screen Shot 2021-12-16 at 11 54 39 AM" src="https://user-images.githubusercontent.com/139499/146414818-6a4f33d3-b7fe-42a5-bf5f-ec637980e8b2.png">
