### PR TITLE
fix(ui): Ensure LatestContextStore is initialized

### DIFF
--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -1,3 +1,7 @@
+// XXX(epurkhiser): Ensure the LatestContextStore is initialized before we set
+// the active org. Otherwise we will trigger an action that does nothing
+import 'sentry/stores/latestContextStore';
+
 import * as Sentry from '@sentry/react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/30804 doesn't quite work due to circular dependencies.

So this is a quick-fix for now for the issue with the LatestContextStore not being initialized when the active org is being set.