### PR TITLE
feat(dashboards): Add beta badge to dataset selector

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -15,6 +15,7 @@ import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import IssueWidgetQueriesForm from 'sentry/components/dashboards/issueWidgetQueriesForm';
 import WidgetQueriesForm from 'sentry/components/dashboards/widgetQueriesForm';
+import FeatureBadge from 'sentry/components/featureBadge';
 import SelectControl from 'sentry/components/forms/selectControl';
 import {PanelAlert} from 'sentry/components/panels';
 import {t, tct} from 'sentry/locale';
@@ -629,6 +630,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
             state.displayType === DisplayType.TABLE && (
               <React.Fragment>
                 <StyledFieldLabel>{t('Data Set')}</StyledFieldLabel>
+                <FeatureBadge type="beta" />
                 <StyledRadioGroup
                   style={{flex: 1}}
                   choices={DATASET_CHOICES}
@@ -764,6 +766,7 @@ const StyledRadioGroup = styled(RadioGroup)`
 
 const StyledFieldLabel = styled(FieldLabel)`
   padding-bottom: ${space(1)};
+  display: inline-flex;
 `;
 
 export default withApi(withGlobalSelection(withTags(AddDashboardWidgetModal)));


### PR DESCRIPTION
Adds a beta badge to dataset selector in widget modal
![image](https://user-images.githubusercontent.com/83961295/147969840-14a71dc4-af8b-4f96-ad00-43f78f960fd1.png)
