### PR TITLE
feat(team-stats): Add a bar chart for crash free rate to the crash free sessions table

### DIFF
--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -80,7 +80,6 @@ type Props = Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'> & {
 function MiniBarChart({
   markers,
   emphasisColors,
-  series: _series,
   series,
   hideDelay,
   tooltipFormatter,

--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -59,6 +59,21 @@ export function getSeriesAverage(
     : totalCount / dataPoints;
 }
 
+export function getSeriesSum(
+  groups: SessionApiResponse['groups'] = [],
+  field: SessionField,
+  intervals: SessionApiResponse['intervals'] = []
+) {
+  const dataPointsSums: number[] = Array(intervals.length).fill(0);
+  const groupSeries = groups.map(group => group.series[field]);
+
+  groupSeries.forEach(series => {
+    series.forEach((dataPoint, idx) => (dataPointsSums[idx] += dataPoint));
+  });
+
+  return dataPointsSums;
+}
+
 export function getSessionStatusRate(
   groups: SessionApiResponse['groups'] = [],
   field: SessionField,

--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -137,7 +137,7 @@ class TeamStability extends AsyncComponent<Props, State> {
     const sumSessions = getSeriesSum(
       response.groups.filter(group => group.by.project === Number(project.id)),
       SessionField.SESSIONS,
-      response.intervals,
+      response.intervals
     );
 
     const countSeries = getCountSeries(
@@ -151,10 +151,12 @@ class TeamStability extends AsyncComponent<Props, State> {
     );
 
     const countSeriesWeeklyTotals: number[] = Array(sumSessions.length / 7).fill(0);
-    countSeries.forEach((s, idx) => countSeriesWeeklyTotals[Math.floor(idx/7)] += s.value);
+    countSeries.forEach(
+      (s, idx) => (countSeriesWeeklyTotals[Math.floor(idx / 7)] += s.value)
+    );
 
     const sumSessionsWeeklyTotals: number[] = Array(sumSessions.length / 7).fill(0);
-    sumSessions.forEach((s, idx) => sumSessionsWeeklyTotals[Math.floor(idx/7)] += s);
+    sumSessions.forEach((s, idx) => (sumSessionsWeeklyTotals[Math.floor(idx / 7)] += s));
 
     const data = countSeriesWeeklyTotals.map((value, idx) => ({
       name: countSeries[idx * 7].name,

--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -4,11 +4,10 @@ import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 import round from 'lodash/round';
 
-import {Client} from 'sentry/api';
 import AsyncComponent from 'sentry/components/asyncComponent';
+import Button from 'sentry/components/button';
 import MiniBarChart from 'sentry/components/charts/miniBarChart';
 import SessionsRequest from 'sentry/components/charts/sessionsRequest';
-import Button from 'sentry/components/button';
 import {DateTimeObject} from 'sentry/components/charts/utils';
 import IdBadge from 'sentry/components/idBadge';
 import {getParams} from 'sentry/components/organizations/globalSelectionHeader/getParams';
@@ -27,7 +26,6 @@ import {
 import {formatFloat} from 'sentry/utils/formatters';
 import {getCountSeries, getCrashFreeRate, getSeriesSum} from 'sentry/utils/sessions';
 import {Color} from 'sentry/utils/theme';
-import withApi from 'sentry/utils/withApi';
 import {displayCrashFreePercent} from 'sentry/views/releases/utils';
 
 import {groupByTrend} from './utils';
@@ -35,7 +33,6 @@ import {groupByTrend} from './utils';
 type Props = AsyncComponent['props'] & {
   organization: Organization;
   projects: Project[];
-  api: Client;
   period?: string;
 } & DateTimeObject;
 
@@ -186,7 +183,7 @@ class TeamStability extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {api, organization, projects, period} = this.props;
+    const {organization, projects, period} = this.props;
 
     const sortedProjects = projects
       .map(project => ({project, trend: this.getTrend(Number(project.id)) ?? 0}))
@@ -196,7 +193,7 @@ class TeamStability extends AsyncComponent<Props, State> {
 
     return (
       <SessionsRequest
-        api={api}
+        api={this.api}
         project={projects.map(({id}) => Number(id))}
         organization={organization}
         interval="1d"
@@ -208,15 +205,16 @@ class TeamStability extends AsyncComponent<Props, State> {
           <StyledPanelTable
             isEmpty={projects.length === 0}
             emptyMessage={t('No Projects With Release Health Enabled')}
-        emptyAction={
-          <Button
-            size="small"
-            external
-            href="https://docs.sentry.io/platforms/dotnet/guides/nlog/configuration/releases/#release-health"
-          >
-            {t('Learn More')}
-          </Button>
-        }headers={[
+            emptyAction={
+              <Button
+                size="small"
+                external
+                href="https://docs.sentry.io/platforms/dotnet/guides/nlog/configuration/releases/#release-health"
+              >
+                {t('Learn More')}
+              </Button>
+            }
+            headers={[
               t('Project'),
               <RightAligned key="last">{tct('Last [period]', {period})}</RightAligned>,
               <RightAligned key="avg">{tct('[period] Avg', {period})}</RightAligned>,
@@ -282,7 +280,7 @@ class TeamStability extends AsyncComponent<Props, State> {
   }
 }
 
-export default withApi(TeamStability);
+export default TeamStability;
 
 const StyledPanelTable = styled(PanelTable)<{isEmpty: boolean}>`
   grid-template-columns: 1fr 0.2fr 0.2fr 0.2fr 0.2fr;

--- a/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
@@ -60,6 +60,38 @@ describe('TeamInsightsOverview', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/sessions/`,
+      body: {
+        start: '2021-10-30T00:00:00Z',
+        end: '2021-12-24T00:00:00Z',
+        query: '',
+        intervals: [],
+        groups: [
+          {
+            by: {project: 1, 'session.status': 'healthy'},
+            totals: {'sum(session)': 0},
+            series: {'sum(session)': []},
+          },
+          {
+            by: {project: 1, 'session.status': 'crashed'},
+            totals: {'sum(session)': 0},
+            series: {'sum(session)': []},
+          },
+          {
+            by: {project: 1, 'session.status': 'errored'},
+            totals: {'sum(session)': 0},
+            series: {'sum(session)': []},
+          },
+          {
+            by: {project: 1, 'session.status': 'abnormal'},
+            totals: {'sum(session)': 0},
+            series: {'sum(session)': []},
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/eventsv2/',
       body: {
         meta: {

--- a/tests/js/spec/views/organizationStats/teamInsights/teamStability.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamStability.spec.jsx
@@ -20,7 +20,7 @@ describe('TeamStability', () => {
     expect(screen.getByText('project-slug')).toBeInTheDocument();
     expect(screen.getAllByText('90%')).toHaveLength(2);
     expect(screen.getByText('0%')).toBeInTheDocument(2);
-    expect(sessionsApi).toHaveBeenCalledTimes(2);
+    expect(sessionsApi).toHaveBeenCalledTimes(3);
   });
 
   it('should render no sessions', async () => {


### PR DESCRIPTION
This adds a weekly chart of crash free sessions % to the crash free rate table in team stats page.

<img width="699" alt="Screen Shot 2021-12-23 at 5 00 47 PM" src="https://user-images.githubusercontent.com/15015880/147303382-6686123b-8076-4679-9261-58bc7ae8f7d8.png">
