### PR TITLE
fix(dashboard-layout): Fix mobile layout error when widgets < layouts

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -528,7 +528,12 @@ function getMobileLayout(desktopLayout: Layout[], widgets: Widget[]) {
     return [];
   }
 
-  const layoutWidgetPairs = zip(desktopLayout, widgets) as [Layout, Widget][];
+  // If there's a layout but no matching widget, then the widget was deleted
+  // in a separate session and should be ignored
+  const widgetGridKeys = new Set(widgets.map(constructGridItemKey));
+  const filteredLayouts = desktopLayout.filter(({i}) => widgetGridKeys.has(i));
+
+  const layoutWidgetPairs = zip(filteredLayouts, widgets) as [Layout, Widget][];
 
   // Sort by y and then subsort by x
   const sorted = sortBy(layoutWidgetPairs, ['0.y', '0.x']);

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -530,6 +530,7 @@ function getMobileLayout(desktopLayout: Layout[], widgets: Widget[]) {
 
   // If there's a layout but no matching widget, then the widget was deleted
   // in a separate session and should be ignored
+  // TODO(nar): Can remove once layouts are stored in the DB
   const widgetGridKeys = new Set(widgets.map(constructGridItemKey));
   const filteredLayouts = desktopLayout.filter(({i}) => widgetGridKeys.has(i));
 

--- a/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
@@ -235,6 +235,7 @@ describe('Dashboards > Detail', function () {
       jest.clearAllMocks();
       if (wrapper) {
         wrapper.unmount();
+        wrapper = null;
       }
     });
 
@@ -462,6 +463,7 @@ describe('Dashboards > Detail', function () {
         />,
         {context: initialData.routerContext}
       );
+      await tick();
 
       await screen.findByText('First Widget');
       await screen.findByText('Second Widget');
@@ -476,7 +478,7 @@ describe('Dashboards > Detail', function () {
             TestStubs.Widget(
               [{name: '', conditions: 'event.type:error', fields: ['count()']}],
               {
-                title: 'First',
+                title: 'First Widget',
                 interval: '1d',
                 id: '1',
               }
@@ -498,9 +500,9 @@ describe('Dashboards > Detail', function () {
         />,
         {context: initialData.routerContext}
       );
+      await tick();
 
       await screen.findByText('First Widget');
-      await screen.findByText('Second Widget');
     });
   });
 });

--- a/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
@@ -1,11 +1,16 @@
 import {enforceActOnUseLegacyStoreHook, mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountGlobalModal} from 'sentry-test/modal';
-import {act} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  mountWithTheme as rtlMountWithTheme,
+  screen,
+} from 'sentry-test/reactTestingLibrary';
 
 import * as modals from 'sentry/actionCreators/modal';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {constructGridItemKey} from 'sentry/views/dashboardsV2/dashboard';
+import * as gridUtils from 'sentry/views/dashboardsV2/gridLayout/utils';
 import * as types from 'sentry/views/dashboardsV2/types';
 import ViewEditDashboard from 'sentry/views/dashboardsV2/view';
 
@@ -417,6 +422,85 @@ describe('Dashboards > Detail', function () {
       wrapper.find('Controls Button[data-test-id="dashboard-edit"]').simulate('click');
       wrapper.update();
       expect(wrapper.find('AddWidget').exists()).toBe(false);
+    });
+
+    it('renders successfully if more widgets than stored layouts', async function () {
+      // A case where someone has async added widgets to a dashboard
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/1/',
+        body: TestStubs.Dashboard(
+          [
+            TestStubs.Widget(
+              [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+              {
+                title: 'First Widget',
+                interval: '1d',
+                id: '1',
+              }
+            ),
+            TestStubs.Widget(
+              [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+              {
+                title: 'Second Widget',
+                interval: '1d',
+                id: '2',
+              }
+            ),
+          ],
+          {id: '1', title: 'Custom Errors'}
+        ),
+      });
+      jest
+        .spyOn(gridUtils, 'getDashboardLayout')
+        .mockReturnValueOnce([{i: 'grid-item-1', x: 0, y: 0, w: 2, h: 6}]);
+      rtlMountWithTheme(
+        <ViewEditDashboard
+          organization={initialData.organization}
+          params={{orgId: 'org-slug', dashboardId: '1'}}
+          router={initialData.router}
+          location={initialData.router.location}
+        />,
+        {context: initialData.routerContext}
+      );
+
+      await screen.findByText('First Widget');
+      await screen.findByText('Second Widget');
+    });
+
+    it('renders successfully if more layouts than stored widgets', async function () {
+      // A case where someone has async removed widgets from a dashboard
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/1/',
+        body: TestStubs.Dashboard(
+          [
+            TestStubs.Widget(
+              [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+              {
+                title: 'First',
+                interval: '1d',
+                id: '1',
+              }
+            ),
+          ],
+          {id: '1', title: 'Custom Errors'}
+        ),
+      });
+      jest.spyOn(gridUtils, 'getDashboardLayout').mockReturnValueOnce([
+        {i: 'grid-item-1', x: 0, y: 0, w: 2, h: 6},
+        {i: 'grid-item-2', x: 2, y: 0, w: 2, h: 2},
+      ]);
+      rtlMountWithTheme(
+        <ViewEditDashboard
+          organization={initialData.organization}
+          params={{orgId: 'org-slug', dashboardId: '1'}}
+          router={initialData.router}
+          location={initialData.router.location}
+        />,
+        {context: initialData.routerContext}
+      );
+
+      await screen.findByText('First Widget');
+      await screen.findByText('Second Widget');
     });
   });
 });


### PR DESCRIPTION
## Problem
Since we're storing in localStorage, our state can get out of sync if someone adds/removes a widget.

Adding a widget isn't a problem because it'll just get assigned the default positioning right now. It might not be where the user would expect but it will render.

Removing a widget was the main issue because to calculate a mobile layout we need to check the widget's display type (because BigNumber and other charts have different heights) and due to a spot where I was using `zip()`, when `layouts.length > widgets.length`, layouts that should be ignored are matched with `undefined`.

## Solution
Filter out any layouts that don't have a matching widget.

This means that we don't get that error state (because a layout will never match with `undefined`) and any new widgets can keep default positioning.

⚠️ This is only really a problem right now since we store this stuff in localStorage. When we move the data to the DB then all users will have the correct stuff.