### PR TITLE
fix(dashboards): Allow widgets to orderby equations

### DIFF
--- a/static/app/components/dashboards/widgetQueriesForm.tsx
+++ b/static/app/components/dashboards/widgetQueriesForm.tsx
@@ -14,6 +14,8 @@ import {
   explodeField,
   generateFieldAsString,
   getAggregateAlias,
+  isEquation,
+  stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
 import {Widget, WidgetQuery, WidgetType} from 'sentry/views/dashboardsV2/types';
 import {generateFieldOptions} from 'sentry/views/eventsV2/utils';
@@ -24,10 +26,16 @@ import WidgetQueryFields from './widgetQueryFields';
 
 const generateOrderOptions = (fields: string[]): SelectValue<string>[] => {
   const options: SelectValue<string>[] = [];
+  let equations = 0;
   fields.forEach(field => {
-    const alias = getAggregateAlias(field);
-    options.push({label: t('%s asc', field), value: alias});
-    options.push({label: t('%s desc', field), value: `-${alias}`});
+    let alias = getAggregateAlias(field);
+    const label = stripEquationPrefix(field);
+    if (isEquation(field)) {
+      alias = `equation[${equations}]`;
+      equations += 1;
+    }
+    options.push({label: t('%s asc', label), value: alias});
+    options.push({label: t('%s desc', label), value: `-${alias}`});
   });
   return options;
 };

--- a/static/app/components/dashboards/widgetQueriesForm.tsx
+++ b/static/app/components/dashboards/widgetQueriesForm.tsx
@@ -30,6 +30,7 @@ const generateOrderOptions = (fields: string[]): SelectValue<string>[] => {
   fields.forEach(field => {
     let alias = getAggregateAlias(field);
     const label = stripEquationPrefix(field);
+    // Equations are referenced via a standard alias following this pattern
     if (isEquation(field)) {
       alias = `equation[${equations}]`;
       equations += 1;


### PR DESCRIPTION
- This fixes a bug where widgets wouldn't sort by equations
   - This was because we used the field label which would be something
     like `equation|count() + 2` when the backend would expect instead
     the equation alias `equations[0]`
- This also fixes a bug where the display would still include the
  `equation|` prefix