### PR TITLE
fix(widget-library): Distribution Widget Line Display Type

### DIFF
--- a/static/app/views/dashboardsV2/widgetLibrary/data.tsx
+++ b/static/app/views/dashboardsV2/widgetLibrary/data.tsx
@@ -11,7 +11,7 @@ export const DEFAULT_WIDGETS: Readonly<Array<WidgetTemplate>> = [
     id: undefined,
     title: t('Duration Distribution'),
     description: t('Compare transaction durations across different percentiles.'),
-    displayType: DisplayType.AREA,
+    displayType: DisplayType.LINE,
     widgetType: WidgetType.DISCOVER,
     interval: '5m',
     queries: [


### PR DESCRIPTION
The distribution widget plots duration percentiles and
since they shouldn't stack (which an area chart does)
changing it to line type. Need to come up with a
different area chart widget.