### PR TITLE
feat(sentry apps): Allow updating features

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -59,6 +59,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                 sentry_app=sentry_app,
                 name=result.get("name"),
                 author=result.get("author"),
+                features=result.get("features"),
                 status=result.get("status"),
                 webhook_url=result.get("webhookUrl"),
                 redirect_url=result.get("redirectUrl"),

--- a/src/sentry/api/serializers/rest_framework/doc_integration.py
+++ b/src/sentry/api/serializers/rest_framework/doc_integration.py
@@ -79,19 +79,12 @@ class DocIntegrationSerializer(Serializer):
     ) -> DocIntegration:
         if validated_data.get("features"):
             features = validated_data.pop("features")
-            # Delete any unused features
-            unused_features = IntegrationFeature.objects.filter(
-                target_id=doc_integration.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
-            ).exclude(feature__in=features)
-            for unused_feature in unused_features:
-                unused_feature.delete()
-            # Create any new features
-            for feature in features:
-                IntegrationFeature.objects.get_or_create(
-                    target_id=doc_integration.id,
-                    target_type=IntegrationTypes.DOC_INTEGRATION.value,
-                    feature=feature,
-                )
+
+            IntegrationFeature.objects.clean_update(
+                incoming_features=features,
+                target=doc_integration,
+                target_type=IntegrationTypes.DOC_INTEGRATION,
+            )
         # If we're publishing...
         if not validated_data.get("is_draft", True):
             if not doc_integration.avatar.exists():

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -7,6 +7,7 @@ from sentry.api.serializers.rest_framework import ListField
 from sentry.api.serializers.rest_framework.base import camel_to_snake_case
 from sentry.api.validators.sentry_apps.schema import validate_ui_element_schema
 from sentry.models import ApiScopes
+from sentry.models.integrationfeature import Feature
 from sentry.models.sentryapp import (
     REQUIRED_EVENT_PERMISSIONS,
     UUID_CHARS_IN_SLUG,
@@ -74,6 +75,9 @@ class SentryAppSerializer(Serializer):
     scopes = ApiScopesField(allow_null=True)
     status = serializers.CharField(required=False, allow_null=True)
     events = EventListField(required=False, allow_null=True)
+    features = serializers.MultipleChoiceField(
+        choices=Feature.as_choices(), allow_blank=True, allow_null=True, required=False
+    )
     schema = SchemaField(required=False, allow_null=True)
     webhookUrl = URLField(required=False, allow_null=True, allow_blank=True)
     redirectUrl = URLField(required=False, allow_null=True, allow_blank=True)

--- a/src/sentry/models/integrationfeature.py
+++ b/src/sentry/models/integrationfeature.py
@@ -150,6 +150,25 @@ class IntegrationFeatureManager(BaseManager):
             for feature in features
         }
 
+    def clean_update(
+        self,
+        incoming_features: List[int],
+        target: Union[SentryApp, DocIntegration],
+        target_type: IntegrationTypes,
+    ):
+        # Delete any unused features
+        IntegrationFeature.objects.filter(
+            target_id=target.id, target_type=target_type.value
+        ).exclude(feature__in=incoming_features).delete()
+
+        # Create any new features
+        for feature in incoming_features:
+            IntegrationFeature.objects.get_or_create(
+                target_id=target.id,
+                target_type=target_type.value,
+                feature=feature,
+            )
+
 
 class IntegrationFeature(Model):
     __include_in_export__ = False


### PR DESCRIPTION
Allow a user to update the features of a sentry app, and restrict updating published app's features to superusers. Having features doesn't have much of a side effect except for showing the type of integration it is in the integration directory, so letting users (only available through the API) edit this is fine.

This is the backend piece to https://github.com/getsentry/getsentry/pull/6846