### PR TITLE
feat(alerts): Add filtering issue alert rules by `sdk.name`

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -46,6 +46,7 @@ ATTR_CHOICES = [
     "user.ip_address",
     "http.method",
     "http.url",
+    "sdk.name",
     "stacktrace.code",
     "stacktrace.module",
     "stacktrace.filename",
@@ -144,6 +145,11 @@ class EventAttributeCondition(EventCondition):
                 return []
 
             return [getattr(event.interfaces["request"], path[1])]
+
+        elif path[0] == "sdk":
+            if path[1] != "name":
+                return []
+            return [event.data["sdk"].get(path[1])]
 
         elif path[0] == "stacktrace":
             stacks = event.interfaces.get("stacktrace")

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -36,6 +36,7 @@ class EventAttributeConditionTest(RuleTestCase):
             "tags": [("environment", "production")],
             "extra": {"foo": {"bar": "baz"}, "biz": ["baz"], "bar": "foo"},
             "platform": "php",
+            "sdk": {"name": "sentry.javascript.react", "version": "6.16.1"},
         }
         data.update(kwargs)
         event = self.store_event(data, project_id=self.project.id)
@@ -295,6 +296,22 @@ class EventAttributeConditionTest(RuleTestCase):
 
         rule = self.get_rule(
             data={"match": MatchType.EQUAL, "attribute": "exception.value", "value": "foo bar"}
+        )
+        self.assertDoesNotPass(rule, event)
+
+    def test_sdk_name(self):
+        event = self.get_event()
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "sdk.name",
+                "value": "sentry.javascript.react",
+            }
+        )
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule(
+            data={"match": MatchType.EQUAL, "attribute": "sdk.name", "value": "sentry.python"}
         )
         self.assertDoesNotPass(rule, event)
 


### PR DESCRIPTION
Adds support for filtering by the `sdk.name` property of issue events in alert rules. This would allow users to filter by `sentry.javascript.react` or whatever string the SDK is passing.

closes #30426