### PR TITLE
fix(doc integrations): Sort DocIntegrations by popularity as well

### DIFF
--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -235,11 +235,10 @@ export class IntegrationListDirectory extends AsyncComponent<
   }
 
   getPopularityWeight = (integration: AppOrProviderOrPlugin) => {
-    return (
-      this.state.publishedApps?.find(i => i === integration)?.popularity ??
-      POPULARITY_WEIGHT[integration.slug] ??
-      1
-    );
+    if (isSentryApp(integration) || isDocIntegration(integration)) {
+      return integration?.popularity ?? 1;
+    }
+    return POPULARITY_WEIGHT[integration.slug] ?? 1;
   };
 
   sortByName = (a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) =>

--- a/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -52,12 +52,13 @@ describe('IntegrationListDirectory', function () {
       expect(wrapper.find('IntegrationRow')).toHaveLength(7);
 
       [
-        'bitbucket',
-        'pagerduty',
-        'my-headband-washer-289499',
-        'clickup',
-        'amazon-sqs',
-        'la-croix-monitor',
+        'bitbucket', // 10
+        'pagerduty', // 10
+        'my-headband-washer-289499', // 10
+        'sample-doc', // 10
+        'clickup', // 9
+        'amazon-sqs', // 8
+        'la-croix-monitor', // 8
       ].map((name, index) =>
         expect(wrapper.find('IntegrationRow').at(index).props().slug).toEqual(name)
       );


### PR DESCRIPTION
See [API-2345](https://getsentry.atlassian.net/browse/API-2345)

This PR sorts the doc integrations by popularity. We were ignoring their popularity values before, now they will be used to determine ranking on the integrations directory.

Before:

<img width="1179" alt="Screen Shot 2022-01-06 at 2 11 18 PM" src="https://user-images.githubusercontent.com/35509934/148460348-15e21f9a-37b7-4608-8015-69811202ecac.png">

After:

<img width="1512" alt="Screen Shot 2022-01-06 at 2 07 31 PM" src="https://user-images.githubusercontent.com/35509934/148460375-24d85288-6175-44d9-a8bf-beb7306a1d83.png">

