### PR TITLE
fix(teamStats): Center project badges, reuse styles

### DIFF
--- a/static/app/views/organizationStats/teamInsights/styles.tsx
+++ b/static/app/views/organizationStats/teamInsights/styles.tsx
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+import IdBadge from 'sentry/components/idBadge';
+
+export const ProjectBadgeContainer = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+export const ProjectBadge = styled(IdBadge)`
+  flex-shrink: 0;
+`;

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -7,7 +7,6 @@ import AsyncComponent from 'sentry/components/asyncComponent';
 import Button from 'sentry/components/button';
 import BarChart from 'sentry/components/charts/barChart';
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
@@ -24,6 +23,8 @@ import {
   barAxisLabel,
   convertDaySeriesToWeeks,
   convertDayValueObjectToSeries,
+  ProjectBadge,
+  ProjectBadgeContainer,
 } from './utils';
 
 type AlertsTriggered = Record<string, number>;
@@ -231,14 +232,6 @@ const StyledPanelTable = styled(PanelTable)`
         padding: 48px ${space(2)};
       }
     `}
-`;
-
-const ProjectBadgeContainer = styled('div')`
-  display: flex;
-`;
-
-const ProjectBadge = styled(IdBadge)`
-  flex-shrink: 0;
 `;
 
 const AlignRight = styled('div')`

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -19,12 +19,11 @@ import {formatPercentage} from 'sentry/utils/formatters';
 import {Color} from 'sentry/utils/theme';
 import {IncidentRule} from 'sentry/views/alerts/incidentRules/types';
 
+import {ProjectBadge, ProjectBadgeContainer} from './styles';
 import {
   barAxisLabel,
   convertDaySeriesToWeeks,
   convertDayValueObjectToSeries,
-  ProjectBadge,
-  ProjectBadgeContainer,
 } from './utils';
 
 type AlertsTriggered = Record<string, number>;

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
@@ -5,7 +5,6 @@ import isEqual from 'lodash/isEqual';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import BarChart, {BarChartSeries} from 'sentry/components/charts/barChart';
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import IdBadge from 'sentry/components/idBadge';
 import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
 import PanelTable from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
@@ -19,6 +18,8 @@ import {
   barAxisLabel,
   convertDaySeriesToWeeks,
   convertDayValueObjectToSeries,
+  ProjectBadge,
+  ProjectBadgeContainer,
 } from './utils';
 
 type StatusCounts = {
@@ -221,14 +222,6 @@ const StyledPanelTable = styled(PanelTable)<{numActions: number}>`
   & > div {
     padding: ${space(1)} ${space(2)};
   }
-`;
-
-const ProjectBadgeContainer = styled('div')`
-  display: flex;
-`;
-
-const ProjectBadge = styled(IdBadge)`
-  flex-shrink: 0;
 `;
 
 const AlignRight = styled('div')`

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
@@ -14,12 +14,11 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 
+import {ProjectBadge, ProjectBadgeContainer} from './styles';
 import {
   barAxisLabel,
   convertDaySeriesToWeeks,
   convertDayValueObjectToSeries,
-  ProjectBadge,
-  ProjectBadgeContainer,
 } from './utils';
 
 type StatusCounts = {

--- a/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
@@ -14,12 +14,11 @@ import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {formatPercentage} from 'sentry/utils/formatters';
 
+import {ProjectBadge, ProjectBadgeContainer} from './styles';
 import {
   barAxisLabel,
   convertDaySeriesToWeeks,
   convertDayValueObjectToSeries,
-  ProjectBadge,
-  ProjectBadgeContainer,
 } from './utils';
 
 type IssuesBreakdown = Record<string, Record<string, {reviewed: number; total: number}>>;

--- a/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
@@ -6,7 +6,6 @@ import isEqual from 'lodash/isEqual';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import BarChart from 'sentry/components/charts/barChart';
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import IdBadge from 'sentry/components/idBadge';
 import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
 import PanelTable from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
@@ -19,6 +18,8 @@ import {
   barAxisLabel,
   convertDaySeriesToWeeks,
   convertDayValueObjectToSeries,
+  ProjectBadge,
+  ProjectBadgeContainer,
 } from './utils';
 
 type IssuesBreakdown = Record<string, Record<string, {reviewed: number; total: number}>>;
@@ -212,14 +213,6 @@ const StyledPanelTable = styled(PanelTable)`
         padding: 48px ${space(2)};
       }
     `}
-`;
-
-const ProjectBadgeContainer = styled('div')`
-  display: flex;
-`;
-
-const ProjectBadge = styled(IdBadge)`
-  flex-shrink: 0;
 `;
 
 const AlignRight = styled('div')`

--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -6,7 +6,6 @@ import {Location} from 'history';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import Button from 'sentry/components/button';
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
 import LoadingError from 'sentry/components/loadingError';
 import PanelTable from 'sentry/components/panels/panelTable';
@@ -24,7 +23,7 @@ import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Color} from 'sentry/utils/theme';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
-import {groupByTrend} from './utils';
+import {groupByTrend, ProjectBadge, ProjectBadgeContainer} from './utils';
 
 type TeamMiseryProps = {
   organization: Organization;
@@ -316,14 +315,6 @@ const StyledIconStar = styled(IconStar)`
   display: block;
   margin-right: ${space(1)};
   margin-bottom: ${space(0.5)};
-`;
-
-const ProjectBadgeContainer = styled('div')`
-  display: flex;
-`;
-
-const ProjectBadge = styled(IdBadge)`
-  flex-shrink: 0;
 `;
 
 const TransactionWrapper = styled('div')`

--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -23,7 +23,8 @@ import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Color} from 'sentry/utils/theme';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
-import {groupByTrend, ProjectBadge, ProjectBadgeContainer} from './utils';
+import {ProjectBadge, ProjectBadgeContainer} from './styles';
+import {groupByTrend} from './utils';
 
 type TeamMiseryProps = {
   organization: Organization;

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -20,13 +20,8 @@ import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {Color, Theme} from 'sentry/utils/theme';
 
-import {
-  barAxisLabel,
-  convertDaySeriesToWeeks,
-  groupByTrend,
-  ProjectBadge,
-  ProjectBadgeContainer,
-} from './utils';
+import {ProjectBadge, ProjectBadgeContainer} from './styles';
+import {barAxisLabel, convertDaySeriesToWeeks, groupByTrend} from './utils';
 
 type Props = AsyncComponent['props'] & {
   theme: Theme;

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -10,7 +10,6 @@ import Button from 'sentry/components/button';
 import BarChart from 'sentry/components/charts/barChart';
 import MarkLine from 'sentry/components/charts/components/markLine';
 import {DateTimeObject, getTooltipArrow} from 'sentry/components/charts/utils';
-import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
 import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
 import PanelTable from 'sentry/components/panels/panelTable';
@@ -21,7 +20,13 @@ import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {Color, Theme} from 'sentry/utils/theme';
 
-import {barAxisLabel, convertDaySeriesToWeeks, groupByTrend} from './utils';
+import {
+  barAxisLabel,
+  convertDaySeriesToWeeks,
+  groupByTrend,
+  ProjectBadge,
+  ProjectBadgeContainer,
+} from './utils';
 
 type Props = AsyncComponent['props'] & {
   theme: Theme;
@@ -342,12 +347,4 @@ const PaddedIconArrow = styled(IconArrow)`
 
 const SubText = styled('div')<{color: Color}>`
   color: ${p => p.theme[p.color]};
-`;
-
-const ProjectBadgeContainer = styled('div')`
-  display: flex;
-`;
-
-const ProjectBadge = styled(IdBadge)`
-  flex-shrink: 0;
 `;

--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -9,7 +9,6 @@ import Button from 'sentry/components/button';
 import MiniBarChart from 'sentry/components/charts/miniBarChart';
 import SessionsRequest from 'sentry/components/charts/sessionsRequest';
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import IdBadge from 'sentry/components/idBadge';
 import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
 import PanelTable from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
@@ -28,7 +27,7 @@ import {getCountSeries, getCrashFreeRate, getSeriesSum} from 'sentry/utils/sessi
 import {Color} from 'sentry/utils/theme';
 import {displayCrashFreePercent} from 'sentry/views/releases/utils';
 
-import {groupByTrend} from './utils';
+import {groupByTrend, ProjectBadge, ProjectBadgeContainer} from './utils';
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;
@@ -327,12 +326,4 @@ const PaddedIconArrow = styled(IconArrow)`
 
 const SubText = styled('div')<{color: Color}>`
   color: ${p => p.theme[p.color]};
-`;
-
-const ProjectBadgeContainer = styled('div')`
-  display: flex;
-`;
-
-const ProjectBadge = styled(IdBadge)`
-  flex-shrink: 0;
 `;

--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -27,7 +27,8 @@ import {getCountSeries, getCrashFreeRate, getSeriesSum} from 'sentry/utils/sessi
 import {Color} from 'sentry/utils/theme';
 import {displayCrashFreePercent} from 'sentry/views/releases/utils';
 
-import {groupByTrend, ProjectBadge, ProjectBadgeContainer} from './utils';
+import {ProjectBadge, ProjectBadgeContainer} from './styles';
+import {groupByTrend} from './utils';
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
@@ -15,13 +15,12 @@ import {Organization, Project} from 'sentry/types';
 import {formatPercentage} from 'sentry/utils/formatters';
 import type {Color} from 'sentry/utils/theme';
 
+import {ProjectBadge, ProjectBadgeContainer} from './styles';
 import {
   barAxisLabel,
   convertDaySeriesToWeeks,
   convertDayValueObjectToSeries,
   groupByTrend,
-  ProjectBadge,
-  ProjectBadgeContainer,
 } from './utils';
 
 type Props = AsyncComponent['props'] & {

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
@@ -5,7 +5,6 @@ import isEqual from 'lodash/isEqual';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import BarChart from 'sentry/components/charts/barChart';
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import IdBadge from 'sentry/components/idBadge';
 import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
 import PanelTable from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
@@ -21,6 +20,8 @@ import {
   convertDaySeriesToWeeks,
   convertDayValueObjectToSeries,
   groupByTrend,
+  ProjectBadge,
+  ProjectBadgeContainer,
 } from './utils';
 
 type Props = AsyncComponent['props'] & {
@@ -258,12 +259,4 @@ const PaddedIconArrow = styled(IconArrow)`
 
 const SubText = styled('div')<{color: Color}>`
   color: ${p => p.theme[p.color]};
-`;
-
-const ProjectBadgeContainer = styled('div')`
-  display: flex;
-`;
-
-const ProjectBadge = styled(IdBadge)`
-  flex-shrink: 0;
 `;

--- a/static/app/views/organizationStats/teamInsights/utils.tsx
+++ b/static/app/views/organizationStats/teamInsights/utils.tsx
@@ -1,9 +1,7 @@
-import styled from '@emotion/styled';
 import chunk from 'lodash/chunk';
 import moment from 'moment';
 
 import BaseChart from 'sentry/components/charts/baseChart';
-import IdBadge from 'sentry/components/idBadge';
 import {SeriesDataUnit} from 'sentry/types/echarts';
 
 /**
@@ -59,12 +57,3 @@ export const barAxisLabel = (
     },
   };
 };
-
-export const ProjectBadgeContainer = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
-export const ProjectBadge = styled(IdBadge)`
-  flex-shrink: 0;
-`;

--- a/static/app/views/organizationStats/teamInsights/utils.tsx
+++ b/static/app/views/organizationStats/teamInsights/utils.tsx
@@ -1,7 +1,9 @@
+import styled from '@emotion/styled';
 import chunk from 'lodash/chunk';
 import moment from 'moment';
 
 import BaseChart from 'sentry/components/charts/baseChart';
+import IdBadge from 'sentry/components/idBadge';
 import {SeriesDataUnit} from 'sentry/types/echarts';
 
 /**
@@ -57,3 +59,12 @@ export const barAxisLabel = (
     },
   };
 };
+
+export const ProjectBadgeContainer = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+export const ProjectBadge = styled(IdBadge)`
+  flex-shrink: 0;
+`;


### PR DESCRIPTION
before
<img width="446" alt="Screen Shot 2022-01-05 at 4 32 54 PM" src="https://user-images.githubusercontent.com/1400464/148309454-2a7b5d8d-28d3-43ef-b362-9b59c32a7546.png">

after
<img width="436" alt="Screen Shot 2022-01-05 at 4 33 02 PM" src="https://user-images.githubusercontent.com/1400464/148309465-4ac497ab-7442-463d-8b39-5776366f9da4.png">

