### PR TITLE
fix(alerts): Omit release fields from alert filter

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -313,7 +313,13 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                 <StyledSearchBar
                   searchSource="alert_builder"
                   defaultQuery={initialData?.query ?? ''}
-                  omitTags={['event.type']}
+                  omitTags={[
+                    'event.type',
+                    'release.version',
+                    'release.stage',
+                    'release.package',
+                    'release.build',
+                  ]}
                   disabled={disabled}
                   useFormWrapper={false}
                   organization={organization}


### PR DESCRIPTION
Omit release fields like  `release.stage` and semver release fields from the alert filter on an alert creation page because these are not supported by the backend.

[FIXES WOR-1539](https://getsentry.atlassian.net/browse/WOR-1539)

# Before
<img width="1024" alt="Screen Shot 2021-12-29 at 1 50 36 PM" src="https://user-images.githubusercontent.com/20312973/147706103-ec691cf2-e406-480c-ba1e-1c930e639a83.png">

# After
<img width="1019" alt="Screen Shot 2021-12-29 at 1 50 07 PM" src="https://user-images.githubusercontent.com/20312973/147706095-6e961fff-0b84-4c88-b0ce-ed8517667fb1.png">
