### PR TITLE
feat(discover-templates): Changes preview to a mode of its own

### DIFF
--- a/static/app/views/dashboardsV2/controls.tsx
+++ b/static/app/views/dashboardsV2/controls.tsx
@@ -29,20 +29,9 @@ type Props = {
 };
 
 class Controls extends React.Component<Props> {
-  render() {
-    const {
-      organization,
-      dashboardState,
-      dashboards,
-      widgetLimitReached,
-      onEdit,
-      onCancel,
-      onCommit,
-      onDelete,
-      onAddWidget,
-    } = this.props;
-
-    const cancelButton = (
+  renderCancelButton(label = t('Cancel')) {
+    const {onCancel} = this.props;
+    return (
       <Button
         data-test-id="dashboard-cancel"
         onClick={e => {
@@ -50,14 +39,27 @@ class Controls extends React.Component<Props> {
           onCancel();
         }}
       >
-        {t('Cancel')}
+        {label}
       </Button>
     );
+  }
+
+  render() {
+    const {
+      organization,
+      dashboardState,
+      dashboards,
+      widgetLimitReached,
+      onEdit,
+      onCommit,
+      onDelete,
+      onAddWidget,
+    } = this.props;
 
     if ([DashboardState.EDIT, DashboardState.PENDING_DELETE].includes(dashboardState)) {
       return (
         <StyledButtonBar gap={1} key="edit-controls">
-          {cancelButton}
+          {this.renderCancelButton()}
           <Confirm
             priority="danger"
             message={t('Are you sure you want to delete this dashboard?')}
@@ -82,10 +84,10 @@ class Controls extends React.Component<Props> {
       );
     }
 
-    if (dashboardState === 'create') {
+    if (dashboardState === DashboardState.CREATE) {
       return (
         <StyledButtonBar gap={1} key="create-controls">
-          {cancelButton}
+          {this.renderCancelButton()}
           <Button
             data-test-id="dashboard-commit"
             onClick={e => {
@@ -95,6 +97,24 @@ class Controls extends React.Component<Props> {
             priority="primary"
           >
             {t('Save and Finish')}
+          </Button>
+        </StyledButtonBar>
+      );
+    }
+
+    if (dashboardState === DashboardState.PREVIEW) {
+      return (
+        <StyledButtonBar gap={1} key="preview-controls">
+          {this.renderCancelButton('Go Back')}
+          <Button
+            data-test-id="dashboard-commit"
+            onClick={e => {
+              e.preventDefault();
+              onCommit();
+            }}
+            priority="primary"
+          >
+            {t('Add Dashboard')}
           </Button>
         </StyledButtonBar>
       );

--- a/static/app/views/dashboardsV2/controls.tsx
+++ b/static/app/views/dashboardsV2/controls.tsx
@@ -105,7 +105,7 @@ class Controls extends React.Component<Props> {
     if (dashboardState === DashboardState.PREVIEW) {
       return (
         <StyledButtonBar gap={1} key="preview-controls">
-          {this.renderCancelButton('Go Back')}
+          {this.renderCancelButton(t('Go Back'))}
           <Button
             data-test-id="dashboard-commit"
             onClick={e => {

--- a/static/app/views/dashboardsV2/create.tsx
+++ b/static/app/views/dashboardsV2/create.tsx
@@ -34,6 +34,7 @@ function CreateDashboard(props: Props) {
     ? DASHBOARDS_TEMPLATES.find(dashboardTemplate => dashboardTemplate.id === templateId)
     : undefined;
   const dashboard = template ? cloneDashboard(template) : cloneDashboard(EMPTY_DASHBOARD);
+  const initialState = template ? DashboardState.PREVIEW : DashboardState.CREATE;
   useEffect(() => {
     const constructedWidget = constructWidgetFromQuery(location.query);
     setNewWidget(constructedWidget);
@@ -49,7 +50,7 @@ function CreateDashboard(props: Props) {
     >
       <DashboardDetail
         {...props}
-        initialState={DashboardState.CREATE}
+        initialState={initialState}
         dashboard={dashboard}
         dashboards={[]}
         newWidget={newWidget}

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -66,6 +66,7 @@ type Props = {
   router: InjectedRouter;
   location: Location;
   widgetLimitReached: boolean;
+  isPreview?: boolean;
   /**
    * Fired when widgets are added/removed/sorted.
    */
@@ -307,7 +308,7 @@ class Dashboard extends Component<Props, State> {
 
   renderWidget(widget: Widget, index: number) {
     const {isMobile} = this.state;
-    const {isEditing, organization, widgetLimitReached} = this.props;
+    const {isEditing, organization, widgetLimitReached, isPreview} = this.props;
 
     const widgetProps = {
       widget,
@@ -316,6 +317,7 @@ class Dashboard extends Component<Props, State> {
       onDelete: this.handleDeleteWidget(widget),
       onEdit: this.handleEditWidget(widget, index),
       onDuplicate: this.handleDuplicateWidget(widget, index),
+      isPreview,
     };
 
     if (organization.features.includes('dashboard-grid-layout')) {

--- a/static/app/views/dashboardsV2/sortableWidget.tsx
+++ b/static/app/views/dashboardsV2/sortableWidget.tsx
@@ -20,6 +20,7 @@ type Props = {
   widgetLimitReached: boolean;
   organization: Organization;
   hideDragHandle?: boolean;
+  isPreview?: boolean;
 };
 
 function SortableWidget(props: Props) {
@@ -33,6 +34,7 @@ function SortableWidget(props: Props) {
     onDelete,
     onEdit,
     onDuplicate,
+    isPreview,
   } = props;
 
   const {
@@ -70,6 +72,7 @@ function SortableWidget(props: Props) {
     hideToolbar: isSorting,
     currentWidgetDragging,
     showContextMenu: true,
+    isPreview,
   };
 
   if (organization.features.includes('dashboard-grid-layout')) {

--- a/static/app/views/dashboardsV2/types.tsx
+++ b/static/app/views/dashboardsV2/types.tsx
@@ -66,6 +66,7 @@ export enum DashboardState {
   EDIT = 'edit',
   CREATE = 'create',
   PENDING_DELETE = 'pending_delete',
+  PREVIEW = 'preview',
 }
 
 // where we launch the dashboard widget from

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -54,6 +54,7 @@ type Props = WithRouterProps & {
   isSorting: boolean;
   currentWidgetDragging: boolean;
   showContextMenu?: boolean;
+  isPreview?: boolean;
   hideToolbar?: boolean;
   draggableProps?: DraggableProps;
   renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
@@ -121,6 +122,7 @@ class WidgetCard extends React.Component<Props> {
       selection,
       organization,
       showContextMenu,
+      isPreview,
       widgetLimitReached,
       onDuplicate,
     } = this.props;
@@ -131,6 +133,7 @@ class WidgetCard extends React.Component<Props> {
         widget={widget}
         selection={selection}
         showContextMenu={showContextMenu}
+        isPreview={isPreview}
         widgetLimitReached={widgetLimitReached}
         onDuplicate={onDuplicate}
       />

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -50,7 +50,7 @@ function WidgetCardContextMenu({
       <ContextWrapper>
         <ContextMenu>
           <PreviewMessage>
-            This is a preview only. To edit, you must add this dashboard
+            {t('This is a preview only. To edit, you must add this dashboard.')}
           </PreviewMessage>
         </ContextMenu>
       </ContextWrapper>

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -24,6 +24,7 @@ type Props = {
   onDuplicate: () => void;
   widgetLimitReached: boolean;
   showContextMenu?: boolean;
+  isPreview?: boolean;
 };
 
 function WidgetCardContextMenu({
@@ -33,6 +34,7 @@ function WidgetCardContextMenu({
   widgetLimitReached,
   onDuplicate,
   showContextMenu,
+  isPreview,
 }: Props) {
   function isAllowWidgetsToDiscover() {
     return organization.features.includes('connect-discover-and-dashboards');
@@ -42,6 +44,18 @@ function WidgetCardContextMenu({
   }
 
   const menuOptions: React.ReactNode[] = [];
+
+  if (isPreview) {
+    return (
+      <ContextWrapper>
+        <ContextMenu>
+          <PreviewMessage>
+            This is a preview only. To edit, you must add this dashboard
+          </PreviewMessage>
+        </ContextMenu>
+      </ContextWrapper>
+    );
+  }
 
   if (
     (widget.displayType === 'table' || isAllowWidgetsToDiscover()) &&
@@ -163,4 +177,9 @@ const StyledMenuItem = styled(MenuItem)`
   :hover {
     color: ${p => p.theme.textColor};
   }
+`;
+
+const PreviewMessage = styled('span')`
+  padding: ${space(1)};
+  display: block;
 `;


### PR DESCRIPTION
- This adds a preview mode to the dashboard details page
  - Swaps the Primary button to Add Dashboard
    - On add, if there's already a dashboard, uses the existing duplicate functionality to append `copy` to the end
  - Swaps the Cancel button to one labelled Go Back (same functionality)
  - Breadcrumb title changes to `Preview Dashboard`
- Widgets context menu gets a disabled message explaining they must add first before editing
  
### Preview
![image](https://user-images.githubusercontent.com/4205004/148608433-d9e3eac0-c1ca-41fd-8d89-c452ed171d5c.png)
