### PR TITLE
fix(ui): Remove z-index from tintrow to avoid tinting other elements

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -639,7 +639,6 @@ const Wrapper = styled(PanelItem)<{
         height: 100%;
         background-color: ${p.theme.bodyBackground};
         opacity: 0.4;
-        z-index: 1;
       }
 
       @keyframes tintRow {


### PR DESCRIPTION
This removes the `z-index` from the `StreamGroup` wrapper because it was adding a shadow/tint to everything rendered above the rows.

Jira: [WOR-1508](https://getsentry.atlassian.net/browse/WOR-1508)

Before:
<img width="447" alt="Screen Shot 2022-01-03 at 1 53 23 PM" src="https://user-images.githubusercontent.com/15015880/147984793-38a05c6a-84f1-4e53-b176-2117350be720.png">

After:
<img width="447" alt="Screen Shot 2022-01-03 at 1 53 12 PM" src="https://user-images.githubusercontent.com/15015880/147984804-ec281f13-4959-41e2-a4fd-dd244694462a.png">
 