### PR TITLE
feat: Add endpoints for managing user roles

### DIFF
--- a/src/sentry/api/endpoints/user_permission_details.py
+++ b/src/sentry/api/endpoints/user_permission_details.py
@@ -1,34 +1,76 @@
+import logging
+
+from django.conf import settings
 from django.db import IntegrityError, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
+from sentry.api.decorators import sudo_required
+from sentry.api.permissions import SuperuserPermission
 from sentry.models import UserPermission
+
+audit_logger = logging.getLogger("sentry.audit.user")
 
 
 class UserPermissionDetailsEndpoint(UserEndpoint):
+    permission_classes = (SuperuserPermission,)
+
     def get(self, request: Request, user, permission_name) -> Response:
+        # XXX(dcramer): we may decide to relax "view" permission over time, but being more restrictive by default
+        # is preferred
+        if not request.access.has_permission("users.admin"):
+            return self.respond(status=403)
+
         has_perm = UserPermission.objects.filter(user=user, permission=permission_name).exists()
         return self.respond(status=204 if has_perm else 404)
 
+    @sudo_required
     def post(self, request: Request, user, permission_name) -> Response:
         if not request.access.has_permission("users.admin"):
             return self.respond(status=403)
 
+        if permission_name not in settings.SENTRY_USER_PERMISSIONS:
+            return self.respond(
+                {"detail": f"'{permission_name}' is not a known permission."}, status=404
+            )
+
         try:
             with transaction.atomic():
                 UserPermission.objects.create(user=user, permission=permission_name)
+                audit_logger.info(
+                    "user.add-permission",
+                    extra={
+                        "actor_id": request.user.id,
+                        "user_id": user.id,
+                        "permission_name": permission_name,
+                    },
+                )
         except IntegrityError as e:
             if "already exists" in str(e):
                 return self.respond(status=410)
             raise
         return self.respond(status=201)
 
+    @sudo_required
     def delete(self, request: Request, user, permission_name) -> Response:
         if not request.access.has_permission("users.admin"):
             return self.respond(status=403)
 
-        deleted, _ = UserPermission.objects.filter(user=user, permission=permission_name).delete()
+        with transaction.atomic():
+            deleted, _ = UserPermission.objects.filter(
+                user=user, permission=permission_name
+            ).delete()
+            if deleted:
+                audit_logger.info(
+                    "user.delete-permission",
+                    extra={
+                        "actor_id": request.user.id,
+                        "user_id": user.id,
+                        "permission_name": permission_name,
+                    },
+                )
+
         if deleted:
             return self.respond(status=204)
         return self.respond(status=404)

--- a/src/sentry/api/endpoints/user_permissions.py
+++ b/src/sentry/api/endpoints/user_permissions.py
@@ -2,10 +2,13 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
+from sentry.api.permissions import SuperuserPermission
 from sentry.models import UserPermission
 
 
 class UserPermissionsEndpoint(UserEndpoint):
+    permission_classes = (SuperuserPermission,)
+
     def get(self, request: Request, user) -> Response:
         permission_list = list(UserPermission.objects.filter(user=user))
         return self.respond([p.permission for p in permission_list])

--- a/src/sentry/api/endpoints/user_permissions_config.py
+++ b/src/sentry/api/endpoints/user_permissions_config.py
@@ -3,9 +3,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
+from sentry.api.permissions import SuperuserPermission
 
 
 class UserPermissionsConfigEndpoint(UserEndpoint):
+    permission_classes = (SuperuserPermission,)
+
     def get(self, request: Request, user) -> Response:
         """
         List all available permissions that can be applied to a user.

--- a/src/sentry/api/endpoints/user_role_details.py
+++ b/src/sentry/api/endpoints/user_role_details.py
@@ -1,0 +1,79 @@
+import logging
+
+from django.db import IntegrityError, transaction
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.bases.user import UserEndpoint
+from sentry.api.decorators import sudo_required
+from sentry.api.permissions import SuperuserPermission
+from sentry.api.serializers import serialize
+from sentry.models import UserRole
+
+audit_logger = logging.getLogger("sentry.audit.user")
+
+
+class UserUserRoleDetailsEndpoint(UserEndpoint):
+    permission_classes = (SuperuserPermission,)
+
+    def get(self, request: Request, user, role_name) -> Response:
+        # XXX(dcramer): we may decide to relax "view" permission over time, but being more restrictive by default
+        # is preferred
+        if not request.access.has_permission("users.admin"):
+            return self.respond(status=403)
+
+        try:
+            role = UserRole.objects.get(users=user, name=role_name)
+        except UserRole.DoesNotExist:
+            return self.respond({"detail": f"'{role_name}' is not a known role."}, status=404)
+        return self.respond(serialize(role, request.user))
+
+    @sudo_required
+    def post(self, request: Request, user, role_name) -> Response:
+        if not request.access.has_permission("users.admin"):
+            return self.respond(status=403)
+
+        try:
+            role = UserRole.objects.get(name=role_name)
+        except UserRole.DoesNotExist:
+            return self.respond({"detail": f"'{role_name}' is not a known role."}, status=404)
+
+        try:
+            with transaction.atomic():
+                role.users.add(user)
+                audit_logger.info(
+                    "user.add-role",
+                    extra={
+                        "actor_id": request.user.id,
+                        "user_id": user.id,
+                        "role_id": role.id,
+                    },
+                )
+        except IntegrityError as e:
+            # TODO(dcramer): this path never gets hit because Django's M2M doesnt expose a failure scenario on `add``
+            if "already exists" in str(e):
+                return self.respond(status=410)
+            raise
+        return self.respond(status=201)
+
+    @sudo_required
+    def delete(self, request: Request, user, role_name) -> Response:
+        if not request.access.has_permission("users.admin"):
+            return self.respond(status=403)
+
+        try:
+            role = UserRole.objects.get(users=user, name=role_name)
+        except UserRole.DoesNotExist:
+            return self.respond({"detail": f"'{role_name}' is not a known role."}, status=404)
+
+        with transaction.atomic():
+            role.users.remove(user)
+            audit_logger.info(
+                "user.remove-role",
+                extra={
+                    "actor_id": request.user.id,
+                    "user_id": user.id,
+                    "role_id": role.id,
+                },
+            )
+        return self.respond(status=204)

--- a/src/sentry/api/endpoints/user_roles.py
+++ b/src/sentry/api/endpoints/user_roles.py
@@ -1,0 +1,20 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.bases.user import UserEndpoint
+from sentry.api.permissions import SuperuserPermission
+from sentry.api.serializers import serialize
+from sentry.models import UserRole
+
+
+class UserUserRolesEndpoint(UserEndpoint):
+    permission_classes = (SuperuserPermission,)
+
+    def get(self, request: Request, user) -> Response:
+        # XXX(dcramer): we may decide to relax "view" permission over time, but being more restrictive by default
+        # is preferred
+        if not request.access.has_permission("users.admin"):
+            return self.respond(status=403)
+
+        role_list = list(UserRole.objects.filter(users=user))
+        return self.respond(serialize(role_list, request.user))

--- a/src/sentry/api/endpoints/userroles_details.py
+++ b/src/sentry/api/endpoints/userroles_details.py
@@ -1,0 +1,89 @@
+import logging
+
+from django.db import IntegrityError, transaction
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+from sentry.api.decorators import sudo_required
+from sentry.api.permissions import SuperuserPermission
+from sentry.api.serializers import serialize
+from sentry.api.validators.userrole import UserRoleValidator
+from sentry.models import UserRole
+
+audit_logger = logging.getLogger("sentry.audit.user")
+
+
+class UserRoleDetailsEndpoint(Endpoint):
+    permission_classes = (SuperuserPermission,)
+
+    @sudo_required
+    def get(self, request: Request, role_name) -> Response:
+        # XXX(dcramer): we may decide to relax "view" permission over time, but being more restrictive by default
+        # is preferred
+        if not request.access.has_permission("users.admin"):
+            return self.respond(status=403)
+
+        try:
+            role = UserRole.objects.get(name=role_name)
+        except UserRole.DoesNotExist:
+            return self.respond({"detail": f"'{role_name}' is not a known role."}, status=404)
+        return self.respond(serialize(role, user=request.user))
+
+    @sudo_required
+    def put(self, request: Request, role_name) -> Response:
+        if not request.access.has_permission("users.admin"):
+            return self.respond(status=403)
+
+        try:
+            role = UserRole.objects.get(name=role_name)
+        except UserRole.DoesNotExist:
+            return self.respond({"detail": f"'{role_name}' is not a known role."}, status=404)
+
+        validator = UserRoleValidator(data=request.data, partial=True)
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
+
+        result = validator.validated_data
+        try:
+            with transaction.atomic():
+                if "name" in result:
+                    role.name = result["name"]
+                if "permissions" in result:
+                    role.permissions = result["permissions"]
+                role.save(update_fields=result.keys())
+                audit_logger.info(
+                    "user-roles.edit",
+                    extra={
+                        "actor_id": request.user.id,
+                        "role_id": role.id,
+                        "form_data": request.data,
+                    },
+                )
+        except IntegrityError as e:
+            if "already exists" in str(e):
+                return self.respond(status=410)
+            raise
+
+        return self.respond(serialize(role, user=request.user))
+
+    @sudo_required
+    def delete(self, request: Request, role_name) -> Response:
+        if not request.access.has_permission("users.admin"):
+            return self.respond(status=403)
+
+        try:
+            role = UserRole.objects.get(name=role_name)
+        except UserRole.DoesNotExist:
+            return self.respond({"detail": f"'{role_name}' is not a known role."}, status=404)
+
+        with transaction.atomic():
+            role.delete()
+            audit_logger.info(
+                "user-roles.delete",
+                extra={
+                    "actor_id": request.user.id,
+                    "role_id": role.id,
+                },
+            )
+        return self.respond(status=204)

--- a/src/sentry/api/endpoints/userroles_index.py
+++ b/src/sentry/api/endpoints/userroles_index.py
@@ -1,0 +1,63 @@
+import logging
+
+from django.db import IntegrityError, transaction
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+from sentry.api.decorators import sudo_required
+from sentry.api.permissions import SuperuserPermission
+from sentry.api.serializers import serialize
+from sentry.api.validators.userrole import UserRoleValidator
+from sentry.models import UserRole
+
+audit_logger = logging.getLogger("sentry.audit.user")
+
+
+class UserRolesEndpoint(Endpoint):
+    permission_classes = (SuperuserPermission,)
+
+    def get(self, request: Request) -> Response:
+        """
+        Return a list of `UserRole`'s.
+        """
+        # XXX(dcramer): we may decide to relax "view" permission over time, but being more restrictive by default
+        # is preferred
+        if not request.access.has_permission("users.admin"):
+            return self.respond(status=403)
+
+        role_list = list(UserRole.objects.all())
+        return self.respond(serialize(role_list, user=request.user))
+
+    @sudo_required
+    def post(self, request: Request) -> Response:
+        """
+        Create a new `UserRole`.
+        """
+        if not request.access.has_permission("users.admin"):
+            return self.respond(status=403)
+
+        validator = UserRoleValidator(data=request.data)
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
+
+        result = validator.validated_data
+        try:
+            with transaction.atomic():
+                role = UserRole.objects.create(
+                    name=result["name"], permissions=result.get("permissions") or []
+                )
+                audit_logger.info(
+                    "user-roles.create",
+                    extra={
+                        "actor_id": request.user.id,
+                        "role_id": role.id,
+                        "form_data": request.data,
+                    },
+                )
+        except IntegrityError as e:
+            if "already exists" in str(e):
+                return self.respond(status=410)
+            raise
+
+        return self.respond(serialize(role, user=request.user), status=201)

--- a/src/sentry/api/serializers/models/userrole.py
+++ b/src/sentry/api/serializers/models/userrole.py
@@ -1,0 +1,14 @@
+from sentry.api.serializers import Serializer, register
+from sentry.models import UserRole
+
+
+@register(UserRole)
+class UserRoleSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            "id": str(obj.id),
+            "name": obj.name,
+            "permissions": obj.permissions,
+            "dateCreated": obj.date_added,
+            "dateUpdated": obj.date_updated,
+        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -440,10 +440,14 @@ from .endpoints.user_password import UserPasswordEndpoint
 from .endpoints.user_permission_details import UserPermissionDetailsEndpoint
 from .endpoints.user_permissions import UserPermissionsEndpoint
 from .endpoints.user_permissions_config import UserPermissionsConfigEndpoint
+from .endpoints.user_role_details import UserUserRoleDetailsEndpoint
+from .endpoints.user_roles import UserUserRolesEndpoint
 from .endpoints.user_social_identities_index import UserSocialIdentitiesIndexEndpoint
 from .endpoints.user_social_identity_details import UserSocialIdentityDetailsEndpoint
 from .endpoints.user_subscriptions import UserSubscriptionsEndpoint
 from .endpoints.useravatar import UserAvatarEndpoint
+from .endpoints.userroles_details import UserRoleDetailsEndpoint
+from .endpoints.userroles_index import UserRolesEndpoint
 
 # issues endpoints are available both top level (by numerical ID) as well as coupled
 # to the organization (and queryable via short ID)
@@ -718,6 +722,16 @@ urlpatterns = [
                     name="sentry-api-0-user-permission-details",
                 ),
                 url(
+                    r"^(?P<user_id>[^\/]+)/roles/$",
+                    UserUserRolesEndpoint.as_view(),
+                    name="sentry-api-0-user-userroles",
+                ),
+                url(
+                    r"^(?P<user_id>[^\/]+)/roles/(?P<role_name>[^\/]+)/$",
+                    UserUserRoleDetailsEndpoint.as_view(),
+                    name="sentry-api-0-user-userrole-details",
+                ),
+                url(
                     r"^(?P<user_id>[^\/]+)/social-identities/$",
                     UserSocialIdentitiesIndexEndpoint.as_view(),
                     name="sentry-api-0-user-social-identities-index",
@@ -746,6 +760,24 @@ urlpatterns = [
                     r"^(?P<user_id>[^\/]+)/user-identities/(?P<category>[\w-]+)/(?P<identity_id>[^\/]+)/$",
                     UserIdentityConfigDetailsEndpoint.as_view(),
                     name="sentry-api-0-user-identity-config-details",
+                ),
+            ]
+        ),
+    ),
+    # UserRoles
+    url(
+        r"^userroles/",
+        include(
+            [
+                url(
+                    r"^$",
+                    UserRolesEndpoint.as_view(),
+                    name="sentry-api-0-userroles",
+                ),
+                url(
+                    r"^(?P<role_name>[^\/]+)/$",
+                    UserRoleDetailsEndpoint.as_view(),
+                    name="sentry-api-0-userroles-details",
                 ),
             ]
         ),

--- a/src/sentry/api/validators/userrole.py
+++ b/src/sentry/api/validators/userrole.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+from rest_framework import serializers
+
+
+class UserRoleValidator(serializers.Serializer):
+    name = serializers.CharField()
+    permissions = serializers.ListField(child=serializers.CharField(), required=False)
+
+    def validate_permissions(self, value):
+        if not value:
+            return value
+
+        for name in value:
+            if name not in settings.SENTRY_USER_PERMISSIONS:
+                raise serializers.ValidationError(f"'{name}' is not a known permission.")
+        return value

--- a/tests/sentry/api/endpoints/test_user_permissions.py
+++ b/tests/sentry/api/endpoints/test_user_permissions.py
@@ -2,19 +2,19 @@ from sentry.models import UserPermission
 from sentry.testutils import APITestCase
 
 
-class UserPermissionsConfigTest(APITestCase):
+class UserPermissionsTest(APITestCase):
     endpoint = "sentry-api-0-user-permissions"
 
     def setUp(self):
         super().setUp()
-        self.user = self.create_user()
-        self.login_as(user=self.user)
+        self.user = self.create_user(is_superuser=True)
+        self.login_as(user=self.user, superuser=True)
+        self.add_user_permission(self.user, "users.admin")
 
 
-class UserPermissionsGetTest(UserPermissionsConfigTest):
+class UserPermissionsGetTest(UserPermissionsTest):
     def test_lookup_self(self):
         UserPermission.objects.create(user=self.user, permission="broadcasts.admin")
-        UserPermission.objects.create(user=self.user, permission="users.admin")
         resp = self.get_response("me")
         assert resp.status_code == 200
         assert len(resp.data) == 2, resp.data

--- a/tests/sentry/api/endpoints/test_user_permissions_config.py
+++ b/tests/sentry/api/endpoints/test_user_permissions_config.py
@@ -6,8 +6,9 @@ class UserPermissionsConfigTest(APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.user = self.create_user()
-        self.login_as(user=self.user)
+        self.user = self.create_user(is_superuser=True)
+        self.login_as(user=self.user, superuser=True)
+        self.add_user_permission(self.user, "users.admin")
 
 
 class UserPermissionsConfigGetTest(UserPermissionsConfigTest):

--- a/tests/sentry/api/endpoints/test_user_role_details.py
+++ b/tests/sentry/api/endpoints/test_user_role_details.py
@@ -1,0 +1,93 @@
+import pytest
+
+from sentry.models import UserRole
+from sentry.testutils import APITestCase
+
+
+class PermissionTestMixin:
+    def test_fails_without_superuser(self):
+        self.user = self.create_user(is_superuser=False)
+        self.login_as(self.user)
+
+        UserRole.objects.create(name="test-role")
+        resp = self.get_response("me", "test-role")
+        assert resp.status_code == 403
+
+        self.user.update(is_superuser=True)
+        resp = self.get_response("me", "test-role")
+        assert resp.status_code == 403
+
+    def test_fails_without_users_admin_permission(self):
+        self.user = self.create_user(is_superuser=True)
+        self.login_as(self.user, superuser=True)
+        resp = self.get_response("me", "test-role")
+        assert resp.status_code == 403
+
+
+class UserUserRolesTest(APITestCase, PermissionTestMixin):
+    endpoint = "sentry-api-0-user-userrole-details"
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user(is_superuser=True)
+        self.login_as(user=self.user, superuser=True)
+        self.add_user_permission(self.user, "users.admin")
+
+
+class UserUserRolesDetailsTest(UserUserRolesTest, PermissionTestMixin):
+    def test_lookup_self(self):
+        role = UserRole.objects.create(name="support", permissions=["broadcasts.admin"])
+        role.users.add(self.user)
+        role2 = UserRole.objects.create(name="admin", permissions=["users.admin"])
+        role2.users.add(self.user)
+        resp = self.get_response("me", "support")
+        assert resp.status_code == 200
+        assert resp.data["name"] == "support"
+
+
+class UserUserRolesCreateTest(UserUserRolesTest, PermissionTestMixin):
+    method = "POST"
+
+    def test_adds_role(self):
+        UserRole.objects.create(name="support", permissions=["broadcasts.admin"])
+        UserRole.objects.create(name="admin", permissions=["users.admin"])
+        resp = self.get_response("me", "support")
+        assert resp.status_code == 201
+        assert UserRole.objects.filter(users=self.user, name="support").exists()
+        assert not UserRole.objects.filter(users=self.user, name="admin").exists()
+
+    def test_invalid_role(self):
+        UserRole.objects.create(name="other", permissions=["users.edit"])
+        resp = self.get_response("me", "blah")
+        assert resp.status_code == 404
+
+    @pytest.mark.xfail
+    def test_existing_role(self):
+        role = UserRole.objects.create(name="support", permissions=["broadcasts.admin"])
+        role.users.add(self.user)
+        resp = self.get_response("me", "support")
+        assert resp.status_code == 410
+
+
+class UserUserRolesDeleteTest(UserUserRolesTest, PermissionTestMixin):
+    method = "DELETE"
+
+    def test_removes_role(self):
+        role = UserRole.objects.create(name="support", permissions=["broadcasts.admin"])
+        role.users.add(self.user)
+        role2 = UserRole.objects.create(name="admin", permissions=["users.admin"])
+        role2.users.add(self.user)
+        resp = self.get_response("me", "support")
+        assert resp.status_code == 204
+        assert not UserRole.objects.filter(users=self.user, name="support").exists()
+        assert UserRole.objects.filter(users=self.user, name="admin").exists()
+
+    def test_invalid_role(self):
+        UserRole.objects.create(name="other", permissions=["users.edit"])
+        resp = self.get_response("me", "blah")
+        assert resp.status_code == 404
+
+    def test_nonexistant_role(self):
+        UserRole.objects.create(name="support", permissions=["broadcasts.admin"])
+        resp = self.get_response("me", "support")
+        assert resp.status_code == 404

--- a/tests/sentry/api/endpoints/test_user_roles.py
+++ b/tests/sentry/api/endpoints/test_user_roles.py
@@ -1,0 +1,47 @@
+from sentry.models import UserRole
+from sentry.testutils import APITestCase
+
+
+class PermissionTestMixin:
+    def test_fails_without_superuser(self):
+        self.user = self.create_user(is_superuser=False)
+        self.login_as(self.user)
+
+        UserRole.objects.create(name="test-role")
+        resp = self.get_response("me")
+        assert resp.status_code == 403
+
+        self.user.update(is_superuser=True)
+        resp = self.get_response("me")
+        assert resp.status_code == 403
+
+    def test_fails_without_users_admin_permission(self):
+        self.user = self.create_user(is_superuser=True)
+        self.login_as(self.user, superuser=True)
+        resp = self.get_response("me")
+        assert resp.status_code == 403
+
+
+class UserUserRolesTest(APITestCase):
+    endpoint = "sentry-api-0-user-userroles"
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user(is_superuser=True)
+        self.login_as(user=self.user, superuser=True)
+        self.add_user_permission(self.user, "users.admin")
+
+
+class UserUserRolesGetTest(UserUserRolesTest, PermissionTestMixin):
+    def test_lookup_self(self):
+        role = UserRole.objects.create(name="support", permissions=["broadcasts.admin"])
+        role.users.add(self.user)
+        role2 = UserRole.objects.create(name="admin", permissions=["users.admin"])
+        role2.users.add(self.user)
+        UserRole.objects.create(name="other", permissions=["users.edit"])
+        resp = self.get_response("me")
+        assert resp.status_code == 200
+        assert len(resp.data) == 2, resp.data
+        role_names = [r["name"] for r in resp.data]
+        assert "support" in role_names
+        assert "admin" in role_names

--- a/tests/sentry/api/endpoints/test_userroles_details.py
+++ b/tests/sentry/api/endpoints/test_userroles_details.py
@@ -1,0 +1,69 @@
+from sentry.models import UserRole
+from sentry.testutils import APITestCase
+
+
+class PermissionTestMixin:
+    def test_fails_without_superuser(self):
+        self.user = self.create_user(is_superuser=False)
+        self.login_as(self.user)
+
+        UserRole.objects.create(name="test-role")
+        resp = self.get_response("test-role")
+        assert resp.status_code == 403
+
+        self.user.update(is_superuser=True)
+        resp = self.get_response("test-role")
+        assert resp.status_code == 403
+
+    def test_fails_without_users_admin_permission(self):
+        self.user = self.create_user(is_superuser=True)
+        self.login_as(self.user, superuser=True)
+        resp = self.get_response("test-role")
+        assert resp.status_code == 403
+
+
+class UserRolesDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-userroles-details"
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user(is_superuser=True)
+        self.login_as(user=self.user, superuser=True)
+        self.add_user_permission(self.user, "users.admin")
+
+
+class UserRolesDetailsGetTest(PermissionTestMixin, UserRolesDetailsTest):
+    def test_simple(self):
+        UserRole.objects.create(name="test-role")
+        UserRole.objects.create(name="test-role2")
+        resp = self.get_response("test-role")
+        assert resp.status_code == 200
+        assert resp.data["name"] == "test-role"
+
+
+class UserRolesDetailsPutTest(PermissionTestMixin, UserRolesDetailsTest):
+    method = "PUT"
+
+    def test_simple(self):
+        role1 = UserRole.objects.create(name="test-role", permissions=["users.edit"])
+        role2 = UserRole.objects.create(name="test-role2", permissions=["users.edit"])
+        resp = self.get_response("test-role", permissions=["users.admin"])
+        assert resp.status_code == 200
+
+        role1 = UserRole.objects.get(id=role1.id)
+        assert role1.permissions == ["users.admin"]
+        role2 = UserRole.objects.get(id=role2.id)
+        assert role2.permissions == ["users.edit"]
+
+
+class UserRolesDetailsDeleteTest(PermissionTestMixin, UserRolesDetailsTest):
+    method = "DELETE"
+
+    def test_simple(self):
+        role1 = UserRole.objects.create(name="test-role")
+        role2 = UserRole.objects.create(name="test-role2")
+        resp = self.get_response("test-role")
+        assert resp.status_code == 204
+
+        assert not UserRole.objects.filter(id=role1.id).exists()
+        assert UserRole.objects.filter(id=role2.id).exists()

--- a/tests/sentry/api/endpoints/test_userroles_index.py
+++ b/tests/sentry/api/endpoints/test_userroles_index.py
@@ -1,0 +1,57 @@
+from sentry.models import UserRole
+from sentry.testutils import APITestCase
+
+
+class PermissionTestMixin:
+    def test_fails_without_superuser(self):
+        self.user = self.create_user(is_superuser=False)
+        self.login_as(self.user)
+
+        UserRole.objects.create(name="test-role")
+        resp = self.get_response(name="test-role")
+        assert resp.status_code == 403
+
+        self.user.update(is_superuser=True)
+        resp = self.get_response(name="test-role")
+        assert resp.status_code == 403
+
+    def test_fails_without_users_admin_permission(self):
+        self.user = self.create_user(is_superuser=True)
+        self.login_as(self.user, superuser=True)
+        resp = self.get_response(name="test-role")
+        assert resp.status_code == 403
+
+
+class UserRolesTest(APITestCase):
+    endpoint = "sentry-api-0-userroles"
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user(is_superuser=True)
+        self.login_as(user=self.user, superuser=True)
+        self.add_user_permission(self.user, "users.admin")
+
+
+class UserRolesGetTest(UserRolesTest, PermissionTestMixin):
+    def test_simple(self):
+        UserRole.objects.create(name="test-role")
+        resp = self.get_response()
+        assert resp.status_code == 200
+        assert len(resp.data) == 1, resp.data
+        assert "test-role" in [r["name"] for r in resp.data]
+
+
+class UserRolesPostTest(UserRolesTest, PermissionTestMixin):
+    method = "POST"
+
+    def test_simple(self):
+        resp = self.get_response(name="test-role", permissions=["users.admin"])
+        assert resp.status_code == 201
+        assert resp.data["name"] == "test-role"
+        role = UserRole.objects.get(name="test-role")
+        assert role.permissions == ["users.admin"]
+
+    def test_already_exists(self):
+        UserRole.objects.create(name="test-role")
+        resp = self.get_response(name="test-role")
+        assert resp.status_code == 410


### PR DESCRIPTION
- Add endpoints for creating, updating, deleting user roles.
- Add endpoints for assigning and unassigning roles from users.
- Add permission validation to endpoints (permissions now must be known).
- Add sudo/superuser requirements to various endpoints involving permissions.
- Add standard audit logs to all permission related endpoints.

Additionally this cleans up the various permission endpoints, improving testing, adding various security (sudo, superuser-only).
