### PR TITLE
fix(codeowners): Fix codeowners for reprocessing again

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,8 +25,6 @@
 /src/sentry/web/api.py             @getsentry/owners-ingest
 /src/sentry/scripts/quotas/        @getsentry/owners-ingest
 /src/sentry/scripts/tsdb/          @getsentry/owners-ingest
-/src/sentry/tasks/reprocessing.py  @getsentry/owners-ingest
-/src/sentry/tasks/reprocessing2.py @getsentry/owners-ingest
 /src/sentry/tasks/store.py         @getsentry/owners-ingest
 /src/sentry/tasks/unmerge.py       @getsentry/owners-ingest
 
@@ -277,10 +275,14 @@ build-utils/        @getsentry/owners-js-build
 /src/sentry/tasks/app_store_connect.py                              @getsentry/owners-native
 /src/sentry/tasks/assemble.py                                       @getsentry/owners-native
 /src/sentry/tasks/low_priority_symbolication.py                     @getsentry/owners-native
-/src/sentry/tasks/reprocessing.py                                   @getsentry/owners-native
-/src/sentry/tasks/reprocessing2.py                                  @getsentry/owners-native
 /src/sentry/tasks/symbolication.py                                  @getsentry/owners-native
 /src/sentry/utils/appleconnect/                                     @getsentry/owners-native
 /tests/sentry/tasks/test_low_priority_symbolication.py              @getsentry/owners-native
+
+
+# Shared ownership of reprocessing as transitionary phase
+/src/sentry/tasks/reprocessing.py  @getsentry/owners-ingest @getsentry/owners-native
+/src/sentry/tasks/reprocessing2.py @getsentry/owners-ingest @getsentry/owners-native
+/src/sentry/reprocessing2.py       @getsentry/owners-ingest @getsentry/owners-native
 
 ## End of Native ##


### PR DESCRIPTION
It turns out that exactly as betty said, the current state will not
assign both teams. This will though, I promise.