### PR TITLE
fix(dashboard): Fixes regression that doesn't honour max widgets

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -65,6 +65,7 @@ type State = {
   modifiedDashboard: DashboardDetails | null;
   widgetToBeUpdated?: Widget;
   layout: RGLLayout[];
+  widgetLimitReached: boolean;
 };
 
 class DashboardDetail extends Component<Props, State> {
@@ -72,6 +73,7 @@ class DashboardDetail extends Component<Props, State> {
     dashboardState: this.props.initialState,
     modifiedDashboard: this.updateModifiedDashboard(this.props.initialState),
     layout: getDashboardLayout(this.props.organization.id, this.props.dashboard.id),
+    widgetLimitReached: this.props.dashboard.widgets.length >= MAX_WIDGETS,
   };
 
   componentDidMount() {
@@ -168,11 +170,6 @@ class DashboardDetail extends Component<Props, State> {
     const {dashboard} = this.props;
     const {modifiedDashboard} = this.state;
     return modifiedDashboard ? modifiedDashboard.title : dashboard.title;
-  }
-
-  get widgetLimitReached() {
-    const {dashboard} = this.props;
-    return dashboard.widgets.length >= MAX_WIDGETS;
   }
 
   onEdit = () => {
@@ -276,7 +273,10 @@ class DashboardDetail extends Component<Props, State> {
       ...cloneDashboard(modifiedDashboard || dashboard),
       widgets: widgets.map(assignTempId),
     };
-    this.setState({modifiedDashboard: newModifiedDashboard});
+    this.setState({
+      modifiedDashboard: newModifiedDashboard,
+      widgetLimitReached: widgets.length >= MAX_WIDGETS,
+    });
     if ([DashboardState.CREATE, DashboardState.EDIT].includes(dashboardState)) {
       return;
     }
@@ -467,6 +467,7 @@ class DashboardDetail extends Component<Props, State> {
       (state: State) => ({
         ...state,
         widgetToBeUpdated: undefined,
+        widgetLimitReached: widgets.length >= MAX_WIDGETS,
         modifiedDashboard: {
           ...(state.modifiedDashboard || this.props.dashboard),
           widgets,
@@ -491,7 +492,7 @@ class DashboardDetail extends Component<Props, State> {
 
   renderDefaultDashboardDetail() {
     const {organization, dashboard, dashboards, params, router, location} = this.props;
-    const {layout, modifiedDashboard, dashboardState} = this.state;
+    const {layout, modifiedDashboard, dashboardState, widgetLimitReached} = this.state;
     const {dashboardId} = params;
 
     return (
@@ -523,7 +524,7 @@ class DashboardDetail extends Component<Props, State> {
                 onAddWidget={this.onAddWidget}
                 onDelete={this.onDelete(dashboard)}
                 dashboardState={dashboardState}
-                widgetLimitReached={this.widgetLimitReached}
+                widgetLimitReached={widgetLimitReached}
               />
             </StyledPageHeader>
             <HookHeader organization={organization} />
@@ -532,7 +533,7 @@ class DashboardDetail extends Component<Props, State> {
               dashboard={modifiedDashboard ?? dashboard}
               organization={organization}
               isEditing={this.isEditing}
-              widgetLimitReached={this.widgetLimitReached}
+              widgetLimitReached={widgetLimitReached}
               onUpdate={this.onUpdateWidget}
               onSetWidgetToBeUpdated={this.onSetWidgetToBeUpdated}
               handleAddLibraryWidgets={this.handleAddLibraryWidgets}
@@ -550,7 +551,7 @@ class DashboardDetail extends Component<Props, State> {
   renderDashboardDetail() {
     const {organization, dashboard, dashboards, params, router, location, newWidget} =
       this.props;
-    const {layout, modifiedDashboard, dashboardState} = this.state;
+    const {layout, modifiedDashboard, dashboardState, widgetLimitReached} = this.state;
     const {dashboardId} = params;
 
     return (
@@ -604,7 +605,7 @@ class DashboardDetail extends Component<Props, State> {
                   onAddWidget={this.onAddWidget}
                   onDelete={this.onDelete(dashboard)}
                   dashboardState={dashboardState}
-                  widgetLimitReached={this.widgetLimitReached}
+                  widgetLimitReached={widgetLimitReached}
                 />
               </Layout.HeaderActions>
             </Layout.Header>
@@ -615,7 +616,7 @@ class DashboardDetail extends Component<Props, State> {
                   dashboard={modifiedDashboard ?? dashboard}
                   organization={organization}
                   isEditing={this.isEditing}
-                  widgetLimitReached={this.widgetLimitReached}
+                  widgetLimitReached={widgetLimitReached}
                   onUpdate={this.onUpdateWidget}
                   handleAddLibraryWidgets={this.handleAddLibraryWidgets}
                   onSetWidgetToBeUpdated={this.onSetWidgetToBeUpdated}

--- a/static/app/views/dashboardsV2/types.tsx
+++ b/static/app/views/dashboardsV2/types.tsx
@@ -4,7 +4,7 @@ import {User} from 'sentry/types';
 // to allow to limit the load on snuba from the
 // parallel requests. Somewhat arbitrary
 // limit that can be changed if necessary.
-export const MAX_WIDGETS = 30;
+export const MAX_WIDGETS = 5;
 
 export enum DisplayType {
   AREA = 'area',

--- a/static/app/views/dashboardsV2/types.tsx
+++ b/static/app/views/dashboardsV2/types.tsx
@@ -4,7 +4,7 @@ import {User} from 'sentry/types';
 // to allow to limit the load on snuba from the
 // parallel requests. Somewhat arbitrary
 // limit that can be changed if necessary.
-export const MAX_WIDGETS = 5;
+export const MAX_WIDGETS = 30;
 
 export enum DisplayType {
   AREA = 'area',

--- a/tests/js/spec/views/dashboardsV2/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/detail.spec.jsx
@@ -666,7 +666,7 @@ describe('Dashboards > Detail', function () {
     });
 
     it('disables add library widgets when max widgets reached', async function () {
-      types.MAX_WIDGETS = 1;
+      types.MAX_WIDGETS = 4;
 
       initialData = initializeOrg({
         organization: TestStubs.Organization({
@@ -693,12 +693,44 @@ describe('Dashboards > Detail', function () {
       await tick();
       wrapper.update();
 
-      // Enter Add Widget mode
+      expect(wrapper.find('WidgetCard')).toHaveLength(3);
+      expect(
+        wrapper.find('Controls Button[data-test-id="add-widget-library"]').props()
+          .disabled
+      ).toEqual(false);
+      expect(wrapper.find('Controls Tooltip').prop('disabled')).toBe(true);
+
+      const card = wrapper.find('WidgetCard').first();
+      card.find('DropdownMenu MoreOptions svg').simulate('click');
+
+      card.update();
+      wrapper.update();
+
+      wrapper
+        .find(`DropdownMenu MenuItem[data-test-id="duplicate-widget"] MenuTarget`)
+        .simulate('click');
+
+      await tick();
+      wrapper.update();
+
+      expect(wrapper.find('WidgetCard')).toHaveLength(4);
       expect(
         wrapper.find('Controls Button[data-test-id="add-widget-library"]').props()
           .disabled
       ).toEqual(true);
       expect(wrapper.find('Controls Tooltip').prop('disabled')).toBe(false);
+
+      const card2 = wrapper.find('WidgetCard').first();
+      card2.find('DropdownMenu MoreOptions svg').simulate('click');
+
+      card2.update();
+      wrapper.update();
+
+      expect(
+        wrapper
+          .find(`DropdownMenu MenuItem[data-test-id="duplicate-widget"] MenuTarget`)
+          .props().disabled
+      ).toEqual(true);
     });
 
     it('duplicates widgets', async function () {


### PR DESCRIPTION
Adding maxWidgetReached as a state of the dashboard details
component so that the "Add Widget" plus button in Edit mode
is hidden when max widgets is reached.