### PR TITLE
feat(insights): Implement all unresolved issues endpoint (WOR-1514)

### DIFF
--- a/src/sentry/api/endpoints/team_all_unresolved_issues.py
+++ b/src/sentry/api/endpoints/team_all_unresolved_issues.py
@@ -1,0 +1,154 @@
+import copy
+from datetime import timedelta
+from itertools import chain
+
+from django.db.models import Count, ExpressionWrapper, F, IntegerField, Min, Q
+from django.db.models.functions import TruncDay
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.base import EnvironmentMixin
+from sentry.api.bases.team import TeamEndpoint
+from sentry.api.utils import get_date_range_from_params
+from sentry.models import Group, GroupHistory, GroupHistoryStatus, Project, Team
+from sentry.models.grouphistory import RESOLVED_STATUSES, UNRESOLVED_STATUSES
+
+OPEN_STATUSES = UNRESOLVED_STATUSES + (GroupHistoryStatus.UNIGNORED,)
+CLOSED_STATUSES = RESOLVED_STATUSES + (GroupHistoryStatus.IGNORED,)
+
+
+class TeamAllUnresolvedIssuesEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignore
+    def get(self, request: Request, team: Team) -> Response:
+        """
+        Returns cumulative counts of unresolved groups per day within the stats period time range.
+        Response:
+        {
+            <project_id>: {
+                <isoformat_date>: {"unresolved": <unresolved_count>},
+                ...
+            }
+            ...
+        }
+        """
+        if not features.has("organizations:team-insights", team.organization, actor=request.user):
+            return Response({"detail": "You do not have the insights feature enabled"}, status=400)
+        start, end = get_date_range_from_params(request.GET)
+        end = end.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+        start = start.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+
+        # First we get the count of unresolved groups from before we were writing `GroupHistory`
+        # records. This will be reasonably accurate but not perfect.
+        oldest_history_date = GroupHistory.objects.filter_to_team(team).aggregate(
+            Min("date_added"),
+        )["date_added__min"]
+
+        project_unresolved = {
+            r["project"]: r["unresolved"]
+            for r in (
+                Group.objects.filter_to_team(team)
+                .filter(first_seen__lt=oldest_history_date)
+                .values("project")
+                .annotate(
+                    total=Count("id"),
+                    resolved=Count("id", filter=Q(resolved_at__lt=oldest_history_date)),
+                )
+                .annotate(
+                    unresolved=ExpressionWrapper(
+                        F("total") - F("resolved"), output_field=IntegerField()
+                    )
+                )
+            )
+        }
+        # TODO: Could get ignored counts from `GroupSnooze` too
+
+        # Next, if there's data in the group history table before the stats period then grab that
+        # and use it to help calculate the initial unresolved value
+        if oldest_history_date < start:
+            new_for_projects = (
+                Group.objects.filter_to_team(team)
+                .filter(
+                    first_seen__gte=oldest_history_date,
+                    first_seen__lt=start,
+                )
+                .values("project")
+                .annotate(open=Count("id"))
+            )
+            initial_project_history_counts = (
+                GroupHistory.objects.filter_to_team(team)
+                .filter(
+                    date_added__gte=oldest_history_date,
+                    date_added__lt=start,
+                )
+                .values("project")
+                .annotate(
+                    reopened=Count("id", filter=Q(status__in=OPEN_STATUSES)),
+                    closed=Count("id", filter=Q(status__in=CLOSED_STATUSES)),
+                )
+            )
+            for row in new_for_projects:
+                project_unresolved.setdefault(row["project"], 0)
+                project_unresolved[row["project"]] += row["open"]
+            for row in initial_project_history_counts:
+                project_unresolved.setdefault(row["project"], 0)
+                project_unresolved[row["project"]] += row["reopened"] - row["closed"]
+
+        # Just a failsafe to make sure we haven't gone below 0
+        for project in list(project_unresolved.keys()):
+            project_unresolved[project] = max(0, project_unresolved[project])
+
+        # Now we grab the rest of the data bucketed by day
+        new_issues = (
+            Group.objects.filter_to_team(team)
+            .filter(
+                first_seen__gte=start,
+                first_seen__lt=end,
+            )
+            .annotate(bucket=TruncDay("first_seen"))
+            .order_by("bucket")
+            .values("project", "bucket")
+            .annotate(open=Count("id"))
+        )
+
+        bucketed_issues = (
+            GroupHistory.objects.filter_to_team(team)
+            .filter(
+                date_added__gte=start,
+                date_added__lte=end,
+            )
+            .annotate(bucket=TruncDay("date_added"))
+            .order_by("bucket")
+            .values("project", "bucket")
+            .annotate(
+                open=Count("id", filter=Q(status__in=OPEN_STATUSES)),
+                closed=Count("id", filter=Q(status__in=CLOSED_STATUSES)),
+            )
+        )
+
+        current_day, date_series_dict = start, {}
+        while current_day < end:
+            date_series_dict[current_day.isoformat()] = {"open": 0, "closed": 0}
+            current_day += timedelta(days=1)
+
+        project_list = Project.objects.get_for_team_ids(team_ids=[team.id])
+        agg_project_precounts = {
+            project.id: copy.deepcopy(date_series_dict) for project in project_list
+        }
+        for r in chain(bucketed_issues, new_issues):
+            bucket = agg_project_precounts[r["project"]][r["bucket"].isoformat()]
+            bucket["open"] += r.get("open", 0)
+            bucket["closed"] += r.get("closed", 0)
+
+        agg_project_counts = {}
+
+        for project, precounts in agg_project_precounts.items():
+            open = project_unresolved.get(project, 0)
+            sorted_bucket_keys = sorted(precounts.keys())
+            project_counts = {}
+            for bucket_key in sorted_bucket_keys:
+                bucket = precounts[bucket_key]
+                open = max(open + bucket["open"] - bucket["closed"], 0)
+                project_counts[bucket_key] = {"unresolved": open}
+            agg_project_counts[project] = project_counts
+
+        return Response(agg_project_counts)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -405,6 +405,7 @@ from .endpoints.team_alerts_triggered import (
     TeamAlertsTriggeredIndexEndpoint,
     TeamAlertsTriggeredTotalsEndpoint,
 )
+from .endpoints.team_all_unresolved_issues import TeamAllUnresolvedIssuesEndpoint
 from .endpoints.team_avatar import TeamAvatarEndpoint
 from .endpoints.team_details import TeamDetailsEndpoint
 from .endpoints.team_groups_old import TeamGroupsOldEndpoint
@@ -1560,6 +1561,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/issue-breakdown/$",
                     TeamIssueBreakdownEndpoint.as_view(),
                     name="sentry-api-0-team-issue-breakdown",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/all-unresolved-issues/$",
+                    TeamAllUnresolvedIssuesEndpoint.as_view(),
+                    name="sentry-api-0-team-all-unresolved-issues",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/notification-settings/$",

--- a/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
+++ b/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
@@ -1,0 +1,118 @@
+from datetime import timedelta
+
+from django.utils import timezone
+from django.utils.timezone import now
+from freezegun import freeze_time
+
+from sentry.models import GroupAssignee, GroupHistory, GroupHistoryStatus
+from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+@freeze_time()
+class TeamIssueBreakdownTest(APITestCase):
+    endpoint = "sentry-api-0-team-all-unresolved-issues"
+
+    def test_status_format(self):
+        project1 = self.create_project(teams=[self.team])
+        group1_1 = self.create_group(project=project1, first_seen=before_now(days=40))
+        group1_2 = self.create_group(project=project1, first_seen=before_now(days=5))
+        group1_3 = self.create_group(
+            project=project1, first_seen=before_now(days=40), resolved_at=before_now(days=35)
+        )
+        group1_4 = self.create_group(
+            project=project1, first_seen=before_now(days=40), resolved_at=before_now(days=9)
+        )
+        group1_5 = self.create_group(project=project1, first_seen=before_now(days=40))
+        GroupAssignee.objects.assign(group1_1, self.user)
+        GroupAssignee.objects.assign(group1_2, self.user)
+        GroupAssignee.objects.assign(group1_3, self.user)
+        GroupAssignee.objects.assign(group1_4, self.user)
+        GroupAssignee.objects.assign(group1_5, self.user)
+        GroupHistory.objects.all().delete()
+
+        self.create_group_history(
+            group=group1_1, date_added=before_now(days=5), status=GroupHistoryStatus.RESOLVED
+        )
+        self.create_group_history(
+            group=group1_1, date_added=before_now(days=3), status=GroupHistoryStatus.UNRESOLVED
+        )
+        self.create_group_history(
+            group=group1_2, date_added=before_now(days=3), status=GroupHistoryStatus.RESOLVED
+        )
+        self.create_group_history(
+            group=group1_2, date_added=before_now(days=3), status=GroupHistoryStatus.REGRESSED
+        )
+        self.create_group_history(
+            group=group1_4, date_added=before_now(days=9), status=GroupHistoryStatus.RESOLVED
+        )
+        project2 = self.create_project(teams=[self.team])
+        group2_1 = self.create_group(project=project2, first_seen=before_now(days=40))
+        GroupAssignee.objects.assign(group2_1, self.user)
+        self.create_group_history(
+            group=group2_1, date_added=before_now(days=6), status=GroupHistoryStatus.RESOLVED
+        )
+        self.create_group_history(
+            group=group2_1, date_added=before_now(days=5), status=GroupHistoryStatus.REGRESSED
+        )
+        self.create_group_history(
+            group=group2_1, date_added=before_now(days=4), status=GroupHistoryStatus.IGNORED
+        )
+        self.create_group_history(
+            group=group2_1, date_added=before_now(days=3), status=GroupHistoryStatus.UNIGNORED
+        )
+        self.create_group_history(
+            group=group2_1,
+            date_added=before_now(days=2),
+            status=GroupHistoryStatus.SET_RESOLVED_IN_RELEASE,
+        )
+        self.create_group_history(
+            group=group2_1, date_added=before_now(days=1), status=GroupHistoryStatus.REGRESSED
+        )
+        self.create_group_history(
+            group=group2_1, date_added=before_now(days=0), status=GroupHistoryStatus.RESOLVED
+        )
+
+        project3 = self.create_project(teams=[self.team])
+        group3_1 = self.create_group(project=project3, first_seen=before_now(days=5))
+        GroupAssignee.objects.assign(group3_1, self.user)
+        self.create_group_history(
+            group=group3_1, date_added=before_now(days=4), status=GroupHistoryStatus.RESOLVED
+        )
+        self.create_group_history(
+            group=group3_1, date_added=before_now(days=4), status=GroupHistoryStatus.UNRESOLVED
+        )
+        self.create_group_history(
+            group=group3_1, date_added=before_now(days=4), status=GroupHistoryStatus.RESOLVED
+        )
+        self.create_group_history(
+            group=group3_1, date_added=before_now(days=4), status=GroupHistoryStatus.UNRESOLVED
+        )
+        self.create_group_history(
+            group=group3_1, date_added=before_now(days=4), status=GroupHistoryStatus.RESOLVED
+        )
+        self.create_group_history(
+            group=group3_1, date_added=before_now(days=4), status=GroupHistoryStatus.UNRESOLVED
+        )
+        self.create_group_history(
+            group=group3_1, date_added=before_now(days=4), status=GroupHistoryStatus.RESOLVED
+        )
+
+        self.login_as(user=self.user)
+        response = self.get_success_response(
+            self.team.organization.slug, self.team.slug, statsPeriod="7d"
+        )
+
+        def compare_response(response, project, expected_results):
+            start = (now() - timedelta(days=len(expected_results) - 1)).replace(
+                hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc
+            )
+            expected = {
+                (start + timedelta(days=i)).isoformat(): {"unresolved": value}
+                for i, value in enumerate(expected_results)
+            }
+            assert expected == response.data[project.id]
+
+        compare_response(response, project1, [2, 2, 2, 3, 3, 3, 3])
+        compare_response(response, project2, [0, 1, 0, 1, 0, 1, 0])
+        compare_response(response, project3, [0, 1, 0, 0, 0, 0, 0])


### PR DESCRIPTION
This implements an endpoint to return the cumulative daily counts of unresolved issues. I'll add a
separate pr to put some useful indexes in place, but they're not required for testing.

To build this data we have these steps:

- Fetch cumulative data of unresolved issues from before we have `GroupHistory` rows. This data won't
  be perfectly accurate, but as time goes on we will rely on this less and the `GroupHistory` table
  more.
- Fetch cumulative data from `GroupHistory` table and group table if rows exist in `GroupHistory`
  before the requested statsperiod.
- Combine these sources together to get the count of unresolved issues per project before the stats
  period. This is then used as the starting point for building up the cumulative stats.
- We then get daily buckets of when issues were "opened" (created, unresolved and similar) and
  "closed" (resolved, ignored, etc).
- Finally, we iterate over all the daily data in order, add it to the cumulative number of
  unresolved issues and use that cumulative number as the number of unresolved issues for that day.