### PR TITLE
chore(suspect-spans): Remove project from suspect span payload

### DIFF
--- a/static/app/utils/performance/suspectSpans/types.tsx
+++ b/static/app/utils/performance/suspectSpans/types.tsx
@@ -21,9 +21,6 @@ export type SpanExample = {
 };
 
 export type SuspectSpan = SpanExample & {
-  projectId: number;
-  project: string;
-  transaction: string;
   frequency?: number;
   count?: number;
   avgOccurrences?: number;

--- a/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.tsx
@@ -23,6 +23,7 @@ import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {ColumnType, fieldAlignment} from 'sentry/utils/discover/fields';
 import SuspectSpansQuery from 'sentry/utils/performance/suspectSpans/suspectSpansQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
+import useProjects from 'sentry/utils/useProjects';
 
 import {SpanSortOthers, SpanSortPercentiles} from '../transactionSpans/types';
 import {
@@ -105,6 +106,8 @@ export default function SuspectSpans(props: Props) {
     order: 'desc',
   };
 
+  const {projects} = useProjects();
+
   return (
     <SuspectSpansQuery
       location={location}
@@ -117,7 +120,7 @@ export default function SuspectSpans(props: Props) {
         const data = (suspectSpans ?? []).map(suspectSpan => {
           const example = suspectSpan.examples[0];
           return {
-            project: suspectSpan.project,
+            project: projects.find(p => p.id === projectId)?.slug,
             op: suspectSpan.op,
             description: example?.description ?? null,
             p75ExclusiveTime: suspectSpan.p75ExclusiveTime,

--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -18,6 +18,7 @@ import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import SuspectSpansQuery from 'sentry/utils/performance/suspectSpans/suspectSpansQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
+import useProjects from 'sentry/utils/useProjects';
 
 import {SetStateAction} from '../types';
 
@@ -44,12 +45,13 @@ type Props = {
   location: Location;
   organization: Organization;
   eventView: EventView;
+  projectId: string;
   setError: SetStateAction<string | undefined>;
   transactionName: string;
 };
 
 function SpansContent(props: Props) {
-  const {location, organization, eventView, setError, transactionName} = props;
+  const {location, organization, eventView, projectId, setError, transactionName} = props;
   const query = decodeScalar(location.query.query, '');
 
   function handleChange(key: string) {
@@ -80,6 +82,8 @@ function SpansContent(props: Props) {
   const sort = getSuspectSpanSortFromEventView(eventView);
   const spansView = getSpansEventView(eventView, sort.field);
   const totalsView = getTotalsView(eventView);
+
+  const {projects} = useProjects();
 
   return (
     <Layout.Main fullWidth>
@@ -164,6 +168,7 @@ function SpansContent(props: Props) {
                         eventView={eventView}
                         totals={totals}
                         preview={2}
+                        project={projects.find(p => p.id === projectId)}
                       />
                     ))}
                     <Pagination pageLinks={pageLinks} />

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanTable.tsx
@@ -6,7 +6,7 @@ import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
-import {Organization} from 'sentry/types';
+import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {ColumnType, fieldAlignment} from 'sentry/utils/discover/fields';
@@ -31,6 +31,7 @@ type Props = {
   transactionName: string;
   isLoading: boolean;
   examples: ExampleTransaction[];
+  project?: Project;
   pageLinks?: string | null;
 };
 
@@ -38,6 +39,7 @@ export default function SpanTable(props: Props) {
   const {
     location,
     organization,
+    project,
     examples,
     suspectSpan,
     transactionName,
@@ -51,7 +53,7 @@ export default function SpanTable(props: Props) {
 
   const data = examples.map(example => ({
     id: example.id,
-    project: suspectSpan.project,
+    project: project?.slug,
     // timestamps are in seconds but want them in milliseconds
     timestamp: example.finishTimestamp * 1000,
     transactionDuration: (example.finishTimestamp - example.startTimestamp) * 1000,

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
@@ -4,7 +4,7 @@ import {Location} from 'history';
 import Button from 'sentry/components/button';
 import Tooltip from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
-import {Organization} from 'sentry/types';
+import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {formatFloat, formatPercentage} from 'sentry/utils/formatters';
@@ -37,6 +37,7 @@ type Props = {
   eventView: EventView;
   totals: SpansTotalValues | null;
   preview: number;
+  project?: Project;
 };
 
 export default function SuspectSpanEntry(props: Props) {
@@ -48,6 +49,7 @@ export default function SuspectSpanEntry(props: Props) {
     eventView,
     totals,
     preview,
+    project,
   } = props;
 
   const expandable = suspectSpan.examples.length > preview;
@@ -77,6 +79,7 @@ export default function SuspectSpanEntry(props: Props) {
           isLoading={false}
           location={location}
           organization={organization}
+          project={project}
           suspectSpan={suspectSpan}
           transactionName={transactionName}
           examples={visibileExamples}

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -133,9 +133,6 @@ function makeExample(opt: ExampleOpt): ExampleTransaction {
 function makeSuspectSpan(opt: SuspectOpt): SuspectSpan {
   const {op, group, examples} = opt;
   return {
-    projectId: 1,
-    project: 'bar',
-    transaction: 'transaction-1',
     op,
     group,
     frequency: 1,


### PR DESCRIPTION
As a minor optimization, we want to remove project from the snuba query as there
will always be 1 project + 1 transaction. This starts by removing the dependence
on it in the payload. A follow up will remove it from the response entirely.