### PR TITLE
ref(ui): Use consistent padding in <ActionButton />

### DIFF
--- a/static/app/components/actions/button.tsx
+++ b/static/app/components/actions/button.tsx
@@ -9,7 +9,7 @@ const BaseButton = (props: React.ComponentProps<typeof Button>) => (
 );
 
 const ActionButton = styled(BaseButton)`
-  padding: ${p => space(0.75)} ${space(1)};
+  padding: ${space(0.75)} ${space(1)};
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 

--- a/static/app/components/actions/button.tsx
+++ b/static/app/components/actions/button.tsx
@@ -9,7 +9,7 @@ const BaseButton = (props: React.ComponentProps<typeof Button>) => (
 );
 
 const ActionButton = styled(BaseButton)`
-  padding: ${p => (p.icon ? space(0.75) : '7px')} ${space(1)};
+  padding: ${p => space(0.75)} ${space(1)};
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 


### PR DESCRIPTION
Before:
<img width="651" alt="Screen Shot 2022-01-03 at 3 14 33 PM" src="https://user-images.githubusercontent.com/44172267/147990390-0d4e1777-0347-47df-a36c-bd47be1b97a9.png">

After:
<img width="694" alt="Screen Shot 2022-01-03 at 3 15 01 PM" src="https://user-images.githubusercontent.com/44172267/147990418-a6e1b20d-368d-4fab-836d-9c99f93e64e1.png">

