### PR TITLE
ref(slack plugin): Don't raise errors for unactionable things

### DIFF
--- a/src/sentry_plugins/slack/client.py
+++ b/src/sentry_plugins/slack/client.py
@@ -26,6 +26,6 @@ class SlackApiClient(ApiClient):
                 path=self.webhook, method="post", data=data, json=False, allow_text=True
             )
         except ApiError as e:
-            # Ignore 4XX from slack webhooks
-            if 401 <= e.code <= 404 or e.text not in IGNORABLE_SLACK_ERRORS:
+            # Ignore 404 and ignorable errors from slack webhooks
+            if e.code != 404 or (e.text and e.text not in IGNORABLE_SLACK_ERRORS):
                 raise e

--- a/src/sentry_plugins/slack/client.py
+++ b/src/sentry_plugins/slack/client.py
@@ -1,6 +1,13 @@
 from sentry.shared_integrations.exceptions import ApiError
 from sentry_plugins.client import ApiClient
 
+IGNORABLE_SLACK_ERRORS = [
+    "channel_is_archived",
+    "invalid_channel",
+    "invalid_token",
+    "action_prohibited",
+]
+
 
 class SlackApiClient(ApiClient):
     plugin_name = "slack"
@@ -19,6 +26,6 @@ class SlackApiClient(ApiClient):
                 path=self.webhook, method="post", data=data, json=False, allow_text=True
             )
         except ApiError as e:
-            # Ignore 404 from slack webhooks
-            if e.code != 404:
+            # Ignore 4XX from slack webhooks
+            if 401 <= e.code <= 404 or e.text not in IGNORABLE_SLACK_ERRORS:
                 raise e

--- a/src/sentry_plugins/slack/client.py
+++ b/src/sentry_plugins/slack/client.py
@@ -27,5 +27,6 @@ class SlackApiClient(ApiClient):
             )
         except ApiError as e:
             # Ignore 404 and ignorable errors from slack webhooks
-            if e.code != 404 or (e.text and e.text not in IGNORABLE_SLACK_ERRORS):
-                raise e
+            if e.text and e.text in IGNORABLE_SLACK_ERRORS or e.code == 404:
+                return
+            raise e


### PR DESCRIPTION
We get [a lot of errors](https://sentry.io/organizations/sentry/issues/2574279737/?project=1) from the Slack plugin (there are others in there like Splunk, but Slack takes up a large majority) for things that are unactionable by us, so we shouldn't raise those errors. I was having trouble replicating this myself (archiving channels and revoking tokens didn't trigger the `ApiError` locally) but I built this list based off of these 2 Slack documents:
https://api.slack.com/messaging/webhooks#handling_errors
https://api.slack.com/changelog/2016-05-17-changes-to-errors-for-incoming-webhooks

I'm open to suggestions on other ways of handling this, but am mainly trying to stop the floodgates of errors.