### PR TITLE
ref(pageFilters): Organize pageFilters parsing into parse module

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -6,10 +6,10 @@ import pick from 'lodash/pick';
 import * as qs from 'query-string';
 
 import PageFiltersActions from 'sentry/actions/pageFiltersActions';
+import {getStateFromQuery} from 'sentry/components/organizations/pageFilters/parse';
 import {
   getDefaultSelection,
   getPageFilterStorage,
-  getStateFromQuery,
   setPageFiltersStorage,
 } from 'sentry/components/organizations/pageFilters/utils';
 import {DATE_TIME, URL_PARAM} from 'sentry/constants/pageFilters';

--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -3,7 +3,7 @@ import {Query} from 'history';
 import AlertActions from 'sentry/actions/alertActions';
 import TagActions from 'sentry/actions/tagActions';
 import {Client} from 'sentry/api';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import TagStore from 'sentry/stores/tagStore';
 import {PageFilters, Tag} from 'sentry/types';
@@ -31,7 +31,9 @@ export function loadOrganizationTags(api: Client, orgId: string, selection: Page
   TagStore.reset();
 
   const url = `/organizations/${orgId}/tags/`;
-  const query: Query = selection.datetime ? {...getParams(selection.datetime)} : {};
+  const query: Query = selection.datetime
+    ? {...normalizeDateTimeParams(selection.datetime)}
+    : {};
   query.use_cache = '1';
 
   if (selection.projects) {

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -18,7 +18,7 @@ import useProjects from 'sentry/utils/useProjects';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import GlobalSelectionHeader from './globalSelectionHeader';
-import {getStateFromQuery} from './utils';
+import {getStateFromQuery} from './parse';
 
 const getDateObjectFromQuery = (query: Record<string, any>) =>
   Object.fromEntries(

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -1,6 +1,6 @@
 import {Location, LocationDescriptor} from 'history';
 
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {OrganizationSummary} from 'sentry/types';
 import {Event} from 'sentry/types/event';
@@ -143,7 +143,7 @@ export function generateTraceTarget(
 ): LocationDescriptor {
   const traceId = event.contexts?.trace?.trace_id ?? '';
 
-  const dateSelection = getParams(getTraceTimeRangeFromEvent(event));
+  const dateSelection = normalizeDateTimeParams(getTraceTimeRangeFromEvent(event));
 
   if (organization.features.includes('performance-view')) {
     // TODO(txiao): Should this persist the current query when going to trace view?

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -11,7 +11,7 @@ import {fetchRecentSearches, saveRecentSearch} from 'sentry/actionCreators/saved
 import {Client} from 'sentry/api';
 import ButtonBar from 'sentry/components/buttonBar';
 import DropdownLink from 'sentry/components/dropdownLink';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {
   FilterType,
   ParseResult,
@@ -779,7 +779,7 @@ class SmartSearchBar extends React.Component<Props, State> {
       }
 
       const {location} = this.props;
-      const endpointParams = getParams(location.query);
+      const endpointParams = normalizeDateTimeParams(location.query);
 
       this.setState({loading: true});
       let values: string[] = [];

--- a/static/app/utils/dates.tsx
+++ b/static/app/utils/dates.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import {parseStatsPeriod} from 'sentry/components/organizations/pageFilters/getParams';
+import {parseStatsPeriod} from 'sentry/components/organizations/pageFilters/parse';
 import ConfigStore from 'sentry/stores/configStore';
 import {DateString} from 'sentry/types';
 

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -9,7 +9,7 @@ import moment from 'moment';
 
 import {EventQuery} from 'sentry/actionCreators/events';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {DEFAULT_PER_PAGE} from 'sentry/constants';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
@@ -347,7 +347,7 @@ class EventView {
   }
 
   static fromLocation(location: Location): EventView {
-    const {start, end, statsPeriod} = getParams(location.query);
+    const {start, end, statsPeriod} = normalizeDateTimeParams(location.query);
 
     return new EventView({
       id: decodeScalar(location.query.id),
@@ -411,7 +411,7 @@ class EventView {
   static fromSavedQuery(saved: NewQuery | SavedQuery): EventView {
     const fields = EventView.getFields(saved);
     // normalize datetime selection
-    const {start, end, statsPeriod} = getParams({
+    const {start, end, statsPeriod} = normalizeDateTimeParams({
       start: saved.start,
       end: saved.end,
       statsPeriod: saved.range,
@@ -449,7 +449,7 @@ class EventView {
     location: Location
   ): EventView {
     let fields = decodeFields(location);
-    const {start, end, statsPeriod} = getParams(location.query);
+    const {start, end, statsPeriod} = normalizeDateTimeParams(location.query);
     const id = decodeScalar(location.query.id);
     const teams = decodeTeams(location);
     const projects = decodeProjects(location);
@@ -1083,7 +1083,7 @@ class EventView {
         };
 
     // normalize datetime selection
-    return getParams({
+    return normalizeDateTimeParams({
       ...dateSelection,
       utc: decodeScalar(query.utc),
     });

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -23,7 +23,7 @@ import CircleIndicator from 'sentry/components/circleIndicator';
 import {
   parseStatsPeriod,
   StatsPeriodType,
-} from 'sentry/components/organizations/pageFilters/getParams';
+} from 'sentry/components/organizations/pageFilters/parse';
 import {Panel, PanelBody, PanelFooter} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import {IconCheckmark, IconFire, IconWarning} from 'sentry/icons';

--- a/static/app/views/dashboardsV2/widget/metricWidget/statsRequest.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/statsRequest.tsx
@@ -5,7 +5,7 @@ import pick from 'lodash/pick';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import {
@@ -85,7 +85,7 @@ function StatsRequest({
     setErrored(false);
     setIsLoading(true);
 
-    const requestExtraParams = getParams(
+    const requestExtraParams = normalizeDateTimeParams(
       pick(
         location.query,
         Object.values(URL_PARAM).filter(param => param !== URL_PARAM.PROJECT)

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -19,7 +19,7 @@ import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {IconFlag} from 'sentry/icons';
@@ -301,7 +301,7 @@ class Results extends React.Component<Props, State> {
   handleSearch = (query: string) => {
     const {router, location} = this.props;
 
-    const queryParams = getParams({
+    const queryParams = normalizeDateTimeParams({
       ...(location.query || {}),
       query,
     });

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -10,7 +10,7 @@ import BarChart from 'sentry/components/charts/barChart';
 import EventsChart from 'sentry/components/charts/eventsChart';
 import {getInterval} from 'sentry/components/charts/utils';
 import WorldMapChart from 'sentry/components/charts/worldMapChart';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Panel} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
@@ -71,7 +71,7 @@ class ResultsChart extends Component<ResultsChartProps> {
       ? getUtcToLocalDateObject(globalSelection.datetime.end)
       : null;
 
-    const {utc} = getParams(location.query);
+    const {utc} = normalizeDateTimeParams(location.query);
     const apiPayload = eventView.getEventsAPIPayload(location);
     const display = eventView.getDisplayMode();
     const isTopEvents =

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -6,7 +6,7 @@ import * as qs from 'query-string';
 import Button from 'sentry/components/button';
 import FeatureBadge from 'sentry/components/featureBadge';
 import Link from 'sentry/components/links/link';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import PageHeading from 'sentry/components/pageHeading';
 import Pagination from 'sentry/components/pagination';
 import {Panel, PanelBody, PanelItem} from 'sentry/components/panels';
@@ -54,7 +54,7 @@ class Monitors extends AsyncView<Props, State> {
     const {location, router} = this.props;
     router.push({
       pathname: location.pathname,
-      query: getParams({
+      query: normalizeDateTimeParams({
         ...(location.query || {}),
         query,
       }),

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -11,7 +11,7 @@ import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
 import PageHeading from 'sentry/components/pageHeading';
 import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
@@ -80,7 +80,7 @@ export class OrganizationStats extends Component<Props> {
       end,
       statsPeriod,
       utc: utcString,
-    } = getParams(query, {
+    } = normalizeDateTimeParams(query, {
       allowEmptyPeriod: true,
       allowAbsoluteDatetime: true,
       allowAbsolutePageDatetime: true,

--- a/static/app/views/organizationStats/teamInsights/overview.tsx
+++ b/static/app/views/organizationStats/teamInsights/overview.tsx
@@ -11,7 +11,7 @@ import TeamSelector from 'sentry/components/forms/teamSelector';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
 import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
 import {t} from 'sentry/locale';
@@ -134,7 +134,7 @@ function TeamInsightsOverview({location, router}: Props) {
       end,
       statsPeriod,
       utc: utcString,
-    } = getParams(query, {
+    } = normalizeDateTimeParams(query, {
       allowEmptyPeriod: true,
       allowAbsoluteDatetime: true,
       allowAbsolutePageDatetime: true,

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -9,7 +9,7 @@ import BarChart from 'sentry/components/charts/barChart';
 import {DateTimeObject} from 'sentry/components/charts/utils';
 import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import PanelTable from 'sentry/components/panels/panelTable';
 import {IconArrow} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -65,7 +65,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
         `/teams/${organization.slug}/${teamSlug}/alerts-triggered/`,
         {
           query: {
-            ...getParams(datetime),
+            ...normalizeDateTimeParams(datetime),
           },
         },
       ],
@@ -74,7 +74,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
         `/teams/${organization.slug}/${teamSlug}/alerts-triggered-index/`,
         {
           query: {
-            ...getParams(datetime),
+            ...normalizeDateTimeParams(datetime),
           },
         },
       ],

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
@@ -5,7 +5,7 @@ import isEqual from 'lodash/isEqual';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import BarChart, {BarChartSeries} from 'sentry/components/charts/barChart';
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import PanelTable from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
 import {IconArrow} from 'sentry/icons';
@@ -68,7 +68,7 @@ class TeamIssuesBreakdown extends AsyncComponent<Props, State> {
         `/teams/${organization.slug}/${teamSlug}/issue-breakdown/`,
         {
           query: {
-            ...getParams(datetime),
+            ...normalizeDateTimeParams(datetime),
             statuses,
           },
         },

--- a/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
@@ -6,7 +6,7 @@ import isEqual from 'lodash/isEqual';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import BarChart from 'sentry/components/charts/barChart';
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import PanelTable from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
@@ -53,7 +53,7 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
         `/teams/${organization.slug}/${teamSlug}/issue-breakdown/`,
         {
           query: {
-            ...getParams(datetime),
+            ...normalizeDateTimeParams(datetime),
           },
         },
       ],

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -11,7 +11,7 @@ import BarChart from 'sentry/components/charts/barChart';
 import MarkLine from 'sentry/components/charts/components/markLine';
 import {DateTimeObject, getTooltipArrow} from 'sentry/components/charts/utils';
 import Link from 'sentry/components/links/link';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import PanelTable from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
 import {IconArrow} from 'sentry/icons';
@@ -65,7 +65,7 @@ class TeamReleases extends AsyncComponent<Props, State> {
         `/teams/${organization.slug}/${teamSlug}/release-count/`,
         {
           query: {
-            ...getParams(datetime),
+            ...normalizeDateTimeParams(datetime),
           },
         },
       ],

--- a/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
@@ -4,7 +4,7 @@ import AsyncComponent from 'sentry/components/asyncComponent';
 import BarChart from 'sentry/components/charts/barChart';
 import {DateTimeObject} from 'sentry/components/charts/utils';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
@@ -43,7 +43,7 @@ class TeamResolutionTime extends AsyncComponent<Props, State> {
         `/teams/${organization.slug}/${teamSlug}/time-to-resolution/`,
         {
           query: {
-            ...getParams(datetime),
+            ...normalizeDateTimeParams(datetime),
           },
         },
       ],

--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -9,7 +9,7 @@ import Button from 'sentry/components/button';
 import MiniBarChart from 'sentry/components/charts/miniBarChart';
 import SessionsRequest from 'sentry/components/charts/sessionsRequest';
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import PanelTable from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
 import {IconArrow} from 'sentry/icons';
@@ -79,7 +79,7 @@ class TeamStability extends AsyncComponent<Props, State> {
         {
           query: {
             ...commonQuery,
-            ...getParams(datetime),
+            ...normalizeDateTimeParams(datetime),
           },
         },
       ],

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
@@ -5,7 +5,7 @@ import isEqual from 'lodash/isEqual';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import BarChart from 'sentry/components/charts/barChart';
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import PanelTable from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
 import {IconArrow} from 'sentry/icons';
@@ -61,7 +61,7 @@ class TeamUnresolvedIssues extends AsyncComponent<Props, State> {
         `/teams/${organization.slug}/${teamSlug}/all-unresolved-issues/`,
         {
           query: {
-            ...getParams(datetime),
+            ...normalizeDateTimeParams(datetime),
           },
         },
       ],

--- a/static/app/views/organizationStats/usageChart/utils.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import {parseStatsPeriod} from 'sentry/components/organizations/pageFilters/getParams';
+import {parseStatsPeriod} from 'sentry/components/organizations/pageFilters/parse';
 import {DataCategory, IntervalPeriod} from 'sentry/types';
 import {parsePeriodToHours} from 'sentry/utils/dates';
 

--- a/static/app/views/performance/charts/index.tsx
+++ b/static/app/views/performance/charts/index.tsx
@@ -7,7 +7,7 @@ import EventsRequest from 'sentry/components/charts/eventsRequest';
 import LoadingPanel from 'sentry/components/charts/loadingPanel';
 import {HeaderTitle} from 'sentry/components/charts/styles';
 import {getInterval} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Panel} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -54,7 +54,7 @@ class Container extends Component<Props> {
       ? getUtcToLocalDateObject(globalSelection.datetime.end)
       : null;
 
-    const {utc} = getParams(location.query);
+    const {utc} = normalizeDateTimeParams(location.query);
     const axisOptions = this.getChartParameters();
 
     const apiPayload = eventView.getEventsAPIPayload(location);

--- a/static/app/views/performance/landing/chart/durationChart.tsx
+++ b/static/app/views/performance/landing/chart/durationChart.tsx
@@ -6,7 +6,7 @@ import EventsRequest from 'sentry/components/charts/eventsRequest';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import {getInterval} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconWarning} from 'sentry/icons';
@@ -54,7 +54,7 @@ function DurationChart({
     ? getUtcToLocalDateObject(globalSelection.datetime.end)
     : null;
 
-  const {utc} = getParams(location.query);
+  const {utc} = normalizeDateTimeParams(location.query);
 
   const _backupField = backupField ? [backupField] : [];
 

--- a/static/app/views/performance/landing/widgets/transforms/transformDiscoverToList.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformDiscoverToList.tsx
@@ -1,4 +1,4 @@
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {defined} from 'sentry/utils';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 import {GenericChildrenProps} from 'sentry/utils/discover/genericDiscoverQuery';
@@ -11,9 +11,12 @@ export function transformDiscoverToList<T extends WidgetDataConstraint>(
   results: GenericChildrenProps<TableData>,
   _: QueryDefinitionWithKey<T>
 ) {
-  const {start, end, utc, interval, statsPeriod} = getParams(widgetProps.location.query, {
-    defaultStatsPeriod: DEFAULT_STATS_PERIOD,
-  });
+  const {start, end, utc, interval, statsPeriod} = normalizeDateTimeParams(
+    widgetProps.location.query,
+    {
+      defaultStatsPeriod: DEFAULT_STATS_PERIOD,
+    }
+  );
 
   const data = results.tableData?.data ?? [];
 

--- a/static/app/views/performance/landing/widgets/transforms/transformEventsToArea.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformEventsToArea.tsx
@@ -1,7 +1,7 @@
 import mean from 'lodash/mean';
 
 import {RenderProps} from 'sentry/components/charts/eventsRequest';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {defined} from 'sentry/utils';
 import {axisLabelFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
@@ -13,7 +13,9 @@ export function transformEventsRequestToArea<T extends WidgetDataConstraint>(
   results: RenderProps,
   _: QueryDefinitionWithKey<T>
 ) {
-  const {start, end, utc, interval, statsPeriod} = getParams(widgetProps.location.query);
+  const {start, end, utc, interval, statsPeriod} = normalizeDateTimeParams(
+    widgetProps.location.query
+  );
 
   const data = results.timeseriesData ?? [];
 

--- a/static/app/views/performance/landing/widgets/transforms/transformEventsToVitals.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformEventsToVitals.tsx
@@ -1,5 +1,5 @@
 import {RenderProps} from 'sentry/components/charts/eventsRequest';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {defined} from 'sentry/utils';
 
 import {QueryDefinitionWithKey, WidgetDataConstraint, WidgetPropUnion} from '../types';
@@ -9,7 +9,9 @@ export function transformEventsRequestToVitals<T extends WidgetDataConstraint>(
   results: RenderProps,
   _: QueryDefinitionWithKey<T>
 ) {
-  const {start, end, utc, interval, statsPeriod} = getParams(widgetProps.location.query);
+  const {start, end, utc, interval, statsPeriod} = normalizeDateTimeParams(
+    widgetProps.location.query
+  );
 
   const data = results.results ?? [];
 

--- a/static/app/views/performance/landing/widgets/transforms/transformMetricsToArea.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformMetricsToArea.tsx
@@ -1,7 +1,7 @@
 import mean from 'lodash/mean';
 import moment from 'moment';
 
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import {axisLabelFormatter} from 'sentry/utils/discover/charts';
@@ -20,7 +20,9 @@ export function transformMetricsToArea<T extends WidgetDataConstraint>(
   results: MetricsRequestRenderProps,
   _: QueryDefinitionWithKey<T>
 ) {
-  const {start, end, utc, interval, statsPeriod} = getParams(widgetProps.location.query);
+  const {start, end, utc, interval, statsPeriod} = normalizeDateTimeParams(
+    widgetProps.location.query
+  );
 
   const {errored, loading, reloading, response, responsePrevious} = results;
 

--- a/static/app/views/performance/landing/widgets/transforms/transformMetricsToList.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformMetricsToList.tsx
@@ -1,4 +1,4 @@
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {defined} from 'sentry/utils';
 import {MetricsRequestRenderProps} from 'sentry/utils/metrics/metricsRequest';
 import {DEFAULT_STATS_PERIOD} from 'sentry/views/performance/data';
@@ -10,9 +10,12 @@ export function transformMetricsToList<T extends WidgetDataConstraint>(
   results: MetricsRequestRenderProps,
   _: QueryDefinitionWithKey<T>
 ) {
-  const {start, end, utc, interval, statsPeriod} = getParams(widgetProps.location.query, {
-    defaultStatsPeriod: DEFAULT_STATS_PERIOD,
-  });
+  const {start, end, utc, interval, statsPeriod} = normalizeDateTimeParams(
+    widgetProps.location.query,
+    {
+      defaultStatsPeriod: DEFAULT_STATS_PERIOD,
+    }
+  );
 
   const {errored, loading, reloading, response} = results;
 

--- a/static/app/views/performance/landing/widgets/transforms/transformMetricsToVitalSeries.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformMetricsToVitalSeries.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {defined} from 'sentry/utils';
 import {MetricsRequestRenderProps} from 'sentry/utils/metrics/metricsRequest';
 import {DEFAULT_STATS_PERIOD} from 'sentry/views/performance/data';
@@ -12,9 +12,12 @@ export function transformMetricsToVitalSeries<T extends WidgetDataConstraint>(
   results: MetricsRequestRenderProps,
   _: QueryDefinitionWithKey<T>
 ) {
-  const {start, end, utc, interval, statsPeriod} = getParams(widgetProps.location.query, {
-    defaultStatsPeriod: DEFAULT_STATS_PERIOD,
-  });
+  const {start, end, utc, interval, statsPeriod} = normalizeDateTimeParams(
+    widgetProps.location.query,
+    {
+      defaultStatsPeriod: DEFAULT_STATS_PERIOD,
+    }
+  );
 
   const metricsField = widgetProps.Queries.chart.fields[0];
 

--- a/static/app/views/performance/traceDetails/index.tsx
+++ b/static/app/views/performance/traceDetails/index.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {Client} from 'sentry/api';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
@@ -37,7 +37,7 @@ class TraceSummary extends Component<Props> {
 
   getDateSelection() {
     const {location} = this.props;
-    const queryParams = getParams(location.query, {
+    const queryParams = normalizeDateTimeParams(location.query, {
       allowAbsolutePageDatetime: true,
     });
     const start = decodeScalar(queryParams.start);

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -8,7 +8,7 @@ import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
 import SearchBar from 'sentry/components/events/searchBar';
 import GlobalSdkUpdateAlert from 'sentry/components/globalSdkUpdateAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
@@ -102,7 +102,7 @@ function Search(props: Props) {
   } = props;
 
   const handleSearch = (query: string) => {
-    const queryParams = getParams({
+    const queryParams = normalizeDateTimeParams({
       ...(location.query || {}),
       query,
     });

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -11,7 +11,7 @@ import TransactionsList, {
 import SearchBar from 'sentry/components/events/searchBar';
 import GlobalSdkUpdateAlert from 'sentry/components/globalSdkUpdateAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -77,7 +77,7 @@ class SummaryContent extends React.Component<Props> {
   handleSearch = (query: string) => {
     const {location} = this.props;
 
-    const queryParams = getParams({
+    const queryParams = normalizeDateTimeParams({
       ...(location.query || {}),
       query,
     });

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart.tsx
@@ -12,7 +12,7 @@ import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import TransitionChart from 'sentry/components/charts/transitionChart';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconWarning} from 'sentry/icons';
@@ -97,7 +97,7 @@ function DurationChart({
 
   const start = propsStart ? getUtcToLocalDateObject(propsStart) : null;
   const end = propsEnd ? getUtcToLocalDateObject(propsEnd) : null;
-  const {utc} = getParams(location.query);
+  const {utc} = normalizeDateTimeParams(location.query);
 
   const legend = {
     right: 10,

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -12,7 +12,7 @@ import {SectionHeading} from 'sentry/components/charts/styles';
 import TransitionChart from 'sentry/components/charts/transitionChart';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import {getInterval} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconWarning} from 'sentry/icons';
@@ -54,7 +54,7 @@ function SidebarCharts({
   const statsPeriod = eventView.statsPeriod;
   const start = eventView.start ? getUtcToLocalDateObject(eventView.start) : undefined;
   const end = eventView.end ? getUtcToLocalDateObject(eventView.end) : undefined;
-  const {utc} = getParams(location.query);
+  const {utc} = normalizeDateTimeParams(location.query);
 
   const colors = theme.charts.getColorPalette(3);
   const axisLineConfig = {

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart.tsx
@@ -12,7 +12,7 @@ import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import TransitionChart from 'sentry/components/charts/transitionChart';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconWarning} from 'sentry/icons';
@@ -79,7 +79,7 @@ function TrendChart({
 
   const start = propsStart ? getUtcToLocalDateObject(propsStart) : null;
   const end = propsEnd ? getUtcToLocalDateObject(propsEnd) : null;
-  const {utc} = getParams(location.query);
+  const {utc} = normalizeDateTimeParams(location.query);
 
   const legend = {
     right: 10,

--- a/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart.tsx
@@ -12,7 +12,7 @@ import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import TransitionChart from 'sentry/components/charts/transitionChart';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconWarning} from 'sentry/icons';
@@ -84,7 +84,7 @@ function VitalsChart({
 
   const start = propsStart ? getUtcToLocalDateObject(propsStart) : null;
   const end = propsEnd ? getUtcToLocalDateObject(propsEnd) : null;
-  const {utc} = getParams(location.query);
+  const {utc} = normalizeDateTimeParams(location.query);
 
   const legend = {
     right: 10,

--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -6,7 +6,7 @@ import omit from 'lodash/omit';
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Pagination from 'sentry/components/pagination';
 import {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -60,7 +60,7 @@ function SpansContent(props: Props) {
     return function (value: string | undefined) {
       ANALYTICS_VALUES[key]?.(organization, value);
 
-      const queryParams = getParams({
+      const queryParams = normalizeDateTimeParams({
         ...(location.query || {}),
         [key]: value,
       });

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeChart.tsx
@@ -11,7 +11,7 @@ import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import TransitionChart from 'sentry/components/charts/transitionChart';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconWarning} from 'sentry/icons';
@@ -42,7 +42,7 @@ export default function ExclusiveTimeChart(props: Props) {
   const period = eventView.statsPeriod;
   const start = eventView.start ? getUtcToLocalDateObject(eventView.start) : null;
   const end = eventView.end ? getUtcToLocalDateObject(eventView.end) : null;
-  const {utc} = getParams(location.query);
+  const {utc} = normalizeDateTimeParams(location.query);
 
   const datetimeSelection = {
     start,

--- a/static/app/views/performance/transactionSummary/transactionTags/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/content.tsx
@@ -7,7 +7,7 @@ import {SectionHeading} from 'sentry/components/charts/styles';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import Radio from 'sentry/components/radio';
 import {t} from 'sentry/locale';
@@ -102,7 +102,7 @@ const InnerContent = (
   const [tagSelected, _changeTagSelected] = useState(initialTag);
 
   const changeTagSelected = (tagKey: string) => {
-    const queryParams = getParams({
+    const queryParams = normalizeDateTimeParams({
       ...(location.query || {}),
       tagKey,
     });
@@ -121,7 +121,7 @@ const InnerContent = (
   }, [initialTag]);
 
   const handleSearch = (query: string) => {
-    const queryParams = getParams({
+    const queryParams = normalizeDateTimeParams({
       ...(location.query || {}),
       query,
     });

--- a/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
@@ -6,7 +6,7 @@ import Button from 'sentry/components/button';
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
@@ -30,7 +30,7 @@ function VitalsContent(props: Props) {
   const query = decodeScalar(location.query.query, '');
 
   const handleSearch = (newQuery: string) => {
-    const queryParams = getParams({
+    const queryParams = normalizeDateTimeParams({
       ...(location.query || {}),
       query: newQuery,
     });

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -7,7 +7,7 @@ import LineChart, {LineChartSeries} from 'sentry/components/charts/lineChart';
 import TransitionChart from 'sentry/components/charts/transitionChart';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import {getTooltipArrow} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import {EventsStatsData, OrganizationSummary, Project} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
@@ -287,7 +287,7 @@ export function Chart({
 
   const start = propsStart ? getUtcToLocalDateObject(propsStart) : null;
   const end = propsEnd ? getUtcToLocalDateObject(propsEnd) : null;
-  const {utc} = getParams(location.query);
+  const {utc} = normalizeDateTimeParams(location.query);
 
   const seriesSelection = decodeList(
     location.query[getUnselectedSeries(trendChangeType)]

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -12,7 +12,7 @@ import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
 import {IconChevron} from 'sentry/icons';
 import {IconFlag} from 'sentry/icons/iconFlag';
@@ -70,7 +70,7 @@ class VitalDetailContent extends React.Component<Props, State> {
   handleSearch = (query: string) => {
     const {location} = this.props;
 
-    const queryParams = getParams({
+    const queryParams = normalizeDateTimeParams({
       ...(location.query || {}),
       query,
     });

--- a/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/react';
 import {fetchTotalCount} from 'sentry/actionCreators/events';
 import EventsChart, {EventsChartProps} from 'sentry/components/charts/eventsChart';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {isSelectionEqual} from 'sentry/components/organizations/pageFilters/utils';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
@@ -45,7 +45,7 @@ class ProjectBaseEventsChart extends Component<Props> {
         query,
         environment: environments,
         project: projects.map(proj => String(proj)),
-        ...getParams(datetime),
+        ...normalizeDateTimeParams(datetime),
       });
       onTotalValuesChange(totals);
     } catch (err) {

--- a/static/app/views/projectDetail/charts/projectSessionsChartRequest.tsx
+++ b/static/app/views/projectDetail/charts/projectSessionsChartRequest.tsx
@@ -6,7 +6,7 @@ import omit from 'lodash/omit';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
 import {shouldFetchPreviousPeriod} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import {
   Organization,
@@ -174,7 +174,7 @@ class ProjectSessionsChartRequest extends React.Component<Props, State> {
     if (!shouldFetchWithPrevious) {
       return {
         ...baseParams,
-        ...getParams(datetime),
+        ...normalizeDateTimeParams(datetime),
       };
     }
 

--- a/static/app/views/projectDetail/projectIssues.tsx
+++ b/static/app/views/projectDetail/projectIssues.tsx
@@ -9,7 +9,7 @@ import ButtonBar from 'sentry/components/buttonBar';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import DiscoverButton from 'sentry/components/discoverButton';
 import GroupList from 'sentry/components/issues/groupList';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Pagination from 'sentry/components/pagination';
 import {Panel, PanelBody} from 'sentry/components/panels';
 import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'sentry/constants';
@@ -64,7 +64,7 @@ function ProjectIssues({organization, location, projectId, query, api}: Props) {
         sort: ['-count'],
         query: ['event.type:error error.unhandled:true', query].join(' ').trim(),
         display: 'top5',
-        ...getParams(pick(location.query, [...Object.values(URL_PARAM)])),
+        ...normalizeDateTimeParams(pick(location.query, [...Object.values(URL_PARAM)])),
       },
     };
   }
@@ -73,7 +73,9 @@ function ProjectIssues({organization, location, projectId, query, api}: Props) {
   const issueQuery = ['is:unresolved error.unhandled:true ', query].join(' ').trim();
   const queryParams = {
     limit: 5,
-    ...getParams(pick(location.query, [...Object.values(URL_PARAM), 'cursor'])),
+    ...normalizeDateTimeParams(
+      pick(location.query, [...Object.values(URL_PARAM), 'cursor'])
+    ),
     query: issueQuery,
     sort: 'freq',
   };

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -4,7 +4,7 @@ import round from 'lodash/round';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import {shouldFetchPreviousPeriod} from 'sentry/components/charts/utils';
 import Count from 'sentry/components/count';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {parseStatsPeriod} from 'sentry/components/organizations/timeRangeSelector/utils';
 import ScoreCard from 'sentry/components/scoreCard';
 import {IconArrow} from 'sentry/icons';
@@ -62,7 +62,7 @@ class ProjectApdexScoreCard extends AsyncComponent<Props, State> {
       [
         'currentApdex',
         `/organizations/${organization.slug}/eventsv2/`,
-        {query: {...commonQuery, ...getParams(datetime)}},
+        {query: {...commonQuery, ...normalizeDateTimeParams(datetime)}},
       ],
     ];
 

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -6,7 +6,7 @@ import {
   getDiffInMinutes,
   shouldFetchPreviousPeriod,
 } from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import ScoreCard from 'sentry/components/scoreCard';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {IconArrow} from 'sentry/icons';
@@ -75,7 +75,7 @@ class ProjectStabilityScoreCard extends AsyncComponent<Props, State> {
         {
           query: {
             ...commonQuery,
-            ...getParams(datetime),
+            ...normalizeDateTimeParams(datetime),
           },
         },
       ],

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {fetchAnyReleaseExistence} from 'sentry/actionCreators/projects';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import {shouldFetchPreviousPeriod} from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {parseStatsPeriod} from 'sentry/components/organizations/timeRangeSelector/utils';
 import ScoreCard from 'sentry/components/scoreCard';
 import {IconArrow} from 'sentry/icons';
@@ -66,7 +66,7 @@ class ProjectVelocityScoreCard extends AsyncComponent<Props, State> {
           method: 'GET',
           query: {
             ...commonQuery,
-            ...getParams(datetime),
+            ...normalizeDateTimeParams(datetime),
           },
         },
       ],

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -10,7 +10,7 @@ import AsyncComponent from 'sentry/components/asyncComponent';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import PickProjectToContinue from 'sentry/components/pickProjectToContinue';
 import {PAGE_URL_PARAM, URL_PARAM} from 'sentry/constants/pageFilters';
 import {IconInfo, IconWarning} from 'sentry/icons';
@@ -121,7 +121,7 @@ class ReleasesDetail extends AsyncView<Props, State> {
         {
           query: {
             adoptionStages: 1,
-            ...getParams(this.pickLocationQuery(location)),
+            ...normalizeDateTimeParams(this.pickLocationQuery(location)),
           },
         },
       ],

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -15,7 +15,7 @@ import TransactionsList, {
   DropdownOption,
 } from 'sentry/components/discover/transactionsList';
 import {Body, Main, Side} from 'sentry/components/layouts/thirds';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
 import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
@@ -293,7 +293,7 @@ class ReleaseOverview extends AsyncView<Props> {
   get pageDateTime(): DateTimeObject {
     const query = this.props.location.query;
 
-    const {start, end, statsPeriod} = getParams(query, {
+    const {start, end, statsPeriod} = normalizeDateTimeParams(query, {
       allowEmptyPeriod: true,
       allowAbsoluteDatetime: true,
       allowAbsolutePageDatetime: true,

--- a/static/app/views/releases/detail/overview/sidebar/totalCrashFreeUsers.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/totalCrashFreeUsers.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 
 import AsyncComponent from 'sentry/components/asyncComponent';
 import Count from 'sentry/components/count';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import SidebarSection from 'sentry/components/sidebarSection';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {t, tn} from 'sentry/locale';
@@ -41,7 +41,7 @@ class TotalCrashFreeUsers extends AsyncComponent<Props, State> {
         )}/stats/`,
         {
           query: {
-            ...getParams(
+            ...normalizeDateTimeParams(
               pick(location.query, [URL_PARAM.PROJECT, URL_PARAM.ENVIRONMENT])
             ),
             type: 'sessions',

--- a/static/app/views/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/releases/list/releasesAdoptionChart.tsx
@@ -27,10 +27,10 @@ import {
 } from 'sentry/components/charts/utils';
 import Count from 'sentry/components/count';
 import {
-  getParams,
+  normalizeDateTimeParams,
   parseStatsPeriod,
   StatsPeriodType,
-} from 'sentry/components/organizations/pageFilters/getParams';
+} from 'sentry/components/organizations/pageFilters/parse';
 import {Panel, PanelBody, PanelFooter} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
@@ -157,7 +157,7 @@ class ReleasesAdoptionChart extends Component<Props> {
         interval={interval}
         groupBy={['release']}
         field={[field]}
-        {...getParams(pick(location.query, Object.values(URL_PARAM)))}
+        {...normalizeDateTimeParams(pick(location.query, Object.values(URL_PARAM)))}
       >
         {({response, loading, reloading}) => {
           const totalCount = getCount(response?.groups, field);

--- a/static/app/views/releases/list/releasesRequest.tsx
+++ b/static/app/views/releases/list/releasesRequest.tsx
@@ -14,7 +14,7 @@ import {
   TWENTY_FOUR_HOURS,
   TWO_WEEKS,
 } from 'sentry/components/charts/utils';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import {
@@ -159,7 +159,7 @@ class ReleasesRequest extends React.Component<Props, State> {
         }, [] as string[])
       ).formatString(),
       interval: getInterval(selection.datetime),
-      ...getParams(pick(location.query, Object.values(URL_PARAM)), {
+      ...normalizeDateTimeParams(pick(location.query, Object.values(URL_PARAM)), {
         defaultStatsPeriod,
       }),
     };

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 
 import {DateTimeObject} from 'sentry/components/charts/utils';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {getParams} from 'sentry/components/organizations/pageFilters/getParams';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {PAGE_URL_PARAM, URL_PARAM} from 'sentry/constants/pageFilters';
 import {desktop, mobile, PlatformKey} from 'sentry/data/platformCategories';
 import {t, tct} from 'sentry/locale';
@@ -171,7 +171,7 @@ type GetReleaseParams = {
 };
 
 export function getReleaseParams({location, releaseBounds}: GetReleaseParams) {
-  const params = getParams(
+  const params = normalizeDateTimeParams(
     pick(location.query, [
       ...Object.values(URL_PARAM),
       ...Object.values(PAGE_URL_PARAM),

--- a/tests/js/spec/components/organizations/parse.spec.jsx
+++ b/tests/js/spec/components/organizations/parse.spec.jsx
@@ -1,35 +1,39 @@
 import {
-  getParams,
+  normalizeDateTimeParams,
   parseStatsPeriod,
-} from 'sentry/components/organizations/pageFilters/getParams';
+} from 'sentry/components/organizations/pageFilters/parse';
 
-describe('getParams', function () {
+describe('normalizeDateTimeParams', function () {
   it('should return default statsPeriod if it is not provided or is invalid', function () {
-    expect(getParams({})).toEqual({statsPeriod: '14d'});
-    expect(getParams({statsPeriod: 'invalid'})).toEqual({statsPeriod: '14d'});
-    expect(getParams({statsPeriod: null})).toEqual({statsPeriod: '14d'});
-    expect(getParams({statsPeriod: undefined})).toEqual({statsPeriod: '14d'});
-    expect(getParams({statsPeriod: '24f'})).toEqual({statsPeriod: '14d'});
-    expect(getParams({statsPeriod: '24'})).toEqual({statsPeriod: '24s'});
+    expect(normalizeDateTimeParams({})).toEqual({statsPeriod: '14d'});
+    expect(normalizeDateTimeParams({statsPeriod: 'invalid'})).toEqual({
+      statsPeriod: '14d',
+    });
+    expect(normalizeDateTimeParams({statsPeriod: null})).toEqual({statsPeriod: '14d'});
+    expect(normalizeDateTimeParams({statsPeriod: undefined})).toEqual({
+      statsPeriod: '14d',
+    });
+    expect(normalizeDateTimeParams({statsPeriod: '24f'})).toEqual({statsPeriod: '14d'});
+    expect(normalizeDateTimeParams({statsPeriod: '24'})).toEqual({statsPeriod: '24s'});
   });
 
   it('should parse statsPeriod', function () {
-    expect(getParams({statsPeriod: '5s'})).toEqual({statsPeriod: '5s'});
-    expect(getParams({statsPeriod: '11h'})).toEqual({statsPeriod: '11h'});
-    expect(getParams({statsPeriod: '14d'})).toEqual({statsPeriod: '14d'});
-    expect(getParams({statsPeriod: '24w'})).toEqual({statsPeriod: '24w'});
-    expect(getParams({statsPeriod: '42m'})).toEqual({statsPeriod: '42m'});
+    expect(normalizeDateTimeParams({statsPeriod: '5s'})).toEqual({statsPeriod: '5s'});
+    expect(normalizeDateTimeParams({statsPeriod: '11h'})).toEqual({statsPeriod: '11h'});
+    expect(normalizeDateTimeParams({statsPeriod: '14d'})).toEqual({statsPeriod: '14d'});
+    expect(normalizeDateTimeParams({statsPeriod: '24w'})).toEqual({statsPeriod: '24w'});
+    expect(normalizeDateTimeParams({statsPeriod: '42m'})).toEqual({statsPeriod: '42m'});
   });
 
   it('should parse first valid statsPeriod', function () {
-    expect(getParams({statsPeriod: ['invalid', '24d', '5s']})).toEqual({
+    expect(normalizeDateTimeParams({statsPeriod: ['invalid', '24d', '5s']})).toEqual({
       statsPeriod: '24d',
     });
   });
 
   it('should return statsPeriod if statsPeriod, start, and end are provided', function () {
     expect(
-      getParams({
+      normalizeDateTimeParams({
         start: '2019-10-01T00:00:00',
         end: '2019-10-02T00:00:00',
         statsPeriod: '55d',
@@ -38,7 +42,7 @@ describe('getParams', function () {
     ).toEqual({statsPeriod: '55d'});
 
     expect(
-      getParams({
+      normalizeDateTimeParams({
         start: '2019-10-01T00:00:00',
         end: '2019-10-02T00:00:00',
         statsPeriod: '55d',
@@ -46,7 +50,7 @@ describe('getParams', function () {
     ).toEqual({statsPeriod: '55d'});
 
     expect(
-      getParams({
+      normalizeDateTimeParams({
         start: '2019-10-01T00:00:00',
         end: '2019-10-02T00:00:00',
         period: '55d',
@@ -55,18 +59,21 @@ describe('getParams', function () {
   });
 
   it('should parse start and end', function () {
-    expect(getParams({start: '2019-10-01T00:00:00', end: '2019-10-02T00:00:00'})).toEqual(
-      {start: '2019-10-01T00:00:00.000', end: '2019-10-02T00:00:00.000'}
-    );
+    expect(
+      normalizeDateTimeParams({start: '2019-10-01T00:00:00', end: '2019-10-02T00:00:00'})
+    ).toEqual({start: '2019-10-01T00:00:00.000', end: '2019-10-02T00:00:00.000'});
 
     expect(
-      getParams({start: '2019-10-23T04:28:49+0000', end: '2019-10-26T02:56:17+0000'})
+      normalizeDateTimeParams({
+        start: '2019-10-23T04:28:49+0000',
+        end: '2019-10-26T02:56:17+0000',
+      })
     ).toEqual({start: '2019-10-23T04:28:49.000', end: '2019-10-26T02:56:17.000'});
   });
 
   it('should parse first valid start and end', function () {
     expect(
-      getParams({
+      normalizeDateTimeParams({
         start: ['invalid', '2019-10-01T00:00:00', '2020-10-01T00:00:00'],
         end: ['invalid', '2019-10-02T00:00:00', '2020-10-02T00:00:00'],
       })
@@ -74,55 +81,55 @@ describe('getParams', function () {
   });
 
   it('should return default statsPeriod if both start and end are not provided, or either are invalid', function () {
-    expect(getParams({start: '2019-10-01T00:00:00'})).toEqual({
+    expect(normalizeDateTimeParams({start: '2019-10-01T00:00:00'})).toEqual({
       statsPeriod: '14d',
     });
-    expect(getParams({start: null})).toEqual({
+    expect(normalizeDateTimeParams({start: null})).toEqual({
       statsPeriod: '14d',
     });
-    expect(getParams({start: undefined})).toEqual({
-      statsPeriod: '14d',
-    });
-
-    expect(getParams({end: '2019-10-01T00:00:00'})).toEqual({
-      statsPeriod: '14d',
-    });
-    expect(getParams({end: null})).toEqual({
-      statsPeriod: '14d',
-    });
-    expect(getParams({end: undefined})).toEqual({
+    expect(normalizeDateTimeParams({start: undefined})).toEqual({
       statsPeriod: '14d',
     });
 
-    expect(getParams({start: undefined, end: undefined})).toEqual({
+    expect(normalizeDateTimeParams({end: '2019-10-01T00:00:00'})).toEqual({
       statsPeriod: '14d',
     });
-    expect(getParams({start: null, end: undefined})).toEqual({
+    expect(normalizeDateTimeParams({end: null})).toEqual({
       statsPeriod: '14d',
     });
-    expect(getParams({start: undefined, end: null})).toEqual({
+    expect(normalizeDateTimeParams({end: undefined})).toEqual({
       statsPeriod: '14d',
     });
-    expect(getParams({start: null, end: null})).toEqual({
+
+    expect(normalizeDateTimeParams({start: undefined, end: undefined})).toEqual({
+      statsPeriod: '14d',
+    });
+    expect(normalizeDateTimeParams({start: null, end: undefined})).toEqual({
+      statsPeriod: '14d',
+    });
+    expect(normalizeDateTimeParams({start: undefined, end: null})).toEqual({
+      statsPeriod: '14d',
+    });
+    expect(normalizeDateTimeParams({start: null, end: null})).toEqual({
       statsPeriod: '14d',
     });
 
     expect(
-      getParams({
+      normalizeDateTimeParams({
         start: ['invalid'],
         end: ['invalid'],
       })
     ).toEqual({statsPeriod: '14d'});
 
     expect(
-      getParams({
+      normalizeDateTimeParams({
         start: ['invalid'],
         end: ['invalid', '2019-10-02T00:00:00', '2020-10-02T00:00:00'],
       })
     ).toEqual({statsPeriod: '14d'});
 
     expect(
-      getParams({
+      normalizeDateTimeParams({
         start: ['invalid', '2019-10-01T00:00:00', '2020-10-01T00:00:00'],
         end: ['invalid'],
       })
@@ -131,7 +138,7 @@ describe('getParams', function () {
 
   it('should use pageStart/pageEnd/pageUtc to override start/end/utc', function () {
     expect(
-      getParams(
+      normalizeDateTimeParams(
         {
           pageStart: '2021-10-23T04:28:49+0000',
           pageEnd: '2021-10-26T02:56:17+0000',
@@ -151,7 +158,7 @@ describe('getParams', function () {
 
   it('should use pageStatsPeriod to override statsPeriod', function () {
     expect(
-      getParams({
+      normalizeDateTimeParams({
         pageStart: '2021-10-23T04:28:49+0000',
         pageEnd: '2021-10-26T02:56:17+0000',
         pageUtc: 'true',
@@ -168,16 +175,25 @@ describe('getParams', function () {
   });
 
   it('does not return default statsPeriod if `allowEmptyPeriod` option is passed', function () {
-    expect(getParams({}, {allowEmptyPeriod: true})).toEqual({});
+    expect(normalizeDateTimeParams({}, {allowEmptyPeriod: true})).toEqual({});
   });
 
   it('should parse utc when it is defined', function () {
-    expect(getParams({utc: 'true'})).toEqual({utc: 'true', statsPeriod: '14d'});
-    expect(getParams({utc: 'false'})).toEqual({utc: 'false', statsPeriod: '14d'});
-    expect(getParams({utc: 'invalid'})).toEqual({utc: 'false', statsPeriod: '14d'});
+    expect(normalizeDateTimeParams({utc: 'true'})).toEqual({
+      utc: 'true',
+      statsPeriod: '14d',
+    });
+    expect(normalizeDateTimeParams({utc: 'false'})).toEqual({
+      utc: 'false',
+      statsPeriod: '14d',
+    });
+    expect(normalizeDateTimeParams({utc: 'invalid'})).toEqual({
+      utc: 'false',
+      statsPeriod: '14d',
+    });
 
-    expect(getParams({utc: null})).toEqual({statsPeriod: '14d'});
-    expect(getParams({utc: undefined})).toEqual({statsPeriod: '14d'});
+    expect(normalizeDateTimeParams({utc: null})).toEqual({statsPeriod: '14d'});
+    expect(normalizeDateTimeParams({utc: undefined})).toEqual({statsPeriod: '14d'});
   });
 });
 
@@ -199,7 +215,7 @@ describe('parseStatsPeriod', function () {
 
   it('does not return start and end if `allowAbsoluteDatetime` option is passed', function () {
     expect(
-      getParams(
+      normalizeDateTimeParams(
         {start: '2019-10-01T00:00:00', end: '2019-10-02T00:00:00'},
         {allowAbsoluteDatetime: false}
       )


### PR DESCRIPTION
Previously query parsing logic was split between utils and getParams. Neither of these modules were very specific.

This PR adds many comments and tightens up types of the query parsing / normalization of page filters from query parameters.