### PR TITLE
fix(ui): Fix visual issues on <IgnoreActions /> & <ResolveActions />

### DIFF
--- a/static/app/components/actions/actionLink.tsx
+++ b/static/app/components/actions/actionLink.tsx
@@ -11,11 +11,16 @@ const StyledAction = styled('a')<{disabled?: boolean}>`
   ${p => p.disabled && 'cursor: not-allowed;'}
 `;
 
-const StyledActionButton = styled(ActionButton)`
+const StyledActionButton = styled(ActionButton)<{
+  disabled?: boolean;
+  hasDropdown?: boolean;
+}>`
   display: flex;
   align-items: center;
-  ${p => p.disabled && 'cursor: not-allowed;'}
   pointer-events: ${p => (p.disabled ? 'none' : 'auto')};
+
+  ${p => p.disabled && 'cursor: not-allowed;'}
+  ${p => p.hasDropdown && `border-radius: ${p.theme.borderRadiusLeft}`};
 `;
 
 type ConfirmableActionProps = React.ComponentProps<typeof ConfirmableAction>;

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -129,13 +129,14 @@ const IgnoreActions = ({
           title={t('Ignore')}
           onAction={() => onUpdate({status: ResolutionStatus.IGNORED})}
           icon={<IconMute size="xs" />}
+          hasDropdown
         >
           {t('Ignore')}
         </ActionLink>
       </Tooltip>
       <StyledDropdownLink
         customTitle={
-          <ActionButton
+          <StyledActionButton
             disabled={disabled}
             icon={<IconChevron direction="down" size="xs" />}
           />
@@ -328,6 +329,10 @@ const StyledActionLink = styled(ActionLink)`
 const StyledForActionLink = styled(ActionLink)`
   padding: ${space(0.5)} 0;
   ${actionLinkCss};
+`;
+
+const StyledActionButton = styled(ActionButton)`
+  box-shadow: none;
 `;
 
 const StyledDropdownLink = styled(DropdownLink)`

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import ActionLink from 'sentry/components/actions/actionLink';
@@ -143,7 +144,7 @@ class ResolveActions extends React.Component<Props> {
     return (
       <DropdownLink
         customTitle={
-          <ActionButton
+          <StyledActionButton
             label={t('More resolve options')}
             disabled={!projectSlug ? disabled : disableDropdown}
             icon={<IconChevron direction="down" size="xs" />}
@@ -244,6 +245,7 @@ class ResolveActions extends React.Component<Props> {
               title={t('Resolve')}
               icon={<IconCheckmark size="xs" />}
               onAction={() => onUpdate({status: ResolutionStatus.RESOLVED})}
+              hasDropdown
             >
               {t('Resolve')}
             </ActionLink>
@@ -256,3 +258,7 @@ class ResolveActions extends React.Component<Props> {
 }
 
 export default withOrganization(ResolveActions);
+
+const StyledActionButton = styled(ActionButton)`
+  box-shadow: none;
+`;

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -606,6 +606,9 @@ const commonTheme = {
   borderRadius: '4px',
   borderRadiusBottom: '0 0 4px 4px',
   borderRadiusTop: '4px 4px 0 0',
+  borderRadiusLeft: '4px 0 0 4px',
+  borderRadiusRight: '0 4px 4px 0',
+
   headerSelectorRowHeight: 44,
   headerSelectorLabelHeight: 28,
 


### PR DESCRIPTION
**1. Fix border radii on the main action buttons**

Following #30920, the main actions buttons in `<IgnoreActions />` & `<ResolveActions />` have strange-looking corners on the right side.

Before:
<img width="225" alt="Screen Shot 2022-01-04 at 2 49 13 PM" src="https://user-images.githubusercontent.com/44172267/148134516-6dc0d7d6-b447-48fc-90d0-5ab68a785cf2.png">

After:
<img width="225" alt="Screen Shot 2022-01-04 at 2 51 20 PM" src="https://user-images.githubusercontent.com/44172267/148134709-74878b75-a954-4823-8e73-c53db075ba76.png">


**2. Remove unnecessary shadows from the dropdown trigger**

The dropdown trigger (button on the right side with the chevron) casts a light shadow over the main action button on the left. That's because by default buttons have shadows. In this case, the shadows should be removed.

Before:
<img width="225" alt="Screen Shot 2022-01-04 at 2 51 52 PM" src="https://user-images.githubusercontent.com/44172267/148134746-3a6d55fc-d6d7-4a73-b62d-72bf29de0ef6.png">

After:
<img width="225" alt="Screen Shot 2022-01-04 at 2 52 05 PM" src="https://user-images.githubusercontent.com/44172267/148134764-d5989e73-c378-4c99-87b3-22848468086b.png">



