### PR TITLE
feat(insights): Allow a list of statuses to be passed to `TeamIssueBreakdownEndpoint` (WOR-1511)

### DIFF
--- a/src/sentry/api/endpoints/team_issue_breakdown.py
+++ b/src/sentry/api/endpoints/team_issue_breakdown.py
@@ -1,7 +1,8 @@
 import copy
 from datetime import timedelta
+from itertools import chain
 
-from django.db.models import Count
+from django.db.models import Count, IntegerField, Value
 from django.db.models.functions import TruncDay
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,8 +11,12 @@ from sentry import features
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.utils import get_date_range_from_params
-from sentry.models import GroupHistory, GroupHistoryStatus, Project, Team
-from sentry.models.grouphistory import ACTIONED_STATUSES
+from sentry.models import Group, GroupHistory, GroupHistoryStatus, Project, Team
+from sentry.models.grouphistory import (
+    ACTIONED_STATUSES,
+    status_to_string_lookup,
+    string_to_status_lookup,
+)
 
 
 class TeamIssueBreakdownEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignore
@@ -19,17 +24,43 @@ class TeamIssueBreakdownEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignor
         """
         Returns a dict of team projects, and a time-series dict of issue stat breakdowns for each.
 
-        Right now the stats we return are the count of reviewed issues and the total count of issues.
+        If a list of statuses is passed then we return the count of each status and the totals.
+        Otherwise we the count of reviewed issues and the total count of issues.
         """
         if not features.has("organizations:team-insights", team.organization, actor=request.user):
             return Response({"detail": "You do not have the insights feature enabled"}, status=400)
         start, end = get_date_range_from_params(request.GET)
         end = end.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
         start = start.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+
+        if "statuses" in request.GET:
+            statuses = [
+                string_to_status_lookup[status] for status in request.GET.getlist("statuses")
+            ]
+            new_format = True
+        else:
+            statuses = [GroupHistoryStatus.UNRESOLVED] + ACTIONED_STATUSES
+            new_format = False
+
+        new_issues = []
+        if GroupHistoryStatus.NEW in statuses:
+            statuses.remove(GroupHistoryStatus.NEW)
+            new_issues = list(
+                Group.objects.filter_to_team(team)
+                .filter(first_seen__gte=start, first_seen__lte=end)
+                .annotate(bucket=TruncDay("first_seen"))
+                .order_by("bucket")
+                .values("project", "bucket")
+                .annotate(
+                    count=Count("id"),
+                    status=Value(GroupHistoryStatus.NEW, output_field=IntegerField()),
+                )
+            )
+
         bucketed_issues = (
             GroupHistory.objects.filter_to_team(team)
             .filter(
-                status__in=[GroupHistoryStatus.UNRESOLVED] + ACTIONED_STATUSES,
+                status__in=statuses,
                 date_added__gte=start,
                 date_added__lte=end,
             )
@@ -39,19 +70,28 @@ class TeamIssueBreakdownEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignor
             .annotate(count=Count("id"))
         )
 
+        base_day_format = {"total": 0}
+        if new_format:
+            for status in statuses:
+                base_day_format[status_to_string_lookup[status]] = 0
+        else:
+            base_day_format["reviewed"] = 0
+
         current_day, date_series_dict = start, {}
         while current_day < end:
-            date_series_dict[current_day.isoformat()] = {"reviewed": 0, "total": 0}
+            date_series_dict[current_day.isoformat()] = copy.deepcopy(base_day_format)
             current_day += timedelta(days=1)
 
         project_list = Project.objects.get_for_team_ids(team_ids=[team.id])
         agg_project_counts = {
             project.id: copy.deepcopy(date_series_dict) for project in project_list
         }
-        for r in bucketed_issues:
+        for r in chain(bucketed_issues, new_issues):
             bucket = agg_project_counts[r["project"]][r["bucket"].isoformat()]
             bucket["total"] += r["count"]
-            if r["status"] != GroupHistoryStatus.UNRESOLVED:
+            if not new_format and r["status"] != GroupHistoryStatus.UNRESOLVED:
                 bucket["reviewed"] += r["count"]
+            if new_format:
+                bucket[status_to_string_lookup[r["status"]]] += r["count"]
 
         return Response(agg_project_counts)

--- a/src/sentry/api/endpoints/team_issue_breakdown.py
+++ b/src/sentry/api/endpoints/team_issue_breakdown.py
@@ -43,6 +43,14 @@ class TeamIssueBreakdownEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignor
             new_format = False
 
         new_issues = []
+
+        base_day_format = {"total": 0}
+        if new_format:
+            for status in statuses:
+                base_day_format[status_to_string_lookup[status]] = 0
+        else:
+            base_day_format["reviewed"] = 0
+
         if GroupHistoryStatus.NEW in statuses:
             statuses.remove(GroupHistoryStatus.NEW)
             new_issues = list(
@@ -69,13 +77,6 @@ class TeamIssueBreakdownEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignor
             .values("project", "bucket", "status")
             .annotate(count=Count("id"))
         )
-
-        base_day_format = {"total": 0}
-        if new_format:
-            for status in statuses:
-                base_day_format[status_to_string_lookup[status]] = 0
-        else:
-            base_day_format["reviewed"] = 0
 
         current_day, date_series_dict = start, {}
         while current_day < end:

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -34,6 +34,29 @@ class GroupHistoryStatus:
     DELETED = 8
     DELETED_AND_DISCARDED = 9
     REVIEWED = 10
+    # Just reserving this for us with queries, we don't store the first time a group is created in
+    # `GroupHistoryStatus`
+    NEW = 20
+
+
+string_to_status_lookup = {
+    "unresolved": GroupHistoryStatus.UNRESOLVED,
+    "resolved": GroupHistoryStatus.RESOLVED,
+    "set_resolved_in_release": GroupHistoryStatus.SET_RESOLVED_IN_RELEASE,
+    "set_resolved_in_commit": GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
+    "set_resolved_in_pull_request": GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST,
+    "auto_resolved": GroupHistoryStatus.AUTO_RESOLVED,
+    "ignored": GroupHistoryStatus.IGNORED,
+    "unignored": GroupHistoryStatus.UNIGNORED,
+    "assigned": GroupHistoryStatus.ASSIGNED,
+    "unassigned": GroupHistoryStatus.UNASSIGNED,
+    "regressed": GroupHistoryStatus.REGRESSED,
+    "deleted": GroupHistoryStatus.DELETED,
+    "deleted_and_discarded": GroupHistoryStatus.DELETED_AND_DISCARDED,
+    "reviewed": GroupHistoryStatus.REVIEWED,
+    "new": GroupHistoryStatus.NEW,
+}
+status_to_string_lookup = {status: string for string, status in string_to_status_lookup.items()}
 
 
 ACTIONED_STATUSES = [

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -383,6 +383,8 @@ class Fixtures:
         return Factories.create_identity_provider(*args, **kwargs)
 
     def create_group_history(self, *args, **kwargs):
+        if "actor" not in kwargs:
+            kwargs["actor"] = self.user.actor
         return Factories.create_group_history(*args, **kwargs)
 
     @pytest.fixture(autouse=True)

--- a/tests/sentry/api/endpoints/test_team_issue_breakdown.py
+++ b/tests/sentry/api/endpoints/test_team_issue_breakdown.py
@@ -89,6 +89,17 @@ class TeamIssueBreakdownTest(APITestCase):
         compare_response(statuses, response.data[project2.id][yesterday])
         compare_response(statuses, response.data[project2.id][two_days_ago])
 
+        statuses = ["resolved", "new"]
+        response = self.get_success_response(
+            self.team.organization.slug, self.team.slug, statsPeriod="7d", statuses=statuses
+        )
+        compare_response(statuses, response.data[project1.id][today], new=1, total=1)
+        compare_response(statuses, response.data[project1.id][yesterday])
+        compare_response(statuses, response.data[project1.id][two_days_ago], resolved=1, total=1)
+        compare_response(statuses, response.data[project2.id][today], new=1, resolved=2, total=3)
+        compare_response(statuses, response.data[project2.id][yesterday])
+        compare_response(statuses, response.data[project2.id][two_days_ago])
+
     def test_old_format(self):
         project1 = self.create_project(teams=[self.team], slug="foo")
         project2 = self.create_project(teams=[self.team], slug="bar")

--- a/tests/sentry/api/endpoints/test_team_issue_breakdown.py
+++ b/tests/sentry/api/endpoints/test_team_issue_breakdown.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from django.utils.timezone import now
 from freezegun import freeze_time
 
-from sentry.models import GroupAssignee, GroupHistory, GroupHistoryStatus
+from sentry.models import GroupAssignee, GroupHistoryStatus
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 
@@ -13,7 +13,83 @@ from sentry.testutils.helpers.datetime import before_now
 class TeamIssueBreakdownTest(APITestCase):
     endpoint = "sentry-api-0-team-issue-breakdown"
 
-    def test_simple(self):
+    def test_status_format(self):
+        project1 = self.create_project(teams=[self.team], slug="foo")
+        project2 = self.create_project(teams=[self.team], slug="bar")
+        group1 = self.create_group(checksum="a" * 32, project=project1)
+        group2 = self.create_group(checksum="b" * 32, project=project2)
+        GroupAssignee.objects.assign(group1, self.user)
+        GroupAssignee.objects.assign(group2, self.user)
+
+        self.create_group_history(
+            group=group1, date_added=before_now(days=5), status=GroupHistoryStatus.UNRESOLVED
+        )
+        self.create_group_history(
+            group=group1, date_added=before_now(days=2), status=GroupHistoryStatus.RESOLVED
+        )
+        self.create_group_history(
+            group=group1, date_added=before_now(days=2), status=GroupHistoryStatus.REGRESSED
+        )
+        self.create_group_history(
+            group=group2, date_added=before_now(days=10), status=GroupHistoryStatus.UNRESOLVED
+        )
+        self.create_group_history(
+            group=group2, date_added=before_now(days=1), status=GroupHistoryStatus.UNRESOLVED
+        )
+        self.create_group_history(group=group2, status=GroupHistoryStatus.RESOLVED)
+        self.create_group_history(group=group2, status=GroupHistoryStatus.RESOLVED)
+        self.create_group_history(group=group2, status=GroupHistoryStatus.IGNORED)
+
+        today = str(
+            now()
+            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+            .isoformat()
+        )
+        yesterday = str(
+            (now() - timedelta(days=1))
+            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+            .isoformat()
+        )
+        two_days_ago = str(
+            (now() - timedelta(days=2))
+            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+            .isoformat()
+        )
+        self.login_as(user=self.user)
+        statuses = ["resolved", "regressed", "unresolved", "ignored"]
+        response = self.get_success_response(
+            self.team.organization.slug, self.team.slug, statsPeriod="7d", statuses=statuses
+        )
+
+        def compare_response(statuses, data_for_day, **expected_status_counts):
+            result = {status: 0 for status in statuses}
+            result["total"] = 0
+            result.update(expected_status_counts)
+            assert result == data_for_day
+
+        compare_response(statuses, response.data[project1.id][today])
+        compare_response(statuses, response.data[project1.id][yesterday])
+        compare_response(
+            statuses, response.data[project1.id][two_days_ago], regressed=1, resolved=1, total=2
+        )
+        compare_response(
+            statuses, response.data[project2.id][today], ignored=1, resolved=2, total=3
+        )
+        compare_response(statuses, response.data[project2.id][yesterday], unresolved=1, total=1)
+        compare_response(statuses, response.data[project2.id][two_days_ago])
+
+        statuses = ["resolved"]
+        response = self.get_success_response(
+            self.team.organization.slug, self.team.slug, statsPeriod="7d", statuses=statuses
+        )
+        compare_response(statuses, response.data[project1.id][today])
+        compare_response(statuses, response.data[project1.id][yesterday])
+        compare_response(statuses, response.data[project1.id][two_days_ago], resolved=1, total=1)
+        compare_response(statuses, response.data[project2.id][today], resolved=2, total=2)
+        compare_response(statuses, response.data[project2.id][yesterday])
+        compare_response(statuses, response.data[project2.id][two_days_ago])
+
+    def test_old_format(self):
         project1 = self.create_project(teams=[self.team], slug="foo")
         project2 = self.create_project(teams=[self.team], slug="bar")
         group1 = self.create_group(checksum="a" * 32, project=project1, times_seen=10)
@@ -21,68 +97,25 @@ class TeamIssueBreakdownTest(APITestCase):
         GroupAssignee.objects.assign(group1, self.user)
         GroupAssignee.objects.assign(group2, self.user)
 
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group1,
-            project=project1,
-            actor=self.user.actor,
-            date_added=before_now(days=5),
-            status=GroupHistoryStatus.UNRESOLVED,
+        self.create_group_history(
+            group=group1, date_added=before_now(days=5), status=GroupHistoryStatus.UNRESOLVED
         )
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group1,
-            project=project1,
-            actor=self.user.actor,
-            status=GroupHistoryStatus.RESOLVED,
-            date_added=before_now(days=2),
+        self.create_group_history(
+            group=group1, date_added=before_now(days=2), status=GroupHistoryStatus.RESOLVED
         )
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group1,
-            project=project1,
-            actor=self.user.actor,
-            status=GroupHistoryStatus.REGRESSED,
-            date_added=before_now(days=2),
+        self.create_group_history(
+            group=group1, date_added=before_now(days=2), status=GroupHistoryStatus.REGRESSED
         )
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group2,
-            project=project2,
-            actor=self.user.actor,
-            date_added=before_now(days=10),
-            status=GroupHistoryStatus.UNRESOLVED,
+        self.create_group_history(
+            group=group2, date_added=before_now(days=10), status=GroupHistoryStatus.UNRESOLVED
         )
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group2,
-            project=project2,
-            actor=self.user.actor,
-            date_added=before_now(days=1),
-            status=GroupHistoryStatus.UNRESOLVED,
+        self.create_group_history(
+            group=group2, date_added=before_now(days=1), status=GroupHistoryStatus.UNRESOLVED
         )
+        self.create_group_history(group=group2, status=GroupHistoryStatus.RESOLVED)
+        self.create_group_history(group=group2, status=GroupHistoryStatus.RESOLVED)
+        self.create_group_history(group=group2, status=GroupHistoryStatus.IGNORED)
 
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group2,
-            project=project2,
-            actor=self.user.actor,
-            status=GroupHistoryStatus.RESOLVED,
-        )
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group2,
-            project=project2,
-            actor=self.user.actor,
-            status=GroupHistoryStatus.RESOLVED,
-        )
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group2,
-            project=project2,
-            actor=self.user.actor,
-            status=GroupHistoryStatus.IGNORED,
-        )
         today = str(
             now()
             .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
@@ -117,30 +150,12 @@ class TeamIssueBreakdownTest(APITestCase):
         assert response.data[project2.id][two_days_ago]["reviewed"] == 0
         assert response.data[project2.id][two_days_ago]["total"] == 0
 
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group1,
-            project=project1,
-            actor=self.user.actor,
-            date_added=before_now(days=1),
-            status=GroupHistoryStatus.UNRESOLVED,
+        self.create_group_history(
+            group=group1, date_added=before_now(days=1), status=GroupHistoryStatus.UNRESOLVED
         )
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group2,
-            project=project2,
-            actor=self.user.actor,
-            status=GroupHistoryStatus.RESOLVED,
-        )
-
+        self.create_group_history(group=group2, status=GroupHistoryStatus.RESOLVED)
         # making sure it doesnt bork anything
-        GroupHistory.objects.create(
-            organization=self.organization,
-            group=group2,
-            project=project2,
-            actor=self.user.actor,
-            status=GroupHistoryStatus.ASSIGNED,
-        )
+        self.create_group_history(group=group2, status=GroupHistoryStatus.ASSIGNED)
 
         response = self.get_success_response(self.team.organization.slug, self.team.slug)
         assert len(response.data) == 2


### PR DESCRIPTION
This allows a list of statuses to be passed to the issue breakdown endpoint. If no list of statuses
is passed, the old behaviour will be used, where we return the data for each bucket like:
`{"total": 0, "reviewed": 0}`

If a list of statuses is passed, then reviewed will be replaced by the specifically requested
statuses instead. So if `["new", "unresolved", "regressed"]` was passed, each bucket would look like
`{"total": 0, "new": 0, "unresolved": 0, "regressed": 0}`