### PR TITLE
ref(ui): Use font-size: 100% for html & body

### DIFF
--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -88,7 +88,7 @@ const Wrapper = styled('div')<{collapsed: boolean}>`
   text-transform: uppercase;
   align-items: center;
   white-space: nowrap;
-  gap: 3rem;
+  gap: ${space(4)};
 
   margin-left: calc(
     -1 * ${p => (p.collapsed ? p.theme.sidebar.collapsedWidth : p.theme.sidebar.expandedWidth)}

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -223,8 +223,6 @@ const Name = styled('div')`
 `;
 
 const Description = styled('div')`
-  font-size: 1.5rem;
-  line-height: 2.1rem;
   margin-bottom: ${space(2)};
 
   li {

--- a/static/app/components/radio.tsx
+++ b/static/app/components/radio.tsx
@@ -12,8 +12,8 @@ type CheckedProps = Props &
 
 const checkedCss = (p: CheckedProps) => css`
   display: block;
-  width: ${p.radioSize === 'small' ? '8px' : '1rem'};
-  height: ${p.radioSize === 'small' ? '8px' : '1rem'};
+  width: ${p.radioSize === 'small' ? '8px' : '0.625rem'};
+  height: ${p.radioSize === 'small' ? '8px' : '0.625rem'};
   border-radius: 50%;
   background-color: ${p.theme.active};
   animation: 0.2s ${growIn} ease;

--- a/static/app/views/onboarding/components/stepHeading.tsx
+++ b/static/app/views/onboarding/components/stepHeading.tsx
@@ -22,7 +22,7 @@ const StepHeading = styled(motion.h2)<{step: number}>`
     background-color: ${p => p.theme.yellow300};
     border-radius: 50%;
     color: ${p => p.theme.textColor};
-    font-size: 1.5rem;
+    font-size: 1rem;
   }
 `;
 

--- a/static/app/views/onboarding/documentationSetup.tsx
+++ b/static/app/views/onboarding/documentationSetup.tsx
@@ -205,7 +205,7 @@ const Content = styled(motion.div)`
 
   .alert h5 {
     font-size: 1em;
-    margin-bottom: 1rem;
+    margin-bottom: 0.625rem;
   }
 
   /**

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -446,10 +446,6 @@ const FeatureListItem = styled('span')`
 `;
 
 const Description = styled('div')`
-  font-size: 1.5rem;
-  line-height: 2.1rem;
-  margin-bottom: ${space(2)};
-
   li {
     margin-bottom: 6px;
   }

--- a/static/app/views/organizationIntegrations/integrationItem.tsx
+++ b/static/app/views/organizationIntegrations/integrationItem.tsx
@@ -50,7 +50,7 @@ const Labels = styled('div')<StyledProps>`
 `;
 
 const IntegrationName = styled('div')`
-  font-size: 1.6rem;
+  font-size: 1rem;
 `;
 
 // Not using the overflowEllipsis style import here
@@ -60,7 +60,7 @@ const DomainName = styled('div')<StyledProps>`
   color: ${p => (p.compact ? p.theme.gray200 : p.theme.gray400)};
   margin-left: ${p => (p.compact ? space(1) : 'inherit')};
   margin-top: ${p => (!p.compact ? space(0.25) : 'inherit')};
-  font-size: 1.4rem;
+  font-size: 0.875rem;
   line-height: 1.2;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -26,7 +26,7 @@ import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHea
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 const PanelBodyLineItem = styled(PanelBody)`
-  font-size: 1.4rem;
+  font-size: 1rem;
   &:not(:last-child) {
     border-bottom: 1px solid ${p => p.theme.innerBorder};
   }

--- a/static/less/base.less
+++ b/static/less/base.less
@@ -12,7 +12,7 @@
 
 html {
   font-family: sans-serif;
-  font-size: 10px;
+  font-size: 100%;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
@@ -22,7 +22,7 @@ html {
 body {
   font-family: @font-family-base;
   margin: 0;
-  font-size: 16px;
+  font-size: 100%;
   line-height: 24px;
   color: @gray-darker;
   background: @white-dark;
@@ -44,27 +44,27 @@ h6 {
 }
 
 h1 {
-  font-size: 3.2rem;
+  font-size: 2.25rem;
 }
 
 h2 {
-  font-size: 2.8rem;
+  font-size: 1.875rem;
 }
 
 h3 {
-  font-size: 2.4rem;
+  font-size: 1.625rem;
 }
 
 h4 {
-  font-size: 2rem;
+  font-size: 1.375rem;
 }
 
 h5 {
-  font-size: 1.8rem;
+  font-size: 1.25rem;
 }
 
 h6 {
-  font-size: 1.4rem;
+  font-size: 1.125rem;
 }
 
 dl {


### PR DESCRIPTION
Currently, we set `font-size: 10px` on the `html` element (in `base.less`). This is problematic because it results in 2 scaling systems: one based on `rem` where `1rem = 10px`, and another based on `em`, where `1em ~ 16px`. 

Ideally everything should use the `rem` scale with a 16px base, since it's the base size in our design system (read: [Sep 9 front-end TSC meeting](https://www.notion.so/sentry/2021-09-09-cd0699f5c1af49f5803e7c349d991f5d)).

As a first step, we should set `font-size: 100%` on both the `html` and `body` element. `100%` means the default font size from the browser. In almost all browsers, this equals 16px (unless the user changes it to something else). This bridges the gap between the `rem` and `em` scale.

I've also updated instances where we use the `rem` scale, scaling them down accordingly (e.g. `1.6rem` => `1rem`). See comments below for screenshots & more info.