### PR TITLE
feat: WIP upgrade urllib3 to 1.26

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.7.1
-boto3==1.13.16
-botocore==1.16.16
+boto3==1.16.17
+botocore==1.19.17
 celery==4.4.7
 click==7.1.2
 # See if we can remove CPATH from lib.sh
@@ -62,7 +62,7 @@ symbolic==8.3.2
 toronado==0.1.0
 ua-parser==0.10.0
 unidiff==0.6.0
-urllib3==1.24.2
+urllib3==1.25.4
 # See if we can remove LDFLAGS from lib.sh
 # https://github.com/getsentry/sentry/pull/30094
 uWSGI==2.0.19.1

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,7 +62,7 @@ symbolic==8.3.2
 toronado==0.1.0
 ua-parser==0.10.0
 unidiff==0.6.0
-urllib3==1.25.4
+urllib3==1.26.7
 # See if we can remove LDFLAGS from lib.sh
 # https://github.com/getsentry/sentry/pull/30094
 uWSGI==2.0.19.1

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -120,9 +120,22 @@ class BlacklistAdapter(HTTPAdapter):
         self._pool_connections = connections
         self._pool_maxsize = maxsize
         self._pool_block = block
+        # Begin custom code.
+        # We use our own SafePoolManager here as well as
+        # setting cert validation to be optional since in urllib3>=1.25,
+        # it's made required (for https connections) by default
+        # and we prefer CERT_OPTIONAL for now
+        # (InsecureRequestWarning will still be emitted),
+        # pending investigation to see if it would be ok to switch to required.
         self.poolmanager = SafePoolManager(
-            num_pools=connections, maxsize=maxsize, block=block, strict=True, **pool_kwargs
+            cert_reqs="CERT_OPTIONAL",
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            strict=True,
+            **pool_kwargs,
         )
+        # End custom code.
 
 
 class TimeoutAdapter(HTTPAdapter):

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -21,6 +21,7 @@ class SafeConnectionMixin:
     to override `_new_conn` with the ability to create our own socket.
     """
 
+    # urllib3.connection.HTTPConnection.host
     # These `host` properties need rebound otherwise `self._dns_host` doesn't
     # get set correctly.
     @property
@@ -49,7 +50,7 @@ class SafeConnectionMixin:
         """
         self._dns_host = value
 
-    # Mostly yanked from https://github.com/urllib3/urllib3/blob/1.22/urllib3/connection.py#L127
+    # urllib3.connection.HTTPConnection._new_conn
     def _new_conn(self):
         """Establish a socket connection and set nodelay settings on it.
         :return: New socket connection.
@@ -62,9 +63,9 @@ class SafeConnectionMixin:
             extra_kw["socket_options"] = self.socket_options
 
         try:
-            # HACK(mattrobenolt): All of this is to replace this one line
-            # to establish our own connection.
+            # Begin custom code.
             conn = safe_create_connection((self._dns_host, self.port), self.timeout, **extra_kw)
+            # End custom code.
 
         except SocketTimeout:
             raise ConnectTimeoutError(
@@ -73,7 +74,7 @@ class SafeConnectionMixin:
             )
 
         except SocketError as e:
-            raise NewConnectionError(self, "Failed to establish a new connection: %s" % e)
+            raise NewConnectionError(self, f"Failed to establish a new connection: {e}")
 
         return conn
 

--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils.encoding import force_text
+from urllib3.exceptions import LocationParseError
 from urllib3.util.connection import _set_socket_options, allowed_gai_family
 
 from sentry.exceptions import RestrictedIPAddress
@@ -96,7 +97,7 @@ def is_safe_hostname(hostname):
     return True
 
 
-# Mostly yanked from https://github.com/urllib3/urllib3/blob/1.22/urllib3/util/connection.py#L36
+# Modifed version of urllib3.util.connection.create_connection.
 def safe_create_connection(
     address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None, socket_options=None
 ):
@@ -105,17 +106,24 @@ def safe_create_connection(
         host = host.strip("[]")
     err = None
 
-    host = ensure_fqdn(host)
-
     # Using the value from allowed_gai_family() in the context of getaddrinfo lets
     # us select whether to work with IPv4 DNS records, IPv6 records, or both.
     # The original create_connection function always returns all records.
     family = allowed_gai_family()
 
+    # Begin custom code.
+    host = ensure_fqdn(host)
+    # End custom code.
+
+    try:
+        host.encode("idna")
+    except UnicodeError:
+        raise LocationParseError("'{host}', label empty or too long") from None
+
     for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
         af, socktype, proto, canonname, sa = res
 
-        # HACK(mattrobenolt): This is the only code that diverges
+        # Begin custom code.
         ip = sa[0]
         if not is_ipaddress_allowed(ip):
             # I am explicitly choosing to be overly aggressive here. This means
@@ -126,6 +134,7 @@ def safe_create_connection(
             if host == ip:
                 raise RestrictedIPAddress("(%s) matches the URL blacklist" % ip)
             raise RestrictedIPAddress(f"({host}/{ip}) matches the URL blacklist")
+        # End custom code.
 
         sock = None
         try:


### PR DESCRIPTION
urllib3 is due for an upgrade. This brings it to the latest 1.26.x and will help in the future for upgrading to urllib3 2 when it's released.

Also, not sure if we actually monkeypatch requests with our Safe stuff yet, if not then this won't have as much of a wide impact on the ecosystem side of things.

This unblocks:
- responses upgrade (unless we relax urllib3 requirements there) https://github.com/getsentry/sentry/pull/30805
- selenium 4 upgrade (as a bonus, can undo this patch https://github.com/getsentry/getsentry/pull/6745) https://github.com/getsentry/sentry/pull/29505#issuecomment-949995603

Requires:
- boto3, botocore upgrades. So we need botocore 1.19.17 (https://github.com/boto/botocore/commit/b2d533b4649716e5ec85b46687a2d0745042bc89) and boto3 1.16.17, but they require urllib3 1.25.4. So might as well just upgrade boto in tandem. Need to do testing similar to what we did in https://github.com/getsentry/sentry/pull/28693.

We override some urllib3 machinery in sentry.http and sentry.net.* (the latter is deprecated api, it's reimported into sentry.http), this involves some private stuff too. It'll have to be synced with upstream. I checked and it's the same, although I don't know why we redefine SafeConnectionMixin.host.
some detail: SafeConnectionMixin has a host attr getter that strips trailing dot for FQDN cause it causes problems with SSL validation. This is separate from the good FQDN forcing (SENTRY_ENSURE_FQDN).

The changelog delta for urllib3 includes some interesting things:
- urllib3/urllib3#1507, "Require and validate certificates by default when using HTTPS". previously we had to urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning) for post process and process_event workers, this might have implications there.
  - So I think, when testing this on staging I'd also like to do this for postprocess, revert https://github.com/getsentry/getsentry/pull/3541, and read the logs because we'll be getting this: https://github.com/urllib3/urllib3/pull/1691
- Deprecated negotiating TLSv1 and TLSv1.1 by default. Users that still wish to use TLS earlier than 1.2 without a deprecation warning should opt-in explicitly by setting ssl_version=ssl.PROTOCOL_TLSv1_1 (Pull #2002) 
- More invalid stuff is gonna be percent encoded when parsing things in general.

I would also like to follow up (or include) a PR to increase SafeSession reuse: https://github.com/getsentry/sentry/pull/26854/commits/809b5c1320fd4888b869f031c037797d6f9a18fa#diff-4a9f39b15b17569c64d1c8e8b1564b7d7ef8c19d9274c9ae6f14555834b2628dR177-R180