### PR TITLE
ref(types): Add popularity to DocIntegration

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -252,6 +252,7 @@ export type DocIntegration = {
   slug: string;
   author: string;
   url: string;
+  popularity: number;
   description: string;
   avatar: Avatar;
   features?: IntegrationFeature[];


### PR DESCRIPTION
When reviewing https://github.com/getsentry/sentry/pull/30772 I missed that `DocIntegration` didn't have `popularity` as a type. 