### PR TITLE
fix(metrics-api): Allow order by percentiles [INGEST-544] [INGEST-807]

### DIFF
--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -1,11 +1,9 @@
-import enum
 import itertools
 import math
 import random
 import re
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from operator import itemgetter
 from typing import (
@@ -260,10 +258,6 @@ class QueryDefinition:
             # orderBy one of the group by fields may be supported in the future
             raise InvalidParams("'orderBy' must be one of the provided 'fields'")
 
-        if op in _OPERATIONS_PERCENTILES:
-            # NOTE(jjbayer): This should work, will fix later
-            raise InvalidParams("'orderBy' percentiles is not yet supported")
-
         return (op, metric_name), direction
 
     def _parse_limit(self, query_params):
@@ -414,31 +408,27 @@ class DataSource(ABC):
         """Get all known values for a specific tag"""
 
 
-@dataclass
-class SnubaField:
-    snuba_function: Literal[
-        "sum", "uniq", "avg", "count", "max", "min", "quantiles(0.5,0.75,0.9,0.95,0.99)"
-    ]
-    snuba_alias: Literal["value", "avg", "count", "max", "min", "percentiles"]
-
-
-_OP_TO_FIELD = {
-    "metrics_counters": {"sum": SnubaField("sum", "value")},
+# Map requested op name to the corresponding Snuba function
+_OP_TO_SNUBA_FUNCTION = {
+    "metrics_counters": {"sum": "sum"},
     "metrics_distributions": {
-        "avg": SnubaField("avg", "avg"),
-        "count": SnubaField("count", "count"),
-        "max": SnubaField("max", "max"),
-        "min": SnubaField("min", "min"),
-        "p50": SnubaField("quantiles(0.5,0.75,0.9,0.95,0.99)", "percentiles"),
-        "p75": SnubaField("quantiles(0.5,0.75,0.9,0.95,0.99)", "percentiles"),
-        "p90": SnubaField("quantiles(0.5,0.75,0.9,0.95,0.99)", "percentiles"),
-        "p95": SnubaField("quantiles(0.5,0.75,0.9,0.95,0.99)", "percentiles"),
-        "p99": SnubaField("quantiles(0.5,0.75,0.9,0.95,0.99)", "percentiles"),
+        "avg": "avg",
+        "count": "count",
+        "max": "max",
+        "min": "min",
+        # TODO: Would be nice to use `quantile(0.50)` (singular) here, but snuba responds with an error
+        "p50": "quantiles(0.50)",
+        "p75": "quantiles(0.75)",
+        "p90": "quantiles(0.90)",
+        "p95": "quantiles(0.95)",
+        "p99": "quantiles(0.99)",
     },
-    "metrics_sets": {"count_unique": SnubaField("uniq", "value")},
+    "metrics_sets": {"count_unique": "uniq"},
 }
 
-_AVAILABLE_OPERATIONS = {type_: sorted(mapping.keys()) for type_, mapping in _OP_TO_FIELD.items()}
+_AVAILABLE_OPERATIONS = {
+    type_: sorted(mapping.keys()) for type_, mapping in _OP_TO_SNUBA_FUNCTION.items()
+}
 
 
 _BASE_TAGS = {
@@ -687,17 +677,6 @@ class MockDataSource(IndexMockingDataSource):
         }
 
 
-PERCENTILE_INDEX = {}
-
-
-class Percentile(enum.Enum):
-    p50 = 0
-    p75 = 1
-    p90 = 2
-    p95 = 3
-    p99 = 4
-
-
 class SnubaQueryBuilder:
 
     #: Datasets actually implemented in snuba:
@@ -743,15 +722,16 @@ class SnubaQueryBuilder:
     ) -> Optional[List[OrderBy]]:
         if query_definition.orderby is None:
             return None
-        (op, metric_name), direction = query_definition.orderby
-        snuba_field = _OP_TO_FIELD[entity][op]
+        (op, _), direction = query_definition.orderby
 
-        return [OrderBy(Column(snuba_field.snuba_alias), direction)]
+        return [OrderBy(Column(op), direction)]
 
     def _build_queries(self, query_definition):
         queries_by_entity = OrderedDict()
         for op, metric_name in query_definition.fields.values():
-            type_ = _get_metric(metric_name)["type"]
+            type_ = _get_metric(metric_name)[
+                "type"
+            ]  # TODO: We should get the metric type from the op name, not the hard-coded lookup of the mock data source
             entity = self._get_entity(type_)
             queries_by_entity.setdefault(entity, []).append((op, metric_name))
 
@@ -766,8 +746,8 @@ class SnubaQueryBuilder:
     @staticmethod
     def _build_select(entity, fields):
         for op, _ in fields:
-            field = _OP_TO_FIELD[entity][op]
-            yield Function(field.snuba_function, [Column("value")], field.snuba_alias)
+            snuba_function = _OP_TO_SNUBA_FUNCTION[entity][op]
+            yield Function(snuba_function, [Column("value")], alias=op)
 
     def _build_queries_for_entity(self, query_definition, entity, fields, where, groupby):
         totals_query = Query(
@@ -866,10 +846,9 @@ class SnubaResultConverter:
         for op in ops:
             key = f"{op}({metric_name})"
 
-            field = _OP_TO_FIELD[entity][op].snuba_alias
-            value = data[field]
-            if field == "percentiles":
-                value = value[Percentile[op].value]
+            value = data[op]
+            if op in _OPERATIONS_PERCENTILES:
+                value = value[0]
 
             # If this is time series data, add it to the appropriate series.
             # Else, add to totals
@@ -1101,7 +1080,7 @@ class MetaFromSnuba:
             value_ids = {value_id for ids in value_id_lists for value_id in ids}
 
         tags = [{"key": tag_name, "value": reverse_resolve(value_id)} for value_id in value_ids]
-        tags.sort(key=itemgetter("key"))
+        tags.sort(key=lambda tag: (tag["key"], tag["value"]))
 
         return tags
 

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -480,6 +480,57 @@ class OrganizationMetricIntegrationTest(SessionMetricsTestCase, APITestCase):
             assert totals == {"count(sentry.transactions.measurements.lcp)": expected_count}
 
     @with_feature(FEATURE_FLAG)
+    def test_orderby_percentile(self):
+        # Record some strings
+        metric_id = indexer.record("sentry.transactions.measurements.lcp")
+        tag1 = indexer.record("tag1")
+        value1 = indexer.record("value1")
+        value2 = indexer.record("value2")
+
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": metric_id,
+                    "timestamp": int(time.time()),
+                    "type": "d",
+                    "value": numbers,
+                    "tags": {tag: value},
+                    "retention_days": 90,
+                }
+                for tag, value, numbers in (
+                    (tag1, value1, [4, 5, 6]),
+                    (tag1, value2, [1, 2, 3]),
+                )
+            ],
+            entity="metrics_distributions",
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field="p50(sentry.transactions.measurements.lcp)",
+            statsPeriod="1h",
+            interval="1h",
+            datasource="snuba",
+            groupBy="tag1",
+            orderBy="p50(sentry.transactions.measurements.lcp)",
+        )
+        groups = response.data["groups"]
+        assert len(groups) == 2
+
+        expected = [
+            ("value2", 2),  # value2 comes first because it has the smaller median
+            ("value1", 5),
+        ]
+        for (expected_tag_value, expected_count), group in zip(expected, groups):
+            # With orderBy, you only get totals:
+            assert "series" not in group
+            assert group["by"] == {"tag1": expected_tag_value}
+            totals = group["totals"]
+            assert totals == {"p50(sentry.transactions.measurements.lcp)": expected_count}
+
+    @with_feature(FEATURE_FLAG)
     def test_unknown_groupby(self):
         """Use a tag name in groupby that does not exist in the indexer"""
         # Insert session metrics:


### PR DESCRIPTION
The limited order by functionality introduced in https://github.com/getsentry/sentry/pull/30091 did not yet allow ordering by one of the percentiles (`p50`, `p75`, ...). This PR fixes that and simplifies some code along the way.