### PR TITLE
fix(ui): Handle issue list page when graph period changes

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -659,10 +659,12 @@ class IssueListOverview extends React.Component<Props, State> {
   };
 
   onSelectStatsPeriod = (period: string) => {
+    const {location} = this.props;
     if (period !== this.getGroupStatsPeriod()) {
-      const cursor = this.props.location.query.cursor;
-      const queryPageInt = parseInt(this.props.location.query.page, 10);
-      this.transitionTo({cursor, page: queryPageInt, groupStatsPeriod: period});
+      const cursor = location.query.cursor;
+      const queryPageInt = parseInt(location.query.page, 10);
+      const page = isNaN(queryPageInt) || !location.query.cursor ? 0 : queryPageInt;
+      this.transitionTo({cursor, page, groupStatsPeriod: period});
     }
   };
 

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -660,7 +660,8 @@ class IssueListOverview extends React.Component<Props, State> {
 
   onSelectStatsPeriod = (period: string) => {
     if (period !== this.getGroupStatsPeriod()) {
-      this.transitionTo({groupStatsPeriod: period});
+      const cursor = this.props.location.query.cursor;
+      this.transitionTo({cursor, groupStatsPeriod: period});
     }
   };
 

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -661,7 +661,8 @@ class IssueListOverview extends React.Component<Props, State> {
   onSelectStatsPeriod = (period: string) => {
     if (period !== this.getGroupStatsPeriod()) {
       const cursor = this.props.location.query.cursor;
-      this.transitionTo({cursor, groupStatsPeriod: period});
+      const queryPageInt = parseInt(this.props.location.query.page, 10);
+      this.transitionTo({cursor, page: queryPageInt, groupStatsPeriod: period});
     }
   };
 


### PR DESCRIPTION
Fix bug where if you go to the second page (or any page other than the first page) of results on the issue list page and click on the graph date period, the page resets to Page 0. This will now stay on the page you're on when you toggle between graph periods.

[FIXES WOR-204](https://getsentry.atlassian.net/browse/WOR-204)