### PR TITLE
fix(widget-library): Consider previous modification to dashboard

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -275,16 +275,16 @@ class DashboardDetail extends Component<Props, State> {
 
   handleAddLibraryWidgets = (widgets: Widget[]) => {
     const {organization, dashboard, api, onDashboardUpdate, location} = this.props;
-    const {dashboardState} = this.state;
-    const modifiedDashboard = {
-      ...cloneDashboard(dashboard),
+    const {dashboardState, modifiedDashboard} = this.state;
+    const newModifiedDashboard = {
+      ...cloneDashboard(modifiedDashboard || dashboard),
       widgets: widgets.map(assignTempId),
     };
-    this.setState({modifiedDashboard});
+    this.setState({modifiedDashboard: newModifiedDashboard});
     if ([DashboardState.CREATE, DashboardState.EDIT].includes(dashboardState)) {
       return;
     }
-    updateDashboard(api, organization.slug, modifiedDashboard).then(
+    updateDashboard(api, organization.slug, newModifiedDashboard).then(
       (newDashboard: DashboardDetails) => {
         if (onDashboardUpdate) {
           onDashboardUpdate(newDashboard);


### PR DESCRIPTION
Consider other modifications to dashboard (like title) when
updating the dashboard state with new widgets. Fixes bug
where when you click Create Dashboard, update title
and add widgets from the library, the title gets reset to 
Untitled Dashboard.