### PR TITLE
feat(cra-alerts): Add a new schema for subscription payloads

### DIFF
--- a/src/sentry/snuba/json_schemas.py
+++ b/src/sentry/snuba/json_schemas.py
@@ -9,30 +9,6 @@ SUBSCRIPTION_WRAPPER_SCHEMA = {
 
 
 SUBSCRIPTION_PAYLOAD_VERSIONS: Mapping[int, Mapping[str, Any]] = {
-    1: {
-        "type": "object",
-        "properties": {
-            "subscription_id": {"type": "string", "minLength": 1},
-            "values": {
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                            "type": "object",
-                            "minProperties": 1,
-                            "additionalProperties": {"type": "number"},
-                        },
-                    }
-                },
-                "required": ["data"],
-            },
-            "timestamp": {"type": "string", "format": "date-time"},
-        },
-        "required": ["subscription_id", "values", "timestamp"],
-        "additionalProperties": False,
-    },
     2: {
         "type": "object",
         "properties": {

--- a/src/sentry/snuba/json_schemas.py
+++ b/src/sentry/snuba/json_schemas.py
@@ -58,4 +58,30 @@ SUBSCRIPTION_PAYLOAD_VERSIONS: Mapping[int, Mapping[str, Any]] = {
         "required": ["subscription_id", "request", "result", "timestamp"],
         "additionalProperties": False,
     },
+    3: {
+        "type": "object",
+        "properties": {
+            "subscription_id": {"type": "string", "minLength": 1},
+            "request": {"type": "object"},
+            "result": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "minItems": 0,
+                        "items": {
+                            "type": "object",
+                            "minProperties": 1,
+                            "additionalProperties": {"type": ["number", "null"]},
+                        },
+                    }
+                },
+                "required": ["data"],
+            },
+            "timestamp": {"type": "string", "format": "date-time"},
+            "entity": {"type": "string", "minLength": 1},
+        },
+        "required": ["subscription_id", "request", "result", "timestamp", "entity"],
+        "additionalProperties": False,
+    },
 }

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -29,7 +29,7 @@ class BaseQuerySubscriptionTest:
 
     @fixture
     def valid_wrapper(self):
-        return {"version": 2, "payload": self.valid_payload}
+        return {"version": 3, "payload": self.valid_payload}
 
     @fixture
     def valid_payload(self):
@@ -42,6 +42,16 @@ class BaseQuerySubscriptionTest:
                         tags[3] WHERE org_id = 1 AND project_id IN tuple(1) AND metric_id = 16
                         AND tags[3] IN tuple(13, 4)""",
             },
+            "entity": "metrics_counters",
+            "timestamp": "2020-01-01T01:23:45.1234",
+        }
+
+    @fixture
+    def old_payload(self):
+        return {
+            "subscription_id": "1234",
+            "result": {"data": [{"hello": 50}]},
+            "request": {"some": "data"},
             "timestamp": "2020-01-01T01:23:45.1234",
         }
 
@@ -146,12 +156,15 @@ class ParseMessageValueTest(BaseQuerySubscriptionTest, unittest.TestCase):
         assert str(cm.exception) == "Version specified in wrapper has no schema"
 
     def test_valid(self):
-        self.run_test({"version": 2, "payload": self.valid_payload})
+        self.run_test({"version": 3, "payload": self.valid_payload})
 
     def test_valid_nan(self):
         payload = deepcopy(self.valid_payload)
         payload["result"]["data"][0]["hello"] = float("nan")
-        self.run_test({"version": 2, "payload": payload})
+        self.run_test({"version": 3, "payload": payload})
+
+    def test_old_version(self):
+        self.run_test({"version": 2, "payload": self.old_payload})
 
     def test_invalid_wrapper(self):
         self.run_invalid_schema_test({})

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -32,14 +32,6 @@ class BaseQuerySubscriptionTest:
         return {"version": 2, "payload": self.valid_payload}
 
     @fixture
-    def old_payload(self):
-        return {
-            "subscription_id": "1234",
-            "values": {"data": [{"hello": 50}]},
-            "timestamp": "2020-01-01T01:23:45.1234",
-        }
-
-    @fixture
     def valid_payload(self):
         return {
             "subscription_id": "1234",
@@ -160,9 +152,6 @@ class ParseMessageValueTest(BaseQuerySubscriptionTest, unittest.TestCase):
         payload = deepcopy(self.valid_payload)
         payload["result"]["data"][0]["hello"] = float("nan")
         self.run_test({"version": 2, "payload": payload})
-
-    def test_old_version(self):
-        self.run_test({"version": 1, "payload": self.old_payload})
 
     def test_invalid_wrapper(self):
         self.run_invalid_schema_test({})

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -95,10 +95,17 @@ class HandleSnubaQueryUpdateTest(TestCase):
         # calls the correct callback, which should result in an incident being created.
 
         message = {
-            "version": 1,
+            "version": 3,
             "payload": {
                 "subscription_id": self.subscription.subscription_id,
-                "values": {"data": [{"some_col": self.trigger.alert_threshold + 1}]},
+                "result": {"data": [{"some_col": 101}]},
+                "request": {
+                    "some": "data",
+                    "query": """MATCH (metrics_counters) SELECT sum(value) AS value BY
+                            tags[3] WHERE org_id = 1 AND project_id IN tuple(1) AND metric_id = 16
+                            AND tags[3] IN tuple(13, 4)""",
+                },
+                "entity": "metrics_counters",
                 "timestamp": "2020-01-01T01:23:45.1234",
             },
         }


### PR DESCRIPTION
Adds a new schema to subscription payload that accepts an `entity` in the payload 
See: https://github.com/getsentry/snuba/pull/2291