### PR TITLE
fix(projectconfig): Fix bug where projectkey deletion would not trigger [ISSUE-1306]

### DIFF
--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -34,12 +34,12 @@ class ProjectKeyStatus:
 class ProjectKeyManager(BaseManager):
     def post_save(self, instance, **kwargs):
         schedule_update_config_cache(
-            project_id=instance.project_id, generate=True, update_reason="projectkey.post_save"
+            public_key=instance.public_key, generate=True, update_reason="projectkey.post_save"
         )
 
     def post_delete(self, instance, **kwargs):
         schedule_update_config_cache(
-            project_id=instance.project_id, generate=True, update_reason="projectkey.post_delete"
+            public_key=instance.public_key, generate=True, update_reason="projectkey.post_delete"
         )
 
 

--- a/src/sentry/relay/projectconfig_debounce_cache/__init__.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/__init__.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
@@ -11,3 +13,7 @@ backend = LazyServiceWrapper(
 )
 
 backend.expose(locals())
+
+if TYPE_CHECKING:
+    check_is_debounced = backend.check_is_debounced
+    mark_task_done = backend.mark_task_done

--- a/src/sentry/relay/projectconfig_debounce_cache/base.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/base.py
@@ -20,7 +20,7 @@ class ProjectConfigDebounceCache(Service):
     def __init__(self, **options):
         pass
 
-    def check_is_debounced(self, project_id, organization_id):
+    def check_is_debounced(self, public_key, project_id, organization_id):
         """
         Check if the given project/organization should be debounced.
 
@@ -30,7 +30,7 @@ class ProjectConfigDebounceCache(Service):
 
         return False
 
-    def mark_task_done(self, project_id, organization_id):
+    def mark_task_done(self, public_key, project_id, organization_id):
         """
         Mark a task done such that `check_is_debounced` starts emitting False
         for the given parameters.

--- a/src/sentry/relay/projectconfig_debounce_cache/redis.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/redis.py
@@ -10,7 +10,7 @@ def _get_redis_key(public_key, project_id, organization_id):
     elif project_id:
         return f"relayconfig-debounce:p:{project_id}"
     elif public_key:
-        return f"relayconfig-debounce:k:{project_id}"
+        return f"relayconfig-debounce:k:{public_key}"
     else:
         raise ValueError()
 

--- a/src/sentry/relay/projectconfig_debounce_cache/redis.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/redis.py
@@ -4,11 +4,13 @@ from sentry.utils.redis import get_dynamic_cluster_from_options, validate_dynami
 REDIS_CACHE_TIMEOUT = 3600  # 1 hr
 
 
-def _get_redis_key(project_id, organization_id):
+def _get_redis_key(public_key, project_id, organization_id):
     if organization_id:
         return f"relayconfig-debounce:o:{organization_id}"
     elif project_id:
         return f"relayconfig-debounce:p:{project_id}"
+    elif public_key:
+        return f"relayconfig-debounce:k:{project_id}"
     else:
         raise ValueError()
 
@@ -29,8 +31,8 @@ class RedisProjectConfigDebounceCache(ProjectConfigDebounceCache):
         else:
             return self.cluster.get_local_client_for_key(routing_key)
 
-    def check_is_debounced(self, project_id, organization_id):
-        key = _get_redis_key(project_id, organization_id)
+    def check_is_debounced(self, public_key, project_id, organization_id):
+        key = _get_redis_key(public_key, project_id, organization_id)
         client = self.__get_redis_client(key)
         if client.get(key):
             return True
@@ -38,7 +40,7 @@ class RedisProjectConfigDebounceCache(ProjectConfigDebounceCache):
         client.setex(key, REDIS_CACHE_TIMEOUT, 1)
         return False
 
-    def mark_task_done(self, project_id, organization_id):
-        key = _get_redis_key(project_id, organization_id)
+    def mark_task_done(self, public_key, project_id, organization_id):
+        key = _get_redis_key(public_key, project_id, organization_id)
         client = self.__get_redis_client(key)
         client.delete(key)

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 @instrumented_task(name="sentry.tasks.relay.update_config_cache", queue="relay_config")
-def update_config_cache(generate, organization_id=None, project_id=None, update_reason=None):
+def update_config_cache(
+    generate, organization_id=None, project_id=None, public_key=None, update_reason=None
+):
     """
     Update the Redis cache for the Relay projectconfig. This task is invoked
     whenever a project/org option has been saved or smart quotas potentially
@@ -26,7 +28,7 @@ def update_config_cache(generate, organization_id=None, project_id=None, update_
         invalidated.
     """
 
-    from sentry.models import Project, ProjectKey, ProjectKeyStatus
+    from sentry.models import Project, ProjectKey
     from sentry.relay import projectconfig_cache
     from sentry.relay.config import get_project_config
 
@@ -38,6 +40,9 @@ def update_config_cache(generate, organization_id=None, project_id=None, update_
         # model and don't want to fetch one
         sentry_sdk.set_tag("organization_id", organization_id)
 
+    if public_key:
+        sentry_sdk.set_tag("public_key", public_key)
+
     sentry_sdk.set_tag("update_reason", update_reason)
     sentry_sdk.set_tag("generate", generate)
 
@@ -47,55 +52,48 @@ def update_config_cache(generate, organization_id=None, project_id=None, update_
     # If this was running at the end of the task, it would be more effective
     # against bursts of updates, but introduces a different race where an
     # outdated cache may be used.
-    projectconfig_debounce_cache.mark_task_done(project_id, organization_id)
+    projectconfig_debounce_cache.mark_task_done(public_key, project_id, organization_id)
 
-    if project_id:
-        projects = [Project.objects.get_from_cache(id=project_id)]
-    elif organization_id:
-        # XXX(markus): I feel like we should be able to cache this but I don't
-        # want to add another method to src/sentry/db/models/manager.py
-        projects = Project.objects.filter(organization_id=organization_id)
+    if organization_id:
+        projects = list(Project.objects.filter(organization_id=organization_id))
+        keys = list(ProjectKey.objects.filter(project__in=projects))
+    elif project_id:
+        projects = [Project.objects.get(id=project_id)]
+        keys = list(ProjectKey.objects.filter(project__in=projects))
+    elif public_key:
+        try:
+            keys = [ProjectKey.objects.get(public_key=public_key)]
+        except ProjectKey.DoesNotExist:
+            # In this particular case, where a project key got deleted and
+            # triggered an update, we at least know the public key that needs
+            # to be deleted from cache.
+            #
+            # In other similar cases, like an org being deleted, we potentially
+            # cannot find any keys anymore, so we don't know which cache keys
+            # to delete.
+            projectconfig_cache.delete_many([public_key])
+            return
 
-    project_keys = {}
-    for key in ProjectKey.objects.filter(project_id__in=[project.id for project in projects]):
-        project_keys.setdefault(key.project_id, []).append(key)
+    else:
+        assert False
 
     if generate:
         config_cache = {}
-        for project in projects:
-            project_config = get_project_config(
-                project, project_keys=project_keys.get(project.id, []), full_config=True
-            )
-            config_cache[project.id] = project_config.to_dict()
-
-            for key in project_keys.get(project.id) or ():
-                # XXX(markus): This is currently the cleanest way to get only
-                # state for a single projectkey (considering quotas and
-                # everything)
-                if key.status != ProjectKeyStatus.ACTIVE:
-                    continue
-
-                project_config = get_project_config(project, project_keys=[key], full_config=True)
-                config_cache[key.public_key] = project_config.to_dict()
+        for key in keys:
+            project_config = get_project_config(key.project, project_keys=[key], full_config=True)
+            config_cache[key.public_key] = project_config.to_dict()
 
         projectconfig_cache.set_many(config_cache)
     else:
         cache_keys_to_delete = []
-        for project in projects:
-            cache_keys_to_delete.append(project.id)
-            for key in project_keys.get(project.id) or ():
-                cache_keys_to_delete.append(key.public_key)
+        for key in keys:
+            cache_keys_to_delete.append(key.public_key)
 
         projectconfig_cache.delete_many(cache_keys_to_delete)
 
-    metrics.incr(
-        "relay.projectconfig_cache.done",
-        tags={"generate": generate, "update_reason": update_reason},
-    )
-
 
 def schedule_update_config_cache(
-    generate, project_id=None, organization_id=None, update_reason=None
+    generate, project_id=None, organization_id=None, public_key=None, update_reason=None
 ):
     """
     Schedule the `update_config_cache` with debouncing applied.
@@ -115,10 +113,13 @@ def schedule_update_config_cache(
         )
         return
 
-    if bool(organization_id) == bool(project_id):
-        raise TypeError("One of organization_id and project_id has to be provided, not both.")
+    bools = sorted((bool(organization_id), bool(project_id), bool(public_key)))
+    if bools != [False, False, True]:
+        raise TypeError(
+            "One of organization_id, project_id, public_key has to be provided, not many."
+        )
 
-    if projectconfig_debounce_cache.check_is_debounced(project_id, organization_id):
+    if projectconfig_debounce_cache.check_is_debounced(public_key, project_id, organization_id):
         metrics.incr(
             "relay.projectconfig_cache.skipped",
             tags={"reason": "debounce", "update_reason": update_reason},
@@ -137,5 +138,6 @@ def schedule_update_config_cache(
         generate=generate,
         project_id=project_id,
         organization_id=organization_id,
+        public_key=public_key,
         update_reason=update_reason,
     )

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -9,7 +9,6 @@ from sentry.tasks.relay import schedule_update_config_cache
 
 
 def _cache_keys_for_project(project):
-    yield project.id
     for key in ProjectKey.objects.filter(project_id=project.id):
         yield key.public_key
 
@@ -73,12 +72,14 @@ def test_debounce(monkeypatch, default_project, default_organization, redis_cach
             "generate": True,
             "project_id": default_project.id,
             "organization_id": None,
+            "public_key": None,
             "update_reason": None,
         },
         {
             "generate": True,
             "project_id": None,
             "organization_id": default_organization.id,
+            "public_key": None,
             "update_reason": None,
         },
     ]
@@ -95,7 +96,7 @@ def test_generate(
     entire_organization,
     redis_cache,
 ):
-    assert not redis_cache.get(default_project.id)
+    assert not redis_cache.get(default_projectkey.public_key)
 
     if not entire_organization:
         kwargs = {"project_id": default_project.id}
@@ -105,7 +106,7 @@ def test_generate(
     with task_runner():
         schedule_update_config_cache(generate=True, **kwargs)
 
-    cfg = redis_cache.get(default_project.id)
+    cfg = redis_cache.get(default_projectkey.public_key)
 
     assert cfg["organizationId"] == default_organization.id
     assert cfg["projectId"] == default_project.id
@@ -124,6 +125,7 @@ def test_generate(
 def test_invalidate(
     monkeypatch,
     default_project,
+    default_projectkey,
     default_organization,
     task_runner,
     entire_organization,
@@ -131,8 +133,8 @@ def test_invalidate(
 ):
 
     cfg = {"foo": "bar"}
-    redis_cache.set_many({default_project.id: cfg})
-    assert redis_cache.get(default_project.id) == cfg
+    redis_cache.set_many({default_projectkey.public_key: cfg})
+    assert redis_cache.get(default_projectkey.public_key) == cfg
 
     if not entire_organization:
         kwargs = {"project_id": default_project.id}
@@ -147,13 +149,13 @@ def test_invalidate(
 
 
 @pytest.mark.django_db
-def test_project_update_option(default_project, task_runner, redis_cache):
+def test_project_update_option(default_projectkey, default_project, task_runner, redis_cache):
     with task_runner():
         default_project.update_option(
             "sentry:relay_pii_config", '{"applications": {"$string": ["@creditcard:mask"]}}'
         )
 
-    assert redis_cache.get(default_project.id)["config"]["piiConfig"] == {
+    assert redis_cache.get(default_projectkey.public_key)["config"]["piiConfig"] == {
         "applications": {"$string": ["@creditcard:mask"]}
     }
 
@@ -203,20 +205,19 @@ def test_projectkeys(default_project, task_runner, redis_cache):
         pk.save()
 
     for key in deleted_pks:
-        # XXX: Ideally we would write `{"disabled": False}` into Redis, however
+        # XXX: Ideally we would write `{"disabled": True}` into Redis, however
         # it's fine if we don't and instead Relay starts hitting the endpoint
         # which will write this for us.
         assert not redis_cache.get(key.public_key)
 
-    for cache_key in (default_project.id, pk.public_key):
-        (pk_json,) = redis_cache.get(cache_key)["publicKeys"]
-        assert pk_json["publicKey"] == pk.public_key
-        assert pk_json["isEnabled"]
+    (pk_json,) = redis_cache.get(pk.public_key)["publicKeys"]
+    assert pk_json["publicKey"] == pk.public_key
+    assert pk_json["isEnabled"]
 
     with task_runner():
         pk.delete()
 
-    assert not redis_cache.get(default_project.id)["publicKeys"]
+    assert not redis_cache.get(pk.public_key)
 
     for key in ProjectKey.objects.filter(project_id=default_project.id):
-        assert not redis_cache.get(default_project.id)
+        assert not redis_cache.get(key.public_key)


### PR DESCRIPTION
In order to improve performance for projects containing a ton of project
keys, refactor code such that project-id-based cache keys are no longer
written (as our ingest relays only look at pk-based redis keys nowadays), and such that a single key is written when a pk is updated
rather than all keys related to the project. This breaks a bunch of unit
tests, which in turn uncover two logic errors in how deletion or update
of project keys is handled.

The customer-visible problem is one of two:

* Have so many keys per project and don't observe updates to eg key
  quota at all, as tasks time out.

* Disable or delete project key, which is not observed in time in Relay.

Disabling of pk: In master we intentionally skip projectkeys that are
not active. We do this to make the projectconfig smaller, and that made
sense back when projectconfig cache keys were projectid based. This is
no longer the case since the refactor.

Deleting of pk: When a pk is deleted, it can't be found in the update
task, and the task crashes. Handle this special case (see code comments
about limitations).