### PR TITLE
feat(profiling): add canvas scheduler

### DIFF
--- a/static/app/utils/profiling/canvasScheduler.tsx
+++ b/static/app/utils/profiling/canvasScheduler.tsx
@@ -1,0 +1,139 @@
+import {mat3} from 'gl-matrix';
+
+import {Rect} from './gl/utils';
+
+type DrawFn = () => void;
+type ArgumentTypes<F> = F extends (args: infer A) => any ? A : never;
+
+export interface FlamegraphEvents<T> {
+  transformConfigView: (transform: mat3) => void;
+  setConfigView: (configView: Rect) => void;
+  zoomIntoFrame: (frame: T) => void;
+  selectedNode: (frame: T | null) => void;
+  resetZoom: () => void;
+}
+
+export class CanvasScheduler<T> {
+  beforeFrameCallbacks: Set<DrawFn> = new Set();
+  afterFrameCallbacks: Set<DrawFn> = new Set();
+  requestAnimationFrame: number | null = null;
+
+  events: {
+    [K in keyof FlamegraphEvents<T>]: Set<FlamegraphEvents<T>[K]>;
+  } = {
+    setConfigView: new Set<FlamegraphEvents<T>['setConfigView']>(),
+    transformConfigView: new Set<FlamegraphEvents<T>['transformConfigView']>(),
+    zoomIntoFrame: new Set<FlamegraphEvents<T>['zoomIntoFrame']>(),
+    selectedNode: new Set<FlamegraphEvents<T>['selectedNode']>(),
+    resetZoom: new Set<FlamegraphEvents<T>['resetZoom']>(),
+  };
+
+  on<K extends keyof FlamegraphEvents<T>>(
+    eventName: K,
+    cb: FlamegraphEvents<T>[K]
+  ): void {
+    const set = this.events[eventName] as unknown as Set<FlamegraphEvents<T>[K]>;
+    if (set.has(cb)) return;
+    set.add(cb);
+  }
+
+  off<K extends keyof FlamegraphEvents<T>>(
+    eventName: K,
+    cb: FlamegraphEvents<T>[K]
+  ): void {
+    const set = this.events[eventName] as unknown as Set<FlamegraphEvents<T>[K]>;
+    if (!set.has(cb)) return;
+    set.delete(cb);
+  }
+
+  dispatch<K extends keyof FlamegraphEvents<T>>(
+    event: K,
+    args: ArgumentTypes<FlamegraphEvents<T>[K]>
+  ): void {
+    for (const handler of this.events[event]) {
+      handler(args);
+    }
+  }
+
+  private registerCallback(cb: DrawFn, pool: Set<DrawFn>) {
+    if (pool.has(cb)) return;
+    pool.add(cb);
+  }
+
+  private unregisterCallback(cb: DrawFn, pool: Set<DrawFn>) {
+    if (pool.has(cb)) {
+      pool.delete(cb);
+    }
+  }
+
+  registerBeforeFrameCallback(cb: DrawFn): void {
+    this.registerCallback(cb, this.beforeFrameCallbacks);
+  }
+  unregisterBeforeFrameCallback(cb: DrawFn): void {
+    this.unregisterCallback(cb, this.beforeFrameCallbacks);
+  }
+  registerAfterFrameCallback(cb: DrawFn): void {
+    this.registerCallback(cb, this.afterFrameCallbacks);
+  }
+  unregisterAfterFrameCallback(cb: DrawFn): void {
+    this.unregisterCallback(cb, this.afterFrameCallbacks);
+  }
+
+  dispose(): void {
+    for (const type in this.events) {
+      this.events[type].clear();
+    }
+  }
+
+  drawSync(): void {
+    for (const cb of this.beforeFrameCallbacks) {
+      cb();
+    }
+
+    for (const cb of this.afterFrameCallbacks) {
+      cb();
+    }
+  }
+
+  draw(): void {
+    if (this.requestAnimationFrame) {
+      window.cancelAnimationFrame(this.requestAnimationFrame);
+    }
+
+    this.requestAnimationFrame = window.requestAnimationFrame(() => {
+      for (const cb of this.beforeFrameCallbacks) {
+        cb();
+      }
+
+      for (const cb of this.afterFrameCallbacks) {
+        cb();
+      }
+      this.requestAnimationFrame = null;
+    });
+  }
+}
+
+export class CanvasPoolManager<T> {
+  schedulers: Set<CanvasScheduler<T>> = new Set();
+
+  registerScheduler(scheduler: CanvasScheduler<T>): void {
+    if (this.schedulers.has(scheduler)) return;
+    this.schedulers.add(scheduler);
+  }
+
+  dispatch<K extends keyof FlamegraphEvents<T>>(
+    event: K,
+    args: ArgumentTypes<FlamegraphEvents<T>[K]>
+  ): void {
+    for (const scheduler of this.schedulers) {
+      scheduler.dispatch(event, args);
+    }
+  }
+
+  unregisterScheduler(scheduler: CanvasScheduler<T>): void {
+    if (this.schedulers.has(scheduler)) {
+      scheduler.dispose();
+      this.schedulers.delete(scheduler);
+    }
+  }
+}

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -12,7 +12,6 @@ export function createShader(
   gl.shaderSource(shader, source);
   gl.compileShader(shader);
   const success = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
-
   if (success) {
     return shader;
   }
@@ -361,7 +360,6 @@ export class Rect {
     if (this.height !== rect.height) {
       return false;
     }
-
     return true;
   }
 

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -12,6 +12,7 @@ export function createShader(
   gl.shaderSource(shader, source);
   gl.compileShader(shader);
   const success = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+
   if (success) {
     return shader;
   }

--- a/tests/js/spec/utils/profiling/canvasScheduler.spec.tsx
+++ b/tests/js/spec/utils/profiling/canvasScheduler.spec.tsx
@@ -1,0 +1,160 @@
+import {CanvasScheduler, FlamegraphEvents} from 'sentry/utils/profiling/canvasScheduler';
+
+const handlers: (keyof FlamegraphEvents<any>)[] = [
+  'setConfigView',
+  'transformConfigView',
+  'zoomIntoFrame',
+  'selectedNode',
+  'resetZoom',
+];
+
+describe('CanvasScheduler', () => {
+  it.each([handlers])('registers and calls %s', key => {
+    const handler = jest.fn();
+    const scheduler = new CanvasScheduler();
+    scheduler.on(key, handler);
+
+    expect(scheduler.events[key].has(handler)).toBe(true);
+    scheduler.dispatch(key, undefined);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+  it.each([handlers])(
+    'does not register duplicate handler and calls %s only once',
+    key => {
+      const handler = jest.fn();
+      const scheduler = new CanvasScheduler();
+      scheduler.on(key, handler);
+      scheduler.on(key, handler);
+
+      expect(scheduler.events[key].has(handler)).toBe(true);
+      scheduler.dispatch(key, undefined);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    }
+  );
+  it.each([handlers])('removes %s registered handler and does not call it', key => {
+    const handler = jest.fn();
+    const scheduler = new CanvasScheduler();
+    scheduler.on(key, handler);
+    scheduler.off(key, handler);
+
+    expect(scheduler.events[key].has(handler)).toBe(false);
+    scheduler.dispatch(key, undefined);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+  it('registerBeforeFrameCallback', () => {
+    jest.useFakeTimers();
+
+    const drawFn = jest.fn();
+    const scheduler = new CanvasScheduler();
+
+    scheduler.registerBeforeFrameCallback(drawFn);
+    scheduler.draw();
+
+    jest.runAllTimers();
+    expect(drawFn).toHaveBeenCalledTimes(1);
+  });
+  it('unregisterBeforeFrameCallback', () => {
+    jest.useFakeTimers();
+
+    const drawFn = jest.fn();
+    const scheduler = new CanvasScheduler();
+
+    scheduler.registerBeforeFrameCallback(drawFn);
+    scheduler.unregisterBeforeFrameCallback(drawFn);
+    scheduler.draw();
+
+    jest.runAllTimers();
+    expect(drawFn).not.toHaveBeenCalled();
+  });
+  it('registerAfterFrameCallback', () => {
+    jest.useFakeTimers();
+
+    const drawFn = jest.fn();
+    const scheduler = new CanvasScheduler();
+
+    scheduler.registerAfterFrameCallback(drawFn);
+    scheduler.draw();
+
+    jest.runAllTimers();
+    expect(drawFn).toHaveBeenCalledTimes(1);
+  });
+  it('unregisterAfterFrameCallback', () => {
+    jest.useFakeTimers();
+
+    const drawFn = jest.fn();
+    const scheduler = new CanvasScheduler();
+
+    scheduler.registerAfterFrameCallback(drawFn);
+    scheduler.unregisterAfterFrameCallback(drawFn);
+    scheduler.draw();
+
+    jest.runAllTimers();
+    expect(drawFn).not.toHaveBeenCalled();
+  });
+  it('calls callbacks in correct order', () => {
+    jest.useFakeTimers();
+
+    const drawBeforeFn = jest.fn().mockImplementationOnce(() => {});
+    const drawAfterFn = jest.fn();
+
+    const scheduler = new CanvasScheduler();
+
+    scheduler.registerBeforeFrameCallback(drawBeforeFn);
+    scheduler.registerAfterFrameCallback(drawAfterFn);
+
+    scheduler.draw();
+
+    jest.runAllTimers();
+    expect(drawBeforeFn.mock.invocationCallOrder[0]).toBeLessThan(
+      drawAfterFn.mock.invocationCallOrder[0]
+    );
+  });
+  it('drawSync', () => {
+    const drawBeforeFn = jest.fn().mockImplementationOnce(() => {});
+    const drawAfterFn = jest.fn();
+
+    const scheduler = new CanvasScheduler();
+
+    scheduler.registerBeforeFrameCallback(drawBeforeFn);
+    scheduler.registerAfterFrameCallback(drawAfterFn);
+
+    // If we do not call drawSync, the test will fail as the assertion will
+    // be evaluated before the callbacks have ran.
+    scheduler.drawSync();
+
+    expect(drawBeforeFn.mock.invocationCallOrder[0]).toBeLessThan(
+      drawAfterFn.mock.invocationCallOrder[0]
+    );
+  });
+  it('dispose', () => {
+    jest.useFakeTimers();
+    const drawBeforeFn = jest.fn().mockImplementationOnce(() => {});
+    const drawAfterFn = jest.fn();
+
+    const handlerFns = handlers.map(key => [key, jest.fn()]);
+
+    const scheduler = new CanvasScheduler();
+
+    scheduler.registerBeforeFrameCallback(drawBeforeFn);
+    scheduler.registerAfterFrameCallback(drawAfterFn);
+
+    for (const [key, handler] of handlerFns) {
+      // @ts-ignore register all handlers
+      scheduler.on(key, handler);
+    }
+    scheduler.dispose();
+    // If we do not call drawSync, the test will fail as the assertion will
+    // be evaluated before the callbacks have ran.
+    scheduler.draw();
+    scheduler.drawSync();
+
+    jest.runAllTimers();
+
+    for (const [_, handler] of handlerFns) {
+      expect(handler).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/tests/js/spec/utils/profiling/canvasScheduler.spec.tsx
+++ b/tests/js/spec/utils/profiling/canvasScheduler.spec.tsx
@@ -1,6 +1,6 @@
 import {CanvasScheduler, FlamegraphEvents} from 'sentry/utils/profiling/canvasScheduler';
 
-const handlers: (keyof FlamegraphEvents<any>)[] = [
+const handlers: (keyof FlamegraphEvents)[] = [
   'setConfigView',
   'transformConfigView',
   'zoomIntoFrame',
@@ -12,24 +12,24 @@ describe('CanvasScheduler', () => {
   it.each([handlers])('registers and calls %s', key => {
     const handler = jest.fn();
     const scheduler = new CanvasScheduler();
-    scheduler.on(key, handler);
 
-    expect(scheduler.events[key].has(handler)).toBe(true);
+    scheduler.on(key, handler);
     scheduler.dispatch(key, undefined);
 
+    expect(scheduler.events[key].has(handler)).toBe(true);
     expect(handler).toHaveBeenCalledTimes(1);
   });
   it.each([handlers])(
     'does not register duplicate handler and calls %s only once',
-    key => {
+    (key: keyof FlamegraphEvents) => {
       const handler = jest.fn();
       const scheduler = new CanvasScheduler();
       scheduler.on(key, handler);
       scheduler.on(key, handler);
 
-      expect(scheduler.events[key].has(handler)).toBe(true);
       scheduler.dispatch(key, undefined);
 
+      expect(scheduler.events[key].has(handler)).toBe(true);
       expect(handler).toHaveBeenCalledTimes(1);
     }
   );
@@ -39,9 +39,9 @@ describe('CanvasScheduler', () => {
     scheduler.on(key, handler);
     scheduler.off(key, handler);
 
-    expect(scheduler.events[key].has(handler)).toBe(false);
     scheduler.dispatch(key, undefined);
 
+    expect(scheduler.events[key].has(handler)).toBe(false);
     expect(handler).not.toHaveBeenCalled();
   });
   it('registerBeforeFrameCallback', () => {

--- a/tests/js/spec/utils/profiling/gl/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/gl/utils.spec.tsx
@@ -175,7 +175,6 @@ describe('Rect', () => {
 
     expect(b.equals(a)).toBe(true);
   });
-
   it('getters return correct values', () => {
     const rect = new Rect(1, 2, 3, 4);
 

--- a/tests/js/spec/utils/profiling/gl/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/gl/utils.spec.tsx
@@ -175,6 +175,7 @@ describe('Rect', () => {
 
     expect(b.equals(a)).toBe(true);
   });
+
   it('getters return correct values', () => {
     const rect = new Rect(1, 2, 3, 4);
 


### PR DESCRIPTION
Adds a canvas scheduler interface that allows us to register flamegraph plugins and scheduler renderers in a before/after render cycle. The scheduler is basically a simple event emitter that can register renderer draw callbacks and allows them to listen to changes.