### PR TITLE
fix(release-health): Ignore sorting order of two functions [INGEST-774]

### DIFF
--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -833,7 +833,8 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
         project_ids: Sequence[ProjectId],
     ) -> Sequence[ProjectRelease]:
         rollup = self.DEFAULT_ROLLUP  # not used
-        schema = [ComparatorType.Exact]
+        schema = ListSet(schema=ComparatorType.Exact, index_by=lambda x: x)
+
         should_compare = (
             lambda _: datetime.now(timezone.utc) - timedelta(days=3) > self.metrics_start
         )
@@ -989,7 +990,11 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
         stats_period: Optional[str] = None,
         environments: Optional[Sequence[str]] = None,
     ) -> Sequence[ProjectRelease]:
-        schema = [ComparatorType.Exact]
+        schema = ListSet(schema=ComparatorType.Exact, index_by=lambda x: x)
+
+        set_tag("get_project_releases_by_stability.limit", str(limit))
+        set_tag("get_project_releases_by_stability.offset", str(offset))
+        set_tag("get_project_releases_by_stability.scope", str(scope))
 
         if stats_period is None:
             stats_period = "24h"

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1231,7 +1231,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             select=query_cols,
             where=where_clause,
             groupby=query_cols,
-            orderby=[OrderBy(col, Direction.DESC) for col in query_cols],
         )
         result = raw_snql_query(
             query,
@@ -1968,9 +1967,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             )
             entity = Entity(EntityKey.MetricsSets.value)
             having_clause = [Condition(users_column, Op.GT, 0)]
-
-        # Tiebreaker
-        order_by_clause.extend([OrderBy(col, Direction.DESC) for col in query_cols])
 
         query = Query(
             dataset=Dataset.Metrics.value,

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1968,6 +1968,12 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             entity = Entity(EntityKey.MetricsSets.value)
             having_clause = [Condition(users_column, Op.GT, 0)]
 
+        # Partial tiebreaker to make comparisons in the release-health duplex
+        # backend more likely to succeed. A perfectly stable sorting would need to
+        # additionally sort by `release`, however in the metrics backend we can't
+        # sort by that the same way as in the sessions backend.
+        order_by_clause.append(OrderBy(Column("project_id"), Direction.DESC))
+
         query = Query(
             dataset=Dataset.Metrics.value,
             match=entity,

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -173,6 +173,12 @@ def _get_project_releases_by_stability(
         "users": ["-users"],
     }[scope]
 
+    # Partial tiebreaker to make comparisons in the release-health duplex
+    # backend more likely to succeed. A perfectly stable sorting would need to
+    # additionally sort by `release`, however in the metrics backend we can't
+    # sort by that the same way as in the sessions backend.
+    orderby.extend(["-project_id"])
+
     conditions = []
     if environments is not None:
         conditions.append(["environment", "IN", environments])

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -173,9 +173,6 @@ def _get_project_releases_by_stability(
         "users": ["-users"],
     }[scope]
 
-    # Tiebreaker
-    orderby.extend(["-project_id", "-release"])
-
     conditions = []
     if environments is not None:
         conditions.append(["environment", "IN", environments])


### PR DESCRIPTION
get_changed_project_release_model_adoptions: This function's return
value initially did not have any orderby. A previous PR by me attempted
to add stable sort order by ordering by (project_id, release), but in
the metrics backend that actually orders by the number returned by the
string indexer. Since this usecase does not have a limit or offset
clause, I'd expect that this change eliminates all known differences and
gets rid of 100% of errors.

get_project_releases_by_stability: This usecase already had a order-by
(ordering by crash rate or something similar). In a previous PR I
attempted to make the sort order stable by adding (project_id, release)
to orderby, which is broken for the same reason it is in
get_changed_project_release_model_adoptions. Since this usecase
additionally sets limit + offset (for pagination), ignoring sort order
within a query result (like done with ListSet in this PR) doesn't really
fix the problem entirely, since orderby can influence which rows appear
on which page. Still, this is better than nothing, and a quick query in
production showed that this should get rid of 70% of errors.

I expect that we'll have to eyeball the comparison errors for
get_project_releases_by_stability, it seems way too hard to eliminate
all false-positives programmatically.