### PR TITLE
fix(ui): Use opaque internal health alerts

### DIFF
--- a/static/app/actionCreators/deployPreview.tsx
+++ b/static/app/actionCreators/deployPreview.tsx
@@ -44,6 +44,7 @@ export function displayExperimentalSpaAlert() {
       'You are developing against production Sentry API, please BE CAREFUL, as your changes will affect production data.'
     ),
     type: 'warning',
+    opaque: true,
     neverExpire: true,
     noDuplicates: true,
   });

--- a/static/app/stores/alertStore.tsx
+++ b/static/app/stores/alertStore.tsx
@@ -10,6 +10,7 @@ import {CommonStoreInterface} from './types';
 type Alert = {
   message: React.ReactNode;
   type: keyof Theme['alert'];
+  opaque?: boolean;
   expireAfter?: number;
   key?: number;
   id?: string;

--- a/static/app/views/admin/installWizard/index.tsx
+++ b/static/app/views/admin/installWizard/index.tsx
@@ -149,6 +149,8 @@ const fixedStyle = css`
 `;
 
 const Pattern = styled('div')`
+  z-index: -1;
+
   &::before {
     ${fixedStyle}
     content: '';

--- a/static/app/views/app/alertMessage.tsx
+++ b/static/app/views/app/alertMessage.tsx
@@ -18,7 +18,7 @@ type Props = {
 const AlertMessage = ({alert, system}: Props) => {
   const handleClose = () => AlertActions.closeAlert(alert);
 
-  const {url, message, type} = alert;
+  const {url, message, type, opaque} = alert;
 
   const icon =
     type === 'success' ? (
@@ -28,7 +28,7 @@ const AlertMessage = ({alert, system}: Props) => {
     );
 
   return (
-    <StyledAlert type={type} icon={icon} system={system}>
+    <StyledAlert type={type} icon={icon} system={system} opaque={opaque}>
       <StyledMessage>
         {url ? <ExternalLink href={url}>{message}</ExternalLink> : message}
       </StyledMessage>

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -89,7 +89,7 @@ function App({children}: Props) {
       const {id, message, url} = problem;
       const type = problem.severity === 'critical' ? 'error' : 'warning';
 
-      AlertActions.addAlert({id, message, type, url});
+      AlertActions.addAlert({id, message, type, url, opaque: true});
     });
   }
 


### PR DESCRIPTION
Before:
<img width="1167" alt="Screen Shot 2022-01-06 at 12 47 17 PM" src="https://user-images.githubusercontent.com/44172267/148463775-e378bd3d-72d8-4004-af31-7f1d31215ea1.png">

After:
<img width="1167" alt="Screen Shot 2022-01-06 at 12 57 03 PM" src="https://user-images.githubusercontent.com/44172267/148463788-d4edea9e-5b94-478f-b37a-c0932e682582.png">

