### PR TITLE
fix(tests): Increase timeout for front end acceptance tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -17,7 +17,7 @@ jobs:
   frontend:
     name: frontend tests
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       matrix:
         # XXX: When updating this, make sure you also update CI_NODE_TOTAL.


### PR DESCRIPTION
They are currently timing out on CI at 20 minutes.