### PR TITLE
feat(gsh): Standalone environment selector

### DIFF
--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -1,0 +1,92 @@
+import {useState} from 'react';
+import {withRouter, WithRouterProps} from 'react-router';
+import styled from '@emotion/styled';
+
+import {updateEnvironments} from 'sentry/actionCreators/globalSelection';
+import DropdownButton from 'sentry/components/dropdownButton';
+import MultipleEnvironmentSelector from 'sentry/components/organizations/multipleEnvironmentSelector';
+import {IconWindow} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import GlobalSelectionStore from 'sentry/stores/globalSelectionStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import space from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+
+type Props = {
+  router: WithRouterProps['router'];
+  /**
+   * Reset these URL params when we fire actions
+   * (custom routing only)
+   */
+  resetParamsOnChange?: string[];
+};
+
+function EnvironmentPageFilter({router, resetParamsOnChange = []}: Props) {
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+  const organization = useOrganization();
+  const {selection, isReady} = useLegacyStore(GlobalSelectionStore);
+
+  const [selectedEnvironments, setSelectedEnvironments] = useState<string[] | null>(null);
+
+  const handleChangeEnvironments = (environments: string[] | null) => {
+    setSelectedEnvironments(environments);
+  };
+
+  const handleUpdateEnvironments = () => {
+    updateEnvironments(selectedEnvironments, router, {
+      save: true,
+      resetParams: resetParamsOnChange,
+    });
+    setSelectedEnvironments(null);
+  };
+
+  const customDropdownButton = ({isOpen, getActorProps, summary}) => {
+    return (
+      <StyledDropdownButton isOpen={isOpen} {...getActorProps()}>
+        <DropdownTitle>
+          <IconWindow />
+          {summary}
+        </DropdownTitle>
+      </StyledDropdownButton>
+    );
+  };
+
+  const customLoadingIndicator = (
+    <StyledDropdownButton showChevron={false} disabled>
+      <DropdownTitle>
+        <IconWindow />
+        {t('Loading\u2026')}
+      </DropdownTitle>
+    </StyledDropdownButton>
+  );
+
+  return (
+    <MultipleEnvironmentSelector
+      organization={organization}
+      projects={projects}
+      loadingProjects={!projectsLoaded || !isReady}
+      selectedProjects={selection.projects}
+      value={selection.environments}
+      onChange={handleChangeEnvironments}
+      onUpdate={handleUpdateEnvironments}
+      customDropdownButton={customDropdownButton}
+      customLoadingIndicator={customLoadingIndicator}
+    />
+  );
+}
+
+const StyledDropdownButton = styled(DropdownButton)`
+  width: 100%;
+  height: 40px;
+`;
+
+const DropdownTitle = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: ${space(1)};
+  align-items: center;
+  white-space: nowrap;
+`;
+
+export default withRouter(EnvironmentPageFilter);

--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -2,12 +2,12 @@ import {useState} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
-import {updateEnvironments} from 'sentry/actionCreators/globalSelection';
+import {updateEnvironments} from 'sentry/actionCreators/pageFilters';
 import DropdownButton from 'sentry/components/dropdownButton';
 import MultipleEnvironmentSelector from 'sentry/components/organizations/multipleEnvironmentSelector';
 import {IconWindow} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import GlobalSelectionStore from 'sentry/stores/globalSelectionStore';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -16,8 +16,7 @@ import useProjects from 'sentry/utils/useProjects';
 type Props = {
   router: WithRouterProps['router'];
   /**
-   * Reset these URL params when we fire actions
-   * (custom routing only)
+   * Reset these URL params when we fire actions (custom routing only)
    */
   resetParamsOnChange?: string[];
 };
@@ -25,7 +24,7 @@ type Props = {
 function EnvironmentPageFilter({router, resetParamsOnChange = []}: Props) {
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const organization = useOrganization();
-  const {selection, isReady} = useLegacyStore(GlobalSelectionStore);
+  const {selection, isReady} = useLegacyStore(PageFiltersStore);
 
   const [selectedEnvironments, setSelectedEnvironments] = useState<string[] | null>(null);
 
@@ -84,7 +83,7 @@ const StyledDropdownButton = styled(DropdownButton)`
 const DropdownTitle = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   white-space: nowrap;
 `;

--- a/static/app/components/organizations/multipleEnvironmentSelector.tsx
+++ b/static/app/components/organizations/multipleEnvironmentSelector.tsx
@@ -8,6 +8,7 @@ import {Client} from 'sentry/api';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
 import {MenuFooterChildProps} from 'sentry/components/dropdownAutoComplete/menu';
 import {Item} from 'sentry/components/dropdownAutoComplete/types';
+import {GetActorPropsFn} from 'sentry/components/dropdownMenu';
 import Highlight from 'sentry/components/highlight';
 import HeaderItem from 'sentry/components/organizations/headerItem';
 import MultipleSelectorSubmitRow from 'sentry/components/organizations/multipleSelectorSubmitRow';
@@ -43,6 +44,12 @@ type Props = WithRouterProps & {
    * When menu is closed
    */
   onUpdate: () => void;
+  customDropdownButton?: (config: {
+    getActorProps: GetActorPropsFn;
+    isOpen: boolean;
+    summary: string;
+  }) => React.ReactElement;
+  customLoadingIndicator?: React.ReactNode;
 } & DefaultProps;
 
 type State = {
@@ -215,7 +222,8 @@ class MultipleEnvironmentSelector extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {value, loadingProjects} = this.props;
+    const {value, loadingProjects, customDropdownButton, customLoadingIndicator} =
+      this.props;
     const environments = this.getEnvironments();
 
     const validatedValue = value.filter(env => environments.includes(env));
@@ -224,17 +232,19 @@ class MultipleEnvironmentSelector extends React.PureComponent<Props, State> {
       : t('All Environments');
 
     return loadingProjects ? (
-      <StyledHeaderItem
-        data-test-id="global-header-environment-selector"
-        icon={<IconWindow />}
-        loading={loadingProjects}
-        hasChanges={false}
-        hasSelected={false}
-        isOpen={false}
-        locked={false}
-      >
-        {t('Loading\u2026')}
-      </StyledHeaderItem>
+      customLoadingIndicator ?? (
+        <StyledHeaderItem
+          data-test-id="global-header-environment-selector"
+          icon={<IconWindow />}
+          loading={loadingProjects}
+          hasChanges={false}
+          hasSelected={false}
+          isOpen={false}
+          locked={false}
+        >
+          {t('Loading\u2026')}
+        </StyledHeaderItem>
+      )
     ) : (
       <ClassNames>
         {({css}) => (
@@ -275,21 +285,25 @@ class MultipleEnvironmentSelector extends React.PureComponent<Props, State> {
               ),
             }))}
           >
-            {({isOpen, getActorProps}) => (
-              <StyledHeaderItem
-                data-test-id="global-header-environment-selector"
-                icon={<IconWindow />}
-                isOpen={isOpen}
-                hasSelected={value && !!value.length}
-                onClear={this.handleClear}
-                hasChanges={false}
-                locked={false}
-                loading={false}
-                {...getActorProps()}
-              >
-                {summary}
-              </StyledHeaderItem>
-            )}
+            {({isOpen, getActorProps}) =>
+              customDropdownButton ? (
+                customDropdownButton({isOpen, getActorProps, summary})
+              ) : (
+                <StyledHeaderItem
+                  data-test-id="global-header-environment-selector"
+                  icon={<IconWindow />}
+                  isOpen={isOpen}
+                  hasSelected={value && !!value.length}
+                  onClear={this.handleClear}
+                  hasChanges={false}
+                  locked={false}
+                  loading={false}
+                  {...getActorProps()}
+                >
+                  {summary}
+                </StyledHeaderItem>
+              )
+            }
           </StyledDropdownAutoComplete>
         )}
       </ClassNames>

--- a/tests/js/spec/components/environmentPageFilter.spec.tsx
+++ b/tests/js/spec/components/environmentPageFilter.spec.tsx
@@ -1,0 +1,60 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
+import GlobalSelectionStore from 'sentry/stores/globalSelectionStore';
+import OrganizationStore from 'sentry/stores/organizationStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+describe('EnvironmentPageFilter', function () {
+  const {organization, router, routerContext} = initializeOrg({
+    organization: {features: ['global-views']},
+    project: undefined,
+    projects: [
+      {
+        id: 2,
+        slug: 'project-2',
+        environments: ['prod', 'staging'],
+      },
+    ],
+    router: {
+      location: {query: {}},
+      params: {orgId: 'org-slug'},
+    },
+  });
+  OrganizationStore.onUpdate(organization, {replace: true});
+  ProjectsStore.loadInitialData(organization.projects);
+  GlobalSelectionStore.onInitializeUrlState({
+    projects: [2],
+    environments: [],
+    datetime: {start: null, end: null, period: '14d', utc: null},
+  });
+
+  it('can pick environment', function () {
+    mountWithTheme(
+      <OrganizationContext.Provider value={organization}>
+        <EnvironmentPageFilter />
+      </OrganizationContext.Provider>,
+      {
+        context: routerContext,
+      }
+    );
+
+    // Open the environment dropdown
+    expect(screen.getByText('All Environments')).toBeInTheDocument();
+    userEvent.click(screen.getByText('All Environments'));
+
+    // Click the first environment's checkbox
+    const envOptions = screen.getAllByTestId('checkbox-fancy');
+    userEvent.click(envOptions[0]);
+
+    // Close the dropdown
+    userEvent.click(screen.getAllByText('prod')[0]);
+
+    // Verify we were redirected
+    expect(router.push).toHaveBeenCalledWith(
+      expect.objectContaining({query: {environment: ['prod']}})
+    );
+  });
+});

--- a/tests/js/spec/components/environmentPageFilter.spec.tsx
+++ b/tests/js/spec/components/environmentPageFilter.spec.tsx
@@ -2,8 +2,8 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
-import GlobalSelectionStore from 'sentry/stores/globalSelectionStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
@@ -25,7 +25,7 @@ describe('EnvironmentPageFilter', function () {
   });
   OrganizationStore.onUpdate(organization, {replace: true});
   ProjectsStore.loadInitialData(organization.projects);
-  GlobalSelectionStore.onInitializeUrlState({
+  PageFiltersStore.onInitializeUrlState({
     projects: [2],
     environments: [],
     datetime: {start: null, end: null, period: '14d', utc: null},


### PR DESCRIPTION
Reusing the multiple environment selector from the GSH and using it in a standalone EnvironmentPageFilter.

Example usage **(not a final placement)**:
![image](https://user-images.githubusercontent.com/9372512/146612347-04e5f26a-3ac4-4019-b7f3-2edad3b0b101.png)

Example loading state:
![image](https://user-images.githubusercontent.com/9372512/146612385-9b2650a0-b222-4788-99a5-115b65fd7f92.png)
