### PR TITLE
ref(integrations): Split up large file

### DIFF
--- a/src/sentry/shared_integrations/client/__init__.py
+++ b/src/sentry/shared_integrations/client/__init__.py
@@ -1,0 +1,8 @@
+__all__ = (
+    "BaseApiClient",
+    "BaseInternalApiClient",
+    "BaseApiResponse",
+)
+
+from .base import BaseApiClient, BaseApiResponse
+from .internal import BaseInternalApiClient

--- a/src/sentry/shared_integrations/client/internal.py
+++ b/src/sentry/shared_integrations/client/internal.py
@@ -1,0 +1,41 @@
+from random import random
+
+import sentry_sdk
+
+from sentry.api import ApiClient
+from sentry.shared_integrations.track_response import TrackResponseMixin
+from sentry.utils import metrics
+
+
+class BaseInternalApiClient(ApiClient, TrackResponseMixin):
+    integration_type = None
+
+    log_path = None
+
+    datadog_prefix = None
+
+    def request(self, *args, **kwargs):
+        metrics.incr(
+            "%s.http_request" % self.datadog_prefix,
+            sample_rate=1.0,
+            tags={self.integration_type: self.name},
+        )
+
+        try:
+            with sentry_sdk.configure_scope() as scope:
+                parent_span_id = scope.span.span_id
+                trace_id = scope.span.trace_id
+        except AttributeError:
+            parent_span_id = None
+            trace_id = None
+
+        with sentry_sdk.start_transaction(
+            op=f"{self.integration_type}.http",
+            name=f"{self.integration_type}.http_response.{self.name}",
+            parent_span_id=parent_span_id,
+            trace_id=trace_id,
+            sampled=random() < 0.05,
+        ) as span:
+            resp = ApiClient.request(self, *args, **kwargs)
+            self.track_response_data(resp.status_code, span, None, resp)
+            return resp

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -1,44 +1,8 @@
-from collections import OrderedDict
 from urllib.parse import urlparse
 
-from bs4 import BeautifulSoup
 from requests.exceptions import RequestException
 
-from sentry.utils import json
-
-
-class ApiError(Exception):
-    code = None
-    json = None
-    xml = None
-
-    def __init__(self, text, code=None, url=None):
-        if code is not None:
-            self.code = code
-        self.text = text
-        self.url = url
-        self.xml = None
-        # TODO(dcramer): pull in XML support from Jira
-        if text:
-            try:
-                self.json = json.loads(text, object_pairs_hook=OrderedDict)
-            except (json.JSONDecodeError, ValueError):
-                if self.text[:5] == "<?xml":
-                    # perhaps it's XML?
-                    self.xml = BeautifulSoup(self.text, "xml")
-                # must be an awful code.
-                self.json = None
-        else:
-            self.json = None
-        super().__init__(text[:1024])
-
-    @classmethod
-    def from_response(cls, response, url=None):
-        if response.status_code == 401:
-            return ApiUnauthorized(response.text)
-        elif response.status_code == 429:
-            return ApiRateLimitedError(response.text)
-        return cls(response.text, response.status_code, url=url)
+from .base import ApiError
 
 
 class ApiHostError(ApiError):

--- a/src/sentry/shared_integrations/exceptions/base.py
+++ b/src/sentry/shared_integrations/exceptions/base.py
@@ -1,0 +1,41 @@
+from collections import OrderedDict
+
+from bs4 import BeautifulSoup
+
+from sentry.utils import json
+
+
+class ApiError(Exception):
+    code = None
+    json = None
+    xml = None
+
+    def __init__(self, text, code=None, url=None):
+        if code is not None:
+            self.code = code
+        self.text = text
+        self.url = url
+        self.xml = None
+        # TODO(dcramer): pull in XML support from Jira
+        if text:
+            try:
+                self.json = json.loads(text, object_pairs_hook=OrderedDict)
+            except (json.JSONDecodeError, ValueError):
+                if self.text[:5] == "<?xml":
+                    # perhaps it's XML?
+                    self.xml = BeautifulSoup(self.text, "xml")
+                # must be an awful code.
+                self.json = None
+        else:
+            self.json = None
+        super().__init__(text[:1024])
+
+    @classmethod
+    def from_response(cls, response, url=None):
+        from sentry.shared_integrations.exceptions import ApiRateLimitedError, ApiUnauthorized
+
+        if response.status_code == 401:
+            return ApiUnauthorized(response.text)
+        elif response.status_code == 429:
+            return ApiRateLimitedError(response.text)
+        return cls(response.text, response.status_code, url=url)

--- a/src/sentry/shared_integrations/response/__init__.py
+++ b/src/sentry/shared_integrations/response/__init__.py
@@ -1,0 +1,13 @@
+__all__ = (
+    "BaseApiResponse",
+    "MappingApiResponse",
+    "SequenceApiResponse",
+    "TextApiResponse",
+    "XmlApiResponse",
+)
+
+from .base import BaseApiResponse
+from .mapping import MappingApiResponse
+from .sequence import SequenceApiResponse
+from .text import TextApiResponse
+from .xml import XmlApiResponse

--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -1,0 +1,77 @@
+from collections import OrderedDict
+
+import requests
+from django.utils.functional import cached_property
+
+from sentry.shared_integrations.exceptions import UnsupportedResponseType
+from sentry.utils import json
+
+
+class BaseApiResponse:
+    text = ""
+
+    def __init__(self, headers=None, status_code=None):
+        self.headers = headers
+        self.status_code = status_code
+
+    def __repr__(self):
+        return "<{}: code={}, content_type={}>".format(
+            type(self).__name__,
+            self.status_code,
+            self.headers.get("Content-Type", "") if self.headers else "",
+        )
+
+    @cached_property
+    def rel(self):
+        if not self.headers:
+            return {}
+        link_header = self.headers.get("Link")
+        if not link_header:
+            return {}
+        return {item["rel"]: item["url"] for item in requests.utils.parse_header_links(link_header)}
+
+    @classmethod
+    def from_response(self, response, allow_text=False):
+        from sentry.shared_integrations.response import (
+            MappingApiResponse,
+            SequenceApiResponse,
+            TextApiResponse,
+            XmlApiResponse,
+        )
+
+        if response.request.method == "HEAD":
+            return BaseApiResponse(response.headers, response.status_code)
+        # XXX(dcramer): this doesnt handle leading spaces, but they're not common
+        # paths so its ok
+        if response.text.startswith("<?xml"):
+            return XmlApiResponse(response.text, response.headers, response.status_code)
+        elif response.text.startswith("<"):
+            if not allow_text:
+                raise ValueError(f"Not a valid response type: {response.text[:128]}")
+            elif response.status_code < 200 or response.status_code >= 300:
+                raise ValueError(
+                    f"Received unexpected plaintext response for code {response.status_code}"
+                )
+            return TextApiResponse(response.text, response.headers, response.status_code)
+
+        # Some APIs will return JSON with an invalid content-type, so we try
+        # to decode it anyways
+        if "application/json" not in response.headers.get("Content-Type", ""):
+            try:
+                data = json.loads(response.text, object_pairs_hook=OrderedDict)
+            except (TypeError, ValueError):
+                if allow_text:
+                    return TextApiResponse(response.text, response.headers, response.status_code)
+                raise UnsupportedResponseType(
+                    response.headers.get("Content-Type", ""), response.status_code
+                )
+        elif response.text == "":
+            return TextApiResponse(response.text, response.headers, response.status_code)
+        else:
+            data = json.loads(response.text, object_pairs_hook=OrderedDict)
+        if isinstance(data, dict):
+            return MappingApiResponse(data, response.headers, response.status_code)
+        elif isinstance(data, (list, tuple)):
+            return SequenceApiResponse(data, response.headers, response.status_code)
+        else:
+            raise NotImplementedError

--- a/src/sentry/shared_integrations/response/mapping.py
+++ b/src/sentry/shared_integrations/response/mapping.py
@@ -1,0 +1,11 @@
+from sentry.shared_integrations.response.base import BaseApiResponse
+
+
+class MappingApiResponse(dict, BaseApiResponse):
+    def __init__(self, data, *args, **kwargs):
+        dict.__init__(self, data)
+        BaseApiResponse.__init__(self, *args, **kwargs)
+
+    @property
+    def json(self):
+        return self

--- a/src/sentry/shared_integrations/response/sequence.py
+++ b/src/sentry/shared_integrations/response/sequence.py
@@ -1,0 +1,11 @@
+from sentry.shared_integrations.response.base import BaseApiResponse
+
+
+class SequenceApiResponse(list, BaseApiResponse):
+    def __init__(self, data, *args, **kwargs):
+        list.__init__(self, data)
+        BaseApiResponse.__init__(self, *args, **kwargs)
+
+    @property
+    def json(self):
+        return self

--- a/src/sentry/shared_integrations/response/text.py
+++ b/src/sentry/shared_integrations/response/text.py
@@ -1,0 +1,7 @@
+from sentry.shared_integrations.response.base import BaseApiResponse
+
+
+class TextApiResponse(BaseApiResponse):
+    def __init__(self, text, *args, **kwargs):
+        self.text = text
+        super().__init__(*args, **kwargs)

--- a/src/sentry/shared_integrations/response/xml.py
+++ b/src/sentry/shared_integrations/response/xml.py
@@ -1,0 +1,9 @@
+from bs4 import BeautifulSoup
+
+from sentry.shared_integrations.response.base import BaseApiResponse
+
+
+class XmlApiResponse(BaseApiResponse):
+    def __init__(self, text, *args, **kwargs):
+        self.xml = BeautifulSoup(text, "xml")
+        super().__init__(*args, **kwargs)

--- a/src/sentry/shared_integrations/track_response.py
+++ b/src/sentry/shared_integrations/track_response.py
@@ -1,0 +1,42 @@
+import logging
+
+from django.utils.functional import cached_property
+
+from sentry.utils import metrics
+from sentry.utils.decorators import classproperty
+
+
+class TrackResponseMixin:
+    @cached_property
+    def logger(self):
+        return logging.getLogger(self.log_path)
+
+    @classproperty
+    def name_field(cls):
+        return "%s_name" % cls.integration_type
+
+    @classproperty
+    def name(cls):
+        return getattr(cls, cls.name_field)
+
+    def track_response_data(self, code, span, error=None, resp=None):
+        metrics.incr(
+            "%s.http_response" % (self.datadog_prefix),
+            sample_rate=1.0,
+            tags={self.integration_type: self.name, "status": code},
+        )
+
+        try:
+            span.set_http_status(int(code))
+        except ValueError:
+            span.set_status(code)
+
+        span.set_tag(self.integration_type, self.name)
+
+        extra = {
+            self.integration_type: self.name,
+            "status_string": str(code),
+            "error": str(error)[:256] if error else None,
+        }
+        extra.update(getattr(self, "logging_context", None) or {})
+        self.logger.info("%s.http_response" % (self.integration_type), extra=extra)

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -46,7 +46,7 @@ class ApiClientTest(TestCase):
         resp = ApiClient().patch("http://example.com")
         assert resp.status_code == 200
 
-    @mock.patch("sentry.shared_integrations.client.cache")
+    @mock.patch("sentry.shared_integrations.client.base.cache")
     @responses.activate
     def test_cache_mocked(self, cache):
         cache.get.return_value = None


### PR DESCRIPTION
The `/sentry/shared_integrations/` is blocking fully adding types to other integrations. However, the files in the directory are too large to type in a single PR.  As a first step, I split the large file into one file per class. There are no functional changes.