### PR TITLE
fix(releases): Allow clicking release tag tooltip link

### DIFF
--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -102,19 +102,19 @@ function ReleaseCardProjectRow({
         {showReleaseAdoptionStages && (
           <AdoptionStageColumn>
             {adoptionStageLabel ? (
-              <Link
-                to={{
-                  pathname: `/organizations/${organization.slug}/releases/`,
-                  query: {
-                    ...location.query,
-                    query: `release.stage:${adoptionStage}`,
-                  },
-                }}
-              >
-                <Tooltip title={adoptionStageLabel.tooltipTitle}>
+              <Tooltip title={adoptionStageLabel.tooltipTitle} isHoverable>
+                <Link
+                  to={{
+                    pathname: `/organizations/${organization.slug}/releases/`,
+                    query: {
+                      ...location.query,
+                      query: `release.stage:${adoptionStage}`,
+                    },
+                  }}
+                >
                   <Tag type={adoptionStageLabel.type}>{adoptionStageLabel.name}</Tag>
-                </Tooltip>
-              </Link>
+                </Link>
+              </Tooltip>
             ) : (
               <NotAvailable />
             )}


### PR DESCRIPTION
Allows hovering + clicking on this tooltip
![image](https://user-images.githubusercontent.com/1400464/148274091-c087da08-3c34-4ba9-bc58-904755da9c51.png)
