### PR TITLE
feat(dashboard): Add Edit and Duplicate to Widget context menu

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -31,6 +31,7 @@ import AddWidget, {ADD_WIDGET_BUTTON_DRAG_ID} from './addWidget';
 import SortableWidget from './sortableWidget';
 import {
   DashboardDetails,
+  DashboardState,
   DashboardWidgetSource,
   DisplayType,
   Widget,
@@ -61,6 +62,7 @@ type Props = {
   api: Client;
   organization: Organization;
   dashboard: DashboardDetails;
+  dashboardState: DashboardState;
   selection: PageFilters;
   isEditing: boolean;
   router: InjectedRouter;
@@ -211,15 +213,26 @@ class Dashboard extends Component<Props, State> {
   };
 
   handleUpdateComplete = (prevWidget: Widget) => (nextWidget: Widget) => {
+    const {dashboardState, handleAddLibraryWidgets} = this.props;
     const nextList = [...this.props.dashboard.widgets];
     const updateIndex = nextList.indexOf(prevWidget);
     nextList[updateIndex] = {...nextWidget, tempId: prevWidget.tempId};
     this.props.onUpdate(nextList);
+    if (dashboardState === DashboardState.VIEW) {
+      handleAddLibraryWidgets(nextList);
+    }
   };
 
   handleDeleteWidget = (widgetToDelete: Widget) => () => {
     const {layouts} = this.state;
-    const {dashboard, onUpdate, onLayoutChange, organization} = this.props;
+    const {
+      dashboard,
+      onUpdate,
+      onLayoutChange,
+      organization,
+      dashboardState,
+      handleAddLibraryWidgets,
+    } = this.props;
 
     const nextList = dashboard.widgets.filter(widget => widget !== widgetToDelete);
     onUpdate(nextList);
@@ -229,6 +242,9 @@ class Dashboard extends Component<Props, State> {
         ({i}) => i !== constructGridItemKey(widgetToDelete)
       );
       onLayoutChange(newLayout);
+    }
+    if (dashboardState === DashboardState.VIEW) {
+      handleAddLibraryWidgets(nextList);
     }
   };
 

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -31,7 +31,6 @@ import AddWidget, {ADD_WIDGET_BUTTON_DRAG_ID} from './addWidget';
 import SortableWidget from './sortableWidget';
 import {
   DashboardDetails,
-  DashboardState,
   DashboardWidgetSource,
   DisplayType,
   Widget,
@@ -62,7 +61,6 @@ type Props = {
   api: Client;
   organization: Organization;
   dashboard: DashboardDetails;
-  dashboardState: DashboardState;
   selection: PageFilters;
   isEditing: boolean;
   router: InjectedRouter;
@@ -213,12 +211,12 @@ class Dashboard extends Component<Props, State> {
   };
 
   handleUpdateComplete = (prevWidget: Widget) => (nextWidget: Widget) => {
-    const {dashboardState, handleAddLibraryWidgets} = this.props;
+    const {isEditing, handleAddLibraryWidgets} = this.props;
     const nextList = [...this.props.dashboard.widgets];
     const updateIndex = nextList.indexOf(prevWidget);
     nextList[updateIndex] = {...nextWidget, tempId: prevWidget.tempId};
     this.props.onUpdate(nextList);
-    if (dashboardState === DashboardState.VIEW) {
+    if (!!!isEditing) {
       handleAddLibraryWidgets(nextList);
     }
   };
@@ -230,7 +228,7 @@ class Dashboard extends Component<Props, State> {
       onUpdate,
       onLayoutChange,
       organization,
-      dashboardState,
+      isEditing,
       handleAddLibraryWidgets,
     } = this.props;
 
@@ -243,13 +241,13 @@ class Dashboard extends Component<Props, State> {
       );
       onLayoutChange(newLayout);
     }
-    if (dashboardState === DashboardState.VIEW) {
+    if (!!!isEditing) {
       handleAddLibraryWidgets(nextList);
     }
   };
 
   handleDuplicateWidget = (widget: Widget, index: number) => () => {
-    const {dashboard, handleAddLibraryWidgets} = this.props;
+    const {dashboard, isEditing, handleAddLibraryWidgets} = this.props;
 
     const widgetCopy = cloneDeep(widget);
     widgetCopy.id = undefined;
@@ -258,7 +256,9 @@ class Dashboard extends Component<Props, State> {
     const nextList = [...dashboard.widgets];
     nextList.splice(index, 0, widgetCopy);
 
-    handleAddLibraryWidgets(nextList);
+    if (!!!isEditing) {
+      handleAddLibraryWidgets(nextList);
+    }
   };
 
   handleEditWidget = (widget: Widget, index: number) => () => {

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -71,7 +71,7 @@ type Props = {
    */
   onUpdate: (widgets: Widget[]) => void;
   onSetWidgetToBeUpdated: (widget: Widget) => void;
-  handleAddLibraryWidgets: (widgets: Widget[]) => void;
+  handleUpdateWidgetList: (widgets: Widget[]) => void;
   handleAddCustomWidget: (widget: Widget) => void;
   layout: Layout[];
   onLayoutChange: (layout: Layout[]) => void;
@@ -159,7 +159,7 @@ class Dashboard extends Component<Props, State> {
       organization,
       dashboard,
       selection,
-      handleAddLibraryWidgets,
+      handleUpdateWidgetList,
       handleAddCustomWidget,
     } = this.props;
     trackAdvancedAnalyticsEvent('dashboards_views.add_widget_modal.opened', {
@@ -175,7 +175,7 @@ class Dashboard extends Component<Props, State> {
         dashboard,
         selection,
         onAddWidget: handleAddCustomWidget,
-        onAddLibraryWidget: (widgets: Widget[]) => handleAddLibraryWidgets(widgets),
+        onAddLibraryWidget: (widgets: Widget[]) => handleUpdateWidgetList(widgets),
         source: DashboardWidgetSource.LIBRARY,
       });
       return;
@@ -211,13 +211,13 @@ class Dashboard extends Component<Props, State> {
   };
 
   handleUpdateComplete = (prevWidget: Widget) => (nextWidget: Widget) => {
-    const {isEditing, handleAddLibraryWidgets} = this.props;
+    const {isEditing, handleUpdateWidgetList} = this.props;
     const nextList = [...this.props.dashboard.widgets];
     const updateIndex = nextList.indexOf(prevWidget);
     nextList[updateIndex] = {...nextWidget, tempId: prevWidget.tempId};
     this.props.onUpdate(nextList);
     if (!!!isEditing) {
-      handleAddLibraryWidgets(nextList);
+      handleUpdateWidgetList(nextList);
     }
   };
 
@@ -229,7 +229,7 @@ class Dashboard extends Component<Props, State> {
       onLayoutChange,
       organization,
       isEditing,
-      handleAddLibraryWidgets,
+      handleUpdateWidgetList,
     } = this.props;
 
     const nextList = dashboard.widgets.filter(widget => widget !== widgetToDelete);
@@ -242,12 +242,12 @@ class Dashboard extends Component<Props, State> {
       onLayoutChange(newLayout);
     }
     if (!!!isEditing) {
-      handleAddLibraryWidgets(nextList);
+      handleUpdateWidgetList(nextList);
     }
   };
 
   handleDuplicateWidget = (widget: Widget, index: number) => () => {
-    const {dashboard, isEditing, handleAddLibraryWidgets} = this.props;
+    const {dashboard, isEditing, handleUpdateWidgetList} = this.props;
 
     const widgetCopy = cloneDeep(widget);
     widgetCopy.id = undefined;
@@ -257,7 +257,7 @@ class Dashboard extends Component<Props, State> {
     nextList.splice(index, 0, widgetCopy);
 
     if (!!!isEditing) {
-      handleAddLibraryWidgets(nextList);
+      handleUpdateWidgetList(nextList);
     }
   };
 

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -282,7 +282,7 @@ class DashboardDetail extends Component<Props, State> {
     });
   };
 
-  handleAddLibraryWidgets = (widgets: Widget[]) => {
+  handleUpdateWidgetList = (widgets: Widget[]) => {
     const {organization, dashboard, api, onDashboardUpdate, location} = this.props;
     const {dashboardState, modifiedDashboard} = this.state;
     const newModifiedDashboard = {
@@ -336,7 +336,7 @@ class DashboardDetail extends Component<Props, State> {
       organization,
       dashboard,
       onAddWidget: (widget: Widget) => this.handleAddCustomWidget(widget),
-      onAddLibraryWidget: (widgets: Widget[]) => this.handleAddLibraryWidgets(widgets),
+      onAddLibraryWidget: (widgets: Widget[]) => this.handleUpdateWidgetList(widgets),
       source: DashboardWidgetSource.LIBRARY,
     });
   };
@@ -564,7 +564,7 @@ class DashboardDetail extends Component<Props, State> {
               widgetLimitReached={widgetLimitReached}
               onUpdate={this.onUpdateWidget}
               onSetWidgetToBeUpdated={this.onSetWidgetToBeUpdated}
-              handleAddLibraryWidgets={this.handleAddLibraryWidgets}
+              handleUpdateWidgetList={this.handleUpdateWidgetList}
               handleAddCustomWidget={this.handleAddCustomWidget}
               router={router}
               location={location}
@@ -647,7 +647,7 @@ class DashboardDetail extends Component<Props, State> {
                   isEditing={this.isEditing}
                   widgetLimitReached={widgetLimitReached}
                   onUpdate={this.onUpdateWidget}
-                  handleAddLibraryWidgets={this.handleAddLibraryWidgets}
+                  handleUpdateWidgetList={this.handleUpdateWidgetList}
                   handleAddCustomWidget={this.handleAddCustomWidget}
                   onSetWidgetToBeUpdated={this.onSetWidgetToBeUpdated}
                   router={router}

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -559,7 +559,6 @@ class DashboardDetail extends Component<Props, State> {
             <Dashboard
               paramDashboardId={dashboardId}
               dashboard={modifiedDashboard ?? dashboard}
-              dashboardState={dashboardState}
               organization={organization}
               isEditing={this.isEditing}
               widgetLimitReached={widgetLimitReached}
@@ -644,7 +643,6 @@ class DashboardDetail extends Component<Props, State> {
                 <Dashboard
                   paramDashboardId={dashboardId}
                   dashboard={modifiedDashboard ?? dashboard}
-                  dashboardState={dashboardState}
                   organization={organization}
                   isEditing={this.isEditing}
                   widgetLimitReached={widgetLimitReached}

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -559,6 +559,7 @@ class DashboardDetail extends Component<Props, State> {
             <Dashboard
               paramDashboardId={dashboardId}
               dashboard={modifiedDashboard ?? dashboard}
+              dashboardState={dashboardState}
               organization={organization}
               isEditing={this.isEditing}
               widgetLimitReached={widgetLimitReached}
@@ -643,6 +644,7 @@ class DashboardDetail extends Component<Props, State> {
                 <Dashboard
                   paramDashboardId={dashboardId}
                   dashboard={modifiedDashboard ?? dashboard}
+                  dashboardState={dashboardState}
                   organization={organization}
                   isEditing={this.isEditing}
                   widgetLimitReached={widgetLimitReached}

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -122,7 +122,9 @@ class WidgetCard extends React.Component<Props> {
       organization,
       showContextMenu,
       widgetLimitReached,
+      onEdit,
       onDuplicate,
+      onDelete,
     } = this.props;
 
     return (
@@ -133,6 +135,8 @@ class WidgetCard extends React.Component<Props> {
         showContextMenu={showContextMenu}
         widgetLimitReached={widgetLimitReached}
         onDuplicate={onDuplicate}
+        onEdit={onEdit}
+        onDelete={onDelete}
       />
     );
   }

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -79,7 +79,7 @@ function WidgetCardContextMenu({
             break;
         }
       }
-      const discoverPath = `${discoverLocation.pathname}${qs.stringify({
+      const discoverPath = `${discoverLocation.pathname}?${qs.stringify({
         ...discoverLocation.query,
       })}`;
       if (widget.queries.length === 1) {

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
 import {openDashboardWidgetQuerySelectorModal} from 'sentry/actionCreators/modal';
+import Confirm from 'sentry/components/confirm';
 import Link from 'sentry/components/links/link';
 import MenuItem from 'sentry/components/menuItem';
 import {t} from 'sentry/locale';
@@ -21,7 +22,9 @@ type Props = {
   organization: Organization;
   widget: Widget;
   selection: PageFilters;
+  onDelete: () => void;
   onDuplicate: () => void;
+  onEdit: () => void;
   widgetLimitReached: boolean;
   showContextMenu?: boolean;
 };
@@ -31,7 +34,9 @@ function WidgetCardContextMenu({
   selection,
   widget,
   widgetLimitReached,
+  onDelete,
   onDuplicate,
+  onEdit,
   showContextMenu,
 }: Props) {
   function isAllowWidgetsToDiscover() {
@@ -74,11 +79,14 @@ function WidgetCardContextMenu({
             break;
         }
       }
+      const discoverPath = `${discoverLocation.pathname}${qs.stringify({
+        ...discoverLocation.query,
+      })}`;
       if (widget.queries.length === 1) {
         menuOptions.push(
           <Link
             key="open-discover-link"
-            to={discoverLocation}
+            to={discoverPath}
             onClick={() => {
               trackAdvancedAnalyticsEvent('dashboards_views.open_in_discover.opened', {
                 organization,
@@ -138,6 +146,24 @@ function WidgetCardContextMenu({
         {t('Duplicate Widget')}
       </StyledMenuItem>
     );
+
+    menuOptions.push(
+      <StyledMenuItem key="edit-widget" data-test-id="edit-widget" onSelect={onEdit}>
+        {t('Edit Widget')}
+      </StyledMenuItem>
+    );
+
+    menuOptions.push(
+      <Confirm
+        key="delete-widget"
+        data-test-id="delete-widget"
+        priority="danger"
+        message={t('Are you sure you want to delete this widget?')}
+        onConfirm={onDelete}
+      >
+        <StyledMenuItem danger>{t('Delete Widget')}</StyledMenuItem>
+      </Confirm>
+    );
   }
 
   if (!menuOptions.length) {
@@ -157,10 +183,10 @@ const ContextWrapper = styled('div')`
   margin-left: ${space(1)};
 `;
 
-const StyledMenuItem = styled(MenuItem)`
+const StyledMenuItem = styled(MenuItem)<{danger?: boolean}>`
   white-space: nowrap;
-  color: ${p => p.theme.textColor};
+  color: ${p => (p.danger ? p.theme.red300 : p.theme.textColor)};
   :hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => (p.danger ? p.theme.red300 : p.theme.textColor)};
   }
 `;

--- a/tests/js/spec/views/dashboardsV2/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/dashboard.spec.tsx
@@ -48,7 +48,7 @@ describe('Dashboards > Dashboard', () => {
         organization={initialData.organization}
         isEditing={false}
         onUpdate={() => undefined}
-        handleAddLibraryWidgets={() => undefined}
+        handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={mockHandleAddCustomWidget}
         onSetWidgetToBeUpdated={() => undefined}
         router={initialData.router}
@@ -74,7 +74,7 @@ describe('Dashboards > Dashboard', () => {
         organization={initialData.organization}
         isEditing={false}
         onUpdate={() => undefined}
-        handleAddLibraryWidgets={() => undefined}
+        handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={mockHandleAddCustomWidget}
         onSetWidgetToBeUpdated={() => undefined}
         router={initialData.router}
@@ -101,7 +101,7 @@ describe('Dashboards > Dashboard', () => {
         organization={initialData.organization}
         onUpdate={() => undefined}
         onSetWidgetToBeUpdated={() => undefined}
-        handleAddLibraryWidgets={() => undefined}
+        handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={() => undefined}
         router={initialData.router}
         location={initialData.location}

--- a/tests/js/spec/views/dashboardsV2/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/detail.spec.jsx
@@ -188,6 +188,7 @@ describe('Dashboards > Detail', function () {
 
     beforeEach(function () {
       initialData = initializeOrg({organization});
+      types.MAX_WIDGETS = 30;
       widgets = [
         TestStubs.Widget(
           [{name: '', conditions: 'event.type:error', fields: ['count()']}],
@@ -745,8 +746,6 @@ describe('Dashboards > Detail', function () {
     });
 
     it('duplicates widgets', async function () {
-      types.MAX_WIDGETS = 30;
-
       wrapper = mountWithTheme(
         <ViewEditDashboard
           organization={initialData.organization}
@@ -780,7 +779,6 @@ describe('Dashboards > Detail', function () {
     });
 
     it('opens edit modal when editing widget from context menu', async function () {
-      types.MAX_WIDGETS = 30;
       wrapper = mountWithTheme(
         <ViewEditDashboard
           organization={initialData.organization}
@@ -826,7 +824,6 @@ describe('Dashboards > Detail', function () {
     });
 
     it('deletes widget', async function () {
-      types.MAX_WIDGETS = 30;
       wrapper = mountWithTheme(
         <ViewEditDashboard
           organization={initialData.organization}

--- a/tests/js/spec/views/dashboardsV2/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/detail.spec.jsx
@@ -778,5 +778,86 @@ describe('Dashboards > Detail', function () {
       const newCard = wrapper.find('WidgetCard').at(1);
       expect(newCard.props().title).toEqual(card.props().title);
     });
+
+    it('opens edit modal when editing widget from context menu', async function () {
+      types.MAX_WIDGETS = 30;
+      wrapper = mountWithTheme(
+        <ViewEditDashboard
+          organization={initialData.organization}
+          params={{orgId: 'org-slug', dashboardId: '1'}}
+          router={initialData.router}
+          location={initialData.router.location}
+        />,
+        initialData.routerContext
+      );
+      await tick();
+      wrapper.update();
+
+      expect(wrapper.find('WidgetCard')).toHaveLength(3);
+
+      const card = wrapper.find('WidgetCard').first();
+      card.find('DropdownMenu MoreOptions svg').simulate('click');
+
+      card.update();
+      wrapper.update();
+
+      wrapper
+        .find(`DropdownMenu MenuItem[data-test-id="edit-widget"] MenuTarget`)
+        .simulate('click');
+
+      expect(openEditModal).toHaveBeenCalledTimes(1);
+      expect(openEditModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          widget: {
+            id: '1',
+            interval: '1d',
+            queries: [
+              {
+                conditions: 'event.type:error',
+                fields: ['count()'],
+                name: '',
+              },
+            ],
+            title: 'Errors',
+            type: 'line',
+          },
+        })
+      );
+    });
+
+    it('deletes widget', async function () {
+      types.MAX_WIDGETS = 30;
+      wrapper = mountWithTheme(
+        <ViewEditDashboard
+          organization={initialData.organization}
+          params={{orgId: 'org-slug', dashboardId: '1'}}
+          router={initialData.router}
+          location={initialData.router.location}
+        />,
+        initialData.routerContext
+      );
+      await tick();
+      wrapper.update();
+
+      expect(wrapper.find('WidgetCard')).toHaveLength(3);
+
+      const card = wrapper.find('WidgetCard').first();
+      card.find('DropdownMenu MoreOptions svg').simulate('click');
+
+      card.update();
+      wrapper.update();
+
+      wrapper
+        .find(`DropdownMenu Confirm[data-test-id="delete-widget"]`)
+        .simulate('click');
+
+      const modal = await mountGlobalModal();
+      modal.find(`button[data-test-id="confirm-button"]`).simulate('click');
+
+      await tick();
+      wrapper.update();
+
+      expect(wrapper.find('WidgetCard')).toHaveLength(2);
+    });
   });
 });

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -69,7 +69,7 @@ describe('Dashboards > Dashboard', () => {
         organization={initialData.organization}
         isEditing={false}
         onUpdate={() => undefined}
-        handleAddLibraryWidgets={() => undefined}
+        handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={mockHandleAddCustomWidget}
         onSetWidgetToBeUpdated={() => undefined}
         router={initialData.router}
@@ -95,7 +95,7 @@ describe('Dashboards > Dashboard', () => {
         organization={initialData.organization}
         isEditing={false}
         onUpdate={() => undefined}
-        handleAddLibraryWidgets={() => undefined}
+        handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={mockHandleAddCustomWidget}
         onSetWidgetToBeUpdated={() => undefined}
         router={initialData.router}
@@ -126,7 +126,7 @@ describe('Dashboards > Dashboard', () => {
         organization={initialData.organization}
         isEditing={false}
         onUpdate={() => undefined}
-        handleAddLibraryWidgets={() => undefined}
+        handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={mockHandleAddCustomWidget}
         onSetWidgetToBeUpdated={() => undefined}
         router={initialData.router}
@@ -161,7 +161,7 @@ describe('Dashboards > Dashboard', () => {
         organization={organizationWithFlag}
         isEditing={false}
         onUpdate={() => undefined}
-        handleAddLibraryWidgets={() => undefined}
+        handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={mockHandleAddCustomWidget}
         onSetWidgetToBeUpdated={() => undefined}
         router={initialData.router}

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -1,23 +1,10 @@
-import {browserHistory} from 'react-router';
-
-import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import * as modal from 'sentry/actionCreators/modal';
 import {Client} from 'sentry/api';
-import {t} from 'sentry/locale';
-import {WidgetType} from 'sentry/views/dashboardsV2/types';
+import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';
 import WidgetCard from 'sentry/views/dashboardsV2/widgetCard';
-
-function openContextMenu(card) {
-  card.find('DropdownMenu MoreOptions svg').simulate('click');
-}
-
-function clickMenuItem(card, selector) {
-  card
-    .find(`DropdownMenu MenuItem[data-test-id="${selector}"] MenuTarget`)
-    .simulate('click');
-}
 
 describe('Dashboards > WidgetCard', function () {
   const initialData = initializeOrg({
@@ -25,23 +12,26 @@ describe('Dashboards > WidgetCard', function () {
       features: ['connect-discover-and-dashboards', 'dashboards-edit', 'discover-basic'],
       projects: [TestStubs.Project()],
     }),
-  });
+    router: {orgId: 'orgId'},
+  } as Parameters<typeof initializeOrg>[0]);
 
-  const multipleQueryWidget = {
+  const multipleQueryWidget: Widget = {
     title: 'Errors',
     interval: '5m',
-    displayType: 'line',
+    displayType: DisplayType.LINE,
     widgetType: WidgetType.DISCOVER,
     queries: [
       {
         conditions: 'event.type:error',
         fields: ['count()', 'failure_count()'],
         name: 'errors',
+        orderby: '',
       },
       {
         conditions: 'event.type:default',
         fields: ['count()', 'failure_count()'],
         name: 'default',
+        orderby: '',
       },
     ],
   };
@@ -50,17 +40,15 @@ describe('Dashboards > WidgetCard', function () {
     environments: ['prod'],
     datetime: {
       period: '14d',
+      start: null,
+      end: null,
+      utc: false,
     },
   };
 
   const api = new Client();
 
-  const mockEvent = {
-    preventDefault: () => undefined,
-  };
-
   beforeEach(function () {
-    browserHistory.push.mockReset();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: [],
@@ -77,7 +65,7 @@ describe('Dashboards > WidgetCard', function () {
 
   it('renders with Open in Discover button and opens the Query Selector Modal when clicked', async function () {
     const spy = jest.spyOn(modal, 'openDashboardWidgetQuerySelectorModal');
-    const wrapper = mountWithTheme(
+    mountWithTheme(
       <WidgetCard
         api={api}
         organization={initialData.organization}
@@ -92,18 +80,14 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      >
-        {() => <div data-test-id="child" />}
-      </WidgetCard>,
-      initialData.routerContext
+      />
     );
 
     await tick();
 
-    const menuOptions = wrapper.find('ContextMenu').props().children;
-    expect(menuOptions.length > 0).toBe(true);
-    expect(menuOptions[0].props.children).toEqual(t('Open in Discover'));
-    menuOptions[0].props.onClick(mockEvent);
+    userEvent.click(screen.getByTestId('context-menu'));
+    expect(screen.getByText('Open in Discover')).toBeInTheDocument();
+    userEvent.click(screen.getByText('Open in Discover'));
     expect(spy).toHaveBeenCalledWith({
       organization: initialData.organization,
       widget: multipleQueryWidget,
@@ -111,7 +95,7 @@ describe('Dashboards > WidgetCard', function () {
   });
 
   it('renders with Open in Discover button and opens in Discover when clicked', async function () {
-    const wrapper = mountWithTheme(
+    mountWithTheme(
       <WidgetCard
         api={api}
         organization={initialData.organization}
@@ -126,38 +110,27 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      >
-        {() => <div data-test-id="child" />}
-      </WidgetCard>,
-      initialData.routerContext
+      />
     );
 
     await tick();
 
-    const menuOptions = wrapper.find('ContextMenu').props().children;
-    expect(menuOptions.length > 0).toBe(true);
-    expect(menuOptions[0].props.children.props.children).toContain(t('Open in Discover'));
-    expect(menuOptions[0].props.to).toEqual(
-      expect.objectContaining({
-        pathname: '/organizations/org-slug/discover/results/',
-        query: expect.objectContaining({
-          field: ['count()', 'failure_count()'],
-          name: 'Errors',
-          query: 'event.type:error',
-          yAxis: ['count()', 'failure_count()'],
-        }),
-      })
+    userEvent.click(screen.getByTestId('context-menu'));
+    expect(screen.getByText('Open in Discover')).toBeInTheDocument();
+    expect(screen.getByText('Open in Discover').closest('a')).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/discover/results/environment=prod&field=count%28%29&field=failure_count%28%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29&yAxis=failure_count%28%29'
     );
   });
 
   it('Opens in Discover with World Map', async function () {
-    const wrapper = mountWithTheme(
+    mountWithTheme(
       <WidgetCard
         api={api}
         organization={initialData.organization}
         widget={{
           ...multipleQueryWidget,
-          displayType: 'world_map',
+          displayType: DisplayType.WORLD_MAP,
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
@@ -170,40 +143,28 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      >
-        {() => <div data-test-id="child" />}
-      </WidgetCard>,
-      initialData.routerContext
+      />
     );
 
     await tick();
 
-    const menuOptions = wrapper.find('ContextMenu').props().children;
-    expect(menuOptions.length > 0).toBe(true);
-    expect(menuOptions[0].props.children.props.children).toContain(t('Open in Discover'));
-    expect(menuOptions[0].props.to).toEqual(
-      expect.objectContaining({
-        pathname: '/organizations/org-slug/discover/results/',
-        query: expect.objectContaining({
-          display: 'worldmap',
-          field: ['geo.country_code', 'count()'],
-          name: 'Errors',
-          query: 'event.type:error has:geo.country_code',
-          yAxis: ['count()'],
-        }),
-      })
+    userEvent.click(screen.getByTestId('context-menu'));
+    expect(screen.getByText('Open in Discover')).toBeInTheDocument();
+    expect(screen.getByText('Open in Discover').closest('a')).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/discover/results/display=worldmap&environment=prod&field=geo.country_code&field=count%28%29&name=Errors&project=1&query=event.type%3Aerror%20has%3Ageo.country_code&statsPeriod=14d&yAxis=count%28%29'
     );
   });
 
   it('calls onDuplicate when Duplicate Widget is clicked', async function () {
     const mock = jest.fn();
-    const wrapper = mountWithTheme(
+    mountWithTheme(
       <WidgetCard
         api={api}
         organization={initialData.organization}
         widget={{
           ...multipleQueryWidget,
-          displayType: 'world_map',
+          displayType: DisplayType.WORLD_MAP,
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
@@ -216,29 +177,26 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      >
-        {() => <div data-test-id="child" />}
-      </WidgetCard>,
-      initialData.routerContext
+      />
     );
 
     await tick();
 
-    openContextMenu(wrapper);
-    wrapper.update();
-    clickMenuItem(wrapper, 'duplicate-widget');
+    userEvent.click(screen.getByTestId('context-menu'));
+    expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
+    userEvent.click(screen.getByText('Duplicate Widget'));
     expect(mock).toHaveBeenCalledTimes(1);
   });
 
   it('does not add duplicate widgets if max widget is reached', async function () {
     const mock = jest.fn();
-    const wrapper = mountWithTheme(
+    mountWithTheme(
       <WidgetCard
         api={api}
         organization={initialData.organization}
         widget={{
           ...multipleQueryWidget,
-          displayType: 'world_map',
+          displayType: DisplayType.WORLD_MAP,
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
@@ -251,17 +209,76 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached
-      >
-        {() => <div data-test-id="child" />}
-      </WidgetCard>,
-      initialData.routerContext
+      />
     );
 
     await tick();
 
-    openContextMenu(wrapper);
-    wrapper.update();
-    clickMenuItem(wrapper, 'duplicate-widget');
+    userEvent.click(screen.getByTestId('context-menu'));
+    expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
+    userEvent.click(screen.getByText('Duplicate Widget'));
     expect(mock).toHaveBeenCalledTimes(0);
+  });
+
+  it('calls onEdit when Edit Widget is clicked', async function () {
+    const mock = jest.fn();
+    mountWithTheme(
+      <WidgetCard
+        api={api}
+        organization={initialData.organization}
+        widget={{
+          ...multipleQueryWidget,
+          displayType: DisplayType.WORLD_MAP,
+          queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
+        }}
+        selection={selection}
+        isEditing={false}
+        onDelete={() => undefined}
+        onEdit={mock}
+        onDuplicate={() => undefined}
+        renderErrorMessage={() => undefined}
+        isSorting={false}
+        currentWidgetDragging={false}
+        showContextMenu
+        widgetLimitReached={false}
+      />
+    );
+
+    await tick();
+
+    userEvent.click(screen.getByTestId('context-menu'));
+    expect(screen.getByText('Edit Widget')).toBeInTheDocument();
+    userEvent.click(screen.getByText('Edit Widget'));
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders delete widget option', async function () {
+    const mock = jest.fn();
+    mountWithTheme(
+      <WidgetCard
+        api={api}
+        organization={initialData.organization}
+        widget={{
+          ...multipleQueryWidget,
+          displayType: DisplayType.WORLD_MAP,
+          queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
+        }}
+        selection={selection}
+        isEditing={false}
+        onDelete={mock}
+        onEdit={() => undefined}
+        onDuplicate={() => undefined}
+        renderErrorMessage={() => undefined}
+        isSorting={false}
+        currentWidgetDragging={false}
+        showContextMenu
+        widgetLimitReached={false}
+      />
+    );
+
+    await tick();
+
+    userEvent.click(screen.getByTestId('context-menu'));
+    expect(screen.getByText('Delete Widget')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -119,7 +119,7 @@ describe('Dashboards > WidgetCard', function () {
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     expect(screen.getByText('Open in Discover').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/discover/results/environment=prod&field=count%28%29&field=failure_count%28%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29&yAxis=failure_count%28%29'
+      '/organizations/org-slug/discover/results/?environment=prod&field=count%28%29&field=failure_count%28%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29&yAxis=failure_count%28%29'
     );
   });
 
@@ -152,7 +152,7 @@ describe('Dashboards > WidgetCard', function () {
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     expect(screen.getByText('Open in Discover').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/discover/results/display=worldmap&environment=prod&field=geo.country_code&field=count%28%29&name=Errors&project=1&query=event.type%3Aerror%20has%3Ageo.country_code&statsPeriod=14d&yAxis=count%28%29'
+      '/organizations/org-slug/discover/results/?display=worldmap&environment=prod&field=geo.country_code&field=count%28%29&name=Errors&project=1&query=event.type%3Aerror%20has%3Ageo.country_code&statsPeriod=14d&yAxis=count%28%29'
     );
   });
 


### PR DESCRIPTION
This is the first step in getting rid of the Dashboard
Edit state. Also updates the widgetCard tests to react
testing lib and typescript.

Screenshot
![Screen Shot 2022-01-10 at 9 49 55 AM](https://user-images.githubusercontent.com/63818634/148785664-f50b4cd3-191f-41ea-a633-71042bb4e68e.png)
