### PR TITLE
feat(profiling): import JS self profile

### DIFF
--- a/static/app/utils/profiling/jsSelfProfiling.tsx
+++ b/static/app/utils/profiling/jsSelfProfiling.tsx
@@ -1,4 +1,5 @@
 import {stackMarkerToHumanReadable} from './formatters/stackMarkerToHumanReadable';
+import {Frame} from './frame';
 
 function createMarkerFrame(marker: JSSelfProfiling.Marker): JSSelfProfiling.Frame {
   return {
@@ -20,15 +21,16 @@ function createMarkerFrame(marker: JSSelfProfiling.Marker): JSSelfProfiling.Fram
 export function resolveJSSelfProfilingStack(
   trace: JSSelfProfiling.Trace,
   stackId: JSSelfProfiling.Sample['stackId'],
+  frameIndex: Record<number, Frame>,
   marker?: JSSelfProfiling.Marker
-): JSSelfProfiling.Frame[] {
+): Frame[] {
   // If there is no stack associated with a sample, it means the thread was idle
 
-  const callStack: JSSelfProfiling.Frame[] = [];
+  const callStack: Frame[] = [];
 
   // There can only be one marker per callStack, so prepend it to the start of the stack
   if (marker && marker !== 'script') {
-    callStack.unshift(createMarkerFrame(marker));
+    callStack.unshift(new Frame({...createMarkerFrame(marker), key: marker}));
   }
 
   if (stackId === undefined) return callStack;
@@ -48,7 +50,7 @@ export function resolveJSSelfProfilingStack(
       return callStack;
     }
 
-    callStack.unshift(trace.frames[stack.frameId]);
+    callStack.unshift(frameIndex[stack.frameId]);
 
     if (stack.parentId) {
       stack = trace.stacks[stack.parentId];

--- a/static/app/utils/profiling/jsSelfProfiling.tsx
+++ b/static/app/utils/profiling/jsSelfProfiling.tsx
@@ -43,7 +43,7 @@ export function resolveJSSelfProfilingStack(
     throw new Error(`Missing stackId ${stackId} in trace, cannot resolve stack`);
   }
 
-  while (stack) {
+  while (stack !== undefined) {
     // If the frameId pointer cannot be resolved, it means the format is corrupt or partial (possibly due to termination reasons).
     // This should never happen, but in the offchance that it somehow does, it should be handled.
     if (!trace.frames[stack.frameId]) {
@@ -52,7 +52,7 @@ export function resolveJSSelfProfilingStack(
 
     callStack.unshift(frameIndex[stack.frameId]);
 
-    if (stack.parentId) {
+    if (stack.parentId !== undefined) {
       stack = trace.stacks[stack.parentId];
     } else {
       stack = undefined;

--- a/static/app/utils/profiling/profile/jsSelfProfile.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.tsx
@@ -1,0 +1,131 @@
+import {lastOfArray} from 'sentry/utils';
+import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
+import {Frame} from 'sentry/utils/profiling/frame';
+
+import {stackMarkerToHumanReadable} from './../formatters/stackMarkerToHumanReadable';
+import {resolveJSSelfProfilingStack} from './../jsSelfProfiling';
+import {Profile} from './profile';
+import {createFrameIndex} from './utils';
+
+export class JSSelfProfile extends Profile {
+  static FromProfile(profile: JSSelfProfiling.Trace): JSSelfProfile {
+    const frameIndex = createFrameIndex(profile.frames, profile);
+    // In the case of JSSelfProfiling, we need to index the abstract marker frames
+    // as they will otherwise not be present in the ProfilerStack.
+    const markers: JSSelfProfiling.Marker[] = [
+      'gc',
+      'layout',
+      'other',
+      'paint',
+      'script',
+      'style',
+    ];
+
+    for (const marker of markers) {
+      frameIndex[marker] = new Frame({
+        key: marker,
+        name: stackMarkerToHumanReadable(marker),
+        line: undefined,
+        column: undefined,
+        is_application: false,
+      });
+    }
+
+    const startedAt = profile.samples[0].timestamp;
+    const endedAt = lastOfArray(profile.samples).timestamp;
+
+    const jsSelfProfile = new JSSelfProfile(
+      endedAt - startedAt,
+      startedAt,
+      endedAt,
+      'JSSelfProfiling',
+      'milliseconds'
+    );
+
+    for (let i = 0; i < profile.samples.length; i++) {
+      const stack = resolveJSSelfProfilingStack(
+        profile,
+        profile.samples[i].stackId,
+        frameIndex,
+        profile.samples[i].marker
+      );
+
+      const time = profile.samples[i - 1]?.timestamp ?? startedAt;
+      jsSelfProfile.appendSample(stack, profile.samples[i].timestamp - time);
+    }
+
+    return jsSelfProfile.build();
+  }
+
+  appendSample(stack: Frame[], weight: number): void {
+    let node = this.appendOrderTree;
+    const framesInStack: CallTreeNode[] = [];
+
+    for (const frame of stack) {
+      const last = lastOfArray(node.children);
+
+      if (last && !last.isLocked() && last.frame === frame) {
+        node = last;
+      } else {
+        const parent = node;
+        node = new CallTreeNode(frame, node);
+        parent.children.push(node);
+      }
+
+      node.addToTotalWeight(weight);
+
+      let start = framesInStack.length - 1;
+
+      while (start >= 0) {
+        if (framesInStack[start].frame === node.frame) {
+          node.setRecursive(node);
+          break;
+        }
+        start--;
+      }
+
+      framesInStack.push(node);
+    }
+
+    node.addToSelfWeight(weight);
+
+    if (weight > 0) {
+      this.minFrameDuration = Math.min(weight, this.minFrameDuration);
+    }
+
+    for (const child of node.children) {
+      child.lock();
+    }
+
+    node.frame.addToSelfWeight(weight);
+
+    for (const stackNode of framesInStack) {
+      stackNode.frame.addToTotalWeight(weight);
+    }
+
+    if (node === lastOfArray(this.samples)) {
+      this.weights[this.weights.length - 1] += weight;
+    } else {
+      this.samples.push(node);
+      this.weights.push(weight);
+    }
+  }
+
+  build(): JSSelfProfile {
+    this.duration = Math.max(
+      this.duration,
+      this.weights.reduce((a, b) => a + b, 0)
+    );
+
+    // We had no frames with duration > 0, so set min duration to timeline duration
+    // which effectively disables any zooming on the flamegraphs
+    if (
+      this.minFrameDuration === Number.POSITIVE_INFINITY ||
+      this.minFrameDuration === 0
+    ) {
+      this.minFrameDuration = this.duration;
+    }
+
+    return this;
+  }
+}

--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -1,10 +1,18 @@
 import {Frame} from 'sentry/utils/profiling/frame';
 
 export function createFrameIndex(
-  frames: Profiling.RawProfileBase['shared']['frames']
+  frames: Profiling.RawProfileBase['shared']['frames'],
+  trace?: JSSelfProfiling.Trace
 ): Record<string | number, Frame> {
   return frames.reduce((acc, frame, index) => {
-    acc[index] = new Frame({key: index, ...frame});
+    acc[index] = new Frame({
+      key: index,
+      resource:
+        trace && typeof frame.resource === 'number'
+          ? trace.resources[frame.resource]
+          : undefined,
+      ...frame,
+    });
     return acc;
   }, {});
 }

--- a/tests/js/spec/utils/profiling/profile/jsSelfProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/jsSelfProfile.spec.tsx
@@ -1,0 +1,220 @@
+import {JSSelfProfile} from 'sentry/utils/profiling/profile/jsSelfProfile';
+
+import {firstCallee, makeTestingBoilerplate, nthCallee} from './profile.spec';
+
+describe('jsSelfProfile', () => {
+  it('imports the base properties', () => {
+    const trace: JSSelfProfiling.Trace = {
+      resources: ['app.js', 'vendor.js'],
+      frames: [{name: 'ReactDOM.render', line: 1, column: 1, resourceId: 0}],
+      samples: [
+        {
+          timestamp: 0,
+        },
+        {
+          timestamp: 1000,
+          stackId: 0,
+        },
+      ],
+      stacks: [
+        {
+          frameId: 0,
+        },
+      ],
+    };
+
+    const profile = JSSelfProfile.FromProfile(trace);
+
+    expect(profile.duration).toBe(1000);
+    expect(profile.startedAt).toBe(0);
+    expect(profile.endedAt).toBe(1000);
+    expect(profile.appendOrderTree.children[0].frame.name).toBe('ReactDOM.render');
+    expect(profile.appendOrderTree.children[0].frame.resource).toBe('app.js');
+  });
+
+  it('handles the first stack sample differently', () => {
+    const trace: JSSelfProfiling.Trace = {
+      resources: ['app.js'],
+      frames: [
+        {name: 'main', line: 1, column: 1, resourceId: 0},
+        {name: 'new Profiler', line: 1, column: 1, resourceId: 0},
+        {name: 'afterProfiler.init', line: 1, column: 1, resourceId: 0},
+      ],
+      samples: [
+        {
+          stackId: 1,
+          timestamp: 500,
+        },
+        {
+          stackId: 2,
+          timestamp: 1500,
+        },
+      ],
+      stacks: [
+        {frameId: 0, parentId: undefined},
+        {frameId: 1, parentId: 0},
+        {frameId: 2, parentId: 0},
+      ],
+    };
+
+    const {open, close, openSpy, closeSpy, timings} = makeTestingBoilerplate();
+
+    const profile = JSSelfProfile.FromProfile(trace);
+
+    profile.forEach(open, close);
+
+    expect(timings).toEqual([
+      ['main', 'open'],
+      ['new Profiler', 'open'],
+      ['new Profiler', 'close'],
+      ['afterProfiler.init', 'open'],
+      ['afterProfiler.init', 'close'],
+      ['main', 'close'],
+    ]);
+    expect(openSpy).toHaveBeenCalledTimes(3);
+    expect(closeSpy).toHaveBeenCalledTimes(3);
+
+    const root = firstCallee(profile.appendOrderTree);
+
+    expect(root.totalWeight).toEqual(1000);
+    expect(root.selfWeight).toEqual(0);
+
+    expect(nthCallee(root, 0).selfWeight).toEqual(0);
+    expect(nthCallee(root, 0).totalWeight).toEqual(0);
+
+    expect(nthCallee(root, 1).selfWeight).toEqual(1000);
+    expect(nthCallee(root, 1).totalWeight).toEqual(1000);
+  });
+
+  it('rebuilds the stack', () => {
+    const trace: JSSelfProfiling.Trace = {
+      resources: ['app.js'],
+      frames: [
+        {name: 'f0', line: 1, column: 1, resourceId: 0},
+        {name: 'f1', line: 1, column: 1, resourceId: 0},
+      ],
+      samples: [
+        {
+          stackId: 0,
+          timestamp: 0,
+        },
+        {
+          timestamp: 1000,
+          stackId: 0,
+        },
+      ],
+      stacks: [{frameId: 1, parentId: 1}, {frameId: 0}],
+    };
+
+    const {open, close, openSpy, closeSpy, timings} = makeTestingBoilerplate();
+
+    const profile = JSSelfProfile.FromProfile(trace);
+
+    profile.forEach(open, close);
+
+    expect(timings).toEqual([
+      ['f0', 'open'],
+      ['f1', 'open'],
+      ['f1', 'close'],
+      ['f0', 'close'],
+    ]);
+    expect(openSpy).toHaveBeenCalledTimes(2);
+    expect(closeSpy).toHaveBeenCalledTimes(2);
+
+    const root = firstCallee(profile.appendOrderTree);
+
+    expect(root.totalWeight).toEqual(1000);
+    expect(firstCallee(root).totalWeight).toEqual(1000);
+
+    expect(root.selfWeight).toEqual(0);
+    expect(firstCallee(root).selfWeight).toEqual(1000);
+  });
+
+  it('marks direct recursion', () => {
+    const trace: JSSelfProfiling.Trace = {
+      resources: ['app.js'],
+      frames: [{name: 'f0', line: 1, column: 1, resourceId: 0}],
+      samples: [
+        {
+          stackId: 0,
+          timestamp: 0,
+        },
+        {
+          stackId: 0,
+          timestamp: 0,
+        },
+      ],
+      stacks: [{frameId: 0, parentId: 1}, {frameId: 0}],
+    };
+
+    const profile = JSSelfProfile.FromProfile(trace);
+
+    expect(firstCallee(firstCallee(profile.appendOrderTree)).isRecursive()).toBe(true);
+  });
+
+  it('marks indirect recursion', () => {
+    const trace: JSSelfProfiling.Trace = {
+      resources: ['app.js'],
+      frames: [
+        {name: 'f0', line: 1, column: 1, resourceId: 0},
+        {name: 'f1', line: 1, column: 1, resourceId: 0},
+      ],
+      samples: [
+        {
+          stackId: 0,
+          timestamp: 0,
+        },
+        {
+          stackId: 2,
+          timestamp: 100,
+        },
+      ],
+      stacks: [
+        {frameId: 0, parentId: undefined},
+        {frameId: 1, parentId: 0},
+        {frameId: 0, parentId: 1},
+      ],
+    };
+
+    const profile = JSSelfProfile.FromProfile(trace);
+
+    expect(
+      firstCallee(firstCallee(firstCallee(profile.appendOrderTree))).isRecursive()
+    ).toBe(true);
+  });
+
+  it('tracks minFrameDuration', () => {
+    const trace: JSSelfProfiling.Trace = {
+      resources: ['app.js'],
+      frames: [
+        {name: 'f0', line: 1, column: 1, resourceId: 0},
+        {name: 'f1', line: 1, column: 1, resourceId: 0},
+        {name: 'f2', line: 1, column: 1, resourceId: 0},
+      ],
+      samples: [
+        {
+          stackId: 0,
+          timestamp: 0,
+        },
+        {
+          stackId: 2,
+          timestamp: 10,
+        },
+        {
+          stackId: 3,
+          timestamp: 100,
+        },
+      ],
+      stacks: [
+        {frameId: 0, parentId: undefined},
+        {frameId: 1, parentId: 0},
+        {frameId: 0, parentId: 1},
+        {frameId: 2},
+      ],
+    };
+
+    const profile = JSSelfProfile.FromProfile(trace);
+
+    expect(profile.minFrameDuration).toBe(10);
+  });
+});

--- a/tests/js/spec/utils/profiling/profile/profile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/profile.spec.tsx
@@ -7,6 +7,7 @@ export const f = (name: string, key: number) =>
   new Frame({name, key, is_application: false});
 export const c = (fr: Frame) => new CallTreeNode(fr, null);
 export const firstCallee = (node: CallTreeNode) => node.children[0];
+export const nthCallee = (node: CallTreeNode, n: number) => node.children[n];
 
 export const makeTestingBoilerplate = () => {
   const timings: [Frame['name'], string][] = [];


### PR DESCRIPTION
Functionality to import JS self profile formats. JS profiles are sampled type, but instead of weights, the samples contain a timestamp, the weight of a sample is basically `profile[i] - profile[i-1]`. This means that we only process samples from 1...samples. To handle that, the first sample is appended with weight 0 which is in line with the spec (a sample is taken when `new Profiler()` is called).