### PR TITLE
ref(lint): Disallow `grid-gap` property

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -20,5 +20,14 @@ module.exports = {
     'no-descending-specificity': null,
 
     'property-no-unknown': [true, {ignoreProperties: [/\$dummyValue/]}],
+
+    'property-disallowed-list': [
+      // Prefer `gap` over `grid-gap`, it does the same thing
+      'grid-gap',
+      // Can't set per-property custom messages.. so try and bring them here
+      {
+        message: 'Disallowed property. (See `stylelint.config.js` as to why)',
+      },
+    ],
   },
 };


### PR DESCRIPTION
Unfortunately we can't add a custom error message per property (See https://github.com/stylelint/stylelint/issues/4117), which would be nice to let the user know that they should use `gap` instead of grid-gap. So instead we'll try and direct them to the stylelint config to find out why.