### PR TITLE
fix(insights): Avoid double counting for a group when determining unresolved issues.

### DIFF
--- a/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
+++ b/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
@@ -34,6 +34,17 @@ class TeamIssueBreakdownTest(APITestCase):
         self.create_group_history(
             group=group1_1, date_added=before_now(days=5), status=GroupHistoryStatus.RESOLVED
         )
+        # Duplicate statuses shouldn't count multiple times.
+        self.create_group_history(
+            group=group1_1,
+            date_added=before_now(days=4, hours=10),
+            status=GroupHistoryStatus.RESOLVED,
+        )
+        self.create_group_history(
+            group=group1_1,
+            date_added=before_now(days=4, hours=8),
+            status=GroupHistoryStatus.RESOLVED,
+        )
         self.create_group_history(
             group=group1_1, date_added=before_now(days=3), status=GroupHistoryStatus.UNRESOLVED
         )
@@ -45,6 +56,16 @@ class TeamIssueBreakdownTest(APITestCase):
         )
         self.create_group_history(
             group=group1_4, date_added=before_now(days=9), status=GroupHistoryStatus.RESOLVED
+        )
+        self.create_group_history(
+            group=group1_4,
+            date_added=before_now(days=8, hours=7),
+            status=GroupHistoryStatus.RESOLVED,
+        )
+        self.create_group_history(
+            group=group1_4,
+            date_added=before_now(days=8, hours=6),
+            status=GroupHistoryStatus.RESOLVED,
         )
         project2 = self.create_project(teams=[self.team])
         group2_1 = self.create_group(project=project2, first_seen=before_now(days=40))


### PR DESCRIPTION
There are duplicate status rows in the `GroupHistory` table. This can happen with a group being
resolved multiple times in a row, or really another other status other than `NEW`.

To make these stats correct we want to only include a `GroupHistory` row in the count if it's not a
duplicate. To determine a duplicate we:
 - Query for the most recent relevant `GroupHistory` row related to the same group that is older
   than the current row. Relevant means that it's either an OPEN or CLOSED status. So we don't care
   about ASSIGNED/UNASSIGNED, but we do care about UNRESOLVED, REGRESSED, RESOLVED, etc.
 - We then look at the status of this row and determine whether it's a CLOSED or OPEN status. We do
   the same for the current row, and if both are either CLOSED or OPEN then this row is a duplicate,
   so we discard it.

This will make this report less efficient, and the way that we have to do this in Django means that
the subquery is repeated multiple times. There are more efficient ways to write this if we break out
the raw sql, but for now this will work and we can see if we end up having performance problems
here.