### PR TITLE
fix(discover): Always coerce tag values to strings

### DIFF
--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -8,6 +8,7 @@ import sentry_sdk
 from parsimonious.exceptions import ParseError
 from sentry_relay import parse_release as parse_release_relay
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
+from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, Condition, Op, Or
 from snuba_sdk.function import Function
 
@@ -1416,8 +1417,8 @@ class QueryFilter(QueryFields):
         # Tags are never null, but promoted tags are columns and so can be null.
         # To handle both cases, use `ifNull` to convert to an empty string and
         # compare so we need to check for empty values.
-        if lhs.subscriptable == "tags":
-            if not isinstance(value, str):
+        if isinstance(lhs, Column) and lhs.subscriptable == "tags":
+            if operator not in ["IN", "NOT IN"] and not isinstance(value, str):
                 sentry_sdk.set_tag("query.lhs", lhs)
                 sentry_sdk.set_tag("query.rhs", value)
                 sentry_sdk.capture_message("Tag value was not a string", level="error")

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from functools import reduce
 from typing import Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
+import sentry_sdk
 from parsimonious.exceptions import ParseError
 from sentry_relay import parse_release as parse_release_relay
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
@@ -1415,8 +1416,12 @@ class QueryFilter(QueryFields):
         # Tags are never null, but promoted tags are columns and so can be null.
         # To handle both cases, use `ifNull` to convert to an empty string and
         # compare so we need to check for empty values.
-        if search_filter.key.is_tag:
-            name = ["ifNull", [name, "''"]]
+        if lhs.subscriptable == "tags":
+            if not isinstance(value, str):
+                sentry_sdk.set_tag("query.lhs", lhs)
+                sentry_sdk.set_tag("query.rhs", value)
+                sentry_sdk.capture_message("Tag value was not a string", level="error")
+                value = str(value)
             lhs = Function("ifNull", [lhs, ""])
 
         # Handle checks for existence


### PR DESCRIPTION
- This is so we don't cause an error in Snuba
- Still throw an error when this happens since this should only happen
  when there's a bug in our search grammar
- Also need to check that the lhs has become a tag rather than the search syntax thinks its a tag since the value being wrong is usually caused by an issue in the search syntax see #30757