### PR TITLE
fix(u2f): resolves User handle exceeds 64 bytes 

### DIFF
--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -102,7 +102,11 @@ class U2fInterface(AuthenticatorInterface):
                     credentials.append(c)
 
             registration_data, state = self.webauthn_registration_server.register_begin(
-                user={"id": bytes(user.id), "name": user.username, "displayName": user.username},
+                user={
+                    "id": user.id.to_bytes(64, byteorder="big"),
+                    "name": user.username,
+                    "displayName": user.username,
+                },
                 credentials=credentials,
                 # user_verification is where the authenticator verifies that the user is authorized
                 # to use the authenticator, this isn't needed for our usecase so set a discouraged

--- a/tests/sentry/auth/authenticators/test_u2f.py
+++ b/tests/sentry/auth/authenticators/test_u2f.py
@@ -39,6 +39,7 @@ class U2FInterfaceTest(TestCase):
             "name": self.user.username,
             "displayName": self.user.username,
         }
+        assert int.from_bytes(challenge["publicKey"]["user"]["id"], byteorder="big") == self.user.id
         assert len(challenge["publicKey"]["pubKeyCredParams"]) == 4
 
     def test_try_enroll_webauthn(self):

--- a/tests/sentry/auth/authenticators/test_u2f.py
+++ b/tests/sentry/auth/authenticators/test_u2f.py
@@ -35,7 +35,7 @@ class U2FInterfaceTest(TestCase):
 
         assert challenge["publicKey"]["rp"] == {"id": "richardmasentry.ngrok.io", "name": "Sentry"}
         assert challenge["publicKey"]["user"] == {
-            "id": bytes(self.user.id),
+            "id": self.user.id.to_bytes(64, byteorder="big"),
             "name": self.user.username,
             "displayName": self.user.username,
         }


### PR DESCRIPTION
beforehand, the User handle exceeds 64 bytes, which caused a problem with registering the device. Now the byte array for user id is set at 64 bytes.