### PR TITLE
fix(copy): create alert button text

### DIFF
--- a/static/app/views/alerts/list/header.tsx
+++ b/static/app/views/alerts/list/header.tsx
@@ -51,7 +51,7 @@ const AlertHeader = ({router, organization, activeTab}: Props) => {
             referrer="alert_stream"
             showPermissionGuide
           >
-            {t('Create Alert Rule')}
+            {t('Create Alert')}
           </CreateAlertButton>
           <Button
             onClick={handleNavigateToSettings}

--- a/static/app/views/alerts/list/index.tsx
+++ b/static/app/views/alerts/list/index.tsx
@@ -215,7 +215,7 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
           priority="primary"
           referrer="alert_stream"
         >
-          {t('Create Alert Rule')}
+          {t('Create Alert')}
         </CreateAlertButton>
       </Fragment>
     );

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -159,7 +159,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
                 size="small"
                 to={`/organizations/${organization.slug}/alerts/rules/`}
               >
-                {t('Create Alert Rule')}
+                {t('Create Alert')}
               </Button>
               <Button
                 size="small"

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -219,7 +219,7 @@ describe('IncidentsList', function () {
     };
 
     createWrapper({organization: noAccessOrg});
-    expect(screen.getByLabelText('Create Alert Rule')).toHaveAttribute(
+    expect(screen.getByLabelText('Create Alert')).toHaveAttribute(
       'aria-disabled',
       'true'
     );
@@ -229,7 +229,7 @@ describe('IncidentsList', function () {
     // Enabled with access
     createWrapper();
 
-    expect(screen.getByLabelText('Create Alert Rule')).toHaveAttribute(
+    expect(screen.getByLabelText('Create Alert')).toHaveAttribute(
       'aria-disabled',
       'false'
     );

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -176,11 +176,11 @@ describe('OrganizationRuleList', () => {
 
     const {rerender} = createWrapper({organization: noAccessOrg});
 
-    expect(await screen.findByLabelText('Create Alert Rule')).toBeDisabled();
+    expect(await screen.findByLabelText('Create Alert')).toBeDisabled();
 
     // Enabled with access
     rerender(getComponent());
-    expect(await screen.findByLabelText('Create Alert Rule')).toBeEnabled();
+    expect(await screen.findByLabelText('Create Alert')).toBeEnabled();
   });
 
   it('searches by name', async () => {


### PR DESCRIPTION
Changing button copy from `Create Alert Rule` -> `Create Alert`

It’s simpler, reads better, and is now consistent with the same button in Discover.

## Before
![CleanShot 2022-01-05 at 10 59 24](https://user-images.githubusercontent.com/1900676/148273640-f4493ead-1314-4d2a-a701-368c5645ac41.png)

## After
![CleanShot 2022-01-05 at 11 00 18](https://user-images.githubusercontent.com/1900676/148273657-783ac112-9a8c-49b3-9089-23578d6736b6.png)

