### PR TITLE
feat(doc integrations): Use docIntegrations from the backend with feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -996,6 +996,8 @@ SENTRY_FEATURES = {
     "organizations:integrations-stacktrace-link": False,
     # Allow orgs to install a custom source code management integration
     "organizations:integrations-custom-scm": False,
+    # Allow orgs to view document integrations from the DB
+    "organizations:integrations-docs-from-db": False,
     # Limit project events endpoint to only query back a certain number of days
     "organizations:project-event-date-limit": False,
     # Allow orgs to debug internal/unpublished sentry apps with logging

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -92,6 +92,7 @@ default_manager.add("organizations:integrations-alert-rule", OrganizationFeature
 default_manager.add("organizations:integrations-chat-unfurl", OrganizationFeature)
 default_manager.add("organizations:integrations-codeowners", OrganizationFeature, True)
 default_manager.add("organizations:integrations-custom-scm", OrganizationFeature, True)
+default_manager.add("organizations:integrations-docs-from-db", OrganizationFeature, True)
 default_manager.add("organizations:integrations-event-hooks", OrganizationFeature)
 default_manager.add("organizations:integrations-incident-management", OrganizationFeature)
 default_manager.add("organizations:integrations-issue-basic", OrganizationFeature)

--- a/static/app/components/avatar/docIntegrationAvatar.tsx
+++ b/static/app/components/avatar/docIntegrationAvatar.tsx
@@ -1,4 +1,5 @@
 import BaseAvatar from 'sentry/components/avatar/baseAvatar';
+import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import {DocIntegration} from 'sentry/types';
 
 type Props = {
@@ -7,7 +8,7 @@ type Props = {
 
 const DocIntegrationAvatar = ({docIntegration, ...props}: Props) => {
   if (!docIntegration?.avatar) {
-    return null;
+    return <PluginIcon {...props} pluginId={docIntegration?.slug} />;
   }
   return (
     <BaseAvatar

--- a/static/app/components/search/searchResult.tsx
+++ b/static/app/components/search/searchResult.tsx
@@ -2,6 +2,8 @@ import {Component, Fragment} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
+import DocIntegrationAvatar from 'sentry/components/avatar/docIntegrationAvatar';
+import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import IdBadge from 'sentry/components/idBadge';
 import {IconInput, IconLink, IconSettings} from 'sentry/icons';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
@@ -73,28 +75,22 @@ class SearchResult extends Component<Props> {
     const {item} = this.props;
     const {resultType, model} = item;
 
-    const isSettings = resultType === 'settings';
-    const isField = resultType === 'field';
-    const isRoute = resultType === 'route';
-    const isIntegration = resultType === 'integration';
-
-    if (isSettings) {
-      return <IconSettings />;
+    switch (resultType) {
+      case 'settings':
+        return <IconSettings />;
+      case 'field':
+        return <IconInput />;
+      case 'route':
+        return <IconLink />;
+      case 'integration':
+        return <StyledPluginIcon pluginId={model.slug} />;
+      case 'sentryApp':
+        return <SentryAppAvatar sentryApp={model} />;
+      case 'docIntegration':
+        return <DocIntegrationAvatar docIntegration={model} />;
+      default:
+        return null;
     }
-
-    if (isField) {
-      return <IconInput />;
-    }
-
-    if (isRoute) {
-      return <IconLink />;
-    }
-
-    if (isIntegration) {
-      return <StyledPluginIcon pluginId={model.slug} />;
-    }
-
-    return null;
   }
 
   render() {

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -471,7 +471,7 @@ class ApiSource extends React.Component<Props, State> {
         createDocIntegrationResults(
           docIntegrations,
           orgId,
-          organization.features.includes('integrations-docs-from-db')
+          organization?.features?.includes('integrations-docs-from-db') ?? false
         ),
       ])
     );

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -7,6 +7,7 @@ import flatten from 'lodash/flatten';
 import {Client, ResponseMeta} from 'sentry/api';
 import {t} from 'sentry/locale';
 import {
+  DocIntegration,
   EventIdResponse,
   IntegrationProvider,
   Member,
@@ -21,7 +22,7 @@ import {defined} from 'sentry/utils';
 import {createFuzzySearch} from 'sentry/utils/createFuzzySearch';
 import {singleLineRenderer as markedSingleLine} from 'sentry/utils/marked';
 import withLatestContext from 'sentry/utils/withLatestContext';
-import {documentIntegrationList} from 'sentry/views/organizationIntegrations/constants';
+import {docIntegrationList} from 'sentry/views/organizationIntegrations/constants';
 
 import {ChildProps, Result, ResultItem} from './types';
 
@@ -187,26 +188,32 @@ async function createSentryAppResults(
     ),
     model: sentryApp,
     sourceType: 'sentryApp',
-    resultType: 'integration',
+    resultType: 'sentryApp',
     to: `/settings/${orgId}/sentry-apps/${sentryApp.slug}/`,
   }));
 }
 
-// Not really async but we need to return a promise
-async function creatDocIntegrationResults(orgId: string): Promise<ResultItem[]> {
-  return documentIntegrationList.map(integration => ({
-    title: integration.name,
+async function createDocIntegrationResults(
+  docIntegrationPromise: Promise<DocIntegration[]>,
+  orgId: string,
+  hasFeatureFlag: boolean
+): Promise<ResultItem[]> {
+  const docIntegrations = hasFeatureFlag
+    ? (await docIntegrationPromise) || []
+    : docIntegrationList;
+  return docIntegrations.map(docIntegration => ({
+    title: docIntegration.name,
     description: (
       <span
         dangerouslySetInnerHTML={{
-          __html: markedSingleLine(integration.description),
+          __html: markedSingleLine(docIntegration.description || ''),
         }}
       />
     ),
-    model: integration,
+    model: docIntegration,
     sourceType: 'docIntegration',
-    resultType: 'integration',
-    to: `/settings/${orgId}/document-integrations/${integration.slug}/`,
+    resultType: hasFeatureFlag ? 'docIntegration' : 'integration',
+    to: `/settings/${orgId}/document-integrations/${docIntegration.slug}/`,
   }));
 }
 
@@ -329,6 +336,7 @@ class ApiSource extends React.Component<Props, State> {
         `/organizations/${orgId}/plugins/configs/`,
         `/organizations/${orgId}/config/integrations/`,
         '/sentry-apps/?status=published',
+        '/doc-integrations/',
       ];
 
       directUrls = [
@@ -398,8 +406,16 @@ class ApiSource extends React.Component<Props, State> {
     //
     // This isn't particularly helpful in its current form because we still wait for all requests to finish before
     // updating state, but you could potentially optimize rendering direct results before all requests are finished.
-    const [organizations, projects, teams, members, plugins, integrations, sentryApps] =
-      searchRequests;
+    const [
+      organizations,
+      projects,
+      teams,
+      members,
+      plugins,
+      integrations,
+      sentryApps,
+      docIntegrations,
+    ] = searchRequests;
     const [shortIdLookup, eventIdLookup] = directRequests;
 
     const [searchResults, directResults] = await Promise.all([
@@ -411,6 +427,7 @@ class ApiSource extends React.Component<Props, State> {
         plugins,
         integrations,
         sentryApps,
+        docIntegrations,
       ]),
       this.getDirectResults([shortIdLookup, eventIdLookup]),
     ]);
@@ -432,8 +449,16 @@ class ApiSource extends React.Component<Props, State> {
   async getSearchableResults(requests) {
     const {params, organization} = this.props;
     const orgId = (params && params.orgId) || (organization && organization.slug);
-    const [organizations, projects, teams, members, plugins, integrations, sentryApps] =
-      requests;
+    const [
+      organizations,
+      projects,
+      teams,
+      members,
+      plugins,
+      integrations,
+      sentryApps,
+      docIntegrations,
+    ] = requests;
     const searchResults = flatten(
       await Promise.all([
         createOrganizationResults(organizations),
@@ -443,7 +468,11 @@ class ApiSource extends React.Component<Props, State> {
         createIntegrationResults(integrations, orgId),
         createPluginResults(plugins, orgId),
         createSentryAppResults(sentryApps, orgId),
-        creatDocIntegrationResults(orgId),
+        createDocIntegrationResults(
+          docIntegrations,
+          orgId,
+          organization.features.includes('integrations-docs-from-db')
+        ),
       ])
     );
 

--- a/static/app/components/search/sources/types.tsx
+++ b/static/app/components/search/sources/types.tsx
@@ -39,6 +39,8 @@ export type ResultItem = {
     | 'issue'
     | 'event'
     | 'integration'
+    | 'sentryApp'
+    | 'docIntegration'
     | 'help-docs'
     | 'help-develop'
     | 'help-help-center'

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -255,7 +255,7 @@ export type DocIntegration = {
   popularity: number;
   description: string;
   isDraft: boolean;
-  avatar: Avatar;
+  avatar?: Avatar;
   features?: IntegrationFeature[];
   resources?: Array<{title: string; url: string}>;
 };

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -445,7 +445,7 @@ export type AppOrProviderOrPlugin =
   | SentryApp
   | IntegrationProvider
   | PluginWithProjectList
-  | DocumentIntegration;
+  | DocIntegration;
 
 /**
  * Webhooks and servicehooks

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -13,7 +13,7 @@ import {t} from 'sentry/locale';
 import HookStore from 'sentry/stores/hookStore';
 import {
   AppOrProviderOrPlugin,
-  DocumentIntegration,
+  DocIntegration,
   Integration,
   IntegrationFeature,
   IntegrationInstallationStatus,
@@ -124,8 +124,8 @@ export const getCategoriesForIntegration = (
   if (isPlugin(integration)) {
     return getCategories(integration.featureDescriptions);
   }
-  if (isDocumentIntegration(integration)) {
-    return getCategories(integration.features);
+  if (isDocIntegration(integration)) {
+    return getCategories(integration.features ?? []);
   }
   return getCategories(integration.metadata.features);
 };
@@ -142,10 +142,10 @@ export function isPlugin(
   return integration.hasOwnProperty('shortName');
 }
 
-export function isDocumentIntegration(
+export function isDocIntegration(
   integration: AppOrProviderOrPlugin
-): integration is DocumentIntegration {
-  return integration.hasOwnProperty('docUrl');
+): integration is DocIntegration {
+  return integration.hasOwnProperty('isDraft');
 }
 
 export const getIntegrationType = (
@@ -157,21 +157,21 @@ export const getIntegrationType = (
   if (isPlugin(integration)) {
     return 'plugin';
   }
-  if (isDocumentIntegration(integration)) {
+  if (isDocIntegration(integration)) {
     return 'document';
   }
   return 'first_party';
 };
 
 export const convertIntegrationTypeToSnakeCase = (
-  type: 'plugin' | 'firstParty' | 'sentryApp' | 'documentIntegration'
+  type: 'plugin' | 'firstParty' | 'sentryApp' | 'docIntegration'
 ) => {
   switch (type) {
     case 'firstParty':
       return 'first_party';
     case 'sentryApp':
       return 'sentry_app';
-    case 'documentIntegration':
+    case 'docIntegration':
       return 'document';
     default:
       return type;

--- a/static/app/views/organizationIntegrations/constants.tsx
+++ b/static/app/views/organizationIntegrations/constants.tsx
@@ -1,4 +1,4 @@
-import {DocumentIntegration} from 'sentry/types';
+import {DocIntegration, DocumentIntegration} from 'sentry/types';
 
 export const INSTALLED = 'Installed' as const;
 export const NOT_INSTALLED = 'Not Installed' as const;
@@ -314,6 +314,16 @@ export const documentIntegrationList: DocumentIntegration[] = [
     ],
   },
 ];
+
+export const docIntegrationList: DocIntegration[] = documentIntegrationList.map(
+  ({resourceLinks, docUrl, ...doc}) => ({
+    ...doc,
+    url: docUrl,
+    resources: resourceLinks,
+    popularity: POPULARITY_WEIGHT[doc.slug],
+    isDraft: false,
+  })
+);
 
 export const documentIntegrations: {
   [key: string]: DocumentIntegration;

--- a/static/app/views/organizationIntegrations/constants.tsx
+++ b/static/app/views/organizationIntegrations/constants.tsx
@@ -325,8 +325,8 @@ export const docIntegrationList: DocIntegration[] = documentIntegrationList.map(
   })
 );
 
-export const documentIntegrations: {
-  [key: string]: DocumentIntegration;
+export const docIntegrations: {
+  [key: string]: DocIntegration;
 } = Object.fromEntries(
-  documentIntegrationList.map(integration => [integration.slug, integration])
+  docIntegrationList.map(integration => [integration.slug, integration])
 );

--- a/static/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -27,9 +27,12 @@ class DocIntegrationDetailedView extends AbstractIntegrationDetailedView<
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {
+      organization,
       params: {integrationSlug},
     } = this.props;
-    return [['doc', `/doc-integrations/${integrationSlug}/`]];
+    return organization.features.includes('integrations-docs-from-db')
+      ? [['doc', `/doc-integrations/${integrationSlug}/`]]
+      : [];
   }
 
   get integrationType() {
@@ -83,12 +86,15 @@ class DocIntegrationDetailedView extends AbstractIntegrationDetailedView<
 
   renderTopButton() {
     return (
-      <ExternalLink href={this.integration.url} onClick={this.trackClick}>
+      <ExternalLink
+        href={this.integration.url}
+        onClick={this.trackClick}
+        data-test-id="learn-more"
+      >
         <LearnMoreButton
           size="small"
           priority="primary"
           style={{marginLeft: space(1)}}
-          data-test-id="learn-more"
           icon={<StyledIconOpen size="xs" />}
         >
           {t('Learn More')}

--- a/static/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -1,35 +1,49 @@
 import styled from '@emotion/styled';
 
+import AsyncComponent from 'sentry/components/asyncComponent';
+import DocIntegrationAvatar from 'sentry/components/avatar/docIntegrationAvatar';
 import Button from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {DocumentIntegration} from 'sentry/types';
+import {DocIntegration} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
-import {documentIntegrations} from './constants';
+import {docIntegrations} from './constants';
 
 type Tab = AbstractIntegrationDetailedView['state']['tab'];
 
-class SentryAppDetailedView extends AbstractIntegrationDetailedView<
+type State = {
+  doc: DocIntegration;
+};
+
+class DocIntegrationDetailedView extends AbstractIntegrationDetailedView<
   AbstractIntegrationDetailedView['props'],
-  AbstractIntegrationDetailedView['state']
+  State & AbstractIntegrationDetailedView['state']
 > {
   tabs: Tab[] = ['overview'];
+
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {
+      params: {integrationSlug},
+    } = this.props;
+    return [['doc', `/doc-integrations/${integrationSlug}/`]];
+  }
 
   get integrationType() {
     return 'document' as const;
   }
 
-  get integration(): DocumentIntegration {
-    const {integrationSlug} = this.props.params;
-    const documentIntegration = documentIntegrations[integrationSlug];
-    if (!documentIntegration) {
-      throw new Error(`No document integration of slug ${integrationSlug} exists`);
-    }
-    return documentIntegration;
+  get integration(): DocIntegration {
+    const {
+      organization,
+      params: {integrationSlug},
+    } = this.props;
+    return organization.features.includes('integrations-docs-from-db')
+      ? this.state.doc
+      : docIntegrations[integrationSlug];
   }
 
   get description() {
@@ -41,7 +55,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get resourceLinks() {
-    return this.integration.resourceLinks;
+    return this.integration.resources ?? [];
   }
 
   get installationStatus() {
@@ -53,7 +67,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get featureData() {
-    return this.integration.features;
+    return this.integration.features ?? [];
   }
 
   componentDidMount() {
@@ -69,7 +83,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
 
   renderTopButton() {
     return (
-      <ExternalLink href={this.integration.docUrl} onClick={this.trackClick}>
+      <ExternalLink href={this.integration.url} onClick={this.trackClick}>
         <LearnMoreButton
           size="small"
           priority="primary"
@@ -81,6 +95,10 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
         </LearnMoreButton>
       </ExternalLink>
     );
+  }
+
+  renderIntegrationIcon() {
+    return <DocIntegrationAvatar docIntegration={this.integration} size={50} />;
   }
 
   // No configurations.
@@ -100,4 +118,4 @@ const StyledIconOpen = styled(IconOpen)`
   top: 1px;
 `;
 
-export default withOrganization(SentryAppDetailedView);
+export default withOrganization(DocIntegrationDetailedView);

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -27,7 +27,7 @@ import PluginDeprecationAlert from './pluginDeprecationAlert';
 
 type Props = {
   organization: Organization;
-  type: 'plugin' | 'firstParty' | 'sentryApp' | 'documentIntegration';
+  type: 'plugin' | 'firstParty' | 'sentryApp' | 'docIntegration';
   slug: string;
   displayName: string;
   publishStatus: 'unpublished' | 'published' | 'internal';
@@ -52,7 +52,7 @@ const urlMap = {
   plugin: 'plugins',
   firstParty: 'integrations',
   sentryApp: 'sentry-apps',
-  documentIntegration: 'document-integrations',
+  docIntegration: 'document-integrations',
 };
 
 const IntegrationRow = (props: Props) => {

--- a/tests/acceptance/test_organization_document_integration_detailed_view.py
+++ b/tests/acceptance/test_organization_document_integration_detailed_view.py
@@ -8,10 +8,8 @@ class OrganizationDocumentIntegrationDetailView(AcceptanceTestCase):
 
     def setUp(self):
         super().setUp()
-        self.doc = self.create_doc_integration(
-            features=[1, 2, 3],
-            has_avatar=True,
-        )
+        self.organization = self.create_organization(owner=self.user)
+        self.doc = self.create_doc_integration(features=[1, 2, 3], is_draft=False)
         self.login_as(self.user)
 
     def load_page(self, slug):

--- a/tests/acceptance/test_organization_document_integration_detailed_view.py
+++ b/tests/acceptance/test_organization_document_integration_detailed_view.py
@@ -8,8 +8,10 @@ class OrganizationDocumentIntegrationDetailView(AcceptanceTestCase):
 
     def setUp(self):
         super().setUp()
-        self.organization = self.create_organization(owner=self.user)
-        self.doc = self.create_doc_integration(features=[1, 2, 3], is_draft=False)
+        self.organization = self.create_organization(owner=self.user, name="Walter Mitty")
+        self.doc = self.create_doc_integration(
+            name="Quintessence of Life", features=[1, 2, 3], is_draft=False
+        )
         self.login_as(self.user)
 
     def load_page(self, slug):

--- a/tests/acceptance/test_organization_document_integration_detailed_view.py
+++ b/tests/acceptance/test_organization_document_integration_detailed_view.py
@@ -8,15 +8,20 @@ class OrganizationDocumentIntegrationDetailView(AcceptanceTestCase):
 
     def setUp(self):
         super().setUp()
+        self.doc = self.create_doc_integration(
+            features=[1, 2, 3],
+            has_avatar=True,
+        )
         self.login_as(self.user)
 
     def load_page(self, slug):
-        url = f"/settings/{self.organization.slug}/document-integrations/{slug}/"
-        self.browser.get(url)
-        self.browser.wait_until_not(".loading-indicator")
+        with self.feature("organizations:integrations-docs-from-db"):
+            url = f"/settings/{self.organization.slug}/document-integrations/{slug}/"
+            self.browser.get(url)
+            self.browser.wait_until_not(".loading-indicator")
 
-    def test_view_datadog(self):
-        self.load_page("datadog")
-        self.browser.snapshot("integrations - document-based detail overview")
-
-        assert self.browser.element_exists('[data-test-id="learn-more"]')
+    def test_view_doc(self):
+        with self.feature("organizations:integrations-docs-from-db"):
+            self.load_page(self.doc.slug)
+            self.browser.snapshot("integrations - document-based detail overview")
+            assert self.browser.element_exists('[data-test-id="learn-more"]')

--- a/tests/fixtures/js-stubs/docIntegration.js
+++ b/tests/fixtures/js-stubs/docIntegration.js
@@ -1,0 +1,31 @@
+export function DocIntegration(params = {}) {
+  return {
+    name: 'Sample Doc',
+    slug: 'sample-doc',
+    author: 'The Sentry Team',
+    url: 'https://example.com/sentry',
+    popularity: '10',
+    description: 'A helpful tutorial on how to setup this integration with Sentry',
+    isDraft: 'false',
+    features: [
+      {
+        featureId: 5,
+        featureGate: 'incident-management',
+        description:
+          'Manage incidents and outages by sending Sentry notifications to Sample Doc.',
+      },
+      {
+        featureId: 7,
+        featureGate: 'alert-rule',
+        description:
+          'Configure Sentry rules to trigger notifications based on conditions you set through the Sentry webhook integration.',
+      },
+    ],
+    resources: [
+      {title: 'Documentation', url: 'https://example.com/sentry/docs'},
+      {title: 'Support', url: 'https://example.com/sentry/support'},
+      {title: 'Demo', url: 'https://example.com/sentry/demo'},
+    ],
+    ...params,
+  };
+}

--- a/tests/fixtures/js-stubs/types.tsx
+++ b/tests/fixtures/js-stubs/types.tsx
@@ -30,6 +30,7 @@ type TestStubFixtures = {
   DebugSymbols: OverridableStub;
   DetailedEvents: SimpleStub;
   DiscoverSavedQuery: OverridableStub;
+  DocIntegration: OverridableStub;
   Entries: SimpleStub;
   Event: OverridableStub;
   EventEntry: OverridableStub;

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -52,6 +52,10 @@ describe('Command Palette Modal', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/doc-integrations/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/internal/health/',
       body: {
         problems: [],

--- a/tests/js/spec/components/search/sources/apiSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/apiSource.spec.jsx
@@ -69,6 +69,10 @@ describe('ApiSource', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/doc-integrations/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/shortids/foo-t/',
       body: [],
     });

--- a/tests/js/spec/views/organizationIntegrations/docIntegrationDetailedView.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/docIntegrationDetailedView.spec.jsx
@@ -1,0 +1,44 @@
+import {mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
+
+import DocIntegrationDetailedView from 'sentry/views/organizationIntegrations/docIntegrationDetailedView';
+
+describe('DocIntegrationDetailedView', function () {
+  const organization = TestStubs.Organization({features: ['integrations-docs-from-db']});
+  const doc = TestStubs.DocIntegration();
+
+  beforeEach(function () {});
+
+  it('renders', async function () {
+    const getMock = MockApiClient.addMockResponse({
+      url: `/doc-integrations/${doc.slug}/`,
+      body: doc,
+    });
+    mountWithTheme(
+      <DocIntegrationDetailedView
+        organization={organization}
+        params={{integrationSlug: doc.slug, orgId: organization.slug}}
+        location={{query: {}}}
+      />
+    );
+    await tick();
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    const docLink = screen.getByTestId('learn-more');
+    expect(docLink).toBeInTheDocument();
+    expect(docLink).toHaveAttribute('href', doc.url);
+
+    expect(screen.getByText(doc.author)).toBeInTheDocument();
+    expect(screen.getByText(doc.description)).toBeInTheDocument();
+
+    for (const resource of doc.resources) {
+      const link = screen.getByText(resource.title);
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', resource.url);
+    }
+
+    for (const feature of doc.features) {
+      expect(screen.getByText(feature.description)).toBeInTheDocument();
+    }
+  });
+});

--- a/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -31,6 +31,7 @@ describe('IntegrationListDirectory', function () {
         ],
         [`/organizations/${org.slug}/sentry-apps/`, TestStubs.OrgOwnedApps()],
         ['/sentry-apps/', TestStubs.PublishedApps()],
+        ['/doc-integrations/', [TestStubs.DocIntegration()]],
         [
           `/organizations/${org.slug}/sentry-app-installations/`,
           TestStubs.SentryAppInstalls(),

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -57,6 +57,10 @@ describe('SettingsSearch', function () {
       url: '/sentry-apps/?status=published',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: '/doc-integrations/',
+      body: [],
+    });
   });
 
   it('renders', async function () {


### PR DESCRIPTION
See [API-2324](https://getsentry.atlassian.net/browse/API-2324)

This PR will adapt the frontend to use the DocIntegrations returned from the backend rather than the hardcoded list in the code right now (if flagged in). Without the flag, the it falls back to the regular list and renders exactly as expected.

Additionally, this PR also makes docIntegrations and sentryApps appear properly in search (with their rendered avatars).

Sorry for the bit of backend diffs in a FE PR, but the only changes on the backend are to:
- Add a super-temporary (like 1-2 days sanity check) feature flag
- Fix an acceptance test

**Screenshots:**
Doc integrations from DB now appear in search
<img width="432" alt="doc int in search" src="https://user-images.githubusercontent.com/35509934/147997594-e7616b72-bdbf-4548-8ae7-f0453ad3dde7.png">
Sentry Apps appear with their avatars
<img width="459" alt="sentry app in search" src="https://user-images.githubusercontent.com/35509934/147997595-d93d15be-325a-4d30-ae8c-6d9239abad0d.png">
Doc integrations from the DB dont show up without the flag
<img width="451" alt="doc int from db without flag" src="https://user-images.githubusercontent.com/35509934/147997596-c57c4c7b-45e7-4a05-9936-0164bce657e3.png">
Doc integrations from the constants list dont show up WITH the flag
<img width="432" alt="doc int from consts with flag" src="https://user-images.githubusercontent.com/35509934/147997597-48449600-4762-4da0-996c-bd07786d1324.png">
Integration list with the flag shows the custom avatars
<img width="682" alt="int list with flag" src="https://user-images.githubusercontent.com/35509934/147997600-1a0eb595-407a-4b6f-abd0-ccbd768022bd.png">
Integration list without the flag only shows the constants
<img width="690" alt="int list without flag" src="https://user-images.githubusercontent.com/35509934/147997602-e1d9cf95-4f82-4691-8fd9-7e4e0b50bf8c.png">
The detailed view renders for DocInts from the DB
<img width="919" alt="detailed view" src="https://user-images.githubusercontent.com/35509934/147997603-e4377b0f-91b9-4ed0-9e5b-5ee099561b93.png">

**TODO**:
- [x] Add tests for detailed doc integration view

