### PR TITLE
fix(msteams): Update alert rule URL

### DIFF
--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -109,7 +109,7 @@ def build_installation_confirmation_message(organization):
         "text": "Now that setup is complete, you can continue by configuring alerts.",
         "wrap": True,
     }
-    alert_rule_url = absolute_uri(f"organizations/{organization.slug}/rules/")
+    alert_rule_url = absolute_uri(f"organizations/{organization.slug}/alerts/rules/")
     alert_rule_button = {
         "type": "Action.OpenUrl",
         "title": "Add Alert Rules",

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -73,7 +73,7 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
                 integration=integration, organization=self.organization
             )
 
-            integration_url = f"organizations/{self.organization.slug}/rules/"
+            integration_url = f"organizations/{self.organization.slug}/alerts/rules/"
             assert integration_url in responses.calls[1].request.body.decode("utf-8")
             assert self.organization.name in responses.calls[1].request.body.decode("utf-8")
 


### PR DESCRIPTION
While updating the MSTeams installation docs I noticed we send a card after installation prompting the user to set up alert rules, and the URL has changed so it was 404ing. This PR updates the link to the current URL.

<img width="466" alt="Screen Shot 2022-01-06 at 10 32 35 AM" src="https://user-images.githubusercontent.com/29959063/148432974-0d6c39c5-209c-4bb3-896f-2329ade9b943.png">
 