### PR TITLE
fix(suspect-spans): Specify columns for suspect spans on overview

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.tsx
@@ -27,6 +27,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {SpanSortOthers, SpanSortPercentiles} from '../transactionSpans/types';
 import {
   getSuspectSpanSortFromLocation,
+  SPAN_SORT_TO_FIELDS,
   spansRouteWithQuery,
 } from '../transactionSpans/utils';
 import {generateTransactionLink} from '../utils';
@@ -99,6 +100,9 @@ export default function SuspectSpans(props: Props) {
       )
     )
     .withSorts([{kind: 'desc', field: sort.field}]);
+  const fields = SPAN_SORT_TO_FIELDS[sort.field];
+  sortedEventView.fields = fields ? fields.map(field => ({field})) : [];
+
   const sortColumn: GridColumnSortBy<SuspectSpanTableColumnKeys> = {
     key: sort.field as SuspectSpanTableColumnKeys,
     width: COL_WIDTH_UNDEFINED,

--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -24,8 +24,13 @@ import {SetStateAction} from '../types';
 import OpsFilter from './opsFilter';
 import {Actions} from './styles';
 import SuspectSpanCard from './suspectSpanCard';
-import {SpanSort, SpanSortOthers, SpanSortPercentiles, SpansTotalValues} from './types';
-import {getSuspectSpanSortFromEventView, getTotalsView, SPAN_SORT_OPTIONS} from './utils';
+import {SpanSort, SpansTotalValues} from './types';
+import {
+  getSuspectSpanSortFromEventView,
+  getTotalsView,
+  SPAN_SORT_OPTIONS,
+  SPAN_SORT_TO_FIELDS,
+} from './utils';
 
 const ANALYTICS_VALUES = {
   spanOp: (organization: Organization, value: string | undefined) =>
@@ -177,46 +182,6 @@ function SpansContent(props: Props) {
     </Layout.Main>
   );
 }
-
-const SPAN_SORT_TO_FIELDS: Record<SpanSort, string[]> = {
-  [SpanSortOthers.SUM_EXCLUSIVE_TIME]: [
-    'percentileArray(spans_exclusive_time, 0.75)',
-    'count()',
-    'sumArray(spans_exclusive_time)',
-  ],
-  [SpanSortOthers.AVG_OCCURRENCE]: [
-    'percentileArray(spans_exclusive_time, 0.75)',
-    'count()',
-    'count_unique(id)',
-    'equation|count()/count_unique(id)',
-    'sumArray(spans_exclusive_time)',
-  ],
-  [SpanSortOthers.COUNT]: [
-    'percentileArray(spans_exclusive_time, 0.75)',
-    'count()',
-    'sumArray(spans_exclusive_time)',
-  ],
-  [SpanSortPercentiles.P50_EXCLUSIVE_TIME]: [
-    'percentileArray(spans_exclusive_time, 0.5)',
-    'count()',
-    'sumArray(spans_exclusive_time)',
-  ],
-  [SpanSortPercentiles.P75_EXCLUSIVE_TIME]: [
-    'percentileArray(spans_exclusive_time, 0.75)',
-    'count()',
-    'sumArray(spans_exclusive_time)',
-  ],
-  [SpanSortPercentiles.P95_EXCLUSIVE_TIME]: [
-    'percentileArray(spans_exclusive_time, 0.95)',
-    'count()',
-    'sumArray(spans_exclusive_time)',
-  ],
-  [SpanSortPercentiles.P99_EXCLUSIVE_TIME]: [
-    'percentileArray(spans_exclusive_time, 0.99)',
-    'count()',
-    'sumArray(spans_exclusive_time)',
-  ],
-};
 
 function getSpansEventView(eventView: EventView, sort: SpanSort): EventView {
   eventView = eventView.clone();

--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -7,7 +7,13 @@ import {isAggregateField} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
-import {SpanSlug, SpanSortOption, SpanSortOthers, SpanSortPercentiles} from './types';
+import {
+  SpanSlug,
+  SpanSort,
+  SpanSortOption,
+  SpanSortOthers,
+  SpanSortPercentiles,
+} from './types';
 
 export function generateSpansRoute({orgSlug}: {orgSlug: String}): string {
   return `/organizations/${orgSlug}/performance/summary/spans/`;
@@ -169,3 +175,43 @@ export function getTotalsView(eventView: EventView): EventView {
   totalsView.query = conditions.formatString();
   return totalsView;
 }
+
+export const SPAN_SORT_TO_FIELDS: Record<SpanSort, string[]> = {
+  [SpanSortOthers.SUM_EXCLUSIVE_TIME]: [
+    'percentileArray(spans_exclusive_time, 0.75)',
+    'count()',
+    'sumArray(spans_exclusive_time)',
+  ],
+  [SpanSortOthers.AVG_OCCURRENCE]: [
+    'percentileArray(spans_exclusive_time, 0.75)',
+    'count()',
+    'count_unique(id)',
+    'equation|count()/count_unique(id)',
+    'sumArray(spans_exclusive_time)',
+  ],
+  [SpanSortOthers.COUNT]: [
+    'percentileArray(spans_exclusive_time, 0.75)',
+    'count()',
+    'sumArray(spans_exclusive_time)',
+  ],
+  [SpanSortPercentiles.P50_EXCLUSIVE_TIME]: [
+    'percentileArray(spans_exclusive_time, 0.5)',
+    'count()',
+    'sumArray(spans_exclusive_time)',
+  ],
+  [SpanSortPercentiles.P75_EXCLUSIVE_TIME]: [
+    'percentileArray(spans_exclusive_time, 0.75)',
+    'count()',
+    'sumArray(spans_exclusive_time)',
+  ],
+  [SpanSortPercentiles.P95_EXCLUSIVE_TIME]: [
+    'percentileArray(spans_exclusive_time, 0.95)',
+    'count()',
+    'sumArray(spans_exclusive_time)',
+  ],
+  [SpanSortPercentiles.P99_EXCLUSIVE_TIME]: [
+    'percentileArray(spans_exclusive_time, 0.99)',
+    'count()',
+    'sumArray(spans_exclusive_time)',
+  ],
+};


### PR DESCRIPTION
An optimization was previously applied to only retrieve the necessary columns.
The suspect spans table was not updated to reflect this. This change makes sure
that the necessary columns are in the query.