### PR TITLE
fix(issues): Fix issue where `get_event_by_id` can fail to return details of an existing event

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from copy import deepcopy
 from datetime import timedelta
 
@@ -201,6 +202,10 @@ class SnubaEventStorage(EventStorage):
                 selected_columns=["group_id"],
                 start=event.datetime,
                 end=event.datetime + timedelta(seconds=1),
+                # XXX: This is a hack to bust the snuba cache. We want to avoid the case where
+                # we cache an empty result, since this can result in us failing to fetch new events
+                # in some cases.
+                conditions=[["timestamp", ">", random.randint(0, 1000000000)]],
                 filter_keys={"project_id": [project_id], "event_id": [event_id]},
                 limit=1,
                 referrer="eventstore.get_event_by_id_nodestore",

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -1,7 +1,7 @@
 import logging
 import random
 from copy import deepcopy
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import sentry_sdk
 from django.utils import timezone
@@ -204,7 +204,9 @@ class SnubaEventStorage(EventStorage):
                 # XXX: This is a hack to bust the snuba cache. We want to avoid the case where
                 # we cache an empty result, since this can result in us failing to fetch new events
                 # in some cases.
-                raw_query_kwargs["conditions"] = [["timestamp", ">", random.randint(0, 1000000000)]]
+                raw_query_kwargs["conditions"] = [
+                    ["timestamp", ">", datetime.fromtimestamp(random.randint(0, 1000000000))]
+                ]
             result = snuba.raw_query(
                 selected_columns=["group_id"],
                 start=event.datetime,


### PR DESCRIPTION
When we call `get_event_by_id` without a `group_id`, we make a call to snuba to fetch the event
details so that we can figure out the `group_id`. If this method is called after an event is
created, but before it exists in snuba, then we cache the empty result for 7 minutes. This then
results in these calls returning no event until the cache expires.

To work around this, I add a useless condition that compares against a random timestamp from before
2002. This means that we will effectively never hit the cache for this query. This adds a small
amount of load to clickhouse, but shouldn't cause any problems. The ideal solution here would be to
just not negative cache for this particular referrer, but that could be a longer term solution.