### PR TITLE
chore(doc-integrations): Add compatibility for DocIntegrationAvatars

### DIFF
--- a/static/app/components/avatar/baseAvatar.tsx
+++ b/static/app/components/avatar/baseAvatar.tsx
@@ -72,7 +72,8 @@ type DefaultProps = {
     | 'team-avatar'
     | 'organization-avatar'
     | 'project-avatar'
-    | 'sentry-app-avatar';
+    | 'sentry-app-avatar'
+    | 'doc-integration-avatar';
 };
 
 type BaseProps = DefaultProps & {

--- a/static/app/components/avatar/docIntegrationAvatar.tsx
+++ b/static/app/components/avatar/docIntegrationAvatar.tsx
@@ -1,0 +1,23 @@
+import BaseAvatar from 'sentry/components/avatar/baseAvatar';
+import {DocIntegration} from 'sentry/types';
+
+type Props = {
+  docIntegration?: DocIntegration;
+} & BaseAvatar['props'];
+
+const DocIntegrationAvatar = ({docIntegration, ...props}: Props) => {
+  if (!docIntegration?.avatar) {
+    return null;
+  }
+  return (
+    <BaseAvatar
+      {...props}
+      type="upload"
+      uploadPath="doc-integration-avatar"
+      uploadId={docIntegration.avatar.avatarUuid}
+      title={docIntegration.name}
+    />
+  );
+};
+
+export default DocIntegrationAvatar;

--- a/static/app/components/avatar/index.tsx
+++ b/static/app/components/avatar/index.tsx
@@ -1,17 +1,25 @@
 import * as React from 'react';
 
+import DocIntegrationAvatar from 'sentry/components/avatar/docIntegrationAvatar';
 import OrganizationAvatar from 'sentry/components/avatar/organizationAvatar';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import UserAvatar from 'sentry/components/avatar/userAvatar';
-import {AvatarProject, AvatarSentryApp, OrganizationSummary, Team} from 'sentry/types';
+import {
+  AvatarProject,
+  AvatarSentryApp,
+  DocIntegration,
+  OrganizationSummary,
+  Team,
+} from 'sentry/types';
 
 type Props = {
   team?: Team;
   organization?: OrganizationSummary;
   project?: AvatarProject;
   sentryApp?: AvatarSentryApp;
+  docIntegration?: DocIntegration;
   /**
    * True if the Avatar is full color, rather than B&W (Used for SentryAppAvatar)
    */
@@ -32,6 +40,7 @@ const Avatar = React.forwardRef(function Avatar(
     sentryApp,
     isColor = true,
     isDefault = false,
+    docIntegration,
     ...props
   }: Props,
   ref: React.Ref<HTMLSpanElement>
@@ -59,6 +68,10 @@ const Avatar = React.forwardRef(function Avatar(
         {...commonProps}
       />
     );
+  }
+
+  if (docIntegration) {
+    return <DocIntegrationAvatar docIntegration={docIntegration} {...commonProps} />;
   }
 
   return <OrganizationAvatar organization={organization} {...commonProps} />;

--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -24,7 +24,8 @@ type AvatarChooserType =
   | 'team'
   | 'organization'
   | 'sentryAppColor'
-  | 'sentryAppSimple';
+  | 'sentryAppSimple'
+  | 'docIntegration';
 type DefaultChoice = {
   preview?: React.ReactNode;
   allowDefault?: boolean;

--- a/static/app/components/avatarCropper.tsx
+++ b/static/app/components/avatarCropper.tsx
@@ -27,7 +27,8 @@ type Props = {
     | 'organization'
     | 'project'
     | 'sentryAppColor'
-    | 'sentryAppSimple';
+    | 'sentryAppSimple'
+    | 'docIntegration';
   savedDataUrl?: string;
 };
 

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -219,6 +219,7 @@ export type IntegrationType = 'document' | 'plugin' | 'first_party' | 'sentry_ap
 export type IntegrationFeature = {
   description: string;
   featureGate: string;
+  featureId: number;
 };
 
 export type IntegrationInstallationStatus =
@@ -232,6 +233,10 @@ type IntegrationDialog = {
   body: string;
 };
 
+/**
+ * @deprecated This type is being removed in favor of DocIntegration
+ * and is will actually coordinate with the backend
+ */
 export type DocumentIntegration = {
   slug: string;
   name: string;
@@ -240,6 +245,17 @@ export type DocumentIntegration = {
   description: string;
   features: IntegrationFeature[];
   resourceLinks: Array<{title: string; url: string}>;
+};
+
+export type DocIntegration = {
+  name: string;
+  slug: string;
+  author: string;
+  url: string;
+  description: string;
+  avatar: Avatar;
+  features?: IntegrationFeature[];
+  resources?: Array<{title: string; url: string}>;
 };
 
 type IntegrationAspects = {

--- a/static/app/views/organizationIntegrations/constants.tsx
+++ b/static/app/views/organizationIntegrations/constants.tsx
@@ -78,6 +78,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'The Sentry-FullStory integration seamlessly integrates the Sentry and FullStory platforms. When you look at a browser error in Sentry, you will see a link to the FullStory session replay at that exact moment in time. When you are watching a FullStory replay and your user experiences an error, you will see a link that will take you to that error in Sentry.',
     features: [
       {
+        featureId: 12, // TODO(Add to integrationfeature.py)
         featureGate: 'session-replay',
         description:
           'Links Sentry errors to the FullStory session replay and vice-versa.',
@@ -104,11 +105,13 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'Quickly discover relationships between production apps and systems performance. See correlations between Sentry events and metrics from infra services like AWS, Elasticsearch, Docker, and Kafka can save time detecting sources of future spikes.',
     features: [
       {
+        featureId: 5,
         featureGate: 'incident-management',
         description:
           'Manage incidents and outages by sending Sentry notifications to DataDog.',
       },
       {
+        featureId: 7,
         featureGate: 'alert-rule',
         description:
           'Configure Sentry rules to trigger notifications based on conditions you set through the Sentry webhook integration.',
@@ -127,6 +130,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'Asayer is a session replay tool for developers. Replay each user session alongside your front/backend logs and other data spread across your stack so you can immediately find, reproduce and fix bugs faster.',
     features: [
       {
+        featureId: 12, // TODO(Add to integrationfeature.py)
         featureGate: 'session-replay',
         description:
           'By integrating Sentry with Asayer, you can see the moments that precede and that lead up to each problem. You can sync your Sentry logs alongside your session replay, JS console and network activity to gain complete visibility over every issue that affect your users.',
@@ -145,10 +149,12 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'Rocket.Chat is a free and open-source team chat collaboration platform that allows users to communicate securely in real-time across devices on the web, desktop or mobile and to customize their interface with a range of plugins, themes, and integrations with other key software.',
     features: [
       {
+        featureId: 11, // TODO(Add to integrationfeature.py)
         featureGate: 'chat',
         description: 'Get Sentry notifications in Rocket.Chat.',
       },
       {
+        featureId: 7,
         featureGate: 'alert-rule',
         description:
           'Configure Sentry rules to trigger notifications based on conditions you set through the Sentry webhook integration.',
@@ -170,6 +176,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'The Sentry Netlify build plugin automatically uploads source maps and notifies Sentry of new releases being deployed to your site after it finishes building in Netlify.',
     features: [
       {
+        featureId: 8, // TODO(Add to integrationfeature.py)
         featureGate: 'release-management',
         description: 'Notify Sentry of new releases being deployed.',
       },
@@ -199,6 +206,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'Notify Sentry of any Bitbucket Pipelines builds to automatically manage releases and quickly surface any errors associated with a given build.\n\n**Requirement:** Bitbucket source code integration must be installed for the release pipe to work.',
     features: [
       {
+        featureId: 8, // TODO(Add to integrationfeature.py)
         featureGate: 'release-management',
         description: 'Notify Sentry of new releases being deployed.',
       },
@@ -223,6 +231,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       "The Sentry Release GitHub Action automatically notifies Sentry of new releases being deployed. After sending Sentry release information, you'll be able to identify suspect commits that are likely the culprit for new errors. You'll also be able to apply source maps to see the original code in Sentry.\n\n**Requirement:** GitHub source code integration must be installed and configured for the Sentry Release GitHub Action to work.",
     features: [
       {
+        featureId: 8, // TODO(Add to integrationfeature.py)
         featureGate: 'release-management',
         description: 'Notify Sentry of new releases being deployed.',
       },
@@ -247,6 +256,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'The Sentry Grafana data source plugin allows you to query and visualize Sentry data within Grafana.',
     features: [
       {
+        featureId: 9, // TODO(Add to integrationfeature.py)
         featureGate: 'visualization',
         description: 'Query and visualize Sentry data in Grafana',
       },
@@ -267,6 +277,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'InsightFinder ingests the errors that Sentry detects through its standard APIs and analyzes them using its patented, unsupervised, neural network algorithms. InsightFinder prioritizes those errors and provides context so anomalous events can be resolved before business is impacted.',
     features: [
       {
+        featureId: 3,
         featureGate: 'webhook',
         description: 'Forward Sentry events to InsightFinder.',
       },
@@ -287,10 +298,12 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'Octohook is a platform that lets you visualize, debug and redistribute your webhooks.',
     features: [
       {
+        featureId: 3,
         featureGate: 'webhook',
         description: 'Record, forward or transform Sentry webhooks to other services.',
       },
       {
+        featureId: 7,
         featureGate: 'alert-rule',
         description:
           'Configure Sentry rules to trigger notifications based on conditions you set, through internal integrations.',


### PR DESCRIPTION
See [API-2332](https://getsentry.atlassian.net/browse/API-2332)

This PR modifies some of the typings on the avatar components to allow DocIntegrations to be uploaded. There isn't a plan to add an AvatarChooser component to getsentry/sentry that references DocIntegrations, but there will be one in getsentry/getsentry. This is just so types and work, and the components are ready.

Part 2 of this PR will use these changes in getsentry/getsentry