### PR TITLE
ref(types): Add Model types to Endpoints

### DIFF
--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -88,7 +88,7 @@ class GroupEndpoint(Endpoint):
             project_id=group.project_id, group_id=group.id, linked_type=GroupLink.LinkedType.issue
         ).values_list("linked_id", flat=True)
 
-    def create_external_comment(self, request: Request, group, group_note):
+    def create_external_comment(self, request: Request, group: Group, group_note):
         for external_issue_id in self.get_external_issue_ids(group):
             create_comment.apply_async(
                 kwargs={
@@ -98,7 +98,7 @@ class GroupEndpoint(Endpoint):
                 }
             )
 
-    def update_external_comment(self, request: Request, group, group_note):
+    def update_external_comment(self, request: Request, group: Group, group_note):
         for external_issue_id in self.get_external_issue_ids(group):
             update_comment.apply_async(
                 kwargs={

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -259,7 +259,11 @@ class OrganizationEndpoint(Endpoint):
         return get_environments(request, organization)
 
     def get_filter_params(
-        self, request: Request, organization, date_filter_optional=False, project_ids=None
+        self,
+        request: Request,
+        organization: Organization,
+        date_filter_optional=False,
+        project_ids=None,
     ):
         """
         Extracts common filter parameters from the request and returns them
@@ -354,7 +358,7 @@ class OrganizationEndpoint(Endpoint):
 class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationReleasePermission,)
 
-    def get_projects(self, request: Request, organization, project_ids=None):
+    def get_projects(self, request: Request, organization: Organization, project_ids=None):
         """
         Get all projects the current user or API token has access to. More
         detail in the parent class's method of the same name.
@@ -380,7 +384,7 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
             project_ids=project_ids,
         )
 
-    def has_release_permission(self, request: Request, organization, release):
+    def has_release_permission(self, request: Request, organization: Organization, release):
         """
         Does the given request have permission to access this release, based
         on the projects to which the release is attached?

--- a/src/sentry/api/bases/organizationissues.py
+++ b/src/sentry/api/bases/organizationissues.py
@@ -4,7 +4,14 @@ from rest_framework.response import Response
 from sentry.api.base import EnvironmentMixin
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import StreamGroupSerializer, serialize
-from sentry.models import Group, GroupStatus, OrganizationMemberTeam, Project, ProjectStatus
+from sentry.models import (
+    Group,
+    GroupStatus,
+    Organization,
+    OrganizationMemberTeam,
+    Project,
+    ProjectStatus,
+)
 
 from .organizationmember import OrganizationMemberEndpoint
 
@@ -12,11 +19,11 @@ ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', a
 
 
 class OrganizationIssuesEndpoint(OrganizationMemberEndpoint, EnvironmentMixin):
-    def get_queryset(self, request, organization, member, project_list):
+    def get_queryset(self, request: Request, organization: Organization, member, project_list):
         # Must return a 'sort_by' selector for pagination that is a datetime
         return Group.objects.none()
 
-    def get(self, request: Request, organization, member) -> Response:
+    def get(self, request: Request, organization: Organization, member) -> Response:
         """
         Return a list of issues assigned to the given member.
         """

--- a/src/sentry/api/bases/organizationmember.py
+++ b/src/sentry/api/bases/organizationmember.py
@@ -4,7 +4,7 @@ from rest_framework.request import Request
 
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.db.models.fields.bounded import BoundedAutoField
-from sentry.models import OrganizationMember
+from sentry.models import Organization, OrganizationMember
 
 from .organization import OrganizationEndpoint
 
@@ -45,7 +45,7 @@ class OrganizationMemberEndpoint(OrganizationEndpoint):
         else:
             raise ResourceDoesNotExist
 
-    def _get_member(self, request: Request, organization, member_id):
+    def _get_member(self, request: Request, organization: Organization, member_id):
         if member_id == "me":
             queryset = OrganizationMember.objects.filter(
                 organization=organization, user__id=request.user.id, user__is_active=True

--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -26,7 +26,7 @@ class UserPermission(SentryPermission):
 class OrganizationUserPermission(UserPermission):
     scope_map = {"DELETE": ["member:admin"]}
 
-    def has_org_permission(self, request: Request, user):
+    def has_org_permission(self, request: Request, user: User):
         """
         Org can act on a user account,
         if the user is a member of only one org

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -19,7 +19,7 @@ class AcceptOrganizationInvite(Endpoint):
     def get_helper(self, request: Request, member_id, token):
         return ApiInviteHelper(request=request, member_id=member_id, instance=self, token=token)
 
-    def get(self, request: Request, member_id, token) -> Response:
+    def get(self, request: Request, member_id: int, token: str) -> Response:
         try:
             helper = self.get_helper(request, member_id, token)
         except OrganizationMember.DoesNotExist:
@@ -84,7 +84,7 @@ class AcceptOrganizationInvite(Endpoint):
 
         return response
 
-    def post(self, request: Request, member_id, token) -> Response:
+    def post(self, request: Request, member_id: int, token: str) -> Response:
         try:
             helper = self.get_helper(request, member_id, token)
         except OrganizationMember.DoesNotExist:

--- a/src/sentry/api/endpoints/api_application_details.py
+++ b/src/sentry/api/endpoints/api_application_details.py
@@ -34,7 +34,7 @@ class ApiApplicationDetailsEndpoint(Endpoint):
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
-    def get(self, request: Request, app_id) -> Response:
+    def get(self, request: Request, app_id: int) -> Response:
         try:
             instance = ApiApplication.objects.get(
                 owner=request.user, client_id=app_id, status=ApiApplicationStatus.active
@@ -44,7 +44,7 @@ class ApiApplicationDetailsEndpoint(Endpoint):
 
         return Response(serialize(instance, request.user))
 
-    def put(self, request: Request, app_id) -> Response:
+    def put(self, request: Request, app_id: int) -> Response:
         try:
             instance = ApiApplication.objects.get(
                 owner=request.user, client_id=app_id, status=ApiApplicationStatus.active
@@ -74,7 +74,7 @@ class ApiApplicationDetailsEndpoint(Endpoint):
             return Response(serialize(instance, request.user), status=200)
         return Response(serializer.errors, status=400)
 
-    def delete(self, request: Request, app_id) -> Response:
+    def delete(self, request: Request, app_id: int) -> Response:
         try:
             instance = ApiApplication.objects.get(
                 owner=request.user, client_id=app_id, status=ApiApplicationStatus.active

--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -47,11 +47,11 @@ class BroadcastDetailsEndpoint(Endpoint):
         serializer_cls = self._get_serializer(request)
         return self.respond(serialize(broadcast, request.user, serializer=serializer_cls()))
 
-    def get(self, request: Request, broadcast_id) -> Response:
+    def get(self, request: Request, broadcast_id: int) -> Response:
         broadcast = self._get_broadcast(request, broadcast_id)
         return self._serialize_response(request, broadcast)
 
-    def put(self, request: Request, broadcast_id) -> Response:
+    def put(self, request: Request, broadcast_id: int) -> Response:
         broadcast = self._get_broadcast(request, broadcast_id)
         validator = self._get_validator(request)(data=request.data, partial=True)
         if not validator.is_valid():

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -1,24 +1,23 @@
 import logging
 from functools import reduce
 from operator import or_
+from typing import Optional
 
 from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.utils import timezone
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import AdminBroadcastSerializer, BroadcastSerializer, serialize
 from sentry.api.validators import AdminBroadcastValidator, BroadcastValidator
 from sentry.db.models.query import in_icontains
-from sentry.models import Broadcast, BroadcastSeen
+from sentry.models import Broadcast, BroadcastSeen, Organization
 from sentry.search.utils import tokenize_query
 
 logger = logging.getLogger("sentry")
-
-
-from rest_framework.request import Request
-from rest_framework.response import Response
 
 
 class BroadcastIndexEndpoint(OrganizationEndpoint):
@@ -43,7 +42,7 @@ class BroadcastIndexEndpoint(OrganizationEndpoint):
 
         return (args, kwargs)
 
-    def get(self, request: Request, organization=None) -> Response:
+    def get(self, request: Request, organization: Optional[Organization] = None) -> Response:
         if request.GET.get("show") == "all" and request.access.has_permission("broadcasts.admin"):
             # superusers can slice and dice
             queryset = Broadcast.objects.all().order_by("-date_added")

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 
 from sentry import options
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
-from sentry.models import FileBlob
+from sentry.models import FileBlob, Organization
 from sentry.utils.compat import zip
 from sentry.utils.files import get_max_file_size
 
@@ -42,7 +42,7 @@ class GzipChunk(BytesIO):
 class ChunkUploadEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationReleasePermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Return chunk upload parameters
         ``````````````````````````````
@@ -89,7 +89,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             }
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Upload chunks and store them as FileBlobs
         `````````````````````````````````````````

--- a/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
+++ b/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
@@ -5,10 +5,11 @@ from sentry_relay import pii_selector_suggestions_from_event
 from sentry import nodestore
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.eventstore.models import Event
+from sentry.models import Organization
 
 
 class DataScrubbingSelectorSuggestionsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Generate a list of data scrubbing selectors from existing event data.
 

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -79,6 +79,9 @@ def has_download_permission(request, project):
     return roles.get(current_role).priority >= roles.get(required_role).priority
 
 
+from sentry.models import Project
+
+
 class DebugFilesEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
@@ -114,7 +117,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
         except OSError:
             raise Http404
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's Debug Information Files
         ````````````````````````````````````````
@@ -191,7 +194,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    def delete(self, request: Request, project) -> Response:
+    def delete(self, request: Request, project: Project) -> Response:
         """
         Delete a specific Project's Debug Information File
         ```````````````````````````````````````````````````
@@ -219,7 +222,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
 
         return Response(status=404)
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Upload a New File
         `````````````````
@@ -243,20 +246,26 @@ class DebugFilesEndpoint(ProjectEndpoint):
         return upload_from_request(request, project=project)
 
 
+from sentry.models import Project
+
+
 class UnknownDebugFilesEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         checksums = request.GET.getlist("checksums")
         missing = ProjectDebugFile.objects.find_missing(checksums, project=project)
         return Response({"missing": missing})
+
+
+from sentry.models import Project
 
 
 class AssociateDSymFilesEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
     # Legacy endpoint, kept for backwards compatibility
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         return Response({"associatedDsymFiles": []})
 
 
@@ -270,10 +279,13 @@ def find_missing_chunks(organization, chunks):
     return list(set(chunks) - owned)
 
 
+from sentry.models import Project
+
+
 class DifAssembleEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Assemble one or multiple chunks (FileBlob) into debug files
         ````````````````````````````````````````````````````````````
@@ -387,10 +399,13 @@ class DifAssembleEndpoint(ProjectEndpoint):
         return Response(file_response, status=200)
 
 
+from sentry.models import Project
+
+
 class SourceMapsEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's Source Map Archives
         ````````````````````````````````````
@@ -446,7 +461,7 @@ class SourceMapsEndpoint(ProjectEndpoint):
             on_results=serialize_results,
         )
 
-    def delete(self, request: Request, project) -> Response:
+    def delete(self, request: Request, project: Project) -> Response:
         """
         Delete an Archive
         ```````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -6,11 +6,12 @@ from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.lang.native.applecrashreport import AppleCrashReport
+from sentry.models import Project
 from sentry.utils.safe import get_path
 
 
 class EventAppleCrashReportEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id: int) -> Response:
+    def get(self, request: Request, project: Project, event_id: int) -> Response:
         """
         Retrieve an Apple Crash Report from an event
         `````````````````````````````````````````````

--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -10,7 +10,7 @@ from sentry.utils.safe import get_path
 
 
 class EventAppleCrashReportEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id) -> Response:
+    def get(self, request: Request, project, event_id: int) -> Response:
         """
         Retrieve an Apple Crash Report from an event
         `````````````````````````````````````````````

--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -45,6 +45,9 @@ class EventAttachmentDetailsPermission(ProjectPermission):
         return current_role.priority >= required_role.priority
 
 
+from sentry.models import Project
+
+
 class EventAttachmentDetailsEndpoint(ProjectEndpoint):
     permission_classes = (EventAttachmentDetailsPermission,)
 
@@ -61,7 +64,9 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
         )
         return response
 
-    def get(self, request: Request, project, event_id: int, attachment_id: int) -> Response:
+    def get(
+        self, request: Request, project: Project, event_id: int, attachment_id: int
+    ) -> Response:
         """
         Retrieve an Attachment
         ``````````````````````
@@ -95,7 +100,7 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
 
         return self.respond(serialize(attachment, request.user))
 
-    def delete(self, request: Request, project, event_id, attachment_id: int) -> Response:
+    def delete(self, request: Request, project: Project, event_id, attachment_id: int) -> Response:
         """
         Delete an Event Attachment by ID
         ````````````````````````````````

--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -61,7 +61,7 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
         )
         return response
 
-    def get(self, request: Request, project, event_id, attachment_id) -> Response:
+    def get(self, request: Request, project, event_id: int, attachment_id: int) -> Response:
         """
         Retrieve an Attachment
         ``````````````````````
@@ -95,7 +95,7 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
 
         return self.respond(serialize(attachment, request.user))
 
-    def delete(self, request: Request, project, event_id, attachment_id) -> Response:
+    def delete(self, request: Request, project, event_id, attachment_id: int) -> Response:
         """
         Delete an Event Attachment by ID
         ````````````````````````````````

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -10,7 +10,7 @@ from sentry.search.utils import tokenize_query
 
 
 class EventAttachmentsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id) -> Response:
+    def get(self, request: Request, project, event_id: int) -> Response:
         """
         Retrieve attachments for an event
         `````````````````````````````````

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -5,12 +5,12 @@ from sentry import eventstore, features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import EventAttachment
+from sentry.models import EventAttachment, Project
 from sentry.search.utils import tokenize_query
 
 
 class EventAttachmentsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id: int) -> Response:
+    def get(self, request: Request, project: Project, event_id: int) -> Response:
         """
         Retrieve attachments for an event
         `````````````````````````````````

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -3,12 +3,12 @@ from rest_framework.response import Response
 
 from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.models import Commit, Group, Release
+from sentry.models import Commit, Group, Project, Release
 from sentry.utils.committers import get_serialized_event_file_committers
 
 
 class EventFileCommittersEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id: int) -> Response:
+    def get(self, request: Request, project: Project, event_id: int) -> Response:
         """
         Retrieve Committer information for an event
         ```````````````````````````````````````````

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -8,7 +8,7 @@ from sentry.utils.committers import get_serialized_event_file_committers
 
 
 class EventFileCommittersEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id) -> Response:
+    def get(self, request: Request, project, event_id: int) -> Response:
         """
         Retrieve Committer information for an event
         ```````````````````````````````````````````

--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -14,9 +14,11 @@ logger = logging.getLogger(__name__)
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.models import Project
+
 
 class EventGroupingInfoEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id: int) -> Response:
+    def get(self, request: Request, project: Project, event_id: int) -> Response:
         """
         Returns the grouping information for an event
         `````````````````````````````````````````````

--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 
 
 class EventGroupingInfoEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id) -> Response:
+    def get(self, request: Request, project, event_id: int) -> Response:
         """
         Returns the grouping information for an event
         `````````````````````````````````````````````

--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -9,7 +9,7 @@ from sentry.models import ActorTuple, ProjectOwnership, Team
 
 
 class EventOwnersEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id) -> Response:
+    def get(self, request: Request, project, event_id: int) -> Response:
         """
         Retrieve suggested owners information for an event
         ``````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -5,11 +5,11 @@ from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer
-from sentry.models import ActorTuple, ProjectOwnership, Team
+from sentry.models import ActorTuple, Project, ProjectOwnership, Team
 
 
 class EventOwnersEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id: int) -> Response:
+    def get(self, request: Request, project: Project, event_id: int) -> Response:
         """
         Retrieve suggested owners information for an event
         ``````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/event_reprocessable.py
+++ b/src/sentry/api/endpoints/event_reprocessable.py
@@ -8,7 +8,7 @@ from sentry.reprocessing2 import CannotReprocess, pull_event_data
 
 
 class EventReprocessableEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id) -> Response:
+    def get(self, request: Request, project, event_id: int) -> Response:
         """
         Retrieve information about whether an event can be reprocessed.
         ```````````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/event_reprocessable.py
+++ b/src/sentry/api/endpoints/event_reprocessable.py
@@ -4,11 +4,12 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.models import Project
 from sentry.reprocessing2 import CannotReprocess, pull_event_data
 
 
 class EventReprocessableEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id: int) -> Response:
+    def get(self, request: Request, project: Project, event_id: int) -> Response:
         """
         Retrieve information about whether an event can be reprocessed.
         ```````````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -5,11 +5,11 @@ from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import CommitFileChange, Release, ReleaseCommit, Repository
+from sentry.models import CommitFileChange, Organization, Release, ReleaseCommit, Repository
 
 
 class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
-    def get(self, request: Request, organization, version: str) -> Response:
+    def get(self, request: Request, organization: Organization, version: str) -> Response:
         """
         Retrieve Files Changed in a Release's Commits
         `````````````````````````````````````````````

--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -9,7 +9,7 @@ from sentry.models import CommitFileChange, Release, ReleaseCommit, Repository
 
 
 class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
-    def get(self, request: Request, organization, version) -> Response:
+    def get(self, request: Request, organization, version: str) -> Response:
         """
         Retrieve Files Changed in a Release's Commits
         `````````````````````````````````````````````

--- a/src/sentry/api/endpoints/group_activities.py
+++ b/src/sentry/api/endpoints/group_activities.py
@@ -4,11 +4,11 @@ from rest_framework.response import Response
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import Activity
+from sentry.models import Activity, Group
 
 
 class GroupActivitiesEndpoint(GroupEndpoint, EnvironmentMixin):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """
         Retrieve all the Activities for a Group
         """

--- a/src/sentry/api/endpoints/group_attachments.py
+++ b/src/sentry/api/endpoints/group_attachments.py
@@ -21,8 +21,11 @@ class GroupEventAttachmentSerializer(EventAttachmentSerializer):
         return result
 
 
+from sentry.models import Group
+
+
 class GroupAttachmentsEndpoint(GroupEndpoint, EnvironmentMixin):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """
         List Event Attachments
         ``````````````````````

--- a/src/sentry/api/endpoints/group_current_release.py
+++ b/src/sentry/api/endpoints/group_current_release.py
@@ -7,7 +7,7 @@ from sentry.api.bases import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.grouprelease import GroupReleaseWithStatsSerializer
-from sentry.models import GroupRelease, ReleaseEnvironment, ReleaseProject
+from sentry.models import Group, GroupRelease, ReleaseEnvironment, ReleaseProject
 
 
 class GroupCurrentReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
@@ -37,7 +37,7 @@ class GroupCurrentReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
         except IndexError:
             return None
 
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """Get the current release in the group's project.
 
         Find the most recent release in the project associated with the issue

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -50,16 +50,16 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         },
     }
 
-    def _get_activity(self, request: Request, group, num):
+    def _get_activity(self, request: Request, group: Group, num):
         return Activity.objects.get_activities_for_group(group, num)
 
-    def _get_seen_by(self, request: Request, group):
+    def _get_seen_by(self, request: Request, group: Group):
         seen_by = list(
             GroupSeen.objects.filter(group=group).select_related("user").order_by("-last_seen")
         )
         return serialize(seen_by, request.user)
 
-    def _get_actions(self, request: Request, group):
+    def _get_actions(self, request: Request, group: Group):
         project = group.project
 
         action_list = []
@@ -86,7 +86,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         return action_list
 
-    def _get_available_issue_plugins(self, request: Request, group):
+    def _get_available_issue_plugins(self, request: Request, group: Group):
         project = group.project
 
         plugin_issues = []
@@ -99,7 +99,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 )
         return plugin_issues
 
-    def _get_context_plugins(self, request: Request, group):
+    def _get_context_plugins(self, request: Request, group: Group):
         project = group.project
         return serialize(
             [
@@ -114,7 +114,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         )
 
     @rate_limit_endpoint(limit=5, window=1)
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """
         Retrieve an Issue
         `````````````````
@@ -229,7 +229,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             raise
 
     @rate_limit_endpoint(limit=5, window=1)
-    def put(self, request: Request, group) -> Response:
+    def put(self, request: Request, group: Group) -> Response:
         """
         Update an Issue
         ```````````````
@@ -298,7 +298,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             raise
 
     @rate_limit_endpoint(limit=5, window=5)
-    def delete(self, request: Request, group) -> Response:
+    def delete(self, request: Request, group: Group) -> Response:
         """
         Remove an Issue
         ```````````````

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -28,8 +28,11 @@ class GroupEventsError(Exception):
     pass
 
 
+from sentry.models import Group
+
+
 class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """
         List an Issue's Events
         ``````````````````````
@@ -62,7 +65,9 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         except GroupEventsError as exc:
             raise ParseError(detail=str(exc))
 
-    def _get_events_snuba(self, request: Request, group, environments, query, tags, start, end):
+    def _get_events_snuba(
+        self, request: Request, group: Group, environments, query, tags, start, end
+    ):
         default_end = timezone.now()
         default_start = default_end - timedelta(days=90)
         params = {
@@ -95,7 +100,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
             paginator=GenericOffsetPaginator(data_fn=data_fn),
         )
 
-    def _get_search_query_and_tags(self, request: Request, group, environments=None):
+    def _get_search_query_and_tags(self, request: Request, group: Group, environments=None):
         raw_query = request.GET.get("query")
 
         if raw_query:

--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -5,6 +5,7 @@ from sentry.api import client
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.group_index import rate_limit_endpoint
+from sentry.models import Group
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -18,7 +19,7 @@ class GroupEventsLatestEndpoint(GroupEndpoint):
     }
 
     @rate_limit_endpoint(limit=15, window=1)
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """
         Retrieve the Latest Event for an Issue
         ``````````````````````````````````````

--- a/src/sentry/api/endpoints/group_events_oldest.py
+++ b/src/sentry/api/endpoints/group_events_oldest.py
@@ -4,10 +4,11 @@ from rest_framework.response import Response
 from sentry.api import client
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
+from sentry.models import Group
 
 
 class GroupEventsOldestEndpoint(GroupEndpoint):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """
         Retrieve the Oldest Event for an Issue
         ``````````````````````````````````````

--- a/src/sentry/api/endpoints/group_external_issue_details.py
+++ b/src/sentry/api/endpoints/group_external_issue_details.py
@@ -3,11 +3,11 @@ from rest_framework.response import Response
 
 from sentry.api.bases.group import GroupEndpoint
 from sentry.mediators import external_issues
-from sentry.models import PlatformExternalIssue
+from sentry.models import Group, PlatformExternalIssue
 
 
 class GroupExternalIssueDetailsEndpoint(GroupEndpoint):
-    def delete(self, request: Request, external_issue_id, group) -> Response:
+    def delete(self, request: Request, external_issue_id, group: Group) -> Response:
         try:
             external_issue = PlatformExternalIssue.objects.get(
                 id=external_issue_id, group_id=group.id

--- a/src/sentry/api/endpoints/group_external_issues.py
+++ b/src/sentry/api/endpoints/group_external_issues.py
@@ -10,8 +10,11 @@ from sentry.models import PlatformExternalIssue
 logger = logging.getLogger("sentry.api")
 
 
+from sentry.models import Group
+
+
 class GroupExternalIssuesEndpoint(GroupEndpoint):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
 
         external_issues = PlatformExternalIssue.objects.filter(group_id=group.id)
 

--- a/src/sentry/api/endpoints/group_first_last_release.py
+++ b/src/sentry/api/endpoints/group_first_last_release.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
 from sentry.api.helpers.group_index import get_first_last_release, rate_limit_endpoint
+from sentry.models import Group
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -17,7 +18,7 @@ class GroupFirstLastReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
     }
 
     @rate_limit_endpoint(limit=5, window=1)
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """Get the first and last release for a group.
 
         This data used to be returned by default in group_details.py, but now that we

--- a/src/sentry/api/endpoints/group_hashes.py
+++ b/src/sentry/api/endpoints/group_hashes.py
@@ -7,13 +7,13 @@ from sentry import eventstore
 from sentry.api.bases import GroupEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, serialize
-from sentry.models import GroupHash
+from sentry.models import Group, GroupHash
 from sentry.tasks.unmerge import unmerge
 from sentry.utils.snuba import raw_query
 
 
 class GroupHashesEndpoint(GroupEndpoint):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """
         List an Issue's Hashes
         ``````````````````````
@@ -45,7 +45,7 @@ class GroupHashesEndpoint(GroupEndpoint):
             paginator=GenericOffsetPaginator(data_fn=data_fn),
         )
 
-    def delete(self, request: Request, group) -> Response:
+    def delete(self, request: Request, group: Group) -> Response:
         id_list = request.GET.getlist("id")
         if id_list is None:
             return Response()

--- a/src/sentry/api/endpoints/group_hashes_split.py
+++ b/src/sentry/api/endpoints/group_hashes_split.py
@@ -18,7 +18,7 @@ from sentry.utils import snuba
 
 
 class GroupHashesSplitEndpoint(GroupEndpoint):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """
         Return information on whether the group can be split up, has been split
         up and what it will be split up into.
@@ -29,7 +29,7 @@ class GroupHashesSplitEndpoint(GroupEndpoint):
 
         return self.respond(_render_trees(group, request.user), status=200)
 
-    def put(self, request: Request, group) -> Response:
+    def put(self, request: Request, group: Group) -> Response:
         """
         Split up a group into subgroups
         ```````````````````````````````
@@ -70,7 +70,7 @@ class GroupHashesSplitEndpoint(GroupEndpoint):
 
         return self.respond(status=200)
 
-    def delete(self, request: Request, group) -> Response:
+    def delete(self, request: Request, group: Group) -> Response:
         """
         Un-split group(s) into their parent group
         `````````````````````````````````````````

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -14,6 +14,9 @@ from sentry.signals import integration_issue_created, integration_issue_linked
 MISSING_FEATURE_MESSAGE = "Your organization does not have access to this feature."
 
 
+from sentry.models import Group
+
+
 class GroupIntegrationDetailsEndpoint(GroupEndpoint):
     def _has_issue_feature(self, organization, user):
         has_issue_basic = features.has(
@@ -26,7 +29,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
 
         return has_issue_sync or has_issue_basic
 
-    def create_issue_activity(self, request: Request, group, installation, external_issue):
+    def create_issue_activity(self, request: Request, group: Group, installation, external_issue):
         issue_information = {
             "title": external_issue.title,
             "provider": installation.model.get_provider().name,
@@ -41,7 +44,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             data=issue_information,
         )
 
-    def get(self, request: Request, group, integration_id: int) -> Response:
+    def get(self, request: Request, group: Group, integration_id: int) -> Response:
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
 
@@ -79,7 +82,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             return Response({"detail": str(e)}, status=400)
 
     # was thinking put for link an existing issue, post for create new issue?
-    def put(self, request: Request, group, integration_id: int) -> Response:
+    def put(self, request: Request, group: Group, integration_id: int) -> Response:
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
 
@@ -167,7 +170,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
-    def post(self, request: Request, group, integration_id: int) -> Response:
+    def post(self, request: Request, group: Group, integration_id: int) -> Response:
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
 
@@ -239,7 +242,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
-    def delete(self, request: Request, group, integration_id: int) -> Response:
+    def delete(self, request: Request, group: Group, integration_id: int) -> Response:
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
 

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -79,7 +79,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             return Response({"detail": str(e)}, status=400)
 
     # was thinking put for link an existing issue, post for create new issue?
-    def put(self, request: Request, group, integration_id) -> Response:
+    def put(self, request: Request, group, integration_id: int) -> Response:
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
 
@@ -239,7 +239,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
-    def delete(self, request: Request, group, integration_id) -> Response:
+    def delete(self, request: Request, group, integration_id: int) -> Response:
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
 

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -41,7 +41,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             data=issue_information,
         )
 
-    def get(self, request: Request, group, integration_id) -> Response:
+    def get(self, request: Request, group, integration_id: int) -> Response:
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
 
@@ -167,7 +167,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
-    def post(self, request: Request, group, integration_id) -> Response:
+    def post(self, request: Request, group, integration_id: int) -> Response:
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
 

--- a/src/sentry/api/endpoints/group_integrations.py
+++ b/src/sentry/api/endpoints/group_integrations.py
@@ -7,11 +7,11 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.integration import IntegrationIssueSerializer
 from sentry.integrations.base import IntegrationFeatures
-from sentry.models import Integration
+from sentry.models import Group, Integration
 
 
 class GroupIntegrationsEndpoint(GroupEndpoint):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         has_issue_basic = features.has(
             "organizations:integrations-issue-basic", group.organization, actor=request.user
         )

--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -9,14 +9,14 @@ from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
 from sentry.api.serializers.rest_framework.mentions import extract_user_ids_from_mentions
-from sentry.models import Activity, GroupSubscription
+from sentry.models import Activity, Group, GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.types.activity import ActivityType
 from sentry.utils.functional import extract_lazy_object
 
 
 class GroupNotesEndpoint(GroupEndpoint):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         notes = Activity.objects.filter(group=group, type=Activity.NOTE).select_related("user")
 
         return self.paginate(
@@ -27,7 +27,7 @@ class GroupNotesEndpoint(GroupEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    def post(self, request: Request, group) -> Response:
+    def post(self, request: Request, group: Group) -> Response:
         serializer = NoteSerializer(
             data=request.data,
             context={

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -15,7 +15,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
     # since an ApiKey is bound to the Organization, not
     # an individual. Not sure if we'd want to allow an ApiKey
     # to delete/update other users' comments
-    def delete(self, request: Request, group, note_id) -> Response:
+    def delete(self, request: Request, group, note_id: int) -> Response:
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="Key doesn't have permission to delete Note")
 
@@ -30,7 +30,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         return Response(status=204)
 
-    def put(self, request: Request, group, note_id) -> Response:
+    def put(self, request: Request, group, note_id: int) -> Response:
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="Key doesn't have permission to edit Note")
 

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -7,7 +7,7 @@ from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
-from sentry.models import Activity
+from sentry.models import Activity, Group
 
 
 class GroupNotesDetailsEndpoint(GroupEndpoint):
@@ -15,7 +15,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
     # since an ApiKey is bound to the Organization, not
     # an individual. Not sure if we'd want to allow an ApiKey
     # to delete/update other users' comments
-    def delete(self, request: Request, group, note_id: int) -> Response:
+    def delete(self, request: Request, group: Group, note_id: int) -> Response:
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="Key doesn't have permission to delete Note")
 
@@ -30,7 +30,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         return Response(status=204)
 
-    def put(self, request: Request, group, note_id: int) -> Response:
+    def put(self, request: Request, group: Group, note_id: int) -> Response:
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="Key doesn't have permission to edit Note")
 

--- a/src/sentry/api/endpoints/group_participants.py
+++ b/src/sentry/api/endpoints/group_participants.py
@@ -3,11 +3,11 @@ from rest_framework.response import Response
 
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import GroupSubscriptionManager
+from sentry.models import Group, GroupSubscriptionManager
 
 
 class GroupParticipantsEndpoint(GroupEndpoint):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         participants = GroupSubscriptionManager.get_participating_users(group)
 
         return Response(serialize(participants, request.user))

--- a/src/sentry/api/endpoints/group_reprocessing.py
+++ b/src/sentry/api/endpoints/group_reprocessing.py
@@ -3,11 +3,12 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases import GroupEndpoint
+from sentry.models import Group
 from sentry.tasks.reprocessing2 import reprocess_group
 
 
 class GroupReprocessingEndpoint(GroupEndpoint):
-    def post(self, request: Request, group) -> Response:
+    def post(self, request: Request, group: Group) -> Response:
         """
         Reprocess a group
         `````````````````

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -20,7 +20,7 @@ def _fix_label(label):
 
 
 class GroupSimilarIssuesEndpoint(GroupEndpoint):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         version = request.GET.get("version", None)
         if version == "2":
             if not feature_flags.has("projects:similarity-view-v2", group.project):

--- a/src/sentry/api/endpoints/group_stats.py
+++ b/src/sentry/api/endpoints/group_stats.py
@@ -5,11 +5,11 @@ from sentry import tsdb
 from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import Environment
+from sentry.models import Environment, Group
 
 
 class GroupStatsEndpoint(GroupEndpoint, EnvironmentMixin, StatsMixin):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         try:
             environment_id = self._get_environment_id_from_request(
                 request, group.project.organization_id

--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -10,7 +10,7 @@ from sentry.models import Environment
 
 
 class GroupTagKeyDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
-    def get(self, request: Request, group, key) -> Response:
+    def get(self, request: Request, group, key: str) -> Response:
         """
         Retrieve Tag Details
         ````````````````````

--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -6,11 +6,11 @@ from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import Environment
+from sentry.models import Environment, Group
 
 
 class GroupTagKeyDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
-    def get(self, request: Request, group, key: str) -> Response:
+    def get(self, request: Request, group: Group, key: str) -> Response:
         """
         Retrieve Tag Details
         ````````````````````

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -11,7 +11,7 @@ from sentry.api.serializers.models.tagvalue import UserTagValueSerializer
 
 
 class GroupTagKeyValuesEndpoint(GroupEndpoint, EnvironmentMixin):
-    def get(self, request: Request, group, key) -> Response:
+    def get(self, request: Request, group, key: str) -> Response:
         """
         List a Tag's Values
         ```````````````````

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -8,10 +8,11 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.tagvalue import UserTagValueSerializer
+from sentry.models import Group
 
 
 class GroupTagKeyValuesEndpoint(GroupEndpoint, EnvironmentMixin):
-    def get(self, request: Request, group, key: str) -> Response:
+    def get(self, request: Request, group: Group, key: str) -> Response:
         """
         List a Tag's Values
         ```````````````````

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -5,10 +5,11 @@ from sentry import tagstore
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import serialize
+from sentry.models import Group
 
 
 class GroupTagsEndpoint(GroupEndpoint):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
 
         # optional queryparam `key` can be used to get results
         # only for specific keys.

--- a/src/sentry/api/endpoints/group_tombstone.py
+++ b/src/sentry/api/endpoints/group_tombstone.py
@@ -4,11 +4,11 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import GroupTombstone
+from sentry.models import GroupTombstone, Project
 
 
 class GroupTombstoneEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         Retrieve a Project's GroupTombstones
         ````````````````````````````````````

--- a/src/sentry/api/endpoints/group_tombstone_details.py
+++ b/src/sentry/api/endpoints/group_tombstone_details.py
@@ -7,7 +7,7 @@ from sentry.models import GroupHash, GroupTombstone
 
 
 class GroupTombstoneDetailsEndpoint(ProjectEndpoint):
-    def delete(self, request: Request, project, tombstone_id) -> Response:
+    def delete(self, request: Request, project, tombstone_id: int) -> Response:
         """
         Remove a GroupTombstone
         ```````````````````````

--- a/src/sentry/api/endpoints/group_tombstone_details.py
+++ b/src/sentry/api/endpoints/group_tombstone_details.py
@@ -3,11 +3,11 @@ from rest_framework.response import Response
 
 from sentry.api.bases import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import GroupHash, GroupTombstone
+from sentry.models import GroupHash, GroupTombstone, Project
 
 
 class GroupTombstoneDetailsEndpoint(ProjectEndpoint):
-    def delete(self, request: Request, project, tombstone_id: int) -> Response:
+    def delete(self, request: Request, project: Project, tombstone_id: int) -> Response:
         """
         Remove a GroupTombstone
         ```````````````````````

--- a/src/sentry/api/endpoints/group_user_reports.py
+++ b/src/sentry/api/endpoints/group_user_reports.py
@@ -5,11 +5,11 @@ from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
-from sentry.models import Environment, UserReport
+from sentry.models import Environment, Group, UserReport
 
 
 class GroupUserReportsEndpoint(GroupEndpoint, EnvironmentMixin):
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: Request, group: Group) -> Response:
         """
         List User Reports
         `````````````````

--- a/src/sentry/api/endpoints/grouping_levels.py
+++ b/src/sentry/api/endpoints/grouping_levels.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from rest_framework.request import Request
+from rest_framework.response import Response
 from snuba_sdk.query import Column, Entity, Function, Query
 
 from sentry import features
@@ -39,10 +41,6 @@ class ProjectNotHierarchical(SentryAPIException):
     status_code = status.HTTP_403_FORBIDDEN
     code = "project_not_hierarchical"
     message = "This project does not have hierarchical grouping."
-
-
-from rest_framework.request import Request
-from rest_framework.response import Response
 
 
 class GroupingLevelsEndpoint(GroupEndpoint):

--- a/src/sentry/api/endpoints/monitor_checkin_details.py
+++ b/src/sentry/api/endpoints/monitor_checkin_details.py
@@ -75,7 +75,7 @@ class MonitorCheckInDetailsEndpoint(Endpoint):
         kwargs.update({"checkin": checkin, "monitor": monitor, "project": project})
         return (args, kwargs)
 
-    def get(self, request: Request, project, monitor, checkin) -> Response:
+    def get(self, request: Request, project: Project, monitor, checkin) -> Response:
         """
         Retrieve a check-in
         ```````````````````
@@ -90,7 +90,7 @@ class MonitorCheckInDetailsEndpoint(Endpoint):
 
         return self.respond(serialize(checkin, request.user))
 
-    def put(self, request: Request, project, monitor, checkin) -> Response:
+    def put(self, request: Request, project: Project, monitor, checkin) -> Response:
         """
         Update a check-in
         `````````````````

--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -1,12 +1,14 @@
 from django.db import transaction
 from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry.api.authentication import DSNAuthentication
 from sentry.api.bases.monitor import MonitorEndpoint
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorStatus, ProjectKey
+from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorStatus, Project, ProjectKey
 
 
 class CheckInSerializer(serializers.Serializer):
@@ -20,14 +22,10 @@ class CheckInSerializer(serializers.Serializer):
     duration = EmptyIntegerField(required=False, allow_null=True)
 
 
-from rest_framework.request import Request
-from rest_framework.response import Response
-
-
 class MonitorCheckInsEndpoint(MonitorEndpoint):
     authentication_classes = MonitorEndpoint.authentication_classes + (DSNAuthentication,)
 
-    def get(self, request: Request, project, monitor) -> Response:
+    def get(self, request: Request, project: Project, monitor) -> Response:
         """
         Retrieve check-ins for an monitor
         `````````````````````````````````
@@ -49,7 +47,7 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
             paginator_cls=OffsetPaginator,
         )
 
-    def post(self, request: Request, project, monitor) -> Response:
+    def post(self, request: Request, project: Project, monitor) -> Response:
         """
         Create a new check-in for a monitor
         ```````````````````````````````````

--- a/src/sentry/api/endpoints/monitor_details.py
+++ b/src/sentry/api/endpoints/monitor_details.py
@@ -5,11 +5,11 @@ from rest_framework.response import Response
 from sentry.api.bases.monitor import MonitorEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.validators import MonitorValidator
-from sentry.models import AuditLogEntryEvent, Monitor, MonitorStatus, ScheduledDeletion
+from sentry.models import AuditLogEntryEvent, Monitor, MonitorStatus, Project, ScheduledDeletion
 
 
 class MonitorDetailsEndpoint(MonitorEndpoint):
-    def get(self, request: Request, project, monitor) -> Response:
+    def get(self, request: Request, project: Project, monitor) -> Response:
         """
         Retrieve a monitor
         ``````````````````
@@ -19,7 +19,7 @@ class MonitorDetailsEndpoint(MonitorEndpoint):
         """
         return self.respond(serialize(monitor, request.user))
 
-    def put(self, request: Request, project, monitor) -> Response:
+    def put(self, request: Request, project: Project, monitor) -> Response:
         """
         Update a monitor
         ````````````````
@@ -70,7 +70,7 @@ class MonitorDetailsEndpoint(MonitorEndpoint):
 
         return self.respond(serialize(monitor, request.user))
 
-    def delete(self, request: Request, project, monitor) -> Response:
+    def delete(self, request: Request, project: Project, monitor) -> Response:
         """
         Delete a monitor
         ````````````````

--- a/src/sentry/api/endpoints/monitor_stats.py
+++ b/src/sentry/api/endpoints/monitor_stats.py
@@ -6,12 +6,12 @@ from rest_framework.response import Response
 from sentry import tsdb
 from sentry.api.base import StatsMixin
 from sentry.api.bases.monitor import MonitorEndpoint
-from sentry.models import CheckInStatus, MonitorCheckIn
+from sentry.models import CheckInStatus, MonitorCheckIn, Project
 
 
 class MonitorStatsEndpoint(MonitorEndpoint, StatsMixin):
     # TODO(dcramer): probably convert to tsdb
-    def get(self, request: Request, project, monitor) -> Response:
+    def get(self, request: Request, project: Project, monitor) -> Response:
         args = self._parse_args(request)
 
         stats = OrderedDict()

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -39,6 +39,9 @@ class AccessRequestSerializer(serializers.Serializer):
     isApproved = serializers.BooleanField()
 
 
+from sentry.models import Organization
+
+
 class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
     permission_classes = [AccessRequestPermission]
 
@@ -58,7 +61,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
             return True
         return False
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Get list of requests to join org/team
 
@@ -81,7 +84,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serialize(access_requests, request.user))
 
-    def put(self, request: Request, organization, request_id: int) -> Response:
+    def put(self, request: Request, organization: Organization, request_id: int) -> Response:
         """
         Approve or deny a request
 

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -81,7 +81,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serialize(access_requests, request.user))
 
-    def put(self, request: Request, organization, request_id) -> Response:
+    def put(self, request: Request, organization, request_id: int) -> Response:
         """
         Approve or deny a request
 

--- a/src/sentry/api/endpoints/organization_activity.py
+++ b/src/sentry/api/endpoints/organization_activity.py
@@ -7,11 +7,11 @@ from sentry.api.base import EnvironmentMixin
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import OrganizationActivitySerializer, serialize
-from sentry.models import Activity, OrganizationMemberTeam, Project
+from sentry.models import Activity, Organization, OrganizationMemberTeam, Project
 
 
 class OrganizationActivityEndpoint(OrganizationMemberEndpoint, EnvironmentMixin):
-    def get(self, request: Request, organization, member) -> Response:
+    def get(self, request: Request, organization: Organization, member) -> Response:
         # There is an activity record created for both sides of the unmerge
         # operation, so we only need to include one of them here to avoid
         # showing the same entry twice.

--- a/src/sentry/api/endpoints/organization_api_key_details.py
+++ b/src/sentry/api/endpoints/organization_api_key_details.py
@@ -17,7 +17,7 @@ class ApiKeySerializer(serializers.ModelSerializer):
 class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAdminPermission,)
 
-    def get(self, request: Request, organization, api_key_id) -> Response:
+    def get(self, request: Request, organization, api_key_id: int) -> Response:
         """
         Retrieves API Key details
         `````````````````````````
@@ -34,7 +34,7 @@ class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serialize(api_key, request.user))
 
-    def put(self, request: Request, organization, api_key_id) -> Response:
+    def put(self, request: Request, organization, api_key_id: int) -> Response:
         """
         Update an API Key
         `````````````````
@@ -70,7 +70,7 @@ class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Request, organization, api_key_id) -> Response:
+    def delete(self, request: Request, organization, api_key_id: int) -> Response:
         """
         Deletes an API Key
         ``````````````````

--- a/src/sentry/api/endpoints/organization_api_key_details.py
+++ b/src/sentry/api/endpoints/organization_api_key_details.py
@@ -14,10 +14,13 @@ class ApiKeySerializer(serializers.ModelSerializer):
         fields = ("label", "scope_list", "allowed_origins")
 
 
+from sentry.models import Organization
+
+
 class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAdminPermission,)
 
-    def get(self, request: Request, organization, api_key_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, api_key_id: int) -> Response:
         """
         Retrieves API Key details
         `````````````````````````
@@ -34,7 +37,7 @@ class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serialize(api_key, request.user))
 
-    def put(self, request: Request, organization, api_key_id: int) -> Response:
+    def put(self, request: Request, organization: Organization, api_key_id: int) -> Response:
         """
         Update an API Key
         `````````````````
@@ -70,7 +73,7 @@ class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Request, organization, api_key_id: int) -> Response:
+    def delete(self, request: Request, organization: Organization, api_key_id: int) -> Response:
         """
         Deletes an API Key
         ``````````````````

--- a/src/sentry/api/endpoints/organization_api_key_index.py
+++ b/src/sentry/api/endpoints/organization_api_key_index.py
@@ -9,10 +9,13 @@ from sentry.models import ApiKey, AuditLogEntryEvent
 DEFAULT_SCOPES = ["project:read", "event:read", "team:read", "org:read", "member:read"]
 
 
+from sentry.models import Organization
+
+
 class OrganizationApiKeyIndexEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAdminPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's API Keys
         ```````````````````````````````````
@@ -24,7 +27,7 @@ class OrganizationApiKeyIndexEndpoint(OrganizationEndpoint):
 
         return Response(serialize(queryset, request.user))
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Create an Organization API Key
         ```````````````````````````````````

--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -10,10 +10,13 @@ from sentry.models import AuditLogEntry
 EVENT_REVERSE_MAP = {v: k for k, v in AuditLogEntry._meta.get_field("event").choices}
 
 
+from sentry.models import Organization
+
+
 class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAuditPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         queryset = AuditLogEntry.objects.filter(organization=organization).select_related("actor")
 
         event = request.GET.get("event")

--- a/src/sentry/api/endpoints/organization_auth_provider_details.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_details.py
@@ -4,13 +4,13 @@ from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationAuthProviderPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import AuthProvider
+from sentry.models import AuthProvider, Organization
 
 
 class OrganizationAuthProviderDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAuthProviderPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieve details about Organization's SSO settings and
         currently installed auth_provider

--- a/src/sentry/api/endpoints/organization_auth_provider_send_reminders.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_send_reminders.py
@@ -11,10 +11,13 @@ from sentry.tasks.auth import email_missing_links
 ERR_NO_SSO = _("The SSO feature is not enabled for this organization.")
 
 
+from sentry.models import Organization
+
+
 class OrganizationAuthProviderSendRemindersEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAdminPermission,)
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:sso-basic", organization, actor=request.user):
             return Response(ERR_NO_SSO, status=403)
 

--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -4,12 +4,13 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationAuthProviderPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.auth import manager
+from sentry.models import Organization
 
 
 class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAuthProviderPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List available auth providers that are available to use for an Organization
         ```````````````````````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_code_mapping_codeowners.py
+++ b/src/sentry/api/endpoints/organization_code_mapping_codeowners.py
@@ -4,7 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
-from sentry.models import OrganizationIntegration, RepositoryProjectPathConfig
+from sentry.models import Organization, OrganizationIntegration, RepositoryProjectPathConfig
 
 
 class OrganizationCodeMappingCodeOwnersEndpoint(OrganizationEndpoint):
@@ -30,7 +30,7 @@ class OrganizationCodeMappingCodeOwnersEndpoint(OrganizationEndpoint):
         install = integration.get_installation(config.organization_integration.organization_id)
         return install.get_codeowner_file(config.repository, ref=config.default_branch)
 
-    def get(self, request: Request, config_id, organization, config) -> Response:
+    def get(self, request: Request, config_id, organization: Organization, config) -> Response:
         if not config.organization_integration:
             return self.respond(
                 {"error": "No associated integration."}, status=status.HTTP_400_BAD_REQUEST

--- a/src/sentry/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/api/endpoints/organization_code_mapping_details.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.api.serializers import serialize
-from sentry.models import OrganizationIntegration, RepositoryProjectPathConfig
+from sentry.models import Organization, OrganizationIntegration, RepositoryProjectPathConfig
 
 from .organization_code_mappings import (
     OrganizationIntegrationMixin,
@@ -32,7 +32,7 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
 
         return (args, kwargs)
 
-    def put(self, request: Request, config_id, organization, config) -> Response:
+    def put(self, request: Request, config_id, organization: Organization, config) -> Response:
         """
         Update a repository project path config
         ``````````````````
@@ -62,7 +62,7 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
             )
         return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Request, config_id, organization, config) -> Response:
+    def delete(self, request: Request, config_id, organization: Organization, config) -> Response:
         """
         Delete a repository project path config
 

--- a/src/sentry/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/api/endpoints/organization_code_mappings.py
@@ -7,7 +7,13 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
-from sentry.models import OrganizationIntegration, Project, Repository, RepositoryProjectPathConfig
+from sentry.models import (
+    Organization,
+    OrganizationIntegration,
+    Project,
+    Repository,
+    RepositoryProjectPathConfig,
+)
 from sentry.utils.compat import map
 
 
@@ -120,7 +126,7 @@ class OrganizationIntegrationMixin:
 class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegrationMixin):
     permission_classes = (OrganizationIntegrationsPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Get the list of repository project path configs
 
@@ -157,7 +163,7 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
         data = map(lambda x: serialize(x, request.user), queryset)
         return self.respond(data)
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Create a new repository project path config
         ``````````````````

--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -4,11 +4,12 @@ from rest_framework.response import Response
 from sentry import features, integrations
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import IntegrationProviderSerializer, serialize
+from sentry.models import Organization
 from sentry.utils.compat import filter
 
 
 class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         def is_provider_enabled(provider):
             if not provider.requires_feature_flag:
                 return True

--- a/src/sentry/api/endpoints/organization_config_repositories.py
+++ b/src/sentry/api/endpoints/organization_config_repositories.py
@@ -2,11 +2,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models import Organization
 from sentry.plugins.base import bindings
 
 
 class OrganizationConfigRepositoriesEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         provider_bindings = bindings.get("repository.provider")
         providers = []
         for provider_id in provider_bindings:

--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -17,6 +17,9 @@ EDIT_FEATURE = "organizations:dashboards-edit"
 READ_FEATURE = "organizations:dashboards-basic"
 
 
+from sentry.models import Organization
+
+
 class OrganizationDashboardBase(OrganizationEndpoint):
     permission_classes = (OrganizationDashboardsPermission,)
 
@@ -30,7 +33,7 @@ class OrganizationDashboardBase(OrganizationEndpoint):
 
         return (args, kwargs)
 
-    def _get_dashboard(self, request: Request, organization, dashboard_id):
+    def _get_dashboard(self, request: Request, organization: Organization, dashboard_id):
         prebuilt = Dashboard.get_prebuilt(dashboard_id)
         sentry_sdk.set_tag("dashboard.is_prebuilt", prebuilt is not None)
         if prebuilt:
@@ -39,7 +42,7 @@ class OrganizationDashboardBase(OrganizationEndpoint):
 
 
 class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
-    def get(self, request: Request, organization, dashboard) -> Response:
+    def get(self, request: Request, organization: Organization, dashboard) -> Response:
         """
         Retrieve an Organization's Dashboard
         ````````````````````````````````````
@@ -58,7 +61,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
 
         return self.respond(serialize(dashboard, request.user))
 
-    def delete(self, request: Request, organization, dashboard) -> Response:
+    def delete(self, request: Request, organization: Organization, dashboard) -> Response:
         """
         Delete an Organization's Dashboard
         ```````````````````````````````````
@@ -90,7 +93,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
 
         return self.respond(status=204)
 
-    def put(self, request: Request, organization, dashboard) -> Response:
+    def put(self, request: Request, organization: Organization, dashboard) -> Response:
         """
         Edit an Organization's Dashboard
         ```````````````````````````````````
@@ -136,7 +139,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
 
 
 class OrganizationDashboardVisitEndpoint(OrganizationDashboardBase):
-    def post(self, request: Request, organization, dashboard) -> Response:
+    def post(self, request: Request, organization: Organization, dashboard) -> Response:
         """
         Update last_visited and increment visits counter
         """

--- a/src/sentry/api/endpoints/organization_dashboard_widget_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widget_details.py
@@ -5,12 +5,13 @@ from sentry import features
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.endpoints.organization_dashboards import OrganizationDashboardsPermission
 from sentry.api.serializers.rest_framework import DashboardWidgetSerializer
+from sentry.models import Organization
 
 
 class OrganizationDashboardWidgetDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationDashboardsPermission,)
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Validate a Widget
         `````````````````

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -26,10 +26,13 @@ class OrganizationDashboardsPermission(OrganizationPermission):
     }
 
 
+from sentry.models import Organization
+
+
 class OrganizationDashboardsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationDashboardsPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieve an Organization's Dashboards
         `````````````````````````````````````
@@ -122,7 +125,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             on_results=handle_results,
         )
 
-    def post(self, request: Request, organization, retry=0) -> Response:
+    def post(self, request: Request, organization: Organization, retry=0) -> Response:
         """
         Create a New Dashboard for an Organization
         ``````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -6,6 +6,8 @@ from django.db import models, transaction
 from django.db.models.query_utils import DeferredAttribute
 from pytz import UTC
 from rest_framework import serializers, status
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from bitfield.types import BitHandler
 from sentry import roles
@@ -439,12 +441,8 @@ class OwnerOrganizationSerializer(OrganizationSerializer):
         return super().save(*args, **kwargs)
 
 
-from rest_framework.request import Request
-from rest_framework.response import Response
-
-
 class OrganizationDetailsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieve an Organization
         ````````````````````````
@@ -467,7 +465,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
 
         return self.respond(context)
 
-    def put(self, request: Request, organization) -> Response:
+    def put(self, request: Request, organization: Organization) -> Response:
         """
         Update an Organization
         ``````````````````````
@@ -559,7 +557,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         return self.respond(context, status=202)
 
     @sudo_required
-    def delete(self, request: Request, organization) -> Response:
+    def delete(self, request: Request, organization: Organization) -> Response:
         """
         Delete an Organization
         ``````````````````````

--- a/src/sentry/api/endpoints/organization_environments.py
+++ b/src/sentry/api/endpoints/organization_environments.py
@@ -4,11 +4,11 @@ from rest_framework.response import Response
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.helpers.environments import environment_visibility_filter_options
 from sentry.api.serializers import serialize
-from sentry.models import Environment, EnvironmentProject
+from sentry.models import Environment, EnvironmentProject, Organization
 
 
 class OrganizationEnvironmentsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         visibility = request.GET.get("visibility", "visible")
         if visibility not in environment_visibility_filter_options:
             return Response(

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -4,11 +4,14 @@ from rest_framework.response import Response
 from sentry import eventstore
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.serializers import serialize
+from sentry.models import Organization
 from sentry.models.project import Project, ProjectStatus
 
 
 class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
-    def get(self, request: Request, organization, project_slug, event_id: int) -> Response:
+    def get(
+        self, request: Request, organization: Organization, project_slug, event_id: int
+    ) -> Response:
         """event_id is validated by a regex in the URL"""
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -8,7 +8,7 @@ from sentry.models.project import Project, ProjectStatus
 
 
 class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
-    def get(self, request: Request, organization, project_slug, event_id) -> Response:
+    def get(self, request: Request, organization, project_slug, event_id: int) -> Response:
         """event_id is validated by a regex in the URL"""
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -6,13 +6,12 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import serialize
-from sentry.models import Project
+from sentry.models import Organization, Project
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
 
 
 class EventIdLookupEndpoint(OrganizationEndpoint):
-
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(1, 1),
@@ -22,7 +21,7 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
     }
 
     @rate_limit_endpoint(limit=1, window=1)
-    def get(self, request: Request, organization, event_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, event_id: int) -> Response:
         """
         Resolve an Event ID
         ``````````````````

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -22,7 +22,7 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
     }
 
     @rate_limit_endpoint(limit=1, window=1)
-    def get(self, request: Request, organization, event_id) -> Response:
+    def get(self, request: Request, organization, event_id: int) -> Response:
         """
         Resolve an Event ID
         ``````````````````

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -37,8 +37,11 @@ ALLOWED_EVENTS_GEO_REFERRERS = {
 }
 
 
+from sentry.models import Organization
+
+
 class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 
@@ -91,11 +94,14 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
                 )
 
 
+from sentry.models import Organization
+
+
 class OrganizationEventsGeoEndpoint(OrganizationEventsV2EndpointBase):
     def has_feature(self, request: Request, organization):
         return features.has("organizations:dashboards-basic", organization, actor=request.user)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(request, organization):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -6,11 +6,12 @@ from rest_framework.response import Response
 
 from sentry import features, tagstore
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.models import Organization
 from sentry.snuba import discover
 
 
 class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -30,6 +30,9 @@ TAG_ALIASES = {"release": "sentry:release", "dist": "sentry:dist", "user": "sent
 DEFAULT_TAG_KEY_LIMIT = 5
 
 
+from sentry.models import Organization
+
+
 class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2EndpointBase):
     def has_feature(self, organization, request):
         return features.has("organizations:performance-view", organization, actor=request.user)
@@ -59,7 +62,7 @@ class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2Endpoi
 
 
 class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsFacetsPerformanceEndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             params, aggregate_column, filter_query = self._setup(request, organization)
         except NoProjects:
@@ -131,7 +134,7 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsFacetsPerfor
 class OrganizationEventsFacetsPerformanceHistogramEndpoint(
     OrganizationEventsFacetsPerformanceEndpointBase
 ):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             params, aggregate_column, filter_query = self._setup(request, organization)
         except NoProjects:

--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -46,8 +46,11 @@ class EventsHasMeasurementsQuerySerializer(serializers.Serializer):
         return data
 
 
+from sentry.models import Organization
+
+
 class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsV2EndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -38,11 +38,14 @@ class HistogramSerializer(serializers.Serializer):
         return fields
 
 
+from sentry.models import Organization
+
+
 class OrganizationEventsHistogramEndpoint(OrganizationEventsV2EndpointBase):
     def has_feature(self, organization, request):
         return features.has("organizations:performance-view", organization, actor=request.user)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -12,12 +12,13 @@ from sentry.api.event_search import parse_search_query
 from sentry.api.helpers.group_index import build_query_params_from_request
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer
+from sentry.models import Organization
 from sentry.search.events.fields import get_function_alias
 from sentry.snuba import discover
 
 
 class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             params = self.get_snuba_params(request, organization)
         except NoProjects:
@@ -37,8 +38,11 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
         return Response({"count": result["data"][0]["count"]})
 
 
+from sentry.models import Organization
+
+
 class OrganizationEventBaseline(OrganizationEventsEndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """Find the event id with the closest value to an aggregate for a given query"""
         if not self.has_feature(organization, request):
             return Response(status=404)
@@ -97,7 +101,7 @@ UNESCAPED_QUOTE_RE = re.compile('(?<!\\\\)"')
 
 
 class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, EnvironmentMixin):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             # events-meta is still used by events v1 which doesn't require global views
             params = self.get_snuba_params(request, organization, check_global_views=False)

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -76,6 +76,9 @@ class TrendQueryBuilder(QueryBuilder):
             return super().resolve_function(function, match, resolve_only, overwrite_alias)
 
 
+from sentry.models import Organization
+
+
 class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
     trend_columns = {
         "p50": "percentile_range({column}, 0.5, {condition}, {boundary}) as {query_alias}",
@@ -417,7 +420,7 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
     def has_snql_feature(self, organization, request):
         return features.has("organizations:performance-use-snql", organization, actor=request.user)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
         use_snql = self.has_snql_feature(organization, request)

--- a/src/sentry/api/endpoints/organization_events_vitals.py
+++ b/src/sentry/api/endpoints/organization_events_vitals.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.models import Organization
 from sentry.search.events.fields import get_function_alias
 from sentry.snuba import discover
 
@@ -20,7 +21,7 @@ class OrganizationEventsVitalsEndpoint(OrganizationEventsV2EndpointBase):
     # Threshold labels
     LABELS = ["good", "meh", "poor"]
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -136,6 +136,9 @@ def inbox_search(
     return results
 
 
+from sentry.models import Organization
+
+
 class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
     permission_classes = (OrganizationEventPermission,)
 
@@ -158,7 +161,12 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
     }
 
     def _search(
-        self, request: Request, organization, projects, environments, extra_query_kwargs=None
+        self,
+        request: Request,
+        organization: Organization,
+        projects,
+        environments,
+        extra_query_kwargs=None,
     ):
         query_kwargs = build_query_params_from_request(
             request, organization, projects, environments
@@ -177,7 +185,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
     @track_slo_response("workflow")
     @rate_limit_endpoint(limit=10, window=1)
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's Issues
         `````````````````````````````
@@ -351,7 +359,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
     @track_slo_response("workflow")
     @rate_limit_endpoint(limit=5, window=5)
-    def put(self, request: Request, organization) -> Response:
+    def put(self, request: Request, organization: Organization) -> Response:
         """
         Bulk Mutate a List of Issues
         ````````````````````````````
@@ -434,7 +442,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
     @track_slo_response("workflow")
     @rate_limit_endpoint(limit=5, window=5)
-    def delete(self, request: Request, organization) -> Response:
+    def delete(self, request: Request, organization: Organization) -> Response:
         """
         Bulk Remove a List of Issues
         ````````````````````````````

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -12,7 +12,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import InvalidParams, get_date_range_from_params
-from sentry.models import Group
+from sentry.models import Group, Organization
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.compat import map
 
@@ -29,7 +29,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
     }
 
     @rate_limit_endpoint(limit=10, window=1)
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Get the stats on an Organization's Issues
         `````````````````````````````

--- a/src/sentry/api/endpoints/organization_has_mobile_app_events.py
+++ b/src/sentry/api/endpoints/organization_has_mobile_app_events.py
@@ -17,8 +17,11 @@ CACHE_TTL = 24 * 60 * 60
 logger = logging.getLogger(__name__)
 
 
+from sentry.models import Organization
+
+
 class OrganizationHasMobileAppEvents(OrganizationEventsEndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         # cache is unique to an org
         cache_key = f"check_mobile_app_events:{organization.id}"
         cache_value = cache.get(cache_key)

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -24,7 +24,7 @@ class IntegrationSerializer(serializers.Serializer):
 
 
 class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint):
-    def get(self, request: Request, organization, integration_id) -> Response:
+    def get(self, request: Request, organization, integration_id: int) -> Response:
         org_integration = self.get_organization_integration(organization, integration_id)
 
         return self.respond(
@@ -96,7 +96,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
 
         return self.respond(status=204)
 
-    def post(self, request: Request, organization, integration_id) -> Response:
+    def post(self, request: Request, organization, integration_id: int) -> Response:
         integration = self.get_integration(organization, integration_id)
         installation = integration.get_installation(organization.id)
         try:

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -23,8 +23,11 @@ class IntegrationSerializer(serializers.Serializer):
     domain = serializers.URLField(required=False, allow_blank=True)
 
 
+from sentry.models import Organization
+
+
 class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint):
-    def get(self, request: Request, organization, integration_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, integration_id: int) -> Response:
         org_integration = self.get_organization_integration(organization, integration_id)
 
         return self.respond(
@@ -34,7 +37,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
         )
 
     @requires_feature("organizations:integrations-custom-scm")
-    def put(self, request: Request, organization, integration_id: int) -> Response:
+    def put(self, request: Request, organization: Organization, integration_id: int) -> Response:
         try:
             integration = Integration.objects.get(organizations=organization, id=integration_id)
         except Integration.DoesNotExist:
@@ -70,7 +73,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
             )
         return self.respond(serializer.errors, status=400)
 
-    def delete(self, request: Request, organization, integration_id: int) -> Response:
+    def delete(self, request: Request, organization: Organization, integration_id: int) -> Response:
         # Removing the integration removes the organization
         # integrations and all linked issues.
         org_integration = self.get_organization_integration(organization, integration_id)
@@ -96,7 +99,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
 
         return self.respond(status=204)
 
-    def post(self, request: Request, organization, integration_id: int) -> Response:
+    def post(self, request: Request, organization: Organization, integration_id: int) -> Response:
         integration = self.get_integration(organization, integration_id)
         installation = integration.get_installation(organization.id)
         try:

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -34,7 +34,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
         )
 
     @requires_feature("organizations:integrations-custom-scm")
-    def put(self, request: Request, organization, integration_id) -> Response:
+    def put(self, request: Request, organization, integration_id: int) -> Response:
         try:
             integration = Integration.objects.get(organizations=organization, id=integration_id)
         except Integration.DoesNotExist:
@@ -70,7 +70,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
             )
         return self.respond(serializer.errors, status=400)
 
-    def delete(self, request: Request, organization, integration_id) -> Response:
+    def delete(self, request: Request, organization, integration_id: int) -> Response:
         # Removing the integration removes the organization
         # integrations and all linked issues.
         org_integration = self.get_organization_integration(organization, integration_id)

--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -9,7 +9,7 @@ from sentry.shared_integrations.exceptions import IntegrationError
 
 
 class OrganizationIntegrationReposEndpoint(OrganizationIntegrationBaseEndpoint):
-    def get(self, request: Request, organization, integration_id) -> Response:
+    def get(self, request: Request, organization, integration_id: int) -> Response:
         """
         Get the list of repositories available in an integration
         ````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -5,11 +5,12 @@ from sentry.api.bases.organization_integrations import OrganizationIntegrationBa
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.integrations.repositories import RepositoryMixin
+from sentry.models import Organization
 from sentry.shared_integrations.exceptions import IntegrationError
 
 
 class OrganizationIntegrationReposEndpoint(OrganizationIntegrationBaseEndpoint):
-    def get(self, request: Request, organization, integration_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, integration_id: int) -> Response:
         """
         Get the list of repositories available in an integration
         ````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from sentry import integrations
 from sentry.api.bases.organization_request_change import OrganizationRequestChangeEndpoint
-from sentry.models import SentryApp
+from sentry.models import Organization, SentryApp
 from sentry.notifications.notifications.organization_request.integration_request import (
     IntegrationRequestNotification,
 )
@@ -38,7 +38,7 @@ def get_provider_name(provider_type: str, provider_slug: str) -> str | None:
 
 
 class OrganizationIntegrationRequestEndpoint(OrganizationRequestChangeEndpoint):
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Email the organization owners asking them to install an integration.
         ````````````````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_integration_serverless_functions.py
+++ b/src/sentry/api/endpoints/organization_integration_serverless_functions.py
@@ -16,9 +16,11 @@ class ServerlessActionSerializer(CamelSnakeSerializer):
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.models import Organization
+
 
 class OrganizationIntegrationServerlessFunctionsEndpoint(OrganizationIntegrationBaseEndpoint):
-    def get(self, request: Request, organization, integration_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, integration_id: int) -> Response:
         """
         Get the list of repository project path configs in an integration
         """
@@ -35,7 +37,7 @@ class OrganizationIntegrationServerlessFunctionsEndpoint(OrganizationIntegration
 
         return self.respond(serverless_functions)
 
-    def post(self, request: Request, organization, integration_id: int) -> Response:
+    def post(self, request: Request, organization: Organization, integration_id: int) -> Response:
         integration = self.get_integration(organization, integration_id)
         install = integration.get_installation(organization.id)
 

--- a/src/sentry/api/endpoints/organization_integration_serverless_functions.py
+++ b/src/sentry/api/endpoints/organization_integration_serverless_functions.py
@@ -18,7 +18,7 @@ from rest_framework.response import Response
 
 
 class OrganizationIntegrationServerlessFunctionsEndpoint(OrganizationIntegrationBaseEndpoint):
-    def get(self, request: Request, organization, integration_id) -> Response:
+    def get(self, request: Request, organization, integration_id: int) -> Response:
         """
         Get the list of repository project path configs in an integration
         """
@@ -35,7 +35,7 @@ class OrganizationIntegrationServerlessFunctionsEndpoint(OrganizationIntegration
 
         return self.respond(serverless_functions)
 
-    def post(self, request: Request, organization, integration_id) -> Response:
+    def post(self, request: Request, organization, integration_id: int) -> Response:
         integration = self.get_integration(organization, integration_id)
         install = integration.get_installation(organization.id)
 

--- a/src/sentry/api/endpoints/organization_integrations.py
+++ b/src/sentry/api/endpoints/organization_integrations.py
@@ -4,13 +4,13 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import ObjectStatus, OrganizationIntegration
+from sentry.models import ObjectStatus, Organization, OrganizationIntegration
 
 
 class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
 
         # filter by integration provider features
         features = [feature.lower() for feature in request.GET.getlist("features", [])]

--- a/src/sentry/api/endpoints/organization_invite_request_details.py
+++ b/src/sentry/api/endpoints/organization_invite_request_details.py
@@ -39,6 +39,9 @@ class InviteRequestPermissions(OrganizationPermission):
     }
 
 
+from sentry.models import Organization
+
+
 class OrganizationInviteRequestDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (InviteRequestPermissions,)
 
@@ -50,7 +53,7 @@ class OrganizationInviteRequestDetailsEndpoint(OrganizationEndpoint):
         except ValueError:
             raise OrganizationMember.DoesNotExist()
 
-    def get(self, request: Request, organization, member_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, member_id: int) -> Response:
         try:
             member = self._get_member(organization, member_id)
         except OrganizationMember.DoesNotExist:
@@ -61,7 +64,7 @@ class OrganizationInviteRequestDetailsEndpoint(OrganizationEndpoint):
             status=status.HTTP_200_OK,
         )
 
-    def put(self, request: Request, organization, member_id: int) -> Response:
+    def put(self, request: Request, organization: Organization, member_id: int) -> Response:
         """
         Update an invite request to Organization
         ````````````````````````````````````````
@@ -131,7 +134,7 @@ class OrganizationInviteRequestDetailsEndpoint(OrganizationEndpoint):
             status=status.HTTP_200_OK,
         )
 
-    def delete(self, request: Request, organization, member_id: int) -> Response:
+    def delete(self, request: Request, organization: Organization, member_id: int) -> Response:
         """
         Delete an invite request to Organization
         ````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_invite_request_details.py
+++ b/src/sentry/api/endpoints/organization_invite_request_details.py
@@ -61,7 +61,7 @@ class OrganizationInviteRequestDetailsEndpoint(OrganizationEndpoint):
             status=status.HTTP_200_OK,
         )
 
-    def put(self, request: Request, organization, member_id) -> Response:
+    def put(self, request: Request, organization, member_id: int) -> Response:
         """
         Update an invite request to Organization
         ````````````````````````````````````````
@@ -131,7 +131,7 @@ class OrganizationInviteRequestDetailsEndpoint(OrganizationEndpoint):
             status=status.HTTP_200_OK,
         )
 
-    def delete(self, request: Request, organization, member_id) -> Response:
+    def delete(self, request: Request, organization, member_id: int) -> Response:
         """
         Delete an invite request to Organization
         ````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_invite_request_details.py
+++ b/src/sentry/api/endpoints/organization_invite_request_details.py
@@ -50,7 +50,7 @@ class OrganizationInviteRequestDetailsEndpoint(OrganizationEndpoint):
         except ValueError:
             raise OrganizationMember.DoesNotExist()
 
-    def get(self, request: Request, organization, member_id) -> Response:
+    def get(self, request: Request, organization, member_id: int) -> Response:
         try:
             member = self._get_member(organization, member_id)
         except OrganizationMember.DoesNotExist:

--- a/src/sentry/api/endpoints/organization_invite_request_index.py
+++ b/src/sentry/api/endpoints/organization_invite_request_index.py
@@ -23,10 +23,13 @@ class InviteRequestPermissions(OrganizationPermission):
     }
 
 
+from sentry.models import Organization
+
+
 class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
     permission_classes = (InviteRequestPermissions,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         queryset = OrganizationMember.objects.filter(
             Q(user__isnull=True),
             Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
@@ -46,7 +49,7 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
             paginator_cls=OffsetPaginator,
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Add a invite request to Organization
         ````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -20,6 +20,9 @@ ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', a
 ISSUES_COUNT_MAX_HITS_LIMIT = 100
 
 
+from sentry.models import Organization
+
+
 class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
     rate_limits = {
         "GET": {
@@ -54,7 +57,7 @@ class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
         return result.hits
 
     @rate_limit_endpoint(limit=10, window=1)
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         stats_period = request.GET.get("groupStatsPeriod")
         try:
             start, end = get_date_range_from_params(request.GET)

--- a/src/sentry/api/endpoints/organization_issues_resolved_in_release.py
+++ b/src/sentry/api/endpoints/organization_issues_resolved_in_release.py
@@ -12,7 +12,7 @@ from sentry.models import Group
 class OrganizationIssuesResolvedInReleaseEndpoint(OrganizationEndpoint, EnvironmentMixin):
     permission_classes = (OrganizationPermission,)
 
-    def get(self, request: Request, organization, version) -> Response:
+    def get(self, request: Request, organization, version: str) -> Response:
         """
         List issues to be resolved in a particular release
         ``````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_issues_resolved_in_release.py
+++ b/src/sentry/api/endpoints/organization_issues_resolved_in_release.py
@@ -6,13 +6,13 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.api.helpers.releases import get_group_ids_resolved_in_release
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializerSnuba
-from sentry.models import Group
+from sentry.models import Group, Organization
 
 
 class OrganizationIssuesResolvedInReleaseEndpoint(OrganizationEndpoint, EnvironmentMixin):
     permission_classes = (OrganizationPermission,)
 
-    def get(self, request: Request, organization, version: str) -> Response:
+    def get(self, request: Request, organization: Organization, version: str) -> Response:
         """
         List issues to be resolved in a particular release
         ``````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_join_request.py
+++ b/src/sentry/api/endpoints/organization_join_request.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.validators import AllowedEmailField
 from sentry.app import ratelimiter
-from sentry.models import AuthProvider, InviteStatus, OrganizationMember
+from sentry.models import AuthProvider, InviteStatus, Organization, OrganizationMember
 from sentry.notifications.notifications.organization_request import JoinRequestNotification
 from sentry.signals import join_request_created
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -50,7 +50,7 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
         }
     }
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         if organization.get_option("sentry:join_requests") is False:
             return Response(
                 {"detail": "Your organization does not allow join requests."}, status=403

--- a/src/sentry/api/endpoints/organization_member_details.py
+++ b/src/sentry/api/endpoints/organization_member_details.py
@@ -124,7 +124,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
 
         return context
 
-    def get(self, request: Request, organization, member_id) -> Response:
+    def get(self, request: Request, organization, member_id: int) -> Response:
         """Currently only returns allowed invite roles for member invite"""
 
         try:

--- a/src/sentry/api/endpoints/organization_member_details.py
+++ b/src/sentry/api/endpoints/organization_member_details.py
@@ -138,7 +138,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
 
         return Response(context)
 
-    def put(self, request: Request, organization, member_id) -> Response:
+    def put(self, request: Request, organization, member_id: int) -> Response:
         try:
             om = self._get_member(request, organization, member_id)
         except OrganizationMember.DoesNotExist:
@@ -245,7 +245,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
 
         return Response(context)
 
-    def delete(self, request: Request, organization, member_id) -> Response:
+    def delete(self, request: Request, organization, member_id: int) -> Response:
         try:
             om = self._get_member(request, organization, member_id)
         except OrganizationMember.DoesNotExist:

--- a/src/sentry/api/endpoints/organization_member_details.py
+++ b/src/sentry/api/endpoints/organization_member_details.py
@@ -74,10 +74,13 @@ class RelaxedMemberPermission(OrganizationPermission):
     }
 
 
+from sentry.models import Organization
+
+
 class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
     permission_classes = [RelaxedMemberPermission]
 
-    def _get_member(self, request: Request, organization, member_id):
+    def _get_member(self, request: Request, organization: Organization, member_id):
         if member_id == "me":
             queryset = OrganizationMember.objects.filter(
                 organization=organization, user__id=request.user.id, user__is_active=True
@@ -124,7 +127,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
 
         return context
 
-    def get(self, request: Request, organization, member_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, member_id: int) -> Response:
         """Currently only returns allowed invite roles for member invite"""
 
         try:
@@ -138,7 +141,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
 
         return Response(context)
 
-    def put(self, request: Request, organization, member_id: int) -> Response:
+    def put(self, request: Request, organization: Organization, member_id: int) -> Response:
         try:
             om = self._get_member(request, organization, member_id)
         except OrganizationMember.DoesNotExist:
@@ -245,7 +248,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
 
         return Response(context)
 
-    def delete(self, request: Request, organization, member_id: int) -> Response:
+    def delete(self, request: Request, organization: Organization, member_id: int) -> Response:
         try:
             om = self._get_member(request, organization, member_id)
         except OrganizationMember.DoesNotExist:

--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -102,10 +102,13 @@ class OrganizationMemberSerializer(serializers.Serializer):
         return role
 
 
+from sentry.models import Organization
+
+
 class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
     permission_classes = (MemberPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         queryset = (
             OrganizationMember.objects.filter(
                 Q(user__is_active=True) | Q(user__isnull=True),
@@ -194,7 +197,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             paginator_cls=OffsetPaginator,
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Add a Member to Organization
         ````````````````````````````

--- a/src/sentry/api/endpoints/organization_member_issues_assigned.py
+++ b/src/sentry/api/endpoints/organization_member_issues_assigned.py
@@ -2,11 +2,11 @@ from django.db.models import Q
 from rest_framework.request import Request
 
 from sentry.api.bases import OrganizationIssuesEndpoint
-from sentry.models import Group, OrganizationMemberTeam, Team
+from sentry.models import Group, Organization, OrganizationMemberTeam, Team
 
 
 class OrganizationMemberIssuesAssignedEndpoint(OrganizationIssuesEndpoint):
-    def get_queryset(self, request: Request, organization, member, project_list):
+    def get_queryset(self, request: Request, organization: Organization, member, project_list):
         teams = Team.objects.filter(
             id__in=OrganizationMemberTeam.objects.filter(
                 organizationmember=member, is_active=True

--- a/src/sentry/api/endpoints/organization_member_issues_bookmarked.py
+++ b/src/sentry/api/endpoints/organization_member_issues_bookmarked.py
@@ -1,11 +1,11 @@
 from rest_framework.request import Request
 
 from sentry.api.bases import OrganizationIssuesEndpoint
-from sentry.models import Group
+from sentry.models import Group, Organization
 
 
 class OrganizationMemberIssuesBookmarkedEndpoint(OrganizationIssuesEndpoint):
-    def get_queryset(self, request: Request, organization, member, project_list):
+    def get_queryset(self, request: Request, organization: Organization, member, project_list):
         return (
             Group.objects.filter(
                 bookmark_set__user=member.user, bookmark_set__project__in=project_list

--- a/src/sentry/api/endpoints/organization_member_issues_viewed.py
+++ b/src/sentry/api/endpoints/organization_member_issues_viewed.py
@@ -1,11 +1,11 @@
 from rest_framework.request import Request
 
 from sentry.api.bases import OrganizationIssuesEndpoint
-from sentry.models import Group
+from sentry.models import Group, Organization
 
 
 class OrganizationMemberIssuesViewedEndpoint(OrganizationIssuesEndpoint):
-    def get_queryset(self, request: Request, organization, member, project_list):
+    def get_queryset(self, request: Request, organization: Organization, member, project_list):
         return (
             Group.objects.filter(groupseen__user=member.user, groupseen__project__in=project_list)
             .extra(select={"sort_by": "sentry_groupseen.last_seen"})

--- a/src/sentry/api/endpoints/organization_member_team_details.py
+++ b/src/sentry/api/endpoints/organization_member_team_details.py
@@ -121,7 +121,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
 
         omt.send_request_email()
 
-    def post(self, request: Request, organization, member_id: int, team_slug) -> Response:
+    def post(self, request: Request, organization, member_id: int, team_slug: str) -> Response:
         """
         Join, request access to or add a member to a team.
 
@@ -167,7 +167,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serialize(team, request.user, TeamWithProjectsSerializer()), status=201)
 
-    def delete(self, request: Request, organization, member_id, team_slug) -> Response:
+    def delete(self, request: Request, organization, member_id, team_slug: str) -> Response:
         """
         Leave or remove a member from a team
         """

--- a/src/sentry/api/endpoints/organization_member_team_details.py
+++ b/src/sentry/api/endpoints/organization_member_team_details.py
@@ -121,7 +121,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
 
         omt.send_request_email()
 
-    def post(self, request: Request, organization, member_id, team_slug) -> Response:
+    def post(self, request: Request, organization, member_id: int, team_slug) -> Response:
         """
         Join, request access to or add a member to a team.
 

--- a/src/sentry/api/endpoints/organization_member_team_details.py
+++ b/src/sentry/api/endpoints/organization_member_team_details.py
@@ -42,10 +42,13 @@ class RelaxedOrganizationPermission(OrganizationPermission):
     }
 
 
+from sentry.models import Organization
+
+
 class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
     permission_classes = [RelaxedOrganizationPermission]
 
-    def _can_create_team_member(self, request: Request, organization, team_slug):
+    def _can_create_team_member(self, request: Request, organization: Organization, team_slug):
         """
         User can join or add a member to a team:
 
@@ -83,7 +86,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
 
         return False
 
-    def _can_admin_team(self, request: Request, organization, team_slug):
+    def _can_admin_team(self, request: Request, organization: Organization, team_slug):
         global_roles = [r.id for r in roles.with_scope("org:write") if r.is_global]
         team_roles = [r.id for r in roles.with_scope("team:write")]
 
@@ -96,7 +99,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
             user__is_active=True,
         ).exists()
 
-    def _get_member(self, request: Request, organization, member_id):
+    def _get_member(self, request: Request, organization: Organization, member_id):
         if member_id == "me":
             queryset = OrganizationMember.objects.filter(
                 organization=organization, user__id=request.user.id, user__is_active=True
@@ -121,7 +124,9 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
 
         omt.send_request_email()
 
-    def post(self, request: Request, organization, member_id: int, team_slug: str) -> Response:
+    def post(
+        self, request: Request, organization: Organization, member_id: int, team_slug: str
+    ) -> Response:
         """
         Join, request access to or add a member to a team.
 
@@ -167,7 +172,9 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serialize(team, request.user, TeamWithProjectsSerializer()), status=201)
 
-    def delete(self, request: Request, organization, member_id, team_slug: str) -> Response:
+    def delete(
+        self, request: Request, organization: Organization, member_id, team_slug: str
+    ) -> Response:
         """
         Leave or remove a member from a team
         """

--- a/src/sentry/api/endpoints/organization_member_unreleased_commits.py
+++ b/src/sentry/api/endpoints/organization_member_unreleased_commits.py
@@ -1,8 +1,10 @@
 from django.db import connections
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import Commit, Repository, UserEmail
+from sentry.models import Commit, Organization, Repository, UserEmail
 from sentry.utils.compat import zip
 
 # TODO(dcramer): once LatestRepoReleaseEnvironment is backfilled, change this query to use the new
@@ -34,12 +36,8 @@ order by c1.date_added desc
 quote_name = connections["default"].ops.quote_name
 
 
-from rest_framework.request import Request
-from rest_framework.response import Response
-
-
 class OrganizationMemberUnreleasedCommitsEndpoint(OrganizationMemberEndpoint):
-    def get(self, request: Request, organization, member) -> Response:
+    def get(self, request: Request, organization: Organization, member) -> Response:
         email_list = list(
             UserEmail.objects.filter(user=member.user_id, is_verified=True).values_list(
                 "email", flat=True

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models import Organization
 from sentry.snuba.metrics import (
     InvalidField,
     InvalidParams,
@@ -24,7 +25,7 @@ def get_datasource(request):
 class OrganizationMetricsEndpoint(OrganizationEndpoint):
     """Get metric name, available operations and the metric unit"""
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:metrics", organization, actor=request.user):
             return Response(status=404)
 
@@ -36,7 +37,7 @@ class OrganizationMetricsEndpoint(OrganizationEndpoint):
 class OrganizationMetricDetailsEndpoint(OrganizationEndpoint):
     """Get metric name, available operations, metric unit and available tags"""
 
-    def get(self, request: Request, organization, metric_name: str) -> Response:
+    def get(self, request: Request, organization: Organization, metric_name: str) -> Response:
         if not features.has("organizations:metrics", organization, actor=request.user):
             return Response(status=404)
 
@@ -60,7 +61,7 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
 
     """
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
 
         if not features.has("organizations:metrics", organization, actor=request.user):
             return Response(status=404)
@@ -79,7 +80,7 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
 class OrganizationMetricsTagDetailsEndpoint(OrganizationEndpoint):
     """Get all existing tag values for a metric"""
 
-    def get(self, request: Request, organization, tag_name: str) -> Response:
+    def get(self, request: Request, organization: Organization, tag_name: str) -> Response:
 
         if not features.has("organizations:metrics", organization, actor=request.user):
             return Response(status=404)
@@ -107,7 +108,7 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
     Based on `OrganizationSessionsEndpoint`.
     """
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:metrics", organization, actor=request.user):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -36,7 +36,7 @@ class OrganizationMetricsEndpoint(OrganizationEndpoint):
 class OrganizationMetricDetailsEndpoint(OrganizationEndpoint):
     """Get metric name, available operations, metric unit and available tags"""
 
-    def get(self, request: Request, organization, metric_name) -> Response:
+    def get(self, request: Request, organization, metric_name: str) -> Response:
         if not features.has("organizations:metrics", organization, actor=request.user):
             return Response(status=404)
 
@@ -79,7 +79,7 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
 class OrganizationMetricsTagDetailsEndpoint(OrganizationEndpoint):
     """Get all existing tag values for a metric"""
 
-    def get(self, request: Request, organization, tag_name) -> Response:
+    def get(self, request: Request, organization, tag_name: str) -> Response:
 
         if not features.has("organizations:metrics", organization, actor=request.user):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_monitors.py
+++ b/src/sentry/api/endpoints/organization_monitors.py
@@ -1,4 +1,6 @@
 from django.db.models import Q
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases import NoProjects
@@ -8,7 +10,7 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.validators import MonitorValidator
 from sentry.db.models.query import in_iexact
-from sentry.models import AuditLogEntryEvent, Monitor, MonitorStatus, MonitorType
+from sentry.models import AuditLogEntryEvent, Monitor, MonitorStatus, MonitorType, Organization
 from sentry.search.utils import tokenize_query
 
 
@@ -21,12 +23,8 @@ def map_value_to_constant(constant, value):
     return getattr(constant, value)
 
 
-from rest_framework.request import Request
-from rest_framework.response import Response
-
-
 class OrganizationMonitorsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieve monitors for an organization
         `````````````````````````````````````
@@ -85,7 +83,7 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
             paginator_cls=OffsetPaginator,
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Create a monitor
         ````````````````

--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -3,7 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
-from sentry.models import OnboardingTaskStatus, OrganizationOnboardingTask
+from sentry.models import OnboardingTaskStatus, Organization, OrganizationOnboardingTask
 from sentry.receivers import try_mark_onboarding_complete
 
 
@@ -14,7 +14,7 @@ class OnboardingTaskPermission(OrganizationPermission):
 class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
     permission_classes = (OnboardingTaskPermission,)
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         try:
             task_id = OrganizationOnboardingTask.TASK_LOOKUP_BY_KEY[request.data["task"]]
         except KeyError:

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -26,10 +26,13 @@ class OrganizationSearchSerializer(serializers.Serializer):
         return value
 
 
+from sentry.models import Organization
+
+
 class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationPinnedSearchPermission,)
 
-    def put(self, request: Request, organization) -> Response:
+    def put(self, request: Request, organization: Organization) -> Response:
         serializer = OrganizationSearchSerializer(data=request.data)
 
         if serializer.is_valid():
@@ -62,7 +65,7 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
             return Response(serialize(pinned_search, request.user), status=201)
         return Response(serializer.errors, status=400)
 
-    def delete(self, request: Request, organization) -> Response:
+    def delete(self, request: Request, organization: Organization) -> Response:
         try:
             search_type = SearchType(int(request.data.get("type", 0)))
         except ValueError as e:

--- a/src/sentry/api/endpoints/organization_plugins.py
+++ b/src/sentry/api/endpoints/organization_plugins.py
@@ -5,12 +5,12 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_plugin import OrganizationPluginSerializer
 from sentry.api.serializers.models.plugin import PluginSerializer
-from sentry.models import ProjectOption
+from sentry.models import Organization, ProjectOption
 from sentry.plugins.base import plugins
 
 
 class OrganizationPluginsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         all_plugins = {p.slug: p for p in plugins.all()}
 
         if "plugins" in request.GET:

--- a/src/sentry/api/endpoints/organization_plugins_configs.py
+++ b/src/sentry/api/endpoints/organization_plugins_configs.py
@@ -6,12 +6,12 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.plugin import PluginSerializer
 from sentry.constants import ObjectStatus
-from sentry.models import Project, ProjectOption
+from sentry.models import Organization, Project, ProjectOption
 from sentry.plugins.base import plugins
 
 
 class OrganizationPluginsConfigsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
 
         """
         List one or more plugin configurations, including a `projectList` for each plugin which contains

--- a/src/sentry/api/endpoints/organization_processingissues.py
+++ b/src/sentry/api/endpoints/organization_processingissues.py
@@ -4,10 +4,11 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.helpers.processing_issues import get_processing_issues
 from sentry.api.serializers import serialize
+from sentry.models import Organization
 
 
 class OrganizationProcessingIssuesEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         For each Project in an Organization, list its processing issues. Can
         be passed `project` to filter down to specific projects.

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -13,8 +13,11 @@ from sentry.search.utils import tokenize_query
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
 
 
+from sentry.models import Organization
+
+
 class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's Projects
         ```````````````````````````````
@@ -123,8 +126,11 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
             )
 
 
+from sentry.models import Organization
+
+
 class OrganizationProjectsCountEndpoint(OrganizationEndpoint, EnvironmentMixin):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         queryset = Project.objects.filter(organization=organization)
 
         all_projects = queryset.count()

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -3,12 +3,12 @@ from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import Project
+from sentry.models import Organization, Project
 from sentry.utils.compat import map
 
 
 class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Verify If Any Project Within An Organization Has Received a First Event
         ```````````````````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -21,10 +21,13 @@ class OrganizationRecentSearchPermission(OrganizationPermission):
     }
 
 
+from sentry.models import Organization
+
+
 class OrganizationRecentSearchesEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationRecentSearchPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List recent searches for a User within an Organization
         ``````````````````````````````````````````````````````
@@ -54,7 +57,7 @@ class OrganizationRecentSearchesEndpoint(OrganizationEndpoint):
 
         return Response(serialize(recent_searches, request.user))
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         serializer = RecentSearchSerializer(data=request.data)
 
         if serializer.is_valid():

--- a/src/sentry/api/endpoints/organization_relay_usage.py
+++ b/src/sentry/api/endpoints/organization_relay_usage.py
@@ -4,13 +4,13 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import serialize
-from sentry.models import RelayUsage
+from sentry.models import Organization, RelayUsage
 
 
 class OrganizationRelayUsage(OrganizationEndpoint):
     permission_classes = (OrganizationPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         has_relays = features.has("organizations:relay", organization, actor=request.user)
         if not has_relays:
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_release_assemble.py
+++ b/src/sentry/api/endpoints/organization_release_assemble.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import Release
+from sentry.models import Organization, Release
 from sentry.tasks.assemble import (
     AssembleTask,
     ChunkFileState,
@@ -15,7 +15,7 @@ from sentry.utils import json
 
 
 class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
-    def post(self, request: Request, organization, version: str) -> Response:
+    def post(self, request: Request, organization: Organization, version: str) -> Response:
         """
         Handle an artifact bundle and merge it into the release
         ```````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_assemble.py
+++ b/src/sentry/api/endpoints/organization_release_assemble.py
@@ -15,7 +15,7 @@ from sentry.utils import json
 
 
 class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
-    def post(self, request: Request, organization, version) -> Response:
+    def post(self, request: Request, organization, version: str) -> Response:
         """
         Handle an artifact bundle and merge it into the release
         ```````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_commits.py
+++ b/src/sentry/api/endpoints/organization_release_commits.py
@@ -4,11 +4,11 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import Release, ReleaseCommit
+from sentry.models import Organization, Release, ReleaseCommit
 
 
 class OrganizationReleaseCommitsEndpoint(OrganizationReleasesBaseEndpoint):
-    def get(self, request: Request, organization, version: str) -> Response:
+    def get(self, request: Request, organization: Organization, version: str) -> Response:
         """
         List an Organization Release's Commits
         ``````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_commits.py
+++ b/src/sentry/api/endpoints/organization_release_commits.py
@@ -8,7 +8,7 @@ from sentry.models import Release, ReleaseCommit
 
 
 class OrganizationReleaseCommitsEndpoint(OrganizationReleasesBaseEndpoint):
-    def get(self, request: Request, organization, version) -> Response:
+    def get(self, request: Request, organization, version: str) -> Response:
         """
         List an Organization Release's Commits
         ``````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -19,7 +19,14 @@ from sentry.api.serializers.rest_framework import (
     ReleaseHeadCommitSerializerDeprecated,
     ReleaseSerializer,
 )
-from sentry.models import Activity, Project, Release, ReleaseCommitError, ReleaseStatus
+from sentry.models import (
+    Activity,
+    Organization,
+    Project,
+    Release,
+    ReleaseCommitError,
+    ReleaseStatus,
+)
 from sentry.models.release import UnsafeReleaseDeletion
 from sentry.snuba.sessions import STATS_PERIODS
 from sentry.utils.sdk import bind_organization_context, configure_scope
@@ -270,7 +277,7 @@ class OrganizationReleaseDetailsEndpoint(
     ReleaseAnalyticsMixin,
     OrganizationReleaseDetailsPaginationMixin,
 ):
-    def get(self, request: Request, organization, version: str) -> Response:
+    def get(self, request: Request, organization: Organization, version: str) -> Response:
         """
         Retrieve an Organization's Release
         ``````````````````````````````````
@@ -368,7 +375,7 @@ class OrganizationReleaseDetailsEndpoint(
             )
         )
 
-    def put(self, request: Request, organization, version: str) -> Response:
+    def put(self, request: Request, organization: Organization, version: str) -> Response:
         """
         Update an Organization's Release
         ````````````````````````````````
@@ -496,7 +503,7 @@ class OrganizationReleaseDetailsEndpoint(
 
             return Response(serialize(release, request.user))
 
-    def delete(self, request: Request, organization, version: str) -> Response:
+    def delete(self, request: Request, organization: Organization, version: str) -> Response:
         """
         Delete an Organization's Release
         ````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -270,7 +270,7 @@ class OrganizationReleaseDetailsEndpoint(
     ReleaseAnalyticsMixin,
     OrganizationReleaseDetailsPaginationMixin,
 ):
-    def get(self, request: Request, organization, version) -> Response:
+    def get(self, request: Request, organization, version: str) -> Response:
         """
         Retrieve an Organization's Release
         ``````````````````````````````````
@@ -368,7 +368,7 @@ class OrganizationReleaseDetailsEndpoint(
             )
         )
 
-    def put(self, request: Request, organization, version) -> Response:
+    def put(self, request: Request, organization, version: str) -> Response:
         """
         Update an Organization's Release
         ````````````````````````````````
@@ -496,7 +496,7 @@ class OrganizationReleaseDetailsEndpoint(
 
             return Response(serialize(release, request.user))
 
-    def delete(self, request: Request, organization, version) -> Response:
+    def delete(self, request: Request, organization, version: str) -> Response:
         """
         Delete an Organization's Release
         ````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_file_details.py
+++ b/src/sentry/api/endpoints/organization_release_file_details.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.endpoints.project_release_file_details import ReleaseFileDetailsMixin
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import Release
+from sentry.models import Organization, Release
 
 
 class ReleaseFileSerializer(serializers.Serializer):
@@ -15,7 +15,7 @@ class ReleaseFileSerializer(serializers.Serializer):
 class OrganizationReleaseFileDetailsEndpoint(
     OrganizationReleasesBaseEndpoint, ReleaseFileDetailsMixin
 ):
-    def get(self, request: Request, organization, version, file_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, version, file_id: int) -> Response:
         """
         Retrieve an Organization Release's File
         ```````````````````````````````````````
@@ -45,7 +45,7 @@ class OrganizationReleaseFileDetailsEndpoint(
             check_permission_fn=lambda: request.access.has_scope("project:write"),
         )
 
-    def put(self, request: Request, organization, version, file_id: int) -> Response:
+    def put(self, request: Request, organization: Organization, version, file_id: int) -> Response:
         """
         Update an Organization Release's File
         `````````````````````````````````````
@@ -71,7 +71,9 @@ class OrganizationReleaseFileDetailsEndpoint(
 
         return self.update_releasefile(request, release, file_id)
 
-    def delete(self, request: Request, organization, version, file_id: int) -> Response:
+    def delete(
+        self, request: Request, organization: Organization, version, file_id: int
+    ) -> Response:
         """
         Delete an Organization Release's File
         `````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_file_details.py
+++ b/src/sentry/api/endpoints/organization_release_file_details.py
@@ -15,7 +15,7 @@ class ReleaseFileSerializer(serializers.Serializer):
 class OrganizationReleaseFileDetailsEndpoint(
     OrganizationReleasesBaseEndpoint, ReleaseFileDetailsMixin
 ):
-    def get(self, request: Request, organization, version, file_id) -> Response:
+    def get(self, request: Request, organization, version, file_id: int) -> Response:
         """
         Retrieve an Organization Release's File
         ```````````````````````````````````````
@@ -45,7 +45,7 @@ class OrganizationReleaseFileDetailsEndpoint(
             check_permission_fn=lambda: request.access.has_scope("project:write"),
         )
 
-    def put(self, request: Request, organization, version, file_id) -> Response:
+    def put(self, request: Request, organization, version, file_id: int) -> Response:
         """
         Update an Organization Release's File
         `````````````````````````````````````
@@ -71,7 +71,7 @@ class OrganizationReleaseFileDetailsEndpoint(
 
         return self.update_releasefile(request, release, file_id)
 
-    def delete(self, request: Request, organization, version, file_id) -> Response:
+    def delete(self, request: Request, organization, version, file_id: int) -> Response:
         """
         Delete an Organization Release's File
         `````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -6,11 +6,11 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.endpoints.project_release_files import ReleaseFilesMixin
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import Release
+from sentry.models import Organization, Release
 
 
 class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseFilesMixin):
-    def get(self, request: Request, organization, version: str) -> Response:
+    def get(self, request: Request, organization: Organization, version: str) -> Response:
         """
         List an Organization Release's Files
         ````````````````````````````````````
@@ -32,7 +32,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
 
         return self.get_releasefiles(request, release, organization.id)
 
-    def post(self, request: Request, organization, version: str) -> Response:
+    def post(self, request: Request, organization: Organization, version: str) -> Response:
         """
         Upload a New Organization Release File
         ``````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -10,7 +10,7 @@ from sentry.models import Release
 
 
 class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseFilesMixin):
-    def get(self, request: Request, organization, version) -> Response:
+    def get(self, request: Request, organization, version: str) -> Response:
         """
         List an Organization Release's Files
         ````````````````````````````````````
@@ -32,7 +32,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
 
         return self.get_releasefiles(request, release, organization.id)
 
-    def post(self, request: Request, organization, version) -> Response:
+    def post(self, request: Request, organization, version: str) -> Response:
         """
         Upload a New Organization Release File
         ``````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -6,11 +6,18 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers.models.release import expose_version_info
-from sentry.models import CommitFileChange, ProjectPlatform, Release, ReleaseCommit, ReleaseProject
+from sentry.models import (
+    CommitFileChange,
+    Organization,
+    ProjectPlatform,
+    Release,
+    ReleaseCommit,
+    ReleaseProject,
+)
 
 
 class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
-    def get(self, request: Request, organization, version: str) -> Response:
+    def get(self, request: Request, organization: Organization, version: str) -> Response:
         """
         Retrieve an Organization's Release's Associated Meta Data
         `````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -10,7 +10,7 @@ from sentry.models import CommitFileChange, ProjectPlatform, Release, ReleaseCom
 
 
 class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
-    def get(self, request: Request, organization, version) -> Response:
+    def get(self, request: Request, organization, version: str) -> Response:
         """
         Retrieve an Organization's Release's Associated Meta Data
         `````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_previous_commits.py
+++ b/src/sentry/api/endpoints/organization_release_previous_commits.py
@@ -9,7 +9,7 @@ from sentry.models import Release
 
 
 class OrganizationReleasePreviousCommitsEndpoint(OrganizationReleasesBaseEndpoint):
-    def get(self, request: Request, organization, version) -> Response:
+    def get(self, request: Request, organization, version: str) -> Response:
         """
         Retrieve an Organization's Most Recent Release with Commits
         ````````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_release_previous_commits.py
+++ b/src/sentry/api/endpoints/organization_release_previous_commits.py
@@ -5,11 +5,11 @@ from sentry import analytics
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import Release
+from sentry.models import Organization, Release
 
 
 class OrganizationReleasePreviousCommitsEndpoint(OrganizationReleasesBaseEndpoint):
-    def get(self, request: Request, organization, version: str) -> Response:
+    def get(self, request: Request, organization: Organization, version: str) -> Response:
         """
         Retrieve an Organization's Most Recent Release with Commits
         ````````````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -24,6 +24,7 @@ from sentry.api.serializers.rest_framework import (
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import (
     Activity,
+    Organization,
     Project,
     Release,
     ReleaseCommitError,
@@ -217,7 +218,7 @@ class OrganizationReleasesEndpoint(
         ]
     )
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's Releases
         ```````````````````````````````
@@ -394,7 +395,7 @@ class OrganizationReleasesEndpoint(
             **paginator_kwargs,
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Create a New Release for an Organization
         ````````````````````````````````````````
@@ -557,7 +558,7 @@ class OrganizationReleasesEndpoint(
 
 
 class OrganizationReleasesStatsEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's Releases specifically for building timeseries
         ```````````````````````````````

--- a/src/sentry/api/endpoints/organization_repositories.py
+++ b/src/sentry/api/endpoints/organization_repositories.py
@@ -12,10 +12,13 @@ from sentry.utils.sdk import capture_exception
 UNMIGRATABLE_PROVIDERS = ("bitbucket", "github")
 
 
+from sentry.models import Organization
+
+
 class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's Repositories
         ```````````````````````````````````
@@ -68,7 +71,7 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
             paginator_cls=OffsetPaginator,
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         if not request.user.is_authenticated:
             return Response(status=401)
         provider_id = request.data.get("provider")

--- a/src/sentry/api/endpoints/organization_repository_commits.py
+++ b/src/sentry/api/endpoints/organization_repository_commits.py
@@ -9,7 +9,7 @@ from sentry.models import Commit, Repository
 
 
 class OrganizationRepositoryCommitsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization, repo_id) -> Response:
+    def get(self, request: Request, organization, repo_id: int) -> Response:
         """
         List a Repository's Commits
         ```````````````````````````

--- a/src/sentry/api/endpoints/organization_repository_commits.py
+++ b/src/sentry/api/endpoints/organization_repository_commits.py
@@ -5,11 +5,11 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
-from sentry.models import Commit, Repository
+from sentry.models import Commit, Organization, Repository
 
 
 class OrganizationRepositoryCommitsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization, repo_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, repo_id: int) -> Response:
         """
         List a Repository's Commits
         ```````````````````````````

--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -28,7 +28,7 @@ class RepositorySerializer(serializers.Serializer):
 class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission,)
 
-    def put(self, request: Request, organization, repo_id) -> Response:
+    def put(self, request: Request, organization, repo_id: int) -> Response:
         if not request.user.is_authenticated:
             return Response(status=401)
 
@@ -85,7 +85,7 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serialize(repo, request.user))
 
-    def delete(self, request: Request, organization, repo_id) -> Response:
+    def delete(self, request: Request, organization, repo_id: int) -> Response:
         if not request.user.is_authenticated:
             return Response(status=401)
 

--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -25,10 +25,13 @@ class RepositorySerializer(serializers.Serializer):
     integrationId = EmptyIntegerField(required=False, allow_null=True)
 
 
+from sentry.models import Organization
+
+
 class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission,)
 
-    def put(self, request: Request, organization, repo_id: int) -> Response:
+    def put(self, request: Request, organization: Organization, repo_id: int) -> Response:
         if not request.user.is_authenticated:
             return Response(status=401)
 
@@ -85,7 +88,7 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
 
         return Response(serialize(repo, request.user))
 
-    def delete(self, request: Request, organization, repo_id: int) -> Response:
+    def delete(self, request: Request, organization: Organization, repo_id: int) -> Response:
         if not request.user.is_authenticated:
             return Response(status=401)
 

--- a/src/sentry/api/endpoints/organization_request_project_creation.py
+++ b/src/sentry/api/endpoints/organization_request_project_creation.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.organization_request_change import OrganizationRequestChangeEndpoint
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.models import Organization
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 
@@ -14,7 +15,7 @@ class OrganizationRequestProjectCreationSerializer(CamelSnakeSerializer):
 
 
 class OrganizationRequestProjectCreation(OrganizationRequestChangeEndpoint):
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Send an email requesting a project be created
         """

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -62,8 +62,11 @@ def serialize(data, projects):
     return [update for update in updates_list if len(update["suggestions"]) > 0]
 
 
+from sentry.models import Organization
+
+
 class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         projects = self.get_projects(request, organization)
 
         len_projects = len(projects)

--- a/src/sentry/api/endpoints/organization_search_details.py
+++ b/src/sentry/api/endpoints/organization_search_details.py
@@ -4,14 +4,14 @@ from rest_framework.response import Response
 from sentry import analytics
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationSearchPermission
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import SavedSearch
+from sentry.models import Organization, SavedSearch
 from sentry.models.search_common import SearchType
 
 
 class OrganizationSearchDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationSearchPermission,)
 
-    def delete(self, request: Request, organization, search_id: int) -> Response:
+    def delete(self, request: Request, organization: Organization, search_id: int) -> Response:
         """
         Delete a saved search
 

--- a/src/sentry/api/endpoints/organization_search_details.py
+++ b/src/sentry/api/endpoints/organization_search_details.py
@@ -11,7 +11,7 @@ from sentry.models.search_common import SearchType
 class OrganizationSearchDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationSearchPermission,)
 
-    def delete(self, request: Request, organization, search_id) -> Response:
+    def delete(self, request: Request, organization, search_id: int) -> Response:
         """
         Delete a saved search
 

--- a/src/sentry/api/endpoints/organization_searches.py
+++ b/src/sentry/api/endpoints/organization_searches.py
@@ -19,10 +19,13 @@ class OrganizationSearchSerializer(serializers.Serializer):
     )
 
 
+from sentry.models import Organization
+
+
 class OrganizationSearchesEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationSearchPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's saved searches
         `````````````````````````````````````
@@ -68,7 +71,7 @@ class OrganizationSearchesEndpoint(OrganizationEndpoint):
 
         return Response(serialize(results, request.user))
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         serializer = OrganizationSearchSerializer(data=request.data)
 
         if serializer.is_valid():

--- a/src/sentry/api/endpoints/organization_sentry_apps.py
+++ b/src/sentry/api/endpoints/organization_sentry_apps.py
@@ -4,12 +4,12 @@ from rest_framework.response import Response
 from sentry.api.bases import OrganizationEndpoint, add_integration_platform_metric_tag
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import SentryApp
+from sentry.models import Organization, SentryApp
 
 
 class OrganizationSentryAppsEndpoint(OrganizationEndpoint):
     @add_integration_platform_metric_tag
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         queryset = SentryApp.objects.filter(owner=organization, application__isnull=False)
 
         return self.paginate(

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -8,12 +8,14 @@ from rest_framework.response import Response
 
 from sentry import features, release_health
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+
+# NOTE: this currently extends `OrganizationEventsEndpointBase` for `handle_query_errors` only, which should ideally be decoupled from the base class.
+from sentry.models import Organization
 from sentry.snuba.sessions_v2 import AllowedResolution, InvalidField, InvalidParams, QueryDefinition
 
 
-# NOTE: this currently extends `OrganizationEventsEndpointBase` for `handle_query_errors` only, which should ideally be decoupled from the base class.
 class OrganizationSessionsEndpoint(OrganizationEventsEndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         with self.handle_query_errors():
             with sentry_sdk.start_span(op="sessions.endpoint", description="build_sessions_query"):
                 query = self.build_sessions_query(request, organization)

--- a/src/sentry/api/endpoints/organization_shortid.py
+++ b/src/sentry/api/endpoints/organization_shortid.py
@@ -4,11 +4,11 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import Group
+from sentry.models import Group, Organization
 
 
 class ShortIdLookupEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization, short_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, short_id: int) -> Response:
         """
         Resolve a Short ID
         ``````````````````

--- a/src/sentry/api/endpoints/organization_shortid.py
+++ b/src/sentry/api/endpoints/organization_shortid.py
@@ -8,7 +8,7 @@ from sentry.models import Group
 
 
 class ShortIdLookupEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization, short_id) -> Response:
+    def get(self, request: Request, organization, short_id: int) -> Response:
         """
         Resolve a Short ID
         ``````````````````

--- a/src/sentry/api/endpoints/organization_slugs.py
+++ b/src/sentry/api/endpoints/organization_slugs.py
@@ -4,11 +4,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.models import Project
+from sentry.models import Organization, Project
 
 
 class SlugsUpdateEndpoint(OrganizationEndpoint):
-    def put(self, request: Request, organization) -> Response:
+    def put(self, request: Request, organization: Organization) -> Response:
         """
         Update Project Slugs
         ````````````````````

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -5,12 +5,12 @@ from sentry import tsdb
 from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import Environment, Project, Team
+from sentry.models import Environment, Organization, Project, Team
 from sentry.utils.compat import map
 
 
 class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMixin):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieve Event Counts for an Organization
         `````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.constants import ALL_ACCESS_PROJECTS
+from sentry.models import Organization
 from sentry.search.utils import InvalidQuery
 from sentry.snuba.outcomes import (
     QueryDefinition,
@@ -30,7 +31,7 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
     }
 
     @rate_limit_endpoint(limit=20, window=1)
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         with self.handle_query_errors():
             with sentry_sdk.start_span(op="outcomes.endpoint", description="build_outcomes_query"):
                 query = self.build_outcomes_query(

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -6,11 +6,12 @@ from sentry import tagstore
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
+from sentry.models import Organization
 from sentry.tagstore.base import TAG_KEY_RE
 
 
 class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
-    def get(self, request: Request, organization, key: str) -> Response:
+    def get(self, request: Request, organization: Organization, key: str) -> Response:
         if not TAG_KEY_RE.match(key):
             return Response({"detail": f'Invalid tag key format for "{key}"'}, status=400)
 

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -10,7 +10,7 @@ from sentry.tagstore.base import TAG_KEY_RE
 
 
 class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
-    def get(self, request: Request, organization, key) -> Response:
+    def get(self, request: Request, organization, key: str) -> Response:
         if not TAG_KEY_RE.match(key):
             return Response({"detail": f'Invalid tag key format for "{key}"'}, status=400)
 

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -4,10 +4,11 @@ from rest_framework.response import Response
 from sentry import tagstore
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.serializers import serialize
+from sentry.models import Organization
 
 
 class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         try:
             filter_params = self.get_filter_params(request, organization)
         except NoProjects:

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -54,6 +54,9 @@ class TeamPostSerializer(serializers.Serializer):
         return attrs
 
 
+from sentry.models import Organization
+
+
 class OrganizationTeamsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationTeamsPermission,)
 
@@ -61,7 +64,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
         # allow child routes to supply own serializer, used in SCIM teams route
         return TeamSerializer()
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's Teams
         ````````````````````````````
@@ -127,7 +130,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
     def should_add_creator_to_team(self, request: Request):
         return request.user.is_authenticated
 
-    def post(self, request: Request, organization, **kwargs) -> Response:
+    def post(self, request: Request, organization: Organization, **kwargs) -> Response:
         """
         Create a new Team
         ``````````````````

--- a/src/sentry/api/endpoints/organization_user_details.py
+++ b/src/sentry/api/endpoints/organization_user_details.py
@@ -10,7 +10,7 @@ from sentry.models import User
 class OrganizationUserDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (MemberPermission,)
 
-    def get(self, request: Request, organization, user_id) -> Response:
+    def get(self, request: Request, organization, user_id: int) -> Response:
         try:
             user = User.objects.get(
                 id=user_id, sentry_orgmember_set__organization_id=organization.id

--- a/src/sentry/api/endpoints/organization_user_details.py
+++ b/src/sentry/api/endpoints/organization_user_details.py
@@ -4,13 +4,13 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.endpoints.organization_member_index import MemberPermission
 from sentry.api.serializers import serialize
-from sentry.models import User
+from sentry.models import Organization, User
 
 
 class OrganizationUserDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (MemberPermission,)
 
-    def get(self, request: Request, organization, user_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, user_id: int) -> Response:
         try:
             user = User.objects.get(
                 id=user_id, sentry_orgmember_set__organization_id=organization.id

--- a/src/sentry/api/endpoints/organization_user_issues.py
+++ b/src/sentry/api/endpoints/organization_user_issues.py
@@ -10,7 +10,7 @@ from sentry.models import EventUser, Group, ProjectTeam, Team
 
 
 class OrganizationUserIssuesEndpoint(OrganizationEndpoint, EnvironmentMixin):
-    def get(self, request: Request, organization, user_id) -> Response:
+    def get(self, request: Request, organization, user_id: int) -> Response:
         limit = request.GET.get("limit", 100)
 
         project_ids = organization.project_set.values_list("id", flat=True)

--- a/src/sentry/api/endpoints/organization_user_issues.py
+++ b/src/sentry/api/endpoints/organization_user_issues.py
@@ -6,11 +6,11 @@ from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import TagBasedStreamGroupSerializer
-from sentry.models import EventUser, Group, ProjectTeam, Team
+from sentry.models import EventUser, Group, Organization, ProjectTeam, Team
 
 
 class OrganizationUserIssuesEndpoint(OrganizationEndpoint, EnvironmentMixin):
-    def get(self, request: Request, organization, user_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, user_id: int) -> Response:
         limit = request.GET.get("limit", 100)
 
         project_ids = organization.project_set.values_list("id", flat=True)

--- a/src/sentry/api/endpoints/organization_user_issues_search.py
+++ b/src/sentry/api/endpoints/organization_user_issues_search.py
@@ -6,11 +6,11 @@ from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer
-from sentry.models import EventUser, Group, OrganizationMemberTeam, Project
+from sentry.models import EventUser, Group, Organization, OrganizationMemberTeam, Project
 
 
 class OrganizationUserIssuesSearchEndpoint(OrganizationEndpoint, EnvironmentMixin):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         email = request.GET.get("email")
 
         if email is None:

--- a/src/sentry/api/endpoints/organization_user_reports.py
+++ b/src/sentry/api/endpoints/organization_user_reports.py
@@ -7,13 +7,13 @@ from sentry.api.helpers.user_reports import user_reports_filter_to_unresolved
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import UserReportWithGroupSerializer
-from sentry.models import UserReport
+from sentry.models import Organization, UserReport
 
 
 class OrganizationUserReportsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationUserReportsPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's User Feedback
         ``````````````````````````````

--- a/src/sentry/api/endpoints/organization_user_teams.py
+++ b/src/sentry/api/endpoints/organization_user_teams.py
@@ -5,11 +5,11 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamWithProjectsSerializer
 from sentry.auth.superuser import is_active_superuser
-from sentry.models import Team, TeamStatus
+from sentry.models import Organization, Team, TeamStatus
 
 
 class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List your Teams In the Current Organization
         ```````````````````````````````````````````

--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -6,11 +6,11 @@ from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import OrganizationMemberWithProjectsSerializer
-from sentry.models import OrganizationMember, OrganizationMemberTeam, ProjectTeam
+from sentry.models import Organization, OrganizationMember, OrganizationMemberTeam, ProjectTeam
 
 
 class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List an Organization's Users
         ````````````````````````````

--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -3,11 +3,12 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models import Organization
 from sentry.rules import rules
 
 
 class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Retrieve the list of rule conditions
         """

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -150,6 +150,9 @@ class ProjectCodeOwnersMixin:
             )
 
 
+from sentry.models import Project
+
+
 class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin, ProjectCodeOwnersMixin):  # type: ignore
     def get(self, request: Request, project: Project) -> Response:
         """

--- a/src/sentry/api/endpoints/project_codeowners_details.py
+++ b/src/sentry/api/endpoints/project_codeowners_details.py
@@ -11,7 +11,7 @@ from sentry.api.endpoints.project_ownership import ProjectOwnershipMixin
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import projectcodeowners as projectcodeowners_serializers
-from sentry.models import ProjectCodeOwners
+from sentry.models import Project, ProjectCodeOwners
 
 from .project_codeowners import ProjectCodeOwnerSerializer, ProjectCodeOwnersMixin
 
@@ -36,7 +36,7 @@ class ProjectCodeOwnersDetailsEndpoint(
 
         return (args, kwargs)
 
-    def put(self, request: Request, project, codeowners) -> Response:
+    def put(self, request: Request, project: Project, codeowners) -> Response:
         """
         Update a CodeOwners
         `````````````
@@ -83,7 +83,7 @@ class ProjectCodeOwnersDetailsEndpoint(
         self.track_response_code("update", status.HTTP_400_BAD_REQUEST)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Request, project, codeowners) -> Response:
+    def delete(self, request: Request, project: Project, codeowners) -> Response:
         """
         Delete a CodeOwners
         """

--- a/src/sentry/api/endpoints/project_codeowners_request.py
+++ b/src/sentry/api/endpoints/project_codeowners_request.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 
 from sentry import roles
 from sentry.api.bases.project_request_change import ProjectRequestChangeEndpoint
-from sentry.models import OrganizationMember
+from sentry.models import OrganizationMember, Project
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 
@@ -32,7 +32,7 @@ def get_codeowners_request_builder_args(project, recipient, requester_name):
 
 
 class ProjectCodeOwnersRequestEndpoint(ProjectRequestChangeEndpoint):
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Request to Add CODEOWNERS to a Project
         ````````````````````````````````````

--- a/src/sentry/api/endpoints/project_create_sample.py
+++ b/src/sentry/api/endpoints/project_create_sample.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.serializers import serialize
+from sentry.models import Project
 from sentry.models.groupinbox import GroupInboxReason, add_group_to_inbox
 from sentry.utils.samples import create_sample_event
 
@@ -12,7 +13,7 @@ class ProjectCreateSampleEndpoint(ProjectEndpoint):
     # This is the same scope that allows members to view all issues for a project.
     permission_classes = (ProjectEventPermission,)
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         event = create_sample_event(project, platform=project.platform, default="javascript")
         add_group_to_inbox(event.group, GroupInboxReason.NEW)
 

--- a/src/sentry/api/endpoints/project_create_sample_transaction.py
+++ b/src/sentry/api/endpoints/project_create_sample_transaction.py
@@ -63,12 +63,15 @@ def fix_event_data(data):
     return data
 
 
+from sentry.models import Project
+
+
 class ProjectCreateSampleTransactionEndpoint(ProjectEndpoint):
     # Members should be able to create sample events.
     # This is the same scope that allows members to view all issues for a project.
     permission_classes = (ProjectEventPermission,)
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         samples_root = os.path.join(DATA_ROOT, "samples")
         with open(os.path.join(samples_root, get_json_name(project))) as fp:
             data = json.load(fp)

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -361,7 +361,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
         return queryset.count()
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         Retrieve a Project
         ``````````````````
@@ -386,7 +386,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
         return Response(data)
 
-    def put(self, request: Request, project) -> Response:
+    def put(self, request: Request, project: Project) -> Response:
         """
         Update a Project
         ````````````````
@@ -753,7 +753,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         return Response(data)
 
     @sudo_required
-    def delete(self, request: Request, project) -> Response:
+    def delete(self, request: Request, project: Project) -> Response:
         """
         Delete a Project
         ````````````````

--- a/src/sentry/api/endpoints/project_docs_platform.py
+++ b/src/sentry/api/endpoints/project_docs_platform.py
@@ -35,8 +35,11 @@ def replace_keys(html, project_key):
     return html
 
 
+from sentry.models import Project
+
+
 class ProjectDocsPlatformEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, platform) -> Response:
+    def get(self, request: Request, project: Project, platform) -> Response:
         data = load_doc(platform)
         if not data:
             raise ResourceDoesNotExist

--- a/src/sentry/api/endpoints/project_environment_details.py
+++ b/src/sentry/api/endpoints/project_environment_details.py
@@ -12,8 +12,11 @@ class ProjectEnvironmentSerializer(serializers.Serializer):
     isHidden = serializers.BooleanField()
 
 
+from sentry.models import Project
+
+
 class ProjectEnvironmentDetailsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, environment) -> Response:
+    def get(self, request: Request, project: Project, environment) -> Response:
         try:
             instance = EnvironmentProject.objects.select_related("environment").get(
                 project=project,
@@ -24,7 +27,7 @@ class ProjectEnvironmentDetailsEndpoint(ProjectEndpoint):
 
         return Response(serialize(instance, request.user))
 
-    def put(self, request: Request, project, environment) -> Response:
+    def put(self, request: Request, project: Project, environment) -> Response:
         try:
             instance = EnvironmentProject.objects.select_related("environment").get(
                 project=project,

--- a/src/sentry/api/endpoints/project_environments.py
+++ b/src/sentry/api/endpoints/project_environments.py
@@ -4,11 +4,11 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.environments import environment_visibility_filter_options
 from sentry.api.serializers import serialize
-from sentry.models import EnvironmentProject
+from sentry.models import EnvironmentProject, Project
 
 
 class ProjectEnvironmentsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's Environments
         ```````````````````````````````

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -10,7 +10,7 @@ from sentry.api.serializers import DetailedEventSerializer, serialize
 
 
 class ProjectEventDetailsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id) -> Response:
+    def get(self, request: Request, project, event_id: int) -> Response:
         """
         Retrieve an Event for a Project
         ```````````````````````````````
@@ -76,7 +76,7 @@ from rest_framework.response import Response
 
 
 class EventJsonEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id) -> Response:
+    def get(self, request: Request, project, event_id: int) -> Response:
         event = eventstore.get_event_by_id(project.id, event_id)
 
         if not event:

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -7,10 +7,11 @@ from rest_framework.response import Response
 from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import DetailedEventSerializer, serialize
+from sentry.models import Project
 
 
 class ProjectEventDetailsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id: int) -> Response:
+    def get(self, request: Request, project: Project, event_id: int) -> Response:
         """
         Retrieve an Event for a Project
         ```````````````````````````````
@@ -74,9 +75,11 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.models import Project
+
 
 class EventJsonEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, event_id: int) -> Response:
+    def get(self, request: Request, project: Project, event_id: int) -> Response:
         event = eventstore.get_event_by_id(project.id, event_id)
 
         if not event:

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -9,6 +9,7 @@ from sentry import eventstore, features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
+from sentry.models import Project
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -23,7 +24,7 @@ class ProjectEventsEndpoint(ProjectEndpoint):
     }
 
     @rate_limit_endpoint(limit=5, window=1)
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's Events
         ```````````````````````

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -8,7 +8,7 @@ from sentry.models.auditlogentry import AuditLogEntryEvent
 
 
 class ProjectFilterDetailsEndpoint(ProjectEndpoint):
-    def put(self, request: Request, project, filter_id) -> Response:
+    def put(self, request: Request, project, filter_id: int) -> Response:
         """
         Update a filter
 

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -4,11 +4,12 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.ingest import inbound_filters
+from sentry.models import Project
 from sentry.models.auditlogentry import AuditLogEntryEvent
 
 
 class ProjectFilterDetailsEndpoint(ProjectEndpoint):
-    def put(self, request: Request, project, filter_id: int) -> Response:
+    def put(self, request: Request, project: Project, filter_id: int) -> Response:
         """
         Update a filter
 

--- a/src/sentry/api/endpoints/project_filters.py
+++ b/src/sentry/api/endpoints/project_filters.py
@@ -3,10 +3,11 @@ from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.ingest import inbound_filters
+from sentry.models import Project
 
 
 class ProjectFiltersEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a project's filters
 

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -26,6 +26,9 @@ from sentry.utils.validators import normalize_event_id
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
 
 
+from sentry.models import Project
+
+
 class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
     permission_classes = (ProjectEventPermission,)
 
@@ -39,7 +42,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
     @track_slo_response("workflow")
     @rate_limit_endpoint(limit=3, window=1)
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's Issues
         ```````````````````````
@@ -171,7 +174,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         return response
 
     @track_slo_response("workflow")
-    def put(self, request: Request, project) -> Response:
+    def put(self, request: Request, project: Project) -> Response:
         """
         Bulk Mutate a List of Issues
         ````````````````````````````
@@ -239,7 +242,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         )
 
     @track_slo_response("workflow")
-    def delete(self, request: Request, project) -> Response:
+    def delete(self, request: Request, project: Project) -> Response:
         """
         Bulk Remove a List of Issues
         ````````````````````````````

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -6,7 +6,7 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.app import tsdb
-from sentry.models import Environment, Group
+from sentry.models import Environment, Group, Project
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -21,7 +21,7 @@ class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
     }
 
     @rate_limit_endpoint(limit=20, window=1)
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         try:
             environment_id = self._get_environment_id_from_request(request, project.organization_id)
         except Environment.DoesNotExist:

--- a/src/sentry/api/endpoints/project_grouping_configs.py
+++ b/src/sentry/api/endpoints/project_grouping_configs.py
@@ -5,6 +5,7 @@ from sentry import features
 from sentry.api.bases import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
+from sentry.models import Project
 from sentry.projectoptions.defaults import BETA_GROUPING_CONFIG, DEFAULT_GROUPING_CONFIG
 
 
@@ -14,7 +15,7 @@ class ProjectGroupingConfigsEndpoint(ProjectEndpoint):
     See GroupingConfigsEndpoint
     """
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
 
         configs = [
             config.as_dict() for config in sorted(CONFIGURATIONS.values(), key=lambda x: x.id)

--- a/src/sentry/api/endpoints/project_issues_resolved_in_release.py
+++ b/src/sentry/api/endpoints/project_issues_resolved_in_release.py
@@ -12,7 +12,7 @@ from sentry.models import Group
 class ProjectIssuesResolvedInReleaseEndpoint(ProjectEndpoint, EnvironmentMixin):
     permission_classes = (ProjectPermission,)
 
-    def get(self, request: Request, project, version) -> Response:
+    def get(self, request: Request, project, version: str) -> Response:
         """
         List issues to be resolved in a particular release
         ``````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/project_issues_resolved_in_release.py
+++ b/src/sentry/api/endpoints/project_issues_resolved_in_release.py
@@ -6,13 +6,13 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.helpers.releases import get_group_ids_resolved_in_release
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer
-from sentry.models import Group
+from sentry.models import Group, Project
 
 
 class ProjectIssuesResolvedInReleaseEndpoint(ProjectEndpoint, EnvironmentMixin):
     permission_classes = (ProjectPermission,)
 
-    def get(self, request: Request, project, version: str) -> Response:
+    def get(self, request: Request, project: Project, version: str) -> Response:
         """
         List issues to be resolved in a particular release
         ``````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/project_key_details.py
+++ b/src/sentry/api/endpoints/project_key_details.py
@@ -9,11 +9,11 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ProjectKeySerializer
 from sentry.loader.browsersdkversion import get_default_sdk_version_for_project
-from sentry.models import AuditLogEntryEvent, ProjectKey, ProjectKeyStatus
+from sentry.models import AuditLogEntryEvent, Project, ProjectKey, ProjectKeyStatus
 
 
 class ProjectKeyDetailsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, key_id: int) -> Response:
+    def get(self, request: Request, project: Project, key_id: int) -> Response:
         try:
             key = ProjectKey.objects.get(
                 project=project, public_key=key_id, roles=F("roles").bitor(ProjectKey.roles.store)
@@ -23,7 +23,7 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
 
         return Response(serialize(key, request.user), status=200)
 
-    def put(self, request: Request, project, key_id: int) -> Response:
+    def put(self, request: Request, project: Project, key_id: int) -> Response:
         """
         Update a Client Key
         ```````````````````
@@ -91,7 +91,7 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
             return Response(serialize(key, request.user), status=200)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Request, project, key_id: int) -> Response:
+    def delete(self, request: Request, project: Project, key_id: int) -> Response:
         """
         Delete a Client Key
         ```````````````````

--- a/src/sentry/api/endpoints/project_key_details.py
+++ b/src/sentry/api/endpoints/project_key_details.py
@@ -13,7 +13,7 @@ from sentry.models import AuditLogEntryEvent, ProjectKey, ProjectKeyStatus
 
 
 class ProjectKeyDetailsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, key_id) -> Response:
+    def get(self, request: Request, project, key_id: int) -> Response:
         try:
             key = ProjectKey.objects.get(
                 project=project, public_key=key_id, roles=F("roles").bitor(ProjectKey.roles.store)
@@ -23,7 +23,7 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
 
         return Response(serialize(key, request.user), status=200)
 
-    def put(self, request: Request, project, key_id) -> Response:
+    def put(self, request: Request, project, key_id: int) -> Response:
         """
         Update a Client Key
         ```````````````````
@@ -91,7 +91,7 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
             return Response(serialize(key, request.user), status=200)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Request, project, key_id) -> Response:
+    def delete(self, request: Request, project, key_id: int) -> Response:
         """
         Delete a Client Key
         ```````````````````

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -24,7 +24,7 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
     }
 
     @rate_limit_endpoint(limit=20, window=1)
-    def get(self, request: Request, project, key_id) -> Response:
+    def get(self, request: Request, project, key_id: int) -> Response:
         try:
             key = ProjectKey.objects.get(
                 project=project, public_key=key_id, roles=F("roles").bitor(ProjectKey.roles.store)

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -9,7 +9,7 @@ from sentry.api.base import StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.group_index import rate_limit_endpoint
-from sentry.models import ProjectKey
+from sentry.models import Project, ProjectKey
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -24,7 +24,7 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
     }
 
     @rate_limit_endpoint(limit=20, window=1)
-    def get(self, request: Request, project, key_id: int) -> Response:
+    def get(self, request: Request, project: Project, key_id: int) -> Response:
         try:
             key = ProjectKey.objects.get(
                 project=project, public_key=key_id, roles=F("roles").bitor(ProjectKey.roles.store)

--- a/src/sentry/api/endpoints/project_keys.py
+++ b/src/sentry/api/endpoints/project_keys.py
@@ -7,11 +7,11 @@ from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ProjectKeySerializer
-from sentry.models import AuditLogEntryEvent, ProjectKey, ProjectKeyStatus
+from sentry.models import AuditLogEntryEvent, Project, ProjectKey, ProjectKeyStatus
 
 
 class ProjectKeysEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's Client Keys
         ````````````````````````````
@@ -41,7 +41,7 @@ class ProjectKeysEndpoint(ProjectEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Create a new Client Key
         ```````````````````````

--- a/src/sentry/api/endpoints/project_member_index.py
+++ b/src/sentry/api/endpoints/project_member_index.py
@@ -4,11 +4,11 @@ from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import OrganizationMember
+from sentry.models import OrganizationMember, Project
 
 
 class ProjectMemberIndexEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         queryset = (
             OrganizationMember.objects.filter(
                 Q(user__is_active=True) | Q(user__isnull=True),

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -106,8 +106,11 @@ class ProjectOwnershipMixin:
             )
 
 
+from sentry.models import Project
+
+
 class ProjectOwnershipEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         Retrieve a Project's Ownership configuration
         ````````````````````````````````````````````
@@ -118,7 +121,7 @@ class ProjectOwnershipEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
         """
         return Response(serialize(self.get_ownership(project), request.user))
 
-    def put(self, request: Request, project) -> Response:
+    def put(self, request: Request, project: Project) -> Response:
         """
         Update a Project's Ownership configuration
         ``````````````````````````````````````````

--- a/src/sentry/api/endpoints/project_platforms.py
+++ b/src/sentry/api/endpoints/project_platforms.py
@@ -3,10 +3,10 @@ from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import ProjectPlatform
+from sentry.models import Project, ProjectPlatform
 
 
 class ProjectPlatformsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         queryset = ProjectPlatform.objects.filter(project_id=project.id)
         return Response(serialize(list(queryset), request.user))

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -24,6 +24,9 @@ ERR_FIELD_REQUIRED = "This field is required."
 OK_UPDATED = "Successfully updated configuration."
 
 
+from sentry.models import Project
+
+
 class ProjectPluginDetailsEndpoint(ProjectEndpoint):
     def _get_plugin(self, plugin_id):
         try:
@@ -31,7 +34,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
         except KeyError:
             raise ResourceDoesNotExist
 
-    def get(self, request: Request, project, plugin_id: int) -> Response:
+    def get(self, request: Request, project: Project, plugin_id: int) -> Response:
         plugin = self._get_plugin(plugin_id)
 
         try:
@@ -45,7 +48,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
             raise Http404
         return Response(context)
 
-    def post(self, request: Request, project, plugin_id: int) -> Response:
+    def post(self, request: Request, project: Project, plugin_id: int) -> Response:
         """
         Enable plugin, Test plugin or Reset plugin values
         """
@@ -85,7 +88,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
 
         return Response(status=201)
 
-    def delete(self, request: Request, project, plugin_id: int) -> Response:
+    def delete(self, request: Request, project: Project, plugin_id: int) -> Response:
         """
         Disable plugin
         """
@@ -106,7 +109,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
 
         return Response(status=204)
 
-    def put(self, request: Request, project, plugin_id: int) -> Response:
+    def put(self, request: Request, project: Project, plugin_id: int) -> Response:
         plugin = self._get_plugin(plugin_id)
 
         config = [

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -31,7 +31,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
         except KeyError:
             raise ResourceDoesNotExist
 
-    def get(self, request: Request, project, plugin_id) -> Response:
+    def get(self, request: Request, project, plugin_id: int) -> Response:
         plugin = self._get_plugin(plugin_id)
 
         try:
@@ -45,7 +45,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
             raise Http404
         return Response(context)
 
-    def post(self, request: Request, project, plugin_id) -> Response:
+    def post(self, request: Request, project, plugin_id: int) -> Response:
         """
         Enable plugin, Test plugin or Reset plugin values
         """
@@ -85,7 +85,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
 
         return Response(status=201)
 
-    def delete(self, request: Request, project, plugin_id) -> Response:
+    def delete(self, request: Request, project, plugin_id: int) -> Response:
         """
         Disable plugin
         """
@@ -106,7 +106,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
 
         return Response(status=204)
 
-    def put(self, request: Request, project, plugin_id) -> Response:
+    def put(self, request: Request, project, plugin_id: int) -> Response:
         plugin = self._get_plugin(plugin_id)
 
         config = [

--- a/src/sentry/api/endpoints/project_plugins.py
+++ b/src/sentry/api/endpoints/project_plugins.py
@@ -4,11 +4,12 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.plugin import PluginSerializer
+from sentry.models import Project
 from sentry.plugins.base import plugins
 
 
 class ProjectPluginsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         context = serialize(
             [plugin for plugin in plugins.configurable_for_project(project, version=None)],
             request.user,

--- a/src/sentry/api/endpoints/project_processingissues.py
+++ b/src/sentry/api/endpoints/project_processingissues.py
@@ -4,14 +4,14 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.processing_issues import get_processing_issues
 from sentry.api.serializers import serialize
-from sentry.models import ApiToken, ProcessingIssue
+from sentry.models import ApiToken, ProcessingIssue, Project
 from sentry.reprocessing import trigger_reprocessing
 from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
 
 
 class ProjectProcessingIssuesDiscardEndpoint(ProjectEndpoint):
-    def delete(self, request: Request, project) -> Response:
+    def delete(self, request: Request, project: Project) -> Response:
         """
         This discards all open processing issues
         """
@@ -19,8 +19,11 @@ class ProjectProcessingIssuesDiscardEndpoint(ProjectEndpoint):
         return Response(status=200)
 
 
+from sentry.models import Project
+
+
 class ProjectProcessingIssuesFixEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         token = None
 
         if request.user_from_signed_request and request.user.is_authenticated:
@@ -64,8 +67,11 @@ class ProjectProcessingIssuesFixEndpoint(ProjectEndpoint):
         return resp
 
 
+from sentry.models import Project
+
+
 class ProjectProcessingIssuesEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a project's processing issues.
         """
@@ -74,7 +80,7 @@ class ProjectProcessingIssuesEndpoint(ProjectEndpoint):
         )[0]
         return Response(serialize(data, request.user))
 
-    def delete(self, request: Request, project) -> Response:
+    def delete(self, request: Request, project: Project) -> Response:
         """
         This deletes all open processing issues and triggers reprocessing if
         the user disabled the checkbox

--- a/src/sentry/api/endpoints/project_release_commits.py
+++ b/src/sentry/api/endpoints/project_release_commits.py
@@ -4,13 +4,13 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import Release, ReleaseCommit, Repository
+from sentry.models import Project, Release, ReleaseCommit, Repository
 
 
 class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version: str) -> Response:
+    def get(self, request: Request, project: Project, version: str) -> Response:
         """
         List a Project Release's Commits
         ````````````````````````````````

--- a/src/sentry/api/endpoints/project_release_commits.py
+++ b/src/sentry/api/endpoints/project_release_commits.py
@@ -10,7 +10,7 @@ from sentry.models import Release, ReleaseCommit, Repository
 class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version) -> Response:
+    def get(self, request: Request, project, version: str) -> Response:
         """
         List a Project Release's Commits
         ````````````````````````````````

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -18,7 +18,7 @@ from sentry.utils.sdk import bind_organization_context, configure_scope
 class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version) -> Response:
+    def get(self, request: Request, project, version: str) -> Response:
         """
         Retrieve a Project's Release
         ````````````````````````````
@@ -61,7 +61,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
             )
         )
 
-    def put(self, request: Request, project, version) -> Response:
+    def put(self, request: Request, project, version: str) -> Response:
         """
         Update a Project's Release
         ``````````````````````````
@@ -138,7 +138,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
 
             return Response(serialize(release, request.user))
 
-    def delete(self, request: Request, project, version) -> Response:
+    def delete(self, request: Request, project, version: str) -> Response:
         """
         Delete a Project's Release
         ``````````````````````````

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -8,7 +8,7 @@ from sentry.api.endpoints.organization_releases import get_stats_period_detail
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ReleaseSerializer
-from sentry.models import Activity, Release
+from sentry.models import Activity, Project, Release
 from sentry.models.release import UnsafeReleaseDeletion
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.snuba.sessions import STATS_PERIODS
@@ -18,7 +18,7 @@ from sentry.utils.sdk import bind_organization_context, configure_scope
 class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version: str) -> Response:
+    def get(self, request: Request, project: Project, version: str) -> Response:
         """
         Retrieve a Project's Release
         ````````````````````````````
@@ -61,7 +61,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
             )
         )
 
-    def put(self, request: Request, project, version: str) -> Response:
+    def put(self, request: Request, project: Project, version: str) -> Response:
         """
         Update a Project's Release
         ``````````````````````````
@@ -138,7 +138,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
 
             return Response(serialize(release, request.user))
 
-    def delete(self, request: Request, project, version: str) -> Response:
+    def delete(self, request: Request, project: Project, version: str) -> Response:
         """
         Delete a Project's Release
         ``````````````````````````

--- a/src/sentry/api/endpoints/project_release_file_details.py
+++ b/src/sentry/api/endpoints/project_release_file_details.py
@@ -175,10 +175,13 @@ class ReleaseFileDetailsMixin:
         return Response(status=204)
 
 
+from sentry.models import Project
+
+
 class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version, file_id: int) -> Response:
+    def get(self, request: Request, project: Project, version, file_id: int) -> Response:
         """
         Retrieve a Project Release's File
         `````````````````````````````````
@@ -209,7 +212,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
             check_permission_fn=lambda: has_download_permission(request, project),
         )
 
-    def put(self, request: Request, project, version, file_id: int) -> Response:
+    def put(self, request: Request, project: Project, version, file_id: int) -> Response:
         """
         Update a File
         `````````````
@@ -236,7 +239,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
 
         return self.update_releasefile(request, release, file_id)
 
-    def delete(self, request: Request, project, version, file_id: int) -> Response:
+    def delete(self, request: Request, project: Project, version, file_id: int) -> Response:
         """
         Delete a File
         `````````````

--- a/src/sentry/api/endpoints/project_release_file_details.py
+++ b/src/sentry/api/endpoints/project_release_file_details.py
@@ -178,7 +178,7 @@ class ReleaseFileDetailsMixin:
 class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version, file_id) -> Response:
+    def get(self, request: Request, project, version, file_id: int) -> Response:
         """
         Retrieve a Project Release's File
         `````````````````````````````````
@@ -209,7 +209,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
             check_permission_fn=lambda: has_download_permission(request, project),
         )
 
-    def put(self, request: Request, project, version, file_id) -> Response:
+    def put(self, request: Request, project, version, file_id: int) -> Response:
         """
         Update a File
         `````````````
@@ -236,7 +236,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin
 
         return self.update_releasefile(request, release, file_id)
 
-    def delete(self, request: Request, project, version, file_id) -> Response:
+    def delete(self, request: Request, project, version, file_id: int) -> Response:
         """
         Delete a File
         `````````````

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -206,10 +206,13 @@ def pseudo_releasefile(url, info, dist):
     )
 
 
+from sentry.models import Project
+
+
 class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version: str) -> Response:
+    def get(self, request: Request, project: Project, version: str) -> Response:
         """
         List a Project Release's Files
         ``````````````````````````````
@@ -233,7 +236,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
 
         return self.get_releasefiles(request, release, project.organization_id)
 
-    def post(self, request: Request, project, version: str) -> Response:
+    def post(self, request: Request, project: Project, version: str) -> Response:
         """
         Upload a New Project Release File
         `````````````````````````````````

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -209,7 +209,7 @@ def pseudo_releasefile(url, info, dist):
 class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version) -> Response:
+    def get(self, request: Request, project, version: str) -> Response:
         """
         List a Project Release's Files
         ``````````````````````````````
@@ -233,7 +233,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
 
         return self.get_releasefiles(request, release, project.organization_id)
 
-    def post(self, request: Request, project, version) -> Response:
+    def post(self, request: Request, project, version: str) -> Response:
         """
         Upload a New Project Release File
         `````````````````````````````````

--- a/src/sentry/api/endpoints/project_release_repositories.py
+++ b/src/sentry/api/endpoints/project_release_repositories.py
@@ -11,7 +11,7 @@ class ProjectReleaseRepositories(ProjectEndpoint):
 
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version) -> Response:
+    def get(self, request: Request, project, version: str) -> Response:
         """
         Retrieve Project Repositories from a Release
         ````````````````````````````

--- a/src/sentry/api/endpoints/project_release_repositories.py
+++ b/src/sentry/api/endpoints/project_release_repositories.py
@@ -4,14 +4,14 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import Release, ReleaseCommit, Repository
+from sentry.models import Project, Release, ReleaseCommit, Repository
 
 
 class ProjectReleaseRepositories(ProjectEndpoint):
 
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version: str) -> Response:
+    def get(self, request: Request, project: Project, version: str) -> Response:
         """
         Retrieve Project Repositories from a Release
         ````````````````````````````

--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -3,14 +3,14 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
-from sentry.models import Deploy, Group, ReleaseCommit, ReleaseProject, Repository
+from sentry.models import Deploy, Group, Project, ReleaseCommit, ReleaseProject, Repository
 from sentry.utils.hashlib import hash_values
 
 
 class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         Get list with release setup progress for a project
         1. tag an error

--- a/src/sentry/api/endpoints/project_release_stats.py
+++ b/src/sentry/api/endpoints/project_release_stats.py
@@ -22,10 +22,13 @@ def upsert_missing_release(project, version):
             return release
 
 
+from sentry.models import Project
+
+
 class ProjectReleaseStatsEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version: str) -> Response:
+    def get(self, request: Request, project: Project, version: str) -> Response:
         """
         Get a Project Release's Stats
         `````````````````````````````

--- a/src/sentry/api/endpoints/project_release_stats.py
+++ b/src/sentry/api/endpoints/project_release_stats.py
@@ -25,7 +25,7 @@ def upsert_missing_release(project, version):
 class ProjectReleaseStatsEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project, version) -> Response:
+    def get(self, request: Request, project, version: str) -> Response:
         """
         Get a Project Release's Stats
         `````````````````````````````

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -9,7 +9,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ReleaseWithVersionSerializer
-from sentry.models import Activity, Environment, Release, ReleaseStatus
+from sentry.models import Activity, Environment, Project, Release, ReleaseStatus
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.signals import release_created
 from sentry.utils.sdk import bind_organization_context, configure_scope
@@ -18,7 +18,7 @@ from sentry.utils.sdk import bind_organization_context, configure_scope
 class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
     permission_classes = (ProjectReleasePermission,)
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's Releases
         `````````````````````````
@@ -68,7 +68,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
             ),
         )
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Create a New Release for a Project
         ``````````````````````````````````

--- a/src/sentry/api/endpoints/project_releases_token.py
+++ b/src/sentry/api/endpoints/project_releases_token.py
@@ -33,6 +33,9 @@ def _get_signature(project_id, plugin_id, token):
     ).hexdigest()
 
 
+from sentry.models import Project
+
+
 class ProjectReleasesTokenEndpoint(ProjectEndpoint):
     permission_classes = (StrictProjectPermission,)
 
@@ -41,7 +44,7 @@ class ProjectReleasesTokenEndpoint(ProjectEndpoint):
         ProjectOption.objects.set_value(project, "sentry:release-token", token)
         return token
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         token = ProjectOption.objects.get_value(project, "sentry:release-token")
 
         if token is None:
@@ -49,7 +52,7 @@ class ProjectReleasesTokenEndpoint(ProjectEndpoint):
 
         return Response({"token": token, "webhookUrl": _get_webhook_url(project, "builtin", token)})
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         token = self._regenerate_token(project)
 
         return Response({"token": token, "webhookUrl": _get_webhook_url(project, "builtin", token)})

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -91,6 +91,9 @@ class PathMappingSerializer(CamelSnakeSerializer):
         return source_url
 
 
+from sentry.models import Project
+
+
 class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
     """
     Returns the parameters associated with the RepositoryProjectPathConfig
@@ -99,7 +102,7 @@ class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
     depending on the source code URL
     """
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         serializer = PathMappingSerializer(
             context={"organization_id": project.organization_id},
             data=request.data,

--- a/src/sentry/api/endpoints/project_reprocessing.py
+++ b/src/sentry/api/endpoints/project_reprocessing.py
@@ -2,13 +2,14 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.models import Project
 from sentry.reprocessing import trigger_reprocessing
 
 
 class ProjectReprocessingEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Triggers the reprocessing process as a task
         """

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -11,6 +11,7 @@ from sentry.integrations.slack import tasks
 from sentry.mediators import project_rules
 from sentry.models import (
     AuditLogEntryEvent,
+    Project,
     Rule,
     RuleActivity,
     RuleActivityType,
@@ -41,7 +42,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
         return args, kwargs
 
     @transaction_start("ProjectRuleDetailsEndpoint")
-    def get(self, request: Request, project, rule) -> Response:
+    def get(self, request: Request, project: Project, rule) -> Response:
         """
         Retrieve a rule
 
@@ -55,7 +56,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
         return Response(data)
 
     @transaction_start("ProjectRuleDetailsEndpoint")
-    def put(self, request: Request, project, rule) -> Response:
+    def put(self, request: Request, project: Project, rule) -> Response:
         """
         Update a rule
 
@@ -134,7 +135,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @transaction_start("ProjectRuleDetailsEndpoint")
-    def delete(self, request: Request, project, rule) -> Response:
+    def delete(self, request: Request, project: Project, rule) -> Response:
         """
         Delete a rule
         """

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -5,13 +5,13 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
 from sentry.integrations.slack import tasks
-from sentry.models import Rule, RuleStatus
+from sentry.models import Project, Rule, RuleStatus
 
 
 class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
     permission_classes = [ProjectSettingPermission]
 
-    def get(self, request: Request, project, task_uuid) -> Response:
+    def get(self, request: Request, project: Project, task_uuid) -> Response:
         """
         Retrieve the status of the async task
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -46,11 +46,14 @@ def trigger_alert_rule_action_creators(
     return created
 
 
+from sentry.models import Project
+
+
 class ProjectRulesEndpoint(ProjectEndpoint):
     permission_classes = (ProjectAlertRulePermission,)
 
     @transaction_start("ProjectRulesEndpoint")
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a project's rules
 
@@ -71,7 +74,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         )
 
     @transaction_start("ProjectRulesEndpoint")
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Create a rule
 

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -4,11 +4,12 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.constants import MIGRATED_CONDITIONS, SCHEMA_FORM_ACTIONS, TICKET_ACTIONS
+from sentry.models import Project
 from sentry.rules import rules
 
 
 class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         Retrieve the list of configuration options for a given project.
         """

--- a/src/sentry/api/endpoints/project_search_details.py
+++ b/src/sentry/api/endpoints/project_search_details.py
@@ -22,7 +22,7 @@ class SavedSearchSerializer(serializers.Serializer):
 class ProjectSearchDetailsEndpoint(ProjectEndpoint):
     permission_classes = (RelaxedSearchPermission,)
 
-    def get(self, request: Request, project, search_id) -> Response:
+    def get(self, request: Request, project, search_id: int) -> Response:
         """
         Retrieve a saved search
 
@@ -38,7 +38,7 @@ class ProjectSearchDetailsEndpoint(ProjectEndpoint):
 
         return Response(serialize(search, request.user))
 
-    def put(self, request: Request, project, search_id) -> Response:
+    def put(self, request: Request, project, search_id: int) -> Response:
         """
         Update a saved search
 
@@ -93,7 +93,7 @@ class ProjectSearchDetailsEndpoint(ProjectEndpoint):
 
         return Response(serialize(search, request.user))
 
-    def delete(self, request: Request, project, search_id) -> Response:
+    def delete(self, request: Request, project, search_id: int) -> Response:
         """
         Delete a saved search
 

--- a/src/sentry/api/endpoints/project_search_details.py
+++ b/src/sentry/api/endpoints/project_search_details.py
@@ -19,10 +19,13 @@ class SavedSearchSerializer(serializers.Serializer):
     isUserDefault = serializers.BooleanField(required=False)
 
 
+from sentry.models import Project
+
+
 class ProjectSearchDetailsEndpoint(ProjectEndpoint):
     permission_classes = (RelaxedSearchPermission,)
 
-    def get(self, request: Request, project, search_id: int) -> Response:
+    def get(self, request: Request, project: Project, search_id: int) -> Response:
         """
         Retrieve a saved search
 
@@ -38,7 +41,7 @@ class ProjectSearchDetailsEndpoint(ProjectEndpoint):
 
         return Response(serialize(search, request.user))
 
-    def put(self, request: Request, project, search_id: int) -> Response:
+    def put(self, request: Request, project: Project, search_id: int) -> Response:
         """
         Update a saved search
 
@@ -93,7 +96,7 @@ class ProjectSearchDetailsEndpoint(ProjectEndpoint):
 
         return Response(serialize(search, request.user))
 
-    def delete(self, request: Request, project, search_id: int) -> Response:
+    def delete(self, request: Request, project: Project, search_id: int) -> Response:
         """
         Delete a saved search
 

--- a/src/sentry/api/endpoints/project_searches.py
+++ b/src/sentry/api/endpoints/project_searches.py
@@ -17,10 +17,13 @@ class SavedSearchSerializer(serializers.Serializer):
     isUserDefault = serializers.BooleanField(required=False)
 
 
+from sentry.models import Project
+
+
 class ProjectSearchesEndpoint(ProjectEndpoint):
     permission_classes = (RelaxedSearchPermission,)
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a project's saved searches
 
@@ -37,7 +40,7 @@ class ProjectSearchesEndpoint(ProjectEndpoint):
 
         return Response(serialize(results, request.user))
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Create a new saved search
 

--- a/src/sentry/api/endpoints/project_servicehook_details.py
+++ b/src/sentry/api/endpoints/project_servicehook_details.py
@@ -8,11 +8,11 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.validators import ServiceHookValidator
 from sentry.constants import ObjectStatus
-from sentry.models import AuditLogEntryEvent, ServiceHook
+from sentry.models import AuditLogEntryEvent, Project, ServiceHook
 
 
 class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, hook_id: int) -> Response:
+    def get(self, request: Request, project: Project, hook_id: int) -> Response:
         """
         Retrieve a Service Hook
         ```````````````````````
@@ -32,7 +32,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
             raise ResourceDoesNotExist
         return self.respond(serialize(hook, request.user))
 
-    def put(self, request: Request, project, hook_id: int) -> Response:
+    def put(self, request: Request, project: Project, hook_id: int) -> Response:
         """
         Update a Service Hook
         `````````````````````
@@ -85,7 +85,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
 
         return self.respond(serialize(hook, request.user))
 
-    def delete(self, request: Request, project, hook_id: int) -> Response:
+    def delete(self, request: Request, project: Project, hook_id: int) -> Response:
         """
         Remove a Service Hook
         `````````````````````

--- a/src/sentry/api/endpoints/project_servicehook_details.py
+++ b/src/sentry/api/endpoints/project_servicehook_details.py
@@ -12,7 +12,7 @@ from sentry.models import AuditLogEntryEvent, ServiceHook
 
 
 class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, hook_id) -> Response:
+    def get(self, request: Request, project, hook_id: int) -> Response:
         """
         Retrieve a Service Hook
         ```````````````````````
@@ -32,7 +32,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
             raise ResourceDoesNotExist
         return self.respond(serialize(hook, request.user))
 
-    def put(self, request: Request, project, hook_id) -> Response:
+    def put(self, request: Request, project, hook_id: int) -> Response:
         """
         Update a Service Hook
         `````````````````````
@@ -85,7 +85,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
 
         return self.respond(serialize(hook, request.user))
 
-    def delete(self, request: Request, project, hook_id) -> Response:
+    def delete(self, request: Request, project, hook_id: int) -> Response:
         """
         Remove a Service Hook
         `````````````````````

--- a/src/sentry/api/endpoints/project_servicehook_stats.py
+++ b/src/sentry/api/endpoints/project_servicehook_stats.py
@@ -7,11 +7,11 @@ from sentry import tsdb
 from sentry.api.base import StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import ServiceHook
+from sentry.models import Project, ServiceHook
 
 
 class ProjectServiceHookStatsEndpoint(ProjectEndpoint, StatsMixin):
-    def get(self, request: Request, project, hook_id: int) -> Response:
+    def get(self, request: Request, project: Project, hook_id: int) -> Response:
         try:
             hook = ServiceHook.objects.get(project_id=project.id, guid=hook_id)
         except ServiceHook.DoesNotExist:

--- a/src/sentry/api/endpoints/project_servicehook_stats.py
+++ b/src/sentry/api/endpoints/project_servicehook_stats.py
@@ -11,7 +11,7 @@ from sentry.models import ServiceHook
 
 
 class ProjectServiceHookStatsEndpoint(ProjectEndpoint, StatsMixin):
-    def get(self, request: Request, project, hook_id) -> Response:
+    def get(self, request: Request, project, hook_id: int) -> Response:
         try:
             hook = ServiceHook.objects.get(project_id=project.id, guid=hook_id)
         except ServiceHook.DoesNotExist:

--- a/src/sentry/api/endpoints/project_servicehooks.py
+++ b/src/sentry/api/endpoints/project_servicehooks.py
@@ -8,14 +8,14 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.validators import ServiceHookValidator
 from sentry.mediators import service_hooks
-from sentry.models import AuditLogEntryEvent, ObjectStatus, ServiceHook
+from sentry.models import AuditLogEntryEvent, ObjectStatus, Project, ServiceHook
 
 
 class ProjectServiceHooksEndpoint(ProjectEndpoint):
     def has_feature(self, request: Request, project):
         return features.has("projects:servicehooks", project=project, actor=request.user)
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's Service Hooks
         ``````````````````````````````
@@ -56,7 +56,7 @@ class ProjectServiceHooksEndpoint(ProjectEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Register a new Service Hook
         ```````````````````````````

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -36,6 +36,9 @@ def get_link(
     return link, attempted_url, error
 
 
+from sentry.models import Project
+
+
 class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
     """
     Returns valid links for source code providers so that
@@ -48,7 +51,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
 
     """
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         # should probably feature gate
         filepath = request.GET.get("file")
         if not filepath:

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -6,11 +6,11 @@ from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
-from sentry.models import Environment
+from sentry.models import Environment, Project
 
 
 class ProjectStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         Retrieve Event Counts for a Project
         ```````````````````````````````````

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -7,11 +7,11 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.constants import PROTECTED_TAG_KEYS
-from sentry.models import AuditLogEntryEvent, Environment
+from sentry.models import AuditLogEntryEvent, Environment, Project
 
 
 class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
-    def get(self, request: Request, project, key: str) -> Response:
+    def get(self, request: Request, project: Project, key: str) -> Response:
         lookup_key = tagstore.prefix_reserved_key(key)
 
         try:
@@ -27,7 +27,7 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         return Response(serialize(tagkey, request.user))
 
-    def delete(self, request: Request, project, key: str) -> Response:
+    def delete(self, request: Request, project: Project, key: str) -> Response:
         """
         Remove all occurrences of the given tag key.
 

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -11,7 +11,7 @@ from sentry.models import AuditLogEntryEvent, Environment
 
 
 class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
-    def get(self, request: Request, project, key) -> Response:
+    def get(self, request: Request, project, key: str) -> Response:
         lookup_key = tagstore.prefix_reserved_key(key)
 
         try:
@@ -27,7 +27,7 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         return Response(serialize(tagkey, request.user))
 
-    def delete(self, request: Request, project, key) -> Response:
+    def delete(self, request: Request, project, key: str) -> Response:
         """
         Remove all occurrences of the given tag key.
 

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -7,11 +7,11 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
-from sentry.models import Environment
+from sentry.models import Environment, Project
 
 
 class ProjectTagKeyValuesEndpoint(ProjectEndpoint, EnvironmentMixin):
-    def get(self, request: Request, project, key: str) -> Response:
+    def get(self, request: Request, project: Project, key: str) -> Response:
         """
         List a Tag's Values
         ```````````````````

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -11,7 +11,7 @@ from sentry.models import Environment
 
 
 class ProjectTagKeyValuesEndpoint(ProjectEndpoint, EnvironmentMixin):
-    def get(self, request: Request, project, key) -> Response:
+    def get(self, request: Request, project, key: str) -> Response:
         """
         List a Tag's Values
         ```````````````````

--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -5,11 +5,11 @@ from sentry import tagstore
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.constants import PROTECTED_TAG_KEYS
-from sentry.models import Environment
+from sentry.models import Environment, Project
 
 
 class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         try:
             environment_id = self._get_environment_id_from_request(request, project.organization_id)
         except Environment.DoesNotExist:

--- a/src/sentry/api/endpoints/project_team_details.py
+++ b/src/sentry/api/endpoints/project_team_details.py
@@ -19,10 +19,13 @@ class ProjectTeamsPermission(ProjectPermission):
     }
 
 
+from sentry.models import Project
+
+
 class ProjectTeamDetailsEndpoint(ProjectEndpoint):
     permission_classes = (ProjectTeamsPermission,)
 
-    def post(self, request: Request, project, team_slug: str) -> Response:
+    def post(self, request: Request, project: Project, team_slug: str) -> Response:
         """
         Give a team access to a project
         ```````````````````````````````
@@ -42,7 +45,7 @@ class ProjectTeamDetailsEndpoint(ProjectEndpoint):
         project.add_team(team)
         return Response(serialize(project, request.user, ProjectWithTeamSerializer()), status=201)
 
-    def delete(self, request: Request, project, team_slug: str) -> Response:
+    def delete(self, request: Request, project: Project, team_slug: str) -> Response:
         """
         Revoke a team's access to a project
         ```````````````````````````````````

--- a/src/sentry/api/endpoints/project_team_details.py
+++ b/src/sentry/api/endpoints/project_team_details.py
@@ -22,7 +22,7 @@ class ProjectTeamsPermission(ProjectPermission):
 class ProjectTeamDetailsEndpoint(ProjectEndpoint):
     permission_classes = (ProjectTeamsPermission,)
 
-    def post(self, request: Request, project, team_slug) -> Response:
+    def post(self, request: Request, project, team_slug: str) -> Response:
         """
         Give a team access to a project
         ```````````````````````````````
@@ -42,7 +42,7 @@ class ProjectTeamDetailsEndpoint(ProjectEndpoint):
         project.add_team(team)
         return Response(serialize(project, request.user, ProjectWithTeamSerializer()), status=201)
 
-    def delete(self, request: Request, project, team_slug) -> Response:
+    def delete(self, request: Request, project, team_slug: str) -> Response:
         """
         Revoke a team's access to a project
         ```````````````````````````````````

--- a/src/sentry/api/endpoints/project_teams.py
+++ b/src/sentry/api/endpoints/project_teams.py
@@ -4,11 +4,11 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import Team
+from sentry.models import Project, Team
 
 
 class ProjectTeamsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's Teams
         ``````````````````````

--- a/src/sentry/api/endpoints/project_transaction_threshold.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold.py
@@ -38,6 +38,9 @@ class ProjectTransactionThresholdSerializer(serializers.Serializer):
         return threshold
 
 
+from sentry.models import Project
+
+
 class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
     permission_classes = (ProjectSettingPermission,)
 
@@ -46,7 +49,7 @@ class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
             "organizations:performance-view", project.organization, actor=request.user
         )
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         if not self.has_feature(project, request):
             return self.respond(status=status.HTTP_404_NOT_FOUND)
 
@@ -69,7 +72,7 @@ class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
             status.HTTP_200_OK,
         )
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         if not self.has_feature(project, request):
             return self.respond(status=status.HTTP_404_NOT_FOUND)
 
@@ -112,7 +115,7 @@ class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
             status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
         )
 
-    def delete(self, request: Request, project) -> Response:
+    def delete(self, request: Request, project: Project) -> Response:
         if not self.has_feature(project, request):
             return self.respond(status=status.HTTP_404_NOT_FOUND)
 

--- a/src/sentry/api/endpoints/project_transaction_threshold_override.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold_override.py
@@ -53,6 +53,9 @@ class ProjectTransactionThresholdOverrideSerializer(serializers.Serializer):
         return data
 
 
+from sentry.models import Organization
+
+
 class ProjectTransactionThresholdOverrideEndpoint(OrganizationEventsV2EndpointBase):
     permission_classes = (ProjectTransactionThresholdOverridePermission,)
 
@@ -63,7 +66,7 @@ class ProjectTransactionThresholdOverrideEndpoint(OrganizationEventsV2EndpointBa
 
         return projects[0]
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return self.respond(status=status.HTTP_404_NOT_FOUND)
 
@@ -86,7 +89,7 @@ class ProjectTransactionThresholdOverrideEndpoint(OrganizationEventsV2EndpointBa
             status.HTTP_200_OK,
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return self.respond(status=status.HTTP_404_NOT_FOUND)
 
@@ -127,7 +130,7 @@ class ProjectTransactionThresholdOverrideEndpoint(OrganizationEventsV2EndpointBa
             status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
         )
 
-    def delete(self, request: Request, organization) -> Response:
+    def delete(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return self.respond(status=status.HTTP_404_NOT_FOUND)
 

--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -22,11 +22,14 @@ class RelaxedProjectPermission(ProjectPermission):
     scope_map = {"POST": ["project:admin"]}
 
 
+from sentry.models import Project
+
+
 class ProjectTransferEndpoint(ProjectEndpoint):
     permission_classes = [RelaxedProjectPermission]
 
     @sudo_required
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Transfer a Project
         ````````````````

--- a/src/sentry/api/endpoints/project_user_details.py
+++ b/src/sentry/api/endpoints/project_user_details.py
@@ -5,15 +5,15 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.auth.superuser import is_active_superuser
-from sentry.models import EventUser
+from sentry.models import EventUser, Project
 
 
 class ProjectUserDetailsEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, user_hash) -> Response:
+    def get(self, request: Request, project: Project, user_hash) -> Response:
         euser = EventUser.objects.get(project_id=project.id, hash=user_hash)
         return Response(serialize(euser, request.user))
 
-    def delete(self, request: Request, project, user_hash) -> Response:
+    def delete(self, request: Request, project: Project, user_hash) -> Response:
         """
         Delete an Event User
         ````````````````````````````````

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -18,10 +18,13 @@ class UserReportSerializer(serializers.ModelSerializer):
         fields = ("name", "email", "comments", "event_id")
 
 
+from sentry.models import Project
+
+
 class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
     authentication_classes = ProjectEndpoint.authentication_classes + (DSNAuthentication,)
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's User Feedback
         ``````````````````````````````
@@ -67,7 +70,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
             **paginate_kwargs,
         )
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Submit User Feedback
         ````````````````````

--- a/src/sentry/api/endpoints/project_user_stats.py
+++ b/src/sentry/api/endpoints/project_user_stats.py
@@ -8,11 +8,11 @@ from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.app import tsdb
-from sentry.models import Environment
+from sentry.models import Environment, Project
 
 
 class ProjectUserStatsEndpoint(EnvironmentMixin, ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         try:
             environment_id = self._get_environment_id_from_request(request, project.organization_id)
         except Environment.DoesNotExist:

--- a/src/sentry/api/endpoints/project_users.py
+++ b/src/sentry/api/endpoints/project_users.py
@@ -5,11 +5,11 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
-from sentry.models import EventUser
+from sentry.models import EventUser, Project
 
 
 class ProjectUsersEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         List a Project's Users
         ``````````````````````

--- a/src/sentry/api/endpoints/relay_details.py
+++ b/src/sentry/api/endpoints/relay_details.py
@@ -10,7 +10,7 @@ from sentry.models import Relay
 class RelayDetailsEndpoint(Endpoint):
     permission_classes = (SuperuserPermission,)
 
-    def delete(self, request: Request, relay_id) -> Response:
+    def delete(self, request: Request, relay_id: int) -> Response:
         """
         Delete one Relay
         ````````````````

--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -26,7 +26,7 @@ class DeploySerializer(serializers.Serializer):
 
 
 class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
-    def get(self, request: Request, organization, version) -> Response:
+    def get(self, request: Request, organization, version: str) -> Response:
         """
         List a Release's Deploys
         ````````````````````````
@@ -54,7 +54,7 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    def post(self, request: Request, organization, version) -> Response:
+    def post(self, request: Request, organization, version: str) -> Response:
         """
         Create a Deploy
         ```````````````

--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -25,8 +25,11 @@ class DeploySerializer(serializers.Serializer):
         return value
 
 
+from sentry.models import Organization
+
+
 class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
-    def get(self, request: Request, organization, version: str) -> Response:
+    def get(self, request: Request, organization: Organization, version: str) -> Response:
         """
         List a Release's Deploys
         ````````````````````````
@@ -54,7 +57,7 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    def post(self, request: Request, organization, version: str) -> Response:
+    def post(self, request: Request, organization: Organization, version: str) -> Response:
         """
         Create a Deploy
         ```````````````

--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -27,10 +27,12 @@ class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.models import Organization
+
 
 class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
     @add_integration_platform_metric_tag
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         project_id = request.GET.get("projectId")
         if not project_id:
             raise ValidationError("Required parameter 'projectId' is missing")

--- a/src/sentry/api/endpoints/sentry_app_installation_external_issue_details.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_external_issue_details.py
@@ -9,7 +9,7 @@ from sentry.models import PlatformExternalIssue
 
 
 class SentryAppInstallationExternalIssueDetailsEndpoint(ExternalIssueBaseEndpoint):
-    def delete(self, request: Request, installation, external_issue_id) -> Response:
+    def delete(self, request: Request, installation, external_issue_id: int) -> Response:
         try:
             platform_external_issue = PlatformExternalIssue.objects.get(
                 id=external_issue_id,

--- a/src/sentry/api/endpoints/sentry_app_installations.py
+++ b/src/sentry/api/endpoints/sentry_app_installations.py
@@ -8,7 +8,7 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH
 from sentry.mediators.sentry_app_installations import Creator
-from sentry.models import SentryAppInstallation
+from sentry.models import Organization, SentryAppInstallation
 
 
 class SentryAppInstallationsSerializer(serializers.Serializer):
@@ -30,7 +30,7 @@ class SentryAppInstallationsSerializer(serializers.Serializer):
 
 
 class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         queryset = SentryAppInstallation.objects.filter(organization=organization)
 
         return self.paginate(
@@ -41,7 +41,7 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         serializer = SentryAppInstallationsSerializer(data=request.data)
 
         if not serializer.is_valid():

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -12,7 +12,7 @@ from sentry.api.serializers.rest_framework import SentryAppSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Creator, InternalCreator
-from sentry.models import SentryApp
+from sentry.models import Organization, SentryApp
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             on_results=lambda x: serialize(x, request.user, access=request.access),
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         data = {
             "name": request.json_body.get("name"),
             "user": request.user,

--- a/src/sentry/api/endpoints/shared_group_details.py
+++ b/src/sentry/api/endpoints/shared_group_details.py
@@ -15,7 +15,7 @@ from sentry.models import Group
 class SharedGroupDetailsEndpoint(Endpoint, EnvironmentMixin):
     permission_classes = ()
 
-    def get(self, request: Request, share_id) -> Response:
+    def get(self, request: Request, share_id: int) -> Response:
         """
         Retrieve an aggregate
 

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -53,7 +53,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
         return Response(serialize(interface))
 
     @sudo_required
-    def get(self, request: Request, user, auth_id) -> Response:
+    def get(self, request: Request, user, auth_id: int) -> Response:
         """
         Get Authenticator Interface
         ```````````````````````````

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -9,7 +9,7 @@ from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.auth.authenticators.u2f import decode_credential_id
 from sentry.auth.superuser import is_active_superuser
-from sentry.models import Authenticator
+from sentry.models import Authenticator, User
 from sentry.security import capture_security_activity
 
 
@@ -53,7 +53,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
         return Response(serialize(interface))
 
     @sudo_required
-    def get(self, request: Request, user, auth_id: int) -> Response:
+    def get(self, request: Request, user: User, auth_id: int) -> Response:
         """
         Get Authenticator Interface
         ```````````````````````````
@@ -91,7 +91,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
         return Response(response)
 
     @sudo_required
-    def put(self, request: Request, user, auth_id, interface_device_id=None) -> Response:
+    def put(self, request: Request, user: User, auth_id, interface_device_id=None) -> Response:
         """
         Modify authenticator interface
         ``````````````````````````````
@@ -115,7 +115,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
             return self._regenerate_recovery_code(authenticator, request, user)
 
     @sudo_required
-    def delete(self, request: Request, user, auth_id, interface_device_id=None) -> Response:
+    def delete(self, request: Request, user: User, auth_id, interface_device_id=None) -> Response:
         """
         Remove authenticator
         ````````````````````

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -15,7 +15,7 @@ from sentry.api.invite_helper import ApiInviteHelper, remove_invite_cookie
 from sentry.api.serializers import serialize
 from sentry.app import ratelimiter
 from sentry.auth.authenticators.base import EnrollmentStatus
-from sentry.models import Authenticator
+from sentry.models import Authenticator, User
 from sentry.security import capture_security_activity
 
 logger = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         return any(features.has("organizations:webauthn-register", org, actor=user) for org in orgs)
 
     @sudo_required
-    def get(self, request: Request, user, interface_id: int) -> Response:
+    def get(self, request: Request, user: User, interface_id: int) -> Response:
         """
         Get Authenticator Interface
         ```````````````````````````
@@ -162,7 +162,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
 
     @sudo_required
     @email_verification_required
-    def post(self, request: Request, user, interface_id: int) -> Response:
+    def post(self, request: Request, user: User, interface_id: int) -> Response:
         """
         Enroll in authenticator interface
         `````````````````````````````````

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -103,7 +103,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         return any(features.has("organizations:webauthn-register", org, actor=user) for org in orgs)
 
     @sudo_required
-    def get(self, request: Request, user, interface_id) -> Response:
+    def get(self, request: Request, user, interface_id: int) -> Response:
         """
         Get Authenticator Interface
         ```````````````````````````
@@ -162,7 +162,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
 
     @sudo_required
     @email_verification_required
-    def post(self, request: Request, user, interface_id) -> Response:
+    def post(self, request: Request, user, interface_id: int) -> Response:
         """
         Enroll in authenticator interface
         `````````````````````````````````

--- a/src/sentry/api/endpoints/user_authenticator_index.py
+++ b/src/sentry/api/endpoints/user_authenticator_index.py
@@ -3,11 +3,11 @@ from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import Authenticator
+from sentry.models import Authenticator, User
 
 
 class UserAuthenticatorIndexEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         """Returns all interface for a user (un-enrolled ones), otherwise an empty array"""
 
         interfaces = Authenticator.objects.all_interfaces_for_user(user, return_missing=True)

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -114,7 +114,7 @@ class DeleteUserSerializer(serializers.Serializer):
 
 
 class UserDetailsEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         """
         Retrieve User Details
         `````````````````````
@@ -126,7 +126,7 @@ class UserDetailsEndpoint(UserEndpoint):
         """
         return Response(serialize(user, request.user, DetailedUserSerializer()))
 
-    def put(self, request: Request, user) -> Response:
+    def put(self, request: Request, user: User) -> Response:
         """
         Update Account Appearance options
         `````````````````````````````````
@@ -189,7 +189,7 @@ class UserDetailsEndpoint(UserEndpoint):
         return Response(serialize(user, request.user, DetailedUserSerializer()))
 
     @sudo_required
-    def delete(self, request: Request, user) -> Response:
+    def delete(self, request: Request, user: User) -> Response:
         """
         Delete User Account
 

--- a/src/sentry/api/endpoints/user_emails.py
+++ b/src/sentry/api/endpoints/user_emails.py
@@ -3,6 +3,8 @@ import logging
 from django.db import IntegrityError, transaction
 from django.db.models import Q
 from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import sudo_required
@@ -51,12 +53,8 @@ def add_email(email, user):
     return new_email
 
 
-from rest_framework.request import Request
-from rest_framework.response import Response
-
-
 class UserEmailsEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         """
         Get list of emails
         ``````````````````
@@ -71,7 +69,7 @@ class UserEmailsEndpoint(UserEndpoint):
         return self.respond(serialize(list(emails), user=user))
 
     @sudo_required
-    def post(self, request: Request, user) -> Response:
+    def post(self, request: Request, user: User) -> Response:
         """
         Adds a secondary email address
         ``````````````````````````````
@@ -106,7 +104,7 @@ class UserEmailsEndpoint(UserEndpoint):
             return self.respond(serialize(new_useremail, user=request.user), status=201)
 
     @sudo_required
-    def put(self, request: Request, user) -> Response:
+    def put(self, request: Request, user: User) -> Response:
         """
         Updates primary email
         `````````````````````
@@ -200,7 +198,7 @@ class UserEmailsEndpoint(UserEndpoint):
         return self.respond(serialize(new_useremail, user=request.user))
 
     @sudo_required
-    def delete(self, request: Request, user) -> Response:
+    def delete(self, request: Request, user: User) -> Response:
         """
         Removes an email from account
         `````````````````````````````

--- a/src/sentry/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/api/endpoints/user_emails_confirm.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.validators import AllowedEmailField
-from sentry.models import UserEmail
+from sentry.models import User, UserEmail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger("sentry.accounts")
@@ -40,7 +40,7 @@ class UserEmailsConfirmEndpoint(UserEndpoint):
         }
     }
 
-    def post(self, request: Request, user) -> Response:
+    def post(self, request: Request, user: User) -> Response:
         """
         Sends a confirmation email to user
         ``````````````````````````````````

--- a/src/sentry/api/endpoints/user_identity.py
+++ b/src/sentry/api/endpoints/user_identity.py
@@ -4,11 +4,11 @@ from rest_framework.response import Response
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import Identity
+from sentry.models import Identity, User
 
 
 class UserIdentityEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         """
         Retrieve all of a users' identities (NOT AuthIdentities)
         `````````````````````````````````

--- a/src/sentry/api/endpoints/user_identity_config.py
+++ b/src/sentry/api/endpoints/user_identity_config.py
@@ -74,7 +74,7 @@ def get_identities(user: User) -> Iterable[UserIdentityConfig]:
 
 
 class UserIdentityConfigEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         """
         Retrieve all of a user's SocialIdentity, Identity, and AuthIdentity values
         ``````````````````````````````````````````````````````````````````````````
@@ -101,14 +101,14 @@ class UserIdentityConfigDetailsEndpoint(UserEndpoint):
                 return identity
         return None
 
-    def get(self, request: Request, user, category, identity_id: int) -> Response:
+    def get(self, request: Request, user: User, category, identity_id: int) -> Response:
         identity = self._get_identity(user, category, identity_id)
         if identity:
             return Response(serialize(identity))
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-    def delete(self, request: Request, user, category, identity_id: int) -> Response:
+    def delete(self, request: Request, user: User, category, identity_id: int) -> Response:
         with transaction.atomic():
             identity = self._get_identity(user, category, identity_id)
             if not identity:

--- a/src/sentry/api/endpoints/user_identity_config.py
+++ b/src/sentry/api/endpoints/user_identity_config.py
@@ -101,14 +101,14 @@ class UserIdentityConfigDetailsEndpoint(UserEndpoint):
                 return identity
         return None
 
-    def get(self, request: Request, user, category, identity_id) -> Response:
+    def get(self, request: Request, user, category, identity_id: int) -> Response:
         identity = self._get_identity(user, category, identity_id)
         if identity:
             return Response(serialize(identity))
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-    def delete(self, request: Request, user, category, identity_id) -> Response:
+    def delete(self, request: Request, user, category, identity_id: int) -> Response:
         with transaction.atomic():
             identity = self._get_identity(user, category, identity_id)
             if not identity:

--- a/src/sentry/api/endpoints/user_identity_details.py
+++ b/src/sentry/api/endpoints/user_identity_details.py
@@ -2,10 +2,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
-from sentry.models import AuthIdentity
+from sentry.models import AuthIdentity, User
 
 
 class UserIdentityDetailsEndpoint(UserEndpoint):
-    def delete(self, request: Request, user, identity_id: int) -> Response:
+    def delete(self, request: Request, user: User, identity_id: int) -> Response:
         AuthIdentity.objects.filter(user=user, id=identity_id).delete()
         return Response(status=204)

--- a/src/sentry/api/endpoints/user_identity_details.py
+++ b/src/sentry/api/endpoints/user_identity_details.py
@@ -6,6 +6,6 @@ from sentry.models import AuthIdentity
 
 
 class UserIdentityDetailsEndpoint(UserEndpoint):
-    def delete(self, request: Request, user, identity_id) -> Response:
+    def delete(self, request: Request, user, identity_id: int) -> Response:
         AuthIdentity.objects.filter(user=user, id=identity_id).delete()
         return Response(status=204)

--- a/src/sentry/api/endpoints/user_ips.py
+++ b/src/sentry/api/endpoints/user_ips.py
@@ -5,12 +5,12 @@ from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
-from sentry.models import UserIP
+from sentry.models import User, UserIP
 
 
 class UserIPsEndpoint(UserEndpoint):
     @sudo_required
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         """
         Get list of IP addresses
         ````````````````````````

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers import Serializer, serialize
-from sentry.models import NotificationSetting, UserOption
+from sentry.models import NotificationSetting, User, UserOption
 from sentry.notifications.types import NotificationScopeType, UserOptionsSettingsKey
 from sentry.notifications.utils.legacy_mappings import (
     USER_OPTION_SETTINGS,
@@ -73,11 +73,11 @@ class UserNotificationDetailsSerializer(serializers.Serializer):
 
 
 class UserNotificationDetailsEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         serialized = serialize(user, request.user, UserNotificationsSerializer())
         return Response(serialized)
 
-    def put(self, request: Request, user) -> Response:
+    def put(self, request: Request, user: User) -> Response:
         serializer = UserNotificationDetailsSerializer(data=request.data)
 
         if not serializer.is_valid():

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import UserNotificationsSerializer
-from sentry.models import NotificationSetting, Project, UserEmail, UserOption
+from sentry.models import NotificationSetting, Project, User, UserEmail, UserOption
 from sentry.notifications.types import FineTuningAPIKey
 from sentry.notifications.utils.legacy_mappings import (
     get_option_value_from_int,
@@ -23,7 +23,7 @@ INVALID_USER_MSG = (
 
 
 class UserNotificationFineTuningEndpoint(UserEndpoint):
-    def get(self, request: Request, user, notification_type) -> Response:
+    def get(self, request: Request, user: User, notification_type) -> Response:
         try:
             notification_type = FineTuningAPIKey(notification_type)
         except ValueError:
@@ -42,7 +42,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
             )
         )
 
-    def put(self, request: Request, user, notification_type) -> Response:
+    def put(self, request: Request, user: User, notification_type) -> Response:
         """
         Update user notification options
         ````````````````````````````````

--- a/src/sentry/api/endpoints/user_organizationintegrations.py
+++ b/src/sentry/api/endpoints/user_organizationintegrations.py
@@ -4,11 +4,11 @@ from rest_framework.response import Response
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import ObjectStatus, OrganizationIntegration
+from sentry.models import ObjectStatus, OrganizationIntegration, User
 
 
 class UserOrganizationIntegrationsEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         """
         Retrieve all of a users' organization integrations
         `````````````````````````````````

--- a/src/sentry/api/endpoints/user_organizations.py
+++ b/src/sentry/api/endpoints/user_organizations.py
@@ -5,10 +5,11 @@ from rest_framework.response import Response
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.models import User
 
 
 class UserOrganizationsEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         queryset = user.get_orgs()
 
         query = request.GET.get("query")

--- a/src/sentry/api/endpoints/user_password.py
+++ b/src/sentry/api/endpoints/user_password.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
 from sentry.auth import password_validation
+from sentry.models import User
 from sentry.security import capture_security_activity
 
 
@@ -42,7 +43,7 @@ class UserPasswordSerializer(serializers.Serializer):
 
 
 class UserPasswordEndpoint(UserEndpoint):
-    def put(self, request: Request, user) -> Response:
+    def put(self, request: Request, user: User) -> Response:
         # pass some context to serializer otherwise when we create a new serializer instance,
         # user.password gets set to new plaintext password from request and
         # `user.has_usable_password` becomes False

--- a/src/sentry/api/endpoints/user_permission_details.py
+++ b/src/sentry/api/endpoints/user_permission_details.py
@@ -3,15 +3,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
-from sentry.models import UserPermission
+from sentry.models import User, UserPermission
 
 
 class UserPermissionDetailsEndpoint(UserEndpoint):
-    def get(self, request: Request, user, permission_name: str) -> Response:
+    def get(self, request: Request, user: User, permission_name: str) -> Response:
         has_perm = UserPermission.objects.filter(user=user, permission=permission_name).exists()
         return self.respond(status=204 if has_perm else 404)
 
-    def post(self, request: Request, user, permission_name: str) -> Response:
+    def post(self, request: Request, user: User, permission_name: str) -> Response:
         if not request.access.has_permission("users.admin"):
             return self.respond(status=403)
 
@@ -24,7 +24,7 @@ class UserPermissionDetailsEndpoint(UserEndpoint):
             raise
         return self.respond(status=201)
 
-    def delete(self, request: Request, user, permission_name: str) -> Response:
+    def delete(self, request: Request, user: User, permission_name: str) -> Response:
         if not request.access.has_permission("users.admin"):
             return self.respond(status=403)
 

--- a/src/sentry/api/endpoints/user_permission_details.py
+++ b/src/sentry/api/endpoints/user_permission_details.py
@@ -7,11 +7,11 @@ from sentry.models import UserPermission
 
 
 class UserPermissionDetailsEndpoint(UserEndpoint):
-    def get(self, request: Request, user, permission_name) -> Response:
+    def get(self, request: Request, user, permission_name: str) -> Response:
         has_perm = UserPermission.objects.filter(user=user, permission=permission_name).exists()
         return self.respond(status=204 if has_perm else 404)
 
-    def post(self, request: Request, user, permission_name) -> Response:
+    def post(self, request: Request, user, permission_name: str) -> Response:
         if not request.access.has_permission("users.admin"):
             return self.respond(status=403)
 
@@ -24,7 +24,7 @@ class UserPermissionDetailsEndpoint(UserEndpoint):
             raise
         return self.respond(status=201)
 
-    def delete(self, request: Request, user, permission_name) -> Response:
+    def delete(self, request: Request, user, permission_name: str) -> Response:
         if not request.access.has_permission("users.admin"):
             return self.respond(status=403)
 

--- a/src/sentry/api/endpoints/user_permissions.py
+++ b/src/sentry/api/endpoints/user_permissions.py
@@ -2,10 +2,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
-from sentry.models import UserPermission
+from sentry.models import User, UserPermission
 
 
 class UserPermissionsEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         permission_list = list(UserPermission.objects.filter(user=user))
         return self.respond([p.permission for p in permission_list])

--- a/src/sentry/api/endpoints/user_permissions_config.py
+++ b/src/sentry/api/endpoints/user_permissions_config.py
@@ -3,10 +3,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
+from sentry.models import User
 
 
 class UserPermissionsConfigEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         """
         List all available permissions that can be applied to a user.
         """

--- a/src/sentry/api/endpoints/user_social_identities_index.py
+++ b/src/sentry/api/endpoints/user_social_identities_index.py
@@ -3,11 +3,12 @@ from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
+from sentry.models import User
 from social_auth.models import UserSocialAuth
 
 
 class UserSocialIdentitiesIndexEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         """
         List Account's Identities
         `````````````````````````

--- a/src/sentry/api/endpoints/user_social_identity_details.py
+++ b/src/sentry/api/endpoints/user_social_identity_details.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("sentry.accounts")
 
 
 class UserSocialIdentityDetailsEndpoint(UserEndpoint):
-    def delete(self, request: Request, user, identity_id) -> Response:
+    def delete(self, request: Request, user, identity_id: int) -> Response:
         """
         Disconnect a Identity from Account
         ```````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/user_social_identity_details.py
+++ b/src/sentry/api/endpoints/user_social_identity_details.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
+from sentry.models import User
 from social_auth.backends import get_backend
 from social_auth.models import UserSocialAuth
 
@@ -11,7 +12,7 @@ logger = logging.getLogger("sentry.accounts")
 
 
 class UserSocialIdentityDetailsEndpoint(UserEndpoint):
-    def delete(self, request: Request, user, identity_id: int) -> Response:
+    def delete(self, request: Request, user: User, identity_id: int) -> Response:
         """
         Disconnect a Identity from Account
         ```````````````````````````````````````````````````````

--- a/src/sentry/api/endpoints/user_subscriptions.py
+++ b/src/sentry/api/endpoints/user_subscriptions.py
@@ -1,6 +1,8 @@
 from django.db.models import F
 from django.utils import timezone
 from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry import newsletter
 from sentry.api.bases.user import UserEndpoint
@@ -16,12 +18,8 @@ class NewsletterValidator(serializers.Serializer):
     subscribed = serializers.BooleanField(required=True)
 
 
-from rest_framework.request import Request
-from rest_framework.response import Response
-
-
 class UserSubscriptionsEndpoint(UserEndpoint):
-    def get(self, request: Request, user) -> Response:
+    def get(self, request: Request, user: User) -> Response:
         """
         Retrieve Account Subscriptions
         `````````````````````````````````````
@@ -52,7 +50,7 @@ class UserSubscriptionsEndpoint(UserEndpoint):
             ]
         )
 
-    def put(self, request: Request, user) -> Response:
+    def put(self, request: Request, user: User) -> Response:
         """
         Update Account Subscriptions
         ````````````````````````````
@@ -83,7 +81,7 @@ class UserSubscriptionsEndpoint(UserEndpoint):
         newsletter.create_or_update_subscription(user, **kwargs)
         return self.respond(status=204)
 
-    def post(self, request: Request, user) -> Response:
+    def post(self, request: Request, user: User) -> Response:
         """
         Configure Newsletter Subscription
         `````````````````````````````````

--- a/src/sentry/auth/providers/github/views.py
+++ b/src/sentry/auth/providers/github/views.py
@@ -3,7 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.auth.view import AuthView, ConfigureView
-from sentry.models import AuthIdentity
+from sentry.models import AuthIdentity, Organization
 
 from .client import GitHubClient
 from .constants import (
@@ -132,5 +132,5 @@ class SelectOrganization(AuthView):
 
 
 class GitHubConfigureView(ConfigureView):
-    def dispatch(self, request: Request, organization, auth_provider):
+    def dispatch(self, request: Request, organization: Organization, auth_provider):
         return self.render("sentry_auth_github/configure.html")

--- a/src/sentry/auth/providers/google/views.py
+++ b/src/sentry/auth/providers/google/views.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.auth.view import AuthView, ConfigureView
+from sentry.models import Organization
 from sentry.utils import json
 from sentry.utils.compat import map
 from sentry.utils.signing import urlsafe_b64decode
@@ -66,7 +67,7 @@ class FetchUser(AuthView):
 
 
 class GoogleConfigureView(ConfigureView):
-    def dispatch(self, request: Request, organization, auth_provider):
+    def dispatch(self, request: Request, organization: Organization, auth_provider):
         config = auth_provider.config
         if config.get("domain"):
             domains = [config["domain"]]

--- a/src/sentry/auth/providers/saml2/generic/views.py
+++ b/src/sentry/auth/providers/saml2/generic/views.py
@@ -10,11 +10,12 @@ from sentry.auth.providers.saml2.forms import (
     process_metadata,
 )
 from sentry.auth.view import AuthView, ConfigureView
+from sentry.models import Organization
 from sentry.utils.http import absolute_uri
 
 
 class SAML2ConfigureView(ConfigureView):
-    def dispatch(self, request: Request, organization, provider):
+    def dispatch(self, request: Request, organization: Organization, provider):
         sp_metadata_url = absolute_uri(
             reverse("sentry-auth-organization-saml-metadata", args=[organization.slug])
         )

--- a/src/sentry/auth/view.py
+++ b/src/sentry/auth/view.py
@@ -2,6 +2,7 @@ __all__ = ["AuthView", "ConfigureView"]
 
 from rest_framework.request import Request
 
+from sentry.models import Organization
 from sentry.plugins.base.view import PluggableViewMixin
 from sentry.web.frontend.base import BaseView
 
@@ -24,5 +25,5 @@ class AuthView(BaseView):
 class ConfigureView(BaseView, PluggableViewMixin):
     """ """
 
-    def dispatch(self, request: Request, organization, auth_provider):
+    def dispatch(self, request: Request, organization: Organization, auth_provider):
         return ""

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -111,10 +111,13 @@ class DataExportQuerySerializer(serializers.Serializer):
         return data
 
 
+from sentry.models import Organization
+
+
 class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
     permission_classes = (OrganizationDataExportPermission,)
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Create a new asynchronous file export task, and
         email user upon completion,

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -6,8 +6,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.bases.organization import OrganizationDataExportPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import Project
-from sentry.models.organization import Organization
+from sentry.models import Organization, Project
 from sentry.utils import metrics
 from sentry.utils.compat import map
 

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -13,7 +13,7 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.utils import InvalidParams
 from sentry.discover.endpoints import serializers
 from sentry.discover.models import TeamKeyTransaction
-from sentry.models import ProjectTeam, Team
+from sentry.models import Organization, ProjectTeam, Team
 
 
 class KeyTransactionPermission(OrganizationPermission):
@@ -28,7 +28,7 @@ class KeyTransactionPermission(OrganizationPermission):
 class KeyTransactionEndpoint(KeyTransactionBase):
     permission_classes = (KeyTransactionPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 
@@ -47,7 +47,7 @@ class KeyTransactionEndpoint(KeyTransactionBase):
 
         return Response(serialize(list(key_teams)), status=200)
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """Create a Key Transaction"""
         if not self.has_feature(organization, request):
             return Response(status=404)
@@ -102,7 +102,7 @@ class KeyTransactionEndpoint(KeyTransactionBase):
 
         return Response(serializer.errors, status=400)
 
-    def delete(self, request: Request, organization) -> Response:
+    def delete(self, request: Request, organization: Organization) -> Response:
         """Remove a Key transaction for a user"""
         if not self.has_feature(organization, request):
             return Response(status=404)
@@ -134,7 +134,7 @@ class KeyTransactionEndpoint(KeyTransactionBase):
 class KeyTransactionListEndpoint(KeyTransactionBase):
     permission_classes = (KeyTransactionPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
 

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -12,6 +12,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.group_index.index import rate_limit_endpoint
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.discover.utils import transform_aliases_and_query
+from sentry.models import Organization
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import snuba
 from sentry.utils.compat import map
@@ -36,7 +37,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
         }
     }
 
-    def has_feature(self, request: Request, organization):
+    def has_feature(self, request: Request, organization: Organization):
         return features.has(
             "organizations:discover", organization, actor=request.user
         ) or features.has("organizations:discover-basic", organization, actor=request.user)
@@ -116,7 +117,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
             )
 
     @rate_limit_endpoint(limit=4)
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(request, organization):
             return Response(status=404)
         logger.info("discover1.request", extra={"organization_id": organization.id})

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -10,6 +10,7 @@ from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
 from sentry.discover.models import DiscoverSavedQuery
+from sentry.models import Organization
 from sentry.search.utils import tokenize_query
 
 
@@ -21,7 +22,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
             "organizations:discover", organization, actor=request.user
         ) or features.has("organizations:discover-query", organization, actor=request.user)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List saved queries for organization
         """
@@ -102,7 +103,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
             default_per_page=25,
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Create a saved query
         """

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -11,6 +11,7 @@ from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
 from sentry.discover.models import DiscoverSavedQuery
+from sentry.models import Organization
 
 
 class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
@@ -21,7 +22,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
             "organizations:discover", organization, actor=request.user
         ) or features.has("organizations:discover-query", organization, actor=request.user)
 
-    def get(self, request: Request, organization, query_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, query_id: int) -> Response:
         """
         Get a saved query
         """
@@ -35,7 +36,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
 
         return Response(serialize(query), status=200)
 
-    def put(self, request: Request, organization, query_id: int) -> Response:
+    def put(self, request: Request, organization: Organization, query_id: int) -> Response:
         """
         Modify a saved query
         """
@@ -73,7 +74,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
 
         return Response(serialize(model), status=200)
 
-    def delete(self, request: Request, organization, query_id: int) -> Response:
+    def delete(self, request: Request, organization: Organization, query_id: int) -> Response:
         """
         Delete a saved query
         """
@@ -93,6 +94,8 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.models import Organization
+
 
 class DiscoverSavedQueryVisitEndpoint(OrganizationEndpoint):
     permission_classes = (DiscoverSavedQueryPermission,)
@@ -100,7 +103,7 @@ class DiscoverSavedQueryVisitEndpoint(OrganizationEndpoint):
     def has_feature(self, organization, request):
         return features.has("organizations:discover-query", organization, actor=request.user)
 
-    def post(self, request: Request, organization, query_id: int) -> Response:
+    def post(self, request: Request, organization: Organization, query_id: int) -> Response:
         """
         Update last_visited and increment visits counter
         """

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -21,7 +21,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
             "organizations:discover", organization, actor=request.user
         ) or features.has("organizations:discover-query", organization, actor=request.user)
 
-    def get(self, request: Request, organization, query_id) -> Response:
+    def get(self, request: Request, organization, query_id: int) -> Response:
         """
         Get a saved query
         """
@@ -35,7 +35,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
 
         return Response(serialize(query), status=200)
 
-    def put(self, request: Request, organization, query_id) -> Response:
+    def put(self, request: Request, organization, query_id: int) -> Response:
         """
         Modify a saved query
         """
@@ -73,7 +73,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
 
         return Response(serialize(model), status=200)
 
-    def delete(self, request: Request, organization, query_id) -> Response:
+    def delete(self, request: Request, organization, query_id: int) -> Response:
         """
         Delete a saved query
         """
@@ -100,7 +100,7 @@ class DiscoverSavedQueryVisitEndpoint(OrganizationEndpoint):
     def has_feature(self, organization, request):
         return features.has("organizations:discover-query", organization, actor=request.user)
 
-    def post(self, request: Request, organization, query_id) -> Response:
+    def post(self, request: Request, organization, query_id: int) -> Response:
         """
         Update last_visited and increment visits counter
         """

--- a/src/sentry/features/helpers.py
+++ b/src/sentry/features/helpers.py
@@ -35,7 +35,7 @@ def requires_feature(
 
     Example:
         >>> @requires_feature('organizations:performance-view')
-        >>> def get(self, request: Request, organization) -> Response:
+        >>> def get(self, request: Request, organization: Organization) -> Response:
         >>>     return Response()
     """
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -61,8 +61,11 @@ def build_action_response(
     return action_response
 
 
+from sentry.models import Organization
+
+
 class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches actions that an alert rule can perform for an organization
         """

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -8,12 +8,12 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.logic import AlreadyDeletedError, delete_alert_rule
-from sentry.models import OrganizationMemberTeam
+from sentry.models import Organization, OrganizationMemberTeam
 from sentry.models.actor import ACTOR_TYPES
 
 
 class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
-    def get(self, request: Request, organization, alert_rule) -> Response:
+    def get(self, request: Request, organization: Organization, alert_rule) -> Response:
         """
         Fetch an alert rule.
         ``````````````````
@@ -22,7 +22,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         data = serialize(alert_rule, request.user, DetailedAlertRuleSerializer())
         return Response(data)
 
-    def put(self, request: Request, organization, alert_rule) -> Response:
+    def put(self, request: Request, organization: Organization, alert_rule) -> Response:
         serializer = DrfAlertRuleSerializer(
             context={"organization": organization, "access": request.access, "user": request.user},
             instance=alert_rule,
@@ -44,7 +44,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Request, organization, alert_rule) -> Response:
+    def delete(self, request: Request, organization: Organization, alert_rule) -> Response:
         if not self._verify_user_has_permission(request, alert_rule):
             return Response(
                 {

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -20,7 +20,7 @@ from sentry.api.serializers.models.alert_rule import CombinedRuleSerializer
 from sentry.api.utils import InvalidParams
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer
 from sentry.incidents.models import AlertRule, Incident
-from sentry.models import OrganizationMemberTeam, Project, Rule, RuleStatus, Team
+from sentry.models import Organization, OrganizationMemberTeam, Project, Rule, RuleStatus, Team
 from sentry.snuba.dataset import Dataset
 from sentry.utils.cursors import Cursor, StringCursor
 
@@ -28,7 +28,7 @@ from .utils import parse_team_params
 
 
 class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches alert rules and legacy rules for an organization
         """
@@ -143,10 +143,13 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         )
 
 
+from sentry.models import Organization
+
+
 class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAlertRulePermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches alert rules for an organization
         """
@@ -168,7 +171,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint):
             default_per_page=25,
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Create an alert rule
         """

--- a/src/sentry/incidents/endpoints/organization_incident_activity_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_activity_index.py
@@ -5,12 +5,13 @@ from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import get_incident_activity
+from sentry.models import Organization
 
 
 class OrganizationIncidentActivityIndexEndpoint(IncidentEndpoint):
     permission_classes = (IncidentPermission,)
 
-    def get(self, request: Request, organization, incident) -> Response:
+    def get(self, request: Request, organization: Organization, incident) -> Response:
         if request.GET.get("desc", "1") == "1":
             order_by = "-date_added"
         else:

--- a/src/sentry/incidents/endpoints/organization_incident_comment_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_comment_details.py
@@ -8,6 +8,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import delete_comment, update_comment
 from sentry.incidents.models import IncidentActivity, IncidentActivityType
+from sentry.models import Organization
 
 
 class CommentSerializer(serializers.Serializer):
@@ -46,7 +47,7 @@ class CommentDetailsEndpoint(IncidentEndpoint):
 class OrganizationIncidentCommentDetailsEndpoint(CommentDetailsEndpoint):
     permission_classes = (IncidentPermission,)
 
-    def delete(self, request: Request, organization, incident, activity) -> Response:
+    def delete(self, request: Request, organization: Organization, incident, activity) -> Response:
         """
         Delete a comment
         ````````````````
@@ -60,7 +61,7 @@ class OrganizationIncidentCommentDetailsEndpoint(CommentDetailsEndpoint):
 
         return Response(status=204)
 
-    def put(self, request: Request, organization, incident, activity) -> Response:
+    def put(self, request: Request, organization: Organization, incident, activity) -> Response:
         """
         Update an existing comment
         ``````````````````````````

--- a/src/sentry/incidents/endpoints/organization_incident_comment_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_comment_index.py
@@ -12,6 +12,7 @@ from sentry.api.serializers.rest_framework.mentions import (
 )
 from sentry.incidents.logic import create_incident_activity
 from sentry.incidents.models import IncidentActivityType
+from sentry.models import Organization
 
 
 class CommentSerializer(serializers.Serializer, MentionsMixin):
@@ -23,7 +24,7 @@ class CommentSerializer(serializers.Serializer, MentionsMixin):
 class OrganizationIncidentCommentIndexEndpoint(IncidentEndpoint):
     permission_classes = (IncidentPermission,)
 
-    def post(self, request: Request, organization, incident) -> Response:
+    def post(self, request: Request, organization: Organization, incident) -> Response:
         serializer = CommentSerializer(
             data=request.data,
             context={

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -7,6 +7,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.incident import DetailedIncidentSerializer
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models import IncidentStatus, IncidentStatusMethod
+from sentry.models import Organization
 
 
 class IncidentSerializer(serializers.Serializer):
@@ -28,7 +29,7 @@ class IncidentSerializer(serializers.Serializer):
 class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
     permission_classes = (IncidentPermission,)
 
-    def get(self, request: Request, organization, incident) -> Response:
+    def get(self, request: Request, organization: Organization, incident) -> Response:
         """
         Fetch an Incident.
         ``````````````````
@@ -38,7 +39,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
 
         return Response(data)
 
-    def put(self, request: Request, organization, incident) -> Response:
+    def put(self, request: Request, organization: Organization, incident) -> Response:
         serializer = IncidentSerializer(data=request.data)
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -18,6 +18,7 @@ from sentry.incidents.models import (
     Incident,
     IncidentStatus,
 )
+from sentry.models import Organization
 from sentry.snuba.dataset import Dataset
 from sentry.utils.dates import ensure_aware
 
@@ -27,7 +28,7 @@ from .utils import parse_team_params
 class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
     permission_classes = (IncidentPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """
         List Incidents that a User can access within an Organization
         ````````````````````````````````````````````````````````````

--- a/src/sentry/incidents/endpoints/organization_incident_seen.py
+++ b/src/sentry/incidents/endpoints/organization_incident_seen.py
@@ -3,12 +3,13 @@ from rest_framework.response import Response
 
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.incidents.logic import set_incident_seen
+from sentry.models import Organization
 
 
 class OrganizationIncidentSeenEndpoint(IncidentEndpoint):
     permission_classes = (IncidentPermission,)
 
-    def post(self, request: Request, organization, incident) -> Response:
+    def post(self, request: Request, organization: Organization, incident) -> Response:
         """
         Mark an incident as seen by the user
         ````````````````````````````````````

--- a/src/sentry/incidents/endpoints/organization_incident_subscription_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_subscription_index.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.incidents.logic import subscribe_to_incident, unsubscribe_from_incident
+from sentry.models import Organization
 
 
 class IncidentSubscriptionPermission(IncidentPermission):
@@ -19,7 +20,7 @@ class IncidentSubscriptionPermission(IncidentPermission):
 class OrganizationIncidentSubscriptionIndexEndpoint(IncidentEndpoint):
     permission_classes = (IncidentSubscriptionPermission,)
 
-    def post(self, request: Request, organization, incident) -> Response:
+    def post(self, request: Request, organization: Organization, incident) -> Response:
         """
         Subscribes the authenticated user to the incident.
         ``````````````````````````````````````````````````
@@ -31,7 +32,7 @@ class OrganizationIncidentSubscriptionIndexEndpoint(IncidentEndpoint):
         subscribe_to_incident(incident, request.user)
         return Response({}, status=201)
 
-    def delete(self, request: Request, organization, incident) -> Response:
+    def delete(self, request: Request, organization: Organization, incident) -> Response:
         """
         Unsubscribes the authenticated user from the incident.
         ``````````````````````````````````````````````````````

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -12,10 +12,11 @@ from sentry.incidents.logic import (
     get_slack_actions_with_async_lookups,
 )
 from sentry.integrations.slack import tasks
+from sentry.models import Project
 
 
 class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
-    def get(self, request: Request, project, alert_rule) -> Response:
+    def get(self, request: Request, project: Project, alert_rule) -> Response:
         """
         Fetch an alert rule.
         ``````````````````
@@ -24,7 +25,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
         data = serialize(alert_rule, request.user, AlertRuleSerializer())
         return Response(data)
 
-    def put(self, request: Request, project, alert_rule) -> Response:
+    def put(self, request: Request, project: Project, alert_rule) -> Response:
         data = request.data
         serializer = DrfAlertRuleSerializer(
             context={
@@ -55,7 +56,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Request, project, alert_rule) -> Response:
+    def delete(self, request: Request, project: Project, alert_rule) -> Response:
         try:
             delete_alert_rule(alert_rule, request.user)
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -17,13 +17,13 @@ from sentry.incidents.endpoints.serializers import AlertRuleSerializer
 from sentry.incidents.logic import get_slack_actions_with_async_lookups
 from sentry.incidents.models import AlertRule
 from sentry.integrations.slack import tasks
-from sentry.models import Rule, RuleStatus
+from sentry.models import Project, Rule, RuleStatus
 from sentry.signals import alert_rule_created
 from sentry.snuba.dataset import Dataset
 
 
 class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         Fetches alert rules and legacy rules for a project
         """
@@ -50,10 +50,13 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         )
 
 
+from sentry.models import Project
+
+
 class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
     permission_classes = (ProjectAlertRulePermission,)
 
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project: Project) -> Response:
         """
         Fetches alert rules for a project
         """
@@ -74,7 +77,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
             default_per_page=25,
         )
 
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project: Project) -> Response:
         """
         Create an alert rule
         """

--- a/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
@@ -6,12 +6,13 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
 from sentry.incidents.models import AlertRule
 from sentry.integrations.slack import tasks
+from sentry.models import Project
 
 
 class ProjectAlertRuleTaskDetailsEndpoint(ProjectEndpoint):
     permission_classes = [ProjectSettingPermission]
 
-    def get(self, request: Request, project, task_uuid) -> Response:
+    def get(self, request: Request, project: Project, task_uuid) -> Response:
         """
         Retrieve the status of the async task
 

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -4,14 +4,14 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.integration import IntegrationEndpoint
-from sentry.models import Integration
+from sentry.models import Integration, Organization
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger("sentry.integrations.bitbucket")
 
 
 class BitbucketSearchEndpoint(IntegrationEndpoint):
-    def get(self, request: Request, organization, integration_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, integration_id: int) -> Response:
         try:
             integration = Integration.objects.get(
                 organizations=organization, id=integration_id, provider="bitbucket"

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("sentry.integrations.bitbucket")
 
 
 class BitbucketSearchEndpoint(IntegrationEndpoint):
-    def get(self, request: Request, organization, integration_id) -> Response:
+    def get(self, request: Request, organization, integration_id: int) -> Response:
         try:
             integration = Integration.objects.get(
                 organizations=organization, id=integration_id, provider="bitbucket"

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -119,7 +119,7 @@ class BitbucketWebhookEndpoint(View):
 
         return super().dispatch(request, *args, **kwargs)
 
-    def post(self, request: Request, organization_id) -> Response:
+    def post(self, request: Request, organization_id: int) -> Response:
         try:
             organization = Organization.objects.get_from_cache(id=organization_id)
         except Organization.DoesNotExist:

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -112,7 +112,7 @@ class BitbucketServerWebhookEndpoint(View):
 
         return super().dispatch(request, *args, **kwargs)
 
-    def post(self, request: Request, organization_id, integration_id) -> Response:
+    def post(self, request: Request, organization_id, integration_id: int) -> Response:
         try:
             organization = Organization.objects.get_from_cache(id=organization_id)
         except Organization.DoesNotExist:

--- a/src/sentry/integrations/custom_scm/repository.py
+++ b/src/sentry/integrations/custom_scm/repository.py
@@ -3,7 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.serializers import serialize
-from sentry.models import Integration, Repository
+from sentry.models import Integration, Organization, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
 
 
@@ -14,7 +14,7 @@ class CustomSCMRepositoryProvider(IntegrationRepositoryProvider):
     def repository_external_slug(self, repo):
         return repo.name
 
-    def dispatch(self, request: Request, organization, **kwargs):
+    def dispatch(self, request: Request, organization: Organization, **kwargs):
         """
         Adding a repository to the Custom SCM integration is
         just two steps:

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -2,12 +2,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.integration import IntegrationEndpoint
-from sentry.models import Integration
+from sentry.models import Integration, Organization
 from sentry.shared_integrations.exceptions import ApiError
 
 
 class GitlabIssueSearchEndpoint(IntegrationEndpoint):
-    def get(self, request: Request, organization, integration_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, integration_id: int) -> Response:
         try:
             integration = Integration.objects.get(
                 organizations=organization, id=integration_id, provider="gitlab"

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -7,7 +7,7 @@ from sentry.shared_integrations.exceptions import ApiError
 
 
 class GitlabIssueSearchEndpoint(IntegrationEndpoint):
-    def get(self, request: Request, organization, integration_id) -> Response:
+    def get(self, request: Request, organization, integration_id: int) -> Response:
         try:
             integration = Integration.objects.get(
                 organizations=organization, id=integration_id, provider="gitlab"

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -3,7 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.integration import IntegrationEndpoint
-from sentry.models import Integration
+from sentry.models import Integration, Organization
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.utils.compat import filter
 
@@ -18,7 +18,7 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             organizations=organization, id=integration_id, provider=self.provider
         )
 
-    def get(self, request: Request, organization, integration_id: int) -> Response:
+    def get(self, request: Request, organization: Organization, integration_id: int) -> Response:
         try:
             integration = self._get_integration(organization, integration_id)
         except Integration.DoesNotExist:

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -18,7 +18,7 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             organizations=organization, id=integration_id, provider=self.provider
         )
 
-    def get(self, request: Request, organization, integration_id) -> Response:
+    def get(self, request: Request, organization, integration_id: int) -> Response:
         try:
             integration = self._get_integration(organization, integration_id)
         except Integration.DoesNotExist:

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.utils.html import format_html
 from rest_framework.request import Request
 
-from sentry.models import Activity, GroupMeta
+from sentry.models import Activity, Group, GroupMeta
 from sentry.plugins.base.v1 import Plugin
 from sentry.signals import issue_tracker_used
 from sentry.utils.auth import get_auth_providers
@@ -32,7 +32,7 @@ class IssueTrackingPlugin(Plugin):
     def get_plugin_type(self):
         return "issue-tracking"
 
-    def _get_group_body(self, request: Request, group, event, **kwargs):
+    def _get_group_body(self, request: Request, group: Group, event, **kwargs):
         result = []
         for interface in event.interfaces.values():
             output = safe_execute(interface.to_string, event, _with_transaction=False)
@@ -40,7 +40,7 @@ class IssueTrackingPlugin(Plugin):
                 result.append(output)
         return "\n\n".join(result)
 
-    def _get_group_description(self, request: Request, group, event):
+    def _get_group_description(self, request: Request, group: Group, event):
         referrer = self.get_conf_key() + "_plugin"
         output = [absolute_uri(group.get_absolute_url(params={"referrer": referrer}))]
         body = self._get_group_body(request, group, event)
@@ -48,7 +48,7 @@ class IssueTrackingPlugin(Plugin):
             output.extend(["", "```", body, "```"])
         return "\n".join(output)
 
-    def _get_group_title(self, request: Request, group, event):
+    def _get_group_title(self, request: Request, group: Group, event):
         return event.title
 
     def is_configured(self, request: Request, project, **kwargs):
@@ -97,7 +97,7 @@ class IssueTrackingPlugin(Plugin):
         """
         return "Unlink %s Issue" % self.get_title()
 
-    def get_new_issue_form(self, request: Request, group, event, **kwargs):
+    def get_new_issue_form(self, request: Request, group: Group, event, **kwargs):
         """
         Return a Form for the "Create new issue" page.
         """
@@ -112,7 +112,7 @@ class IssueTrackingPlugin(Plugin):
         """
         return []
 
-    def get_link_existing_issue_form(self, request: Request, group, event, **kwargs):
+    def get_link_existing_issue_form(self, request: Request, group: Group, event, **kwargs):
         if not self.link_issue_form:
             return None
         return self.link_issue_form(
@@ -126,7 +126,7 @@ class IssueTrackingPlugin(Plugin):
         """
         raise NotImplementedError
 
-    def get_issue_title_by_id(self, request: Request, group, issue_id):
+    def get_issue_title_by_id(self, request: Request, group: Group, issue_id):
         """
         Given an issue_id return the issue's title.
         """
@@ -140,25 +140,25 @@ class IssueTrackingPlugin(Plugin):
         """
         return "#%s" % issue_id
 
-    def create_issue(self, request: Request, group, form_data, **kwargs):
+    def create_issue(self, request: Request, group: Group, form_data, **kwargs):
         """
         Creates the issue on the remote service and returns an issue ID.
         """
         raise NotImplementedError
 
-    def link_issue(self, request: Request, group, form_data, **kwargs):
+    def link_issue(self, request: Request, group: Group, form_data, **kwargs):
         """
         Can be overridden for any actions needed when linking issues
         (like adding a comment to an existing issue).
         """
 
-    def get_initial_form_data(self, request: Request, group, event, **kwargs):
+    def get_initial_form_data(self, request: Request, group: Group, event, **kwargs):
         return {
             "description": self._get_group_description(request, group, event),
             "title": self._get_group_title(request, group, event),
         }
 
-    def get_initial_link_form_data(self, request: Request, group, event, **kwargs):
+    def get_initial_link_form_data(self, request: Request, group: Group, event, **kwargs):
         return {}
 
     def has_auth_configured(self, **kwargs):
@@ -167,11 +167,11 @@ class IssueTrackingPlugin(Plugin):
 
         return self.auth_provider in get_auth_providers()
 
-    def handle_unlink_issue(self, request: Request, group, **kwargs):
+    def handle_unlink_issue(self, request: Request, group: Group, **kwargs):
         GroupMeta.objects.unset_value(group, "%s:tid" % self.get_conf_key())
         return self.redirect(group.get_absolute_url())
 
-    def view(self, request: Request, group, **kwargs):
+    def view(self, request: Request, group: Group, **kwargs):
         has_auth_configured = self.has_auth_configured()
         if not (has_auth_configured and self.is_configured(project=group.project, request=request)):
             if self.auth_provider:
@@ -286,7 +286,7 @@ class IssueTrackingPlugin(Plugin):
 
         return self.render(self.create_issue_template, context)
 
-    def actions(self, request: Request, group, action_list, **kwargs):
+    def actions(self, request: Request, group: Group, action_list, **kwargs):
         if not self.is_configured(request=request, project=group.project):
             return action_list
         prefix = self.get_conf_key()
@@ -298,7 +298,7 @@ class IssueTrackingPlugin(Plugin):
             )
         return action_list
 
-    def tags(self, request: Request, group, tag_list, **kwargs):
+    def tags(self, request: Request, group: Group, tag_list, **kwargs):
         if not self.is_configured(request=request, project=group.project):
             return tag_list
 

--- a/src/sentry/plugins/endpoints.py
+++ b/src/sentry/plugins/endpoints.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.models import GroupMeta
+from sentry.models import GroupMeta, Project
 
 
 class PluginProjectEndpoint(ProjectEndpoint):
@@ -17,10 +17,10 @@ class PluginProjectEndpoint(ProjectEndpoint):
             return Response(status=405)
         return self.view(request, project, *args, **kwargs)
 
-    def get(self, request: Request, project, *args, **kwargs) -> Response:
+    def get(self, request: Request, project: Project, *args, **kwargs) -> Response:
         return self._handle(request, project, *args, **kwargs)
 
-    def post(self, request: Request, project, *args, **kwargs) -> Response:
+    def post(self, request: Request, project: Project, *args, **kwargs) -> Response:
         return self._handle(request, project, *args, **kwargs)
 
     def respond(self, *args, **kwargs):

--- a/src/sentry/plugins/endpoints.py
+++ b/src/sentry/plugins/endpoints.py
@@ -30,12 +30,14 @@ class PluginProjectEndpoint(ProjectEndpoint):
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.models import Group
+
 
 class PluginGroupEndpoint(GroupEndpoint):
     plugin = None
     view = None
 
-    def _handle(self, request: Request, group, *args, **kwargs):
+    def _handle(self, request: Request, group: Group, *args, **kwargs):
         if self.view is None:
             return Response(status=405)
 
@@ -43,10 +45,10 @@ class PluginGroupEndpoint(GroupEndpoint):
 
         return self.view(request, group, *args, **kwargs)
 
-    def get(self, request: Request, group, *args, **kwargs) -> Response:
+    def get(self, request: Request, group: Group, *args, **kwargs) -> Response:
         return self._handle(request, group, *args, **kwargs)
 
-    def post(self, request: Request, group, *args, **kwargs) -> Response:
+    def post(self, request: Request, group: Group, *args, **kwargs) -> Response:
         return self._handle(request, group, *args, **kwargs)
 
     def respond(self, *args, **kwargs):

--- a/src/sentry/plugins/examples/issue_tracking.py
+++ b/src/sentry/plugins/examples/issue_tracking.py
@@ -1,5 +1,6 @@
 from rest_framework.request import Request
 
+from sentry.models import Group
 from sentry.plugins.bases.issue2 import IssuePlugin2
 
 
@@ -21,11 +22,11 @@ class ExampleIssueTrackingPlugin(IssuePlugin2):
     def is_configured(self, request: Request, project, **kwargs):
         return bool(self.get_option("repo", project))
 
-    def get_new_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_new_issue_fields(self, request: Request, group: Group, event, **kwargs):
         fields = super().get_new_issue_fields(request, group, event, **kwargs)
         return [{"name": "tracker_url", "label": "Issue Tracker URL", "type": "text"}] + fields
 
-    def create_issue(self, request: Request, group, form_data, **kwargs):
+    def create_issue(self, request: Request, group: Group, form_data, **kwargs):
         return "1"
 
     def get_issue_label(self, group, issue_id, **kwargs):

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -12,7 +12,7 @@ from sentry import analytics
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.integrations import IntegrationInstallation
-from sentry.models import Integration, Repository
+from sentry.models import Integration, Organization, Repository
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.signals import repo_linked
 
@@ -48,7 +48,7 @@ class IntegrationRepositoryProvider:
         installation: IntegrationInstallation = integration_model.get_installation(organization_id)
         return installation
 
-    def dispatch(self, request: Request, organization, **kwargs):
+    def dispatch(self, request: Request, organization: Organization, **kwargs):
         try:
             config = self.get_repository_data(organization, request.data)
             result = self.build_repository_config(organization=organization, data=config)

--- a/src/sentry/plugins/providers/repository.py
+++ b/src/sentry/plugins/providers/repository.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 
 from sentry.api.serializers import serialize
 from sentry.exceptions import PluginError
-from sentry.models import Repository
+from sentry.models import Organization, Repository
 from sentry.plugins.config import ConfigValidator
 from sentry.signals import repo_linked
 
@@ -29,7 +29,7 @@ class RepositoryProvider(ProviderMixin):
     def __init__(self, id):
         self.id = id
 
-    def dispatch(self, request: Request, organization, **kwargs):
+    def dispatch(self, request: Request, organization: Organization, **kwargs):
         if self.needs_auth(request.user):
             # TODO(dcramer): this should be a 401
             return Response(

--- a/src/sentry/scim/endpoints/schemas.py
+++ b/src/sentry/scim/endpoints/schemas.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from ...models import Organization
 from .constants import SCIM_SCHEMA_GROUP, SCIM_SCHEMA_USER
 from .utils import SCIMEndpoint
 
@@ -183,7 +184,7 @@ SCIM_SCHEMA_LIST = [SCIM_USER_ATTRIBUTES_SCHEMA, SCIM_GROUP_ATTRIBUTES_SCHEMA]
 
 
 class OrganizationSCIMSchemaIndex(SCIMEndpoint):
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         query_params = self.get_query_parameters(request)
 
         return Response(

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -16,6 +16,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamSCIMSerializer
 from sentry.models import (
     AuditLogEntryEvent,
+    Organization,
     OrganizationMember,
     OrganizationMemberTeam,
     Team,
@@ -55,7 +56,7 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint, OrganizationTeamsEndpoint):
     def should_add_creator_to_team(self, request: Request):
         return False
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
 
         query_params = self.get_query_parameters(request)
 
@@ -85,7 +86,7 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint, OrganizationTeamsEndpoint):
             cursor_cls=SCIMCursor,
         )
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         # shim displayName from SCIM api in order to work with
         # our regular team index POST
         request.data.update(
@@ -115,7 +116,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             raise Team.DoesNotExist
         return team
 
-    def get(self, request: Request, organization, team) -> Response:
+    def get(self, request: Request, organization: Organization, team) -> Response:
         query_params = self.get_query_parameters(request)
 
         context = serialize(
@@ -178,7 +179,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                 data=team.get_audit_log_data(),
             )
 
-    def patch(self, request: Request, organization, team):
+    def patch(self, request: Request, organization: Organization, team):
         """
         A SCIM Group PATCH request takes a series of operations to perform on a team.
         It does them sequentially and if any of them fail no operations should go through.
@@ -227,10 +228,10 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
 
         return self.respond(status=204)
 
-    def delete(self, request: Request, organization, team) -> Response:
+    def delete(self, request: Request, organization: Organization, team) -> Response:
         return super().delete(request, team)
 
-    def put(self, request: Request, organization, team) -> Response:
+    def put(self, request: Request, organization: Organization, team) -> Response:
         # override parent's put since we don't have puts
         # in SCIM Team routes
         return self.http_method_not_allowed(request)

--- a/src/sentry/web/frontend/account_identity.py
+++ b/src/sentry/web/frontend/account_identity.py
@@ -11,7 +11,7 @@ from sentry.web.helpers import render_to_response
 
 class AccountIdentityAssociateView(OrganizationView):
     @never_cache
-    def handle(self, request: Request, organization, provider_key, external_id) -> Response:
+    def handle(self, request: Request, organization, provider_key, external_id: int) -> Response:
         try:
             provider_model = IdentityProvider.objects.get(
                 type=provider_key, external_id=external_id

--- a/src/sentry/web/frontend/account_identity.py
+++ b/src/sentry/web/frontend/account_identity.py
@@ -4,14 +4,16 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.identity.pipeline import IdentityProviderPipeline
-from sentry.models import IdentityProvider
+from sentry.models import IdentityProvider, Organization
 from sentry.web.frontend.base import OrganizationView
 from sentry.web.helpers import render_to_response
 
 
 class AccountIdentityAssociateView(OrganizationView):
     @never_cache
-    def handle(self, request: Request, organization, provider_key, external_id: int) -> Response:
+    def handle(
+        self, request: Request, organization: Organization, provider_key, external_id: int
+    ) -> Response:
         try:
             provider_model = IdentityProvider.objects.get(
                 type=provider_key, external_id=external_id

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -15,7 +15,7 @@ class AuthOrganizationLoginView(AuthLoginView):
     def respond_login(self, request: Request, context, *args, **kwargs) -> Response:
         return self.respond("sentry/organization-login.html", context)
 
-    def handle_sso(self, request: Request, organization, auth_provider):
+    def handle_sso(self, request: Request, organization: Organization, auth_provider):
         if request.method == "POST":
             helper = AuthHelper(
                 request=request,

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -46,7 +46,7 @@ class AuthOrganizationLoginView(AuthLoginView):
 
     @never_cache
     @transaction.atomic
-    def handle(self, request: Request, organization_slug) -> Response:
+    def handle(self, request: Request, organization_slug: str) -> Response:
         try:
             organization = Organization.objects.get(slug=organization_slug)
         except Organization.DoesNotExist:

--- a/src/sentry/web/frontend/disabled_member_view.py
+++ b/src/sentry/web/frontend/disabled_member_view.py
@@ -3,7 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.auth.access import get_cached_organization_member
-from sentry.models import OrganizationMember
+from sentry.models import Organization, OrganizationMember
 
 from .react_page import ReactPageView
 
@@ -12,7 +12,7 @@ class DisabledMemberView(ReactPageView):
     def is_member_disabled_from_limit(self, request: Request, organization):
         return False
 
-    def handle(self, request: Request, organization, **kwargs) -> Response:
+    def handle(self, request: Request, organization: Organization, **kwargs) -> Response:
         user = request.user
         # if org member is not restricted, redirect user out of the disabled view
         try:

--- a/src/sentry/web/frontend/group_event_json.py
+++ b/src/sentry/web/frontend/group_event_json.py
@@ -3,7 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore
-from sentry.models import Group, GroupMeta, get_group_with_redirect
+from sentry.models import Group, GroupMeta, Organization, get_group_with_redirect
 from sentry.utils import json
 from sentry.web.frontend.base import OrganizationView
 
@@ -11,7 +11,9 @@ from sentry.web.frontend.base import OrganizationView
 class GroupEventJsonView(OrganizationView):
     required_scope = "event:read"
 
-    def get(self, request: Request, organization, group_id, event_id_or_latest) -> Response:
+    def get(
+        self, request: Request, organization: Organization, group_id, event_id_or_latest
+    ) -> Response:
         try:
             # TODO(tkaemming): This should *actually* redirect, see similar
             # comment in ``GroupEndpoint.convert_args``.

--- a/src/sentry/web/frontend/group_plugin_action.py
+++ b/src/sentry/web/frontend/group_plugin_action.py
@@ -5,7 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.serializers.models.plugin import is_plugin_deprecated
-from sentry.models import Group, GroupMeta
+from sentry.models import Group, GroupMeta, Project
 from sentry.plugins.base import plugins
 from sentry.web.frontend.base import ProjectView
 
@@ -13,7 +13,7 @@ from sentry.web.frontend.base import ProjectView
 class GroupPluginActionView(ProjectView):
     required_scope = "event:read"
 
-    def handle(self, request: Request, organization, project, group_id, slug) -> Response:
+    def handle(self, request: Request, organization, project: Project, group_id, slug) -> Response:
         group = get_object_or_404(Group, pk=group_id, project=project)
 
         try:

--- a/src/sentry/web/frontend/group_plugin_action.py
+++ b/src/sentry/web/frontend/group_plugin_action.py
@@ -5,7 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.serializers.models.plugin import is_plugin_deprecated
-from sentry.models import Group, GroupMeta, Project
+from sentry.models import Group, GroupMeta, Organization, Project
 from sentry.plugins.base import plugins
 from sentry.web.frontend.base import ProjectView
 
@@ -13,7 +13,9 @@ from sentry.web.frontend.base import ProjectView
 class GroupPluginActionView(ProjectView):
     required_scope = "event:read"
 
-    def handle(self, request: Request, organization, project: Project, group_id, slug) -> Response:
+    def handle(
+        self, request: Request, organization: Organization, project: Project, group_id, slug
+    ) -> Response:
         group = get_object_or_404(Group, pk=group_id, project=project)
 
         try:

--- a/src/sentry/web/frontend/group_tag_export.py
+++ b/src/sentry/web/frontend/group_tag_export.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from sentry.api.base import EnvironmentMixin
 from sentry.data_export.base import ExportError
 from sentry.data_export.processors.issues_by_tag import IssuesByTagProcessor
-from sentry.models import Environment
+from sentry.models import Environment, Project
 from sentry.web.frontend.base import ProjectView
 from sentry.web.frontend.mixins.csv import CsvMixin
 
@@ -21,7 +21,7 @@ class GroupTagExportView(ProjectView, CsvMixin, EnvironmentMixin):
         item_dict = IssuesByTagProcessor.serialize_row(item, key)
         return (item_dict[field] for field in fields)
 
-    def get(self, request: Request, organization, project, group_id, key: str) -> Response:
+    def get(self, request: Request, organization, project: Project, group_id, key: str) -> Response:
 
         # If the environment doesn't exist then the tag can't possibly exist
         try:

--- a/src/sentry/web/frontend/group_tag_export.py
+++ b/src/sentry/web/frontend/group_tag_export.py
@@ -21,7 +21,7 @@ class GroupTagExportView(ProjectView, CsvMixin, EnvironmentMixin):
         item_dict = IssuesByTagProcessor.serialize_row(item, key)
         return (item_dict[field] for field in fields)
 
-    def get(self, request: Request, organization, project, group_id, key) -> Response:
+    def get(self, request: Request, organization, project, group_id, key: str) -> Response:
 
         # If the environment doesn't exist then the tag can't possibly exist
         try:

--- a/src/sentry/web/frontend/group_tag_export.py
+++ b/src/sentry/web/frontend/group_tag_export.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from sentry.api.base import EnvironmentMixin
 from sentry.data_export.base import ExportError
 from sentry.data_export.processors.issues_by_tag import IssuesByTagProcessor
-from sentry.models import Environment, Project
+from sentry.models import Environment, Organization, Project
 from sentry.web.frontend.base import ProjectView
 from sentry.web.frontend.mixins.csv import CsvMixin
 
@@ -21,7 +21,9 @@ class GroupTagExportView(ProjectView, CsvMixin, EnvironmentMixin):
         item_dict = IssuesByTagProcessor.serialize_row(item, key)
         return (item_dict[field] for field in fields)
 
-    def get(self, request: Request, organization, project: Project, group_id, key: str) -> Response:
+    def get(
+        self, request: Request, organization: Organization, project: Project, group_id, key: str
+    ) -> Response:
 
         # If the environment doesn't exist then the tag can't possibly exist
         try:

--- a/src/sentry/web/frontend/integration_extension_configuration.py
+++ b/src/sentry/web/frontend/integration_extension_configuration.py
@@ -77,7 +77,7 @@ class IntegrationExtensionConfigurationView(BaseView):
         # if anything before fails, we give up and send them to the link page where we can display errors
         return self.redirect(f"/extensions/{self.provider}/link/?{urlencode(request.GET.dict())}")
 
-    def init_pipeline(self, request: Request, organization, params):
+    def init_pipeline(self, request: Request, organization: Organization, params):
         pipeline = ExternalIntegrationPipeline(
             request=request, organization=organization, provider_key=self.external_provider_key
         )

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -67,12 +67,15 @@ def auth_provider_settings_form(provider, auth_provider, organization, request):
     return form
 
 
+from sentry.models import Organization
+
+
 class OrganizationAuthSettingsView(OrganizationView):
     # We restrict auth settings to org:write as it allows a non-owner to
     # escalate members to own by disabling the default role.
     required_scope = "org:write"
 
-    def _disable_provider(self, request: Request, organization, auth_provider):
+    def _disable_provider(self, request: Request, organization: Organization, auth_provider):
         self.create_audit_entry(
             request,
             organization=organization,
@@ -96,7 +99,7 @@ class OrganizationAuthSettingsView(OrganizationView):
             auth_provider.disable_scim(request.user)
         auth_provider.delete()
 
-    def handle_existing_provider(self, request: Request, organization, auth_provider):
+    def handle_existing_provider(self, request: Request, organization: Organization, auth_provider):
         provider = auth_provider.get_provider()
 
         if request.method == "POST":
@@ -182,7 +185,7 @@ class OrganizationAuthSettingsView(OrganizationView):
         return self.respond("sentry/organization-auth-provider-settings.html", context)
 
     @transaction.atomic
-    def handle(self, request: Request, organization) -> Response:
+    def handle(self, request: Request, organization: Organization) -> Response:
         try:
             auth_provider = AuthProvider.objects.get(organization=organization)
         except AuthProvider.DoesNotExist:

--- a/src/sentry/web/frontend/organization_integration_setup.py
+++ b/src/sentry/web/frontend/organization_integration_setup.py
@@ -15,7 +15,7 @@ class OrganizationIntegrationSetupView(OrganizationView):
 
     csrf_protect = False
 
-    def handle(self, request: Request, organization, provider_id) -> Response:
+    def handle(self, request: Request, organization, provider_id: int) -> Response:
         pipeline = IntegrationPipeline(
             request=request, organization=organization, provider_key=provider_id
         )

--- a/src/sentry/web/frontend/organization_integration_setup.py
+++ b/src/sentry/web/frontend/organization_integration_setup.py
@@ -10,12 +10,15 @@ from sentry.web.frontend.base import OrganizationView
 logger = logging.getLogger("sentry.integrations")
 
 
+from sentry.models import Organization
+
+
 class OrganizationIntegrationSetupView(OrganizationView):
     required_scope = "org:integrations"
 
     csrf_protect = False
 
-    def handle(self, request: Request, organization, provider_id: int) -> Response:
+    def handle(self, request: Request, organization: Organization, provider_id: int) -> Response:
         pipeline = IntegrationPipeline(
             request=request, organization=organization, provider_key=provider_id
         )

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -31,7 +31,7 @@ class PipelineAdvancerView(BaseView):
     csrf_protect = False
 
     @transaction_start("PipelineAdvancerView")
-    def handle(self, request: Request, provider_id) -> Response:
+    def handle(self, request: Request, provider_id: int) -> Response:
         pipeline = None
 
         for pipeline_cls in PIPELINE_CLASSES:

--- a/src/sentry/web/frontend/project_event.py
+++ b/src/sentry/web/frontend/project_event.py
@@ -10,7 +10,7 @@ from sentry.web.frontend.base import ProjectView
 class ProjectEventRedirect(ProjectView):
     required_scope = "event:read"
 
-    def handle(self, request: Request, organization, project, client_event_id) -> Response:
+    def handle(self, request: Request, organization, project, client_event_id: int) -> Response:
         """
         Given a client event id and project, redirects to the event page
         """

--- a/src/sentry/web/frontend/project_event.py
+++ b/src/sentry/web/frontend/project_event.py
@@ -4,7 +4,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore
-from sentry.models import Project
+from sentry.models import Organization, Project
 from sentry.web.frontend.base import ProjectView
 
 
@@ -12,7 +12,7 @@ class ProjectEventRedirect(ProjectView):
     required_scope = "event:read"
 
     def handle(
-        self, request: Request, organization, project: Project, client_event_id: int
+        self, request: Request, organization: Organization, project: Project, client_event_id: int
     ) -> Response:
         """
         Given a client event id and project, redirects to the event page

--- a/src/sentry/web/frontend/project_event.py
+++ b/src/sentry/web/frontend/project_event.py
@@ -4,13 +4,16 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore
+from sentry.models import Project
 from sentry.web.frontend.base import ProjectView
 
 
 class ProjectEventRedirect(ProjectView):
     required_scope = "event:read"
 
-    def handle(self, request: Request, organization, project, client_event_id: int) -> Response:
+    def handle(
+        self, request: Request, organization, project: Project, client_event_id: int
+    ) -> Response:
         """
         Given a client event id and project, redirects to the event page
         """

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -3,7 +3,7 @@ from django.middleware.csrf import get_token as get_csrf_token
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.models import Project
+from sentry.models import Organization, Project
 from sentry.signals import first_event_pending
 from sentry.web.frontend.base import BaseView, OrganizationView
 from sentry.web.helpers import render_to_response
@@ -34,7 +34,7 @@ class ReactPageView(OrganizationView, ReactMixin):
         # For normal users, let parent class handle (e.g. redirect to login page)
         return super().handle_auth_required(request, *args, **kwargs)
 
-    def handle(self, request: Request, organization, **kwargs) -> Response:
+    def handle(self, request: Request, organization: Organization, **kwargs) -> Response:
         if "project_id" in kwargs and request.GET.get("onboarding"):
             project = Project.objects.filter(
                 organization=organization, slug=kwargs["project_id"]

--- a/src/sentry/web/frontend/restore_organization.py
+++ b/src/sentry/web/frontend/restore_organization.py
@@ -3,6 +3,8 @@ import logging
 from django.contrib import messages
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry.api import client
 from sentry.models import AuditLogEntryEvent, Organization, OrganizationStatus
@@ -17,10 +19,6 @@ ERR_MESSAGES = {
 MSG_RESTORE_SUCCESS = _("Organization restored successfully.")
 
 delete_logger = logging.getLogger("sentry.deletions.ui")
-
-
-from rest_framework.request import Request
-from rest_framework.response import Response
 
 
 class RestoreOrganizationView(OrganizationView):
@@ -38,7 +36,7 @@ class RestoreOrganizationView(OrganizationView):
         except StopIteration:
             return None
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         if organization.status == OrganizationStatus.VISIBLE:
             return self.redirect(organization.get_url())
 
@@ -52,7 +50,7 @@ class RestoreOrganizationView(OrganizationView):
 
         return render_to_response("sentry/restore-organization.html", context, self.request)
 
-    def post(self, request: Request, organization) -> Response:
+    def post(self, request: Request, organization: Organization) -> Response:
         deletion_statuses = [
             OrganizationStatus.PENDING_DELETION,
             OrganizationStatus.DELETION_IN_PROGRESS,

--- a/src/sentry/web/frontend/twofactor.py
+++ b/src/sentry/web/frontend/twofactor.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from sentry import features, options
 from sentry.app import ratelimiter
 from sentry.auth.authenticators.u2f import U2fInterface
-from sentry.models import Authenticator
+from sentry.models import Authenticator, User
 from sentry.utils import auth, json
 from sentry.web.forms.accounts import TwoFactorForm
 from sentry.web.frontend.base import BaseView
@@ -22,13 +22,13 @@ COOKIE_MAX_AGE = 60 * 60 * 24 * 31
 class TwoFactorAuthView(BaseView):
     auth_required = False
 
-    def _check_can_webauthn_signin(self, user, request_user):
+    def _check_can_webauthn_signin(self, user: User, request_user):
         orgs = user.get_orgs()
         return any(
             features.has("organizations:webauthn-login", org, actor=request_user) for org in orgs
         )
 
-    def perform_signin(self, request: Request, user, interface=None):
+    def perform_signin(self, request: Request, user: User, interface=None):
         assert auth.login(request, user, passed_2fa=True)
         rv = HttpResponseRedirect(auth.get_login_redirect(request))
         if interface is not None:
@@ -42,7 +42,7 @@ class TwoFactorAuthView(BaseView):
                 )
         return rv
 
-    def fail_signin(self, request: Request, user, form):
+    def fail_signin(self, request: Request, user: User, form):
         # Ladies and gentlemen: the world's shittiest bruteforce
         # prevention.
         time.sleep(2.0)

--- a/src/sentry_plugins/asana/plugin.py
+++ b/src/sentry_plugins/asana/plugin.py
@@ -21,6 +21,9 @@ issues to existing tasks in Asana.
 """
 
 
+from sentry.models import Group
+
+
 class AsanaPlugin(CorePluginMixin, IssuePlugin2):
     description = DESCRIPTION
     slug = "asana"
@@ -65,7 +68,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
     def get_workspace_choices(self, workspaces):
         return [(w["gid"], w["name"]) for w in workspaces["data"]]
 
-    def get_new_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_new_issue_fields(self, request: Request, group: Group, event, **kwargs):
         fields = super().get_new_issue_fields(request, group, event, **kwargs)
         client = self.get_client(request.user)
         workspaces = client.get_workspaces()
@@ -114,7 +117,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
             ]
         )
 
-    def get_link_existing_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_link_existing_issue_fields(self, request: Request, group: Group, event, **kwargs):
         return [
             {
                 "name": "issue_id",
@@ -147,7 +150,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
             return " ".join(e["message"] for e in errors)
         return "unknown error"
 
-    def create_issue(self, request: Request, group, form_data, **kwargs):
+    def create_issue(self, request: Request, group: Group, form_data, **kwargs):
         client = self.get_client(request.user)
 
         try:
@@ -159,7 +162,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
 
         return response["data"]["gid"]
 
-    def link_issue(self, request: Request, group, form_data, **kwargs):
+    def link_issue(self, request: Request, group: Group, form_data, **kwargs):
         client = self.get_client(request.user)
         try:
             issue = client.get_issue(issue_id=form_data["issue_id"])["data"]
@@ -235,7 +238,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
             }
         ]
 
-    def view_autocomplete(self, request: Request, group, **kwargs):
+    def view_autocomplete(self, request: Request, group: Group, **kwargs):
         field = request.GET.get("autocomplete_field")
         query = request.GET.get("autocomplete_query")
 

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -32,6 +32,9 @@ ERR_404 = (
 )
 
 
+from sentry.models import Group
+
+
 class BitbucketPlugin(BitbucketMixin, IssuePlugin2):
     description = "Integrate Bitbucket issues by linking a repository to a project."
     slug = "bitbucket"
@@ -75,7 +78,7 @@ class BitbucketPlugin(BitbucketMixin, IssuePlugin2):
     def is_configured(self, request: Request, project, **kwargs):
         return bool(self.get_option("repo", project))
 
-    def get_new_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_new_issue_fields(self, request: Request, group: Group, event, **kwargs):
         fields = super().get_new_issue_fields(request, group, event, **kwargs)
         return (
             [
@@ -106,7 +109,7 @@ class BitbucketPlugin(BitbucketMixin, IssuePlugin2):
             ]
         )
 
-    def get_link_existing_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_link_existing_issue_fields(self, request: Request, group: Group, event, **kwargs):
         return [
             {
                 "name": "issue_id",
@@ -134,7 +137,7 @@ class BitbucketPlugin(BitbucketMixin, IssuePlugin2):
             return ERR_404
         return super().message_from_error(exc)
 
-    def create_issue(self, request: Request, group, form_data, **kwargs):
+    def create_issue(self, request: Request, group: Group, form_data, **kwargs):
         client = self.get_client(request.user)
 
         try:
@@ -146,7 +149,7 @@ class BitbucketPlugin(BitbucketMixin, IssuePlugin2):
 
         return response["local_id"]
 
-    def link_issue(self, request: Request, group, form_data, **kwargs):
+    def link_issue(self, request: Request, group: Group, form_data, **kwargs):
         client = self.get_client(request.user)
         repo = self.get_option("repo", group.project)
         try:
@@ -170,7 +173,7 @@ class BitbucketPlugin(BitbucketMixin, IssuePlugin2):
         repo = self.get_option("repo", group.project)
         return f"https://bitbucket.org/{repo}/issue/{issue_id}/"
 
-    def view_autocomplete(self, request: Request, group, **kwargs):
+    def view_autocomplete(self, request: Request, group: Group, **kwargs):
         field = request.GET.get("autocomplete_field")
         query = request.GET.get("autocomplete_query")
         if field != "issue_id" or not query:

--- a/src/sentry_plugins/github/endpoints/webhook.py
+++ b/src/sentry_plugins/github/endpoints/webhook.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import logging
+from typing import Optional
 
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, transaction
@@ -369,7 +370,7 @@ class GithubWebhookBase(View):
     def get_secret(self, organization):
         raise NotImplementedError
 
-    def handle(self, request: Request, organization=None) -> Response:
+    def handle(self, request: Request, organization: Optional[Organization] = None) -> Response:
         secret = self.get_secret(organization)
 
         if secret is None:

--- a/src/sentry_plugins/gitlab/plugin.py
+++ b/src/sentry_plugins/gitlab/plugin.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 
 from sentry.integrations import FeatureDescription, IntegrationFeatures
+from sentry.models import Group
 from sentry.plugins.bases.issue2 import IssuePlugin2
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
@@ -53,7 +54,7 @@ class GitLabPlugin(CorePluginMixin, IssuePlugin2):
             and self.get_option("gitlab_url", project)
         )
 
-    def get_new_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_new_issue_fields(self, request: Request, group: Group, event, **kwargs):
         fields = super().get_new_issue_fields(request, group, event, **kwargs)
         return (
             [
@@ -86,7 +87,7 @@ class GitLabPlugin(CorePluginMixin, IssuePlugin2):
             ]
         )
 
-    def get_link_existing_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_link_existing_issue_fields(self, request: Request, group: Group, event, **kwargs):
         return [
             {
                 "name": "issue_id",
@@ -107,7 +108,7 @@ class GitLabPlugin(CorePluginMixin, IssuePlugin2):
             },
         ]
 
-    def get_allowed_assignees(self, request: Request, group):
+    def get_allowed_assignees(self, request: Request, group: Group):
         repo = self.get_option("gitlab_repo", group.project)
         client = self.get_client(group.project)
         try:
@@ -127,7 +128,7 @@ class GitLabPlugin(CorePluginMixin, IssuePlugin2):
 
         return GitLabClient(url, token)
 
-    def create_issue(self, request: Request, group, form_data, **kwargs):
+    def create_issue(self, request: Request, group: Group, form_data, **kwargs):
         repo = self.get_option("gitlab_repo", group.project)
 
         client = self.get_client(group.project)
@@ -147,7 +148,7 @@ class GitLabPlugin(CorePluginMixin, IssuePlugin2):
 
         return response["iid"]
 
-    def link_issue(self, request: Request, group, form_data, **kwargs):
+    def link_issue(self, request: Request, group: Group, form_data, **kwargs):
         client = self.get_client(group.project)
         repo = self.get_option("gitlab_repo", group.project)
         try:

--- a/src/sentry_plugins/jira/plugin.py
+++ b/src/sentry_plugins/jira/plugin.py
@@ -27,6 +27,9 @@ JIRA_CUSTOM_FIELD_TYPES = {
 }
 
 
+from sentry.models import Group
+
+
 class JiraPlugin(CorePluginMixin, IssuePlugin2):
     description = "Integrate JIRA issues by linking a project."
     slug = "jira"
@@ -59,7 +62,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
             return False
         return True
 
-    def get_group_description(self, request: Request, group, event):
+    def get_group_description(self, request: Request, group: Group, event):
         # mostly the same as parent class, but change ``` to {code}
         output = [absolute_uri(group.get_absolute_url(params={"referrer": "jira_plugin"}))]
         body = self.get_group_body(request, group, event)
@@ -132,7 +135,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
 
         return issue_type_meta
 
-    def get_new_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_new_issue_fields(self, request: Request, group: Group, event, **kwargs):
         fields = super().get_new_issue_fields(request, group, event, **kwargs)
 
         jira_project_key = self.get_option("default_project", group.project)
@@ -231,7 +234,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
 
         return fields
 
-    def get_link_existing_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_link_existing_issue_fields(self, request: Request, group: Group, event, **kwargs):
         return [
             {
                 "name": "issue_id",
@@ -250,7 +253,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
             },
         ]
 
-    def link_issue(self, request: Request, group, form_data, **kwargs):
+    def link_issue(self, request: Request, group: Group, form_data, **kwargs):
         client = self.get_jira_client(group.project)
         try:
             issue = client.get_issue(form_data["issue_id"])
@@ -281,7 +284,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
         )
         return {"id": user["name"], "text": display}
 
-    def view_autocomplete(self, request: Request, group, **kwargs):
+    def view_autocomplete(self, request: Request, group: Group, **kwargs):
         query = request.GET.get("autocomplete_query")
         field = request.GET.get("autocomplete_field")
         project = self.get_option("default_project", group.project)
@@ -399,7 +402,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
             message += " ".join(f"{k}: {v}" for k, v in data.get("errors").items())
         return message
 
-    def create_issue(self, request: Request, group, form_data, **kwargs):
+    def create_issue(self, request: Request, group: Group, form_data, **kwargs):
         cleaned_data = {}
 
         # protect against mis-configured plugin submitting a form without an

--- a/src/sentry_plugins/phabricator/plugin.py
+++ b/src/sentry_plugins/phabricator/plugin.py
@@ -33,6 +33,9 @@ def query_to_result(field, result):
     return result["fields"]["name"]
 
 
+from sentry.models import Group
+
+
 class PhabricatorPlugin(CorePluginMixin, IssuePlugin2):
     description = DESCRIPTION
 
@@ -96,7 +99,7 @@ class PhabricatorPlugin(CorePluginMixin, IssuePlugin2):
             },
         ]
 
-    def get_new_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_new_issue_fields(self, request: Request, group: Group, event, **kwargs):
         fields = super().get_new_issue_fields(request, group, event, **kwargs)
         return fields + [
             {
@@ -119,7 +122,7 @@ class PhabricatorPlugin(CorePluginMixin, IssuePlugin2):
             },
         ]
 
-    def get_link_existing_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_link_existing_issue_fields(self, request: Request, group: Group, event, **kwargs):
         return [
             {
                 "name": "issue_id",
@@ -196,7 +199,7 @@ class PhabricatorPlugin(CorePluginMixin, IssuePlugin2):
         host = self.get_option("host", group.project)
         return urljoin(host, "T%s" % issue_id)
 
-    def view_autocomplete(self, request: Request, group, **kwargs):
+    def view_autocomplete(self, request: Request, group: Group, **kwargs):
         field = request.GET.get("autocomplete_field")
         query = request.GET.get("autocomplete_query")
 
@@ -220,7 +223,7 @@ class PhabricatorPlugin(CorePluginMixin, IssuePlugin2):
 
         return Response({field: results})
 
-    def create_issue(self, request: Request, group, form_data, **kwargs):
+    def create_issue(self, request: Request, group: Group, form_data, **kwargs):
         api = self.get_api(group.project)
         try:
             data = api.maniphest.createtask(
@@ -236,7 +239,7 @@ class PhabricatorPlugin(CorePluginMixin, IssuePlugin2):
 
         return data["id"]
 
-    def link_issue(self, request: Request, group, form_data, **kwargs):
+    def link_issue(self, request: Request, group: Group, form_data, **kwargs):
         api = self.get_api(group.project)
 
         try:

--- a/src/sentry_plugins/pivotal/plugin.py
+++ b/src/sentry_plugins/pivotal/plugin.py
@@ -25,6 +25,9 @@ chunks and have important conversations about deliverables and scope.
 """
 
 
+from sentry.models import Group
+
+
 class PivotalPlugin(CorePluginMixin, IssuePlugin2):
     description = DESCRIPTION
     slug = "pivotal"
@@ -59,7 +62,7 @@ class PivotalPlugin(CorePluginMixin, IssuePlugin2):
     def is_configured(self, request: Request, project, **kwargs):
         return all(self.get_option(k, project) for k in ("token", "project"))
 
-    def get_link_existing_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_link_existing_issue_fields(self, request: Request, group: Group, event, **kwargs):
         return [
             {
                 "name": "issue_id",
@@ -84,7 +87,7 @@ class PivotalPlugin(CorePluginMixin, IssuePlugin2):
         status = 400 if isinstance(error, PluginError) else 502
         return Response({"error_type": "validation", "errors": {"__all__": msg}}, status=status)
 
-    def view_autocomplete(self, request: Request, group, **kwargs):
+    def view_autocomplete(self, request: Request, group: Group, **kwargs):
         field = request.GET.get("autocomplete_field")
         query = request.GET.get("autocomplete_query")
         if field != "issue_id" or not query:
@@ -109,7 +112,7 @@ class PivotalPlugin(CorePluginMixin, IssuePlugin2):
 
         return Response({field: issues})
 
-    def link_issue(self, request: Request, group, form_data, **kwargs):
+    def link_issue(self, request: Request, group: Group, form_data, **kwargs):
         comment = form_data.get("comment")
         if not comment:
             return
@@ -144,7 +147,7 @@ class PivotalPlugin(CorePluginMixin, IssuePlugin2):
         }
         return safe_urlopen(_url, json=json_data, headers=req_headers, allow_redirects=True)
 
-    def create_issue(self, request: Request, group, form_data, **kwargs):
+    def create_issue(self, request: Request, group: Group, form_data, **kwargs):
         json_data = {
             "story_type": "bug",
             "name": force_text(form_data["title"], encoding="utf-8", errors="replace"),
@@ -177,7 +180,7 @@ class PivotalPlugin(CorePluginMixin, IssuePlugin2):
     def get_issue_url(self, group, issue_id, **kwargs):
         return "https://www.pivotaltracker.com/story/show/%s" % issue_id
 
-    def get_issue_title_by_id(self, request: Request, group, issue_id):
+    def get_issue_title_by_id(self, request: Request, group: Group, issue_id):
         _url = "{}/{}".format(self.build_api_url(group, "stories"), issue_id)
         req = self.make_api_request(group.project, _url)
 

--- a/src/sentry_plugins/redmine/plugin.py
+++ b/src/sentry_plugins/redmine/plugin.py
@@ -4,6 +4,7 @@ from rest_framework.request import Request
 import sentry
 from sentry.exceptions import PluginError
 from sentry.integrations import FeatureDescription, IntegrationFeatures
+from sentry.models import Group
 from sentry.plugins.bases.issue import IssuePlugin
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
@@ -64,13 +65,13 @@ class RedminePlugin(CorePluginMixin, IssuePlugin):
     def get_new_issue_title(self, **kwargs):
         return "Create Redmine Task"
 
-    def get_initial_form_data(self, request: Request, group, event, **kwargs):
+    def get_initial_form_data(self, request: Request, group: Group, event, **kwargs):
         return {
             "description": self._get_group_description(request, group, event),
             "title": self._get_group_title(request, group, event),
         }
 
-    def _get_group_description(self, request: Request, group, event):
+    def _get_group_description(self, request: Request, group: Group, event):
         output = [absolute_uri(group.get_absolute_url())]
         body = self._get_group_body(request, group, event)
         if body:

--- a/src/sentry_plugins/trello/plugin.py
+++ b/src/sentry_plugins/trello/plugin.py
@@ -24,6 +24,9 @@ and organize anything, trusted by millions of people from all over the world.
 """
 
 
+from sentry.models import Group
+
+
 class TrelloPlugin(CorePluginMixin, IssuePlugin2):
     description = DESCRIPTION
     slug = "trello"
@@ -139,7 +142,7 @@ class TrelloPlugin(CorePluginMixin, IssuePlugin2):
     def map_to_options(self, items):
         return [(item["id"], item["name"]) for item in items]
 
-    def get_new_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_new_issue_fields(self, request: Request, group: Group, event, **kwargs):
         """
         Return the fields needed for creating a new issue
         """
@@ -169,7 +172,7 @@ class TrelloPlugin(CorePluginMixin, IssuePlugin2):
             },
         ]
 
-    def get_link_existing_issue_fields(self, request: Request, group, event, **kwargs):
+    def get_link_existing_issue_fields(self, request: Request, group: Group, event, **kwargs):
         """
         Return the fields needed for linking to an existing issue
         """
@@ -204,7 +207,7 @@ class TrelloPlugin(CorePluginMixin, IssuePlugin2):
             return " ".join(e["message"] for e in errors)
         return "unknown error"
 
-    def create_issue(self, request: Request, group, form_data, **kwargs):
+    def create_issue(self, request: Request, group: Group, form_data, **kwargs):
         client = self.get_client(group.project)
 
         try:
@@ -216,7 +219,7 @@ class TrelloPlugin(CorePluginMixin, IssuePlugin2):
 
         return response["shortLink"]
 
-    def link_issue(self, request: Request, group, form_data, **kwargs):
+    def link_issue(self, request: Request, group: Group, form_data, **kwargs):
         client = self.get_client(group.project)
 
         try:
@@ -255,7 +258,7 @@ class TrelloPlugin(CorePluginMixin, IssuePlugin2):
             return issue.split("/", 1)[1]
         return "https://trello.com/c/%s" % issue
 
-    def view_options(self, request: Request, group, **kwargs):
+    def view_options(self, request: Request, group: Group, **kwargs):
         """
         Return the lists on a given Trello board
         """
@@ -280,7 +283,7 @@ class TrelloPlugin(CorePluginMixin, IssuePlugin2):
 
         return Response({field: results})
 
-    def view_autocomplete(self, request: Request, group, **kwargs):
+    def view_autocomplete(self, request: Request, group: Group, **kwargs):
         """
         Return the cards matching a given query and the organization of the configuration
         """


### PR DESCRIPTION
This is the second step on the path to getting `src/sentry/endpoints/` into `mypy.ini`. There are still too many endpoint files and functions to manually type them in a human lifespan so I'm relying on machines.

To achieve this I again ran a series of global find/replaces. I found function definitions inside endpoint that were either `get()`, `post()`, `put()`, `delete()`, `handle()`, or `dispatch()` and transform them from:
```py
def get(request: Request, organization, user_id) -> Response:
    ...
```
to:
```py
def get(request, organization: Organization, user_id: int) -> Response:
    ...
```
I did this with two general strategies:
- Anything of the form `.*_id` I transformed to `$1_id: int`.
- I replaced all `(user|team|project|organization|group|event)` with `user: User`, `team: Team`, etc. (I handled cases where we already had typing by replacing `user: User: User` with `user: User` after the initial transform.

In order to make this work tractable I ran this variable by variable and this is reflected in the commits. If this PR is unreviewable as-is, it can be split up either by these commits or by groups of files.