### PR TITLE
feat(insights): Add api to break down alert triggers by alert rule (WOR-1518)

### DIFF
--- a/src/sentry/api/endpoints/team_alerts_triggered.py
+++ b/src/sentry/api/endpoints/team_alerts_triggered.py
@@ -2,13 +2,18 @@ from datetime import timedelta
 
 from django.db.models import Count, Q
 from django.db.models.functions import TruncDay
+from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.team import TeamEndpoint
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
 from sentry.api.utils import get_date_range_from_params
 from sentry.incidents.models import (
+    AlertRule,
     IncidentActivity,
     IncidentActivityType,
     IncidentProject,
@@ -17,7 +22,7 @@ from sentry.incidents.models import (
 from sentry.models import Project
 
 
-class TeamAlertsTriggeredEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignore
+class TeamAlertsTriggeredTotalsEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignore
     def get(self, request: Request, team) -> Response:
         """
         Return a time-bucketed (by day) count of triggered alerts owned by a given team.
@@ -61,3 +66,85 @@ class TeamAlertsTriggeredEndpoint(TeamEndpoint, EnvironmentMixin):  # type: igno
             current_day += timedelta(days=1)
 
         return Response(counts)
+
+
+class TriggeredAlertRuleSerializer(AlertRuleSerializer):
+    WEEKS_TO_FETCH = 8
+
+    def get_attrs(self, item_list, user, **kwargs):
+        result = super().get_attrs(item_list, user, **kwargs)
+        end = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+        start = end - timedelta(days=7 * self.WEEKS_TO_FETCH)
+
+        qs = (
+            AlertRule.objects.filter(
+                (
+                    Q(incident__incidentactivity__type=IncidentActivityType.CREATED.value)
+                    | Q(
+                        incident__incidentactivity__type=IncidentActivityType.STATUS_CHANGE.value,
+                        incident__incidentactivity__value__in=[
+                            str(IncidentStatus.OPEN.value),
+                            str(IncidentStatus.CRITICAL.value),
+                            str(IncidentStatus.WARNING.value),
+                        ],
+                    )
+                ),
+                incident__date_added__gte=start,
+                incident__date_added__lt=end,
+                id__in=[item.id for item in item_list],
+            )
+            .values("id")
+            .annotate()
+            .annotate(count=Count("id"))
+        )
+        alert_rule_counts = {row["id"]: row["count"] for row in qs}
+        for alert_rule in item_list:
+            alert_rule_attrs = result.setdefault(alert_rule, {})
+            alert_rule_attrs["weekly_avg"] = (
+                alert_rule_counts.get(alert_rule.id, 0) / self.WEEKS_TO_FETCH
+            )
+        return result
+
+    def serialize(self, obj, attrs, user):
+        result = super().serialize(obj, attrs, user)
+        result["weeklyAvg"] = attrs["weekly_avg"]
+        result["totalThisWeek"] = obj.count
+        return result
+
+
+class TeamAlertsTriggeredIndexEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignore
+    def get(self, request, team) -> Response:
+        """
+        Returns alert rules ordered by highest number of alerts fired this week.
+        """
+        owner_ids = [team.actor_id] + list(team.member_set.values_list("user__actor_id", flat=True))
+
+        end = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+        start = end - timedelta(days=7)
+
+        qs = AlertRule.objects.filter(
+            (
+                Q(incident__incidentactivity__type=IncidentActivityType.CREATED.value)
+                | Q(
+                    incident__incidentactivity__type=IncidentActivityType.STATUS_CHANGE.value,
+                    incident__incidentactivity__value__in=[
+                        str(IncidentStatus.OPEN.value),
+                        str(IncidentStatus.CRITICAL.value),
+                        str(IncidentStatus.WARNING.value),
+                    ],
+                )
+            ),
+            incident__incidentactivity__date_added__gte=start,
+            incident__incidentactivity__date_added__lt=end,
+            organization_id=team.organization_id,
+            owner__in=owner_ids,
+        ).annotate(count=Count("id"))
+
+        return self.paginate(
+            default_per_page=10,
+            request=request,
+            queryset=qs,
+            order_by=("-count", "name"),
+            on_results=lambda x: serialize(x, request.user, TriggeredAlertRuleSerializer()),
+            paginator_cls=OffsetPaginator,
+        )

--- a/src/sentry/api/endpoints/team_alerts_triggered.py
+++ b/src/sentry/api/endpoints/team_alerts_triggered.py
@@ -142,6 +142,8 @@ class TeamAlertsTriggeredIndexEndpoint(TeamEndpoint, EnvironmentMixin):  # type:
         ).annotate(count=Count("id"))
 
         stats_start, stats_end = get_date_range_from_params(request.GET)
+        stats_end = end.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+        stats_start = start.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
 
         return self.paginate(
             default_per_page=10,

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -400,7 +400,10 @@ from .endpoints.setup_wizard import SetupWizard
 from .endpoints.shared_group_details import SharedGroupDetailsEndpoint
 from .endpoints.system_health import SystemHealthEndpoint
 from .endpoints.system_options import SystemOptionsEndpoint
-from .endpoints.team_alerts_triggered import TeamAlertsTriggeredEndpoint
+from .endpoints.team_alerts_triggered import (
+    TeamAlertsTriggeredIndexEndpoint,
+    TeamAlertsTriggeredTotalsEndpoint,
+)
 from .endpoints.team_avatar import TeamAvatarEndpoint
 from .endpoints.team_details import TeamDetailsEndpoint
 from .endpoints.team_groups_old import TeamGroupsOldEndpoint
@@ -1544,8 +1547,13 @@ urlpatterns = [
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/alerts-triggered/$",
-                    TeamAlertsTriggeredEndpoint.as_view(),
+                    TeamAlertsTriggeredTotalsEndpoint.as_view(),
                     name="sentry-api-0-team-alerts-triggered",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/alerts-triggered-index/$",
+                    TeamAlertsTriggeredIndexEndpoint.as_view(),
+                    name="sentry-api-0-team-alerts-triggered-index",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/issue-breakdown/$",

--- a/tests/sentry/api/endpoints/test_team_alerts_triggered.py
+++ b/tests/sentry/api/endpoints/test_team_alerts_triggered.py
@@ -98,8 +98,6 @@ class TeamAlertsTriggeredTotalsEndpointTest(APITestCase):
                 == 1
             )
 
-        assert False
-
     def test_not_as_simple(self):
         team_with_user = self.create_team(
             organization=self.organization, name="Lonely Team", members=[self.user]

--- a/tests/sentry/api/endpoints/test_team_alerts_triggered.py
+++ b/tests/sentry/api/endpoints/test_team_alerts_triggered.py
@@ -234,7 +234,9 @@ class TeamAlertsTriggeredIndexEndpointTest(APITestCase):
         IncidentActivity.objects.bulk_create(activities)
 
         self.login_as(user=self.user)
-        response = self.get_success_response(self.team.organization.slug, self.team.slug)
+        response = self.get_success_response(
+            self.team.organization.slug, self.team.slug, statsPeriod="8w"
+        )
         assert [
             {"id": row["id"], "totalThisWeek": row["totalThisWeek"], "weeklyAvg": row["weeklyAvg"]}
             for row in response.data
@@ -244,21 +246,25 @@ class TeamAlertsTriggeredIndexEndpointTest(APITestCase):
         ]
 
         response = self.get_success_response(
-            self.team.organization.slug, self.team.slug, per_page=1
+            self.team.organization.slug, self.team.slug, per_page=1, statsPeriod="10w"
         )
         assert [
             {"id": row["id"], "totalThisWeek": row["totalThisWeek"], "weeklyAvg": row["weeklyAvg"]}
             for row in response.data
         ] == [
-            {"id": str(team_owned_rule.id), "totalThisWeek": 2, "weeklyAvg": 1.375},
+            {"id": str(team_owned_rule.id), "totalThisWeek": 2, "weeklyAvg": 1.1},
         ]
         next_cursor = self.get_cursor_headers(response)[1]
         response = self.get_success_response(
-            self.team.organization.slug, self.team.slug, per_page=1, cursor=next_cursor
+            self.team.organization.slug,
+            self.team.slug,
+            per_page=1,
+            cursor=next_cursor,
+            statsPeriod="10w",
         )
         assert [
             {"id": row["id"], "totalThisWeek": row["totalThisWeek"], "weeklyAvg": row["weeklyAvg"]}
             for row in response.data
         ] == [
-            {"id": str(user_owned_rule.id), "totalThisWeek": 1, "weeklyAvg": 1},
+            {"id": str(user_owned_rule.id), "totalThisWeek": 1, "weeklyAvg": 0.8},
         ]


### PR DESCRIPTION
This adds in an api to give us a breakdown of alert rules that fired the most in the last week, and
gives us average stats over the last 8 weeks as a comparison. Supports pagination.