### PR TITLE
fix(ui): Use full opacity for close button in app alerts

### DIFF
--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -172,7 +172,7 @@ function IncompatibleQueryAlert({
         </React.Fragment>
       )}
       <StyledCloseButton
-        icon={<IconClose color="yellow300" size="sm" isCircled />}
+        icon={<IconClose size="sm" />}
         aria-label={t('Close')}
         size="zero"
         onClick={onClose}
@@ -438,6 +438,5 @@ const StyledCloseButton = styled(Button)`
   &:hover,
   &:focus {
     background-color: transparent;
-    opacity: 1;
   }
 `;

--- a/static/app/views/app/alertMessage.tsx
+++ b/static/app/views/app/alertMessage.tsx
@@ -33,7 +33,7 @@ const AlertMessage = ({alert, system}: Props) => {
         {url ? <ExternalLink href={url}>{message}</ExternalLink> : message}
       </StyledMessage>
       <StyledCloseButton
-        icon={<IconClose size="md" isCircled />}
+        icon={<IconClose size="sm" />}
         aria-label={t('Close')}
         onClick={alert.onClose ?? handleClose}
         size="zero"
@@ -57,7 +57,6 @@ const StyledMessage = styled('span')`
 
 const StyledCloseButton = styled(Button)`
   background-color: transparent;
-  opacity: 0.4;
   transition: opacity 0.1s linear;
   position: absolute;
   top: 50%;


### PR DESCRIPTION
The current close buttons are set to opacity: 0.4. This is too light and not accessible - we should use full opacity instead. Also, the circle around IconClose seems unnecessary, we could remove it and the meaning would stay the same.

Before:
<img width="984" alt="Screen Shot 2021-12-21 at 9 52 31 AM" src="https://user-images.githubusercontent.com/44172267/146976061-1f700dcb-8022-4dde-b380-f8e22cc15030.png">

After:
<img width="984" alt="Screen Shot 2021-12-21 at 9 52 12 AM" src="https://user-images.githubusercontent.com/44172267/146975980-2e3ce1fc-5a15-4399-bbe4-73245e4788f8.png">

