### PR TITLE
fix(teamStats): All unresolved issues handle no team projects

### DIFF
--- a/src/sentry/api/endpoints/team_all_unresolved_issues.py
+++ b/src/sentry/api/endpoints/team_all_unresolved_issues.py
@@ -33,6 +33,11 @@ class TeamAllUnresolvedIssuesEndpoint(TeamEndpoint, EnvironmentMixin):  # type: 
         """
         if not features.has("organizations:team-insights", team.organization, actor=request.user):
             return Response({"detail": "You do not have the insights feature enabled"}, status=400)
+
+        # Team has no projects
+        if not Project.objects.get_for_team_ids(team_ids=[team.id]).exists():
+            return Response({})
+
         start, end = get_date_range_from_params(request.GET)
         end = end.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
         start = start.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)

--- a/src/sentry/api/endpoints/team_all_unresolved_issues.py
+++ b/src/sentry/api/endpoints/team_all_unresolved_issues.py
@@ -35,7 +35,8 @@ class TeamAllUnresolvedIssuesEndpoint(TeamEndpoint, EnvironmentMixin):  # type: 
             return Response({"detail": "You do not have the insights feature enabled"}, status=400)
 
         # Team has no projects
-        if not Project.objects.get_for_team_ids(team_ids=[team.id]).exists():
+        project_list = Project.objects.get_for_team_ids(team_ids=[team.id])
+        if len(project_list) == 0:
             return Response({})
 
         start, end = get_date_range_from_params(request.GET)
@@ -158,7 +159,6 @@ class TeamAllUnresolvedIssuesEndpoint(TeamEndpoint, EnvironmentMixin):  # type: 
             date_series_dict[current_day.isoformat()] = {"open": 0, "closed": 0}
             current_day += timedelta(days=1)
 
-        project_list = Project.objects.get_for_team_ids(team_ids=[team.id])
         agg_project_precounts = {
             project.id: copy.deepcopy(date_series_dict) for project in project_list
         }

--- a/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
+++ b/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
@@ -137,3 +137,10 @@ class TeamIssueBreakdownTest(APITestCase):
         compare_response(response, project1, [2, 2, 2, 3, 3, 3, 3])
         compare_response(response, project2, [0, 1, 0, 1, 0, 1, 0])
         compare_response(response, project3, [0, 1, 0, 0, 0, 0, 0])
+
+    def test_no_projects(self):
+        self.login_as(user=self.user)
+        response = self.get_success_response(
+            self.team.organization.slug, self.team.slug, statsPeriod="7d"
+        )
+        assert response.status_code == 200, response.content


### PR DESCRIPTION
return an empty object when team has no projects which would would've been the result anyway. Currently returns a 500

fixes SENTRY-T10