### PR TITLE
ref(cra-metrics): Refactor tag key and tag values logic

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -2,7 +2,7 @@ import re
 from abc import ABC, abstractmethod
 from copy import copy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Type, TypedDict, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, TypedDict, Union
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, CRASH_RATE_ALERT_SESSION_COUNT_ALIAS
 from sentry.eventstore import Filter
@@ -329,33 +329,42 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             "granularity": self.get_granularity(),
         }
 
-    def aggregate_query_results(
-        self, data: List[Dict[str, Any]], alias: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
-        aggregated_results: List[Dict[str, Any]]
+    @staticmethod
+    def translate_sessions_tag_keys_and_values(
+        data: List[Dict[str, Any]], org_id: int, alias: Optional[str] = None
+    ) -> Tuple[int, int]:
         value_col_name = alias if alias else "value"
         try:
             translated_data: Dict[str, Any] = {}
-            session_status = tag_key(self.org_id, "session.status")
+            session_status = tag_key(org_id, "session.status")
             for row in data:
-                tag_value = reverse_tag_value(self.org_id, row[session_status])
+                tag_value = reverse_tag_value(org_id, row[session_status])
                 translated_data[tag_value] = row[value_col_name]
 
             total_session_count = translated_data.get("init", 0)
             crash_count = translated_data.get("crashed", 0)
-            if total_session_count == 0:
-                metrics.incr(
-                    "incidents.entity_subscription.metrics.aggregate_query_results.no_session_data"
-                )
-                crash_free_rate = None
-            else:
-                crash_free_rate = round((1 - crash_count / total_session_count) * 100, 3)
-
-            col_name = alias if alias else CRASH_RATE_ALERT_AGGREGATE_ALIAS
-
-            aggregated_results = [{col_name: crash_free_rate}]
         except MetricIndexNotFound:
-            aggregated_results = [{}]
+            metrics.incr("incidents.entity_subscription.metric_index_not_found")
+            total_session_count = crash_count = 0
+        return total_session_count, crash_count
+
+    def aggregate_query_results(
+        self, data: List[Dict[str, Any]], alias: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        aggregated_results: List[Dict[str, Any]]
+        total_session_count, crash_count = self.translate_sessions_tag_keys_and_values(
+            org_id=self.org_id, data=data, alias=alias
+        )
+        if total_session_count == 0:
+            metrics.incr(
+                "incidents.entity_subscription.metrics.aggregate_query_results.no_session_data"
+            )
+            crash_free_rate = None
+        else:
+            crash_free_rate = round((1 - crash_count / total_session_count) * 100, 3)
+
+        col_name = alias if alias else CRASH_RATE_ALERT_AGGREGATE_ALIAS
+        aggregated_results = [{col_name: crash_free_rate}]
         return aggregated_results
 
 

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1637,6 +1637,8 @@ class CrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass):
 class MetricsCrashRateAlertProcessUpdateTest(
     CrashRateAlertProcessUpdateTest, SessionMetricsTestCase
 ):
+    entity_subscription_metrics = patcher("sentry.snuba.entity_subscription.metrics")
+
     def setUp(self):
         super().setUp()
         for status in ["exited", "crashed"]:
@@ -1715,9 +1717,14 @@ class MetricsCrashRateAlertProcessUpdateTest(
             }
         )
         self.assert_no_active_incident(rule)
+        self.entity_subscription_metrics.incr.assert_has_calls(
+            [
+                call("incidents.entity_subscription.metric_index_not_found"),
+            ]
+        )
         self.metrics.incr.assert_has_calls(
             [
-                call("incidents.alert_rules.ignore_update.metric_index_not_found"),
+                call("incidents.alert_rules.ignore_update_no_session_data"),
                 call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
             ]
         )


### PR DESCRIPTION
Creates static func translate_sessions_tag_keys_and_values
that refactors the logic relying on the indexer to con-
vert tag keys and values to readable strings