### PR TITLE
feat(suspect-spans): Support unnamed spans in the table

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -317,4 +317,4 @@ const EmptyValueContainer = styled('span')`
   color: ${p => p.theme.gray300};
 `;
 
-export const emptyValue = <EmptyValueContainer>{t('n/a')}</EmptyValueContainer>;
+const emptyValue = <EmptyValueContainer>{t('(unnamed span)')}</EmptyValueContainer>;

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
@@ -110,7 +110,7 @@ function renderBodyCellWithMeta(
       });
       return (
         <TableCellContainer>
-          <Link to={target}>{dataRow[column.key]}</Link>
+          <Link to={target}>{dataRow[column.key] ?? <i>{t('(unnamed span)')}</i>}</Link>
         </TableCellContainer>
       );
     }

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
@@ -110,7 +110,7 @@ function renderBodyCellWithMeta(
       });
       return (
         <TableCellContainer>
-          <Link to={target}>{dataRow[column.key] ?? <i>{t('(unnamed span)')}</i>}</Link>
+          <Link to={target}>{dataRow[column.key] ?? t('(unnamed span)')}</Link>
         </TableCellContainer>
       );
     }

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
@@ -201,12 +201,12 @@ const COLUMN_ORDER: Record<SpanSort, TableColumnKey[]> = {
 const COLUMNS: Record<TableColumnKey, TableColumn> = {
   operation: {
     key: 'operation',
-    name: t('Operation'),
+    name: t('Span Operation'),
     width: COL_WIDTH_UNDEFINED,
   },
   description: {
     key: 'description',
-    name: t('Description'),
+    name: t('Span Name'),
     width: COL_WIDTH_UNDEFINED,
   },
   totalCount: {

--- a/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
@@ -115,8 +115,8 @@ describe('Performance > Transaction Spans', function () {
 
       // default visible columns
       const grid = await screen.findByTestId('grid-editable');
-      expect(await within(grid).findByText('Operation')).toBeInTheDocument();
-      expect(await within(grid).findByText('Description')).toBeInTheDocument();
+      expect(await within(grid).findByText('Span Operation')).toBeInTheDocument();
+      expect(await within(grid).findByText('Span Name')).toBeInTheDocument();
       expect(await within(grid).findByText('Total Count')).toBeInTheDocument();
       expect(await within(grid).findByText('Frequency')).toBeInTheDocument();
       expect(await within(grid).findByText('P75 Exclusive Time')).toBeInTheDocument();
@@ -148,8 +148,8 @@ describe('Performance > Transaction Spans', function () {
         );
 
         const grid = await screen.findByTestId('grid-editable');
-        expect(await within(grid).findByText('Operation')).toBeInTheDocument();
-        expect(await within(grid).findByText('Description')).toBeInTheDocument();
+        expect(await within(grid).findByText('Span Operation')).toBeInTheDocument();
+        expect(await within(grid).findByText('Span Name')).toBeInTheDocument();
         expect(await within(grid).findByText('Total Count')).toBeInTheDocument();
         expect(await within(grid).findByText('Frequency')).toBeInTheDocument();
         expect(await within(grid).findByText(label)).toBeInTheDocument();
@@ -168,8 +168,8 @@ describe('Performance > Transaction Spans', function () {
       );
 
       const grid = await screen.findByTestId('grid-editable');
-      expect(await within(grid).findByText('Operation')).toBeInTheDocument();
-      expect(await within(grid).findByText('Description')).toBeInTheDocument();
+      expect(await within(grid).findByText('Span Operation')).toBeInTheDocument();
+      expect(await within(grid).findByText('Span Name')).toBeInTheDocument();
       expect(await within(grid).findByText('Total Count')).toBeInTheDocument();
       expect(await within(grid).findByText('Frequency')).toBeInTheDocument();
       expect(await within(grid).findByText('P75 Exclusive Time')).toBeInTheDocument();
@@ -187,8 +187,8 @@ describe('Performance > Transaction Spans', function () {
       );
 
       const grid = await screen.findByTestId('grid-editable');
-      expect(await within(grid).findByText('Operation')).toBeInTheDocument();
-      expect(await within(grid).findByText('Description')).toBeInTheDocument();
+      expect(await within(grid).findByText('Span Operation')).toBeInTheDocument();
+      expect(await within(grid).findByText('Span Name')).toBeInTheDocument();
       expect(await within(grid).findByText('Average Occurrences')).toBeInTheDocument();
       expect(await within(grid).findByText('Frequency')).toBeInTheDocument();
       expect(await within(grid).findByText('P75 Exclusive Time')).toBeInTheDocument();

--- a/tests/js/spec/views/performance/transactionSummary/suspectSpans.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/suspectSpans.spec.tsx
@@ -63,8 +63,8 @@ describe('SuspectSpans', function () {
 
       expect(await screen.findByText('Suspect Spans')).toBeInTheDocument();
       expect(await screen.findByText('View All Spans')).toBeInTheDocument();
-      expect(await screen.findByText('Operation')).toBeInTheDocument();
-      expect(await screen.findByText('Description')).toBeInTheDocument();
+      expect(await screen.findByText('Span Operation')).toBeInTheDocument();
+      expect(await screen.findByText('Span Name')).toBeInTheDocument();
       expect(await screen.findByText('Total Count')).toBeInTheDocument();
       expect(await screen.findByText('Frequency')).toBeInTheDocument();
       expect(await screen.findByText('P75 Exclusive Time')).toBeInTheDocument();


### PR DESCRIPTION
Unnamed spans do not have any clickable text to link to the span details page.
This adds `(unnamed span)` in italics as the link.