### PR TITLE
feat(insights): Add break down by alert rule table to team stats page

### DIFF
--- a/static/app/views/organizationStats/teamInsights/overview.tsx
+++ b/static/app/views/organizationStats/teamInsights/overview.tsx
@@ -280,6 +280,7 @@ function TeamInsightsOverview({location, router}: Props) {
             >
               <TeamAlertsTriggered
                 organization={organization}
+                projects={projects}
                 teamSlug={currentTeam!.slug}
                 period={period}
                 start={start?.toString()}

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -181,6 +181,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
             <AlignRight key="curr">{t('This Week')}</AlignRight>,
             <AlignRight key="diff">{t('Difference')}</AlignRight>,
           ]}
+          isEmpty={!alertsTriggeredRules || alertsTriggeredRules.length === 0}
         >
           {alertsTriggeredRules &&
             alertsTriggeredRules.map(rule => (
@@ -227,6 +228,13 @@ const StyledPanelTable = styled(PanelTable)`
   & > div {
     padding: ${space(1)} ${space(2)};
   }
+  ${p =>
+    p.isEmpty &&
+    css`
+      & > div:last-child {
+        padding: 48px ${space(2)};
+      }
+    `}
 `;
 
 const ProjectBadgeContainer = styled('div')`

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -5,11 +6,19 @@ import AsyncComponent from 'sentry/components/asyncComponent';
 import Button from 'sentry/components/button';
 import BarChart from 'sentry/components/charts/barChart';
 import {DateTimeObject} from 'sentry/components/charts/utils';
+import IdBadge from 'sentry/components/idBadge';
+import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {getParams} from 'sentry/components/organizations/globalSelectionHeader/getParams';
-import {t} from 'sentry/locale';
+import {IconArrow} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Organization} from 'sentry/types';
+import {Organization, Project} from 'sentry/types';
+import {formatPercentage} from 'sentry/utils/formatters';
+import {Color} from 'sentry/utils/theme';
+import {IncidentRule} from 'sentry/views/alerts/incidentRules/types';
+
+import PanelTable from '../../../components/panels/panelTable';
 
 import PanelTable from '../../../components/panels/panelTable';
 
@@ -21,13 +30,20 @@ import {
 
 type AlertsTriggered = Record<string, number>;
 
+type AlertsTriggeredRule = IncidentRule & {
+  weeklyAvg: number;
+  totalThisWeek: number;
+};
+
 type Props = AsyncComponent['props'] & {
   organization: Organization;
+  projects: Project[];
   teamSlug: string;
 } & DateTimeObject;
 
 type State = AsyncComponent['state'] & {
   alertsTriggered: AlertsTriggered | null;
+  alertsTriggeredRules: AlertsTriggeredRule[] | null;
 };
 
 class TeamAlertsTriggered extends AsyncComponent<Props, State> {
@@ -37,6 +53,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
     return {
       ...super.getDefaultState(),
       alertsTriggered: null,
+      alertsTriggeredRules: null,
     };
   }
 
@@ -48,6 +65,15 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
       [
         'alertsTriggered',
         `/teams/${organization.slug}/${teamSlug}/alerts-triggered/`,
+        {
+          query: {
+            ...getParams(datetime),
+          },
+        },
+      ],
+      [
+        'alertsTriggeredRules',
+        `/teams/${organization.slug}/${teamSlug}/alerts-triggered-index/`,
         {
           query: {
             ...getParams(datetime),
@@ -71,6 +97,24 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
     }
   }
 
+  renderTrend(rule: AlertsTriggeredRule) {
+    const {weeklyAvg, totalThisWeek} = rule;
+    const diff = totalThisWeek - weeklyAvg;
+
+    // weeklyAvg can only be 0 only if totalThisWeek is also 0
+    // but those should never be returned in alerts-triggered-index request
+    if (weeklyAvg === 0) {
+      return '\u2014';
+    }
+
+    return (
+      <SubText color={diff <= 0 ? 'green300' : 'red300'}>
+        {formatPercentage(Math.abs(diff / weeklyAvg), 0)}
+        <PaddedIconArrow direction={diff <= 0 ? 'down' : 'up'} size="xs" />
+      </SubText>
+    );
+  }
+
   renderLoading() {
     return (
       <ChartWrapper>
@@ -80,14 +124,15 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {organization} = this.props;
-    const {alertsTriggered} = this.state;
+    const {organization, period, projects} = this.props;
+    const {alertsTriggered, alertsTriggeredRules} = this.state;
     const data = convertDayValueObjectToSeries(alertsTriggered ?? {});
     const seriesData = convertDaySeriesToWeeks(data);
 
     return (
-      <ChartWrapper>
-        <StyledPanelTable
+      <Fragment>
+        <ChartWrapper>
+          <StyledPanelTable
           isEmpty={!alertsTriggered || data.length === 0}
           emptyMessage={t('No Alerts Owned By This Team')}
           emptyAction={
@@ -110,24 +155,56 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
           }
           headers={[]}
         >
-          <BarChart
-            style={{height: 190}}
-            isGroupedByDate
-            useShortDate
-            period="7d"
-            legend={{right: 0, top: 0}}
-            yAxis={{minInterval: 1}}
-            xAxis={barAxisLabel(seriesData.length)}
-            series={[
-              {
-                seriesName: t('Alerts Triggered'),
-                data: seriesData,
-                silent: true,
-              },
-            ]}
-          />
+            <BarChart
+              style={{height: 190}}
+              isGroupedByDate
+              useShortDate
+              period="7d"
+              legend={{right: 0, top: 0}}
+              yAxis={{minInterval: 1}}
+              xAxis={barAxisLabel(seriesData.length)}
+              series={[
+                {
+                  seriesName: t('Alerts Triggered'),
+                  data: seriesData,
+                  silent: true,
+                },
+              ]}
+            />
+          </StyledPanelTable>
+        </ChartWrapper>
+        <StyledPanelTable
+          headers={[
+            t('Alert Rule'),
+            t('Project'),
+            <AlignRight key="last">{tct('Last [period] Average', {period})}</AlignRight>,
+            <AlignRight key="curr">{t('This Week')}</AlignRight>,
+            <AlignRight key="diff">{t('Difference')}</AlignRight>,
+          ]}
+        >
+          {alertsTriggeredRules &&
+            alertsTriggeredRules.map(rule => (
+              <Fragment key={rule.id}>
+                <div>
+                  <Link
+                    to={`/organizations/${organization.id}/alerts/rules/details/${rule.id}/`}
+                  >
+                    {rule.name}
+                  </Link>
+                </div>
+                <ProjectBadgeContainer>
+                  <ProjectBadge
+                    avatarSize={18}
+                    project={projects.find(p => p.slug === rule.projects[0])}
+                  />
+                </ProjectBadgeContainer>
+                <AlignRight>{rule.weeklyAvg}</AlignRight>
+                <AlignRight>{rule.totalThisWeek}</AlignRight>
+                <AlignRight>{this.renderTrend(rule)}</AlignRight>
+              </Fragment>
+            ))}
         </StyledPanelTable>
-      </ChartWrapper>
+      </Fragment>
     );
   }
 }
@@ -136,6 +213,41 @@ export default TeamAlertsTriggered;
 
 const ChartWrapper = styled('div')`
   padding: ${space(2)} ${space(2)} 0 ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const StyledPanelTable = styled(PanelTable)`
+  grid-template-columns: 1fr 0.5fr 0.2fr 0.2fr 0.2fr;
+  font-size: ${p => p.theme.fontSizeMedium};
+  white-space: nowrap;
+  margin-bottom: 0;
+  border: 0;
+  box-shadow: unset;
+
+  & > div {
+    padding: ${space(1)} ${space(2)};
+  }
+`;
+
+const ProjectBadgeContainer = styled('div')`
+  display: flex;
+`;
+
+const ProjectBadge = styled(IdBadge)`
+  flex-shrink: 0;
+`;
+
+const AlignRight = styled('div')`
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+`;
+
+const PaddedIconArrow = styled(IconArrow)`
+  margin: 0 ${space(0.5)};
+`;
+
+const SubText = styled('div')<{color: Color}>`
+  color: ${p => p.theme[p.color]};
 `;
 
 const StyledPanelTable = styled(PanelTable)<{isEmpty: boolean}>`

--- a/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
@@ -124,7 +124,7 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
 
     return (
       <Fragment>
-        <IssuesChartWrapper>
+        <ChartWrapper>
           {loading && <Placeholder height="200px" />}
           {!loading && (
             <BarChart
@@ -149,7 +149,7 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
               ]}
             />
           )}
-        </IssuesChartWrapper>
+        </ChartWrapper>
         <StyledPanelTable
           isEmpty={projects.length === 0}
           emptyMessage={t('No Projects Assigned To This Team')}
@@ -186,9 +186,6 @@ export default TeamIssuesReviewed;
 
 const ChartWrapper = styled('div')`
   padding: ${space(2)} ${space(2)} 0 ${space(2)};
-`;
-
-const IssuesChartWrapper = styled(ChartWrapper)`
   border-bottom: 1px solid ${p => p.theme.border};
 `;
 

--- a/tests/fixtures/js-stubs/types.tsx
+++ b/tests/fixtures/js-stubs/types.tsx
@@ -109,6 +109,8 @@ type TestStubFixtures = {
   Tags: OverridableStubList;
   Team: OverridableStub;
   TeamAlertsTriggered: SimpleStub;
+  TeamAlertsTriggeredBreakdown: SimpleStub;
+  TeamIssuesReviewed: SimpleStub;
   TeamIssuesBreakdown: SimpleStub;
   TeamResolutionTime: SimpleStub;
   Tombstones: OverridableStubList;

--- a/tests/fixtures/js-stubs/types.tsx
+++ b/tests/fixtures/js-stubs/types.tsx
@@ -109,7 +109,6 @@ type TestStubFixtures = {
   Tags: OverridableStubList;
   Team: OverridableStub;
   TeamAlertsTriggered: SimpleStub;
-  TeamAlertsTriggeredBreakdown: SimpleStub;
   TeamIssuesReviewed: SimpleStub;
   TeamIssuesBreakdown: SimpleStub;
   TeamResolutionTime: SimpleStub;

--- a/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
@@ -144,7 +144,7 @@ describe('TeamInsightsOverview', () => {
     });
     MockApiClient.addMockResponse({
       url: `/teams/org-slug/${team2.slug}/alerts-triggered-breakdown/`,
-      body: TestStubs.TeamAlertsTriggeredBreakdown(),
+      body: [],
     });
     MockApiClient.addMockResponse({
       url: `/teams/org-slug/${team2.slug}/time-to-resolution/`,

--- a/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
@@ -122,8 +122,8 @@ describe('TeamInsightsOverview', () => {
       body: TestStubs.TeamAlertsTriggered(),
     });
     MockApiClient.addMockResponse({
-      url: `/teams/org-slug/${team1.slug}/alerts-triggered-breakdown/`,
-      body: TestStubs.TeamAlertsTriggered(),
+      url: `/teams/org-slug/${team1.slug}/alerts-triggered-index/`,
+      body: [],
     });
     MockApiClient.addMockResponse({
       url: `/teams/org-slug/${team1.slug}/time-to-resolution/`,
@@ -143,7 +143,7 @@ describe('TeamInsightsOverview', () => {
       body: TestStubs.TeamAlertsTriggered(),
     });
     MockApiClient.addMockResponse({
-      url: `/teams/org-slug/${team2.slug}/alerts-triggered-breakdown/`,
+      url: `/teams/org-slug/${team2.slug}/alerts-triggered-index/`,
       body: [],
     });
     MockApiClient.addMockResponse({

--- a/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
@@ -122,6 +122,10 @@ describe('TeamInsightsOverview', () => {
       body: TestStubs.TeamAlertsTriggered(),
     });
     MockApiClient.addMockResponse({
+      url: `/teams/org-slug/${team1.slug}/alerts-triggered-breakdown/`,
+      body: TestStubs.TeamAlertsTriggered(),
+    });
+    MockApiClient.addMockResponse({
       url: `/teams/org-slug/${team1.slug}/time-to-resolution/`,
       body: TestStubs.TeamResolutionTime(),
     });
@@ -137,6 +141,10 @@ describe('TeamInsightsOverview', () => {
     MockApiClient.addMockResponse({
       url: `/teams/org-slug/${team2.slug}/alerts-triggered/`,
       body: TestStubs.TeamAlertsTriggered(),
+    });
+    MockApiClient.addMockResponse({
+      url: `/teams/org-slug/${team2.slug}/alerts-triggered-breakdown/`,
+      body: TestStubs.TeamAlertsTriggeredBreakdown(),
     });
     MockApiClient.addMockResponse({
       url: `/teams/org-slug/${team2.slug}/time-to-resolution/`,


### PR DESCRIPTION
This adds a table for the breakdown of metric alerts triggered to the team stats page. Removed the `Alert Owner` column from the table since all alerts are owned by the team on top of the page.

Example table:
![Screen Shot 2021-12-21 at 10 04 47 AM](https://user-images.githubusercontent.com/15015880/146977961-a31cbf49-e990-4c0b-af10-54834b26a27b.png)

