### PR TITLE
feat(profiling): move flamegraph and differential flamegraph

### DIFF
--- a/static/app/utils/profiling/differentialFlamegraph.tsx
+++ b/static/app/utils/profiling/differentialFlamegraph.tsx
@@ -1,3 +1,4 @@
+import {FlamegraphTheme} from './flamegraph/FlamegraphTheme';
 import {relativeChange} from './units/units';
 import {Flamegraph} from './flamegraph';
 import {FlamegraphFrame} from './flamegraphFrame';

--- a/static/app/utils/profiling/differentialFlamegraph.tsx
+++ b/static/app/utils/profiling/differentialFlamegraph.tsx
@@ -9,8 +9,11 @@ function countFrameOccurences(frames: FlamegraphFrame[]): Map<string, number> {
     const key = frame.frame.name + frame.frame.file;
 
     // @ts-ignore
-    if (counts.has(key)) counts.set(key, counts.get(key) + 1);
-    else counts.set(key, 1);
+    if (counts.has(key)) {
+      counts.set(key, counts.get(key) + 1);
+    } else {
+      counts.set(key, 1);
+    }
   }
 
   return counts;

--- a/static/app/utils/profiling/differentialFlamegraph.tsx
+++ b/static/app/utils/profiling/differentialFlamegraph.tsx
@@ -1,0 +1,87 @@
+import {relativeChange} from './units/units';
+import {Flamegraph} from './flamegraph';
+import {FlamegraphFrame} from './flamegraphFrame';
+
+function countFrameOccurences(frames: FlamegraphFrame[]): Map<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const frame of frames) {
+    const key = frame.frame.name + frame.frame.file;
+
+    // @ts-ignore
+    if (counts.has(key)) counts.set(key, counts.get(key) + 1);
+    else counts.set(key, 1);
+  }
+
+  return counts;
+}
+
+export class DifferentialFlamegraph extends Flamegraph {
+  countDiff: Map<string, number> = new Map();
+  count: Map<string, number> = new Map();
+  referenceCount: Map<string, number> = new Map();
+
+  static FromFlamegraphs(
+    reference: Flamegraph, // Reference chart is the one we compare the new flamegraph with
+    flamegraph: Flamegraph,
+    theme: FlamegraphTheme
+  ): DifferentialFlamegraph {
+    const differentialFlamegraph = new DifferentialFlamegraph(
+      flamegraph.profile,
+      flamegraph.profileIndex,
+      reference.inverted,
+      reference.leftHeavy
+    );
+
+    const referenceCounts = countFrameOccurences(reference.frames);
+    const counts = countFrameOccurences(flamegraph.frames);
+
+    const countDiff: Map<string, number> = new Map();
+    const colorMap: Map<string | number, number[]> =
+      differentialFlamegraph.colors ?? new Map();
+
+    for (const frame of flamegraph.frames) {
+      const key = frame.frame.name + frame.frame.file;
+
+      const count = counts.get(key);
+      const referenceCount = referenceCounts.get(key);
+
+      let diff = 0;
+      let color: number[] = [];
+
+      if (count === undefined) {
+        diff = -1;
+        color = [...theme.COLORS.DIFFERENTIAL_DECREASE, 1];
+      } else if (referenceCount === undefined) {
+        diff = 1;
+        color = [...theme.COLORS.DIFFERENTIAL_INCREASE, 1];
+      } else if (count > referenceCount) {
+        diff = relativeChange(referenceCount, count);
+        color = [
+          ...theme.COLORS.DIFFERENTIAL_INCREASE,
+          Math.abs((count - referenceCount) / count),
+        ];
+      } else if (referenceCount > count) {
+        diff = relativeChange(referenceCount, count);
+        color = [
+          ...theme.COLORS.DIFFERENTIAL_DECREASE,
+          Math.abs((count - referenceCount) / referenceCount),
+        ];
+      } else {
+        countDiff.set(key, 0);
+        continue;
+      }
+
+      countDiff.set(key, diff);
+      colorMap.set(key, color);
+    }
+
+    differentialFlamegraph.countDiff = countDiff;
+    differentialFlamegraph.count = counts;
+    differentialFlamegraph.referenceCount = referenceCounts;
+
+    differentialFlamegraph.setColors(colorMap);
+
+    return differentialFlamegraph;
+  }
+}

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -50,7 +50,16 @@ export class Flamegraph {
       this.configSpace = new Rect(0, 0, this.duration, this.depth);
     } else {
       // If we have no frames, set the trace duration to 1 second so that we can render a placeholder grid
-      this.configSpace = new Rect(0, 0, 1_000_000, 0);
+      this.configSpace = new Rect(
+        0,
+        0,
+        this.profile.unit === 'microseconds'
+          ? 1e6
+          : this.profile.unit === 'milliseconds'
+          ? 1e3
+          : 1,
+        0
+      );
     }
   }
 

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -92,13 +92,17 @@ export class Flamegraph {
     const closeFrame = (_: CallTreeNode, value: number) => {
       const stackTop = stack.pop();
 
-      if (!stackTop) throw new Error('Unbalanced stack');
+      if (!stackTop) {
+        throw new Error('Unbalanced stack');
+      }
 
       stackTop.end = value;
       stackTop.depth = stack.length;
       frames.push(stackTop);
 
-      if (stackTop.end - stackTop.start === 0) return;
+      if (stackTop.end - stackTop.start === 0) {
+        return;
+      }
       this.depth = Math.max(stackTop.depth, this.depth);
     };
 
@@ -139,14 +143,18 @@ export class Flamegraph {
     const closeFrame = (_node: CallTreeNode, value: number) => {
       const stackTop = stack.pop();
 
-      if (!stackTop) throw new Error('Unbalanced stack');
+      if (!stackTop) {
+        throw new Error('Unbalanced stack');
+      }
 
       stackTop.end = value;
       stackTop.depth = stack.length;
 
       frames.push(stackTop);
       // Dont draw 0 width frames
-      if (stackTop.end - stackTop.start === 0) return;
+      if (stackTop.end - stackTop.start === 0) {
+        return;
+      }
 
       this.depth = Math.max(stackTop.depth, this.depth);
     };

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -1,0 +1,201 @@
+import {lastOfArray} from 'sentry/utils';
+
+import {Rect} from './gl/utils';
+import {Profile} from './profile/profile';
+import {CallTreeNode} from './callTreeNode';
+import {FlamegraphFrame} from './flamegraphFrame';
+
+export class Flamegraph {
+  profile: Profile;
+  frames: FlamegraphFrame[] = [];
+
+  name: string;
+  profileIndex: number;
+  startedAt: number;
+  endedAt: number;
+
+  inverted?: boolean = false;
+  leftHeavy?: boolean = false;
+
+  colors: Map<string | number, number[]> | null = null;
+
+  depth = 0;
+  duration = 0;
+  configSpace: Rect = new Rect(0, 0, 0, 0);
+
+  constructor(
+    profile: Profile,
+    profileIndex: number,
+    inverted = false,
+    leftHeavy = false
+  ) {
+    this.inverted = inverted;
+    this.leftHeavy = leftHeavy;
+    this.profile = profile;
+
+    this.duration = profile.duration;
+    this.profileIndex = profileIndex;
+    this.name = profile.name;
+
+    this.startedAt = profile.startedAt;
+    this.endedAt = profile.endedAt;
+
+    this.frames = leftHeavy
+      ? this.buildLeftHeavyGraph(profile)
+      : this.buildCallOrderGraph(profile);
+
+    if (this.frames.length) {
+      this.configSpace = new Rect(0, 0, this.duration, this.depth);
+    } else {
+      // If we have no frames, set the trace duration to 1 second so that we can render a placeholder grid
+      this.configSpace = new Rect(0, 0, 1_000_000, 0);
+    }
+  }
+
+  static Empty(): Flamegraph {
+    return new Flamegraph(
+      new Profile(1_000_000, 0, 1_000_000, 'Profile', 'milliseconds'),
+      0,
+      false,
+      false
+    );
+  }
+
+  static From(from: Flamegraph, inverted = false, leftHeavy = false): Flamegraph {
+    return new Flamegraph(from.profile, from.profileIndex, inverted, leftHeavy);
+  }
+
+  buildCallOrderGraph(profile: Profile): FlamegraphFrame[] {
+    const frames: FlamegraphFrame[] = [];
+    const stack: FlamegraphFrame[] = [];
+
+    const openFrame = (node: CallTreeNode, value: number) => {
+      const parent = lastOfArray(stack);
+
+      const frame: FlamegraphFrame = {
+        frame: node.frame,
+        node,
+        parent,
+        children: [],
+        depth: 0,
+        start: value,
+        end: value,
+      };
+
+      if (parent) {
+        parent.children.push(frame);
+      }
+
+      stack.push(frame);
+    };
+
+    const closeFrame = (_: CallTreeNode, value: number) => {
+      const stackTop = stack.pop();
+
+      if (!stackTop) throw new Error('Unbalanced stack');
+
+      stackTop.end = value;
+      stackTop.depth = stack.length;
+      frames.push(stackTop);
+
+      if (stackTop.end - stackTop.start === 0) return;
+      this.depth = Math.max(stackTop.depth, this.depth);
+    };
+
+    profile.forEach(openFrame, closeFrame);
+    return frames;
+  }
+
+  buildLeftHeavyGraph(profile: Profile): FlamegraphFrame[] {
+    const frames: FlamegraphFrame[] = [];
+    const stack: FlamegraphFrame[] = [];
+
+    const sortTree = (node: CallTreeNode) => {
+      node.children.sort((a, b) => -(a.totalWeight - b.totalWeight));
+      node.children.forEach(c => sortTree(c));
+    };
+
+    sortTree(profile.appendOrderTree);
+
+    const openFrame = (node: CallTreeNode, value: number) => {
+      const parent = lastOfArray(stack);
+      const frame: FlamegraphFrame = {
+        frame: node.frame,
+        node,
+        parent,
+        children: [],
+        depth: 0,
+        start: value,
+        end: value,
+      };
+
+      if (parent) {
+        parent.children.push(frame);
+      }
+
+      stack.push(frame);
+    };
+
+    const closeFrame = (_node: CallTreeNode, value: number) => {
+      const stackTop = stack.pop();
+
+      if (!stackTop) throw new Error('Unbalanced stack');
+
+      stackTop.end = value;
+      stackTop.depth = stack.length;
+
+      frames.push(stackTop);
+      // Dont draw 0 width frames
+      if (stackTop.end - stackTop.start === 0) return;
+
+      this.depth = Math.max(stackTop.depth, this.depth);
+    };
+
+    function visit(node: CallTreeNode, start: number) {
+      if (!node.frame.isRoot()) {
+        openFrame(node, start);
+      }
+
+      let childTime = 0;
+
+      node.children.forEach(child => {
+        visit(child, start + childTime);
+        childTime += child.totalWeight;
+      });
+
+      if (!node.frame.isRoot()) {
+        closeFrame(node, start + node.totalWeight);
+      }
+    }
+    visit(profile.appendOrderTree, 0);
+    return frames;
+  }
+
+  setColors(colors: Map<string | number, number[]> | null): void {
+    this.colors = colors;
+  }
+
+  withOffset(offset: number): Flamegraph {
+    const mutateFrame = (frame: FlamegraphFrame) => {
+      frame.start = offset + frame.start;
+      frame.end = offset + frame.end;
+
+      return frame;
+    };
+
+    const visit = (frame: FlamegraphFrame): void => {
+      mutateFrame(frame);
+    };
+
+    for (const frame of this.frames) {
+      visit(frame);
+    }
+
+    return this;
+  }
+
+  setConfigSpace(configSpace: Rect): Flamegraph {
+    this.configSpace = configSpace;
+    return this;
+  }
+}

--- a/static/app/utils/profiling/flamegraphFrame.tsx
+++ b/static/app/utils/profiling/flamegraphFrame.tsx
@@ -1,0 +1,12 @@
+import {CallTreeNode} from './callTreeNode';
+import {Frame} from './frame';
+
+export interface FlamegraphFrame {
+  frame: Frame;
+  node: CallTreeNode;
+  start: number;
+  end: number;
+  depth: number;
+  parent: FlamegraphFrame | null;
+  children: FlamegraphFrame[];
+}

--- a/static/app/utils/profiling/frame.tsx
+++ b/static/app/utils/profiling/frame.tsx
@@ -49,4 +49,8 @@ export class Frame extends WeightedNode {
       }
     }
   }
+
+  isRoot(): boolean {
+    return Frame.Root === this;
+  }
 }

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -12,13 +12,20 @@ export function createShader(
   gl.shaderSource(shader, source);
   gl.compileShader(shader);
   const success = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+<<<<<<< HEAD
 
+=======
+>>>>>>> 0928245583 (feat(profiling): add gl utils and gl-matrix lib)
   if (success) {
     return shader;
   }
 
   gl.deleteShader(shader);
+<<<<<<< HEAD
   throw new Error('Failed to compile shader');
+=======
+  throw new Error('Failed to create shader');
+>>>>>>> 0928245583 (feat(profiling): add gl utils and gl-matrix lib)
 }
 
 export function createProgram(

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -12,20 +12,12 @@ export function createShader(
   gl.shaderSource(shader, source);
   gl.compileShader(shader);
   const success = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
-<<<<<<< HEAD
-
-=======
->>>>>>> 0928245583 (feat(profiling): add gl utils and gl-matrix lib)
   if (success) {
     return shader;
   }
 
   gl.deleteShader(shader);
-<<<<<<< HEAD
   throw new Error('Failed to compile shader');
-=======
-  throw new Error('Failed to create shader');
->>>>>>> 0928245583 (feat(profiling): add gl utils and gl-matrix lib)
 }
 
 export function createProgram(

--- a/static/app/utils/profiling/units/units.ts
+++ b/static/app/utils/profiling/units/units.ts
@@ -1,0 +1,3 @@
+export function relativeChange(final: number, initial: number): number {
+  return (initial - final) / final;
+}

--- a/static/app/utils/profiling/units/units.ts
+++ b/static/app/utils/profiling/units/units.ts
@@ -1,3 +1,3 @@
 export function relativeChange(final: number, initial: number): number {
-  return (initial - final) / final;
+  return (final - initial) / initial;
 }

--- a/tests/js/spec/utils/profiling/differentialFlamegraph.spec.tsx
+++ b/tests/js/spec/utils/profiling/differentialFlamegraph.spec.tsx
@@ -1,5 +1,6 @@
 import {DifferentialFlamegraph} from 'sentry/utils/profiling/differentialFlamegraph';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/FlamegraphTheme';
 import {EventedProfile} from 'sentry/utils/profiling/profile/eventedProfile';
 
 const makeEvent = (times: number, frame: number): Profiling.Event[] => {
@@ -28,7 +29,7 @@ const THEME = {
     DIFFERENTIAL_DECREASE: [0, 0, 1],
     DIFFERENTIAL_INCREASE: [1, 0, 0],
   },
-};
+} as FlamegraphTheme;
 
 describe('differentialFlamegraph', () => {
   it('INCREASE: color encodes new frames red', () => {

--- a/tests/js/spec/utils/profiling/differentialFlamegraph.spec.tsx
+++ b/tests/js/spec/utils/profiling/differentialFlamegraph.spec.tsx
@@ -1,7 +1,86 @@
+import {DifferentialFlamegraph} from 'sentry/utils/profiling/differentialFlamegraph';
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {EventedProfile} from 'sentry/utils/profiling/profile/eventedProfile';
+
+const makeEvent = (times: number, frame: number): Profiling.Event[] => {
+  return new Array(times * 2).fill(0).map((_, i) => {
+    return {type: i % 2 === 0 ? 'O' : 'C', at: i, frame};
+  });
+};
+
+const baseProfile: Profiling.EventedProfile = {
+  name: 'profile',
+  startValue: 0,
+  endValue: 1000,
+  unit: 'milliseconds',
+  type: 'evented',
+  events: [],
+  shared: {
+    frames: [{name: 'f0'}, {name: 'f1'}, {name: 'f2'}, {name: 'f3'}],
+  },
+};
+const makeFlamegraph = (profile: Profiling.EventedProfile) => {
+  return new Flamegraph(EventedProfile.FromProfile(profile), 0, false, false);
+};
+
+const THEME = {
+  COLORS: {
+    DIFFERENTIAL_DECREASE: [0, 0, 1],
+    DIFFERENTIAL_INCREASE: [1, 0, 0],
+  },
+};
+
 describe('differentialFlamegraph', () => {
-  it.todo('diffs two flamegraph');
-  it.todo('color encodes new frames red');
-  it.todo('color encodes an increase in new frames red');
-  it.todo('color encodes missing frames blue');
-  it.todo('color encodes a decrease in new frames blue');
+  it('INCREASE: color encodes new frames red', () => {
+    const from = makeFlamegraph({
+      ...baseProfile,
+      events: [],
+    });
+    const to = makeFlamegraph({
+      ...baseProfile,
+      events: [...makeEvent(1, 0)],
+    });
+
+    const flamegraph = DifferentialFlamegraph.Diff(from, to, THEME);
+    expect(flamegraph.colors?.get('f0')).toEqual([1, 0, 0, 1]);
+  });
+  it('INCREASE: color encodes relative increase in red', () => {
+    const from = makeFlamegraph({
+      ...baseProfile,
+      events: [...makeEvent(2, 0)],
+    });
+    const to = makeFlamegraph({
+      ...baseProfile,
+      events: [...makeEvent(3, 0)],
+    });
+
+    const flamegraph = DifferentialFlamegraph.Diff(from, to, THEME);
+    expect(flamegraph.colors?.get('f0')).toEqual([1, 0, 0, 0.5]);
+  });
+  it('DECREASE: color encodes relative decrease in blue', () => {
+    const from = makeFlamegraph({
+      ...baseProfile,
+      events: [...makeEvent(4, 0)],
+    });
+    const to = makeFlamegraph({
+      ...baseProfile,
+      events: [...makeEvent(2, 0)],
+    });
+
+    const flamegraph = DifferentialFlamegraph.Diff(from, to, THEME);
+    expect(flamegraph.colors?.get('f0')).toEqual([0, 0, 1, 0.5]);
+  });
+  it('No change: no color is set', () => {
+    const from = makeFlamegraph({
+      ...baseProfile,
+      events: [...makeEvent(2, 0)],
+    });
+    const to = makeFlamegraph({
+      ...baseProfile,
+      events: [...makeEvent(2, 0)],
+    });
+
+    const flamegraph = DifferentialFlamegraph.Diff(from, to, THEME);
+    expect(flamegraph.colors?.get('f0')).toBe(undefined);
+  });
 });

--- a/tests/js/spec/utils/profiling/differentialFlamegraph.spec.tsx
+++ b/tests/js/spec/utils/profiling/differentialFlamegraph.spec.tsx
@@ -1,0 +1,7 @@
+describe('differentialFlamegraph', () => {
+  it.todo('diffs two flamegraph');
+  it.todo('color encodes new frames red');
+  it.todo('color encodes an increase in new frames red');
+  it.todo('color encodes missing frames blue');
+  it.todo('color encodes a decrease in new frames blue');
+});

--- a/tests/js/spec/utils/profiling/flamegraph.spec.tsx
+++ b/tests/js/spec/utils/profiling/flamegraph.spec.tsx
@@ -192,9 +192,13 @@ describe('flamegraph', () => {
 
     expect(flamegraph.frames[0].frame.name).toBe('f0');
     expect(flamegraph.frames[0].frame.totalWeight).toBe(1);
+    expect(flamegraph.frames[0].start).toBe(2);
+    expect(flamegraph.frames[0].end).toBe(3);
 
     expect(flamegraph.frames[1].frame.name).toBe('f1');
     expect(flamegraph.frames[1].frame.totalWeight).toBe(2);
+    expect(flamegraph.frames[1].start).toBe(0);
+    expect(flamegraph.frames[1].end).toBe(2);
   });
 
   it('updates startTime and endTime of left heavy children graph', () => {

--- a/tests/js/spec/utils/profiling/flamegraph.spec.tsx
+++ b/tests/js/spec/utils/profiling/flamegraph.spec.tsx
@@ -7,7 +7,7 @@ const makeEmptyEventedTrace = (): EventedProfile => {
     name: 'profile',
     startValue: 0,
     endValue: 0,
-    unit: 'milliseconds',
+    unit: 'microseconds',
     type: 'evented',
     events: [],
     shared: {
@@ -252,9 +252,11 @@ describe('flamegraph', () => {
       Flamegraph.From(flamegraph, false, false).configSpace.equals(flamegraph.configSpace)
     ).toBe(true);
   });
+
   it('Empty', () => {
-    expect(Flamegraph.Empty().configSpace.width).toEqual(1_000_000);
-    expect(Flamegraph.Empty().configSpace.height).toEqual(0);
+    expect(Flamegraph.Empty().configSpace.equals(new Rect(0, 0, 1_000_000, 0))).toBe(
+      true
+    );
   });
 
   it('withOffset', () => {

--- a/tests/js/spec/utils/profiling/flamegraph.spec.tsx
+++ b/tests/js/spec/utils/profiling/flamegraph.spec.tsx
@@ -1,14 +1,290 @@
-describe('flamegraph', () => {
-  it.todo('From');
-  it.todo('Empty');
-  it.todo('setColors');
-  it.todo('withOffset');
-  it.todo('setConfigSpace');
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {Rect} from 'sentry/utils/profiling/gl/utils';
+import {EventedProfile} from 'sentry/utils/profiling/profile/eventedProfile';
 
-  describe('call order graph', () => {
-    it.todo('build the graph in correct order');
+const makeEmptyEventedTrace = (): EventedProfile => {
+  return EventedProfile.FromProfile({
+    name: 'profile',
+    startValue: 0,
+    endValue: 0,
+    unit: 'milliseconds',
+    type: 'evented',
+    events: [],
+    shared: {
+      frames: [],
+    },
   });
-  describe('left heavy', () => {
-    it.todo('build the graph in correct order');
+};
+
+describe('flamegraph', () => {
+  it('sets default timeline for empty flamegraph', () => {
+    const flamegraph = new Flamegraph(makeEmptyEventedTrace(), 0, false, false);
+
+    expect(flamegraph.configSpace.equals(new Rect(0, 0, 1_000_000, 0))).toBe(true);
+    expect(flamegraph.inverted).toBe(false);
+    expect(flamegraph.leftHeavy).toBe(false);
+  });
+
+  it('stores profile properties', () => {
+    const trace: Profiling.EventedProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'O', at: 1, frame: 1},
+        {type: 'C', at: 2, frame: 1},
+        {type: 'C', at: 3, frame: 0},
+      ],
+      shared: {
+        frames: [{name: 'f0'}, {name: 'f1'}],
+      },
+    };
+
+    const flamegraph = new Flamegraph(EventedProfile.FromProfile(trace), 10, true, true);
+
+    expect(flamegraph.inverted).toBe(true);
+    expect(flamegraph.leftHeavy).toBe(true);
+
+    expect(flamegraph.duration).toBe(1000);
+    expect(flamegraph.profileIndex).toBe(10);
+    expect(flamegraph.name).toBe('profile');
+
+    expect(flamegraph.startedAt).toBe(0);
+    expect(flamegraph.endedAt).toBe(1000);
+  });
+
+  it('creates a call order graph', () => {
+    const trace: Profiling.EventedProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'O', at: 1, frame: 1},
+        {type: 'O', at: 2, frame: 2},
+        {type: 'C', at: 3, frame: 2},
+        {type: 'C', at: 4, frame: 1},
+        {type: 'C', at: 5, frame: 0},
+      ],
+      shared: {
+        frames: [{name: 'f0'}, {name: 'f1'}, {name: 'f2'}],
+      },
+    };
+
+    const flamegraph = new Flamegraph(
+      EventedProfile.FromProfile(trace),
+      10,
+      false,
+      false
+    );
+
+    const order = ['f0', 'f1', 'f2'];
+    for (let i = 0; i < order.length; i++) {
+      expect(flamegraph.frames[i].frame.name).toBe(order[i]);
+      expect(flamegraph.frames[i].depth).toBe(i);
+    }
+  });
+
+  it('omits 0 width frames', () => {
+    const trace: Profiling.EventedProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'O', at: 1, frame: 1},
+        {type: 'C', at: 1, frame: 1},
+        {type: 'C', at: 3, frame: 0},
+      ],
+      shared: {
+        frames: [{name: 'f0'}, {name: 'f1'}],
+      },
+    };
+
+    const flamegraph = new Flamegraph(
+      EventedProfile.FromProfile(trace),
+      10,
+      false,
+      false
+    );
+    expect(flamegraph.frames.length).toBe(1);
+    expect(flamegraph.frames.every(f => f.frame.name !== 'f1')).toBe(true);
+  });
+
+  it('tracks max stack depth', () => {
+    const trace: Profiling.EventedProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'O', at: 1, frame: 1},
+        {type: 'O', at: 2, frame: 1},
+        {type: 'C', at: 3, frame: 1},
+        {type: 'C', at: 4, frame: 1},
+        {type: 'C', at: 5, frame: 0},
+      ],
+      shared: {
+        frames: [{name: 'f0'}, {name: 'f1'}],
+      },
+    };
+
+    const flamegraph = new Flamegraph(
+      EventedProfile.FromProfile(trace),
+      10,
+      false,
+      false
+    );
+
+    expect(flamegraph.depth).toBe(2);
+  });
+
+  it('throws on unbalanced stack', () => {
+    const trace: Profiling.EventedProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'O', at: 1, frame: 1},
+        {type: 'C', at: 1, frame: 1},
+      ],
+      shared: {
+        frames: [{name: 'f0'}, {name: 'f1'}],
+      },
+    };
+
+    expect(
+      () => new Flamegraph(EventedProfile.FromProfile(trace), 10, false, false)
+    ).toThrow('Unbalanced append order stack');
+  });
+
+  it('creates leftHeavy graph', () => {
+    const trace: Profiling.EventedProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'C', at: 1, frame: 0},
+        {type: 'O', at: 2, frame: 1},
+        {type: 'C', at: 4, frame: 1},
+      ],
+      shared: {
+        frames: [{name: 'f0'}, {name: 'f1'}],
+      },
+    };
+
+    const flamegraph = new Flamegraph(EventedProfile.FromProfile(trace), 10, false, true);
+
+    expect(flamegraph.frames[0].frame.name).toBe('f0');
+    expect(flamegraph.frames[0].frame.totalWeight).toBe(1);
+
+    expect(flamegraph.frames[1].frame.name).toBe('f1');
+    expect(flamegraph.frames[1].frame.totalWeight).toBe(2);
+  });
+
+  it('updates startTime and endTime of left heavy children graph', () => {
+    const trace: Profiling.EventedProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'O', at: 1, frame: 1},
+        {type: 'C', at: 2, frame: 1},
+        {type: 'O', at: 2, frame: 2},
+        {type: 'C', at: 4, frame: 2},
+        {type: 'C', at: 6, frame: 0},
+      ],
+      shared: {
+        frames: [{name: 'f0'}, {name: 'f1'}, {name: 'f2'}],
+      },
+    };
+
+    const flamegraph = new Flamegraph(EventedProfile.FromProfile(trace), 10, false, true);
+
+    expect(flamegraph.frames[0].frame.name).toBe('f0');
+  });
+
+  it('From', () => {
+    const trace: Profiling.EventedProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'O', at: 1, frame: 1},
+        {type: 'C', at: 2, frame: 1},
+        {type: 'O', at: 2, frame: 2},
+        {type: 'C', at: 4, frame: 2},
+        {type: 'C', at: 6, frame: 0},
+      ],
+      shared: {
+        frames: [{name: 'f0'}, {name: 'f1'}, {name: 'f2'}],
+      },
+    };
+
+    const flamegraph = new Flamegraph(EventedProfile.FromProfile(trace), 10, false, true);
+
+    expect(
+      Flamegraph.From(flamegraph, false, false).configSpace.equals(flamegraph.configSpace)
+    ).toBe(true);
+  });
+  it('Empty', () => {
+    expect(Flamegraph.Empty().configSpace.width).toEqual(1_000_000);
+    expect(Flamegraph.Empty().configSpace.height).toEqual(0);
+  });
+
+  it('withOffset', () => {
+    const trace: Profiling.EventedProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'O', at: 1, frame: 1},
+        {type: 'C', at: 2, frame: 1},
+        {type: 'C', at: 3, frame: 0},
+      ],
+      shared: {
+        frames: [{name: 'f0'}, {name: 'f1'}],
+      },
+    };
+
+    const flamegraph = new Flamegraph(EventedProfile.FromProfile(trace), 10, false, true);
+    flamegraph.withOffset(500);
+
+    expect(flamegraph.frames[0].start).toBe(500);
+    expect(flamegraph.frames[1].start).toBe(500);
+    expect(flamegraph.frames[1].end).toBe(501);
+    expect(flamegraph.frames[0].end).toBe(503);
+  });
+
+  it('setConfigSpace', () => {
+    expect(
+      Flamegraph.Empty()
+        .setConfigSpace(new Rect(0, 0, 10, 5))
+        .configSpace.equals(new Rect(0, 0, 10, 5))
+    ).toBe(true);
   });
 });

--- a/tests/js/spec/utils/profiling/flamegraph.spec.tsx
+++ b/tests/js/spec/utils/profiling/flamegraph.spec.tsx
@@ -1,0 +1,14 @@
+describe('flamegraph', () => {
+  it.todo('From');
+  it.todo('Empty');
+  it.todo('setColors');
+  it.todo('withOffset');
+  it.todo('setConfigSpace');
+
+  describe('call order graph', () => {
+    it.todo('build the graph in correct order');
+  });
+  describe('left heavy', () => {
+    it.todo('build the graph in correct order');
+  });
+});

--- a/tests/js/spec/utils/profiling/gl/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/gl/utils.spec.tsx
@@ -175,7 +175,6 @@ describe('Rect', () => {
 
     expect(b.equals(a)).toBe(true);
   });
-
   it('getters return correct values', () => {
     const rect = new Rect(1, 2, 3, 4);
 

--- a/tests/js/spec/utils/profiling/gl/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/gl/utils.spec.tsx
@@ -175,6 +175,7 @@ describe('Rect', () => {
 
     expect(b.equals(a)).toBe(true);
   });
+
   it('getters return correct values', () => {
     const rect = new Rect(1, 2, 3, 4);
 


### PR DESCRIPTION
Port over the main flamegraph and differential flamegraph classes.

The two classes are used to build (not rendering) the flamegraph in different ways (see buildCallOrderGraph and buildLeftHeavyGraph). They are mainly responsible for outputting an array of frames to render and giving us a configuration view (usually at x:0, y:0, width: timeline duration, height: max stack height).

There are two main functions to look at - buildLeftHeavyGraph and buildCallOrderGraph.
They both iterate over all frames of a profile and append the frames to render to `this.frames` with the slight difference that buildLeftHeavyGraph sorts the tree first (depth first) and updates the frames startTime and endTime based on their new positions so that startTime is the sum of all child frames preceding the current frame. 

<details>
<summary>e.g. left heavy timings change</summary>
<img width="751" alt="CleanShot 2022-01-13 at 10 19 28@2x" src="https://user-images.githubusercontent.com/9317857/149301554-6c15eeb0-6fdb-4057-b690-a56c2cc10d9e.png">
</details>


Note that the order of this.frames doesn't matter and it will be up to whoever consumes the flamegraph to determine what and when to render.