### PR TITLE
feat(suspect-spans): Add span details to breadcrumbs

### DIFF
--- a/static/app/utils/performance/suspectSpans/types.tsx
+++ b/static/app/utils/performance/suspectSpans/types.tsx
@@ -39,3 +39,8 @@ export type SpanOp = {
 };
 
 export type SpanOps = SpanOp[];
+
+export type SpanSlug = {
+  op: string;
+  group: string;
+};

--- a/static/app/views/performance/breadcrumb.tsx
+++ b/static/app/views/performance/breadcrumb.tsx
@@ -4,6 +4,7 @@ import {Location, LocationDescriptor} from 'history';
 import Breadcrumbs, {Crumb} from 'sentry/components/breadcrumbs';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
+import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 
 import Tab from './transactionSummary/tabs';
@@ -23,6 +24,7 @@ type Props = {
     name: string;
   };
   vitalName?: string;
+  spanSlug?: SpanSlug;
   eventSlug?: string;
   traceSlug?: string;
   tab?: Tab;
@@ -31,8 +33,16 @@ type Props = {
 class Breadcrumb extends Component<Props> {
   getCrumbs() {
     const crumbs: Crumb[] = [];
-    const {organization, location, transaction, vitalName, eventSlug, traceSlug, tab} =
-      this.props;
+    const {
+      organization,
+      location,
+      transaction,
+      vitalName,
+      spanSlug,
+      eventSlug,
+      traceSlug,
+      tab,
+    } = this.props;
 
     const performanceTarget: LocationDescriptor = {
       pathname: getPerformanceLandingUrl(organization),
@@ -118,7 +128,12 @@ class Breadcrumb extends Component<Props> {
       }
     }
 
-    if (transaction && eventSlug) {
+    if (transaction && spanSlug) {
+      crumbs.push({
+        to: '',
+        label: t('Span Details'),
+      });
+    } else if (transaction && eventSlug) {
       crumbs.push({
         to: '',
         label: t('Event Details'),

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/chart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/chart.tsx
@@ -5,8 +5,7 @@ import {ChartContainer} from 'sentry/components/charts/styles';
 import {Panel} from 'sentry/components/panels';
 import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
-
-import {SpanSlug} from '../types';
+import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 
 import ExclusiveTimeChart from './exclusiveTimeChart';
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -18,12 +18,11 @@ import SpanExamplesQuery, {
 import SuspectSpansQuery, {
   ChildrenProps as SuspectSpansProps,
 } from 'sentry/utils/performance/suspectSpans/suspectSpansQuery';
-import {SuspectSpan} from 'sentry/utils/performance/suspectSpans/types';
+import {SpanSlug, SuspectSpan} from 'sentry/utils/performance/suspectSpans/types';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 
 import {PerformanceDuration} from '../../../utils';
 import Tab from '../../tabs';
-import {SpanSlug} from '../types';
 import {getTotalsView} from '../utils';
 
 import SpanChart from './chart';
@@ -53,6 +52,7 @@ export default function SpanDetailsContentWrapper(props: Props) {
               name: transactionName,
             }}
             tab={Tab.Spans}
+            spanSlug={spanSlug}
           />
           <Layout.Title>{transactionName}</Layout.Title>
         </Layout.HeaderContent>

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeChart.tsx
@@ -21,9 +21,8 @@ import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import EventView from 'sentry/utils/discover/eventView';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import useApi from 'sentry/utils/useApi';
-
-import {SpanSlug} from '../types';
 
 type Props = WithRouterProps & {
   location: Location;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
@@ -1,6 +1,6 @@
 import {Query} from 'history';
 
-import {SpanSlug} from '../types';
+import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 
 export function generateSpanDetailsRoute({
   orgSlug,

--- a/static/app/views/performance/transactionSummary/transactionSpans/types.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/types.tsx
@@ -22,8 +22,3 @@ export type SpanSortOption = {
 export type SpansTotalValues = {
   count: number;
 };
-
-export type SpanSlug = {
-  op: string;
-  group: string;
-};

--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -6,16 +6,11 @@ import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {isAggregateField} from 'sentry/utils/discover/fields';
+import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
-import {
-  SpanSlug,
-  SpanSort,
-  SpanSortOption,
-  SpanSortOthers,
-  SpanSortPercentiles,
-} from './types';
+import {SpanSort, SpanSortOption, SpanSortOthers, SpanSortPercentiles} from './types';
 
 export function generateSpansRoute({orgSlug}: {orgSlug: String}): string {
   return `/organizations/${orgSlug}/performance/summary/spans/`;


### PR DESCRIPTION
This adds the span details page to the breadcrumbs so users can navigate back to
the spans tab.