### PR TITLE
fix(ui): Encode release version in two api calls [INGEST-638]

### DIFF
--- a/static/app/views/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.tsx
@@ -185,7 +185,9 @@ class ReleaseIssues extends Component<Props, State> {
         };
       case IssuesType.RESOLVED:
         return {
-          path: `/organizations/${organization.slug}/releases/${version}/resolved/`,
+          path: `/organizations/${organization.slug}/releases/${encodeURIComponent(
+            version
+          )}/resolved/`,
           queryParams: {...queryParams, query: ''},
         };
       case IssuesType.UNHANDLED:
@@ -224,7 +226,9 @@ class ReleaseIssues extends Component<Props, State> {
   async fetchIssuesCount() {
     const {api, organization, version} = this.props;
     const issueCountEndpoint = this.getIssueCountEndpoint();
-    const resolvedEndpoint = `/organizations/${organization.slug}/releases/${version}/resolved/`;
+    const resolvedEndpoint = `/organizations/${
+      organization.slug
+    }/releases/${encodeURIComponent(version)}/resolved/`;
 
     try {
       await Promise.all([

--- a/static/app/views/releases/detail/overview/sidebar/totalCrashFreeUsers.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/totalCrashFreeUsers.tsx
@@ -36,7 +36,9 @@ class TotalCrashFreeUsers extends AsyncComponent<Props, State> {
     return [
       [
         'releaseStats',
-        `/projects/${organization.slug}/${projectSlug}/releases/${version}/stats/`,
+        `/projects/${organization.slug}/${projectSlug}/releases/${encodeURIComponent(
+          version
+        )}/stats/`,
         {
           query: {
             ...getParams(


### PR DESCRIPTION
We encode release versions in most of the places, we missed these two occurrences.