### PR TITLE
fix(trends): Catch user errors from the trends endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -465,25 +465,28 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
         query = request.GET.get("query")
 
         if use_snql:
-            trend_query = TrendQueryBuilder(
-                dataset=Dataset.Discover,
-                params=params,
-                selected_columns=selected_columns,
-                auto_fields=False,
-                auto_aggregations=True,
-                use_aggregate_conditions=True,
-            )
-            snql_trend_columns = self.resolve_trend_columns(trend_query, function, column, middle)
-            trend_query.columns.extend(snql_trend_columns.values())
-            trend_query.aggregates.extend(snql_trend_columns.values())
-            trend_query.params["aliases"] = self.get_snql_function_aliases(
-                snql_trend_columns, trend_type
-            )
-            # Both orderby and conditions need to be resolved after the columns because of aliasing
-            trend_query.orderby = trend_query.resolve_orderby(orderby)
-            where, having = trend_query.resolve_conditions(query, use_aggregate_conditions=True)
-            trend_query.where += where
-            trend_query.having += having
+            with self.handle_query_errors():
+                trend_query = TrendQueryBuilder(
+                    dataset=Dataset.Discover,
+                    params=params,
+                    selected_columns=selected_columns,
+                    auto_fields=False,
+                    auto_aggregations=True,
+                    use_aggregate_conditions=True,
+                )
+                snql_trend_columns = self.resolve_trend_columns(
+                    trend_query, function, column, middle
+                )
+                trend_query.columns.extend(snql_trend_columns.values())
+                trend_query.aggregates.extend(snql_trend_columns.values())
+                trend_query.params["aliases"] = self.get_snql_function_aliases(
+                    snql_trend_columns, trend_type
+                )
+                # Both orderby and conditions need to be resolved after the columns because of aliasing
+                trend_query.orderby = trend_query.resolve_orderby(orderby)
+                where, having = trend_query.resolve_conditions(query, use_aggregate_conditions=True)
+                trend_query.where += where
+                trend_query.having += having
         else:
             params["aliases"] = self.get_function_aliases(trend_type)
             trend_columns = self.get_trend_columns(function, column, middle)


### PR DESCRIPTION
- This fixes a bug where user errors would present as a 500 since an
  invalid errors wouldn't be caught
- Fixes SENTRY-T11
- Fixes SENTRY-T12