### PR TITLE
fix(ui): Make button labels span full height

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -292,6 +292,7 @@ const ButtonLabel = styled('span', {
     typeof prop === 'string' && isPropValid(prop) && !buttonLabelPropKeys.includes(prop),
 })<ButtonLabelProps>`
   display: grid;
+  height: 100%;
   grid-auto-flow: column;
   align-items: center;
   justify-content: ${p => p.align};


### PR DESCRIPTION
Before - in Transaction Summary page, `<SuspectSpansHeader />`:
<img width="207" alt="Screen Shot 2022-01-03 at 9 50 48 AM" src="https://user-images.githubusercontent.com/44172267/147962955-8531d1a7-8c42-4cc0-8c17-c999e80e9f75.png">

After:
<img width="207" alt="Screen Shot 2022-01-03 at 9 51 03 AM" src="https://user-images.githubusercontent.com/44172267/147962973-a1a00f3f-dd53-49b1-a4f3-0267460979a2.png">

