### PR TITLE
fix(ui-component): Encode body in response header

### DIFF
--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -64,7 +64,7 @@ class AlertRuleActionRequester(Mediator):
         return {
             "Content-Type": "application/json",
             "Request-ID": request_uuid,
-            "Sentry-App-Signature": self.sentry_app.build_signature(""),
+            "Sentry-App-Signature": self.sentry_app.build_signature(self.body),
         }
 
     @memoize

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -61,7 +61,7 @@ class TestAlertRuleActionRequester(TestCase):
         assert payload == data
 
         assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
-            json.dumps(data)
+            json.dumps(payload)
         )
 
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -48,7 +48,7 @@ class TestAlertRuleActionRequester(TestCase):
         assert result["success"]
 
         request = responses.calls[0].request
-        assert request.headers["Sentry-App-Signature"]
+
         data = {
             "fields": {
                 "title": "An Alert",
@@ -59,6 +59,10 @@ class TestAlertRuleActionRequester(TestCase):
         }
         payload = json.loads(request.body)
         assert payload == data
+
+        assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
+            json.dumps(data)
+        )
 
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
         requests = buffer.get_requests()

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -56,7 +56,6 @@ class TestIssueLinkRequester(TestCase):
         }
 
         request = responses.calls[0].request
-        assert request.headers["Sentry-App-Signature"]
         data = {
             "fields": {"title": "An Issue", "description": "a bug was found", "assignee": "user-1"},
             "issueId": self.group.id,
@@ -67,7 +66,9 @@ class TestIssueLinkRequester(TestCase):
         }
         payload = json.loads(request.body)
         assert payload == data
-
+        assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
+            json.dumps(data)
+        )
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
         requests = buffer.get_requests()
 

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -67,7 +67,7 @@ class TestIssueLinkRequester(TestCase):
         payload = json.loads(request.body)
         assert payload == data
         assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
-            json.dumps(data)
+            json.dumps(payload)
         )
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
         requests = buffer.get_requests()

--- a/tests/sentry/mediators/external_requests/test_select_requester.py
+++ b/tests/sentry/mediators/external_requests/test_select_requester.py
@@ -44,8 +44,7 @@ class TestSelectRequester(TestCase):
         }
 
         request = responses.calls[0].request
-        assert request.headers["Sentry-App-Signature"]
-
+        assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature("")
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
         requests = buffer.get_requests()
 


### PR DESCRIPTION
## Objective:
Currently we don't encode the response body data in the response header `Sentry-App-Signature` for Alert Rule Actions. This does not follow our existing convention for other UI Components and Webhooks.

## Tests
Updated tests for the requester mediators to check for a valid response header `Sentry-App-Signature` if they are used for POST requests. GET method requester mediators do not have a response body that needs to be validated.