### PR TITLE
Fix/performance table column mismatch in mobile react native view

### DIFF
--- a/static/app/views/performance/landing/content.tsx
+++ b/static/app/views/performance/landing/content.tsx
@@ -204,8 +204,8 @@ class LandingContent extends Component<Props, State> {
     const axisOptions = getMobileAxisOptions(organization);
     const {leftAxis, rightAxis} = getDisplayAxes(axisOptions, location);
 
-    const isReactNative = checkIsReactNative(eventView);
     // only react native should contain the stall percentage column
+    const isReactNative = checkIsReactNative(eventView);
     const columnTitles = isReactNative
       ? REACT_NATIVE_COLUMN_TITLES
       : MOBILE_COLUMN_TITLES;

--- a/static/app/views/performance/landing/content.tsx
+++ b/static/app/views/performance/landing/content.tsx
@@ -37,6 +37,7 @@ import {
   REACT_NATIVE_COLUMN_TITLES,
 } from './data';
 import {
+  checkIsReactNative,
   getCurrentLandingDisplay,
   getDefaultDisplayFieldForPlatform,
   getDisplayAxes,
@@ -203,10 +204,8 @@ class LandingContent extends Component<Props, State> {
     const axisOptions = getMobileAxisOptions(organization);
     const {leftAxis, rightAxis} = getDisplayAxes(axisOptions, location);
 
+    const isReactNative = checkIsReactNative(eventView);
     // only react native should contain the stall percentage column
-    const isReactNative = Boolean(
-      eventView.getFields().find(field => field.includes('measurements.stall_percentage'))
-    );
     const columnTitles = isReactNative
       ? REACT_NATIVE_COLUMN_TITLES
       : MOBILE_COLUMN_TITLES;

--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -278,3 +278,10 @@ export function getDisplayAxes(options: AxisOption[], location: Location) {
     rightAxis,
   };
 }
+
+export function checkIsReactNative(eventView) {
+  // only react native should contain the stall percentage column
+  return Boolean(
+    eventView.getFields().find(field => field.includes('measurements.stall_percentage'))
+  );
+}

--- a/static/app/views/performance/landing/views/mobileView.tsx
+++ b/static/app/views/performance/landing/views/mobileView.tsx
@@ -3,13 +3,17 @@ import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/perf
 
 import Table from '../../table';
 import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
-import {MOBILE_COLUMN_TITLES} from '../data';
+import {MOBILE_COLUMN_TITLES, REACT_NATIVE_COLUMN_TITLES} from '../data';
+import {checkIsReactNative} from '../utils';
 import {DoubleChartRow, TripleChartRow} from '../widgets/components/widgetChartRow';
 import {PerformanceWidgetSetting} from '../widgets/widgetDefinitions';
 
 import {BasePerformanceViewProps} from './types';
 
 export function MobileView(props: BasePerformanceViewProps) {
+  const columnTitles = checkIsReactNative(props.eventView)
+    ? REACT_NATIVE_COLUMN_TITLES
+    : MOBILE_COLUMN_TITLES;
   return (
     <PerformanceDisplayProvider value={{performanceType: PROJECT_PERFORMANCE_TYPE.ANY}}>
       <div>
@@ -34,7 +38,7 @@ export function MobileView(props: BasePerformanceViewProps) {
         />
         <Table
           {...props}
-          columnTitles={MOBILE_COLUMN_TITLES} // TODO(k-fish): Add react native column titles
+          columnTitles={columnTitles}
           setError={usePageError().setPageError}
         />
       </div>

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -8,6 +8,8 @@ import TeamStore from 'sentry/stores/teamStore';
 import EventView from 'sentry/utils/discover/eventView';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import {PerformanceLanding} from 'sentry/views/performance/landing';
+import {REACT_NATIVE_COLUMN_TITLES} from 'sentry/views/performance/landing/data';
+import * as utils from 'sentry/views/performance/landing/utils';
 import {LandingDisplayField} from 'sentry/views/performance/landing/utils';
 
 const WrappedComponent = ({data}) => {
@@ -151,6 +153,21 @@ describe('Performance > Landing > Index', function () {
     wrapper.update();
 
     expect(wrapper.find('Table').exists()).toBe(true);
+  });
+
+  it('renders react-native table headers in mobile view', async function () {
+    jest.spyOn(utils, 'checkIsReactNative').mockReturnValueOnce(true);
+    const data = initializeData({
+      query: {landingDisplay: LandingDisplayField.MOBILE},
+    });
+
+    wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    await tick();
+    wrapper.update();
+
+    const table = wrapper.find('Table');
+    expect(table.exists()).toBe(true);
+    expect(table.props().columnTitles).toEqual(REACT_NATIVE_COLUMN_TITLES);
   });
 
   it('renders all transactions view', async function () {


### PR DESCRIPTION
There was a mismatch in the Table headers being rendered on the performance landing page for a react-native view. Notice that Frozen Frame % is showing user counts and the User column is showing User Misery

<img width="1136" alt="Screen Shot 2021-12-23 at 3 11 08 PM" src="https://user-images.githubusercontent.com/22846452/147287689-be88f42c-1997-4a19-b619-4093f17d1324.png">

React Native displays different data for now, so I updated the column titles to account for that.
<img width="1165" alt="Screen Shot 2021-12-23 at 3 10 29 PM" src="https://user-images.githubusercontent.com/22846452/147287786-dbfb735b-e659-40c3-9907-d18f40d5049f.png">



