### PR TITLE
ref(ui) Fix dark mode colors for usage charts

### DIFF
--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -34,8 +34,8 @@ const COLOR_TRANSACTIONS = Color(commonTheme.dataCategory.transactions)
 const COLOR_ATTACHMENTS = Color(commonTheme.dataCategory.attachments)
   .lighten(0.65)
   .string();
+
 const COLOR_DROPPED = commonTheme.red300;
-const COLOR_PROJECTED = commonTheme.gray100;
 const COLOR_FILTERED = commonTheme.pink100;
 
 export const CHART_OPTIONS_DATACATEGORY: SelectValue<DataCategory>[] = [
@@ -204,7 +204,8 @@ export class UsageChart extends React.Component<Props, State> {
   }
 
   get chartColors() {
-    const {dataCategory} = this.props;
+    const {dataCategory, theme} = this.props;
+    const COLOR_PROJECTED = theme.chartOther;
 
     if (dataCategory === DataCategory.ERRORS) {
       return [COLOR_ERRORS, COLOR_FILTERED, COLOR_DROPPED, COLOR_PROJECTED];


### PR DESCRIPTION
Improve the dark mode and hover colors for projected series on subscription usage. Previously the hover state would result in invisible bars and the dark theme had too much contrast.


### Before
![Screen Shot 2022-01-06 at 2 29 02 PM](https://user-images.githubusercontent.com/24086/148440386-32b52bf1-a376-40ea-a2d9-42447a9a5dea.png)
![Screen Shot 2022-01-06 at 2 29 13 PM](https://user-images.githubusercontent.com/24086/148440387-3b435a90-4d9d-4fe4-a034-4b932b576cc4.png)


### After
![Screen Shot 2022-01-06 at 2 28 45 PM](https://user-images.githubusercontent.com/24086/148440366-5373abbc-8d00-4c9a-a50a-c5707ce438af.png)
![Screen Shot 2022-01-06 at 2 28 35 PM](https://user-images.githubusercontent.com/24086/148440362-2caead43-1794-4d5e-8a94-86ffa940a083.png)
