### PR TITLE
fix(dashboard): Only show Add Widget if dashboard-edit enabled

### DIFF
--- a/static/app/views/dashboardsV2/controls.tsx
+++ b/static/app/views/dashboardsV2/controls.tsx
@@ -118,7 +118,7 @@ class Controls extends React.Component<Props> {
               >
                 {t('Edit Dashboard')}
               </Button>
-              {organization.features.includes('widget-library') ? (
+              {organization.features.includes('widget-library') && hasFeature ? (
                 <Tooltip
                   title={tct('Max widgets ([maxWidgets]) per dashboard reached.', {
                     maxWidgets: MAX_WIDGETS,


### PR DESCRIPTION
The Add Widget button is displayed on dashboard-basic
feature but should be hidden.

Before:
![Screen Shot 2021-12-16 at 2 25 02 PM](https://user-images.githubusercontent.com/63818634/146435750-c54c7b7b-e59e-414d-b538-f73744e2ee14.png)

After:
![Screen Shot 2021-12-16 at 2 19 50 PM](https://user-images.githubusercontent.com/63818634/146435766-6203efb0-326b-43fa-bde7-77b4534e4215.png)

