### PR TITLE
feat(projectkey): Auto disable org-subdomains locally

### DIFF
--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -230,7 +230,11 @@ class ProjectKey(Model):
 
         if features.has("organizations:org-subdomains", self.project.organization):
             urlparts = urlparse(endpoint)
-            if urlparts.scheme and urlparts.netloc:
+            if (
+                urlparts.scheme
+                and urlparts.netloc
+                and urlparts.netloc.split(":")[0] not in ("localhost", "127.0.0.1")
+            ):
                 endpoint = "{}://{}.{}{}".format(
                     urlparts.scheme,
                     settings.SENTRY_ORG_SUBDOMAIN_TEMPLATE.format(


### PR DESCRIPTION
Turning on this feature just definitely does a bad thing for most local development. I'm one of those people that turn on all feature flags and this is the only one I need to turn off. This change now makes it so that if localhost is detected it will not try to subdomainify the ingestion endpoint.

Fixes #30775
