### PR TITLE
feat(ratelimits): Add headers with rate limit details

### DIFF
--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -11,7 +11,7 @@ from sentry.ratelimits import (
     get_rate_limit_key,
     get_rate_limit_value,
 )
-from sentry.types.ratelimit import RateLimitCategory
+from sentry.types.ratelimit import RateLimitCategory, RateLimitMeta
 
 DEFAULT_ERROR_MESSAGE = (
     "You are attempting to use this endpoint too frequently. Limit is "
@@ -22,7 +22,7 @@ DEFAULT_ERROR_MESSAGE = (
 class RatelimitMiddleware(MiddlewareMixin):
     """Middleware that applies a rate limit to every endpoint."""
 
-    rate_limit_check_dict: dict | None = None
+    rate_limit_metadata: RateLimitMeta | None = None
 
     def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response | None:
         """Check if the endpoint call will violate."""
@@ -46,24 +46,29 @@ class RatelimitMiddleware(MiddlewareMixin):
         if rate_limit is None:
             return
 
-        self.rate_limit_check_dict = above_rate_limit_check(key, rate_limit)
-        if self.rate_limit_check_dict["is_limited"]:
+        self.rate_limit_metadata = above_rate_limit_check(key, rate_limit)
+        if self.rate_limit_metadata.is_limited:
             request.will_be_rate_limited = True
             enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
             if enforce_rate_limit:
                 return HttpResponse(
                     {
                         "detail": DEFAULT_ERROR_MESSAGE.format(
-                            limit=self.rate_limit_check_dict["limit"],
-                            window=self.rate_limit_check_dict["window"],
+                            limit=self.rate_limit_metadata.limit,
+                            window=self.rate_limit_metadata.window,
                         )
                     },
                     status=429,
                 )
 
     def process_response(self, request: Request, response: Response) -> Response:
-        if self.rate_limit_check_dict is not None:
-            response["X-Sentry-Ratelimit-Count"] = self.rate_limit_check_dict.get("current", 0)
-            response["X-Sentry-Ratelimit-Max"] = self.rate_limit_check_dict["limit"]
-            response["X-Sentry-Ratelimit-Window"] = self.rate_limit_check_dict["window"]
+        if self.rate_limit_metadata is not None:
+            remaining_count = (
+                self.rate_limit_metadata.limit - self.rate_limit_metadata.current
+                if not self.rate_limit_metadata.is_limited
+                else 0
+            )
+            response["X-Sentry-Rate-Limit-Remaining"] = remaining_count
+            response["X-Sentry-Rate-Limit-Limit"] = self.rate_limit_metadata.limit
+            response["X-Sentry-Rate-Limit-Reset"] = self.rate_limit_metadata.reset_time
         return response

--- a/src/sentry/ratelimits/base.py
+++ b/src/sentry/ratelimits/base.py
@@ -16,7 +16,7 @@ class RateLimiter(Service):  # type: ignore
     def is_limited(
         self, key: str, limit: int, project: Project | None = None, window: int | None = None
     ) -> bool:
-        is_limited, _ = self.is_limited_with_value(key, limit, project=project, window=window)
+        is_limited, _, _ = self.is_limited_with_value(key, limit, project=project, window=window)
         return is_limited
 
     def current_value(
@@ -26,8 +26,8 @@ class RateLimiter(Service):  # type: ignore
 
     def is_limited_with_value(
         self, key: str, limit: int, project: Project | None = None, window: int | None = None
-    ) -> tuple[bool, int]:
-        return False, 0
+    ) -> tuple[bool, int, int]:
+        return False, 0, 0
 
     def validate(self) -> None:
         raise NotImplementedError

--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -18,13 +18,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _time_bucket(request_time: float, window: int) -> int:
+    """Bucket number lookup for given UTC time since epoch"""
+    return int(request_time / window)
+
+
+def _bucket_start_time(bucket_number: int, window: int) -> int:
+    """Determine bucket start time in seconds from epoch in UTC"""
+    return bucket_number * window
+
+
 class RedisRateLimiter(RateLimiter):
     def __init__(self, **options: Any) -> None:
         cluster_key = getattr(settings, "SENTRY_RATE_LIMIT_REDIS_CLUSTER", "default")
         self.client = redis.redis_clusters.get(cluster_key)
 
     def _construct_redis_key(
-        self, key: str, project: Project | None = None, window: int | None = None
+        self,
+        key: str,
+        project: Project | None = None,
+        window: int | None = None,
+        request_time: float | None = None,
     ) -> str:
         """
         Construct a rate limit key using the args given. Key will have a format of:
@@ -35,8 +49,11 @@ class RedisRateLimiter(RateLimiter):
         if window is None or window == 0:
             window = self.window
 
+        if request_time is None:
+            request_time = time()
+
         key_hex = md5_text(key).hexdigest()
-        bucket = int(time() / window)
+        bucket = _time_bucket(request_time, window)
 
         redis_key = f"rl:{key_hex}"
         if project is not None:
@@ -74,13 +91,16 @@ class RedisRateLimiter(RateLimiter):
 
     def is_limited_with_value(
         self, key: str, limit: int, project: Project | None = None, window: int | None = None
-    ) -> tuple[bool, int]:
+    ) -> tuple[bool, int, int]:
         """Does a rate limit check as well as return the new rate limit value"""
+        request_time = time()
         if window is None or window == 0:
             window = self.window
         redis_key = self._construct_redis_key(key, project=project, window=window)
 
-        expiration = window - int(time() % window)
+        expiration = window - int(request_time % window)
+        # Reset Time = next time bucket's start time
+        reset_time = _bucket_start_time(_time_bucket(request_time, window) + 1, window)
         try:
             result = self.client.incr(redis_key)
             self.client.expire(redis_key, expiration)
@@ -88,6 +108,6 @@ class RedisRateLimiter(RateLimiter):
             # We don't want rate limited endpoints to fail when ratelimits
             # can't be updated. We do want to know when that happens.
             logger.exception("Failed to retrieve current value from redis")
-            return False, 0
+            return False, 0, reset_time
 
-        return result > limit, result
+        return result > limit, result, reset_time

--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -92,7 +92,10 @@ class RedisRateLimiter(RateLimiter):
     def is_limited_with_value(
         self, key: str, limit: int, project: Project | None = None, window: int | None = None
     ) -> tuple[bool, int, int]:
-        """Does a rate limit check as well as return the new rate limit value"""
+        """
+        Does a rate limit check as well as returning the new rate limit value and when the next
+        rate limit window will start
+        """
         request_time = time()
         if window is None or window == 0:
             window = self.window

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -7,7 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.types.ratelimit import RateLimit, RateLimitCategory, RateLimitMeta
 from sentry.utils.hashlib import md5_text
 
 from . import backend as ratelimiter
@@ -119,16 +119,17 @@ def get_rate_limit_value(
     return settings.SENTRY_RATELIMITER_DEFAULTS[category]
 
 
-def above_rate_limit_check(key: str, rate_limit: RateLimit) -> Mapping[str, bool | int]:
-    is_limited, current = ratelimiter.is_limited_with_value(
+def above_rate_limit_check(key: str, rate_limit: RateLimit) -> RateLimitMeta:
+    is_limited, current, reset_time = ratelimiter.is_limited_with_value(
         key, limit=rate_limit.limit, window=rate_limit.window
     )
-    return {
-        "is_limited": is_limited,
-        "current": current,
-        "limit": rate_limit.limit,
-        "window": rate_limit.window,
-    }
+    return RateLimitMeta(
+        is_limited=is_limited,
+        current=current,
+        limit=rate_limit.limit,
+        window=rate_limit.window,
+        reset_time=reset_time,
+    )
 
 
 def for_organization_member_invite(

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -21,3 +21,23 @@ class RateLimit:
 
     limit: int
     window: int
+
+
+@dataclass
+class RateLimitMeta:
+    """
+    Rate Limit response metadata
+
+    Attributes:
+        is_limited (bool): request is rate limited
+        current (int): number of requests done in the current window
+        limit (int): max number of requests per window
+        window (int): window size in seconds
+        reset_time (int): UTC Epoch time in seconds when the current window expires
+    """
+
+    is_limited: bool
+    current: int
+    limit: int
+    window: int
+    reset_time: int

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -259,7 +259,8 @@ class TestRatelimitHeader(APITestCase):
         Ensure that functions that can't be rate limited don't have rate limit headers
 
         These functions include, but are not limited to:
-            - UI Statistics
+            - UI Statistics Endpoints
+            - Endpoints that don't inherit api.base.Endpoint
         """
         can_be_ratelimited_patch.return_value = False
         response = self.get_response()

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -240,18 +240,23 @@ class TestRatelimitHeader(APITestCase):
             expected_reset_time = int(time() + 100)
             response = self.get_success_response()
             assert int(response["X-Sentry-Rate-Limit-Remaining"]) == 1
-            assert int(response["X-Sentry-Rate-Limit-Limit"]) == 1
+            assert int(response["X-Sentry-Rate-Limit-Limit"]) == 2
+            assert int(response["X-Sentry-Rate-Limit-Reset"]) == expected_reset_time
+
+            response = self.get_success_response()
+            assert int(response["X-Sentry-Rate-Limit-Remaining"]) == 0
+            assert int(response["X-Sentry-Rate-Limit-Limit"]) == 2
             assert int(response["X-Sentry-Rate-Limit-Reset"]) == expected_reset_time
 
             response = self.get_error_response()
-            assert int(response["X-Sentry-Ratelimit-Remaining"]) == 0
-            assert int(response["X-Sentry-Ratelimit-Limit"]) == 1
-            assert int(response["X-Sentry-Ratelimit-Reset"]) == expected_reset_time
+            assert int(response["X-Sentry-Rate-Limit-Remaining"]) == 0
+            assert int(response["X-Sentry-Rate-Limit-Limit"]) == 2
+            assert int(response["X-Sentry-Rate-Limit-Reset"]) == expected_reset_time
 
             response = self.get_error_response()
-            assert int(response["X-Sentry-Ratelimit-Remaining"]) == 0
-            assert int(response["X-Sentry-Ratelimit-Limit"]) == 1
-            assert int(response["X-Sentry-Ratelimit-Reset"]) == expected_reset_time
+            assert int(response["X-Sentry-Rate-Limit-Remaining"]) == 0
+            assert int(response["X-Sentry-Rate-Limit-Limit"]) == 2
+            assert int(response["X-Sentry-Rate-Limit-Reset"]) == expected_reset_time
 
     @patch("sentry.ratelimits.utils.can_be_ratelimited")
     def test_omit_header(self, can_be_ratelimited_patch):
@@ -264,6 +269,6 @@ class TestRatelimitHeader(APITestCase):
         """
         can_be_ratelimited_patch.return_value = False
         response = self.get_response()
-        assert "X-Sentry-Ratelimit-Count" not in response._headers
-        assert "X-Sentry-Ratelimit-Max" not in response._headers
-        assert "X-Sentry-Ratelimit-Window" not in response._headers
+        assert "X-Sentry-Rate-Limit-Remaining" not in response._headers
+        assert "X-Sentry-Rate-Limit-Limit" not in response._headers
+        assert "X-Sentry-Rate-Limit-Reset" not in response._headers

--- a/tests/sentry/ratelimits/test_redis.py
+++ b/tests/sentry/ratelimits/test_redis.py
@@ -1,3 +1,5 @@
+from time import time
+
 from freezegun import freeze_time
 
 from sentry.ratelimits.redis import RedisRateLimiter
@@ -45,10 +47,21 @@ class RedisRateLimiterTest(TestCase):
             assert self.backend.current_value("foo", window=10) == 0
 
     def test_is_limited_with_value(self):
-        with freeze_time("2000-01-01", tick=True):
-            limited, value = self.backend.is_limited_with_value("foo", 1)
+        with freeze_time("2000-01-01") as frozen_time:
+            expected_reset_time = int(time() + 5)
+
+            limited, value, reset_time = self.backend.is_limited_with_value("foo", 1, window=5)
             assert not limited
             assert value == 1
-            limited, value = self.backend.is_limited_with_value("foo", 1)
+            assert reset_time == expected_reset_time
+
+            limited, value, reset_time = self.backend.is_limited_with_value("foo", 1, window=5)
             assert limited
             assert value == 2
+            assert reset_time == expected_reset_time
+
+            frozen_time.tick(5)
+            limited, value, reset_time = self.backend.is_limited_with_value("foo", 1, window=5)
+            assert not limited
+            assert value == 1
+            assert reset_time == expected_reset_time + 5

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -1,10 +1,17 @@
+from time import time
 from unittest import TestCase
 
+from freezegun import freeze_time
+
 from sentry.ratelimits import above_rate_limit_check
-from sentry.types.ratelimit import RateLimit
+from sentry.types.ratelimit import RateLimit, RateLimitMeta
 
 
 class RatelimitMiddlewareTest(TestCase):
     def test_above_rate_limit_check(self):
-        return_val = above_rate_limit_check("foo", RateLimit(10, 100))
-        assert return_val == dict(is_limited=False, current=1, limit=10, window=100)
+        with freeze_time("2000-01-01"):
+            expected_reset_time = int(time() + 100)
+            return_val = above_rate_limit_check("foo", RateLimit(10, 100))
+            assert return_val == RateLimitMeta(
+                is_limited=False, current=1, limit=10, window=100, reset_time=expected_reset_time
+            )


### PR DESCRIPTION
The headers allow API users to know where they are in terms of their rate limits. It'll be returned for every API that can be rate limited except when there is an internal exception. At the time of this commit, rate limits are not enforced except for some specific endpoints.

Closes API-2212