### PR TITLE
ref(analytics): converts smartSearchBar

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -37,7 +37,7 @@ import MemberListStore from 'sentry/stores/memberListStore';
 import space from 'sentry/styles/space';
 import {Organization, SavedSearchType, Tag, User} from 'sentry/types';
 import {defined} from 'sentry/utils';
-import {trackAnalyticsEvent} from 'sentry/utils/analytics';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {callIfFunction} from 'sentry/utils/callIfFunction';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -402,11 +402,8 @@ class SmartSearchBar extends React.Component<Props, State> {
       savedSearchType,
       searchSource,
     } = this.props;
-
-    trackAnalyticsEvent({
-      eventKey: 'search.searched',
-      eventName: 'Search: Performed search',
-      organization_id: organization.id,
+    trackAdvancedAnalyticsEvent('search.searched', {
+      organization,
       query,
       search_type: savedSearchType === 0 ? 'issues' : 'events',
       search_source: searchSource,
@@ -1208,10 +1205,8 @@ class SmartSearchBar extends React.Component<Props, State> {
     let replaceToken = replaceText;
     if (cursorToken.type === Token.Filter) {
       if (item.type === ItemType.TAG_OPERATOR) {
-        trackAnalyticsEvent({
-          eventKey: 'search.operator_autocompleted',
-          eventName: 'Search: Operator Autocompleted',
-          organization_id: this.props.organization.id,
+        trackAdvancedAnalyticsEvent('search.operator_autocompleted', {
+          organization: this.props.organization,
           query: removeSpace(query),
           search_operator: replaceText,
           search_type: this.props.savedSearchType === 0 ? 'issues' : 'events',
@@ -1281,12 +1276,10 @@ class SmartSearchBar extends React.Component<Props, State> {
 
   onAutoComplete = (replaceText: string, item: SearchItem) => {
     if (item.type === ItemType.RECENT_SEARCH) {
-      trackAnalyticsEvent({
-        eventKey: 'search.searched',
-        eventName: 'Search: Performed search',
-        organization_id: this.props.organization.id,
+      trackAdvancedAnalyticsEvent('search.searched', {
+        organization: this.props.organization,
         query: replaceText,
-        source: this.props.savedSearchType === 0 ? 'issues' : 'events',
+        search_type: this.props.savedSearchType === 0 ? 'issues' : 'events',
         search_source: 'recent_search',
       });
 

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -27,15 +27,6 @@ export type IssueEventParameters = {
     search_source: string;
     error: string;
   };
-  'search.searched': {
-    query: string;
-    search_type: string;
-    search_source: string;
-  };
-  'organization_saved_search.selected': {
-    search_type: string;
-    id: number;
-  };
   'issue.search_sidebar_clicked': {};
   'inbox_tab.issue_clicked': {
     group_id: string;
@@ -60,9 +51,6 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_error_banner.viewed': 'Issue Error Banner Viewed',
   'issues_tab.viewed': 'Viewed Issues Tab', // high volume but send to our secondary event store anyways
   'issue_search.failed': 'Issue Search: Failed',
-  'search.searched': 'Search: Performed search',
-  'organization_saved_search.selected':
-    'Organization Saved Search: Selected saved search',
   'issue.search_sidebar_clicked': 'Issue Search Sidebar Clicked',
   'inbox_tab.issue_clicked': 'Clicked Issue from Inbox Tab',
   'issues_stream.issue_clicked': 'Clicked Issue from Issues Stream',

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -1,0 +1,23 @@
+type SearchEventBase = {
+  query: string;
+  search_type: string;
+  search_source?: string;
+};
+
+export type SearchEventParameters = {
+  'search.searched': SearchEventBase & {search_source?: string};
+  'search.operator_autocompleted': SearchEventBase & {search_operator: string};
+  'organization_saved_search.selected': {
+    search_type: string;
+    id: number;
+  };
+};
+
+export type SearchEventKey = keyof SearchEventParameters;
+
+export const searchEventMap: Record<SearchEventKey, string | null> = {
+  'search.searched': 'Search: Performed search',
+  'search.operator_autocompleted': 'Search: Operator Autocompleted',
+  'organization_saved_search.selected':
+    'Organization Saved Search: Selected saved search',
+};

--- a/static/app/utils/analytics/trackAdvancedAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/trackAdvancedAnalyticsEvent.tsx
@@ -7,6 +7,7 @@ import {
   performanceEventMap,
   PerformanceEventParameters,
 } from './performanceAnalyticsEvents';
+import {searchEventMap, SearchEventParameters} from './searchAnalyticsEvents';
 import {TeamInsightsEventParameters, workflowEventMap} from './workflowAnalyticsEvents';
 
 type EventParameters = GrowthEventParameters &
@@ -14,7 +15,8 @@ type EventParameters = GrowthEventParameters &
   PerformanceEventParameters &
   DashboardsEventParameters &
   DiscoverEventParameters &
-  TeamInsightsEventParameters;
+  TeamInsightsEventParameters &
+  SearchEventParameters;
 
 const allEventMap = {
   ...growthEventMap,
@@ -23,6 +25,7 @@ const allEventMap = {
   ...dashboardsEventMap,
   ...discoverEventMap,
   ...workflowEventMap,
+  ...searchEventMap,
 };
 
 /**


### PR DESCRIPTION
This PR uses the new `trackAdvancedAnalyticsEvent` in the `SmartSearchBar` component. I also made a new file just for search analytics events.