### PR TITLE
ref(auth): Capture warning in case of ambiguous email resolution

### DIFF
--- a/src/sentry/auth/email.py
+++ b/src/sentry/auth/email.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+import sentry_sdk
+
+from sentry.models import User, UserEmail
+
+
+def resolve_email_to_user(email: str) -> Optional[User]:
+    candidate_users = list(
+        User.objects.filter(
+            id__in=UserEmail.objects.filter(email__iexact=email).values("user"), is_active=True
+        )
+    )
+
+    if not candidate_users:
+        return None
+    if len(candidate_users) == 1:
+        return candidate_users[0]
+
+    with sentry_sdk.push_scope() as scope:
+        scope.level = "warning"
+        scope.set_tag("email", email)
+        scope.set_extra("user_ids", sorted(user.id for user in candidate_users))
+        sentry_sdk.capture_message("Ambiguous email resolution")
+    return candidate_users[0]


### PR DESCRIPTION
Replaces the `User.objects.filter(...).first()` query with a stand-alone function. For now, the function is behaviorally the same, but captures a warning message in case we would be choosing arbitrarily from among more than one user.

I've pulled the function out to a new module in the hope that we'll eventually both put better resolution logic there, and pull in some code that solves a similar problem from [`getsentry/web/identity.py`](https://github.com/getsentry/getsentry/blob/master/getsentry/web/identity.py).