### PR TITLE
fix(suspect-spans): Limit date filter to 30 days on span details

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.tsx
@@ -1,7 +1,5 @@
 import {Location} from 'history';
-import pick from 'lodash/pick';
 
-import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -11,15 +9,11 @@ import PageLayout from '../pageLayout';
 import Tab from '../tabs';
 
 import SpansContent from './content';
-import {generateSpansEventView} from './utils';
-
-const RELATIVE_PERIODS = pick(DEFAULT_RELATIVE_PERIODS, [
-  '1h',
-  '24h',
-  '7d',
-  '14d',
-  '30d',
-]);
+import {
+  generateSpansEventView,
+  SPAN_RELATIVE_PERIODS,
+  SPAN_RETENTION_DAYS,
+} from './utils';
 
 type Props = {
   location: Location;
@@ -39,8 +33,8 @@ function TransactionSpans(props: Props) {
       getDocumentTitle={getDocumentTitle}
       generateEventView={generateSpansEventView}
       childComponent={SpansContent}
-      relativeDateOptions={RELATIVE_PERIODS}
-      maxPickableDays={30}
+      relativeDateOptions={SPAN_RELATIVE_PERIODS}
+      maxPickableDays={SPAN_RETENTION_DAYS}
     />
   );
 }

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
@@ -14,7 +14,12 @@ import useProjects from 'sentry/utils/useProjects';
 
 import {getTransactionName} from '../../../utils';
 import {NoAccess} from '../../pageLayout';
-import {generateSpansEventView, parseSpanSlug} from '../utils';
+import {
+  generateSpansEventView,
+  parseSpanSlug,
+  SPAN_RELATIVE_PERIODS,
+  SPAN_RETENTION_DAYS,
+} from '../utils';
 
 import SpanDetailsContent from './content';
 
@@ -54,6 +59,8 @@ export default function SpanDetails(props: Props) {
           specificProjectSlugs={defined(project) ? [project.slug] : []}
           disableMultipleProjectSelection
           showProjectSettingsLink
+          relativeDateOptions={SPAN_RELATIVE_PERIODS}
+          maxPickableDays={SPAN_RETENTION_DAYS}
         >
           <StyledPageContent>
             <NoProjectMessage organization={organization}>

--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -1,5 +1,7 @@
 import {Location, Query} from 'history';
+import pick from 'lodash/pick';
 
+import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
@@ -47,6 +49,16 @@ export function spansRouteWithQuery({
     },
   };
 }
+
+export const SPAN_RETENTION_DAYS = 30;
+
+export const SPAN_RELATIVE_PERIODS = pick(DEFAULT_RELATIVE_PERIODS, [
+  '1h',
+  '24h',
+  '7d',
+  '14d',
+  '30d',
+]);
 
 export const SPAN_SORT_OPTIONS: SpanSortOption[] = [
   {


### PR DESCRIPTION
Like the span tab, the span details page should be limited to 30 days.