### PR TITLE
fix(dashboard): Use modified dashboard state when available

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -302,11 +302,14 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   handleAddCustomWidget = (widget: Widget) => {
+    const {dashboard} = this.props;
+    const {modifiedDashboard} = this.state;
+    const newModifiedDashboard = modifiedDashboard || dashboard;
     let newWidget = widget;
     if (this.props.organization.features.includes('dashboard-grid-layout')) {
       newWidget = assignTempId(widget);
     }
-    this.onUpdateWidget([...this.props.dashboard.widgets, newWidget]);
+    this.onUpdateWidget([...newModifiedDashboard.widgets, newWidget]);
   };
 
   onAddWidget = () => {


### PR DESCRIPTION
Use modified dashboard state when adding widgets.
If dashboard prop is used then only the latest
widget changes are reflected in edit mode.