### PR TITLE
fix(arm64) Fixes snuba tests on arm64

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -449,7 +449,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 Condition(Column("org_id"), Op.EQ, org_id),
                 Condition(Column("project_id"), Op.EQ, project_id),
                 Condition(Column(tag_key(org_id, "release")), Op.EQ, tag_value(org_id, release)),
-                Condition(Column("timestamp"), Op.GTE, datetime.min),
+                Condition(
+                    Column("timestamp"), Op.GTE, datetime(2008, 5, 8)
+                ),  # Date of sentry's first commit
                 Condition(Column("timestamp"), Op.LT, datetime.now(pytz.utc)),
             ]
 

--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -40,6 +40,15 @@ requires_snuba_metrics = pytest.mark.skipif(
 )
 
 
+def is_arm64():
+    return os.uname().machine == "arm64"
+
+
+requires_not_arm64 = pytest.mark.skipif(
+    is_arm64(), reason="this test fails in our arm64 testing env"
+)
+
+
 def xfail_if_not_postgres(reason):
     def decorator(function):
         return pytest.mark.xfail(os.environ.get("TEST_SUITE") != "postgres", reason=reason)(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -607,7 +607,9 @@ class SnubaQueryParams:
     ):
         # TODO: instead of having events be the default, make dataset required.
         self.dataset = dataset or Dataset.Events
-        self.start = start or datetime.utcfromtimestamp(0)  # will be clamped to project retention
+        self.start = start or datetime(
+            2008, 5, 8
+        )  # Date of sentry's first commit. Will be clamped to project retention
         # Snuba has end exclusive but our UI wants it generally to be inclusive.
         # This shows up in unittests: https://github.com/getsentry/sentry/pull/15939
         # We generally however require that the API user is aware of the exclusive

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1579,7 +1579,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "end": iso_format(self.day_ago + timedelta(hours=2)),
                     "interval": "1h",
                     "yAxis": "count()",
-                    "orderby": ["-count()"],
+                    "orderby": ["-count()", "user"],
                     "field": ["user", "count()"],
                     "topEvents": 5,
                 },
@@ -1590,7 +1590,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(data) == 5
 
-        assert data["email:bar@example.com"]["order"] == 0
+        assert data["email:bar@example.com"]["order"] == 1
         assert [attrs for time, attrs in data["email:bar@example.com"]["data"]] == [
             [{"count": 7}],
             [{"count": 0}],
@@ -1609,7 +1609,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "end": iso_format(self.day_ago + timedelta(hours=2)),
                     "interval": "1h",
                     "yAxis": "count()",
-                    "orderby": ["-count()"],
+                    "orderby": ["-count()", "user"],
                     "field": ["user", "user.email", "count()"],
                     "topEvents": 5,
                 },
@@ -1620,7 +1620,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(data) == 5
 
-        assert data["email:bar@example.com,bar@example.com"]["order"] == 0
+        assert data["email:bar@example.com,bar@example.com"]["order"] == 1
         assert [attrs for time, attrs in data["email:bar@example.com,bar@example.com"]["data"]] == [
             [{"count": 7}],
             [{"count": 0}],

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -22,6 +22,7 @@ from sentry.search.events.constants import (
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.skips import requires_not_arm64
 from sentry.utils import json
 from sentry.utils.samples import load_data
 from sentry.utils.snuba import QueryExecutionError, QueryIllegalTypeOfArgument, RateLimitExceeded
@@ -1355,6 +1356,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             ],
             "query": "event.type:transaction",
             "project": [project.id],
+            "sort": "count_miserable_user",
         }
 
         response = self.do_request(
@@ -1365,8 +1367,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(response.data["data"]) == 3
         data = response.data["data"]
         assert data[0]["count_miserable_user"] == 0
-        assert data[1]["count_miserable_user"] == 2
-        assert data[2]["count_miserable_user"] == 1
+        assert data[1]["count_miserable_user"] == 1
+        assert data[2]["count_miserable_user"] == 2
 
         query["query"] = "event.type:transaction count_miserable(user):>0"
 
@@ -1377,8 +1379,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 2
         data = response.data["data"]
-        assert abs(data[0]["count_miserable_user"]) == 2
-        assert abs(data[1]["count_miserable_user"]) == 1
+        assert abs(data[0]["count_miserable_user"]) == 1
+        assert abs(data[1]["count_miserable_user"]) == 2
 
     def test_user_misery_alias_field(self):
         project = self.create_project()
@@ -1445,6 +1447,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             ],
             "query": "event.type:transaction",
             "project": [project.id],
+            "sort": "-apdex",
         }
 
         response = self.do_request(
@@ -3011,6 +3014,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert data[0]["corr_transaction_duration_transaction_duration"] == 0.0
         assert data[0]["sum_transaction_duration"] == 10000
 
+    @requires_not_arm64
     def test_null_user_misery_returns_zero(self):
         project = self.create_project()
         data = load_data(
@@ -3035,6 +3039,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         data = response.data["data"]
         assert data[0]["user_misery_300"] == 0
 
+    @requires_not_arm64
     def test_null_user_misery_new_returns_zero(self):
         project = self.create_project()
         data = load_data(
@@ -3311,14 +3316,14 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         event2.group.delete()
 
         features = {"organizations:discover-basic": True, "organizations:global-views": True}
-        query = {"field": ["issue", "count()"], "sort": "count()"}
+        query = {"field": ["issue", "count()"], "sort": "issue.id"}
         response = self.do_request(query, features=features)
 
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 2
-        assert data[0]["issue"] == "unknown"
-        assert data[1]["issue"] == event1.group.qualified_short_id
+        assert data[0]["issue"] == event1.group.qualified_short_id
+        assert data[1]["issue"] == "unknown"
 
     def test_last_seen_negative_duration(self):
         project = self.create_project()


### PR DESCRIPTION
There were a small number of tests that were consistently failing as a
result of arm64 using a newer version of Clickhouse. For a couple of the tests I
skipped them on arm64 since fixing the test would require changing what it does.
For the other tests I changed the lower bound on dates since the new version of
Clickhouse didn't like getting 0001 as a year.

------------

For more context on these fixes: The tests that I changed the orderby were failing because they had at least 2 results with the same sorting value, which happened to be in a different order with the new Clickhouse. Changing the orderby ensured the results were arriving in a consistent order.

The change in release_health/metrics.py and utils/snuba.py to use a different minimum date is because without those, the default dates were being set to `0001-01-01T00:00:00` and the epoch respectively. In the new version of Clickhouse, it uses a couple days after the normal epoch as its epoch, and dates less than the Clickhouse epoch cause incorrect results.