### PR TITLE
test(ui): Add createHref mock implementation

### DIFF
--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -9,6 +9,7 @@ import Enzyme from 'enzyme'; // eslint-disable-line no-restricted-imports
 import {Location} from 'history';
 import MockDate from 'mockdate';
 import PropTypes from 'prop-types';
+import * as qs from 'query-string';
 
 import type {Client} from 'sentry/__mocks__/api';
 import ConfigStore from 'sentry/stores/configStore';
@@ -167,7 +168,21 @@ const routerFixtures = {
     goForward: jest.fn(),
     setRouteLeaveHook: jest.fn(),
     isActive: jest.fn(),
-    createHref: jest.fn(),
+    createHref: jest.fn().mockImplementation(to => {
+      if (typeof to === 'string') {
+        return to;
+      }
+
+      if (typeof to === 'object') {
+        if (!to.query) {
+          return to.pathname;
+        }
+
+        return `${to.pathname}?${qs.stringify(to.query)}`;
+      }
+
+      return '';
+    }),
     location: TestStubs.location(),
     createPath: jest.fn(),
     routes: [],


### PR DESCRIPTION
In enzyme tests, we sometimes have checked the "to" prop of a `Link` element directly. In RTL this isn't an option. Clicking the element and checking the output via the mocked `router.push` is a decent option. This adds the ability to see the href in the debug as well.

Given this test
```ts
import {mountWithTheme} from 'sentry-test/reactTestingLibrary';

const context = TestStubs.routerContext();
const wrapper = mountWithTheme(
	  <Link to={{pathname: '/path', query: {project: 'abc'}}}>Hello</Link>,
	  {context}
);
wrapper.debug();
```

before
```html
<a>
    Hello
</a>
```

after
```html
<a href="/path?project=abc">
    Hello
</a>
```
