### PR TITLE
fix(ui): Use white for Quick Start sidebar item

### DIFF
--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -116,7 +116,7 @@ function OnboardingStatus({
 const Heading = styled('div')`
   transition: color 100ms;
   font-size: ${p => p.theme.backgroundSecondary};
-  color: ${p => p.theme.subText};
+  color: ${p => p.theme.white};
   margin-bottom: ${space(0.25)};
 `;
 

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -116,7 +116,7 @@ function OnboardingStatus({
 const Heading = styled('div')`
   transition: color 100ms;
   font-size: ${p => p.theme.backgroundSecondary};
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.subText};
   margin-bottom: ${space(0.25)};
 `;
 


### PR DESCRIPTION
Use `white` instead of `gray200` for the Quick Start sidebar item.

Before (dark mode):
<img width="215" alt="Screen Shot 2021-12-16 at 3 33 11 PM" src="https://user-images.githubusercontent.com/44172267/146465068-1d9e096c-23ee-4813-a7ad-6ad4b084b27f.png">

After (dark & light mode):
<img width="215" alt="Screen Shot 2021-12-16 at 3 58 46 PM" src="https://user-images.githubusercontent.com/44172267/146466374-dbc05293-be38-4b24-8671-9fba3c277bbc.png">
<img width="215" alt="Screen Shot 2021-12-16 at 3 58 27 PM" src="https://user-images.githubusercontent.com/44172267/146466338-dd502db7-be17-4c17-9930-66592e15bba1.png">

