### PR TITLE
fix(ui): Project page filter

### DIFF
--- a/static/app/components/organizations/pageFilters/utils.tsx
+++ b/static/app/components/organizations/pageFilters/utils.tsx
@@ -160,7 +160,11 @@ export function setPageFiltersStorage(
   }
 
   const {project, environment} = update;
-  const validatedProject = project?.map(Number).filter(value => !isNaN(value));
+  const validatedProject = project
+    ? (Array.isArray(project) ? project : [project])
+        .map(Number)
+        .filter(value => !isNaN(value))
+    : undefined;
   const validatedEnvironment = environment;
 
   const dataToSave = {


### PR DESCRIPTION
We are getting `o.map is not a function` errors even though there is optional chaining used.
That leaves me thinking that the type is wrong and we can also receive singular ProjectId (on top of ProjectId[]).

This is a hotfix, I'll check the types in a follow-up PR.

Relates to https://github.com/getsentry/sentry/pull/30959

Fixes JAVASCRIPT-26DW