### PR TITLE
fix(dashboards): only display dataset selector when opening the widget modal from dashboards

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -540,6 +540,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       selectedWidgets,
       onUpdateWidget,
       onAddLibraryWidget,
+      source,
     } = this.props;
     const state = this.state;
     const errors = state.errors;
@@ -626,6 +627,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
             </StyledField>
           </DoubleFieldWrapper>
           {organization.features.includes('issues-in-dashboards') &&
+            source === DashboardWidgetSource.DASHBOARDS &&
             state.displayType === DisplayType.TABLE && (
               <React.Fragment>
                 <StyledFieldLabel>{t('Data Set')}</StyledFieldLabel>

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -627,7 +627,9 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
             </StyledField>
           </DoubleFieldWrapper>
           {organization.features.includes('issues-in-dashboards') &&
-            source === DashboardWidgetSource.DASHBOARDS &&
+            [DashboardWidgetSource.DASHBOARDS, DashboardWidgetSource.LIBRARY].includes(
+              source
+            ) &&
             state.displayType === DisplayType.TABLE && (
               <React.Fragment>
                 <StyledFieldLabel>{t('Data Set')}</StyledFieldLabel>

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -1111,7 +1111,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       wrapper.unmount();
     });
 
-    it('renders the dataset selector', async function () {
+    it('renders the dataset selector', function () {
       const wrapper = mountModalWithRtl({
         onAddWidget: () => undefined,
         onUpdateWidget: () => undefined,

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -1050,7 +1050,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
   });
 
   describe('Issue Widgets', function () {
-    function mountIssueModal({onAddWidget, onUpdateWidget, widget}) {
+    function mountModalWithRtl({onAddWidget, onUpdateWidget, widget, source}) {
       return reactMountWithTheme(
         <AddDashboardWidgetModal
           Header={stubEl}
@@ -1062,13 +1062,14 @@ describe('Modals -> AddDashboardWidgetModal', function () {
           onUpdateWidget={onUpdateWidget}
           widget={widget}
           closeModal={() => void 0}
+          source={source || types.DashboardWidgetSource.DASHBOARDS}
         />
       );
     }
 
     it('sets widgetType to issues', async function () {
       const onAdd = jest.fn(() => {});
-      const wrapper = mountIssueModal({
+      const wrapper = mountModalWithRtl({
         onAddWidget: onAdd,
         onUpdateWidget: () => undefined,
       });
@@ -1094,6 +1095,32 @@ describe('Modals -> AddDashboardWidgetModal', function () {
           widgetType: 'issue',
         })
       );
+      wrapper.unmount();
+    });
+
+    it('does not render the dataset selector', async function () {
+      const wrapper = mountModalWithRtl({
+        onAddWidget: () => undefined,
+        onUpdateWidget: () => undefined,
+        source: types.DashboardWidgetSource.DISCOVERV2,
+      });
+      await tick();
+      userEvent.click(screen.getByText('Line Chart'));
+      userEvent.click(screen.getByText('Table'));
+      expect(screen.queryByText('Data Set')).not.toBeInTheDocument();
+      wrapper.unmount();
+    });
+
+    it('renders the dataset selector', async function () {
+      const wrapper = mountModalWithRtl({
+        onAddWidget: () => undefined,
+        onUpdateWidget: () => undefined,
+        source: types.DashboardWidgetSource.DASHBOARDS,
+      });
+      userEvent.click(screen.getByText('Line Chart'));
+      userEvent.click(screen.getByText('Table'));
+
+      expect(screen.getByText('Data Set')).toBeInTheDocument();
       wrapper.unmount();
     });
   });


### PR DESCRIPTION
Hides the dataset selector when opening the add widget modal from outside of dashboards (example: from discover). Dataset selector should only be displayed when the user is editing from a dashboard.