### PR TITLE
feat(suspect-spans): Only query the visible aggregations on span tab

### DIFF
--- a/static/app/utils/performance/suspectSpans/spanExamplesQuery.tsx
+++ b/static/app/utils/performance/suspectSpans/spanExamplesQuery.tsx
@@ -16,7 +16,7 @@ type SpanExamplesProps = {
 
 type RequestProps = DiscoverQueryProps & SpanExamplesProps;
 
-type ChildrenProps = Omit<GenericChildrenProps<SpanExamplesProps>, 'tableData'> & {
+export type ChildrenProps = Omit<GenericChildrenProps<SpanExamplesProps>, 'tableData'> & {
   examples: SpanExample[] | null;
 };
 

--- a/static/app/utils/performance/suspectSpans/suspectSpansQuery.tsx
+++ b/static/app/utils/performance/suspectSpans/suspectSpansQuery.tsx
@@ -17,7 +17,7 @@ type SuspectSpansProps = {
 
 type RequestProps = DiscoverQueryProps & SuspectSpansProps;
 
-type ChildrenProps = Omit<GenericChildrenProps<SuspectSpansProps>, 'tableData'> & {
+export type ChildrenProps = Omit<GenericChildrenProps<SuspectSpansProps>, 'tableData'> & {
   suspectSpans: SuspectSpans | null;
 };
 
@@ -37,9 +37,7 @@ function getSuspectSpanPayload(props: RequestProps) {
   if (!defined(payload.spanGroup)) {
     delete payload.spanGroup;
   }
-  const additionalPayload = omit(props.eventView.getEventsAPIPayload(props.location), [
-    'field',
-  ]);
+  const additionalPayload = props.eventView.getEventsAPIPayload(props.location);
   return Object.assign(payload, additionalPayload);
 }
 

--- a/static/app/utils/performance/suspectSpans/types.tsx
+++ b/static/app/utils/performance/suspectSpans/types.tsx
@@ -24,14 +24,14 @@ export type SuspectSpan = SpanExample & {
   projectId: number;
   project: string;
   transaction: string;
-  frequency: number;
-  count: number;
-  avgOccurrences: number;
-  sumExclusiveTime: number;
-  p50ExclusiveTime: number;
-  p75ExclusiveTime: number;
-  p95ExclusiveTime: number;
-  p99ExclusiveTime: number;
+  frequency?: number;
+  count?: number;
+  avgOccurrences?: number;
+  sumExclusiveTime?: number;
+  p50ExclusiveTime?: number;
+  p75ExclusiveTime?: number;
+  p95ExclusiveTime?: number;
+  p99ExclusiveTime?: number;
 };
 
 export type SuspectSpans = SuspectSpan[];

--- a/static/app/views/performance/transactionSummary/transactionSpans/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.tsx
@@ -4,9 +4,6 @@ import pick from 'lodash/pick';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
-import EventView from 'sentry/utils/discover/eventView';
-import {decodeScalar} from 'sentry/utils/queryString';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
 
@@ -14,8 +11,7 @@ import PageLayout from '../pageLayout';
 import Tab from '../tabs';
 
 import SpansContent from './content';
-import {SpanSortOthers, SpanSortPercentiles} from './types';
-import {getSuspectSpanSortFromLocation} from './utils';
+import {generateSpansEventView} from './utils';
 
 const RELATIVE_PERIODS = pick(DEFAULT_RELATIVE_PERIODS, [
   '1h',
@@ -41,35 +37,12 @@ function TransactionSpans(props: Props) {
       projects={projects}
       tab={Tab.Spans}
       getDocumentTitle={getDocumentTitle}
-      generateEventView={generateEventView}
+      generateEventView={generateSpansEventView}
       childComponent={SpansContent}
       relativeDateOptions={RELATIVE_PERIODS}
       maxPickableDays={30}
     />
   );
-}
-
-function generateEventView(location: Location, transactionName: string): EventView {
-  const query = decodeScalar(location.query.query, '');
-  const conditions = new MutableSearch(query);
-  conditions
-    .setFilterValues('event.type', ['transaction'])
-    .setFilterValues('transaction', [transactionName]);
-
-  const eventView = EventView.fromNewQueryWithLocation(
-    {
-      id: undefined,
-      version: 2,
-      name: transactionName,
-      fields: [...Object.values(SpanSortOthers), ...Object.values(SpanSortPercentiles)],
-      query: conditions.formatString(),
-      projects: [],
-    },
-    location
-  );
-
-  const sort = getSuspectSpanSortFromLocation(location);
-  return eventView.withSorts([{field: sort.field, kind: 'desc'}]);
 }
 
 function getDocumentTitle(transactionName: string): string {

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanTable.tsx
@@ -29,13 +29,21 @@ type Props = {
   organization: Organization;
   suspectSpan: SuspectSpan;
   transactionName: string;
+  isLoading: boolean;
   examples: ExampleTransaction[];
   pageLinks?: string | null;
 };
 
 export default function SpanTable(props: Props) {
-  const {location, organization, examples, suspectSpan, transactionName, pageLinks} =
-    props;
+  const {
+    location,
+    organization,
+    examples,
+    suspectSpan,
+    transactionName,
+    isLoading,
+    pageLinks,
+  } = props;
 
   if (!defined(examples)) {
     return null;
@@ -59,6 +67,7 @@ export default function SpanTable(props: Props) {
   return (
     <Fragment>
       <GridEditable
+        isLoading={isLoading}
         data={data}
         columnOrder={SPANS_TABLE_COLUMN_ORDER}
         columnSortBy={[]}

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
@@ -74,6 +74,7 @@ export default function SuspectSpanEntry(props: Props) {
       </UpperPanel>
       <LowerPanel expandable={expandable} data-test-id="suspect-card-lower">
         <SpanTable
+          isLoading={false}
           location={location}
           organization={organization}
           suspectSpan={suspectSpan}
@@ -139,23 +140,27 @@ function SpanCount(props: HeaderItemProps) {
   }
 
   if (sort.field === SpanSortOthers.AVG_OCCURRENCE) {
+    const {avgOccurrences} = suspectSpan;
     return (
       <HeaderItem
         label={t('Average Count')}
-        value={formatFloat(suspectSpan.avgOccurrences, 2)}
+        value={defined(avgOccurrences) ? formatFloat(avgOccurrences, 2) : '\u2014'}
         align="right"
         isSortKey
       />
     );
   }
 
+  let {frequency} = suspectSpan;
+  if (!defined(frequency)) {
+    return <HeaderItem label={t('Frequency')} value={'\u2014'} align="right" />;
+  }
+
   // Because the frequency is computed using `count_unique(id)` internally,
   // it is an approximate value. This means that it has the potential to be
   // greater than `totals.count` when it shouldn't. So let's clip the
   // frequency value to make sure we don't see values over 100%.
-  const frequency = defined(totals?.count)
-    ? Math.min(suspectSpan.frequency, totals!.count)
-    : suspectSpan.frequency;
+  frequency = defined(totals?.count) ? Math.min(frequency, totals!.count) : frequency;
 
   const value = defined(totals?.count) ? (
     <Tooltip
@@ -176,16 +181,26 @@ function SpanCount(props: HeaderItemProps) {
 function TotalCumulativeDuration(props: HeaderItemProps) {
   const {sort, suspectSpan, totals} = props;
 
-  let value = (
-    <PerformanceDuration abbreviation milliseconds={suspectSpan.sumExclusiveTime} />
-  );
+  const {sumExclusiveTime} = suspectSpan;
+  if (!defined(sumExclusiveTime)) {
+    return (
+      <HeaderItem
+        label={t('Total Exclusive Time')}
+        value={'\u2014'}
+        align="right"
+        isSortKey={sort.field === SpanSortOthers.SUM_EXCLUSIVE_TIME}
+      />
+    );
+  }
+
+  let value = <PerformanceDuration abbreviation milliseconds={sumExclusiveTime} />;
 
   if (defined(totals?.sum_transaction_duration)) {
     value = (
       <Tooltip
         title={tct('[percentage] of the total transaction duration of [duration]', {
           percentage: formatPercentage(
-            suspectSpan.sumExclusiveTime / totals!.sum_transaction_duration
+            sumExclusiveTime / totals!.sum_transaction_duration
           ),
           duration: (
             <PerformanceDuration


### PR DESCRIPTION
The additional aggregations being queried on the span tab can be rather
expensive to compute. This restricts the aggregates that are queried to save on
computations.