### PR TITLE
feat(profiling): move color utils

### DIFF
--- a/static/app/utils/profiling/colors/Color.tsx
+++ b/static/app/utils/profiling/colors/Color.tsx
@@ -1,0 +1,28 @@
+import {toRGBAString} from './utils';
+
+export class Color {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+
+  constructor(r: number = 0, g: number = 0, b: number = 0, a: number = 1) {
+    this.r = r;
+    this.g = g;
+    this.b = b;
+    this.a = a;
+  }
+
+  static fromLCH(color: number[]): Color {
+    // Initialize alpha to full opacity so we dont end up not seeing colors in case of wrong initial values
+    return new Color(color[0] ?? 0, color[1] ?? 0, color[2] ?? 0, color[3] ?? 1);
+  }
+
+  withAlpha(alpha: number): Color {
+    return Color.fromLCH([this.r, this.g, this.b, alpha]);
+  }
+
+  toRGBAString(): string {
+    return toRGBAString(this.r, this.g, this.b, this.a);
+  }
+}

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -1,0 +1,153 @@
+import {Frame} from '../frame';
+
+import {Color, FlamegraphTheme} from './../flamegraph/FlamegraphTheme';
+
+const uniqueBy = <T,>(arr: ReadonlyArray<T>, predicate: (t: T) => unknown): Array<T> => {
+  const cb = typeof predicate === 'function' ? predicate : (o: T) => o[predicate];
+
+  return [
+    ...arr
+      .reduce((map, item) => {
+        const key = item === null || item === undefined ? item : cb(item);
+
+        if (key === undefined || key === null) return map;
+        map.has(key) || map.set(key, item);
+
+        return map;
+      }, new Map())
+      .values(),
+  ];
+};
+
+// https://en.wikipedia.org/wiki/HSL_and_HSV#From_luma/chroma/hue
+export const fract = (x: number): number => x - Math.floor(x);
+export const triangle = (x: number): number => 2.0 * Math.abs(fract(x) - 0.5) - 1.0;
+export function fromLumaChromaHue(L: number, C: number, H: number): Color {
+  const hPrime = H / 60;
+  const X = C * (1 - Math.abs((hPrime % 2) - 1));
+  const [R1, G1, B1] =
+    hPrime < 1
+      ? [C, X, 0]
+      : hPrime < 2
+      ? [X, C, 0]
+      : hPrime < 3
+      ? [0, C, X]
+      : hPrime < 4
+      ? [0, X, C]
+      : hPrime < 5
+      ? [X, 0, C]
+      : [C, 0, X];
+
+  const m = L - (0.3 * R1 + 0.59 * G1 + 0.11 * B1);
+
+  return [clamp(R1 + m, 0, 1), clamp(G1 + m, 0, 1), clamp(B1 + m, 0, 1.0)];
+}
+
+export const isNumber = (input: unknown): input is number => {
+  return typeof input === 'number' && !isNaN(input);
+};
+
+export function clamp(number: number, min?: number, max?: number): number {
+  if (!isNumber(min) && !isNumber(max)) {
+    throw new Error('Clamp requires at least a min or max parameter');
+  }
+
+  if (isNumber(min) && isNumber(max)) {
+    return number < min ? min : number > max ? max : number;
+  }
+
+  if (isNumber(max)) {
+    return number > max ? max : number;
+  }
+
+  if (isNumber(min)) {
+    return number < min ? min : number;
+  }
+
+  throw new Error('Unreachable case detected');
+}
+
+export function toRGBAString(r: number, g: number, b: number, alpha: number): string {
+  return `rgba(${r * 255}, ${g * 255}, ${b * 255}, ${alpha})`;
+}
+
+export function defaultFrameSortKey(frame: Frame): string {
+  return (frame.file || '') + frame.name;
+}
+
+export const makeColorMap = (
+  frames: ReadonlyArray<Frame>,
+  colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET'],
+  sortByKey: typeof defaultFrameSortKey = defaultFrameSortKey
+): Map<Frame['key'], Color> => {
+  const colors = new Map<Frame['key'], Color>();
+
+  const sortedFrames = [...frames].sort((a, b) => (sortByKey(a) > sortByKey(b) ? 1 : -1));
+  const length = sortedFrames.length;
+
+  for (let i = 0; i < length; i++) {
+    colors.set(
+      sortedFrames[i].name + sortedFrames[i].file,
+      colorBucket(Math.floor((255 * i) / frames.length) / 256, sortedFrames[i])
+    );
+  }
+
+  return colors;
+};
+
+export const colorMapByRecursion = (
+  frames: ReadonlyArray<Frame>,
+  colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
+): Map<Frame['key'], Color> => {
+  const colors = new Map<Frame['key'], Color>();
+
+  const sortedFrames = uniqueBy(
+    frames.filter(f => f.recursive),
+    defaultFrameSortKey
+  );
+
+  for (let i = 0; i < sortedFrames.length; i++) {
+    const frame = sortedFrames[i];
+
+    colors.set(
+      frame.name + frame.file,
+      colorBucket(Math.floor((255 * i) / sortedFrames.length) / 256, frame)
+    );
+  }
+
+  return colors;
+};
+
+export const colorMapByImage = (
+  frames: ReadonlyArray<Frame>,
+  colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
+): Map<Frame['key'], Color> => {
+  const colors = new Map<Frame['key'], Color>();
+
+  const reverseFrameToImageIndex: Record<string, Frame[]> = {};
+
+  const uniqueFrames = uniqueBy(frames, f => f.image);
+  const sortedFrames = [...uniqueFrames].sort((a, b) =>
+    (a.image ?? '') > (b.image ?? '') ? 1 : -1
+  );
+
+  for (const frame of frames) {
+    const key = frame.image ?? '';
+
+    if (!reverseFrameToImageIndex[key]) reverseFrameToImageIndex[key] = [];
+    reverseFrameToImageIndex[key].push(frame);
+  }
+
+  for (let i = 0; i < sortedFrames.length; i++) {
+    const imageFrames = reverseFrameToImageIndex[sortedFrames[i]?.image ?? ''];
+
+    for (const frame of imageFrames) {
+      colors.set(
+        frame.name + frame.file,
+        colorBucket(Math.floor((255 * i) / sortedFrames.length) / 256, frame)
+      );
+    }
+  }
+
+  return colors;
+};

--- a/static/app/utils/profiling/flamegraph/FlamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/FlamegraphTheme.tsx
@@ -1,4 +1,4 @@
-import {makeColorBucketTheme, makeColorMap} from './../colors/utils';
+import {makeColorBucketTheme, makeColorMap, makeStackToColor} from './../colors/utils';
 import {Frame} from './../frame';
 
 const MONOSPACE_FONT = `ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono', 'Roboto Mono',
@@ -88,6 +88,7 @@ export interface FlamegraphTheme {
   };
 }
 
+// Luma chroma hue settings for light theme
 export const LCH_LIGHT = {
   C_0: 0.25,
   C_d: 0.2,
@@ -95,45 +96,12 @@ export const LCH_LIGHT = {
   L_d: 0.15,
 };
 
+// Luma chroma hue settings for dark theme
 export const LCH_DARK = {
   C_0: 0.2,
   C_d: 0.1,
   L_0: 0.2,
   L_d: 0.1,
-};
-
-const makeStackToColor = (
-  fallback: [number, number, number, number]
-): FlamegraphTheme['COLORS']['STACK_TO_COLOR'] => {
-  return (
-    frames: ReadonlyArray<Frame>,
-    colorMap: FlamegraphTheme['COLORS']['COLOR_MAP'],
-    colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
-  ) => {
-    const colors = colorMap(frames, colorBucket);
-    const colorBuffer: number[] = [];
-
-    const length = frames.length;
-
-    for (let index = 0; index < length; index++) {
-      const frame = frames[index];
-      const c = colors.get(frame.name + frame.file);
-      const colorWithAlpha = c ? [...c, 1] : fallback;
-
-      for (let i = 0; i < 6; i++) {
-        const offset = index * 6 * 4 + i * 4;
-        colorBuffer[offset] = colorWithAlpha[0];
-        colorBuffer[offset + 1] = colorWithAlpha[1];
-        colorBuffer[offset + 2] = colorWithAlpha[2];
-        colorBuffer[offset + 3] = colorWithAlpha[3];
-      }
-    }
-
-    return {
-      colorBuffer,
-      colorMap: colors,
-    };
-  };
 };
 
 export const LightFlamegraphTheme: FlamegraphTheme = {

--- a/static/app/utils/profiling/flamegraph/FlamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/FlamegraphTheme.tsx
@@ -1,4 +1,4 @@
-import {fromLumaChromaHue, makeColorMap, triangle} from './../colors/utils';
+import {makeColorBucketTheme, makeColorMap} from './../colors/utils';
 import {Frame} from './../frame';
 
 const MONOSPACE_FONT = `ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono', 'Roboto Mono',
@@ -71,7 +71,7 @@ export interface FlamegraphTheme {
     COLOR_MAP: (
       frames: ReadonlyArray<Frame>,
       colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET'],
-      sortByKey?: (frame: Frame) => string
+      sortByKey?: (a: Frame, b: Frame) => number
     ) => Map<Frame['key'], Color>;
     STACK_TO_COLOR: (
       frames: ReadonlyArray<Frame>,
@@ -100,16 +100,6 @@ export const LCH_DARK = {
   C_d: 0.1,
   L_0: 0.2,
   L_d: 0.1,
-};
-
-export const makeColorBucketTheme = (lch: LCH) => {
-  return (t: number): Color => {
-    const x = triangle(30.0 * t);
-    const H = 360.0 * (0.9 * t);
-    const C = lch.C_0 + lch.C_d * x;
-    const L = lch.L_0 - lch.L_d * x;
-    return fromLumaChromaHue(L, C, H);
-  };
 };
 
 const makeStackToColor = (

--- a/static/app/utils/profiling/flamegraph/FlamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/FlamegraphTheme.tsx
@@ -1,0 +1,256 @@
+import {fromLumaChromaHue, makeColorMap, triangle} from './../colors/utils';
+import {Frame} from './../frame';
+
+const MONOSPACE_FONT = `ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono', 'Roboto Mono',
+'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro', 'Fira Mono', 'Droid Sans Mono',
+'Courier New', monospace`;
+
+// Luma chroma hue settings
+export interface LCH {
+  C_0: number;
+  C_d: number;
+  L_0: number;
+  L_d: number;
+}
+// Color can be rgb or rgba. I want to probably eliminate rgb and just use rgba, but we would be allocating 25% more memory,
+// and I'm not sure about the impact we'd need. There is a tradeoff between memory and runtime performance checks that I'll need to evaluate at some point.
+export type Color = [number, number, number] | [number, number, number, number];
+
+export interface FlamegraphTheme {
+  CONFIG: {
+    HIGHLIGHT_RECURSION: boolean;
+  };
+  SIZES: {
+    BAR_HEIGHT: number;
+    BAR_FONT_SIZE: number;
+    BAR_PADDING: number;
+    HOVERED_FRAME_BORDER_WIDTH: number;
+    FLAMEGRAPH_DEPTH_OFFSET: number;
+    FRAME_BORDER_WIDTH: number;
+    // Spans
+    SPANS_BAR_HEIGHT: number;
+    SPANS_DEPTH_OFFSET: number;
+    SPANS_FONT_SIZE: number;
+    // Request
+    REQUEST_TAIL_HEIGHT: number;
+    REQUEST_BAR_HEIGHT: number;
+    REQUEST_FONT_SIZE: number;
+    REQUEST_DEPTH_OFFSET: number;
+
+    MINIMAP_POSITION_OVERLAY_BORDER_WIDTH: number;
+    TIMELINE_HEIGHT: number;
+    LABEL_FONT_SIZE: number;
+    LABEL_FONT_PADDING: number;
+  };
+  // @TODO, most colors are defined as strings, which is a mistake as we loose a lot of functionality and impose constraints.
+  // They should instead be defined as arrays of numbers so we can use them with glsl and avoid unnecessary parsing
+  COLORS: {
+    LABEL_FONT_COLOR: string;
+    BAR_LABEL_FONT_COLOR: string;
+    CURSOR_CROSSHAIR: string;
+    GRID_LINE_COLOR: string;
+    GRID_FRAME_BACKGROUND_COLOR: string;
+    SELECTED_FRAME_BORDER_COLOR: string;
+    HOVERED_FRAME_BORDER_COLOR: string;
+    MINIMAP_POSITION_OVERLAY_COLOR: string;
+    MINIMAP_POSITION_OVERLAY_BORDER_COLOR: string;
+    // Nice color picker for GLSL colors - https://keiwando.com/color-picker/
+    REQUEST_WAIT_TIME: string;
+    REQUEST_DNS_TIME: string;
+    REQUEST_TCP_TIME: string;
+    REQUEST_SSL_TIME: string;
+    REQUEST_2XX_RESPONSE: string;
+    REQUEST_4XX_RESPONSE: string;
+
+    SEARCH_RESULT_FRAME_COLOR: string;
+    SPAN_FRAME_BACKGROUND: string;
+    SPAN_FRAME_BORDER: string;
+    DIFFERENTIAL_INCREASE: Color;
+    DIFFERENTIAL_DECREASE: Color;
+    COLOR_BUCKET: (t: number, frame?: Frame) => Color;
+    COLOR_MAP: (
+      frames: ReadonlyArray<Frame>,
+      colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET'],
+      sortByKey?: (frame: Frame) => string
+    ) => Map<Frame['key'], Color>;
+    STACK_TO_COLOR: (
+      frames: ReadonlyArray<Frame>,
+      colorMapFn: FlamegraphTheme['COLORS']['COLOR_MAP'],
+      colorBucketFn: FlamegraphTheme['COLORS']['COLOR_BUCKET']
+    ) => {
+      colorBuffer: Array<number>;
+      colorMap: Map<Frame['key'], Color>;
+    };
+    FRAME_FALLBACK_COLOR: [number, number, number, number];
+  };
+  FONTS: {
+    FONT: string;
+  };
+}
+
+export const LCH_LIGHT = {
+  C_0: 0.25,
+  C_d: 0.2,
+  L_0: 0.8,
+  L_d: 0.15,
+};
+
+export const LCH_DARK = {
+  C_0: 0.2,
+  C_d: 0.1,
+  L_0: 0.2,
+  L_d: 0.1,
+};
+
+export const makeColorBucketTheme = (lch: LCH) => {
+  return (t: number): Color => {
+    const x = triangle(30.0 * t);
+    const H = 360.0 * (0.9 * t);
+    const C = lch.C_0 + lch.C_d * x;
+    const L = lch.L_0 - lch.L_d * x;
+    return fromLumaChromaHue(L, C, H);
+  };
+};
+
+const makeStackToColor = (
+  fallback: [number, number, number, number]
+): FlamegraphTheme['COLORS']['STACK_TO_COLOR'] => {
+  return (
+    frames: ReadonlyArray<Frame>,
+    colorMap: FlamegraphTheme['COLORS']['COLOR_MAP'],
+    colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
+  ) => {
+    const colors = colorMap(frames, colorBucket);
+    const colorBuffer: number[] = [];
+
+    const length = frames.length;
+
+    for (let index = 0; index < length; index++) {
+      const frame = frames[index];
+      const c = colors.get(frame.name + frame.file);
+      const colorWithAlpha = c ? [...c, 1] : fallback;
+
+      for (let i = 0; i < 6; i++) {
+        const offset = index * 6 * 4 + i * 4;
+        colorBuffer[offset] = colorWithAlpha[0];
+        colorBuffer[offset + 1] = colorWithAlpha[1];
+        colorBuffer[offset + 2] = colorWithAlpha[2];
+        colorBuffer[offset + 3] = colorWithAlpha[3];
+      }
+    }
+
+    return {
+      colorBuffer,
+      colorMap: colors,
+    };
+  };
+};
+
+export const LightFlamegraphTheme: FlamegraphTheme = {
+  CONFIG: {
+    HIGHLIGHT_RECURSION: false,
+  },
+  SIZES: {
+    BAR_HEIGHT: 20,
+    BAR_FONT_SIZE: 12,
+    BAR_PADDING: 4,
+    FLAMEGRAPH_DEPTH_OFFSET: 12,
+    SPANS_DEPTH_OFFSET: 4,
+    SPANS_FONT_SIZE: 10,
+    SPANS_BAR_HEIGHT: 14,
+    REQUEST_TAIL_HEIGHT: 8,
+    REQUEST_BAR_HEIGHT: 14,
+    REQUEST_FONT_SIZE: 10,
+    REQUEST_DEPTH_OFFSET: 4,
+    MINIMAP_POSITION_OVERLAY_BORDER_WIDTH: 2,
+    TIMELINE_HEIGHT: 20,
+    LABEL_FONT_SIZE: 10,
+    LABEL_FONT_PADDING: 6,
+    FRAME_BORDER_WIDTH: 2,
+    HOVERED_FRAME_BORDER_WIDTH: 1,
+  },
+  COLORS: {
+    LABEL_FONT_COLOR: '#1f233a',
+    BAR_LABEL_FONT_COLOR: '#000',
+    GRID_LINE_COLOR: '#e5e7eb',
+    GRID_FRAME_BACKGROUND_COLOR: 'rgba(255, 255, 255, 0.8)',
+    SEARCH_RESULT_FRAME_COLOR: 'vec4(0.99, 0.70, 0.35, 1.0)',
+    SELECTED_FRAME_BORDER_COLOR: '#005aff',
+    HOVERED_FRAME_BORDER_COLOR: 'rgba(0, 0, 0, 0.8)',
+    CURSOR_CROSSHAIR: '#bbbbbb',
+    SPAN_FRAME_BORDER: 'rgba(200, 200, 200, 1)',
+    SPAN_FRAME_BACKGROUND: 'rgba(231, 231, 231, 0.5)',
+    MINIMAP_POSITION_OVERLAY_COLOR: 'rgba(0,0,0,0.1)',
+    MINIMAP_POSITION_OVERLAY_BORDER_COLOR: 'rgba(0,0,0, 0.2)',
+    REQUEST_WAIT_TIME: `rgba(253,252,224, 1)`,
+    REQUEST_DNS_TIME: `rgba(57, 146, 152, 1)`,
+    REQUEST_TCP_TIME: `rgba(242, 146,57,1)`,
+    REQUEST_SSL_TIME: `rgba(207,84,218, 1)`,
+    REQUEST_2XX_RESPONSE: 'rgba(218, 231, 209, 1)',
+    REQUEST_4XX_RESPONSE: 'rgba(255,96, 96, 1)',
+    DIFFERENTIAL_INCREASE: [0.98, 0.2058, 0.4381],
+    DIFFERENTIAL_DECREASE: [0.309, 0.2058, 0.98],
+    COLOR_BUCKET: makeColorBucketTheme(LCH_LIGHT),
+    COLOR_MAP: makeColorMap,
+    STACK_TO_COLOR: makeStackToColor([0, 0, 0, 0.035]),
+    FRAME_FALLBACK_COLOR: [0, 0, 0, 0.035],
+  },
+  FONTS: {
+    FONT: MONOSPACE_FONT,
+  },
+};
+
+export const DarkFlamegraphTheme: FlamegraphTheme = {
+  CONFIG: {
+    HIGHLIGHT_RECURSION: false,
+  },
+  SIZES: {
+    BAR_HEIGHT: 20,
+    BAR_FONT_SIZE: 12,
+    BAR_PADDING: 4,
+    FLAMEGRAPH_DEPTH_OFFSET: 12,
+    SPANS_DEPTH_OFFSET: 4,
+    SPANS_FONT_SIZE: 10,
+    SPANS_BAR_HEIGHT: 14,
+    REQUEST_TAIL_HEIGHT: 8,
+    REQUEST_BAR_HEIGHT: 14,
+    REQUEST_FONT_SIZE: 10,
+    REQUEST_DEPTH_OFFSET: 4,
+
+    MINIMAP_POSITION_OVERLAY_BORDER_WIDTH: 2,
+    TIMELINE_HEIGHT: 20,
+    LABEL_FONT_SIZE: 10,
+    LABEL_FONT_PADDING: 6,
+    FRAME_BORDER_WIDTH: 2,
+    HOVERED_FRAME_BORDER_WIDTH: 1,
+  },
+  COLORS: {
+    LABEL_FONT_COLOR: 'rgba(255, 255, 255, 0.8)',
+    BAR_LABEL_FONT_COLOR: 'rgb(255 255 255 / 80%)',
+    GRID_LINE_COLOR: '#222227',
+    GRID_FRAME_BACKGROUND_COLOR: 'rgba(0, 0, 0, 0.4)',
+    SEARCH_RESULT_FRAME_COLOR: 'vec4(0.99, 0.70, 0.35, 0.7)',
+    SELECTED_FRAME_BORDER_COLOR: '#3482ea',
+    HOVERED_FRAME_BORDER_COLOR: 'rgba(255, 255, 255, 0.8)',
+    CURSOR_CROSSHAIR: '#828285',
+    SPAN_FRAME_BORDER: '#57575b',
+    SPAN_FRAME_BACKGROUND: 'rgba(232, 232, 232, 0.2)',
+    REQUEST_WAIT_TIME: `rgba(253,252,224, 1)`,
+    REQUEST_DNS_TIME: `rgba(57, 146, 152, 1)`,
+    REQUEST_TCP_TIME: `rgba(242, 146,57,1)`,
+    REQUEST_SSL_TIME: `rgba(207,84,218, 1)`,
+    REQUEST_2XX_RESPONSE: 'rgba(218, 231, 209, 1)',
+    REQUEST_4XX_RESPONSE: 'rgba(255,96, 96, 1)',
+    MINIMAP_POSITION_OVERLAY_COLOR: 'rgba(255,255,255,0.1)',
+    MINIMAP_POSITION_OVERLAY_BORDER_COLOR: 'rgba(255,255,255, 0.2)',
+    DIFFERENTIAL_INCREASE: [0.98, 0.2058, 0.4381],
+    DIFFERENTIAL_DECREASE: [0.309, 0.2058, 0.98],
+    COLOR_BUCKET: makeColorBucketTheme(LCH_DARK),
+    COLOR_MAP: makeColorMap,
+    STACK_TO_COLOR: makeStackToColor([1, 1, 1, 0.1]),
+    FRAME_FALLBACK_COLOR: [1, 1, 1, 0.1],
+  },
+  FONTS: {
+    FONT: MONOSPACE_FONT,
+  },
+};

--- a/tests/js/spec/utils/profiling/colors/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/colors/utils.spec.tsx
@@ -3,6 +3,7 @@ import {
   makeColorMap,
   makeColorMapByImage,
   makeColorMapByRecursion,
+  makeStackToColor,
 } from 'sentry/utils/profiling/colors/utils';
 import {LCH_LIGHT} from 'sentry/utils/profiling/flamegraph/FlamegraphTheme';
 import {Frame} from 'sentry/utils/profiling/frame';
@@ -10,14 +11,72 @@ import {Frame} from 'sentry/utils/profiling/frame';
 const f = (name: string, file?: string, image?: string) =>
   new Frame({key: name + (file ? file : ''), name, file, image});
 
-const dominantColor = (
+const getDominantColor = (
   c: [number, number, number] | [number, number, number, number] | undefined
 ): string => {
   if (!c) throw new Error('Color not found');
 
-  const index = c.indexOf(Math.max(...c));
+  const index = c.indexOf(Math.max(...c.slice(0, 3)));
   return index === 0 ? 'red' : index === 1 ? 'green' : 'blue';
 };
+
+describe('makeStackToColor', () => {
+  it('uses fallback color in case frames is not found', () => {
+    // Bright red color fallback
+    const fallback = [1, 0, 0, 1] as [number, number, number, number];
+
+    const makeFn = makeStackToColor(fallback);
+
+    const frames = [f('a')];
+
+    const {colorBuffer} = makeFn(
+      frames,
+      () => new Map(),
+      makeColorBucketTheme(LCH_LIGHT)
+    );
+    expect(colorBuffer.slice(0, 4)).toEqual(fallback);
+    expect(colorBuffer).toHaveLength(24);
+  });
+
+  it('uses the color encoding', () => {
+    // Bright red color fallback
+    const fallback = [1, 0, 0, 1] as [number, number, number, number];
+
+    const makeFn = makeStackToColor(fallback);
+
+    const frames = [f('a')];
+
+    const {colorBuffer} = makeFn(frames, makeColorMap, makeColorBucketTheme(LCH_LIGHT));
+    expect(colorBuffer.slice(0, 4)).toEqual([
+      0.9750000000000001, 0.7250000000000001, 0.7250000000000001, 1,
+    ]);
+    expect(
+      getDominantColor(colorBuffer.slice(0, 4) as [number, number, number, number])
+    ).toBe('red');
+    expect(colorBuffer).toHaveLength(24);
+  });
+
+  it('sets alpha component if none is set by the colorMap fn', () => {
+    // Bright red color fallback
+    const fallback = [1, 0, 0, 1] as [number, number, number, number];
+
+    const makeFn = makeStackToColor(fallback);
+    const frames = [f('a')];
+
+    const {colorBuffer} = makeFn(
+      frames,
+      () => {
+        const m = new Map();
+        // Only set rgb
+        m.set('a', [1, 0, 0]);
+        return m;
+      },
+      makeColorBucketTheme(LCH_LIGHT)
+    );
+    expect(colorBuffer.slice(0, 4)).toEqual([1, 0, 0, 1]);
+    expect(colorBuffer).toHaveLength(24);
+  });
+});
 
 describe('makeColorMap', () => {
   it('default colors by frame name', () => {
@@ -26,9 +85,9 @@ describe('makeColorMap', () => {
 
     const map = makeColorMap(frames, makeColorBucketTheme(LCH_LIGHT));
 
-    expect(dominantColor(map.get('a'))).toBe('red');
-    expect(dominantColor(map.get('b'))).toBe('green');
-    expect(dominantColor(map.get('c'))).toBe('blue');
+    expect(getDominantColor(map.get('a'))).toBe('red');
+    expect(getDominantColor(map.get('b'))).toBe('green');
+    expect(getDominantColor(map.get('c'))).toBe('blue');
   });
 
   it('colors by custom sort', () => {
@@ -39,9 +98,9 @@ describe('makeColorMap', () => {
       b.name > a.name ? 1 : -1
     );
 
-    expect(dominantColor(map.get('a'))).toBe('blue');
-    expect(dominantColor(map.get('b'))).toBe('green');
-    expect(dominantColor(map.get('c'))).toBe('red');
+    expect(getDominantColor(map.get('a'))).toBe('blue');
+    expect(getDominantColor(map.get('b'))).toBe('green');
+    expect(getDominantColor(map.get('c'))).toBe('red');
   });
 
   it('colors by image', () => {
@@ -54,9 +113,9 @@ describe('makeColorMap', () => {
 
     const map = makeColorMapByImage(frames, makeColorBucketTheme(LCH_LIGHT));
 
-    expect(dominantColor(map.get('a'))).toBe('red');
-    expect(dominantColor(map.get('b'))).toBe('green');
-    expect(dominantColor(map.get('c'))).toBe('blue');
+    expect(getDominantColor(map.get('a'))).toBe('red');
+    expect(getDominantColor(map.get('b'))).toBe('green');
+    expect(getDominantColor(map.get('c'))).toBe('blue');
   });
 
   it('colors by recursive frames', () => {
@@ -68,7 +127,7 @@ describe('makeColorMap', () => {
 
     const map = makeColorMapByRecursion(frames, makeColorBucketTheme(LCH_LIGHT));
 
-    expect(dominantColor(map.get('aaa'))).toBe('red');
+    expect(getDominantColor(map.get('aaa'))).toBe('red');
     expect(map.get('c')).toBeUndefined();
   });
 });

--- a/tests/js/spec/utils/profiling/colors/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/colors/utils.spec.tsx
@@ -1,0 +1,74 @@
+import {
+  makeColorBucketTheme,
+  makeColorMap,
+  makeColorMapByImage,
+  makeColorMapByRecursion,
+} from 'sentry/utils/profiling/colors/utils';
+import {LCH_LIGHT} from 'sentry/utils/profiling/flamegraph/FlamegraphTheme';
+import {Frame} from 'sentry/utils/profiling/frame';
+
+const f = (name: string, file?: string, image?: string) =>
+  new Frame({key: name + (file ? file : ''), name, file, image});
+
+const dominantColor = (
+  c: [number, number, number] | [number, number, number, number] | undefined
+): string => {
+  if (!c) throw new Error('Color not found');
+
+  const index = c.indexOf(Math.max(...c));
+  return index === 0 ? 'red' : index === 1 ? 'green' : 'blue';
+};
+
+describe('makeColorMap', () => {
+  it('default colors by frame name', () => {
+    // Reverse order to ensure we actually sort
+    const frames = [f('c'), f('b'), f('a')];
+
+    const map = makeColorMap(frames, makeColorBucketTheme(LCH_LIGHT));
+
+    expect(dominantColor(map.get('a'))).toBe('red');
+    expect(dominantColor(map.get('b'))).toBe('green');
+    expect(dominantColor(map.get('c'))).toBe('blue');
+  });
+
+  it('colors by custom sort', () => {
+    // Reverse order to ensure we actually sort
+    const frames = [f('c'), f('b'), f('a')];
+
+    const map = makeColorMap(frames, makeColorBucketTheme(LCH_LIGHT), (a, b) =>
+      b.name > a.name ? 1 : -1
+    );
+
+    expect(dominantColor(map.get('a'))).toBe('blue');
+    expect(dominantColor(map.get('b'))).toBe('green');
+    expect(dominantColor(map.get('c'))).toBe('red');
+  });
+
+  it('colors by image', () => {
+    // Reverse order to ensure we actually sort
+    const frames = [
+      f('c', undefined, 'c'),
+      f('b', undefined, 'b'),
+      f('a', undefined, 'a'),
+    ];
+
+    const map = makeColorMapByImage(frames, makeColorBucketTheme(LCH_LIGHT));
+
+    expect(dominantColor(map.get('a'))).toBe('red');
+    expect(dominantColor(map.get('b'))).toBe('green');
+    expect(dominantColor(map.get('c'))).toBe('blue');
+  });
+
+  it('colors by recursive frames', () => {
+    // Reverse order to ensure we actually sort
+    const frames = [f('aaa'), f('aaa'), f('aaa'), f('c')];
+
+    frames[1].recursive = frames[0];
+    frames[2].recursive = frames[1];
+
+    const map = makeColorMapByRecursion(frames, makeColorBucketTheme(LCH_LIGHT));
+
+    expect(dominantColor(map.get('aaa'))).toBe('red');
+    expect(map.get('c')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This PR moves some color utils for generating the flamegraph color theme. ~Draft for now, as I need to write the tests~.

We have a few different ways to allow users to visualize the flamegraph by changing the color of the frames - by recursion, binary/image and frame names. By default, we color code by frame name + binary.

The colors used for the flamegraphs are still the Specto colors, we will update the design to match Sentry after we've integrated the project and have an MVP working