### PR TITLE
fix(js): Ensure Reflux Actions specify store dependants

### DIFF
--- a/static/app/actions/alertActions.tsx
+++ b/static/app/actions/alertActions.tsx
@@ -1,3 +1,5 @@
+import 'sentry/stores/alertStore';
+
 import Reflux from 'reflux';
 
 const AlertActions = Reflux.createActions(['addAlert', 'closeAlert']);

--- a/static/app/actions/committerActions.tsx
+++ b/static/app/actions/committerActions.tsx
@@ -1,3 +1,12 @@
+import 'sentry/stores/committerStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['reset', 'load', 'loadError', 'loadSuccess']);
+const ComitterActions = Reflux.createActions([
+  'reset',
+  'load',
+  'loadError',
+  'loadSuccess',
+]);
+
+export default ComitterActions;

--- a/static/app/actions/environmentActions.tsx
+++ b/static/app/actions/environmentActions.tsx
@@ -1,7 +1,11 @@
+import 'sentry/stores/organizationEnvironmentsStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions([
+const EnvironmentActions = Reflux.createActions([
   'fetchEnvironments',
   'fetchEnvironmentsError',
   'fetchEnvironmentsSuccess',
 ]);
+
+export default EnvironmentActions;

--- a/static/app/actions/formSearchActions.tsx
+++ b/static/app/actions/formSearchActions.tsx
@@ -1,3 +1,7 @@
+import 'sentry/stores/formSearchStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['loadSearchMap']);
+const FormSearchActions = Reflux.createActions(['loadSearchMap']);
+
+export default FormSearchActions;

--- a/static/app/actions/globalSelectionActions.tsx
+++ b/static/app/actions/globalSelectionActions.tsx
@@ -1,6 +1,8 @@
+import 'sentry/stores/globalSelectionStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions([
+const GlobalSelectionActions = Reflux.createActions([
   'reset',
   'setOrganization',
   'initializeUrlState',
@@ -9,3 +11,5 @@ export default Reflux.createActions([
   'updateEnvironments',
   'save',
 ]);
+
+export default GlobalSelectionActions;

--- a/static/app/actions/groupActions.tsx
+++ b/static/app/actions/groupActions.tsx
@@ -1,3 +1,6 @@
+import 'sentry/stores/groupingStore';
+import 'sentry/stores/groupStore';
+
 import Reflux from 'reflux';
 
 // TODO(dcramer): we should probably just make every parameter update

--- a/static/app/actions/groupingActions.tsx
+++ b/static/app/actions/groupingActions.tsx
@@ -1,3 +1,5 @@
+import 'sentry/stores/groupingStore';
+
 import Reflux from 'reflux';
 
 // Actions for "Grouping" view - for merging/unmerging events/issues
@@ -11,4 +13,5 @@ const GroupingActions = Reflux.createActions([
   'toggleCollapseFingerprint',
   'toggleCollapseFingerprints',
 ]);
+
 export default GroupingActions;

--- a/static/app/actions/guideActions.tsx
+++ b/static/app/actions/guideActions.tsx
@@ -1,3 +1,5 @@
+import 'sentry/stores/guideStore';
+
 import Reflux from 'reflux';
 
 const GuideActions = Reflux.createActions([

--- a/static/app/actions/indicatorActions.tsx
+++ b/static/app/actions/indicatorActions.tsx
@@ -1,3 +1,5 @@
+import 'sentry/stores/indicatorStore';
+
 import Reflux from 'reflux';
 
 const IndicatorActions = Reflux.createActions([

--- a/static/app/actions/memberActions.tsx
+++ b/static/app/actions/memberActions.tsx
@@ -1,3 +1,5 @@
+import 'sentry/stores/memberListStore';
+
 import Reflux from 'reflux';
 
 const MemberActions = Reflux.createActions([

--- a/static/app/actions/modalActions.tsx
+++ b/static/app/actions/modalActions.tsx
@@ -1,3 +1,7 @@
+import 'sentry/stores/modalStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['openModal', 'closeModal']);
+const ModalActions = Reflux.createActions(['openModal', 'closeModal']);
+
+export default ModalActions;

--- a/static/app/actions/navigationActions.tsx
+++ b/static/app/actions/navigationActions.tsx
@@ -1,3 +1,7 @@
+import 'sentry/stores/latestContextStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['setLastRoute']);
+const NavigationActions = Reflux.createActions(['setLastRoute']);
+
+export default NavigationActions;

--- a/static/app/actions/organizationActions.tsx
+++ b/static/app/actions/organizationActions.tsx
@@ -1,3 +1,9 @@
+import 'sentry/stores/latestContextStore';
+import 'sentry/stores/releaseStore';
+import 'sentry/stores/organizationStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['reset', 'fetchOrgError', 'update']);
+const OrganizationActions = Reflux.createActions(['reset', 'fetchOrgError', 'update']);
+
+export default OrganizationActions;

--- a/static/app/actions/organizationsActions.tsx
+++ b/static/app/actions/organizationsActions.tsx
@@ -1,3 +1,7 @@
+import 'sentry/stores/organizationsStore';
+import 'sentry/stores/latestContextStore';
+import 'sentry/stores/guideStore';
+
 import Reflux from 'reflux';
 
 const OrganizationsActions = Reflux.createActions([

--- a/static/app/actions/pluginActions.tsx
+++ b/static/app/actions/pluginActions.tsx
@@ -1,3 +1,5 @@
+import 'sentry/stores/pluginsStore';
+
 import Reflux from 'reflux';
 
 const PluginActions = Reflux.createActions([

--- a/static/app/actions/preferencesActions.tsx
+++ b/static/app/actions/preferencesActions.tsx
@@ -1,3 +1,5 @@
+import 'sentry/stores/preferencesStore';
+
 import Reflux from 'reflux';
 
 const PreferencesActions = Reflux.createActions([

--- a/static/app/actions/projectActions.tsx
+++ b/static/app/actions/projectActions.tsx
@@ -1,6 +1,10 @@
+import 'sentry/stores/projectsStore';
+import 'sentry/stores/projectsStatsStore';
+import 'sentry/stores/latestContextStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions([
+const ProjectActions = Reflux.createActions([
   'addTeam',
   'addTeamError',
   'addTeamSuccess',
@@ -23,3 +27,5 @@ export default Reflux.createActions([
   'updateError',
   'updateSuccess',
 ]);
+
+export default ProjectActions;

--- a/static/app/actions/releaseActions.tsx
+++ b/static/app/actions/releaseActions.tsx
@@ -1,6 +1,8 @@
+import 'sentry/stores/releaseStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions([
+const ReleaseActions = Reflux.createActions([
   'loadRelease', // Singular as it loads 1 release
   'loadReleaseError',
   'loadReleaseSuccess',
@@ -8,3 +10,5 @@ export default Reflux.createActions([
   'loadDeploysError',
   'loadDeploysSuccess',
 ]);
+
+export default ReleaseActions;

--- a/static/app/actions/repositoryActions.tsx
+++ b/static/app/actions/repositoryActions.tsx
@@ -1,8 +1,12 @@
+import 'sentry/stores/repositoryStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions([
+const RepositoryActions = Reflux.createActions([
   'resetRepositories',
   'loadRepositories',
   'loadRepositoriesError',
   'loadRepositoriesSuccess',
 ]);
+
+export default RepositoryActions;

--- a/static/app/actions/savedSearchesActions.tsx
+++ b/static/app/actions/savedSearchesActions.tsx
@@ -1,6 +1,8 @@
+import 'sentry/stores/savedSearchesStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions([
+const SavedSearchActions = Reflux.createActions([
   'resetSavedSearches',
   'startFetchSavedSearches',
   'fetchSavedSearchesSuccess',
@@ -11,3 +13,5 @@ export default Reflux.createActions([
   'pinSearchSuccess',
   'unpinSearch',
 ]);
+
+export default SavedSearchActions;

--- a/static/app/actions/sdkUpdatesActions.tsx
+++ b/static/app/actions/sdkUpdatesActions.tsx
@@ -1,3 +1,5 @@
+import 'sentry/stores/sdkUpdatesStore';
+
 import Reflux from 'reflux';
 
 const SdkUpdatesActions = Reflux.createActions(['load']);

--- a/static/app/actions/sentryAppComponentActions.tsx
+++ b/static/app/actions/sentryAppComponentActions.tsx
@@ -1,3 +1,7 @@
+import 'sentry/stores/sentryAppComponentsStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['loadComponents']);
+const SentryAppComponentActions = Reflux.createActions(['loadComponents']);
+
+export default SentryAppComponentActions;

--- a/static/app/actions/settingsBreadcrumbActions.tsx
+++ b/static/app/actions/settingsBreadcrumbActions.tsx
@@ -1,3 +1,7 @@
+import 'sentry/stores/settingsBreadcrumbStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['mapTitle', 'trimMappings']);
+const SettingsBreadcrumbActions = Reflux.createActions(['mapTitle', 'trimMappings']);
+
+export default SettingsBreadcrumbActions;

--- a/static/app/actions/sidebarPanelActions.tsx
+++ b/static/app/actions/sidebarPanelActions.tsx
@@ -1,3 +1,11 @@
+import 'sentry/stores/sidebarPanelStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['activatePanel', 'togglePanel', 'hidePanel']);
+const SidebarPanelActions = Reflux.createActions([
+  'activatePanel',
+  'togglePanel',
+  'hidePanel',
+]);
+
+export default SidebarPanelActions;

--- a/static/app/actions/tagActions.tsx
+++ b/static/app/actions/tagActions.tsx
@@ -1,3 +1,9 @@
+import 'sentry/stores/groupStore';
+import 'sentry/stores/groupingStore';
+import 'sentry/stores/tagStore';
+
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['loadTagsError', 'loadTagsSuccess']);
+const TagActions = Reflux.createActions(['loadTagsError', 'loadTagsSuccess']);
+
+export default TagActions;

--- a/static/app/actions/teamActions.tsx
+++ b/static/app/actions/teamActions.tsx
@@ -1,3 +1,6 @@
+import 'sentry/stores/teamStore';
+import 'sentry/stores/projectsStore';
+
 import Reflux from 'reflux';
 
 const TeamActions = Reflux.createActions([


### PR DESCRIPTION
This fixes an issue where store actions may be triggered without any stores actually listening to those actions yet, because webpack did not know the store needed to be loaded and initialized.

This scenario could be seen with the LatestContextStore, as it seems the loading of this store has changed at some point recently so that it is no longer initialized before the `OrganizationActions.setActive` action was being called, thus the latest context was never correctly set.