### PR TITLE
ref(auth): Warn about ambiguous email only when lazily init'ing user

### DIFF
--- a/src/sentry/auth/email.py
+++ b/src/sentry/auth/email.py
@@ -1,12 +1,17 @@
-from typing import Optional
-
-import sentry_sdk
+from typing import Optional, Sequence, Tuple
 
 from sentry.models import User, UserEmail
 
 
+class AmbiguousUserFromEmail(Exception):
+    def __init__(self, email: str, users: Sequence[User]) -> None:
+        super().__init__(f"Resolved {email!r} to {[user.id for user in users]}")
+        self.email: str = email
+        self.users: Tuple[User] = tuple(users)
+
+
 def resolve_email_to_user(email: str) -> Optional[User]:
-    candidate_users = list(
+    candidate_users = tuple(
         User.objects.filter(
             id__in=UserEmail.objects.filter(email__iexact=email).values("user"), is_active=True
         )
@@ -16,12 +21,4 @@ def resolve_email_to_user(email: str) -> Optional[User]:
         return None
     if len(candidate_users) == 1:
         return candidate_users[0]
-
-    arbitrary_choice = candidate_users[0]
-    with sentry_sdk.push_scope() as scope:
-        scope.level = "warning"
-        scope.set_tag("email", email)
-        scope.set_extra("user_ids", sorted(user.id for user in candidate_users))
-        scope.set_extra("chosen_user", arbitrary_choice.id)
-        sentry_sdk.capture_message("Ambiguous email resolution")
-    return arbitrary_choice
+    raise AmbiguousUserFromEmail(email, candidate_users)

--- a/tests/sentry/auth/test_email.py
+++ b/tests/sentry/auth/test_email.py
@@ -1,0 +1,25 @@
+from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
+from sentry.models import UserEmail
+from sentry.testutils import TestCase
+
+
+class EmailResolverTest(TestCase):
+    def setUp(self) -> None:
+        self.user1 = self.create_user()
+        self.user2 = self.create_user()
+
+    def test_no_match(self):
+        result = resolve_email_to_user("no_one@example.com")
+        assert result is None
+
+    def test_single_match(self):
+        result = resolve_email_to_user(self.user1.email)
+        assert result == self.user1
+
+    def test_ambiguous_match(self):
+        for user in (self.user1, self.user2):
+            UserEmail.objects.create(user=user, email="me@example.com")
+
+        with self.assertRaises(AmbiguousUserFromEmail) as context:
+            resolve_email_to_user("me@example.com")
+        assert set(context.exception.users) == {self.user1, self.user2}


### PR DESCRIPTION
Have `resolve_email_to_user` raise an exception if it can't resolve unambiguously to a user, rather than sending a warning message itself.

Lazily initialize the user in `AuthIdentityHandler`, so that it doesn't cause extra noise from needlessly resolving the email to handle an existing identity.

https://getsentry.atlassian.net/browse/ER-891