### PR TITLE
chore(sentry-apps): Add avatars to the SentryAppsStats endpoint

### DIFF
--- a/src/sentry/api/endpoints/sentry_apps_stats.py
+++ b/src/sentry/api/endpoints/sentry_apps_stats.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from sentry.api.bases import SentryAppsBaseEndpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.api.serializers import serialize
-from sentry.models import SentryApp
+from sentry.models import SentryApp, SentryAppAvatar
 
 
 class SentryAppsStatsEndpoint(SentryAppsBaseEndpoint):
@@ -21,6 +21,7 @@ class SentryAppsStatsEndpoint(SentryAppsBaseEndpoint):
         if "per_page" in request.query_params:
             sentry_apps = sentry_apps[: int(request.query_params["per_page"])]
 
+        avatars_to_app_map = SentryAppAvatar.objects.get_by_apps_as_dict(sentry_apps=sentry_apps)
         apps = [
             {
                 "id": app.id,
@@ -28,7 +29,7 @@ class SentryAppsStatsEndpoint(SentryAppsBaseEndpoint):
                 "slug": app.slug,
                 "name": app.name,
                 "installs": app.installations__count,
-                "avatars": [serialize(avatar) for avatar in app.avatar.all()],
+                "avatars": serialize(avatars_to_app_map[app.id], request.user),
             }
             for app in sentry_apps
         ]

--- a/src/sentry/api/endpoints/sentry_apps_stats.py
+++ b/src/sentry/api/endpoints/sentry_apps_stats.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases import SentryAppsBaseEndpoint
 from sentry.api.permissions import SuperuserPermission
+from sentry.api.serializers import serialize
 from sentry.models import SentryApp
 
 
@@ -21,7 +22,14 @@ class SentryAppsStatsEndpoint(SentryAppsBaseEndpoint):
             sentry_apps = sentry_apps[: int(request.query_params["per_page"])]
 
         apps = [
-            {"id": app.id, "slug": app.slug, "name": app.name, "installs": app.installations__count}
+            {
+                "id": app.id,
+                "uuid": app.uuid,
+                "slug": app.slug,
+                "name": app.name,
+                "installs": app.installations__count,
+                "avatars": [serialize(avatar) for avatar in app.avatar.all()],
+            }
             for app in sentry_apps
         ]
 

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -187,6 +187,7 @@ export const AVATAR_URL_MAP = {
   user: 'avatar',
   sentryAppColor: 'sentry-app-avatar',
   sentryAppSimple: 'sentry-app-avatar',
+  docIntegration: 'doc-integration-avatar',
 };
 
 export const MENU_CLOSE_DELAY = 200;

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -254,6 +254,7 @@ export type DocIntegration = {
   url: string;
   popularity: number;
   description: string;
+  isDraft: boolean;
   avatar: Avatar;
   features?: IntegrationFeature[];
   resources?: Array<{title: string; url: string}>;

--- a/tests/sentry/api/endpoints/test_sentry_apps_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps_stats.py
@@ -1,5 +1,7 @@
 from django.urls import reverse
 
+from sentry.api.serializers.base import serialize
+from sentry.models.sentryappavatar import SentryAppAvatar
 from sentry.testutils import APITestCase
 from sentry.utils import json
 
@@ -13,6 +15,9 @@ class SentryAppsStatsTest(APITestCase):
 
         self.app_1 = self.create_sentry_app(
             name="Test", organization=self.super_org, published=True
+        )
+        self.app_1_avatar = SentryAppAvatar.objects.create(
+            sentry_app=self.app_1, color=True, avatar_type=0
         )
 
         self.app_2 = self.create_sentry_app(name="Testin", organization=self.org)
@@ -30,16 +35,20 @@ class SentryAppsStatsTest(APITestCase):
         assert response.status_code == 200
         assert {
             "id": self.app_2.id,
+            "uuid": self.app_2.uuid,
             "slug": self.app_2.slug,
             "name": self.app_2.name,
             "installs": 1,
+            "avatars": [],
         } in json.loads(response.content)
 
         assert {
             "id": self.app_1.id,
+            "uuid": self.app_1.uuid,
             "slug": self.app_1.slug,
             "name": self.app_1.name,
             "installs": 1,
+            "avatars": [serialize(self.app_1_avatar)],
         } in json.loads(response.content)
 
     def test_nonsuperusers_have_no_access(self):


### PR DESCRIPTION
See [API-2332](https://getsentry.atlassian.net/browse/API-2332)

Jokes on me for thinking this would only be 2 PRs. In order to add the avatars in _admin tools, we'll need access to the avatars from this endpoint. It is already restricted to SuperUsers only so there isn't functionality change besides extra fields and we're not gonna be leaking anything. Tests have also been updated to reflect the change.