### PR TITLE
fix(alerts): Add title to the alert rule details open in discover columns

### DIFF
--- a/static/app/views/alerts/incidentRules/incidentRulePresets.tsx
+++ b/static/app/views/alerts/incidentRules/incidentRulePresets.tsx
@@ -27,6 +27,7 @@ type PresetCtaOpts = {
   eventType?: string;
   start?: string;
   end?: string;
+  fields?: string[];
 };
 
 /**
@@ -39,6 +40,7 @@ export function makeDefaultCta({
   eventType,
   start,
   end,
+  fields,
 }: PresetCtaOpts): PresetCta {
   if (!rule) {
     return {
@@ -61,6 +63,7 @@ export function makeDefaultCta({
       start,
       end,
       extraQueryParams,
+      fields,
     }),
   };
 }

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -281,6 +281,7 @@ class MetricChart extends React.PureComponent<Props, State> {
       eventType: query,
       start: timePeriod.start,
       end: timePeriod.end,
+      fields: ['issue', 'title', 'count()', 'count_unique(user)'],
     };
 
     const {buttonText, ...props} = makeDefaultCta(ctaOpts);

--- a/static/app/views/alerts/utils/getIncidentRuleDiscoverUrl.tsx
+++ b/static/app/views/alerts/utils/getIncidentRuleDiscoverUrl.tsx
@@ -21,8 +21,9 @@ export function getIncidentRuleDiscoverUrl(opts: {
   start?: string;
   end?: string;
   extraQueryParams?: Partial<NewQuery>;
+  fields?: string[];
 }) {
-  const {orgSlug, projects, rule, eventType, start, end, extraQueryParams} = opts;
+  const {orgSlug, projects, rule, eventType, start, end, extraQueryParams, fields} = opts;
   const eventTypeTagFilter = eventType && rule?.query ? eventType : '';
 
   if (!projects || !projects.length || !rule || (!start && !end)) {
@@ -41,10 +42,11 @@ export function getIncidentRuleDiscoverUrl(opts: {
       .filter(({slug}) => rule.projects.includes(slug))
       .map(({id}) => Number(id)),
     version: 2,
-    fields:
-      rule.dataset === Dataset.ERRORS
-        ? ['issue', 'count()', 'count_unique(user)']
-        : ['transaction', rule.aggregate],
+    fields: fields
+      ? fields
+      : rule.dataset === Dataset.ERRORS
+      ? ['issue', 'count()', 'count_unique(user)']
+      : ['transaction', rule.aggregate],
     start,
     end,
     ...extraQueryParams,


### PR DESCRIPTION
Added `title` as a field to the `Open in Discover` button link query.

Jira: [WOR-1499](https://getsentry.atlassian.net/browse/WOR-1499)