### PR TITLE
Test out hypothesis re: template context

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -169,9 +169,6 @@ class BaseAccess:
         """
         return self.has_project_access(project) and self.has_scope(scope)
 
-    def to_django_context(self):
-        return {s.replace(":", "_"): self.has_scope(s) for s in settings.SENTRY_SCOPES}
-
 
 class Access(BaseAccess):
     # TODO(dcramer): this is still a little gross, and ideally backend access

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -354,11 +354,7 @@ class AuthIdentityHandler:
         context: Mapping[str, Any] = None,
         status: int = 200,
     ) -> HttpResponse:
-        default_context = {"organization": self.organization}
-        if context:
-            default_context.update(context)
-
-        return render_to_response(template, default_context, self.request, status=status)
+        return render_to_response(template, context, self.request, status=status)
 
     def _post_login_redirect(self) -> HttpResponseRedirect:
         url = auth.get_login_redirect(self.request)

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -1,77 +1,17 @@
 import logging
 
-from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse
 from django.template import loader
 
-from sentry.auth import access
-from sentry.models import Team
 from sentry.utils.auth import get_login_url  # NOQA: backwards compatibility
 
 logger = logging.getLogger("sentry")
 
 
-def get_default_context(request, existing_context=None, team=None):
-    context = {}
-
-    if existing_context:
-        if team is None and "team" in existing_context:
-            team = existing_context["team"]
-
-        if "project" in existing_context:
-            project = existing_context["project"]
-        else:
-            project = None
-    else:
-        project = None
-
-    if team:
-        organization = team.organization
-    elif project:
-        organization = project.organization
-    else:
-        organization = None
-
-    if request:
-        if (not existing_context or "TEAM_LIST" not in existing_context) and team:
-            context["TEAM_LIST"] = Team.objects.get_for_user(
-                organization=team.organization, user=request.user, with_projects=True
-            )
-
-        user = request.user
-    else:
-        user = AnonymousUser()
-
-    if not existing_context or "ACCESS" not in existing_context:
-        if request:
-            context["ACCESS"] = access.from_request(
-                request=request, organization=organization
-            ).to_django_context()
-        else:
-            context["ACCESS"] = access.from_user(
-                user=user, organization=organization
-            ).to_django_context()
-
-    return context
-
-
-def render_to_string(template, context=None, request=None):
-
-    # HACK: set team session value for dashboard redirect
-    if context and "team" in context and isinstance(context["team"], Team):
-        team = context["team"]
-    else:
-        team = None
-
-    default_context = get_default_context(request, context, team=team)
-
-    if context is None:
-        context = default_context
-    else:
-        context = dict(context)
-        context.update(default_context)
-
-    return loader.render_to_string(template, context=context, request=request)
+def render_to_string(*a, **kw):
+    # TODO: Remove this entirely. Turns out we don't need it anymore, but
+    # replacing imports everywhere is bigger than I want to do in one PR.
+    return loader.render_to_string(*a, **kw)
 
 
 def render_to_response(template, context=None, request=None, status=200, content_type="text/html"):

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse
 from django.template import loader
@@ -13,15 +12,7 @@ logger = logging.getLogger("sentry")
 
 
 def get_default_context(request, existing_context=None, team=None):
-    from sentry import options
-    from sentry.plugins.base import plugins
-
-    context = {
-        "URL_PREFIX": options.get("system.url-prefix"),
-        "SINGLE_ORGANIZATION": settings.SENTRY_SINGLE_ORGANIZATION,
-        "PLUGINS": plugins,
-        "ONPREMISE": settings.SENTRY_ONPREMISE,
-    }
+    context = {}
 
     if existing_context:
         if team is None and "team" in existing_context:


### PR DESCRIPTION
From what I can tell, we no longer use Django template contexts to vary response bodies. This PR therefore removes the code that populates the Django template context (except for csrf!).

### To Do

- [x] ~Dig up the Git history where we stop using each context value. I suspect it happened when we converted to a SPA at some point a few years ago.~
- [x] ~Think through plugins (or other downstream consumers?) that might still depend on these values.~
- [x] Close this PR without merging because goodness gracious do I really want this blood on my hands?