### PR TITLE
feat(doc integrations): Add GET endpoint for all default IntegrationFeatures

### DIFF
--- a/src/sentry/api/endpoints/integration_features.py
+++ b/src/sentry/api/endpoints/integration_features.py
@@ -1,0 +1,31 @@
+import logging
+from typing import Any
+
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+from sentry.api.bases.integration import PARANOID_GET
+from sentry.api.permissions import SentryPermission
+from sentry.api.serializers import serialize
+from sentry.models.integrationfeature import Feature, IntegrationFeature
+
+logger = logging.getLogger(__name__)
+
+
+class IntegrationFeaturesPermissions(SentryPermission):
+    scope_map = {"GET": PARANOID_GET}
+
+
+class IntegrationFeaturesEndpoint(Endpoint):
+    permission_classes = (IntegrationFeaturesPermissions,)
+
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        return self.respond(
+            [
+                serialize(IntegrationFeature(feature=feature), request.user, has_target=False)
+                for feature, _ in Feature.as_choices()
+            ],
+            status=status.HTTP_200_OK,
+        )

--- a/src/sentry/api/serializers/models/integration_feature.py
+++ b/src/sentry/api/serializers/models/integration_feature.py
@@ -8,7 +8,11 @@ from sentry.models.user import User
 @register(IntegrationFeature)
 class IntegrationFeatureSerializer(Serializer):
     def get_attrs(
-        self, item_list: List[IntegrationFeature], user: Any, has_target: bool = True, **kwargs: Any
+        self,
+        item_list: List[IntegrationFeature],
+        user: User,
+        has_target: bool = True,
+        **kwargs: Any,
     ) -> MutableMapping[Any, Any]:
         # Perform DB calls for description field in bulk
         description_attrs = (

--- a/src/sentry/api/serializers/models/integration_feature.py
+++ b/src/sentry/api/serializers/models/integration_feature.py
@@ -1,12 +1,19 @@
 from sentry.api.serializers import Serializer, register
 from sentry.models import IntegrationFeature
+from sentry.models.user import User
 
 
 @register(IntegrationFeature)
 class IntegrationFeatureSerializer(Serializer):
-    def serialize(self, obj, attrs, user):
-        return {
-            "description": obj.description.strip(),
+    def serialize(self, obj: IntegrationFeature, attrs, user: User, has_target: bool = True):
+        data = {
+            "featureId": obj.feature,
             # feature gating work done in getsentry expects the format 'featureGate'
             "featureGate": obj.feature_str(),
         }
+        if has_target:
+            # These properties require a target on the IntegrationFeature.
+            # If no target is provided, the serialized IntegrationFeature payload will be generic,
+            # and not only applicable to one target.
+            data.update({"description": obj.description.strip()})
+        return data

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 
+from sentry.api.endpoints.integration_features import IntegrationFeaturesEndpoint
 from sentry.api.endpoints.project_grouping_configs import ProjectGroupingConfigsEndpoint
 from sentry.api.endpoints.project_transaction_threshold_override import (
     ProjectTransactionThresholdOverrideEndpoint,
@@ -2128,6 +2129,12 @@ urlpatterns = [
         r"^doc-integrations/(?P<doc_integration_slug>[^\/]+)/avatar/$",
         DocIntegrationAvatarEndpoint.as_view(),
         name="sentry-api-0-doc-integration-avatar",
+    ),
+    # Integration Features
+    url(
+        r"^integration-features/$",
+        IntegrationFeaturesEndpoint.as_view(),
+        name="sentry-api-0-integration-features",
     ),
     # Grouping configs
     url(

--- a/tests/sentry/api/endpoints/test_integration_features.py
+++ b/tests/sentry/api/endpoints/test_integration_features.py
@@ -1,0 +1,34 @@
+from rest_framework import status
+
+from sentry.models.integrationfeature import Feature, IntegrationFeature
+from sentry.testutils import APITestCase
+
+
+class IntegrationFeaturesTest(APITestCase):
+    endpoint = "sentry-api-0-integration-features"
+    method = "GET"
+
+    def setUp(self):
+        self.user = self.create_user(email="cynthia@poke.mon")
+        self.login_as(self.user)
+
+    def test_returns_all_features(self):
+        """
+        Tests that all of the default IntegrationFeatures were returned
+        """
+        response = self.get_success_response(status_code=status.HTTP_200_OK)
+        all_features = Feature.as_choices()
+        # Ensure all features were returned
+        assert len({item["featureId"] for item in response.data}) == len(all_features)
+        for feature in response.data:
+            # Ensure their featureGate matches the featureId
+            assert feature["featureGate"] == Feature.as_str(feature["featureId"])
+
+    def test_no_records_are_created(self):
+        """
+        Tests that calling this endpoint does not save any
+        IntegrationFeatures to the database
+        """
+        existing_count = IntegrationFeature.objects.count()
+        self.get_success_response(status_code=status.HTTP_200_OK)
+        assert existing_count == IntegrationFeature.objects.count()

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -55,6 +55,7 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
                     "owner": {"id": self.org.id, "slug": self.org.slug},
                     "featureData": [
                         {
+                            "featureId": 0,
                             "featureGate": "integrations-api",
                             "description": "Testin can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
                         }

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -133,6 +133,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             "owner": {"id": self.org.id, "slug": self.org.slug},
             "featureData": [
                 {
+                    "featureId": 0,
                     "description": "Test can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
                     "featureGate": "integrations-api",
                 }

--- a/tests/sentry/api/endpoints/test_sentry_app_features.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_features.py
@@ -26,11 +26,13 @@ class SentryAppFeaturesTest(APITestCase):
         assert response.status_code == 200
 
         assert {
+            "featureId": self.api_feature.feature,
             "description": self.api_feature.description,
             "featureGate": self.api_feature.feature_str(),
         } in response.data
 
         assert {
+            "featureId": self.issue_link_feature.feature,
             "description": self.issue_link_feature.description,
             "featureGate": self.issue_link_feature.feature_str(),
         } in response.data

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -86,6 +86,7 @@ class GetSentryAppsTest(SentryAppsTest):
             "owner": {"id": self.org.id, "slug": self.org.slug},
             "featureData": [
                 {
+                    "featureId": 0,
                     "featureGate": "integrations-api",
                     "description": "Test can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
                 }
@@ -194,6 +195,7 @@ class GetSentryAppsTest(SentryAppsTest):
             "owner": {"id": self.org.id, "slug": self.org.slug},
             "featureData": [
                 {
+                    "featureId": 0,
                     "featureGate": "integrations-api",
                     "description": "Test can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
                 }
@@ -243,6 +245,7 @@ class GetSentryAppsTest(SentryAppsTest):
             "owner": {"id": self.org.id, "slug": self.org.slug},
             "featureData": [
                 {
+                    "featureId": 0,
                     "featureGate": "integrations-api",
                     "description": "Testin can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
                 }
@@ -296,6 +299,7 @@ class GetSentryAppsTest(SentryAppsTest):
             "owner": {"id": self.org.id, "slug": self.org.slug},
             "featureData": [
                 {
+                    "featureId": 0,
                     "featureGate": "integrations-api",
                     "description": "Boo Far can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
                 }

--- a/tests/sentry/api/serializers/test_sentry_app.py
+++ b/tests/sentry/api/serializers/test_sentry_app.py
@@ -18,6 +18,7 @@ class SentryAppSerializerTest(TestCase):
         assert result["name"] == "Tesla App"
         assert result["featureData"] == [
             {
+                "featureId": 0,
                 "description": "Tesla App can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
                 "featureGate": "integrations-api",
             }


### PR DESCRIPTION
See [API-2333](https://getsentry.atlassian.net/browse/API-2333)

This PR adds an endpoint to view all the default IntegrationFeatures. Since it lives in Python and not the DB, My work around to "serialize" it was to create an IntegrationFeature in memory, and serialize that one without any FK fields. I could have just manually assembled the dictionary in the endpoint, or created a new serializer just for the Features enum, but I thought this was the best compromise.