### PR TITLE
ref(ui): Replace `grid-gap` with `gap`

### DIFF
--- a/docs-ui/stories/assets/iconProps.stories.js
+++ b/docs-ui/stories/assets/iconProps.stories.js
@@ -133,7 +133,7 @@ const SwatchWrapper = styled('div')`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(5, auto);
-  grid-gap: 16px;
+  gap: 16px;
 `;
 
 const Swatches = styled('div')`

--- a/docs-ui/stories/assets/iconSet.stories.js
+++ b/docs-ui/stories/assets/iconSet.stories.js
@@ -39,7 +39,7 @@ const SwatchWrapper = styled('div')`
 const Swatches = styled('div')`
   display: grid;
   grid-template-columns: repeat(auto-fill, 160px);
-  grid-gap: 8px;
+  gap: 8px;
 `;
 
 const Swatch = styled('div')`

--- a/docs-ui/stories/components/alert.stories.js
+++ b/docs-ui/stories/components/alert.stories.js
@@ -141,5 +141,5 @@ Expandable.parameters = {
 
 const Grid = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;

--- a/docs-ui/stories/components/progressBar.stories.js
+++ b/docs-ui/stories/components/progressBar.stories.js
@@ -23,5 +23,5 @@ _ProgressBar.storyName = 'Progress Bar';
 const Wrapper = styled('div')`
   width: 200px;
   display: grid;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 `;

--- a/docs-ui/stories/components/progressRing.stories.js
+++ b/docs-ui/stories/components/progressRing.stories.js
@@ -85,5 +85,5 @@ const Grid = styled('div')`
   grid-template-columns: repeat(auto-fit, 50px);
   align-items: center;
   justify-content: center;
-  grid-gap: 8px;
+  gap: 8px;
 `;

--- a/docs-ui/stories/components/scoreCard.stories.js
+++ b/docs-ui/stories/components/scoreCard.stories.js
@@ -38,6 +38,6 @@ Default.storyName = 'Default';
 
 const Wrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-template-columns: repeat(4, minmax(0, 1fr));
 `;

--- a/docs-ui/stories/core/colors/tables.tsx
+++ b/docs-ui/stories/core/colors/tables.tsx
@@ -16,7 +16,7 @@ type ColorGroup = {
 const Wrap = styled('div')`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(16em, 1fr));
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 
   & > * {
     grid-column-end: span 1;

--- a/src/sentry/templates/sentry/debug/chart-renderer.html
+++ b/src/sentry/templates/sentry/debug/chart-renderer.html
@@ -10,7 +10,7 @@
       .charts {
         margin: 2rem;
         display: grid;
-        grid-gap: 1rem;
+        gap: 1rem;
       }
 
       .charts img {

--- a/static/app/components/assistant/guideAnchor.tsx
+++ b/static/app/components/assistant/guideAnchor.tsx
@@ -238,7 +238,7 @@ export default class GuideAnchorWrapper extends React.Component<WrapperProps> {
 const GuideContainer = styled('div')`
   display: grid;
   grid-template-rows: repeat(2, auto);
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   text-align: center;
   line-height: 1.5;
   background-color: ${p => p.theme.purple300};
@@ -249,7 +249,7 @@ const GuideContainer = styled('div')`
 const GuideContent = styled('div')`
   display: grid;
   grid-template-rows: repeat(2, auto);
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 
   a {
     color: ${p => p.theme.white};
@@ -269,7 +269,7 @@ const GuideDescription = styled('div')`
 const GuideAction = styled('div')`
   display: grid;
   grid-template-rows: repeat(2, auto);
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const StyledButton = styled(Button)`

--- a/static/app/components/charts/styles.tsx
+++ b/static/app/components/charts/styles.tsx
@@ -15,7 +15,7 @@ export const SubHeading = styled('h3')`
 export const SectionHeading = styled('h4')`
   display: inline-grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
@@ -53,7 +53,7 @@ export const ChartControls = styled('div')`
 export const HeaderTitle = styled('div')`
   display: inline-grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   font-size: ${p => p.theme.fontSizeLarge};
   color: ${p => p.theme.textColor};
   align-items: center;
@@ -72,7 +72,7 @@ export const HeaderTitleLegend = styled(HeaderTitle)`
 export const HeaderValue = styled('div')`
   display: inline-grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: baseline;
   background-color: ${p => p.theme.background};
   position: absolute;

--- a/static/app/components/clipboardTooltip.tsx
+++ b/static/app/components/clipboardTooltip.tsx
@@ -42,7 +42,7 @@ const TooltipClipboardWrapper = styled('div')`
   display: grid;
   grid-template-columns: auto max-content;
   align-items: center;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
 `;
 
 const TooltipClipboardIconWrapper = styled('div')`

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -120,7 +120,7 @@ function EventOrGroupExtraDetails({
 const GroupExtra = styled('div')`
   display: inline-grid;
   grid-auto-flow: column dense;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
   justify-content: start;
   align-items: center;
   color: ${p => p.theme.textColor};
@@ -142,7 +142,7 @@ const ShadowlessProjectBadge = styled(ProjectBadge)`
 
 const CommentsLink = styled(Link)`
   display: inline-grid;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   align-items: center;
   grid-auto-flow: column;
   color: ${p => p.theme.textColor};

--- a/static/app/components/events/eventCauseEmpty.tsx
+++ b/static/app/components/events/eventCauseEmpty.tsx
@@ -243,7 +243,7 @@ const Description = styled('div')`
 const ButtonList = styled('div')`
   display: inline-grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   justify-self: end;
   margin-bottom: 16px;

--- a/static/app/components/events/eventTagsAndScreenshot/dataSection.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/dataSection.tsx
@@ -42,7 +42,7 @@ export default DataSection;
 const TitleWrapper = styled('div')`
   display: grid;
   grid-template-columns: repeat(2, max-content);
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   align-items: center;
   padding: ${space(0.75)} 0;
 `;

--- a/static/app/components/events/eventTagsAndScreenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.tsx
@@ -66,7 +66,7 @@ export default EventTagsAndScreenshots;
 
 const Wrapper = styled(DataSection)<{isBorderless: boolean}>`
   display: grid;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     && {
@@ -78,7 +78,7 @@ const Wrapper = styled(DataSection)<{isBorderless: boolean}>`
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     padding-bottom: ${space(2)};
     grid-template-columns: 1fr auto;
-    grid-gap: ${space(4)};
+    gap: ${space(4)};
 
     > *:first-child {
       border-bottom: 0;

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -296,7 +296,7 @@ const TextWithQuestionTooltip = styled('div')`
   display: grid;
   align-items: center;
   grid-template-columns: max-content min-content;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
 `;
 
 const Hash = styled('span')`

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/summary.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/summary.tsx
@@ -38,7 +38,7 @@ const Wrapper = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   font-family: ${p => p.theme.text.familyMono};
   display: grid;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   overflow: hidden;
 `;
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -229,7 +229,7 @@ const StyledPanelTable = styled(PanelTable)<{scrollbarSize: number}>`
 const Time = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   cursor: pointer;
 `;
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
@@ -264,5 +264,5 @@ const StyledPlatformIcon = styled(PlatformIcon)`
 `;
 
 const StyledList = styled(List)`
-  grid-gap: 0;
+  gap: 0;
 `;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
@@ -258,7 +258,7 @@ function StackTraceContent({
 export default StackTraceContent;
 
 const StyledList = styled(List)`
-  grid-gap: 0;
+  gap: 0;
   position: relative;
   overflow: hidden;
   z-index: 1;

--- a/static/app/components/events/interfaces/csp/help/index.tsx
+++ b/static/app/components/events/interfaces/csp/help/index.tsx
@@ -64,7 +64,7 @@ const StyledP = styled('p')`
   text-align: right;
   display: grid;
   grid-template-columns: repeat(3, max-content);
-  grid-gap: ${space(0.25)};
+  gap: ${space(0.25)};
 `;
 
 const StyledExternalLink = styled(ExternalLink)`

--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/information/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/information/index.tsx
@@ -268,7 +268,7 @@ const Details = styled('div')`
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeSmall};
 `;
@@ -277,7 +277,7 @@ const TimeSinceWrapper = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
   align-items: center;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   font-variant-numeric: tabular-nums;
 `;
 
@@ -290,5 +290,5 @@ const StyledProcessingList = styled(ProcessingList)`
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;

--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
@@ -388,7 +388,7 @@ const Header = styled('div')`
 const Title = styled('div')`
   padding-right: ${space(4)};
   display: grid;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   grid-template-columns: repeat(2, max-content);
   align-items: center;
   font-weight: 600;

--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -352,14 +352,14 @@ export default DebugImageDetails;
 
 const Content = styled('div')`
   display: grid;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const Title = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   font-size: ${p => p.theme.fontSizeExtraLarge};
   max-width: calc(100% - 40px);

--- a/static/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -606,7 +606,7 @@ const StyledPanelTable = styled(PanelTable)<{scrollbarWidth?: number}>`
 const TitleWrapper = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   align-items: center;
   padding: ${space(0.75)} 0;
 `;

--- a/static/app/components/events/interfaces/debugMeta/debugImage.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImage.tsx
@@ -269,7 +269,7 @@ const DebugImageItem = styled(PanelItem)`
   font-size: ${p => p.theme.fontSizeSmall};
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: grid;
-    grid-gap: ${space(1)};
+    gap: ${space(1)};
     position: relative;
   }
 `;

--- a/static/app/components/events/interfaces/frame/line.tsx
+++ b/static/app/components/events/interfaces/frame/line.tsx
@@ -430,7 +430,7 @@ const RepeatedContent = styled(VertCenterWrapper)`
 const NativeLineContent = styled('div')<{isFrameAfterLastNonApp: boolean}>`
   display: grid;
   flex: 1;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   grid-template-columns: ${p =>
     `minmax(${p.isFrameAfterLastNonApp ? '167px' : '117px'}, auto)  1fr`};
   align-items: center;

--- a/static/app/components/events/interfaces/frame/lineV2/native.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/native.tsx
@@ -177,7 +177,7 @@ const PackageInfo = styled('span')`
 const NativeLineContent = styled('div')<{isFrameAfterLastNonApp: boolean}>`
   display: grid;
   flex: 1;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   grid-template-columns: auto 1fr;
   align-items: center;
   justify-content: flex-start;

--- a/static/app/components/events/interfaces/frame/lineV2/nativeV2.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/nativeV2.tsx
@@ -184,7 +184,7 @@ const PackageInfo = styled('span')`
 const NativeLineContent = styled('div')<{isFrameAfterLastNonApp: boolean}>`
   display: grid;
   flex: 1;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   grid-template-columns: auto 1fr;
   align-items: center;
   justify-content: flex-start;

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -58,7 +58,7 @@ export const OpenInContainer = styled('div')<{columnQuantity: number}>`
   z-index: 1;
   display: grid;
   grid-template-columns: repeat(${p => p.columnQuantity}, max-content);
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   color: ${p => p.theme.subText};
   background-color: ${p => p.theme.background};
   font-family: ${p => p.theme.text.family};
@@ -74,7 +74,7 @@ export const OpenInLink = styled(ExternalLink)`
   display: inline-grid;
   align-items: center;
   grid-template-columns: max-content auto;
-  grid-gap: ${space(0.75)};
+  gap: ${space(0.75)};
   color: ${p => p.theme.gray300};
 `;
 

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
@@ -177,18 +177,18 @@ class StacktraceLinkModal extends Component<Props, State> {
 const SourceCodeInput = styled('div')`
   display: grid;
   grid-template-columns: 5fr 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const ManualSetup = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   justify-items: center;
 `;
 
 const ModalContainer = styled('div')`
   display: grid;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 
   code {
     word-break: break-word;

--- a/static/app/components/events/interfaces/searchBarAction/index.tsx
+++ b/static/app/components/events/interfaces/searchBarAction/index.tsx
@@ -33,14 +33,14 @@ export default SearchBarAction;
 
 const Wrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   width: 100%;
   margin-top: ${space(1)};
   position: relative;
 
   @media (min-width: ${props => props.theme.breakpoints[0]}) {
     margin-top: 0;
-    grid-gap: 0;
+    gap: 0;
     grid-template-columns: ${p =>
       p.children && Children.toArray(p.children).length === 1
         ? '1fr'

--- a/static/app/components/events/interfaces/searchBarAction/searchBarActionFilter.tsx
+++ b/static/app/components/events/interfaces/searchBarAction/searchBarActionFilter.tsx
@@ -128,7 +128,7 @@ const Header = styled('div')`
 `;
 
 const StyledList = styled(List)`
-  grid-gap: 0;
+  gap: 0;
 `;
 
 const StyledListItem = styled(ListItem)<{isChecked: boolean; hasDescription: boolean}>`

--- a/static/app/components/events/interfaces/threads/threadSelector/styles.tsx
+++ b/static/app/components/events/interfaces/threads/threadSelector/styles.tsx
@@ -6,7 +6,7 @@ import space from 'sentry/styles/space';
 const Grid = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   grid-template-columns: 30px 2.5fr 4fr 0fr 40px;
   @media (min-width: ${p => p.theme.breakpoints[0]}) {

--- a/static/app/components/events/rrwebReplayer/index.tsx
+++ b/static/app/components/events/rrwebReplayer/index.tsx
@@ -112,7 +112,7 @@ const RRWebReplayer = styled(BaseRRWebReplayer)`
     display: grid;
     grid-auto-flow: column;
     grid-auto-columns: max-content;
-    grid-gap: ${space(0.75)};
+    gap: ${space(0.75)};
     align-items: center;
     justify-content: center;
     font-size: ${p => p.theme.fontSizeSmall};

--- a/static/app/components/events/traceEventDataSection/displayOptions.tsx
+++ b/static/app/components/events/traceEventDataSection/displayOptions.tsx
@@ -265,7 +265,7 @@ const OptionsButton = styled(DropdownButton)`
 `;
 
 const OptionList = styled(List)`
-  grid-gap: 0;
+  gap: 0;
 `;
 
 const ItemContent = styled('div')<{isChecked: boolean; isDisabled: boolean}>`

--- a/static/app/components/events/traceEventDataSection/index.tsx
+++ b/static/app/components/events/traceEventDataSection/index.tsx
@@ -197,7 +197,7 @@ const Header = styled('div')<{raw: boolean; nativePlatform: boolean}>`
   grid-template-columns: 1fr max-content;
   grid-template-rows: ${p =>
     p.raw && !p.nativePlatform ? 'repeat(2, 1fr)' : 'repeat(3, 1fr)'};
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   flex: 1;
   z-index: 3;
@@ -225,7 +225,7 @@ const RawToggler = styled(BooleanField)`
   padding: 0;
   display: grid;
   grid-template-columns: repeat(2, max-content);
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   border-bottom: none;
   justify-content: flex-end;
 

--- a/static/app/components/fileChange.tsx
+++ b/static/app/components/fileChange.tsx
@@ -34,7 +34,7 @@ const FileItem = styled(ListGroupItem)`
 const Filename = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   margin-right: ${space(3)};
   align-items: center;
   grid-template-columns: max-content 1fr;

--- a/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
+++ b/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
@@ -52,7 +52,7 @@ export default UpdateAlert;
 
 const Notices = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   margin-bottom: ${space(3)};
 `;
 
@@ -63,5 +63,5 @@ const NoMarginBottomAlert = styled(Alert)`
 const AlertContent = styled('div')`
   display: grid;
   grid-template-columns: 1fr max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;

--- a/static/app/components/globalSdkUpdateAlert.tsx
+++ b/static/app/components/globalSdkUpdateAlert.tsx
@@ -170,7 +170,7 @@ const Content = styled('div')`
 const Actions = styled('div')`
   display: grid;
   grid-template-columns: repeat(3, max-content);
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const GlobalSdkSuggestions = withOrganization(

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -34,7 +34,7 @@ export const HeaderTitle = styled('h4')`
 
 export const HeaderButtonContainer = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-auto-flow: column;
   grid-auto-columns: auto;
   justify-items: end;

--- a/static/app/components/group/suggestedOwners/suggestedAssignees.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedAssignees.tsx
@@ -62,6 +62,6 @@ const Subheading = styled('small')`
 
 const Content = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-template-columns: repeat(auto-fill, 20px);
 `;

--- a/static/app/components/helpSearch.tsx
+++ b/static/app/components/helpSearch.tsx
@@ -62,7 +62,7 @@ const HelpSearch = props => (
 const SectionHeading = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   background: ${p => p.theme.backgroundSecondary};
   padding: ${space(1)} ${space(2)};

--- a/static/app/components/issueLink.tsx
+++ b/static/app/components/issueLink.tsx
@@ -121,7 +121,7 @@ const Section = styled('section')`
 const Grid = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 `;
 const HovercardEventMessage = styled(EventMessage)`
   font-size: 12px;

--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -17,7 +17,7 @@ export const Body = styled('div')`
     display: grid;
     grid-template-columns: 66% auto;
     align-content: start;
-    grid-gap: ${space(3)};
+    gap: ${space(3)};
     padding: ${space(3)} ${space(4)};
   }
 

--- a/static/app/components/list/index.tsx
+++ b/static/app/components/list/index.tsx
@@ -53,7 +53,7 @@ const List = styled(
   padding: 0;
   list-style: none;
   display: grid;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   ${p =>
     typeof p.symbol === 'string' &&
     listSymbol[p.symbol] &&

--- a/static/app/components/loadingError.tsx
+++ b/static/app/components/loadingError.tsx
@@ -57,7 +57,7 @@ const StyledAlert = styled(Alert)`
 
 const Content = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-template-columns: min-content auto max-content;
   align-items: center;
 `;

--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
@@ -131,7 +131,7 @@ const Container = styled('div')`
   position: relative;
   display: grid;
   grid-template-columns: max-content 1fr max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: start;
   flex-grow: 1;
   border-radius: ${p => p.theme.borderRadius};

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
@@ -313,7 +313,7 @@ const HeaderContent = styled('div')`
   display: grid;
   grid-template-columns: max-content max-content 1fr;
   align-items: center;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const NumericSymbol = styled('div')`
@@ -356,7 +356,7 @@ const StyledButton = styled(Button)`
 
 const Alerts = styled('div')`
   display: grid;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
   margin-bottom: ${space(3)};
 `;
 

--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -445,7 +445,7 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
 
 const Heading = styled('h1')`
   display: inline-grid;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
   grid-auto-flow: column;
   align-items: center;
   font-weight: 400;
@@ -461,7 +461,7 @@ const Subtext = styled('p')`
 
 const inviteRowGrid = css`
   display: grid;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
   grid-template-columns: 3fr 180px 2fr max-content;
 `;
 
@@ -487,13 +487,13 @@ const FooterContent = styled('div')`
   width: 100%;
   display: grid;
   grid-template-columns: 1fr max-content max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const StatusMessage = styled('div')<{status?: 'success' | 'error'}>`
   display: grid;
   grid-template-columns: max-content max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => (p.status === 'error' ? p.theme.red300 : p.theme.gray400)};

--- a/static/app/components/modals/inviteMembersModal/renderEmailValue.tsx
+++ b/static/app/components/modals/inviteMembersModal/renderEmailValue.tsx
@@ -37,7 +37,7 @@ function renderEmailValue<Option>(
 const EmailLabel = styled('div')`
   display: inline-grid;
   grid-auto-flow: column;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   align-items: center;
 `;
 

--- a/static/app/components/modals/reprocessEventModal.tsx
+++ b/static/app/components/modals/reprocessEventModal.tsx
@@ -135,7 +135,7 @@ const Introduction = styled('p')`
 `;
 
 const StyledList = styled(List)`
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   margin-bottom: ${space(4)};
   font-size: ${p => p.theme.fontSizeMedium};
 `;

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -206,7 +206,7 @@ export default class SentryAppDetailsModal extends AsyncComponent<Props, State> 
 const Heading = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   margin-bottom: ${space(2)};
 `;

--- a/static/app/components/modals/suggestProjectModal.tsx
+++ b/static/app/components/modals/suggestProjectModal.tsx
@@ -206,7 +206,7 @@ class SuggestProjectModal extends Component<Props, State> {
 
 const ModalContainer = styled('div')`
   display: grid;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 
   code {
     word-break: break-word;

--- a/static/app/components/modals/teamAccessRequestModal.tsx
+++ b/static/app/components/modals/teamAccessRequestModal.tsx
@@ -81,7 +81,7 @@ class CreateTeamAccessRequest extends Component<Props, State> {
 const ButtonGroup = styled('div')`
   display: grid;
   grid-template-columns: max-content max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 export default withApi(CreateTeamAccessRequest);

--- a/static/app/components/onboardingWizard/sidebar.tsx
+++ b/static/app/components/onboardingWizard/sidebar.tsx
@@ -192,7 +192,7 @@ AnimatedTaskItem.defaultProps = {
 const TaskList = styled('div')`
   display: grid;
   grid-auto-flow: row;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   margin: ${space(1)} ${space(4)} ${space(4)} ${space(4)};
 `;
 

--- a/static/app/components/onboardingWizard/task.tsx
+++ b/static/app/components/onboardingWizard/task.tsx
@@ -165,7 +165,7 @@ const TaskCard = styled(Card)`
 const IncompleteTitle = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   font-weight: 600;
 `;
@@ -211,7 +211,7 @@ const InProgressIndicator = styled(({user, ...props}: InProgressIndicatorProps) 
   display: grid;
   grid-template-columns: max-content max-content;
   align-items: center;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const StyledIconClose = styled(IconClose)`

--- a/static/app/components/performance/waterfall/rowDetails.tsx
+++ b/static/app/components/performance/waterfall/rowDetails.tsx
@@ -13,7 +13,7 @@ export const ErrorMessageContent = styled('div')`
   display: grid;
   align-items: center;
   grid-template-columns: 16px 72px auto;
-  grid-gap: ${space(0.75)};
+  gap: ${space(0.75)};
   margin-top: ${space(0.75)};
 `;
 

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -22,7 +22,7 @@ const PLATFORM_CATEGORIES = [...categoryList, {id: 'all', name: t('All')}] as co
 
 const PlatformList = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-template-columns: repeat(auto-fill, 112px);
   margin-bottom: ${space(2)};
 `;
@@ -176,7 +176,7 @@ class PlatformPicker extends React.Component<Props, State> {
 const NavContainer = styled('div')`
   margin-bottom: ${space(2)};
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   grid-template-columns: 1fr minmax(0, 300px);
   align-items: start;
   border-bottom: 1px solid ${p => p.theme.border};

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -153,7 +153,7 @@ const StyledDropdownButton = styled(DropdownButton)`
 const DropdownTitle = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   white-space: nowrap;
 `;

--- a/static/app/components/quickTrace/styles.tsx
+++ b/static/app/components/quickTrace/styles.tsx
@@ -144,7 +144,7 @@ export const QuickTraceValue = styled(Truncate)`
 export const ErrorNodeContent = styled('div')`
   display: grid;
   grid-template-columns: repeat(2, auto);
-  grid-gap: ${space(0.25)};
+  gap: ${space(0.25)};
   align-items: center;
 `;
 

--- a/static/app/components/roleSelectControl.tsx
+++ b/static/app/components/roleSelectControl.tsx
@@ -67,7 +67,7 @@ function RoleSelectControl({roles, disableUnallowed, ...props}: Props) {
 const RoleItem = styled('div')`
   display: grid;
   grid-template-columns: 80px 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 
   h1,
   div {

--- a/static/app/components/scoreCard.tsx
+++ b/static/app/components/scoreCard.tsx
@@ -60,7 +60,7 @@ export const ScorePanel = styled(Panel)`
 export const HeaderTitle = styled('div')`
   display: inline-grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   width: fit-content;
 `;

--- a/static/app/components/shortId.tsx
+++ b/static/app/components/shortId.tsx
@@ -36,7 +36,7 @@ const StyledShortId = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
   display: grid;
   grid-auto-flow: column;
-  grid-gap: 0.5em;
+  gap: 0.5em;
   align-items: center;
   justify-content: flex-end;
 `;

--- a/static/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/static/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -153,13 +153,13 @@ const UpdatesList = styled('div')`
   margin-top: ${space(3)};
   display: grid;
   grid-auto-flow: row;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 `;
 
 const Header = styled('div')`
   display: grid;
   grid-template-columns: 1fr auto;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   margin-bottom: ${space(0.25)};
   align-items: center;
 `;

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -126,7 +126,7 @@ const Remaining = styled('div')`
   color: ${p => p.theme.gray300};
   display: grid;
   grid-template-columns: max-content max-content;
-  grid-gap: ${space(0.75)};
+  gap: ${space(0.75)};
   align-items: center;
 `;
 
@@ -163,7 +163,7 @@ const Container = styled('div')<{isActive: boolean}>`
   cursor: pointer;
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
   align-items: center;
   transition: background 100ms;
 

--- a/static/app/components/sidebar/sidebarOrgSummary.tsx
+++ b/static/app/components/sidebar/sidebarOrgSummary.tsx
@@ -27,7 +27,7 @@ const SidebarOrgSummary = ({organization, projectCount}: Props) => (
 const OrgSummary = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   padding: ${space(1)} ${p => p.theme.sidebar.menuSpacing};
   overflow: hidden;

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1458,7 +1458,7 @@ const Container = styled('div')<{isOpen: boolean}>`
   position: relative;
   display: grid;
   grid-template-columns: max-content 1fr max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: start;
 
   border-radius: ${p =>

--- a/static/app/components/suggestProjectCTA.tsx
+++ b/static/app/components/suggestProjectCTA.tsx
@@ -214,7 +214,7 @@ export default withApi(withProjects(SuggestProjectCTA));
 const Content = styled('div')`
   display: grid;
   grid-template-columns: 1fr max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const StyledIconClose = styled(IconClose)`

--- a/static/app/views/admin/adminEnvironment.tsx
+++ b/static/app/views/admin/adminEnvironment.tsx
@@ -103,6 +103,6 @@ export default class AdminEnvironment extends AsyncView<{}, State> {
 const VersionLabel = styled('dt')`
   display: inline-grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
 `;

--- a/static/app/views/admin/adminUserEdit.tsx
+++ b/static/app/views/admin/adminUserEdit.tsx
@@ -208,7 +208,7 @@ class AdminUserEdit extends AsyncView<Props, State> {
 const ModalFooter = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   justify-content: end;
   padding: 20px 30px;
   margin: 20px -30px -30px;

--- a/static/app/views/admin/installWizard/index.tsx
+++ b/static/app/views/admin/installWizard/index.tsx
@@ -171,7 +171,7 @@ const Pattern = styled('div')`
 
 const Heading = styled('h1')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   justify-content: space-between;
   grid-auto-flow: column;
   line-height: 36px;

--- a/static/app/views/alerts/issueRuleEditor/memberTeamFields.tsx
+++ b/static/app/views/alerts/issueRuleEditor/memberTeamFields.tsx
@@ -120,7 +120,7 @@ const PanelItemGrid = styled(PanelItem)`
   grid-template-columns: 200px 200px;
   padding: 0;
   align-items: center;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 `;
 
 export default MemberTeamFields;

--- a/static/app/views/alerts/issueRuleEditor/ruleNodeList.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNodeList.tsx
@@ -253,7 +253,7 @@ const StyledSelectControl = styled(SelectControl)`
 const RuleNodes = styled('div')`
   display: grid;
   margin-bottom: ${space(1)};
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 
   @media (max-width: ${p => p.theme.breakpoints[1]}) {
     grid-auto-flow: row;

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -502,7 +502,7 @@ const HeaderGrid = styled('div')`
   display: grid;
   grid-template-columns: auto auto auto;
   align-items: stretch;
-  grid-gap: 60px;
+  gap: 60px;
 `;
 
 const HeaderItem = styled('div')`
@@ -544,7 +544,7 @@ const Status = styled('div')`
   position: relative;
   display: grid;
   grid-template-columns: auto auto auto;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   font-size: ${p => p.theme.fontSizeLarge};
 `;
 

--- a/static/app/views/alerts/rules/details/header.tsx
+++ b/static/app/views/alerts/rules/details/header.tsx
@@ -73,7 +73,7 @@ const AlertBreadcrumbs = styled(Breadcrumbs)`
 const Controls = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const Details = styled(PageHeader)`
@@ -82,7 +82,7 @@ const Details = styled(PageHeader)`
 
   grid-template-columns: max-content auto;
   display: grid;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
   grid-auto-flow: column;
 
   @media (max-width: ${p => p.theme.breakpoints[1]}) {

--- a/static/app/views/alerts/rules/details/relatedIssuesNotAvailable.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssuesNotAvailable.tsx
@@ -45,7 +45,7 @@ const StyledAlert = styled(Alert)`
 
 const Content = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-template-columns: min-content auto max-content;
   align-items: center;
 `;

--- a/static/app/views/alerts/wizard/radioPanelGroup.tsx
+++ b/static/app/views/alerts/wizard/radioPanelGroup.tsx
@@ -46,7 +46,7 @@ export default RadioPanelGroup;
 
 const Container = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-auto-flow: row;
   grid-auto-rows: max-content;
   grid-auto-columns: auto;
@@ -56,7 +56,7 @@ const RadioLineItem = styled('label')<{
   index: number;
 }>`
   display: grid;
-  grid-gap: ${space(0.25)} ${space(1)};
+  gap: ${space(0.25)} ${space(1)};
   grid-template-columns: max-content auto max-content;
   align-items: center;
   cursor: pointer;

--- a/static/app/views/auth/login.tsx
+++ b/static/app/views/auth/login.tsx
@@ -152,7 +152,7 @@ const FormWrapper = styled('div')<{hasAuthProviders: boolean}>`
 const formFooterClass = `
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   justify-items: end;
   border-top: none;

--- a/static/app/views/auth/loginForm.tsx
+++ b/static/app/views/auth/loginForm.tsx
@@ -162,7 +162,7 @@ class LoginForm extends Component<Props, State> {
 
 const FormWrapper = styled('div')<{hasLoginProvider: boolean}>`
   display: grid;
-  grid-gap: 60px;
+  gap: 60px;
   grid-template-columns: ${p => (p.hasLoginProvider ? '1fr 0.8fr' : '1fr')};
 `;
 
@@ -177,7 +177,7 @@ const ProviderWrapper = styled('div')`
   position: relative;
   display: grid;
   grid-auto-rows: max-content;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
 
   &:before {
     position: absolute;

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -464,7 +464,7 @@ const WidgetContainer = styled('div')`
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-auto-flow: row dense;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/static/app/views/dashboardsV2/manage/dashboardList.tsx
+++ b/static/app/views/dashboardsV2/manage/dashboardList.tsx
@@ -216,7 +216,7 @@ const DashboardGrid = styled('div')`
   display: grid;
   grid-template-columns: minmax(100px, 1fr);
   grid-template-rows: repeat(3, max-content);
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: repeat(2, minmax(100px, 1fr));
@@ -231,7 +231,7 @@ const WidgetGrid = styled('div')`
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-auto-flow: row dense;
-  grid-gap: ${space(0.25)};
+  gap: ${space(0.25)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -294,7 +294,7 @@ const StyledPageHeader = styled('div')`
 const StyledActions = styled('div')`
   display: grid;
   grid-template-columns: auto max-content;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   margin-bottom: ${space(2)};
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
@@ -324,7 +324,7 @@ const TemplateContainer = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints[3]}) {
     grid-template-columns: repeat(2, 1fr);
   }
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   padding-bottom: ${space(4)};
 `;
 

--- a/static/app/views/dashboardsV2/widget/buildStep.tsx
+++ b/static/app/views/dashboardsV2/widget/buildStep.tsx
@@ -26,7 +26,7 @@ export default BuildStep;
 
 const StyledListItem = styled(ListItem)`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 `;
 
 const Description = styled('h4')`
@@ -41,7 +41,7 @@ const SubDescription = styled('div')`
 
 const Header = styled('div')`
   display: grid;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
 `;
 
 const Content = styled('div')`

--- a/static/app/views/dashboardsV2/widget/buildSteps.tsx
+++ b/static/app/views/dashboardsV2/widget/buildSteps.tsx
@@ -16,7 +16,7 @@ export default BuildSteps;
 
 const StyledList = styled(List)`
   display: grid;
-  grid-gap: ${space(4)};
+  gap: ${space(4)};
   max-width: 100%;
 
   @media (min-width: ${p => p.theme.breakpoints[4]}) {

--- a/static/app/views/dashboardsV2/widget/eventWidget/index.tsx
+++ b/static/app/views/dashboardsV2/widget/eventWidget/index.tsx
@@ -356,5 +356,5 @@ const StyledPageContent = styled(PageContent)`
 
 const VisualizationWrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
 `;

--- a/static/app/views/dashboardsV2/widget/eventWidget/queries.tsx
+++ b/static/app/views/dashboardsV2/widget/eventWidget/queries.tsx
@@ -155,7 +155,7 @@ const fieldsColumns = (p: {
 const Fields = styled('div')<{displayDeleteButton: boolean; displayLegendAlias: boolean}>`
   display: grid;
   grid-template-columns: ${fieldsColumns};
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
 `;
 

--- a/static/app/views/dashboardsV2/widget/metricWidget/filtersAndGroups.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/filtersAndGroups.tsx
@@ -52,11 +52,11 @@ export default FiltersAndGroups;
 
 const Wrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[3]}) {
     grid-template-columns: 1fr 33%;
-    grid-gap: ${space(1)};
+    gap: ${space(1)};
     align-items: center;
   }
 `;

--- a/static/app/views/dashboardsV2/widget/metricWidget/groupByField.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/groupByField.tsx
@@ -106,7 +106,7 @@ const Field = styled('div')<{isOpen: boolean; hasSelected: boolean}>`
 const Item = styled('div')`
   display: grid;
   grid-template-columns: 1fr max-content;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
   word-break: break-all;
 `;
 

--- a/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
@@ -388,5 +388,5 @@ const StyledSelectField = styled(SelectField)`
 
 const VisualizationWrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
 `;

--- a/static/app/views/dashboardsV2/widget/metricWidget/queries.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/queries.tsx
@@ -102,19 +102,19 @@ const IconDeleteWrapper = styled('div')`
 
 const Fields = styled('div')<{displayDeleteButton: boolean}>`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[3]}) {
     grid-template-columns: ${p =>
       p.displayDeleteButton ? '1fr 33% max-content' : '1fr 33%'};
-    grid-gap: ${space(1)};
+    gap: ${space(1)};
     align-items: center;
   }
 `;
 
 const Wrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   @media (max-width: ${p => p.theme.breakpoints[3]}) {
     ${Fields} {
       :not(:first-child) {

--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -350,7 +350,7 @@ const StyledSearchBar = styled(SearchBar)`
 
 const StyledActions = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   grid-template-columns: auto max-content min-content;
   align-items: center;
   margin-bottom: ${space(2)};

--- a/static/app/views/eventsV2/queryList.tsx
+++ b/static/app/views/eventsV2/queryList.tsx
@@ -364,7 +364,7 @@ const PaginationRow = styled(Pagination)`
 const QueryGrid = styled('div')`
   display: grid;
   grid-template-columns: minmax(100px, 1fr);
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: repeat(2, minmax(100px, 1fr));

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -637,7 +637,7 @@ const Container = styled('div')<{
     p.tripleLayout
       ? `grid-template-columns: 1fr 2fr;`
       : `grid-template-columns: repeat(${p.gridColumns}, 1fr) ${p.error ? 'auto' : ''};`}
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
 
   flex-grow: 1;

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -105,7 +105,7 @@ class IssueListFilters extends React.Component<Props> {
 
 const SearchContainer = styled('div')<{hasIssuePercentDisplay?: boolean}>`
   display: inline-grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   margin-bottom: ${space(2)};
   width: 100%;
 
@@ -120,7 +120,7 @@ const SearchContainer = styled('div')<{hasIssuePercentDisplay?: boolean}>`
 
 const DropdownsWrapper = styled('div')<{hasIssuePercentDisplay?: boolean}>`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-template-columns: 1fr ${p => (p.hasIssuePercentDisplay ? '1fr' : '')};
   align-items: start;
 

--- a/static/app/views/onboarding/components/firstEventIndicator.tsx
+++ b/static/app/views/onboarding/components/firstEventIndicator.tsx
@@ -69,7 +69,7 @@ const Container = styled('div')`
 const StatusWrapper = styled(motion.div)`
   display: grid;
   grid-template-columns: 1fr max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   font-size: ${p => p.theme.fontSizeMedium};
   /* Keep the wrapper in the parent grids first cell for transitions */

--- a/static/app/views/onboarding/components/setupIntroduction.tsx
+++ b/static/app/views/onboarding/components/setupIntroduction.tsx
@@ -31,7 +31,7 @@ export default function SetupIntroduction({stepHeaderText, platform}: Props) {
 const TitleContainer = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   align-items: center;
   justify-items: end;
 

--- a/static/app/views/onboarding/components/stepHeading.tsx
+++ b/static/app/views/onboarding/components/stepHeading.tsx
@@ -9,7 +9,7 @@ const StepHeading = styled(motion.h2)<{step: number}>`
   position: relative;
   display: inline-grid;
   grid-template-columns: max-content max-content;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   align-items: center;
 
   &:before {

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -280,7 +280,7 @@ const HeaderRight = styled('div')`
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 ProgressStatus.defaultProps = {

--- a/static/app/views/organizationActivity/activityFeedItem.tsx
+++ b/static/app/views/organizationActivity/activityFeedItem.tsx
@@ -386,7 +386,7 @@ class ActivityItem extends Component<Props, State> {
 
 export default styled(ActivityItem)`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-template-columns: max-content auto;
   position: relative;
   margin: 0;

--- a/static/app/views/organizationGroupDetails/groupSimilarIssues/similarTraceID/header.tsx
+++ b/static/app/views/organizationGroupDetails/groupSimilarIssues/similarTraceID/header.tsx
@@ -31,7 +31,7 @@ export default Header;
 const Wrapper = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   font-size: ${p => p.theme.headerFontSize};
   color: ${p => p.theme.gray300};
@@ -46,7 +46,7 @@ const Wrapper = styled('div')`
 const ClipboardWrapper = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   &:hover {
     cursor: pointer;

--- a/static/app/views/organizationGroupDetails/groupSimilarIssues/similarTraceID/index.tsx
+++ b/static/app/views/organizationGroupDetails/groupSimilarIssues/similarTraceID/index.tsx
@@ -22,5 +22,5 @@ export default SimilarTraceID;
 
 const Wrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 `;

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -323,7 +323,7 @@ const Footer = styled('p')`
 
 const Body = styled('div')`
   display: grid;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 `;
 
 const StyledPanelTable = styled(PanelTable)`
@@ -362,7 +362,7 @@ const Content = styled('div')<{isReloading: boolean}>`
 
 const SliderWrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
   grid-template-columns: max-content max-content;
   justify-content: space-between;
   align-items: flex-start;

--- a/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
@@ -55,13 +55,13 @@ const EventDetails = styled('div')`
 const ExtraInfo = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   justify-content: flex-start;
 `;
 
 const TimeWrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   grid-template-columns: max-content 1fr;
   align-items: center;
   font-size: ${p => p.theme.fontSizeSmall};

--- a/static/app/views/organizationGroupDetails/quickTrace/configureDistributedTracing.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/configureDistributedTracing.tsx
@@ -189,7 +189,7 @@ const ExampleQuickTracePanel = styled(Panel)`
   display: grid;
   grid-template-columns: 1.5fr 1fr;
   grid-template-rows: auto max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   background: none;
   padding: ${space(2)};
   margin: ${space(2)} 0;

--- a/static/app/views/organizationGroupDetails/reprocessingProgress.tsx
+++ b/static/app/views/organizationGroupDetails/reprocessingProgress.tsx
@@ -54,7 +54,7 @@ const Content = styled('div')`
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeMedium};
   display: grid;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
   justify-items: center;
   max-width: 402px;
   width: 100%;
@@ -62,13 +62,13 @@ const Content = styled('div')`
 
 const Inner = styled('div')`
   display: grid;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
   justify-items: center;
 `;
 
 const Header = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   color: ${p => p.theme.textColor};
   max-width: 557px;
 `;

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -455,7 +455,7 @@ const Metadata = styled(Flex)`
   display: grid;
   grid-auto-rows: max-content;
   grid-auto-flow: row;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   font-size: 0.9em;
   margin-left: ${space(4)};
   margin-right: 100px;
@@ -468,7 +468,7 @@ const AuthorInfo = styled('div')`
 const ExternalLinkContainer = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
 `;
 

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -555,7 +555,7 @@ export class IntegrationListDirectory extends AsyncComponent<
 const ActionContainer = styled('div')`
   display: grid;
   grid-template-columns: 240px max-content;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 `;
 
 const EmptyResultsContainer = styled('div')`

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -334,7 +334,7 @@ export default withOrganization(OrganizationStats);
 const PageGrid = styled('div')`
   display: grid;
   grid-template-columns: 1fr;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: repeat(2, 1fr);

--- a/static/app/views/performance/landing/content.tsx
+++ b/static/app/views/performance/landing/content.tsx
@@ -326,7 +326,7 @@ class LandingContent extends Component<Props, State> {
 
 const SearchContainer = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   margin-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {

--- a/static/app/views/performance/landing/display/doubleAxisDisplay.tsx
+++ b/static/app/views/performance/landing/display/doubleAxisDisplay.tsx
@@ -103,7 +103,7 @@ function DoubleAxisDisplay(props: Props) {
 const DoubleChartContainer = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
   min-height: 282px;
 `;
 

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -226,7 +226,7 @@ const StyledHeading = styled(PageHeading)`
 
 const SearchContainerWithFilter = styled('div')`
   display: grid;
-  grid-gap: ${space(0)};
+  gap: ${space(0)};
   margin-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {

--- a/static/app/views/performance/styles.tsx
+++ b/static/app/views/performance/styles.tsx
@@ -16,7 +16,7 @@ export const DoubleHeaderContainer = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
   padding: ${space(2)} ${space(3)} ${space(1)} ${space(3)};
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 `;
 
 export const ErrorPanel = styled('div')`

--- a/static/app/views/performance/traceDetails/styles.tsx
+++ b/static/app/views/performance/traceDetails/styles.tsx
@@ -38,7 +38,7 @@ export const TraceViewHeaderContainer = styled(SecondaryHeader)`
 export const TraceDetailHeader = styled('div')`
   display: grid;
   grid-template-columns: 1fr;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
   margin-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {

--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -168,7 +168,7 @@ const EventDetailHeader = styled('div')<{type?: 'transaction' | 'event'}>`
   display: grid;
   grid-template-columns: repeat(${p => (p.type === 'transaction' ? 3 : 2)}, 1fr);
   grid-template-rows: repeat(2, auto);
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   margin-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {

--- a/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
@@ -262,7 +262,7 @@ const MenuItemContent = styled('div')`
 const RadioLabel = styled('label')`
   display: grid;
   cursor: pointer;
-  grid-gap: 0.25em 0.5em;
+  gap: 0.25em 0.5em;
   grid-template-columns: max-content auto;
   align-items: center;
   outline: none;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -276,7 +276,7 @@ function getSpansEventView(eventView: EventView): EventView {
 const ContentHeader = styled('div')`
   display: grid;
   grid-template-columns: 1fr;
-  grid-gap: ${space(4)};
+  gap: ${space(4)};
   margin-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
@@ -308,5 +308,5 @@ const SectionSubtext = styled('div')`
 const PercentileHeaderBodyWrapper = styled('div')`
   display: grid;
   grid-template-columns: repeat(3, max-content);
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 `;

--- a/static/app/views/performance/transactionSummary/transactionSpans/styles.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/styles.tsx
@@ -16,7 +16,7 @@ import {PerformanceDuration} from '../../utils';
 
 export const Actions = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   grid-template-columns: min-content 1fr min-content;
   align-items: center;
 `;
@@ -32,11 +32,11 @@ export const UpperPanel = styled(Panel)`
   display: grid;
 
   grid-template-columns: 1fr;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: auto repeat(3, max-content);
-    grid-gap: 48px;
+    gap: 48px;
   }
 `;
 

--- a/static/app/views/performance/transactionSummary/transactionTags/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/content.tsx
@@ -249,7 +249,7 @@ const RadioLabel = styled('label')`
   grid-auto-flow: column;
   grid-auto-columns: max-content 1fr;
   align-items: center;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const SidebarTagValue = styled('span')`
@@ -270,7 +270,7 @@ const ReversedLayoutBody = styled('div')`
     display: grid;
     grid-template-columns: auto 66%;
     align-content: start;
-    grid-gap: ${space(3)};
+    gap: ${space(3)};
   }
 
   @media (min-width: ${p => p.theme.breakpoints[2]}) {

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -312,7 +312,7 @@ const AlignRight = styled('div')`
 const LinkContainer = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   justify-content: flex-end;
   align-items: center;
 `;

--- a/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
@@ -113,7 +113,7 @@ const StyledSearchBar = styled(SearchBar)`
 
 const StyledActions = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   grid-template-columns: auto max-content max-content;
   align-items: center;
   margin-bottom: ${space(3)};

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -351,7 +351,7 @@ const StyledSearchContainer = styled('div')`
 
 const TrendsLayoutContainer = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -325,7 +325,7 @@ export {CreateProject};
 const CreateProjectForm = styled('form')`
   display: grid;
   grid-template-columns: 300px minmax(250px, max-content) max-content;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   align-items: end;
   padding: ${space(3)} 0;
   box-shadow: 0 -1px 0 rgba(0, 0, 0, 0.1);

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -307,7 +307,7 @@ export default withOrganization(IssueAlertOptions);
 const CustomizeAlertsGrid = styled('div')`
   display: grid;
   grid-template-columns: repeat(5, max-content);
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
 `;
 const InlineInput = styled(Input)`

--- a/static/app/views/projectInstall/overview.tsx
+++ b/static/app/views/projectInstall/overview.tsx
@@ -121,7 +121,7 @@ const DsnInfo = styled('div')`
 const DsnContainer = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1.5)} ${space(2)};
+  gap: ${space(1.5)} ${space(2)};
   align-items: center;
   margin-bottom: ${space(2)};
 `;

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -439,7 +439,7 @@ const NotAvailable = styled('div')`
   font-weight: normal;
   display: grid;
   grid-template-columns: auto auto;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   align-items: center;
 `;
 

--- a/static/app/views/projectsDashboard/resources.tsx
+++ b/static/app/views/projectsDashboard/resources.tsx
@@ -55,7 +55,7 @@ const ResourcesWrapper = styled('div')`
 const ResourceCards = styled('div')`
   display: grid;
   grid-template-columns: minmax(100px, 1fr);
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));

--- a/static/app/views/projectsDashboard/teamSection.tsx
+++ b/static/app/views/projectsDashboard/teamSection.tsx
@@ -44,7 +44,7 @@ const TeamSection = ({team, projects, title, showBorder, orgId, access}: Props) 
 const ProjectCards = styled('div')`
   display: grid;
   grid-template-columns: minmax(100px, 1fr);
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: repeat(2, minmax(100px, 1fr));

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -375,7 +375,7 @@ const ProjectsFooterMessage = styled('div')`
   display: grid;
   align-items: center;
   grid-template-columns: min-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 export {ReleaseContext, ReleasesDetailContainer};

--- a/static/app/views/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.tsx
@@ -447,7 +447,7 @@ const StyledButtonBar = styled(ButtonBar)`
   grid-template-columns: repeat(4, 1fr);
   ${ButtonLabel} {
     white-space: nowrap;
-    grid-gap: ${space(0.5)};
+    gap: ${space(0.5)};
     span:last-child {
       color: ${p => p.theme.buttonCount};
     }

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -260,7 +260,7 @@ const ReleaseInfoHeader = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
   display: grid;
   grid-template-columns: minmax(0, 1fr) max-content;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   align-items: center;
 `;
 

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -236,7 +236,7 @@ const AdoptionWrapper = styled('span')`
   flex: 1;
   display: inline-grid;
   grid-template-columns: 30px 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
 
   /* Chart tooltips need overflow */

--- a/static/app/views/settings/account/accountEmails.tsx
+++ b/static/app/views/settings/account/accountEmails.tsx
@@ -201,7 +201,7 @@ const EmailRow = ({
 const EmailTags = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
 `;
 

--- a/static/app/views/settings/account/accountSecurity/accountSecurityDetails.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityDetails.tsx
@@ -210,7 +210,7 @@ const AuthenticatorActions = styled('div')`
 
 const AuthenticatorDates = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   grid-template-columns: max-content auto;
 `;
 

--- a/static/app/views/settings/account/accountSecurity/components/recoveryCodes.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/recoveryCodes.tsx
@@ -101,7 +101,7 @@ const CodeContainer = styled(Panel)`
 const Actions = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const Code = styled(PanelItem)`

--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -235,7 +235,7 @@ const AuthenticatorTitle = styled('div')`
 const Actions = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const AuthenticatorStatus = styled(CircleIndicator)`

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/utils.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/utils.tsx
@@ -3,6 +3,6 @@ import space from 'sentry/styles/space';
 export const tableLayout = `
   display: grid;
   grid-template-columns: auto 140px 140px;
-  grid-gap ${space(1)};
+  gap ${space(1)};
   align-items: center;
 `;

--- a/static/app/views/settings/account/accountSubscriptions.tsx
+++ b/static/app/views/settings/account/accountSubscriptions.tsx
@@ -174,7 +174,7 @@ class AccountSubscriptions extends AsyncView<AsyncView['props'], State> {
 const Heading = styled(PanelItem)`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
   font-size: ${p => p.theme.fontSizeMedium};
   padding: ${space(1.5)} ${space(2)};

--- a/static/app/views/settings/components/dataScrubbing/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.tsx
@@ -207,7 +207,7 @@ const PanelAction = styled('div')`
   padding: ${space(1)} ${space(2)};
   position: relative;
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-template-columns: auto auto;
   justify-content: flex-end;
   border-top: 1px solid ${p => p.theme.border};

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -191,7 +191,7 @@ const FieldGroup = styled('div')<{hasTwoColumns: boolean}>`
   display: grid;
   margin-bottom: ${space(2)};
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    grid-gap: ${space(2)};
+    gap: ${space(2)};
     ${p => p.hasTwoColumns && `grid-template-columns: 1fr 1fr;`}
     margin-bottom: ${p => (p.hasTwoColumns ? 0 : space(2))};
   }
@@ -231,7 +231,7 @@ const Toggle = styled(Button)`
   }
   > *:first-child {
     display: grid;
-    grid-gap: ${space(0.5)};
+    gap: ${space(0.5)};
     grid-template-columns: repeat(2, max-content);
     align-items: center;
   }

--- a/static/app/views/settings/components/dataScrubbing/modals/form/selectField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/selectField.tsx
@@ -70,5 +70,5 @@ const Description = styled('div')`
 const Wrapper = styled('div')`
   display: grid;
   grid-template-columns: 1fr auto;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;

--- a/static/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
@@ -476,7 +476,7 @@ const Suggestions = styled('ul')<{error?: string}>`
 const Suggestion = styled('li')<{active: boolean}>`
   display: grid;
   grid-template-columns: auto 1fr max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   border-bottom: 1px solid ${p => p.theme.border};
   padding: ${space(1)} ${space(2)};
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/views/settings/components/dataScrubbing/modals/form/sourceSuggestionExamples.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/sourceSuggestionExamples.tsx
@@ -40,7 +40,7 @@ const Content = styled('span')`
   display: inline-grid;
   grid-template-columns: repeat(2, max-content);
   align-items: center;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeSmall};
   text-decoration: underline;

--- a/static/app/views/settings/components/defaultSearchBar.tsx
+++ b/static/app/views/settings/components/defaultSearchBar.tsx
@@ -10,7 +10,7 @@ export type RenderSearch = React.ComponentProps<
 export const SearchWrapper = styled('div')`
   display: flex;
   grid-template-columns: 1fr max-content;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
   margin-top: ${space(4)};
   margin-bottom: ${space(1.5)};
   position: relative;

--- a/static/app/views/settings/components/forms/controls/radioGroup.tsx
+++ b/static/app/views/settings/components/forms/controls/radioGroup.tsx
@@ -7,7 +7,7 @@ import space from 'sentry/styles/space';
 
 const Container = styled('div')<{orientInline?: boolean}>`
   display: grid;
-  grid-gap: ${p => space(p.orientInline ? 3 : 1)};
+  gap: ${p => space(p.orientInline ? 3 : 1)};
   grid-auto-flow: ${p => (p.orientInline ? 'column' : 'row')};
   grid-auto-rows: max-content;
   grid-auto-columns: max-content;
@@ -83,7 +83,7 @@ export const RadioLineItem = styled('label', {shouldForwardProp})<{
   index: number;
 }>`
   display: grid;
-  grid-gap: 0.25em 0.5em;
+  gap: 0.25em 0.5em;
   grid-template-columns: max-content auto;
   align-items: center;
   cursor: ${p => (p.disabled ? 'default' : 'pointer')};

--- a/static/app/views/settings/components/forms/controls/rangeSlider.tsx
+++ b/static/app/views/settings/components/forms/controls/rangeSlider.tsx
@@ -372,5 +372,5 @@ const SliderAndInputWrapper = styled('div')<{showCustomInput?: boolean}>`
   align-items: center;
   grid-auto-flow: column;
   grid-template-columns: 4fr ${p => p.showCustomInput && '1fr'};
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;

--- a/static/app/views/settings/components/forms/form.tsx
+++ b/static/app/views/settings/components/forms/form.tsx
@@ -280,7 +280,7 @@ const StyledFooter = styled('div')<{saveOnBlur?: boolean}>`
 
 const DefaultButtons = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-auto-flow: column;
   justify-content: flex-end;
   flex: 1;

--- a/static/app/views/settings/components/forms/formField/index.tsx
+++ b/static/app/views/settings/components/forms/formField/index.tsx
@@ -456,7 +456,7 @@ export default FormField;
 const MessageAndActions = styled('div')`
   display: grid;
   grid-template-columns: 1fr max-content;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   align-items: flex-start;
 `;
 

--- a/static/app/views/settings/components/forms/projectMapperField.tsx
+++ b/static/app/views/settings/components/forms/projectMapperField.tsx
@@ -336,7 +336,7 @@ const MappedItemValue = styled('div')`
   grid-auto-flow: column;
   grid-auto-columns: max-content;
   align-items: center;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   width: 100%;
 `;
 
@@ -385,7 +385,7 @@ const NextButtonPanelAlert = styled(PanelAlert)`
 const NextButtonWrapper = styled('div')`
   display: grid;
   grid-template-columns: 1fr max-content;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
 `;
 

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -156,7 +156,7 @@ const MonoDetail = styled('code')`
 const TimestampInfo = styled('div')`
   display: grid;
   grid-template-rows: auto auto;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -151,7 +151,7 @@ const ProviderInfo = styled('div')`
   flex: 1;
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 `;
 
 const ProviderLogo = styled('div')`

--- a/static/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/static/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -154,7 +154,7 @@ const FilterHeader = styled('h2')`
 const FilterLists = styled('div')`
   display: grid;
   grid-template-columns: 100px max-content;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
   margin: ${space(1.5)};
   margin-top: ${space(0.75)};
 `;
@@ -162,7 +162,7 @@ const FilterLists = styled('div')`
 const FilterList = styled('div')`
   display: grid;
   grid-template-rows: repeat(auto-fit, minmax(0, max-content));
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   font-size: ${p => p.theme.fontSizeMedium};
 
   h3 {
@@ -175,7 +175,7 @@ const FilterList = styled('div')`
   label {
     display: grid;
     grid-template-columns: max-content 1fr max-content;
-    grid-gap: ${space(0.75)};
+    gap: ${space(0.75)};
     align-items: center;
     font-weight: normal;
     white-space: nowrap;

--- a/static/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/static/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -173,7 +173,7 @@ const JoinRequestIndicator = styled(Tag)`
 const StyledPanelItem = styled(PanelItem)`
   display: grid;
   grid-template-columns: minmax(150px, auto) minmax(100px, 140px) 220px max-content;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   align-items: center;
 `;
 
@@ -206,7 +206,7 @@ const TeamSelectControl = styled(TeamSelector)`
 const ButtonGroup = styled('div')`
   display: inline-grid;
   grid-template-columns: repeat(2, max-content);
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 export default InviteRequestRow;

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -401,7 +401,7 @@ const Details = styled('div')`
   display: grid;
   grid-auto-flow: column;
   grid-template-columns: 2fr 1fr 1fr;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   width: 100%;
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
@@ -433,7 +433,7 @@ const CodeInput = styled('code')`
 
 const InviteActions = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-auto-flow: column;
   justify-content: flex-end;
   margin-top: ${space(2)};

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -238,14 +238,14 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
 const StyledPanelItem = styled(PanelItem)`
   display: grid;
   grid-template-columns: minmax(150px, 2fr) minmax(90px, 1fr) minmax(120px, 1fr) 90px;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   align-items: center;
 `;
 
 const Section = styled('div')`
   display: inline-grid;
   grid-template-columns: max-content auto;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   align-items: center;
 `;
 

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -390,7 +390,7 @@ const StyledMembersFilter = styled(MembersFilter)`
 const StyledPanelItem = styled('div')`
   display: grid;
   grid-template-columns: minmax(150px, auto) minmax(100px, 140px) 420px;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   align-items: center;
   width: 100%;
 `;

--- a/static/app/views/settings/organizationRelay/modals/add/index.tsx
+++ b/static/app/views/settings/organizationRelay/modals/add/index.tsx
@@ -60,5 +60,5 @@ export default Add;
 
 const StyledList = styled(List)`
   display: grid;
-  grid-gap: ${space(3)};
+  gap: ${space(3)};
 `;

--- a/static/app/views/settings/organizationRelay/modals/add/item.tsx
+++ b/static/app/views/settings/organizationRelay/modals/add/item.tsx
@@ -19,7 +19,7 @@ const Item = styled(({title, subtitle, children, className}: Props) => (
   </ListItem>
 ))`
   display: grid;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
 `;
 
 export default Item;

--- a/static/app/views/settings/organizationRelay/modals/add/terminal.tsx
+++ b/static/app/views/settings/organizationRelay/modals/add/terminal.tsx
@@ -23,7 +23,7 @@ const Wrapper = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(0.75)};
+  gap: ${space(0.75)};
 `;
 
 const Prompt = styled('div')`

--- a/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
+++ b/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
@@ -138,7 +138,7 @@ class OrganizationAccessRequests extends React.Component<Props, State> {
 const StyledPanelItem = styled(PanelItem)`
   display: grid;
   grid-template-columns: auto max-content;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   align-items: center;
 `;
 

--- a/static/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -146,7 +146,7 @@ const StyledSearchBar = styled(SearchBar)`
 
 const LoadMoreWrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   align-items: center;
   justify-content: end;
   grid-auto-flow: column;

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -328,7 +328,7 @@ const StyledMemberContainer = styled(PanelItem)`
 const StyledUserListElement = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   align-items: center;
 `;
 

--- a/static/app/views/settings/project/filtersAndSampling/modal/legacyBrowsers.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/legacyBrowsers.tsx
@@ -70,7 +70,7 @@ const Wrapper = styled('div')`
   grid-column: 1/-1;
   display: grid;
   grid-template-columns: 1fr max-content;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   font-size: ${p => p.theme.fontSizeLarge};
   color: ${p => p.theme.gray400};
   padding-top: ${space(2)};

--- a/static/app/views/settings/project/filtersAndSampling/modal/ruleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/ruleModal.tsx
@@ -301,7 +301,7 @@ export default RuleModal;
 
 const Fields = styled('div')`
   display: grid;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
 `;
 
 const StyledMenuItem = styled(MenuItem)`

--- a/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
@@ -179,7 +179,7 @@ export default TransactionRuleModal;
 const TracingWrapper = styled('div')`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   cursor: ${p => (p.onClick ? 'pointer' : 'not-allowed')};
 `;
 

--- a/static/app/views/settings/project/filtersAndSampling/rules/rule/conditions.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/rules/rule/conditions.tsx
@@ -63,7 +63,7 @@ export default Conditions;
 
 const Wrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
 `;
 
 const Label = styled('span')`

--- a/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -222,7 +222,7 @@ const RateLimitRow = styled('div')`
   display: grid;
   grid-template-columns: 2fr 1fr 2fr;
   align-items: center;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const EventsIn = styled('small')`

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -125,7 +125,7 @@ const Title = styled('div')<{disabled: boolean}>`
 const Controls = styled('div')`
   display: grid;
   align-items: center;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-auto-flow: column;
 `;
 

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
@@ -288,7 +288,7 @@ const SourceFileBody = styled(PanelBody)`
 
 const IntegrationsList = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   justify-items: center;
   margin-top: ${space(2)};
 `;

--- a/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
+++ b/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
@@ -143,7 +143,7 @@ const SyncDate = styled('div')`
 const Controls = styled('div')`
   display: grid;
   align-items: center;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   grid-auto-flow: column;
   justify-content: flex-end;
 `;

--- a/static/app/views/settings/project/projectUserFeedback.tsx
+++ b/static/app/views/settings/project/projectUserFeedback.tsx
@@ -106,7 +106,7 @@ class ProjectUserFeedbackSettings extends AsyncView<Props> {
 const ButtonList = styled('div')`
   display: inline-grid;
   grid-auto-flow: column;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   margin-bottom: ${space(2)};
 `;
 

--- a/static/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/static/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -192,7 +192,7 @@ const StyledFileSize = styled(FileSize)`
 
 const TimeWrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   grid-template-columns: min-content 1fr;
   flex: 2;
   align-items: center;

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -251,7 +251,7 @@ const Actions = styled('div')`
 const Wrapper = styled('div')`
   display: grid;
   grid-template-columns: auto 1fr;
-  grid-gap: ${space(4)};
+  gap: ${space(4)};
   align-items: center;
   margin-top: ${space(4)};
   margin-bottom: ${space(1)};
@@ -265,7 +265,7 @@ const Filters = styled('div')`
   grid-template-columns: min-content minmax(200px, 400px);
   align-items: center;
   justify-content: flex-end;
-  grid-gap: ${space(2)};
+  gap: ${space(2)};
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: min-content 1fr;
   }

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/actions.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/actions.tsx
@@ -187,7 +187,7 @@ const StyledButtonBar = styled(ButtonBar)`
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     grid-auto-flow: row;
-    grid-gap: ${space(1)};
+    gap: ${space(1)};
     margin-top: ${space(0.5)};
   }
 `;

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/details.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/details.tsx
@@ -42,7 +42,7 @@ export default Details;
 
 const Wrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
   margin-top: ${space(0.5)};
   align-items: center;
 
@@ -52,7 +52,7 @@ const Wrapper = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     margin-top: ${space(1)};
     grid-template-columns: max-content 1fr;
-    grid-gap: ${space(1)};
+    gap: ${space(1)};
     grid-row: 3/3;
     grid-column: 1/-1;
   }

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/repository.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/repository.tsx
@@ -76,12 +76,12 @@ const TypeAndStatus = styled('div')`
   color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
   display: grid;
-  grid-gap: ${space(1.5)};
+  gap: ${space(1.5)};
   align-items: center;
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: max-content minmax(200px, max-content);
     grid-row: 2 / 3;
-    grid-gap: ${space(1)};
+    gap: ${space(1)};
   }
 `;

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/status.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/status.tsx
@@ -70,7 +70,7 @@ const Wrapper = styled('div')<{color: string}>`
   display: grid;
   grid-template-columns: repeat(2, max-content);
   align-items: center;
-  grid-gap: ${space(0.75)};
+  gap: ${space(0.75)};
   color: ${p => p.color};
   font-size: ${p => p.theme.fontSizeMedium};
   height: 14px;

--- a/static/app/views/settings/projectProguard/projectProguardRow.tsx
+++ b/static/app/views/settings/projectProguard/projectProguardRow.tsx
@@ -111,7 +111,7 @@ const Name = styled('div')`
 
 const TimeWrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   grid-template-columns: min-content 1fr;
   font-size: ${p => p.theme.fontSizeMedium};
   align-items: center;

--- a/static/app/views/settings/projectSourceMaps/detail/sourceMapsArtifactRow.tsx
+++ b/static/app/views/settings/projectSourceMaps/detail/sourceMapsArtifactRow.tsx
@@ -132,7 +132,7 @@ const TimeAndDistWrapper = styled('div')`
 
 const TimeWrapper = styled('div')`
   display: grid;
-  grid-gap: ${space(0.5)};
+  gap: ${space(0.5)};
   grid-template-columns: min-content 1fr;
   font-size: ${p => p.theme.fontSizeMedium};
   align-items: center;

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -374,7 +374,7 @@ const OrganizationName = styled('div')`
 const GridLayout = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  grid-gap: 16px;
+  gap: 16px;
 `;
 
 const GridPanel = styled(Panel)`


### PR DESCRIPTION
Stop using `grid-gap` start using `gap`.

`gap` for `display: grid` is the most unsupported in older Safari. Safari < 12 specifically, which we have a very very low percentage of users on (less than 30 users).

