### PR TITLE
feat(dashboard-templates): Hook up the Preview button

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -980,6 +980,11 @@ function buildRoutes() {
           component={SafeLazyLoad}
         />
       </Route>
+      <Route
+        path="/organizations/:orgId/dashboards/new/:templateId"
+        componentPromise={() => import('sentry/views/dashboardsV2/create')}
+        component={SafeLazyLoad}
+      />
       <Redirect
         from="/organizations/:orgId/dashboards/:dashboardId/"
         to="/organizations/:orgId/dashboard/:dashboardId/"

--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -36,6 +36,9 @@ export type DashboardsEventParameters = {
   'dashboards_manage.templates.toggle': {
     show_templates: boolean;
   };
+  'dashboards_manage.templates.preview': {
+    dashboard_id: string;
+  };
 };
 
 export type DashboardsEventKey = keyof DashboardsEventParameters;
@@ -64,4 +67,5 @@ export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
   'dashboards_manage.change_sort': 'Dashboards Manager: Sort By Changed',
   'dashboards_manage.create.start': 'Dashboards Manager: Dashboard Create Started',
   'dashboards_manage.templates.toggle': 'Dashboards Manager: Template Toggle Changed',
+  'dashboards_manage.templates.preview': 'Dashboards Manager: Template Previewed',
 };

--- a/static/app/views/dashboardsV2/create.tsx
+++ b/static/app/views/dashboardsV2/create.tsx
@@ -30,9 +30,9 @@ function CreateDashboard(props: Props) {
     );
   }
 
-  const template = DASHBOARDS_TEMPLATES.find(
-    dashboardTemplate => dashboardTemplate.id === templateId
-  );
+  const template = templateId
+    ? DASHBOARDS_TEMPLATES.find(dashboardTemplate => dashboardTemplate.id === templateId)
+    : undefined;
   const dashboard = template ? cloneDashboard(template) : cloneDashboard(EMPTY_DASHBOARD);
   useEffect(() => {
     const constructedWidget = constructWidgetFromQuery(location.query);

--- a/static/app/views/dashboardsV2/create.tsx
+++ b/static/app/views/dashboardsV2/create.tsx
@@ -8,18 +8,19 @@ import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 
-import {EMPTY_DASHBOARD} from './data';
+import {DASHBOARDS_TEMPLATES, EMPTY_DASHBOARD} from './data';
 import DashboardDetail from './detail';
 import {DashboardState, Widget} from './types';
 import {cloneDashboard, constructWidgetFromQuery} from './utils';
 
-type Props = RouteComponentProps<{orgId: string}, {}> & {
+type Props = RouteComponentProps<{orgId: string; templateId?: string}, {}> & {
   organization: Organization;
   children: React.ReactNode;
 };
 
 function CreateDashboard(props: Props) {
   const {organization, location} = props;
+  const {templateId} = props.params;
   const [newWidget, setNewWidget] = useState<Widget | undefined>();
   function renderDisabled() {
     return (
@@ -29,7 +30,10 @@ function CreateDashboard(props: Props) {
     );
   }
 
-  const dashboard = cloneDashboard(EMPTY_DASHBOARD);
+  const template = DASHBOARDS_TEMPLATES.find(
+    dashboardTemplate => dashboardTemplate.id === templateId
+  );
+  const dashboard = template ? cloneDashboard(template) : cloneDashboard(EMPTY_DASHBOARD);
   useEffect(() => {
     const constructedWidget = constructWidgetFromQuery(location.query);
     setNewWidget(constructedWidget);

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -72,6 +72,7 @@ type Props = {
   layout: Layout[];
   onLayoutChange: (layout: Layout[]) => void;
   paramDashboardId?: string;
+  paramTemplateId?: string;
   newWidget?: Widget;
 };
 

--- a/static/app/views/dashboardsV2/data.tsx
+++ b/static/app/views/dashboardsV2/data.tsx
@@ -1,6 +1,7 @@
 import {t} from 'sentry/locale';
+import {uniqueId} from 'sentry/utils/guid';
 
-import {DashboardDetails} from './types';
+import {DashboardDetails, DisplayType} from './types';
 
 export const EMPTY_DASHBOARD: DashboardDetails = {
   id: '',
@@ -9,6 +10,404 @@ export const EMPTY_DASHBOARD: DashboardDetails = {
   title: t('Untitled dashboard'),
   widgets: [],
 };
+
+export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
+  {
+    // This also exists in the backend at sentry/models/dashboard.py
+    id: 'default-template',
+    dateCreated: '',
+    createdBy: undefined,
+    title: t('Default'),
+    widgets: [
+      {
+        title: 'Number of Errors',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: '!event.type:transaction',
+            fields: ['count()'],
+            orderby: 'count()',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Number of Issues',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: '!event.type:transaction',
+            fields: ['count_unique(issue)'],
+            orderby: 'count_unique(issue)',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Events',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'Events',
+            conditions: '!event.type:transaction',
+            fields: ['count()'],
+            orderby: 'count()',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Affected Users',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'Known Users',
+            conditions: 'has:user.email !event.type:transaction',
+            fields: ['count_unique(user)'],
+            orderby: 'count_unique(user)',
+          },
+          {
+            name: 'Anonymous Users',
+            conditions: '!has:user.email !event.type:transaction',
+            fields: ['count_unique(user)'],
+            orderby: 'count_unique(user)',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Handled vs. Unhandled',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'Handled',
+            conditions: 'error.handled:true',
+            fields: ['count()'],
+            orderby: 'count()',
+          },
+          {
+            name: 'Unhandled',
+            conditions: 'error.handled:false',
+            fields: ['count()'],
+            orderby: 'count()',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Errors by Country',
+        displayType: DisplayType.WORLD_MAP,
+        interval: '5m',
+        queries: [
+          {
+            name: 'Error counts',
+            conditions: '!event.type:transaction has:geo.country_code',
+            fields: ['count()'],
+            orderby: 'count()',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Errors by Browser',
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: '!event.type:transaction has:browser.name',
+            fields: ['browser.name', 'count()'],
+            orderby: '-count',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+    ],
+  },
+  {
+    id: 'frontend-template',
+    title: 'Frontend',
+    dateCreated: '',
+    createdBy: undefined,
+    widgets: [
+      {
+        title: 'Overall LCP',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: 'event.type:transaction',
+            fields: ['p75(measurements.lcp)'],
+            orderby: 'measurements.lcp',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Overall FCP',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: 'event.type:transaction',
+            fields: ['p75(measurements.fcp)'],
+            orderby: 'measurements.fcp',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Overall FID',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: 'event.type:transaction',
+            fields: ['p75(measurements.fid)'],
+            orderby: 'measurements.fid',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'LCP over time',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'LCP',
+            conditions: 'event.type:transaction',
+            fields: ['p75(measurements.lcp)'],
+            orderby: 'measurements.lcp',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'FCP over time',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'FCP',
+            conditions: 'event.type:transaction',
+            fields: ['p75(measurements.fcp)'],
+            orderby: 'measurements.fcp',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'FID over time',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'FID',
+            conditions: 'event.type:transaction',
+            fields: ['p75(measurements.fid)'],
+            orderby: 'measurements.fid',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+    ],
+  },
+  {
+    id: 'backend-template',
+    title: 'Backend',
+    dateCreated: '',
+    createdBy: undefined,
+    widgets: [
+      {
+        title: 'Overall Apdex',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: 'event.type:transaction',
+            fields: ['apdex()'],
+            orderby: 'apdex',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Failing Transactions',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: 'event.type:transaction',
+            fields: ['failure_count()'],
+            orderby: 'failure_count',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Overall Misery',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: 'event.type:transaction',
+            fields: ['user_misery()'],
+            orderby: 'user_misery',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Apdex over time',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'Apdex',
+            conditions: 'event.type:transaction',
+            fields: ['apdex()'],
+            orderby: 'apdex',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Failure Transactions over time',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'Failing Transactions',
+            conditions: 'event.type:transaction',
+            fields: ['failure_count()'],
+            orderby: 'failure_count',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Misery over time',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'Miserable Users',
+            conditions: 'event.type:transaction',
+            fields: ['user_misery()'],
+            orderby: 'user_misery',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+    ],
+  },
+  {
+    id: 'mobile-template',
+    title: 'Mobile',
+    dateCreated: '',
+    createdBy: undefined,
+    widgets: [
+      {
+        title: 'Overall Cold Start',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: 'event.type:transaction',
+            fields: ['p75(measurements.app_start_cold)'],
+            orderby: 'p75(measurements.app_start_cold)',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Overall Warm Start',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: 'event.type:transaction',
+            fields: ['p75(measurements.app_start_warm)'],
+            orderby: 'p75(measurements.app_start_warm)',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Transactions Per Minute',
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            conditions: 'event.type:transaction',
+            fields: ['tpm()'],
+            orderby: 'tpm',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Cold Start over time',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'Cold Start',
+            conditions: 'event.type:transaction',
+            fields: ['p75(measurements.app_start_cold)'],
+            orderby: 'p75(measurements.app_start_cold)',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'Warm Start over time',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'Warm Start',
+            conditions: 'event.type:transaction',
+            fields: ['p75(measurements.app_start_warm)'],
+            orderby: 'p75(measurements.app_start_warm)',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+      {
+        title: 'TPM over time',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'TPM',
+            conditions: 'event.type:transaction',
+            fields: ['tpm()'],
+            orderby: 'tpm',
+          },
+        ],
+        tempId: uniqueId(),
+      },
+    ],
+  },
+];
 
 export const DISPLAY_TYPE_CHOICES = [
   {label: t('Area Chart'), value: 'area'},

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -249,6 +249,14 @@ class DashboardDetail extends Component<Props, State> {
 
   onCancel = () => {
     const {organization, dashboard, location, params} = this.props;
+    const {modifiedDashboard} = this.state;
+    if (!isEqual(modifiedDashboard, dashboard)) {
+      // Ignore no-alert here, so that the confirm on cancel matches onUnload & onRouteLeave
+      /* eslint no-alert:0 */
+      if (!confirm(UNSAVED_MESSAGE)) {
+        return;
+      }
+    }
     if (params.dashboardId) {
       trackAnalyticsEvent({
         eventKey: 'dashboards2.edit.cancel',

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -187,10 +187,14 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   onRouteLeave = () => {
+    const {dashboard} = this.props;
+    const {modifiedDashboard} = this.state;
+
     if (
       ![DashboardState.VIEW, DashboardState.PENDING_DELETE].includes(
         this.state.dashboardState
-      )
+      ) &&
+      !isEqual(modifiedDashboard, dashboard)
     ) {
       return UNSAVED_MESSAGE;
     }
@@ -198,10 +202,14 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   onUnload = (event: BeforeUnloadEvent) => {
+    const {dashboard} = this.props;
+    const {modifiedDashboard} = this.state;
+
     if (
       [DashboardState.VIEW, DashboardState.PENDING_DELETE].includes(
         this.state.dashboardState
-      )
+      ) ||
+      isEqual(modifiedDashboard, dashboard)
     ) {
       return;
     }

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -28,7 +28,7 @@ import withOrganization from 'sentry/utils/withOrganization';
 import {getDashboardLayout, saveDashboardLayout} from './gridLayout/utils';
 import Controls from './controls';
 import Dashboard, {assignTempId, constructGridItemKey} from './dashboard';
-import {DEFAULT_STATS_PERIOD, EMPTY_DASHBOARD} from './data';
+import {DEFAULT_STATS_PERIOD} from './data';
 import DashboardTitle from './title';
 import {
   DashboardDetails,
@@ -124,7 +124,6 @@ class DashboardDetail extends Component<Props, State> {
     const {dashboard} = this.props;
     switch (dashboardState) {
       case DashboardState.CREATE:
-        return cloneDashboard(EMPTY_DASHBOARD);
       case DashboardState.EDIT:
         return cloneDashboard(dashboard);
       default: {

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -222,6 +222,10 @@ class ManageDashboards extends AsyncView<Props, State> {
 
   onPreview(dashboardId: string) {
     const {organization, location} = this.props;
+    trackAdvancedAnalyticsEvent('dashboards_manage.templates.preview', {
+      organization,
+      dashboard_id: dashboardId,
+    });
 
     browserHistory.push({
       pathname: `/organizations/${organization.slug}/dashboards/new/${dashboardId}`,

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -23,6 +23,7 @@ import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 
+import {DASHBOARDS_TEMPLATES} from '../data';
 import {DashboardListItem} from '../types';
 
 import DashboardList from './dashboardList';
@@ -140,10 +141,14 @@ class ManageDashboards extends AsyncView<Props, State> {
     return (
       <Feature organization={organization} features={['dashboards-template']}>
         <TemplateContainer>
-          <TemplateCard title="Default" widgetCount={10} />
-          <TemplateCard title="Frontend" widgetCount={9} />
-          <TemplateCard title="Backend" widgetCount={13} />
-          <TemplateCard title="Mobile" widgetCount={4} />
+          {DASHBOARDS_TEMPLATES.map(dashboard => (
+            <TemplateCard
+              title={dashboard.title}
+              widgetCount={dashboard.widgets.length}
+              onPreview={() => this.onPreview(dashboard.id)}
+              key={dashboard.title}
+            />
+          ))}
         </TemplateContainer>
       </Feature>
     );
@@ -211,6 +216,15 @@ class ManageDashboards extends AsyncView<Props, State> {
 
     browserHistory.push({
       pathname: `/organizations/${organization.slug}/dashboards/new/`,
+      query: location.query,
+    });
+  }
+
+  onPreview(dashboardId: string) {
+    const {organization, location} = this.props;
+
+    browserHistory.push({
+      pathname: `/organizations/${organization.slug}/dashboards/new/${dashboardId}`,
       query: location.query,
     });
   }

--- a/static/app/views/dashboardsV2/manage/templateCard.tsx
+++ b/static/app/views/dashboardsV2/manage/templateCard.tsx
@@ -11,9 +11,10 @@ import space from 'sentry/styles/space';
 type Props = {
   title: string;
   widgetCount: number;
+  onPreview: () => void;
 };
 
-function TemplateCard({title, widgetCount}: Props) {
+function TemplateCard({title, widgetCount, onPreview}: Props) {
   return (
     <StyledCard>
       <Header>
@@ -24,7 +25,9 @@ function TemplateCard({title, widgetCount}: Props) {
         </CardText>
       </Header>
       <ButtonContainer>
-        <StyledButton priority="default">{t('Preview')}</StyledButton>
+        <StyledButton priority="default" onClick={onPreview}>
+          {t('Preview')}
+        </StyledButton>
         <StyledButton priority="primary" icon={<IconAdd size="xs" isCircled />}>
           {t('Add Dashboard')}
         </StyledButton>

--- a/tests/js/spec/views/dashboardsV2/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/detail.spec.jsx
@@ -401,6 +401,7 @@ describe('Dashboards > Detail', function () {
 
     it('does not update if api update fails', async function () {
       const fireEvent = createListeners('window');
+      window.confirm = jest.fn(() => true);
 
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
@@ -443,6 +444,7 @@ describe('Dashboards > Detail', function () {
         'Updated Name'
       );
       wrapper.find('Controls Button[data-test-id="dashboard-cancel"]').simulate('click');
+
       expect(wrapper.find('DashboardTitle EditableText').props().value).toEqual(
         'Custom Errors'
       );


### PR DESCRIPTION
- This adds functionality to the preview button
   - Add will be coming in a later PR
   - Clicking preview will open the dashboard in edit mode so its easy to add more widgets
- This adds some sample widgets to frontend/backend/mobile templates, these are temporary and just so that there's a starting point for them
- This changes the existing behaviour from showing the alert anytime edit was opened, to only showing the alert if the modified dashboarddiffers from the previous one

## Preview
<video src="https://user-images.githubusercontent.com/4205004/147975851-13cdb657-5b03-42de-b3f4-cc9e6e1b6244.mp4">