### PR TITLE
fix(ui): Collapse Images Loaded section

### DIFF
--- a/static/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -65,6 +65,7 @@ type State = {
   filteredImagesByFilter: Images;
   filterOptions: FilterOptions;
   scrollbarWidth: number;
+  isOpen: boolean;
   panelTableHeight?: number;
 };
 
@@ -81,6 +82,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
   state: State = {
     searchTerm: '',
     scrollbarWidth: 0,
+    isOpen: false,
     filterOptions: {},
     filteredImages: [],
     filteredImagesByFilter: [],
@@ -99,7 +101,10 @@ class DebugMeta extends React.PureComponent<Props, State> {
   }
 
   componentDidUpdate(_prevProps: Props, prevState: State) {
-    if (prevState.filteredImages.length === 0 && this.state.filteredImages.length > 0) {
+    if (
+      this.state.isOpen ||
+      (prevState.filteredImages.length === 0 && this.state.filteredImages.length > 0)
+    ) {
       this.getPanelBodyHeight();
     }
 
@@ -255,6 +260,12 @@ class DebugMeta extends React.PureComponent<Props, State> {
         onClose: this.handleCloseImageDetailsModal,
       }
     );
+  };
+
+  toggleImagesLoaded = () => {
+    this.setState(state => ({
+      isOpen: !state.isOpen,
+    }));
   };
 
   getPanelBodyHeight() {
@@ -507,6 +518,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
       searchTerm,
       filterOptions,
       scrollbarWidth,
+      isOpen,
       filteredImagesByFilter: filteredImages,
     } = this.state;
     const {data} = this.props;
@@ -518,8 +530,16 @@ class DebugMeta extends React.PureComponent<Props, State> {
 
     const displayFilter = (Object.values(filterOptions ?? {})[0] ?? []).length > 1;
 
+    const actions = (
+      <div>
+        <ToggleButton onClick={this.toggleImagesLoaded} priority="link">
+          {isOpen ? t('Hide Details') : t('Show Details')}
+        </ToggleButton>
+      </div>
+    );
+
     return (
-      <StyledEventDataSection
+      <EventDataSection
         type="images-loaded"
         title={
           <TitleWrapper>
@@ -535,47 +555,41 @@ class DebugMeta extends React.PureComponent<Props, State> {
             />
           </TitleWrapper>
         }
-        actions={
-          <StyledSearchBarAction
-            placeholder={t('Search images loaded')}
-            onChange={value => this.handleChangeSearchTerm(value)}
-            query={searchTerm}
-            filter={
-              displayFilter ? (
-                <SearchBarActionFilter
-                  onChange={this.handleChangeFilter}
-                  options={filterOptions}
-                />
-              ) : undefined
-            }
-          />
-        }
+        actions={actions}
         wrapTitle={false}
         isCentered
       >
-        <StyledPanelTable
-          isEmpty={!filteredImages.length}
-          scrollbarWidth={scrollbarWidth}
-          headers={[t('Status'), t('Image'), t('Processing'), t('Details'), '']}
-          {...this.getEmptyMessage()}
-        >
-          <div ref={this.panelTableRef}>{this.renderList()}</div>
-        </StyledPanelTable>
-      </StyledEventDataSection>
+        {isOpen && (
+          <div>
+            <StyledSearchBarAction
+              placeholder={t('Search images loaded')}
+              onChange={value => this.handleChangeSearchTerm(value)}
+              query={searchTerm}
+              filter={
+                displayFilter ? (
+                  <SearchBarActionFilter
+                    onChange={this.handleChangeFilter}
+                    options={filterOptions}
+                  />
+                ) : undefined
+              }
+            />
+            <StyledPanelTable
+              isEmpty={!filteredImages.length}
+              scrollbarWidth={scrollbarWidth}
+              headers={[t('Status'), t('Image'), t('Processing'), t('Details'), '']}
+              {...this.getEmptyMessage()}
+            >
+              <div ref={this.panelTableRef}>{this.renderList()}</div>
+            </StyledPanelTable>
+          </div>
+        )}
+      </EventDataSection>
     );
   }
 }
 
 export default withRouter(DebugMeta);
-
-const StyledEventDataSection = styled(EventDataSection)`
-  padding-bottom: ${space(4)};
-
-  /* to increase specificity */
-  @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    padding-bottom: ${space(2)};
-  }
-`;
 
 const StyledPanelTable = styled(PanelTable)<{scrollbarWidth?: number}>`
   overflow: hidden;
@@ -627,4 +641,14 @@ const StyledList = styled(List as any)<React.ComponentProps<typeof List>>`
 
 const StyledSearchBarAction = styled(SearchBarAction)`
   z-index: 1;
+  margin-bottom: ${space(1)};
+`;
+
+const ToggleButton = styled(Button)`
+  font-weight: 700;
+  color: ${p => p.theme.subText};
+  &:hover,
+  &:focus {
+    color: ${p => p.theme.textColor};
+  }
 `;

--- a/static/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -531,11 +531,9 @@ class DebugMeta extends React.PureComponent<Props, State> {
     const displayFilter = (Object.values(filterOptions ?? {})[0] ?? []).length > 1;
 
     const actions = (
-      <div>
-        <ToggleButton onClick={this.toggleImagesLoaded} priority="link">
-          {isOpen ? t('Hide Details') : t('Show Details')}
-        </ToggleButton>
-      </div>
+      <ToggleButton onClick={this.toggleImagesLoaded} priority="link">
+        {isOpen ? t('Hide Details') : t('Show Details')}
+      </ToggleButton>
     );
 
     return (
@@ -560,7 +558,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
         isCentered
       >
         {isOpen && (
-          <div>
+          <React.Fragment>
             <StyledSearchBarAction
               placeholder={t('Search images loaded')}
               onChange={value => this.handleChangeSearchTerm(value)}
@@ -582,7 +580,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
             >
               <div ref={this.panelTableRef}>{this.renderList()}</div>
             </StyledPanelTable>
-          </div>
+          </React.Fragment>
         )}
       </EventDataSection>
     );


### PR DESCRIPTION
Collapse Images Loaded section on page load and be able to show/hide the images.

[FIXES WOR-1533](https://getsentry.atlassian.net/browse/WOR-1533)
[FIXES GH-30454](https://github.com/getsentry/sentry/issues/30454)

# Before
<img width="859" alt="Screen Shot 2022-01-07 at 12 33 47 AM" src="https://user-images.githubusercontent.com/20312973/148542150-4c78562a-70a5-498b-a003-7a5bd1fa1922.png">

# After

### Collapsed
<img width="872" alt="Screen Shot 2022-01-07 at 3 53 16 AM" src="https://user-images.githubusercontent.com/20312973/148542090-ad97ba57-9119-4372-a937-91b8a435ed7f.png">

### Expanded
<img width="866" alt="Screen Shot 2022-01-07 at 3 53 25 AM" src="https://user-images.githubusercontent.com/20312973/148542129-c1269f9b-f388-4139-bfd5-05bb2b254a11.png">

