### PR TITLE
ref(sentry apps): Don't raise IgnoreableSentryAppError

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -998,8 +998,6 @@ SENTRY_FEATURES = {
     "organizations:integrations-custom-scm": False,
     # Limit project events endpoint to only query back a certain number of days
     "organizations:project-event-date-limit": False,
-    # Allow orgs to debug internal/unpublished sentry apps with logging
-    "organizations:sentry-app-debugging": False,
     # Enable data forwarding functionality for organizations.
     "organizations:data-forwarding": True,
     # Enable react-grid-layout dashboards

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -142,7 +142,6 @@ default_manager.add("organizations:required-email-verification", OrganizationFea
 default_manager.add("organizations:rule-page", OrganizationFeature)
 default_manager.add("organizations:selection-filters-v2", OrganizationFeature, True)
 default_manager.add("organizations:semver", OrganizationFeature, True)
-default_manager.add("organizations:sentry-app-debugging", OrganizationFeature, True)
 default_manager.add("organizations:set-grouping-config", OrganizationFeature)
 default_manager.add("organizations:sso-basic", OrganizationFeature)
 default_manager.add("organizations:sso-migration", OrganizationFeature)

--- a/src/sentry/shared_integrations/exceptions.py
+++ b/src/sentry/shared_integrations/exceptions.py
@@ -105,10 +105,6 @@ class IntegrationFormError(IntegrationError):
         self.field_errors = field_errors
 
 
-class IgnorableSentryAppError(RequestException):
-    pass
-
-
 class ClientError(RequestException):
     """4xx Error Occurred"""
 

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -4,7 +4,7 @@ from celery.task import current
 from django.urls import reverse
 from requests.exceptions import ConnectionError, RequestException, Timeout
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.serializers import AppPlatformEvent, serialize
 from sentry.constants import SentryAppInstallationStatus
 from sentry.eventstore.models import Event
@@ -186,18 +186,6 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
     event = f"{name}.{action}"
 
     if event not in VALID_EVENTS:
-        org_id = Project.objects.get_from_cache(id=instance.project_id).organization_id
-        org = Organization.objects.get_from_cache(id=org_id)
-        if features.has("organizations:sentry-app-debugging", org):
-            logger.info(
-                "_process_resource_change.invalid_event.debug",
-                extra={
-                    "event_type": event,
-                    "organization_id": org_id,
-                    "project_id": instance.project_id,
-                    "valid_events": VALID_EVENTS,
-                },
-            )
         return
 
     org = None
@@ -342,15 +330,6 @@ def send_webhooks(installation, event, **kwargs):
         return
 
     if event not in servicehook.events:
-        organization = Organization.objects.get_from_cache(id=installation.organization_id)
-        if features.has("organizations:sentry-app-debugging", organization):
-            logger.info(
-                "send_webhooks.dropped_event.debug",
-                extra={
-                    "event_type": event,
-                    "organization_id": installation.organization_id,
-                },
-            )
         return
 
     # The service hook applies to all projects if there are no
@@ -421,18 +400,6 @@ def send_and_save_webhook_request(sentry_app, app_platform_event, url=None):
         resp = safe_urlopen(
             url=url, data=app_platform_event.body, headers=app_platform_event.headers, timeout=5
         )
-        organization = Organization.objects.get_from_cache(id=org_id)
-        if features.has("organizations:sentry-app-debugging", organization):
-            project_id = app_platform_event.data["error"].get("project")
-            logger.info(
-                "send_and_save_webhook_request.debug",
-                extra={
-                    "event_type": event,
-                    "organization_id": org_id,
-                    "integration_slug": sentry_app.slug,
-                    "project_id": project_id,
-                },
-            )
     except (Timeout, ConnectionError) as e:
         error_type = e.__class__.__name__.lower()
         logger.info(
@@ -451,19 +418,6 @@ def send_and_save_webhook_request(sentry_app, app_platform_event, url=None):
 
     else:
         track_response_code(resp.status_code, slug, event)
-        organization = Organization.objects.get_from_cache(id=org_id)
-        if features.has("organizations:sentry-app-debugging", organization):
-            project_id = app_platform_event.data["error"].get("project")
-            logger.info(
-                "send_and_save_webhook_request.error",
-                extra={
-                    "event_type": event,
-                    "organization_id": org_id,
-                    "integration_slug": sentry_app.slug,
-                    "status": resp.status_code,
-                    "project_id": project_id,
-                },
-            )
         buffer.add_request(
             response_code=resp.status_code,
             org_id=org_id,

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -395,6 +395,8 @@ def ignore_unpublished_app_errors(func):
         except Exception:
             if sentry_app.is_published:
                 raise
+            else:
+                return
 
     return wrapper
 

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -20,12 +20,7 @@ from sentry.models import (
     User,
 )
 from sentry.models.sentryapp import VALID_EVENTS, track_response_code
-from sentry.shared_integrations.exceptions import (
-    ApiHostError,
-    ApiTimeoutError,
-    ClientError,
-    IgnorableSentryAppError,
-)
+from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
 from sentry.utils.compat import filter
@@ -42,7 +37,7 @@ TASK_OPTIONS = {
 
 RETRY_OPTIONS = {
     "on": (RequestException, ApiHostError, ApiTimeoutError),
-    "ignore": (IgnorableSentryAppError, ClientError),
+    "ignore": (ClientError),
 }
 
 # We call some models by a different name, publicly, than their class name.

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -395,8 +395,6 @@ def ignore_unpublished_app_errors(func):
         except Exception:
             if sentry_app.is_published:
                 raise
-            else:
-                raise IgnorableSentryAppError("unpublished or internal app")
 
     return wrapper
 

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -69,7 +69,7 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
 class DeleteSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
     @responses.activate
     def test_delete_install(self):
-        responses.add(url="https://example.com/webhook", method=responses.POST, body={})
+        responses.add(url="https://example.com/webhook", method=responses.POST, body=b"")
         self.login_as(user=self.user)
         response = self.client.delete(self.url, format="json")
 

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -4,6 +4,7 @@ import responses
 from django.db import connection
 from requests.exceptions import RequestException
 
+from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_app_installations import Creator, Destroyer
 from sentry.models import (
     ApiGrant,
@@ -139,7 +140,7 @@ class TestDestroyer(TestCase):
     @responses.activate
     def test_deletes_on_request_exception(self):
         install = self.install
-
+        self.sentry_app.update(status=SentryAppStatus.PUBLISHED)
         responses.add(
             responses.POST,
             "https://example.com/webhook",
@@ -152,7 +153,6 @@ class TestDestroyer(TestCase):
 
     @responses.activate
     def test_fail_on_other_error(self):
-        from sentry.constants import SentryAppStatus
 
         install = self.install
         self.sentry_app.update(status=SentryAppStatus.PUBLISHED)

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -10,7 +10,7 @@ from sentry.api.serializers import serialize
 from sentry.constants import SentryAppStatus
 from sentry.models import Rule, SentryApp, SentryAppInstallation
 from sentry.receivers.sentry_apps import *  # NOQA
-from sentry.shared_integrations.exceptions import ClientError, IgnorableSentryAppError
+from sentry.shared_integrations.exceptions import ClientError
 from sentry.tasks.post_process import post_process_group
 from sentry.tasks.sentry_apps import (
     installation_webhook,
@@ -572,40 +572,3 @@ class TestWebhookRequests(TestCase):
         assert first_request["organization_id"] == self.install.organization.id
         assert first_request["error_id"] == "d5111da2c28645c5889d072017e3445d"
         assert first_request["project_id"] == "1"
-
-    @patch("sentry.tasks.sentry_apps.safe_urlopen", return_value=MockResponse404)
-    def test_raises_ignorable_error_for_internal_apps(self, safe_urlopen):
-        data = {"issue": serialize(self.issue)}
-        self.sentry_app.update(status=SentryAppStatus.INTERNAL)
-        with self.assertRaises(IgnorableSentryAppError):
-            send_webhooks(
-                installation=self.install, event="issue.assigned", data=data, actor=self.user
-            )
-
-        requests = self.buffer.get_requests()
-        requests_count = len(requests)
-        first_request = requests[0]
-
-        assert safe_urlopen.called
-        assert requests_count == 1
-        assert first_request["response_code"] == 404
-        assert first_request["event_type"] == "issue.assigned"
-
-    @patch("sentry.tasks.sentry_apps.safe_urlopen", return_value=MockResponse404)
-    def test_raises_ignorable_error_for_unpublished_apps(self, safe_urlopen):
-        data = {"issue": serialize(self.issue)}
-        self.sentry_app.update(status=SentryAppStatus.UNPUBLISHED)
-        with self.assertRaises(IgnorableSentryAppError):
-            send_webhooks(
-                installation=self.install, event="issue.assigned", data=data, actor=self.user
-            )
-
-        requests = self.buffer.get_requests()
-        requests_count = len(requests)
-        first_request = requests[0]
-
-        assert safe_urlopen.called
-        assert requests_count == 1
-        assert first_request["response_code"] == 404
-        assert first_request["event_type"] == "issue.assigned"
-        assert first_request["organization_id"] == self.install.organization.id


### PR DESCRIPTION
We don't care about these issues, so don't raise them which creates an event in Sentry.

Fixes [SENTRY-SMJ](https://sentry.io/organizations/sentry/issues/2764448409/?project=1&referrer=slack)