### PR TITLE
ref(integration feature): Add features for doc integrations

### DIFF
--- a/src/sentry/models/integrationfeature.py
+++ b/src/sentry/models/integrationfeature.py
@@ -20,6 +20,10 @@ class Feature:
     INCIDENT_MANAGEMENT = 5
     FEATURE_FLAG = 6
     ALERTS = 7
+    RELEASE_MANAGEMENT = 8
+    VISUALIZATION = 9
+    CHAT = 11
+    SESSION_REPLAY = 12
 
     @classmethod
     def as_choices(cls):
@@ -32,6 +36,10 @@ class Feature:
             (cls.INCIDENT_MANAGEMENT, "integrations-incident-management"),
             (cls.FEATURE_FLAG, "integrations-feature-flag"),
             (cls.ALERTS, "integrations-alert-rule"),
+            (cls.RELEASE_MANAGEMENT, "integrations-release-management"),
+            (cls.VISUALIZATION, "integrations-visualization"),
+            (cls.CHAT, "integrations-chat"),
+            (cls.SESSION_REPLAY, "integrations-session-replay"),
         )
 
     @classmethod
@@ -50,6 +58,14 @@ class Feature:
             return "integrations-feature-flag"
         if feature == cls.ALERTS:
             return "integrations-alert-rule"
+        if feature == cls.RELEASE_MANAGEMENT:
+            return "integrations-release-management"
+        if feature == cls.VISUALIZATION:
+            return "integrations-visualization"
+        if feature == cls.CHAT:
+            return "integrations-chat"
+        if feature == cls.SESSION_REPLAY:
+            return "integrations-session-replay"
         return "integrations-api"
 
     @classmethod
@@ -68,6 +84,14 @@ class Feature:
             return "%s allows organizations to **forward events to another service**." % name
         if feature == cls.ALERTS:
             return "Configure Sentry alerts to trigger notifications in %s." % name
+        if feature == cls.RELEASE_MANAGEMENT:
+            return "Notify Sentry of new releases being deployed in %s." % name
+        if feature == cls.VISUALIZATION:
+            return "Visualize Sentry data in %s" % name
+        if feature == cls.CHAT:
+            return "Get Sentry notifications in %s" & name
+        if feature == cls.SESSION_REPLAY:
+            return "Link Sentry errors to the session replay in %s " % name
         # default
         return (
             "%s can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course)."

--- a/src/sentry/models/integrationfeature.py
+++ b/src/sentry/models/integrationfeature.py
@@ -87,11 +87,11 @@ class Feature:
         if feature == cls.RELEASE_MANAGEMENT:
             return "Notify Sentry of new releases being deployed in %s." % name
         if feature == cls.VISUALIZATION:
-            return "Visualize Sentry data in %s" % name
+            return "Visualize Sentry data in %s." % name
         if feature == cls.CHAT:
-            return "Get Sentry notifications in %s" & name
+            return "Get Sentry notifications in %s." & name
         if feature == cls.SESSION_REPLAY:
-            return "Link Sentry errors to the session replay in %s " % name
+            return "Link Sentry errors to the session replay in %s." % name
         # default
         return (
             "%s can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course)."

--- a/static/app/views/organizationIntegrations/constants.tsx
+++ b/static/app/views/organizationIntegrations/constants.tsx
@@ -78,7 +78,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'The Sentry-FullStory integration seamlessly integrates the Sentry and FullStory platforms. When you look at a browser error in Sentry, you will see a link to the FullStory session replay at that exact moment in time. When you are watching a FullStory replay and your user experiences an error, you will see a link that will take you to that error in Sentry.',
     features: [
       {
-        featureId: 12, // TODO(Add to integrationfeature.py)
+        featureId: 12,
         featureGate: 'session-replay',
         description:
           'Links Sentry errors to the FullStory session replay and vice-versa.',
@@ -130,7 +130,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'Asayer is a session replay tool for developers. Replay each user session alongside your front/backend logs and other data spread across your stack so you can immediately find, reproduce and fix bugs faster.',
     features: [
       {
-        featureId: 12, // TODO(Add to integrationfeature.py)
+        featureId: 12,
         featureGate: 'session-replay',
         description:
           'By integrating Sentry with Asayer, you can see the moments that precede and that lead up to each problem. You can sync your Sentry logs alongside your session replay, JS console and network activity to gain complete visibility over every issue that affect your users.',
@@ -149,7 +149,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'Rocket.Chat is a free and open-source team chat collaboration platform that allows users to communicate securely in real-time across devices on the web, desktop or mobile and to customize their interface with a range of plugins, themes, and integrations with other key software.',
     features: [
       {
-        featureId: 11, // TODO(Add to integrationfeature.py)
+        featureId: 11,
         featureGate: 'chat',
         description: 'Get Sentry notifications in Rocket.Chat.',
       },
@@ -176,7 +176,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'The Sentry Netlify build plugin automatically uploads source maps and notifies Sentry of new releases being deployed to your site after it finishes building in Netlify.',
     features: [
       {
-        featureId: 8, // TODO(Add to integrationfeature.py)
+        featureId: 8,
         featureGate: 'release-management',
         description: 'Notify Sentry of new releases being deployed.',
       },
@@ -206,7 +206,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'Notify Sentry of any Bitbucket Pipelines builds to automatically manage releases and quickly surface any errors associated with a given build.\n\n**Requirement:** Bitbucket source code integration must be installed for the release pipe to work.',
     features: [
       {
-        featureId: 8, // TODO(Add to integrationfeature.py)
+        featureId: 8,
         featureGate: 'release-management',
         description: 'Notify Sentry of new releases being deployed.',
       },
@@ -231,7 +231,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       "The Sentry Release GitHub Action automatically notifies Sentry of new releases being deployed. After sending Sentry release information, you'll be able to identify suspect commits that are likely the culprit for new errors. You'll also be able to apply source maps to see the original code in Sentry.\n\n**Requirement:** GitHub source code integration must be installed and configured for the Sentry Release GitHub Action to work.",
     features: [
       {
-        featureId: 8, // TODO(Add to integrationfeature.py)
+        featureId: 8,
         featureGate: 'release-management',
         description: 'Notify Sentry of new releases being deployed.',
       },
@@ -256,7 +256,7 @@ export const documentIntegrationList: DocumentIntegration[] = [
       'The Sentry Grafana data source plugin allows you to query and visualize Sentry data within Grafana.',
     features: [
       {
-        featureId: 9, // TODO(Add to integrationfeature.py)
+        featureId: 9,
         featureGate: 'visualization',
         description: 'Query and visualize Sentry data in Grafana',
       },


### PR DESCRIPTION
In order to backfill the existing doc integrations into the `DocIntegration` table, we need to add the features they have into the `Feature` class so they show up on the integration feature endpoint response. 