### PR TITLE
chore(auth): remove deprecated SSO key check

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -206,7 +206,7 @@ def has_completed_sso(request, organization_id) -> bool:
         metrics.incr("sso.session-timed-out")
         return False
 
-    metrics.incr("sso.had-session")
+    metrics.incr("sso.session-verify-success")
 
     return True
 

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -17,7 +17,6 @@ logger = logging.getLogger("sentry.auth")
 
 _LOGIN_URL = None
 
-DEPRECATED_SSO_SESSION_KEY = "sso"
 from typing import Any, Dict, Mapping
 
 MFA_SESSION_KEY = "mfa"
@@ -187,7 +186,7 @@ def mark_sso_complete(request, organization_id):
     request.session.modified = True
 
 
-def has_completed_sso(request, organization_id):
+def has_completed_sso(request, organization_id) -> bool:
     """
     look for the org id under the sso session key, and check that the timestamp isn't past our expiry limit
     """
@@ -196,16 +195,11 @@ def has_completed_sso(request, organization_id):
     )
 
     if not sso_session_in_request:
-        # TODO: remove this old logic after two weeks
-        deprecated_sso = request.session.get(DEPRECATED_SSO_SESSION_KEY, "").split(",")
-        has_sso_session_for_org = str(organization_id) in deprecated_sso
-
         metrics.incr(
-            "sso.deprecated-session-checked",
-            tags={"success": has_sso_session_for_org},
-            sample_rate=0.1,
+            "sso.no-value-in-session",
+            sample_rate=1,
         )
-        return has_sso_session_for_org
+        return False
 
     django_session_value = SsoSession.from_django_session_value(
         organization_id, sso_session_in_request
@@ -214,6 +208,8 @@ def has_completed_sso(request, organization_id):
     if django_session_value and django_session_value.is_sso_authtime_fresh():
         metrics.incr("sso.new-session-checked-success", sample_rate=0.1)
         return True
+
+    return False
 
 
 def find_users(username, with_valid_password=True, is_active=None):

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -195,21 +195,20 @@ def has_completed_sso(request, organization_id) -> bool:
     )
 
     if not sso_session_in_request:
-        metrics.incr(
-            "sso.no-value-in-session",
-            sample_rate=1,
-        )
+        metrics.incr("sso.no-value-in-session")
         return False
 
     django_session_value = SsoSession.from_django_session_value(
         organization_id, sso_session_in_request
     )
 
-    if django_session_value and django_session_value.is_sso_authtime_fresh():
-        metrics.incr("sso.new-session-checked-success", sample_rate=0.1)
-        return True
+    if not django_session_value.is_sso_authtime_fresh():
+        metrics.incr("sso.session-timed-out")
+        return False
 
-    return False
+    metrics.incr("sso.had-session")
+
+    return True
 
 
 def find_users(username, with_valid_password=True, is_active=None):

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 
 from sentry.models import AuthIdentity, AuthProvider
 from sentry.testutils import AuthProviderTestCase
-from sentry.utils.auth import DEPRECATED_SSO_SESSION_KEY, SSO_EXPIRY_TIME, SsoSession
+from sentry.utils.auth import SSO_EXPIRY_TIME, SsoSession
 from sentry.utils.linksign import generate_signed_link
 
 
@@ -47,13 +47,6 @@ class AuthenticationTest(AuthProviderTestCase):
         # superuser should still require SSO as they're a member of the org
         self.user.update(is_superuser=True)
         self._test_paths_with_status(401)
-
-    def test_sso_deprecated_works(self):
-        # XXX(dcramer): using internal API as exposing a request object is hard
-        # now that SSO is marked as complete, we should be able to access dash
-        self.session[DEPRECATED_SSO_SESSION_KEY] = str(self.organization.id)
-        self.save_session()
-        self._test_paths_with_status(200)
 
     def test_sso_with_expiry_valid(self):
         sso_session = SsoSession.create(self.organization.id)


### PR DESCRIPTION
In #29422 we introduced a new SSO session key for facilitating the expiry of SSO sessions. We checked the old value as to not log everyone out at the same time. Some time has passed and a majority of users are now authenticated via the new key.

Our django session expiry is set to two weeks, however, this expiration value is refreshed whenever the user makes a request / the session is updated, so a minority of users (30%) still have the old values. This PR will make them re-authenticate with SSO when deployed as we no longer check the old value. I don't expect this to cause issues, but we can always roll this back if necessary.

This is valuable to do because the new SSO session has an expiration set, which improves the security of our auth model, and it is ideal to have this be applied to all user sessions.