### PR TITLE
fix(search): Updating invalid date keys

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1052,14 +1052,11 @@ default_config = SearchConfig(
     date_keys={
         "start",
         "end",
-        "first_seen",
-        "last_seen",
+        "last_seen()",
         "time",
         "timestamp",
         "timestamp.to_hour",
         "timestamp.to_day",
-        "transaction.start_time",
-        "transaction.end_time",
     },
     boolean_keys={
         "error.handled",

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -31,7 +31,7 @@ issue_search_config = SearchConfig.create_from(
     allow_boolean=False,
     is_filter_translation=is_filter_translation,
     numeric_keys=default_config.numeric_keys | {"times_seen"},
-    date_keys=default_config.date_keys | {"date"},
+    date_keys=default_config.date_keys | {"date", "first_seen", "last_seen"},
     key_mappings={
         "assigned_to": ["assigned"],
         "bookmarked_by": ["bookmarks"],

--- a/tests/fixtures/search-syntax/invalid_date_formats.json
+++ b/tests/fixtures/search-syntax/invalid_date_formats.json
@@ -1,6 +1,6 @@
 [
   {
-    "query": "first_seen:hello",
+    "query": "timestamp:hello",
     "result": [
       {"type": "spaces", "value": ""},
       {
@@ -11,7 +11,7 @@
           "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. 2017-10-17 or 2017-10-17T02:41:00.000Z)",
           "expectedType": ["date", "specificDate", "relativeDate"]
         },
-        "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
+        "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "hello", "quoted": false}
       },
@@ -19,7 +19,7 @@
     ]
   },
   {
-    "query": "first_seen:123",
+    "query": "timestamp:123",
     "result": [
       {"type": "spaces", "value": ""},
       {
@@ -30,7 +30,7 @@
           "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. 2017-10-17 or 2017-10-17T02:41:00.000Z)",
           "expectedType": ["date", "specificDate", "relativeDate"]
         },
-        "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
+        "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "123", "quoted": false}
       },
@@ -38,7 +38,7 @@
     ]
   },
   {
-    "query": "first_seen:2018-01-01T00:01ZZ",
+    "query": "timestamp:2018-01-01T00:01ZZ",
     "result": [
       {"type": "spaces", "value": ""},
       {
@@ -49,7 +49,7 @@
           "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. 2017-10-17 or 2017-10-17T02:41:00.000Z)",
           "expectedType": ["date", "specificDate", "relativeDate"]
         },
-        "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
+        "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "2018-01-01T00:01ZZ", "quoted": false}
       },

--- a/tests/fixtures/search-syntax/other_dates.json
+++ b/tests/fixtures/search-syntax/other_dates.json
@@ -1,14 +1,14 @@
 [
   {
     "desc": "test date format with other name",
-    "query": "first_seen:>2015-05-18",
+    "query": "timestamp:>2015-05-18",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "date",
         "negated": false,
-        "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
+        "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": ">",
         "value": {"type": "valueIso8601Date", "value": "2015-05-18T00:00:00.000Z"}
       },
@@ -16,14 +16,14 @@
     ]
   },
   {
-    "query": "first_seen:>2018-01-01T05:06:07+00:00",
+    "query": "timestamp.to_hour:>2018-01-01T05:06:07+00:00",
     "result": [
       {"type": "spaces", "value": ""},
       {
         "type": "filter",
         "filter": "date",
         "negated": false,
-        "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
+        "key": {"type": "keySimple", "value": "timestamp.to_hour", "quoted": false},
         "operator": ">",
         "value": {"type": "valueIso8601Date", "value": "2018-01-01T05:06:07.000Z"}
       },

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from sentry.api.event_search import (
+    AggregateFilter,
     AggregateKey,
     SearchConfig,
     SearchFilter,
@@ -223,16 +224,16 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
     def test_rel_time_filter(self):
         now = timezone.now()
         with freeze_time(now):
-            assert parse_search_query("first_seen:+7d") == [
+            assert parse_search_query("time:+7d") == [
                 SearchFilter(
-                    key=SearchKey(name="first_seen"),
+                    key=SearchKey(name="time"),
                     operator="<=",
                     value=SearchValue(raw_value=now - timedelta(days=7)),
                 )
             ]
-            assert parse_search_query("first_seen:-2w") == [
+            assert parse_search_query("time:-2w") == [
                 SearchFilter(
-                    key=SearchKey(name="first_seen"),
+                    key=SearchKey(name="time"),
                     operator=">=",
                     value=SearchValue(raw_value=now - timedelta(days=14)),
                 )
@@ -245,15 +246,15 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
         now = timezone.now()
         with freeze_time(now):
             assert parse_search_query("last_seen():+7d") == [
-                SearchFilter(
-                    key=SearchKey(name="last_seen()"),
+                AggregateFilter(
+                    key=AggregateKey(name="last_seen()"),
                     operator="<=",
                     value=SearchValue(raw_value=now - timedelta(days=7)),
                 )
             ]
             assert parse_search_query("last_seen():-2w") == [
-                SearchFilter(
-                    key=SearchKey(name="last_seen()"),
+                AggregateFilter(
+                    key=AggregateKey(name="last_seen()"),
                     operator=">=",
                     value=SearchValue(raw_value=now - timedelta(days=14)),
                 )
@@ -263,29 +264,29 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
             ]
 
     def test_specific_time_filter(self):
-        assert parse_search_query("first_seen:2018-01-01") == [
+        assert parse_search_query("time:2018-01-01") == [
             SearchFilter(
-                key=SearchKey(name="first_seen"),
+                key=SearchKey(name="time"),
                 operator=">=",
                 value=SearchValue(raw_value=datetime.datetime(2018, 1, 1, tzinfo=timezone.utc)),
             ),
             SearchFilter(
-                key=SearchKey(name="first_seen"),
+                key=SearchKey(name="time"),
                 operator="<",
                 value=SearchValue(raw_value=datetime.datetime(2018, 1, 2, tzinfo=timezone.utc)),
             ),
         ]
 
-        assert parse_search_query("first_seen:2018-01-01T05:06:07Z") == [
+        assert parse_search_query("time:2018-01-01T05:06:07Z") == [
             SearchFilter(
-                key=SearchKey(name="first_seen"),
+                key=SearchKey(name="time"),
                 operator=">=",
                 value=SearchValue(
                     raw_value=datetime.datetime(2018, 1, 1, 5, 1, 7, tzinfo=timezone.utc)
                 ),
             ),
             SearchFilter(
-                key=SearchKey(name="first_seen"),
+                key=SearchKey(name="time"),
                 operator="<",
                 value=SearchValue(
                     raw_value=datetime.datetime(2018, 1, 1, 5, 12, 7, tzinfo=timezone.utc)
@@ -293,16 +294,16 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
             ),
         ]
 
-        assert parse_search_query("first_seen:2018-01-01T05:06:07+00:00") == [
+        assert parse_search_query("time:2018-01-01T05:06:07+00:00") == [
             SearchFilter(
-                key=SearchKey(name="first_seen"),
+                key=SearchKey(name="time"),
                 operator=">=",
                 value=SearchValue(
                     raw_value=datetime.datetime(2018, 1, 1, 5, 1, 7, tzinfo=timezone.utc)
                 ),
             ),
             SearchFilter(
-                key=SearchKey(name="first_seen"),
+                key=SearchKey(name="time"),
                 operator="<",
                 value=SearchValue(
                     raw_value=datetime.datetime(2018, 1, 1, 5, 12, 7, tzinfo=timezone.utc)


### PR DESCRIPTION
- Some of these date keys are incorrect for discover search, which means
  we're treating their values as dates, but turning the keys into tags
  instead