### PR TITLE
fix(ui): Truncate alert rule chart labels

### DIFF
--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -26,6 +26,7 @@ import {
 } from 'sentry/components/organizations/pageFilters/getParams';
 import {Panel, PanelBody, PanelFooter} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
+import Truncate from 'sentry/components/truncate';
 import {IconCheckmark, IconFire, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -535,7 +536,7 @@ class MetricChart extends React.PureComponent<Props, State> {
         ''
     );
 
-    const queryFilter = filter?.map((f, idx) => <Filters key={idx}>{f}</Filters>);
+    const queryFilter = filter?.join(' ');
 
     return (
       <ChartPanel>
@@ -548,7 +549,7 @@ class MetricChart extends React.PureComponent<Props, State> {
           <ChartFilters>
             <StyledCircleIndicator size={8} />
             <Filters>{rule.aggregate}</Filters>
-            {queryFilter}
+            <Truncate value={`${queryFilter}`} maxLength={75} />
           </ChartFilters>
           {getDynamicText({
             value: (
@@ -822,6 +823,14 @@ const ChartFilters = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   font-family: ${p => p.theme.text.family};
   color: ${p => p.theme.textColor};
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 `;
 
 const Filters = styled('span')`

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -549,7 +549,7 @@ class MetricChart extends React.PureComponent<Props, State> {
           <ChartFilters>
             <StyledCircleIndicator size={8} />
             <Filters>{rule.aggregate}</Filters>
-            <Truncate value={`${queryFilter}`} maxLength={75} />
+            <Truncate value={queryFilter ?? ''} maxLength={75} />
           </ChartFilters>
           {getDynamicText({
             value: (


### PR DESCRIPTION
Truncate alert rule chart labels.

[FIXES WOR-1545](https://getsentry.atlassian.net/browse/WOR-1545)

# Before
<img width="1203" alt="Screen Shot 2022-01-07 at 4 00 56 PM" src="https://user-images.githubusercontent.com/20312973/148622957-ae69a9f2-f8c7-4036-9546-529cecc0277a.png">

# After
<img width="839" alt="Screen Shot 2022-01-07 at 4 07 53 PM" src="https://user-images.githubusercontent.com/20312973/148623040-4c5027d4-77a9-45ae-83f4-10b27a66044a.png">
<img width="1196" alt="Screen Shot 2022-01-07 at 4 08 00 PM" src="https://user-images.githubusercontent.com/20312973/148623044-1521c467-f263-4d08-b511-879592caba77.png">

![ezgif com-gif-maker](https://user-images.githubusercontent.com/20312973/148623178-948245a1-788c-467d-ba24-8224045c3be7.gif)

