### PR TITLE
ref(asyncComponent): Default disableReport to true - [ISSUE-1346]

### DIFF
--- a/static/app/components/asyncComponent.tsx
+++ b/static/app/components/asyncComponent.tsx
@@ -377,7 +377,7 @@ class AsyncComponent<
     return <LoadingIndicator />;
   }
 
-  renderError(error?: Error, disableLog = false, disableReport = false): React.ReactNode {
+  renderError(error?: Error, disableLog = false, disableReport = true): React.ReactNode {
     const {errors} = this.state;
 
     // 401s are captured by SudoModal, but may be passed back to AsyncComponent if they close the modal without identifying

--- a/static/app/views/eventsV2/eventDetails/linkedIssue.tsx
+++ b/static/app/views/eventsV2/eventDetails/linkedIssue.tsx
@@ -40,7 +40,7 @@ class LinkedIssue extends AsyncComponent<
     return <Placeholder height="120px" bottomGutter={2} />;
   }
 
-  renderError(error?: Error, disableLog = false, disableReport = false): React.ReactNode {
+  renderError(error?: Error, disableLog = false, disableReport = true): React.ReactNode {
     const {errors} = this.state;
     const hasNotFound = Object.values(errors).find(resp => resp && resp.status === 404);
     if (hasNotFound) {

--- a/static/app/views/organizationActivity/index.tsx
+++ b/static/app/views/organizationActivity/index.tsx
@@ -48,7 +48,7 @@ class OrganizationActivity extends AsyncView<Props, State> {
     );
   }
 
-  renderError(error?: Error, disableLog = false, disableReport = false): React.ReactNode {
+  renderError(error?: Error, disableLog = false, disableReport = true): React.ReactNode {
     const {errors} = this.state;
     const notFound = Object.values(errors).find(resp => resp && resp.status === 404);
     if (notFound) {

--- a/static/app/views/routeError.tsx
+++ b/static/app/views/routeError.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import Alert from 'sentry/components/alert';
+import List from 'sentry/components/list';
+import ListItem from 'sentry/components/list/listItem';
 import {IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -14,7 +16,7 @@ import withProject from 'sentry/utils/withProject';
 
 type Props = WithRouterProps & {
   organization: Organization;
-  error: Error | undefined;
+  error?: Error;
   /**
    * Disable logging to Sentry
    */
@@ -97,15 +99,15 @@ class RouteError extends Component<Props> {
           `)}
         </p>
         <p>{t("If you're daring, you may want to try the following:")}</p>
-        <ul>
+        <List symbol="bullet">
           {window && window.adblockSuspected && (
-            <li>
+            <ListItem>
               {t(
                 "We detected something AdBlock-like. Try disabling it, as it's known to cause issues."
               )}
-            </li>
+            </ListItem>
           )}
-          <li>
+          <ListItem>
             {tct(`Give it a few seconds and [link:reload the page].`, {
               link: (
                 <a
@@ -115,13 +117,13 @@ class RouteError extends Component<Props> {
                 />
               ),
             })}
-          </li>
-          <li>
+          </ListItem>
+          <ListItem>
             {tct(`If all else fails, [link:contact us] with more details.`, {
               link: <a href="https://github.com/getsentry/sentry/issues/new/choose" />,
             })}
-          </li>
-        </ul>
+          </ListItem>
+        </List>
       </Alert>
     );
   }


### PR DESCRIPTION
**Problem Description**
the `AsyncComponent` component is widely used on the front-end being extended by classes that need to make asynchronous requests. This component is nice because it already has some useful utilities and handles errors.

But because it's used in several different components on the same page and the `renderError` method has the default `disableReport` parameter to `false`, when several requests fail and aren't bad requests, the `RouteError` component renders several ` Sentry.showReportDialog() ` causing the UI to render multiple feedback dialog. This behavior can be annoying as the user is forced to click on the close button multiple times.

**Problem Solution**
The parameter `disableReport` of the function `renderError` defaults now to `true`.  So when a request fails, the following UI will still be rendered, but the error dialog won't be displayed by default.

![image](https://user-images.githubusercontent.com/29228205/147941561-acb571d4-68fa-4011-a3ec-845b877fca13.png)
