### PR TITLE
Test out Postgres 10

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1754,7 +1754,7 @@ SENTRY_DEVSERVICES = {
     ),
     "postgres": lambda settings, options: (
         {
-            "image": "postgres:9.6-alpine",
+            "image": "postgres:10.19-alpine",
             "pull": True,
             "ports": {"5432/tcp": 5432},
             "environment": {"POSTGRES_DB": "sentry", "POSTGRES_HOST_AUTH_METHOD": "trust"},


### PR DESCRIPTION
This is an experiment to provide information for self-hosters on RDS who need to upgrade to Postgres 10 before SaaS needs to. See https://github.com/getsentry/self-hosted/issues/1097.

I think we probably want to start running CI against Postgres 10 in addition to 9, but I figured I'd start with a single run against 10 to get an initial sense of how hard this is going to be.