### PR TITLE
ref(ratelimit): Add rate limit category to api logs

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -205,6 +205,7 @@ class Endpoint(APIView):
                 caller_ip=str(self.request.META.get("REMOTE_ADDR")),
                 user_agent=str(self.request.META.get("HTTP_USER_AGENT")),
                 rate_limited=str(getattr(self.request, "will_be_rate_limited", False)),
+                rate_limit_category=str(getattr(self.request, "rate_limit_category", None)),
                 request_duration_seconds=time.time() - request_start_time,
             )
             api_access_logger.info("api.access", extra=log_metrics)

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -22,9 +22,10 @@ DEFAULT_ERROR_MESSAGE = (
 class RatelimitMiddleware(MiddlewareMixin):
     """Middleware that applies a rate limit to every endpoint."""
 
-    def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response:
+    def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response | None:
         """Check if the endpoint call will violate."""
         request.will_be_rate_limited = False
+        request.rate_limit_category = None
 
         if not can_be_ratelimited(request, view_func):
             return
@@ -32,11 +33,13 @@ class RatelimitMiddleware(MiddlewareMixin):
         key = get_rate_limit_key(view_func, request)
         if key is None:
             return
+        category_str = key.split(":", 1)[0]
+        request.rate_limit_category = category_str
 
         rate_limit = get_rate_limit_value(
             http_method=request.method,
             endpoint=view_func.view_class,
-            category=RateLimitCategory(key.split(":", 1)[0]),
+            category=RateLimitCategory(category_str),
         )
         if rate_limit is None:
             return


### PR DESCRIPTION
We want to know what rate limit is being enforced for each request. Best way to do that is to log the category. This PR adds the category to the request object which is then added to the api access logs.