### PR TITLE
fix(auth): standardize setting active org

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -345,7 +345,7 @@ class OrganizationEndpoint(Endpoint):
         # Never track any org (regardless of whether the user does or doesn't have
         # membership in that org) when the user is in active superuser mode
         if request.auth is None and request.user and not is_active_superuser(request):
-            request.session["activeorg"] = organization.slug
+            auth.set_active_org(request, organization.slug)
 
         kwargs["organization"] = organization
         return (args, kwargs)

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -173,7 +173,7 @@ class AuthIdentityHandler:
 
         if not is_active_superuser(self.request):
             # set activeorg to ensure correct redirect upon logging in
-            self.request.session["activeorg"] = self.organization.slug
+            auth.set_active_org(self.request, self.organization.slug)
         return HttpResponseRedirect(auth.get_login_redirect(self.request))
 
     def _handle_new_membership(self, auth_identity: AuthIdentity) -> Optional[OrganizationMember]:
@@ -526,8 +526,7 @@ class AuthIdentityHandler:
         state.clear()
 
         if not is_active_superuser(self.request):
-            # set activeorg to ensure correct redirect upon logging in
-            self.request.session["activeorg"] = self.organization.slug
+            auth.set_active_org(self.request, self.organization.slug)
         return self._post_login_redirect()
 
     @property

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -339,6 +339,13 @@ def is_user_signed_request(request):
         return False
 
 
+def set_active_org(request: Request, org_slug: str) -> None:
+    # even if the value being set is the same this will trigger a session
+    # modification and reset the users expiry, so check if they are different first.
+    if request.session.get("activeorg") != org_slug:
+        request.session["activeorg"] = org_slug
+
+
 class EmailAuthBackend(ModelBackend):
     """
     Authenticate against django.contrib.auth.models.User.

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -214,8 +214,7 @@ class AuthLoginView(BaseView):
                         and request.user
                         and not is_active_superuser(request)
                     ):
-                        # set activeorg to ensure correct redirect upon logging in
-                        request.session["activeorg"] = organization.slug
+                        auth.set_active_org(request, organization.slug)
 
                     if settings.SENTRY_SINGLE_ORGANIZATION:
                         try:

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -104,8 +104,7 @@ class OrganizationMixin:
                 logger.info("User is not a member of any organizations")
 
         if active_organization and self._is_org_member(request.user, active_organization):
-            if active_organization.slug != request.session.get("activeorg"):
-                request.session["activeorg"] = active_organization.slug
+            auth.set_active_org(request, active_organization.slug)
 
         self._active_org = (active_organization, request.user)
 


### PR DESCRIPTION
### Problem
By setting the activeorg, we implicitly set `request.session.modified` to `True` which resets the session duration. A majority of the time the activeorg in the session is the same as the one we're setting, so we are resetting the duration for no reason

### Solution
Simply check that the org is different before modifying. This change should cause our user's sessions to expire more frequently (good thing), as before we were modifying the session every API request.