### PR TITLE
ref(ui): Use 4px border radius for buttons

### DIFF
--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -439,7 +439,7 @@ const generateLevelTheme = (colors: BaseColors) => ({
 });
 
 const generateButtonTheme = (colors: BaseColors, alias: Aliases) => ({
-  borderRadius: '3px',
+  borderRadius: '4px',
 
   default: {
     color: alias.textColor,


### PR DESCRIPTION
In the design system (i.e. Figma), buttons use a 4px border radius. The current value of 3px is incorrect. Fixing this will help make buttons will look more harmonious with form inputs, tables, and the rest of the UI, which all have a 4px border radius.

Before - notice that the button's corners are ever so slightly sharper than the input's:
<img width="155" alt="Screen Shot 2022-01-04 at 1 01 09 PM" src="https://user-images.githubusercontent.com/44172267/148123430-ce5d8cfb-cba9-4cfd-aa2f-1e12b449993a.png">

After:
<img width="155" alt="Screen Shot 2022-01-04 at 1 01 23 PM" src="https://user-images.githubusercontent.com/44172267/148123457-176e8af5-2fd8-4ec3-9232-9a4455cd2d16.png">

