### PR TITLE
fix(ui): Specify allowed periods for legacy basic error chart

### DIFF
--- a/static/app/views/projectDetail/charts/projectErrorsBasicChart.tsx
+++ b/static/app/views/projectDetail/charts/projectErrorsBasicChart.tsx
@@ -12,7 +12,7 @@ import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
 
-const ALLOWED_TIME_PERIODS = ['1h', '24h', '7d', '14d', '30d'];
+export const ERRORS_BASIC_CHART_PERIODS = ['1h', '24h', '7d', '14d', '30d'];
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;
@@ -56,7 +56,7 @@ class ProjectErrorsBasicChart extends AsyncComponent<Props, State> {
 
   componentDidMount() {
     const {location} = this.props;
-    if (!ALLOWED_TIME_PERIODS.includes(location.query.statsPeriod)) {
+    if (!ERRORS_BASIC_CHART_PERIODS.includes(location.query.statsPeriod)) {
       browserHistory.replace({
         pathname: location.pathname,
         query: {
@@ -79,7 +79,7 @@ class ProjectErrorsBasicChart extends AsyncComponent<Props, State> {
     const {location} = this.props;
     const statsPeriod = location.query.statsPeriod;
 
-    if (ALLOWED_TIME_PERIODS.includes(statsPeriod)) {
+    if (ERRORS_BASIC_CHART_PERIODS.includes(statsPeriod)) {
       return statsPeriod;
     }
 

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
+import pick from 'lodash/pick';
 
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organization';
 import {updateProjects} from 'sentry/actionCreators/pageFilters';
@@ -20,6 +21,7 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import MissingProjectMembership from 'sentry/components/projects/missingProjectMembership';
 import TextOverflow from 'sentry/components/textOverflow';
+import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
@@ -175,10 +177,12 @@ class ProjectDetail extends AsyncView<Props, State> {
     const project = this.project;
     const {query} = location.query;
     const hasPerformance = organization.features.includes('performance-view');
+    const hasDiscover = organization.features.includes('discover-basic');
     const hasTransactions = hasPerformance && project?.firstTransactionEvent;
     const isProjectStabilized = this.isProjectStabilized();
     const visibleCharts = ['chart1'];
     const hasSessions = project?.hasSessions ?? null;
+    const hasOnlyBasicChart = !hasPerformance && !hasDiscover && !hasSessions;
 
     if (hasTransactions || hasSessions) {
       visibleCharts.push('chart2');
@@ -197,6 +201,12 @@ class ProjectDetail extends AsyncView<Props, State> {
         disableMultipleProjectSelection
         skipLoadLastUsed
         onUpdateProjects={this.handleProjectChange}
+        relativeDateOptions={
+          hasOnlyBasicChart
+            ? pick(DEFAULT_RELATIVE_PERIODS, ['1h', '24h', '7d', '14d', '30d'])
+            : undefined
+        }
+        showAbsolute={!hasOnlyBasicChart}
       >
         <NoProjectMessage organization={organization}>
           <StyledPageContent>

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -33,6 +33,7 @@ import withPageFilters from 'sentry/utils/withPageFilters';
 import withProjects from 'sentry/utils/withProjects';
 import AsyncView from 'sentry/views/asyncView';
 
+import {ERRORS_BASIC_CHART_PERIODS} from './charts/projectErrorsBasicChart';
 import ProjectScoreCards from './projectScoreCards/projectScoreCards';
 import ProjectCharts from './projectCharts';
 import ProjectFilters from './projectFilters';
@@ -203,7 +204,7 @@ class ProjectDetail extends AsyncView<Props, State> {
         onUpdateProjects={this.handleProjectChange}
         relativeDateOptions={
           hasOnlyBasicChart
-            ? pick(DEFAULT_RELATIVE_PERIODS, ['1h', '24h', '7d', '14d', '30d'])
+            ? pick(DEFAULT_RELATIVE_PERIODS, ERRORS_BASIC_CHART_PERIODS)
             : undefined
         }
         showAbsolute={!hasOnlyBasicChart}


### PR DESCRIPTION
There are multiple charts on Project Details page that rely on performance/discover/release health data.
![image](https://user-images.githubusercontent.com/9060071/148539302-1620789b-c7de-4ac2-b78c-8d37ef4b4b6d.png)

If the user is on one of the legacy plans, that does not support any of these features, we fall back to a basic error count chart. In that case, the Number of Errors chart does not take its data from discover endpoint, but from a projects endpoint.
This endpoint does not support 90d statsPeriod and absolute periods.

In this PR we hide these options from the global selection header to avoid any confusion. We could display these options as upsells on getsentry side, but this page is already pretty filled with those in this particular scenario.