### PR TITLE
ref(ui): Use translucent borders for tooltips

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -573,7 +573,7 @@ const ChartContainer = styled('div')`
     border-radius: ${p => p.theme.borderRadiusBottom};
   }
   .tooltip-arrow {
-    top: 100%;
+    top: calc(100% + 1px);
     left: 50%;
     position: absolute;
     pointer-events: none;
@@ -582,14 +582,14 @@ const ChartContainer = styled('div')`
     border-top: 8px solid ${p => p.theme.backgroundElevated};
     margin-left: -8px;
     &:before {
-      border-left: 9px solid transparent;
-      border-right: 9px solid transparent;
-      border-top: 9px solid ${p => p.theme.border};
+      border-left: 8px solid transparent;
+      border-right: 8px solid transparent;
+      border-top: 8px solid ${p => p.theme.translucentBorder};
       content: '';
       display: block;
       position: absolute;
-      top: -8px;
-      left: -9px;
+      top: -7px;
+      left: -8px;
       z-index: -1;
     }
   }

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -273,10 +273,8 @@ export default function Tooltip({
   return {
     show: true,
     trigger: 'item',
-    borderWidth: 1,
-    borderColor: `${theme.border}`,
     backgroundColor: `${theme.backgroundElevated}`,
-    extraCssText: `box-shadow: ${theme.dropShadowHeavy}`,
+    extraCssText: `box-shadow: 0 0 0 1px ${theme.translucentBorder}, ${theme.dropShadowHeavy}`,
     transitionDuration: 0,
     padding: 0,
     className: 'tooltip-container',

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -250,6 +250,8 @@ const Content = styled('div')`
   padding: ${space(4)};
   background: ${p => p.theme.background};
   border-radius: 8px;
+  border: ${p => p.theme.modalBorder};
+  box-shadow: ${p => p.theme.modalBoxShadow};
 `;
 
 type State = {

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -250,8 +250,6 @@ const Content = styled('div')`
   padding: ${space(4)};
   background: ${p => p.theme.background};
   border-radius: 8px;
-  border: ${p => p.theme.modalBorder};
-  box-shadow: ${p => p.theme.modalBoxShadow};
 `;
 
 type State = {

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -328,8 +328,7 @@ const TooltipContent = styled(motion.div)<Pick<Props, 'popperStyle'>>`
   background: ${p => p.theme.backgroundElevated};
   padding: ${space(1)} ${space(1.5)};
   border-radius: ${p => p.theme.borderRadius};
-  border: solid 1px ${p => p.theme.border};
-  box-shadow: ${p => p.theme.dropShadowHeavy};
+  box-shadow: 0 0 0 1px ${p => p.theme.translucentBorder}, ${p => p.theme.dropShadowHeavy};
   overflow-wrap: break-word;
   max-width: 225px;
 
@@ -355,7 +354,7 @@ const TooltipArrow = styled('span')`
     position: absolute;
     width: 0;
     height: 0;
-    border: solid 7px transparent;
+    border: solid 6px transparent;
     z-index: -1;
   }
 
@@ -364,9 +363,9 @@ const TooltipArrow = styled('span')`
     margin-top: -12px;
     border-bottom-color: ${p => p.theme.backgroundElevated};
     &::before {
-      bottom: -6px;
-      left: -7px;
-      border-bottom-color: ${p => p.theme.border};
+      bottom: -5px;
+      left: -6px;
+      border-bottom-color: ${p => p.theme.translucentBorder};
     }
   }
 
@@ -375,9 +374,9 @@ const TooltipArrow = styled('span')`
     margin-bottom: -12px;
     border-top-color: ${p => p.theme.backgroundElevated};
     &::before {
-      top: -6px;
-      left: -7px;
-      border-top-color: ${p => p.theme.border};
+      top: -5px;
+      left: -6px;
+      border-top-color: ${p => p.theme.translucentBorder};
     }
   }
 
@@ -386,9 +385,9 @@ const TooltipArrow = styled('span')`
     margin-left: -12px;
     border-right-color: ${p => p.theme.backgroundElevated};
     &::before {
-      top: -7px;
-      right: -6px;
-      border-right-color: ${p => p.theme.border};
+      top: -6px;
+      right: -5px;
+      border-right-color: ${p => p.theme.translucentBorder};
     }
   }
 
@@ -397,9 +396,9 @@ const TooltipArrow = styled('span')`
     margin-right: -12px;
     border-left-color: ${p => p.theme.backgroundElevated};
     &::before {
-      top: -7px;
-      left: -6px;
-      border-left-color: ${p => p.theme.border};
+      top: -6px;
+      left: -5px;
+      border-left-color: ${p => p.theme.translucentBorder};
     }
   }
 `;

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -182,6 +182,16 @@ const generateAliases = (colors: BaseColors) => ({
   translucentInnerBorder: colors.translucentGray100,
 
   /**
+   * Border around modals
+   */
+  modalBorder: 'none',
+
+  /**
+   * Box shadow on the modal
+   */
+  modalBoxShadow: 'none',
+
+  /**
    * A color that denotes a "success", or something good
    */
   success: colors.green300,

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -24,6 +24,13 @@ export const lightColors = {
   gray200: '#DBD6E1',
   gray100: '#EBE6EF',
 
+  /**
+   * Alternative version of gray200 that's translucent.
+   * Useful for borders on tooltips, popovers, and dialogs.
+   */
+  translucentGray200: 'rgba(58, 17, 95, 0.18)',
+  translucentGray100: 'rgba(45, 0, 85, 0.1)',
+
   purple400: '#584AC0',
   purple300: '#6C5FC7',
   purple200: 'rgba(108, 95, 199, 0.5)',
@@ -73,6 +80,13 @@ export const darkColors = {
   gray300: '#998DA5',
   gray200: '#43384C',
   gray100: '#342B3B',
+
+  /**
+   * Alternative version of gray200 that's translucent.
+   * Useful for borders on tooltips, popovers, and dialogs.
+   */
+  translucentGray200: 'rgba(218, 184, 245, 0.18)',
+  translucentGray100: 'rgba(208, 168, 240, 0.1)',
 
   purple400: '#6859CF',
   purple300: '#7669D3',
@@ -159,21 +173,13 @@ const generateAliases = (colors: BaseColors) => ({
    * Primary border color
    */
   border: colors.gray200,
+  translucentBorder: colors.translucentGray200,
 
   /**
    * Inner borders, e.g. borders inside of a grid
    */
   innerBorder: colors.gray100,
-
-  /**
-   * Border around modals
-   */
-  modalBorder: 'none',
-
-  /**
-   * Box shadow on the modal
-   */
-  modalBoxShadow: 'none',
+  translucentInnerBorder: colors.translucentGray100,
 
   /**
    * A color that denotes a "success", or something good


### PR DESCRIPTION
When borders are implemented as translucent box shadows (`box-shadow: 0 0 0 1px ${theme.translucentBorder}), they let content from the background bleed through. This results in more natural-looking components. Useful for tooltips, overlay menus, and dialogs. 

First implementation is on tooltips - we can do the same for overlays and modals in future PRs.

**Before:**

<img width="304" alt="nav-before" src="https://user-images.githubusercontent.com/44172267/148307098-f51cfa86-dbb7-48b8-80e5-d05d903fa6bb.png">
<img width="731" alt="charts2-before" src="https://user-images.githubusercontent.com/44172267/148307102-4b79ece5-5102-4945-ac6b-f3975fb3bf54.png">
<img width="465" alt="charts-before" src="https://user-images.githubusercontent.com/44172267/148307109-c82f286c-0430-48a8-a8d1-024d2ceaea50.png">

**After:**

<img width="304" alt="nav-after" src="https://user-images.githubusercontent.com/44172267/148307159-c04df123-40ed-4f1b-809c-306baccefcaa.png">
<img width="731" alt="charts2-after" src="https://user-images.githubusercontent.com/44172267/148307163-026985eb-2524-4585-9331-5ab345ea3867.png">
<img width="465" alt="charts-after" src="https://user-images.githubusercontent.com/44172267/148307164-7c7e6136-528b-406d-9e0c-3b441cf319ee.png">

