### PR TITLE
test(cleanup): Automatically unmount global modals in jest

### DIFF
--- a/tests/js/sentry-test/modal.jsx
+++ b/tests/js/sentry-test/modal.jsx
@@ -2,10 +2,23 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 
 import GlobalModal from 'sentry/components/globalModal';
 
+const mountedModals = [];
+
 export async function mountGlobalModal(context) {
   const modal = mountWithTheme(<GlobalModal />, context);
+  mountedModals.push(modal);
   await tick();
   modal.update();
 
   return modal;
 }
+
+afterEach(() => {
+  while (mountedModals.length) {
+    const modal = mountedModals.pop();
+    if (modal.length === 1) {
+      // modal is still mounted
+      modal.unmount();
+    }
+  }
+});

--- a/tests/js/sentry-test/modal.jsx
+++ b/tests/js/sentry-test/modal.jsx
@@ -16,7 +16,7 @@ export async function mountGlobalModal(context) {
 afterEach(() => {
   while (mountedModals.length) {
     const modal = mountedModals.pop();
-    if (modal.length === 1) {
+    if (modal.exists()) {
       // modal is still mounted
       modal.unmount();
     }

--- a/tests/js/spec/components/modals/reprocessEventModal.spec.tsx
+++ b/tests/js/spec/components/modals/reprocessEventModal.spec.tsx
@@ -30,7 +30,7 @@ async function renderComponent() {
 describe('ReprocessEventModal', function () {
   let wrapper: any;
 
-  beforeAll(async function () {
+  beforeEach(async function () {
     wrapper = await renderComponent();
   });
 


### PR DESCRIPTION
We often unmount components, but forget to cleanup the global modal. This PR keeps track of which modals are mounted and if it's still mounted, call `unmount` on them after each test.