### PR TITLE
feat(stacktrace): Simplify api response for stacktrace preview

### DIFF
--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -5,6 +5,7 @@ from sentry.api import client
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.group_index import rate_limit_endpoint
+from sentry.api.serializers import EventSerializer, serialize
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -33,6 +34,10 @@ class GroupEventsLatestEndpoint(GroupEndpoint):
 
         if not event:
             return Response({"detail": "No events found for group"}, status=404)
+
+        collapse = request.GET.getlist("collapse", [])
+        if "stacktraceOnly" in collapse:
+            return Response(serialize(event, request.user, EventSerializer()))
 
         try:
             return client.get(

--- a/static/app/components/stacktracePreview.tsx
+++ b/static/app/components/stacktracePreview.tsx
@@ -85,7 +85,7 @@ class StacktracePreview extends React.Component<Props, State> {
     try {
       const event = await api.requestPromise(
         eventId && projectSlug
-          ? `/projects/${organization.slug}/${projectSlug}/events/${eventId}/`
+          ? `/projects/${organization.slug}/${projectSlug}/events/${eventId}/?collapse=stacktraceOnly`
           : `/issues/${issueId}/events/latest/`
       );
       clearTimeout(this.loaderTimeout);

--- a/tests/sentry/api/endpoints/test_group_events_latest.py
+++ b/tests/sentry/api/endpoints/test_group_events_latest.py
@@ -54,3 +54,12 @@ class GroupEventsLatestEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["id"] == str(self.event_b.event_id)
         assert response.data["previousEventID"] is None
         assert response.data["nextEventID"] is None
+
+    def test_collapse_event_only(self):
+        url = f"/api/0/issues/{self.event_a.group.id}/events/latest/"
+        response = self.client.get(url, format="json", data={"collapse": ["stacktraceOnly"]})
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == str(self.event_c.event_id)
+        assert "previousEventID" not in response.data
+        assert "nextEventID" not in response.data


### PR DESCRIPTION
Returns a simplified event that uses fewer snuba queries that could speed up the stacktrace preview and reduce server load.

The frontend changes do not depend on the backend, it's just a query parameter that is ignored.

https://getsentry.atlassian.net/browse/WOR-1500