### PR TITLE
fix(u2f): Hotfix for super user modal with new webauthn registered devices

### DIFF
--- a/src/sentry/api/endpoints/authenticator_index.py
+++ b/src/sentry/api/endpoints/authenticator_index.py
@@ -1,3 +1,5 @@
+from base64 import b64encode
+
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -27,6 +29,11 @@ class AuthenticatorIndexEndpoint(Endpoint):
         )
 
         challenge = interface.activate(request._request, webauthn_ff).challenge
+
+        if webauthn_ff:
+            webAuthnAuthenticationData = b64encode(challenge)
+            challenge = {}
+            challenge["webAuthnAuthenticationData"] = webAuthnAuthenticationData
 
         # I don't think we currently support multiple interfaces of the same type
         # but just future proofing I guess

--- a/src/sentry/web/frontend/sudo.py
+++ b/src/sentry/web/frontend/sudo.py
@@ -1,5 +1,6 @@
 from rest_framework.request import Request
 
+from sentry import features
 from sentry.models import Authenticator
 from sentry.utils import json
 from sudo.views import SudoView as BaseSudoView
@@ -19,7 +20,13 @@ class SudoView(BaseSudoView):
         except LookupError:
             return False
 
-        challenge = interface.activate(request).challenge
+        orgs = request.user.get_orgs()
+        webauthn_ff = any(
+            features.has("organizations:webauthn-login", org, actor=request.user) for org in orgs
+        )
+
+        challenge = interface.activate(request, webauthn_ff).challenge
+
         if request.method == "POST":
             if "challenge" in request.POST and "response" in request.POST:
                 try:
@@ -28,7 +35,7 @@ class SudoView(BaseSudoView):
                 except ValueError:
                     pass
                 else:
-                    if interface.validate_response(request, challenge, response):
+                    if interface.validate_response(request, challenge, response, webauthn_ff):
                         return True
         context["u2f_challenge"] = challenge
         return False


### PR DESCRIPTION
Superuser modal u2f 2fa was broken due to interface.activate being changed to conform to webauthn registered devices. Made the necessary fixes to make it work.