### PR TITLE
ref(metrics): Consolidate wrappers around string indexer [INGEST-784]

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -855,7 +855,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             "sessions": Function("sum", [Column("value")], "value"),
         }[stat]
 
-        metric_name = resolve({"sessions": MetricKey.SESSION, "users": MetricKey.USER}[stat])
+        metric_name = resolve({"sessions": MetricKey.SESSION, "users": MetricKey.USER}[stat].value)
 
         for row in raw_snql_query(
             Query(

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -54,6 +54,14 @@ from sentry.release_health.metrics_sessions_v2 import run_sessions_query
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.sessions import SessionMetricKey as MetricKey
 from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.snuba.metrics import (
+    MetricIndexNotFound,
+    resolve,
+    resolve_many_weak,
+    resolve_tag_key,
+    resolve_weak,
+    reverse_resolve,
+)
 from sentry.snuba.sessions import _make_stats, get_rollup_starts_and_buckets, parse_snuba_datetime
 from sentry.snuba.sessions_v2 import QueryDefinition
 from sentry.utils.dates import to_datetime, to_timestamp
@@ -65,51 +73,9 @@ SMALLEST_METRICS_BUCKET = 10
 logger = logging.getLogger(__name__)
 
 
-class MetricIndexNotFound(Exception):
-    pass
-
-
 _K1 = TypeVar("_K1")
 _K2 = TypeVar("_K2")
 _V = TypeVar("_V")
-
-
-def get_tag_values_list(org_id: int, values: Sequence[str]) -> Sequence[int]:
-    return [x for x in [try_get_string_index(org_id, x) for x in values] if x is not None]
-
-
-def metric_id(org_id: int, metric_key: MetricKey) -> int:
-    index = indexer.resolve(metric_key.value)  # type: ignore
-    if index is None:
-        raise MetricIndexNotFound(metric_key.value)
-    return index  # type: ignore
-
-
-def tag_key(org_id: int, name: str) -> str:
-    index = indexer.resolve(name)  # type: ignore
-    if index is None:
-        raise MetricIndexNotFound(name)
-    return f"tags[{index}]"
-
-
-def tag_value(org_id: int, name: str) -> int:
-    index = indexer.resolve(name)  # type: ignore
-    if index is None:
-        raise MetricIndexNotFound(name)
-    return index  # type: ignore
-
-
-def try_get_string_index(org_id: int, name: str) -> Optional[int]:
-    return indexer.resolve(name)  # type: ignore
-
-
-def reverse_tag_value(org_id: int, index: int) -> str:
-    str_value = indexer.reverse_resolve(index)  # type: ignore
-    # If the value can't be reversed it's very likely a real programming bug
-    # instead of something to be caught down: We probably got back a value from
-    # Snuba that's not in the indexer => partial data loss
-    assert str_value is not None
-    return str_value  # type: ignore
 
 
 def filter_projects_by_project_release(project_releases: Sequence[ProjectRelease]) -> Condition:
@@ -120,9 +86,9 @@ def filter_releases_by_project_release(
     org_id: int, project_releases: Sequence[ProjectRelease]
 ) -> Condition:
     return Condition(
-        Column(tag_key(org_id, "release")),
+        Column(resolve_tag_key("release")),
         Op.IN,
-        get_tag_values_list(org_id, [x for _, x in project_releases]),
+        resolve_many_weak([x for _, x in project_releases]),
     )
 
 
@@ -212,7 +178,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         data: Dict[int, Dict[str, float]] = {}
 
-        session_status = tag_key(org_id, "session.status")
+        session_status = resolve_tag_key("session.status")
 
         count_query = Query(
             dataset=Dataset.Metrics.value,
@@ -221,7 +187,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             where=[
                 Condition(Column("org_id"), Op.EQ, org_id),
                 Condition(Column("project_id"), Op.IN, project_ids),
-                Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION)),
+                Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)),
                 Condition(Column("timestamp"), Op.GTE, start),
                 Condition(Column("timestamp"), Op.LT, end),
             ],
@@ -238,7 +204,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         for row in count_data:
             project_data = data.setdefault(row["project_id"], {})
-            tag_value = reverse_tag_value(org_id, row[session_status])
+            tag_value = reverse_resolve(row[session_status])
             project_data[tag_value] = row["value"]
 
         return data
@@ -289,17 +255,15 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 filter_projects_by_project_release(project_releases),
                 Condition(Column("timestamp"), Op.GTE, start),
                 Condition(Column("timestamp"), Op.LT, now),
-                Condition(
-                    Column(tag_key(org_id, "session.status")), Op.EQ, tag_value(org_id, "init")
-                ),
+                Condition(Column(resolve_tag_key("session.status")), Op.EQ, resolve_weak("init")),
             ]
 
             if environments is not None:
                 where_common.append(
                     Condition(
-                        Column(tag_key(org_id, "environment")),
+                        Column(resolve_tag_key("environment")),
                         Op.IN,
-                        get_tag_values_list(org_id, environments),
+                        resolve_many_weak(environments),
                     )
                 )
 
@@ -312,13 +276,13 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             if total:
                 return [Column("project_id")]
             else:
-                return [Column("project_id"), Column(tag_key(org_id, "release"))]
+                return [Column("project_id"), Column(resolve_tag_key("release"))]
 
         def _convert_results(data: Any, total: bool) -> Dict[Any, int]:
             if total:
                 return {x["project_id"]: x["value"] for x in data}
             else:
-                release_tag = tag_key(org_id, "release")
+                release_tag = resolve_tag_key("release")
                 return {(x["project_id"], x[release_tag]): x["value"] for x in data}
 
         def _count_sessions(total: bool, referrer: str) -> Dict[Any, int]:
@@ -328,7 +292,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 select=[Function("sum", [Column("value")], "value")],
                 where=_get_common_where(total)
                 + [
-                    Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION)),
+                    Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)),
                 ],
                 groupby=_get_common_groupby(total),
             )
@@ -349,7 +313,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 select=[Function("uniq", [Column("value")], "value")],
                 where=_get_common_where(total)
                 + [
-                    Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.USER)),
+                    Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.USER)),
                 ],
                 groupby=_get_common_groupby(total),
             )
@@ -394,7 +358,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         rv = {}
 
         for project_id, release in project_releases:
-            release_tag_value = indexer.resolve(release)  # type: ignore
+            release_tag_value = indexer.resolve(release)
             if release_tag_value is None:
                 # Don't emit empty releases -- for exact compatibility with
                 # sessions table backend.
@@ -448,7 +412,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             where: List[Condition] = [
                 Condition(Column("org_id"), Op.EQ, org_id),
                 Condition(Column("project_id"), Op.EQ, project_id),
-                Condition(Column(tag_key(org_id, "release")), Op.EQ, tag_value(org_id, release)),
+                Condition(Column(resolve_tag_key("release")), Op.EQ, resolve_weak(release)),
                 Condition(
                     Column("timestamp"), Op.GTE, datetime(2008, 5, 8)
                 ),  # Date of sentry's first commit
@@ -456,11 +420,11 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             ]
 
             if environments is not None:
-                env_filter = get_tag_values_list(org_id, environments)
+                env_filter = resolve_many_weak(environments)
                 if not env_filter:
                     raise MetricIndexNotFound()
 
-                where.append(Condition(Column(tag_key(org_id, "environment")), Op.IN, env_filter))
+                where.append(Condition(Column(resolve_tag_key("environment")), Op.IN, env_filter))
         except MetricIndexNotFound:
             # Some filter condition can't be constructed and therefore can't be
             # satisfied.
@@ -490,9 +454,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 select=select,
                 where=where
                 + [
-                    Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION)),
+                    Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)),
                     Condition(
-                        Column(tag_key(org_id, "session.status")), Op.EQ, tag_value(org_id, "init")
+                        Column(resolve_tag_key("session.status")), Op.EQ, resolve_weak("init")
                     ),
                 ],
             )
@@ -518,9 +482,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 select=select,
                 where=where
                 + [
-                    Condition(
-                        Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION_DURATION)
-                    ),
+                    Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION_DURATION)),
                 ],
             )
             rows.extend(
@@ -586,15 +548,15 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         where_clause = [
             Condition(Column("org_id"), Op.EQ, org_id),
             Condition(Column("project_id"), Op.IN, project_ids),
-            Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION)),
+            Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)),
             Condition(Column("timestamp"), Op.GTE, start),
             Condition(Column("timestamp"), Op.LT, now),
         ]
 
         if includes_releases:
             releases = [x[1] for x in projects_list]  # type: ignore
-            release_column_name = tag_key(org_id, "release")
-            releases_ids = get_tag_values_list(org_id, releases)
+            release_column_name = resolve_tag_key("release")
+            releases_ids = resolve_many_weak(releases)
             where_clause.append(Condition(Column(release_column_name), Op.IN, releases_ids))
             column_names = ["project_id", release_column_name]
 
@@ -606,7 +568,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         ) -> Callable[[Mapping[str, Union[int, str]]], ProjectOrRelease]:
             def f(row: Mapping[str, Union[int, str]]) -> ProjectOrRelease:
                 if include_releases:
-                    return row["project_id"], reverse_tag_value(org_id, row.get(release_column_name))  # type: ignore
+                    return row["project_id"], reverse_resolve(row.get(release_column_name))  # type: ignore
                 else:
                     return row["project_id"]  # type: ignore
 
@@ -641,12 +603,12 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
     ) -> Set[ReleaseName]:
 
         try:
-            metric_id_session = metric_id(organization_id, MetricKey.SESSION)
-            release_column_name = tag_key(organization_id, "release")
+            metric_id_session = resolve(MetricKey.SESSION)
+            release_column_name = resolve_tag_key("release")
         except MetricIndexNotFound:
             return set()
 
-        releases_ids = get_tag_values_list(organization_id, release_versions)
+        releases_ids = resolve_many_weak(release_versions)
         query = Query(
             dataset=Dataset.Metrics.value,
             match=Entity(EntityKey.MetricsCounters.value),
@@ -669,7 +631,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         )
 
         def extract_row_info(row: Mapping[str, Union[OrganizationId, str]]) -> ReleaseName:
-            return reverse_tag_value(organization_id, row.get(release_column_name))  # type: ignore
+            return reverse_resolve(row.get(release_column_name))  # type: ignore
 
         return {extract_row_info(row) for row in result["data"]}
 
@@ -684,7 +646,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         """
         rv_durations: Dict[Tuple[int, str], Any] = {}
 
-        release_column_name = tag_key(org_id, "release")
+        release_column_name = resolve_tag_key("release")
         aggregates: List[SelectableExpression] = [
             Column(release_column_name),
             Column("project_id"),
@@ -704,13 +666,11 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 ],
                 where=where
                 + [
+                    Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION_DURATION)),
                     Condition(
-                        Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION_DURATION)
-                    ),
-                    Condition(
-                        Column(tag_key(org_id, "session.status")),
+                        Column(resolve_tag_key("session.status")),
                         Op.EQ,
-                        tag_value(org_id, "exited"),
+                        resolve_weak("exited"),
                     ),
                 ],
                 groupby=aggregates,
@@ -719,7 +679,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             referrer="release_health.metrics.get_session_duration_data_for_overview",
         )["data"]:
             # See https://github.com/getsentry/snuba/blob/8680523617e06979427bfa18c6b4b4e8bf86130f/snuba/datasets/entities/metrics.py#L184 for quantiles
-            key = (row["project_id"], reverse_tag_value(org_id, row[release_column_name]))
+            key = (row["project_id"], reverse_resolve(row[release_column_name]))
             rv_durations[key] = {
                 "duration_p50": row["percentiles"][0],
                 "duration_p90": row["percentiles"][1],
@@ -739,7 +699,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         """
         rv_errored_sessions: Dict[Tuple[int, str], int] = {}
 
-        release_column_name = tag_key(org_id, "release")
+        release_column_name = resolve_tag_key("release")
         aggregates: List[SelectableExpression] = [
             Column(release_column_name),
             Column("project_id"),
@@ -752,16 +712,14 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 select=aggregates + [Function("uniq", [Column("value")], "value")],
                 where=where
                 + [
-                    Condition(
-                        Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION_ERROR)
-                    ),
+                    Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION_ERROR)),
                 ],
                 groupby=aggregates,
                 granularity=Granularity(rollup),
             ),
             referrer="release_health.metrics.get_errored_sessions_for_overview",
         )["data"]:
-            key = row["project_id"], reverse_tag_value(org_id, row[release_column_name])
+            key = row["project_id"], reverse_resolve(row[release_column_name])
             rv_errored_sessions[key] = row["value"]
 
         return rv_errored_sessions
@@ -773,8 +731,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         """
         Counts of init, abnormal and crashed sessions, purpose-built for overview
         """
-        release_column_name = tag_key(org_id, "release")
-        session_status_column_name = tag_key(org_id, "session.status")
+        release_column_name = resolve_tag_key("release")
+        session_status_column_name = resolve_tag_key("session.status")
 
         aggregates: List[SelectableExpression] = [
             Column(release_column_name),
@@ -791,13 +749,11 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 select=aggregates + [Function("sum", [Column("value")], "value")],
                 where=where
                 + [
-                    Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION)),
+                    Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)),
                     Condition(
                         Column(session_status_column_name),
                         Op.IN,
-                        get_tag_values_list(
-                            org_id, ["abnormal", "crashed", "init", "errored_preaggr"]
-                        ),
+                        resolve_many_weak(["abnormal", "crashed", "init", "errored_preaggr"]),
                     ),
                 ],
                 groupby=aggregates,
@@ -807,8 +763,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         )["data"]:
             key = (
                 row["project_id"],
-                reverse_tag_value(org_id, row[release_column_name]),
-                reverse_tag_value(org_id, row[session_status_column_name]),
+                reverse_resolve(row[release_column_name]),
+                reverse_resolve(row[session_status_column_name]),
             )
             rv_sessions[key] = row["value"]
 
@@ -818,8 +774,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
     def _get_users_and_crashed_users_for_overview(
         where: List[Condition], org_id: int, rollup: int
     ) -> Mapping[Tuple[int, str, str], int]:
-        release_column_name = tag_key(org_id, "release")
-        session_status_column_name = tag_key(org_id, "session.status")
+        release_column_name = resolve_tag_key("release")
+        session_status_column_name = resolve_tag_key("session.status")
 
         aggregates: List[SelectableExpression] = [
             Column(release_column_name),
@@ -833,11 +789,11 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         # Avoid mutating input parameters here
         select = aggregates + [Function("uniq", [Column("value")], "value")]
         where = where + [
-            Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.USER)),
+            Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.USER)),
             Condition(
                 Column(session_status_column_name),
                 Op.IN,
-                get_tag_values_list(org_id, ["crashed", "init"]),
+                resolve_many_weak(["crashed", "init"]),
             ),
         ]
 
@@ -854,8 +810,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         )["data"]:
             key = (
                 row["project_id"],
-                reverse_tag_value(org_id, row[release_column_name]),
-                reverse_tag_value(org_id, row[session_status_column_name]),
+                reverse_resolve(row[release_column_name]),
+                reverse_resolve(row[session_status_column_name]),
             )
             rv_users[key] = row["value"]
 
@@ -869,9 +825,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         stat: OverviewStat,
         now: datetime,
     ) -> Mapping[ProjectRelease, List[List[int]]]:
-        release_column_name = tag_key(org_id, "release")
-        session_status_column_name = tag_key(org_id, "session.status")
-        session_init_tag_value = tag_value(org_id, "init")
+        release_column_name = resolve_tag_key("release")
+        session_status_column_name = resolve_tag_key("session.status")
+        session_init_tag_value = resolve_weak("init")
 
         stats_rollup, stats_start, stats_buckets = get_rollup_starts_and_buckets(
             health_stats_period
@@ -895,9 +851,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             "sessions": Function("sum", [Column("value")], "value"),
         }[stat]
 
-        metric_name = metric_id(
-            org_id, {"sessions": MetricKey.SESSION, "users": MetricKey.USER}[stat]
-        )
+        metric_name = resolve({"sessions": MetricKey.SESSION, "users": MetricKey.USER}[stat])
 
         for row in raw_snql_query(
             Query(
@@ -924,7 +878,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 (parse_snuba_datetime(row["bucketed_time"]) - stats_start).total_seconds()
                 / stats_rollup
             )
-            key = row["project_id"], reverse_tag_value(org_id, row[release_column_name])
+            key = row["project_id"], reverse_resolve(row[release_column_name])
             timeseries = rv[key]
             if time_bucket < len(timeseries):
                 timeseries[time_bucket][1] = row["value"]
@@ -957,9 +911,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         if environments is not None:
             where.append(
                 Condition(
-                    Column(tag_key(org_id, "environment")),
+                    Column(resolve_tag_key("environment")),
                     Op.IN,
-                    get_tag_values_list(org_id, environments),
+                    resolve_many_weak(environments),
                 )
             )
 
@@ -1078,24 +1032,24 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         # 1) Get required string indexes
         try:
-            release_key = tag_key(org_id, "release")
-            release_value = tag_value(org_id, release)
-            environment_key = tag_key(org_id, "environment")
-            status_key = tag_key(org_id, "session.status")
+            release_key = resolve_tag_key("release")
+            release_value = resolve_weak(release)
+            environment_key = resolve_tag_key("environment")
+            status_key = resolve_tag_key("session.status")
         except MetricIndexNotFound:
             # No need to query snuba if any of these is missing
             return generate_defaults
 
         environment_values = None
         if environments is not None:
-            environment_values = get_tag_values_list(org_id, environments)
+            environment_values = resolve_many_weak(environments)
 
         if environment_values == []:
             # No need to query snuba with an empty list
             return generate_defaults
 
-        status_init = try_get_string_index(org_id, "init")
-        status_crashed = try_get_string_index(org_id, "crashed")
+        status_init = indexer.resolve("init")
+        status_crashed = indexer.resolve("crashed")
 
         conditions = [
             Condition(Column("org_id"), Op.EQ, org_id),
@@ -1111,7 +1065,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             def _get_data(entity_key: EntityKey, metric_key: MetricKey) -> Tuple[int, int]:
                 total = 0
                 crashed = 0
-                metric_id = try_get_string_index(org_id, metric_key.value)
+                metric_id = indexer.resolve(metric_key.value)
                 if metric_id is not None:
                     where = conditions + [
                         Condition(Column("metric_id"), Op.EQ, metric_id),
@@ -1215,14 +1169,14 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             return []
 
         org_id = self._get_org_id(project_ids)
-        release_column_name = tag_key(org_id, "release")
+        release_column_name = resolve_tag_key("release")
 
         query_cols = [Column("project_id"), Column(release_column_name)]
 
         where_clause = [
             Condition(Column("org_id"), Op.EQ, org_id),
             Condition(Column("project_id"), Op.IN, project_ids),
-            Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION)),
+            Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)),
             Condition(Column("timestamp"), Op.GTE, start),
             Condition(Column("timestamp"), Op.LT, now),
         ]
@@ -1241,7 +1195,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         )
 
         def extract_row_info(row: Mapping[str, Union[OrganizationId, str]]) -> ProjectRelease:
-            return row.get("project_id"), reverse_tag_value(org_id, row.get(release_column_name))  # type: ignore
+            return row.get("project_id"), reverse_resolve(row.get(release_column_name))  # type: ignore
 
         return [extract_row_info(row) for row in result["data"]]
 
@@ -1255,13 +1209,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         project_ids: List[ProjectId] = [x[0] for x in project_releases]
         org_id = self._get_org_id(project_ids)
-        release_column_name = tag_key(org_id, "release")
+        release_column_name = resolve_tag_key("release")
         releases = [x[1] for x in project_releases]
-        releases_ids = [
-            release_id
-            for release_id in [try_get_string_index(org_id, release) for release in releases]
-            if release_id is not None
-        ]
+        releases_ids = resolve_many_weak(releases)
 
         query_cols = [
             Column("project_id"),
@@ -1277,7 +1227,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         where_clause = [
             Condition(Column("org_id"), Op.EQ, org_id),
             Condition(Column("project_id"), Op.IN, project_ids),
-            Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION)),
+            Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)),
             Condition(Column("timestamp"), Op.GTE, start),
             Condition(Column("timestamp"), Op.LT, now),
             Condition(Column(release_column_name), Op.IN, releases_ids),
@@ -1300,9 +1250,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         result = {}
 
         for row in rows:
-            result[row["project_id"], reverse_tag_value(org_id, row[release_column_name])] = row[
-                "oldest"
-            ]
+            result[row["project_id"], reverse_resolve(row[release_column_name])] = row["oldest"]
 
         return result
 
@@ -1331,17 +1279,17 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         ]
 
         try:
-            release_column_name = tag_key(organization_id, "release")
+            release_column_name = resolve_tag_key("release")
         except MetricIndexNotFound:
             return 0
 
         if environments is not None:
             try:
-                environment_column_name = tag_key(organization_id, "environment")
+                environment_column_name = resolve_tag_key("environment")
             except MetricIndexNotFound:
                 return 0
 
-            environment_values = get_tag_values_list(organization_id, environments)
+            environment_values = resolve_many_weak(environments)
             where.append(Condition(Column(environment_column_name), Op.IN, environment_values))
 
         having = []
@@ -1392,7 +1340,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         rollup: int,
     ) -> Mapping[datetime, DurationPercentiles]:
         series: MutableMapping[datetime, DurationPercentiles] = {}
-        session_status_healthy = try_get_string_index(org_id, "exited")
+        session_status_healthy = indexer.resolve("exited")
         if session_status_healthy is not None:
             duration_series_data = raw_snql_query(
                 Query(
@@ -1402,7 +1350,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                         Condition(
                             Column("metric_id"),
                             Op.EQ,
-                            metric_id(org_id, MetricKey.SESSION_DURATION),
+                            resolve(MetricKey.SESSION_DURATION),
                         ),
                         Condition(Column(session_status_key), Op.EQ, session_status_healthy),
                     ],
@@ -1442,8 +1390,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         session_series_data = raw_snql_query(
             Query(
                 dataset=Dataset.Metrics.value,
-                where=where
-                + [Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION))],
+                where=where + [Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION))],
                 granularity=Granularity(rollup),
                 match=Entity(EntityKey.MetricsCounters.value),
                 select=[
@@ -1458,7 +1405,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         for row in session_series_data:
             dt = parse_snuba_datetime(row["bucketed_time"])
             target = series[dt]
-            status = reverse_tag_value(org_id, row[session_status_key])
+            status = reverse_resolve(row[session_status_key])
             value = int(row["value"])
             if status == "init":
                 target["sessions"] = value
@@ -1482,11 +1429,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             Query(
                 dataset=Dataset.Metrics.value,
                 where=where
-                + [
-                    Condition(
-                        Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION_ERROR)
-                    )
-                ],
+                + [Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION_ERROR))],
                 granularity=Granularity(rollup),
                 match=Entity(EntityKey.MetricsSets.value),
                 select=[
@@ -1537,8 +1480,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         user_series_data = raw_snql_query(
             Query(
                 dataset=Dataset.Metrics.value,
-                where=where
-                + [Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.USER))],
+                where=where + [Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.USER))],
                 granularity=Granularity(rollup),
                 match=Entity(EntityKey.MetricsSets.value),
                 select=[
@@ -1551,8 +1493,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         user_totals_data = raw_snql_query(
             Query(
                 dataset=Dataset.Metrics.value,
-                where=where
-                + [Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.USER))],
+                where=where + [Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.USER))],
                 granularity=Granularity(rollup),
                 match=Entity(EntityKey.MetricsSets.value),
                 select=[
@@ -1572,7 +1513,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 else:
                     dt = parse_snuba_datetime(row["bucketed_time"])
                     target = series[dt]
-                status = reverse_tag_value(org_id, row[session_status_key])
+                status = reverse_resolve(row[session_status_key])
                 value = int(row["value"])
                 if status == "init":
                     target["users"] = value
@@ -1662,7 +1603,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         }
 
         try:
-            release_value = tag_value(org_id, release)
+            release_value = resolve_weak(release)
         except MetricIndexNotFound:
             # No data for this release
             return self._sort_by_timestamp(base_series), base_totals  # type: ignore
@@ -1672,19 +1613,19 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             Condition(Column("project_id"), Op.EQ, project_id),
             Condition(Column("timestamp"), Op.GTE, start),
             Condition(Column("timestamp"), Op.LT, end),
-            Condition(Column(tag_key(org_id, "release")), Op.EQ, release_value),
+            Condition(Column(resolve_tag_key("release")), Op.EQ, release_value),
         ]
 
         if environments is not None:
             where.append(
                 Condition(
-                    Column(tag_key(org_id, "environment")),
+                    Column(resolve_tag_key("environment")),
                     Op.IN,
-                    get_tag_values_list(org_id, environments),
+                    resolve_many_weak(environments),
                 )
             )
 
-        session_status_key = tag_key(org_id, "session.status")
+        session_status_key = resolve_tag_key("session.status")
 
         duration_series = self._get_project_release_stats_durations(
             org_id, where, session_status_key, rollup
@@ -1724,15 +1665,15 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         columns = [Function("sum", [Column("value")], "value")]
 
         try:
-            status_key = tag_key(org_id, "session.status")
-            status_init = tag_value(org_id, "init")
+            status_key = resolve_tag_key("session.status")
+            status_init = resolve_weak("init")
         except MetricIndexNotFound:
             return 0
 
         where_clause = [
             Condition(Column("org_id"), Op.EQ, org_id),
             Condition(Column("project_id"), Op.EQ, project_id),
-            Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION)),
+            Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)),
             Condition(Column("timestamp"), Op.GTE, start),
             Condition(Column("timestamp"), Op.LT, end),
             Condition(Column(status_key), Op.EQ, status_init),
@@ -1747,8 +1688,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 return 0  # could not find the requested environment
 
             try:
-                snuba_env_id = tag_value(org_id, env_name)
-                env_id = tag_key(org_id, "environment")
+                snuba_env_id = resolve_weak(env_name)
+                env_id = resolve_tag_key("environment")
             except MetricIndexNotFound:
                 return 0
 
@@ -1782,14 +1723,14 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         columns = [Function("sum", [Column("value")], alias="value"), Column("project_id")]
 
         try:
-            status_key = tag_key(org_id, "session.status")
-            status_init = tag_value(org_id, "init")
+            status_key = resolve_tag_key("session.status")
+            status_init = resolve_weak("init")
         except MetricIndexNotFound:
             return []
 
         where_clause = [
             Condition(Column("org_id"), Op.EQ, org_id),
-            Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION)),
+            Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)),
             Condition(Column("timestamp"), Op.GTE, start),
             Condition(Column("timestamp"), Op.LT, end),
             Condition(Column(status_key), Op.EQ, status_init),
@@ -1803,8 +1744,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             env_names = [value for value in env_names_dict.values() if value is not None]
 
             try:
-                env_id = tag_key(org_id, "environment")
-                snuba_env_ids = get_tag_values_list(org_id, env_names)
+                env_id = resolve_tag_key("environment")
+                snuba_env_ids = resolve_many_weak(env_names)
             except MetricIndexNotFound:
                 return []
 
@@ -1844,11 +1785,11 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         environments_ids: Optional[Sequence[int]] = None
 
         if environments is not None:
-            environments_ids = get_tag_values_list(org_id, environments)
-            if len(environments_ids) == 0:
+            environments_ids = resolve_many_weak(environments)
+            if not environments_ids:
                 return []
 
-        release_column_name = tag_key(org_id, "release")
+        release_column_name = resolve_tag_key("release")
 
         if stats_period is None:
             stats_period = "24h"
@@ -1874,14 +1815,14 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         ]
 
         if environments_ids is not None:
-            environment_column_name = tag_key(org_id, "environment")
+            environment_column_name = resolve_tag_key("environment")
             where_clause.append(Condition(Column(environment_column_name), Op.IN, environments_ids))
 
         having_clause: Optional[List[Condition]] = None
 
-        status_init = tag_value(org_id, "init")
-        status_crashed = tag_value(org_id, "crashed")
-        session_status_column_name = tag_key(org_id, "session.status")
+        status_init = resolve_weak("init")
+        status_crashed = resolve_weak("crashed")
+        session_status_column_name = resolve_tag_key("session.status")
 
         order_by_clause = None
         if scope == "crash_free_sessions":
@@ -1914,17 +1855,13 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                     direction=Direction.DESC,
                 )
             ]
-            where_clause.append(
-                Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION))
-            )
+            where_clause.append(Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)))
             entity = Entity(EntityKey.MetricsCounters.value)
         elif scope == "sessions":
             order_by_clause = [
                 OrderBy(exp=Function("sum", [Column("value")], "value"), direction=Direction.DESC)
             ]
-            where_clause.append(
-                Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.SESSION))
-            )
+            where_clause.append(Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.SESSION)))
             entity = Entity(EntityKey.MetricsCounters.value)
         elif scope == "crash_free_users":
             order_by_clause = [
@@ -1956,17 +1893,13 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                     direction=Direction.DESC,
                 )
             ]
-            where_clause.append(
-                Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.USER))
-            )
+            where_clause.append(Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.USER)))
             entity = Entity(EntityKey.MetricsSets.value)
             having_clause = [Condition(Function("uniq", [Column("value")], "users"), Op.GT, 0)]
         else:  # users
             users_column = Function("uniq", [Column("value")], "users")
             order_by_clause = [OrderBy(exp=users_column, direction=Direction.DESC)]
-            where_clause.append(
-                Condition(Column("metric_id"), Op.EQ, metric_id(org_id, MetricKey.USER))
-            )
+            where_clause.append(Condition(Column("metric_id"), Op.EQ, resolve(MetricKey.USER)))
             entity = Entity(EntityKey.MetricsSets.value)
             having_clause = [Condition(users_column, Op.GT, 0)]
 
@@ -1996,6 +1929,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         )
 
         def extract_row_info(row: Mapping[str, Union[OrganizationId, str]]) -> ProjectRelease:
-            return row.get("project_id"), reverse_tag_value(org_id, row.get(release_column_name))  # type: ignore
+            return row.get("project_id"), reverse_resolve(row.get(release_column_name))  # type: ignore
 
         return [extract_row_info(row) for row in rows["data"]]

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -37,16 +37,14 @@ from sentry.release_health.base import (
 )
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.sessions import SessionMetricKey as MetricKey
-from sentry.snuba.dataset import Dataset, EntityKey
-from sentry.snuba.metrics import (
-    TS_COL_GROUP,
-    TS_COL_QUERY,
+from sentry.sentry_metrics.utils import (
     MetricIndexNotFound,
-    get_intervals,
     resolve_tag_key,
     reverse_resolve,
     reverse_resolve_weak,
 )
+from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.snuba.metrics import TS_COL_GROUP, TS_COL_QUERY, get_intervals
 from sentry.snuba.sessions_v2 import QueryDefinition, finite_or_none
 from sentry.utils.snuba import raw_snql_query
 

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -38,7 +38,15 @@ from sentry.release_health.base import (
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.sessions import SessionMetricKey as MetricKey
 from sentry.snuba.dataset import Dataset, EntityKey
-from sentry.snuba.metrics import TS_COL_GROUP, TS_COL_QUERY, get_intervals
+from sentry.snuba.metrics import (
+    TS_COL_GROUP,
+    TS_COL_QUERY,
+    MetricIndexNotFound,
+    get_intervals,
+    resolve_tag_key,
+    reverse_resolve,
+    reverse_resolve_weak,
+)
 from sentry.snuba.sessions_v2 import QueryDefinition, finite_or_none
 from sentry.utils.snuba import raw_snql_query
 
@@ -62,30 +70,6 @@ REFERRERS = {
         "totals": "release_health.metrics.sessions_v2.session.error.totals",
     },
 }
-
-
-def _resolve(name: str) -> Optional[int]:
-    """Wrapper for typing"""
-    return indexer.resolve(name)  # type: ignore
-
-
-def _resolve_ensured(name: str) -> int:
-    """Assume the index entry exists"""
-    index = _resolve(name)
-    assert index is not None
-    return index
-
-
-def _reverse_resolve(index: int) -> Optional[str]:
-    """Wrapper for typing"""
-    return indexer.reverse_resolve(index)  # type: ignore
-
-
-def _reverse_resolve_ensured(index: int) -> str:
-    """Assume the index entry exists"""
-    string = _reverse_resolve(index)
-    assert string is not None
-    return string
 
 
 _SessionStatus = Literal[
@@ -331,17 +315,17 @@ def _get_snuba_query(
     conditions += _get_filter_conditions(org_id, query.conditions)
     conditions += extra_conditions
 
-    groupby_tags = [field for field in query.raw_groupby if field != "project"]
+    groupby = {}
+    for field in query.raw_groupby:
+        if field == "project":
+            groupby["project"] = Column("project_id")
+            continue
 
-    tag_keys = {field: _resolve(field) for field in groupby_tags}
-    groupby = {
-        field: Column(f"tags[{tag_id}]")
-        for field, tag_id in tag_keys.items()
-        if tag_id is not None  # exclude unresolved keys from groupby
-    }
-
-    if "project" in query.raw_groupby:
-        groupby["project"] = Column("project_id")
+        try:
+            groupby[field] = resolve_tag_key(field)
+        except MetricIndexNotFound:
+            # exclude unresolved keys from groupby
+            pass
 
     full_groupby = set(groupby.values()) - remove_groupby
     if series:
@@ -399,7 +383,7 @@ def _fetch_data(
 
     # It greatly simplifies code if we just assume that these two tags exist:
     # TODO: Can we get away with that assumption?
-    tag_key_session_status = _resolve_ensured("session.status")
+    tag_key_session_status = resolve_tag_key("session.status")
 
     data: List[Tuple[MetricKey, _SnubaData]] = []
 
@@ -407,7 +391,7 @@ def _fetch_data(
     metric_to_output_field: MutableMapping[Tuple[MetricKey, _VirtualColumnName], _OutputField] = {}
 
     if "count_unique(user)" in query.raw_fields:
-        metric_id = _resolve(MetricKey.USER.value)
+        metric_id = indexer.resolve(MetricKey.USER.value)
         if metric_id is not None:
             data.extend(
                 _get_snuba_query_data(
@@ -423,7 +407,7 @@ def _fetch_data(
 
     duration_fields = [field for field in query.raw_fields if "session.duration" in field]
     if duration_fields:
-        metric_id = _resolve(MetricKey.SESSION_DURATION.value)
+        metric_id = indexer.resolve(MetricKey.SESSION_DURATION.value)
         if metric_id is not None:
 
             def get_virtual_column(field: SessionsQueryFunction) -> _VirtualColumnName:
@@ -440,11 +424,9 @@ def _fetch_data(
                     seen_fields.add(column.alias)
 
             # sessions_v2 only exposes healthy session's durations
-            healthy = _resolve("exited")
-            extra_conditions = [
-                Condition(Column(f"tags[{tag_key_session_status}]"), Op.EQ, healthy)
-            ]
-            remove_groupby = {Column(f"tags[{tag_key_session_status}]")}
+            healthy = indexer.resolve("exited")
+            extra_conditions = [Condition(Column(tag_key_session_status), Op.EQ, healthy)]
+            remove_groupby = {Column(tag_key_session_status)}
 
             if tag_key_session_status is not None and healthy is not None:
                 data.extend(
@@ -467,7 +449,7 @@ def _fetch_data(
                     ] = _SessionDurationField(field, col, group_by_status)
 
     if "sum(session)" in query.raw_fields:
-        metric_id = _resolve(MetricKey.SESSION.value)
+        metric_id = indexer.resolve(MetricKey.SESSION.value)
         if metric_id is not None:
             if "session.status" in query.raw_groupby:
                 # We need session counters grouped by status, as well as the number of errored sessions
@@ -485,9 +467,9 @@ def _fetch_data(
                 )
 
                 # 2: session.error
-                error_metric_id = _resolve(MetricKey.SESSION_ERROR.value)
+                error_metric_id = indexer.resolve(MetricKey.SESSION_ERROR.value)
                 if error_metric_id is not None:
-                    remove_groupby = {Column(f"tags[{tag_key_session_status}]")}
+                    remove_groupby = {Column(tag_key_session_status)}
                     data.extend(
                         _get_snuba_query_data(
                             org_id,
@@ -501,11 +483,9 @@ def _fetch_data(
                     )
             else:
                 # Simply count the number of started sessions:
-                init = _resolve("init")
+                init = indexer.resolve("init")
                 if tag_key_session_status is not None and init is not None:
-                    extra_conditions = [
-                        Condition(Column(f"tags[{tag_key_session_status}]"), Op.EQ, init)
-                    ]
+                    extra_conditions = [Condition(Column(tag_key_session_status), Op.EQ, init)]
                     data.extend(
                         _get_snuba_query_data(
                             org_id,
@@ -529,20 +509,20 @@ def _flatten_data(org_id: int, data: _SnubaDataByMetric) -> _DataPoints:
 
     # It greatly simplifies code if we just assume that these two tags exist:
     # TODO: Can we get away with that assumption?
-    tag_key_release = _resolve_ensured("release")
-    tag_key_environment = _resolve_ensured("environment")
-    tag_key_session_status = _resolve_ensured("session.status")
+    tag_key_release = resolve_tag_key("release")
+    tag_key_environment = resolve_tag_key("environment")
+    tag_key_session_status = resolve_tag_key("session.status")
 
     for metric_key, metric_data in data:
         for row in metric_data:
-            raw_session_status = row.pop(f"tags[{tag_key_session_status}]", None)
+            raw_session_status = row.pop(tag_key_session_status, None)
             if raw_session_status is not None:
-                raw_session_status = _reverse_resolve_ensured(raw_session_status)
+                raw_session_status = reverse_resolve(raw_session_status)
             flat_key = _DataPointKey(
                 metric_key=metric_key,
                 raw_session_status=raw_session_status,
-                release=row.pop(f"tags[{tag_key_release}]", None),
-                environment=row.pop(f"tags[{tag_key_environment}]", None),
+                release=row.pop(tag_key_release, None),
+                environment=row.pop(tag_key_environment, None),
                 bucketed_time=row.pop("bucketed_time", None),
                 project_id=row.pop("project_id", None),
             )
@@ -601,10 +581,12 @@ def run_sessions_query(
 
         by: MutableMapping[GroupByFieldName, Union[str, int]] = {}
         if key.release is not None:
-            # Note: If the tag value reverse-resolves to None here, it's a bug in the tag indexer
-            by["release"] = _reverse_resolve_ensured(key.release)
+            # Every session has a release, so this should not throw
+            by["release"] = reverse_resolve(key.release)
         if key.environment is not None:
-            by["environment"] = _reverse_resolve_ensured(key.environment)
+            # To match behavior of the old sessions backend, session data
+            # without environment is grouped under the empty string.
+            by["environment"] = reverse_resolve_weak(key.environment) or ""
         if key.project_id is not None:
             by["project"] = key.project_id
 
@@ -663,16 +645,14 @@ def _translate_conditions(org_id: int, input_: Any) -> Any:
         # Alternative would be:
         #   * if tag key or value does not exist in AND-clause, return no data
         #   * if tag key or value does not exist in OR-clause, remove condition
-        tag_key = _resolve_ensured(input_.name)
-
-        return Column(f"tags[{tag_key}]")
+        return Column(resolve_tag_key(input_.name))
 
     if isinstance(input_, str):
         # Assuming this is the right-hand side, we need to fetch a tag value.
         # It's OK if the tag value resolves to None, the snuba query will then
         # return no results, as is intended behavior
 
-        return _resolve(input_)
+        return indexer.resolve(input_)
 
     if isinstance(input_, Function):
         return Function(

--- a/src/sentry/sentry_metrics/indexer/__init__.py
+++ b/src/sentry/sentry_metrics/indexer/__init__.py
@@ -10,3 +10,10 @@ backend = LazyServiceWrapper(
     settings.SENTRY_METRICS_INDEXER_OPTIONS,
 )
 backend.expose(locals())
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    record = backend.record
+    resolve = backend.resolve
+    reverse_resolve = backend.reverse_resolve

--- a/src/sentry/sentry_metrics/indexer/base.py
+++ b/src/sentry/sentry_metrics/indexer/base.py
@@ -7,6 +7,8 @@ class StringIndexer(Service):  # type: ignore
     """
     Provides integer IDs for metric names, tag keys and tag values
     and the corresponding reverse lookup.
+
+    Check `sentry.snuba.metrics` for convenience functions.
     """
 
     __all__ = ("record", "resolve", "reverse_resolve", "bulk_record")

--- a/src/sentry/sentry_metrics/utils.py
+++ b/src/sentry/sentry_metrics/utils.py
@@ -1,0 +1,74 @@
+from typing import Optional, Sequence
+
+from sentry.api.utils import InvalidParams
+from sentry.sentry_metrics import indexer
+
+
+class MetricIndexNotFound(InvalidParams):  # type: ignore
+    pass
+
+
+def reverse_resolve(index: int) -> str:
+    assert index != 0
+    resolved = indexer.reverse_resolve(index)
+    # The indexer should never return None for integers > 0:
+    if resolved is None:
+        raise MetricIndexNotFound()
+
+    return resolved  # type: ignore
+
+
+def reverse_resolve_weak(index: int) -> Optional[str]:
+    """
+    Resolve an index value back to a string, special-casing 0 to return None.
+
+    This is useful in situations where a `GROUP BY tags[123]` clause produces a
+    tuple for metric buckets that are missing that tag, i.e. `tags[123] == 0`.
+    """
+
+    if index == 0:
+        return None
+
+    return reverse_resolve(index)
+
+
+def resolve(string: str) -> int:
+    resolved = indexer.resolve(string)
+    if resolved is None:
+        raise MetricIndexNotFound(f"Unknown string: {string!r}")
+
+    return resolved  # type: ignore
+
+
+def resolve_tag_key(string: str) -> str:
+    resolved = resolve(string)
+    return f"tags[{resolved}]"
+
+
+def resolve_weak(string: str) -> int:
+    """
+    A version of `resolve` that returns 0 for missing values.
+
+    When using `resolve_weak` to produce a WHERE-clause, it is quite
+    useful to make the WHERE-clause "impossible" with `WHERE x = 0` instead of
+    explicitly handling that exception.
+    """
+    resolved = indexer.resolve(string)
+    if resolved is None:
+        return 0
+
+    return resolved  # type: ignore
+
+
+def resolve_many_weak(strings: Sequence[str]) -> Sequence[int]:
+    """
+    Resolve multiple values at once, omitting missing ones. This is useful in
+    the same way as `resolve_weak` is, e.g. `WHERE x in values`.
+    """
+    rv = []
+    for string in strings:
+        resolved = resolve_weak(string)
+        if resolved != 0:
+            rv.append(resolved)
+
+    return rv

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -290,7 +290,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
     ) -> Filter:
         snuba_filter = get_filter(query, params=params)
         conditions = copy(snuba_filter.conditions)
-        session_status_tag_values = resolve_many_weak(self.org_id, ["crashed", "init"])
+        session_status_tag_values = resolve_many_weak(["crashed", "init"])
         snuba_filter.update_with(
             {
                 "aggregations": [[f"{self.aggregation_func}(value)", None, "value"]],

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -11,8 +11,7 @@ from sentry.models import Environment
 from sentry.search.events.fields import resolve_field_list
 from sentry.search.events.filter import get_filter
 from sentry.sentry_metrics.sessions import SessionMetricKey
-from sentry.snuba.dataset import EntityKey
-from sentry.snuba.metrics import (
+from sentry.sentry_metrics.utils import (
     MetricIndexNotFound,
     resolve,
     resolve_many_weak,
@@ -20,6 +19,7 @@ from sentry.snuba.metrics import (
     resolve_weak,
     reverse_resolve,
 )
+from sentry.snuba.dataset import EntityKey
 from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
 from sentry.utils import metrics
 from sentry.utils.snuba import Dataset, resolve_column, resolve_snuba_aliases
@@ -295,7 +295,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             {
                 "aggregations": [[f"{self.aggregation_func}(value)", None, "value"]],
                 "conditions": [
-                    ["metric_id", "=", resolve(self.metric_key)],
+                    ["metric_id", "=", resolve(self.metric_key.value)],
                     [self.session_status, "IN", session_status_tag_values],
                 ],
                 "groupby": self.get_query_groupby(),

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -8,18 +8,18 @@ from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, CRASH_RATE_ALERT_
 from sentry.eventstore import Filter
 from sentry.exceptions import InvalidQuerySubscription, UnsupportedQuerySubscription
 from sentry.models import Environment
-from sentry.release_health.metrics import (
-    MetricIndexNotFound,
-    get_tag_values_list,
-    metric_id,
-    reverse_tag_value,
-    tag_key,
-    tag_value,
-)
 from sentry.search.events.fields import resolve_field_list
 from sentry.search.events.filter import get_filter
 from sentry.sentry_metrics.sessions import SessionMetricKey
 from sentry.snuba.dataset import EntityKey
+from sentry.snuba.metrics import (
+    MetricIndexNotFound,
+    resolve,
+    resolve_many_weak,
+    resolve_tag_key,
+    resolve_weak,
+    reverse_resolve,
+)
 from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
 from sentry.utils import metrics
 from sentry.utils.snuba import Dataset, resolve_column, resolve_snuba_aliases
@@ -260,7 +260,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
                 "building snuba filter for a metrics subscription"
             )
         self.org_id = extra_fields["org_id"]
-        self.session_status = tag_key(self.org_id, "session.status")
+        self.session_status = resolve_tag_key("session.status")
         self.time_window = time_window
 
     def get_query_groupby(self) -> List[str]:
@@ -290,12 +290,12 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
     ) -> Filter:
         snuba_filter = get_filter(query, params=params)
         conditions = copy(snuba_filter.conditions)
-        session_status_tag_values = get_tag_values_list(self.org_id, ["crashed", "init"])
+        session_status_tag_values = resolve_many_weak(self.org_id, ["crashed", "init"])
         snuba_filter.update_with(
             {
                 "aggregations": [[f"{self.aggregation_func}(value)", None, "value"]],
                 "conditions": [
-                    ["metric_id", "=", metric_id(self.org_id, self.metric_key)],
+                    ["metric_id", "=", resolve(self.metric_key)],
                     [self.session_status, "IN", session_status_tag_values],
                 ],
                 "groupby": self.get_query_groupby(),
@@ -304,7 +304,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
         )
         if environment:
             snuba_filter.conditions.append(
-                [tag_key(self.org_id, "environment"), "=", tag_value(self.org_id, environment.name)]
+                [resolve_tag_key("environment"), "=", resolve_weak(environment.name)]
             )
         if query and len(conditions) > 0:
             release_conditions = [
@@ -314,9 +314,9 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             for release_condition in release_conditions:
                 snuba_filter.conditions.append(
                     [
-                        tag_key(self.org_id, release_condition[0]),
+                        resolve_tag_key(release_condition[0]),
                         release_condition[1],
-                        tag_value(self.org_id, release_condition[2]),
+                        resolve_weak(release_condition[2]),
                     ]
                 )
 
@@ -336,9 +336,9 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
         value_col_name = alias if alias else "value"
         try:
             translated_data: Dict[str, Any] = {}
-            session_status = tag_key(org_id, "session.status")
+            session_status = resolve_tag_key("session.status")
             for row in data:
-                tag_value = reverse_tag_value(org_id, row[session_status])
+                tag_value = reverse_resolve(row[session_status])
                 translated_data[tag_value] = row[value_col_name]
 
             total_session_count = translated_data.get("init", 0)

--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -99,7 +99,7 @@ def reverse_resolve_weak(index: int) -> Optional[str]:
 def resolve(string: str) -> int:
     resolved = indexer.resolve(string)
     if resolved is None:
-        raise MetricIndexNotFound(f"Unknown tag key: '{string}'")
+        raise MetricIndexNotFound(f"Unknown string: {string!r}")
 
     return resolved
 

--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -127,7 +127,7 @@ def resolve_weak(string: str) -> int:
 def resolve_many_weak(strings: Sequence[str]) -> Sequence[int]:
     """
     Resolve multiple values at once, omitting missing ones. This is useful in
-    the same way as `resolve_weak` is, except for `WHERE x in values`.
+    the same way as `resolve_weak` is, e.g. `WHERE x in values`.
     """
     rv = []
     for string in strings:

--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -31,6 +31,12 @@ from sentry.relay.config import ALL_MEASUREMENT_METRICS
 from sentry.search.events.filter import QueryFilter
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.sessions import SessionMetricKey
+from sentry.sentry_metrics.utils import (
+    resolve_tag_key,
+    resolve_weak,
+    reverse_resolve,
+    reverse_resolve_weak,
+)
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.sessions_v2 import (  # TODO: unite metrics and sessions_v2
     ONE_DAY,
@@ -66,76 +72,6 @@ MAX_POINTS = 10000
 
 TS_COL_QUERY = "timestamp"
 TS_COL_GROUP = "bucketed_time"
-
-
-class MetricIndexNotFound(InvalidParams):
-    pass
-
-
-def reverse_resolve(index: int) -> str:
-    assert index != 0
-    resolved = indexer.reverse_resolve(index)
-    # The indexer should never return None for integers > 0:
-    if resolved is None:
-        raise MetricIndexNotFound()
-
-    return resolved
-
-
-def reverse_resolve_weak(index: int) -> Optional[str]:
-    """
-    Resolve an index value back to a string, special-casing 0 to return None.
-
-    This is useful in situations where a `GROUP BY tags[123]` clause produces a
-    tuple for metric buckets that are missing that tag, i.e. `tags[123] == 0`.
-    """
-
-    if index == 0:
-        return None
-
-    return reverse_resolve(index)
-
-
-def resolve(string: str) -> int:
-    resolved = indexer.resolve(string)
-    if resolved is None:
-        raise MetricIndexNotFound(f"Unknown string: {string!r}")
-
-    return resolved
-
-
-def resolve_tag_key(string: str) -> str:
-    resolved = resolve(string)
-    return f"tags[{resolved}]"
-
-
-def resolve_weak(string: str) -> int:
-    """
-    A version of `resolve` that returns 0 for missing values.
-
-    When using `resolve_weak` to produce a WHERE-clause, it is quite
-    useful to make the WHERE-clause "impossible" with `WHERE x = 0` instead of
-    explicitly handling that exception.
-    """
-    resolved = indexer.resolve(string)
-    if resolved is None:
-        return 0
-
-    return resolved
-
-
-def resolve_many_weak(strings: Sequence[str]) -> Sequence[int]:
-    """
-    Resolve multiple values at once, omitting missing ones. This is useful in
-    the same way as `resolve_weak` is, e.g. `WHERE x in values`.
-    """
-    rv = []
-    for string in strings:
-        resolved = resolve_weak(string)
-        if resolved != 0:
-            rv.append(resolved)
-
-    return rv
 
 
 def parse_field(field: str) -> Tuple[str, str]:

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -39,8 +39,8 @@ from sentry.incidents.subscription_processor import (
     update_alert_rule_stats,
 )
 from sentry.models import Integration
-from sentry.release_health.metrics import tag_key, tag_value
 from sentry.sentry_metrics.indexer.models import MetricsKeyIndexer
+from sentry.snuba.metrics import resolve_tag_key, resolve_weak
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.cases import SessionMetricsTestCase
@@ -1848,9 +1848,9 @@ class MetricsCrashRateAlertProcessUpdateTest(
                 else:
                     denominator = count
                     numerator = int(value * denominator)
-            session_status = tag_key(self.project.organization.id, "session.status")
-            tag_value_init = tag_value(self.project.organization.id, "init")
-            tag_value_crashed = tag_value(self.project.organization.id, "crashed")
+            session_status = resolve_tag_key("session.status")
+            tag_value_init = resolve_weak("init")
+            tag_value_crashed = resolve_weak("crashed")
             processor.process_update(
                 {
                     "subscription_id": subscription.subscription_id

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -40,7 +40,7 @@ from sentry.incidents.subscription_processor import (
 )
 from sentry.models import Integration
 from sentry.sentry_metrics.indexer.models import MetricsKeyIndexer
-from sentry.snuba.metrics import resolve_tag_key, resolve_weak
+from sentry.sentry_metrics.utils import resolve_tag_key, resolve_weak
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.cases import SessionMetricsTestCase

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -1,5 +1,4 @@
 from sentry.exceptions import InvalidQuerySubscription, UnsupportedQuerySubscription
-from sentry.release_health.metrics import get_tag_values_list, metric_id, tag_key
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.sessions import SessionMetricKey
 from sentry.snuba.dataset import EntityKey
@@ -12,6 +11,7 @@ from sentry.snuba.entity_subscription import (
     TransactionsEntitySubscription,
     get_entity_subscription_for_dataset,
 )
+from sentry.snuba.metrics import resolve, resolve_many_weak, resolve_tag_key
 from sentry.snuba.models import QueryDatasets
 from sentry.testutils import TestCase
 
@@ -99,8 +99,7 @@ class EntitySubscriptionTestCase(TestCase):
         )
         assert isinstance(entity_subscription, MetricsSetsEntitySubscription)
         assert entity_subscription.aggregate == aggregate
-        org_id = self.organization.id
-        groupby = [tag_key(org_id, "session.status")]
+        groupby = [resolve_tag_key("session.status")]
         assert entity_subscription.get_entity_extra_params() == {
             "organization": self.organization.id,
             "groupby": groupby,
@@ -109,13 +108,13 @@ class EntitySubscriptionTestCase(TestCase):
         assert entity_subscription.entity_key == EntityKey.MetricsSets
         assert entity_subscription.time_col == ENTITY_TIME_COLUMNS[EntityKey.MetricsSets]
         assert entity_subscription.dataset == QueryDatasets.METRICS
-        session_status = tag_key(org_id, "session.status")
-        session_status_tag_values = get_tag_values_list(org_id, ["crashed", "init"])
+        session_status = resolve_tag_key("session.status")
+        session_status_tag_values = resolve_many_weak(["crashed", "init"])
         snuba_filter = entity_subscription.build_snuba_filter("", None, None)
         assert snuba_filter
         assert snuba_filter.aggregations == [["uniq(value)", None, "value"]]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", metric_id(org_id, SessionMetricKey.USER)],
+            ["metric_id", "=", resolve(SessionMetricKey.USER)],
             [session_status, "IN", session_status_tag_values],
         ]
         assert snuba_filter.groupby == groupby
@@ -131,8 +130,7 @@ class EntitySubscriptionTestCase(TestCase):
         )
         assert isinstance(entity_subscription, MetricsCountersEntitySubscription)
         assert entity_subscription.aggregate == aggregate
-        org_id = self.organization.id
-        groupby = [tag_key(org_id, "session.status")]
+        groupby = [resolve_tag_key("session.status")]
         assert entity_subscription.get_entity_extra_params() == {
             "organization": self.organization.id,
             "groupby": groupby,
@@ -141,13 +139,13 @@ class EntitySubscriptionTestCase(TestCase):
         assert entity_subscription.entity_key == EntityKey.MetricsCounters
         assert entity_subscription.time_col == ENTITY_TIME_COLUMNS[EntityKey.MetricsCounters]
         assert entity_subscription.dataset == QueryDatasets.METRICS
-        session_status = tag_key(org_id, "session.status")
-        session_status_tag_values = get_tag_values_list(org_id, ["crashed", "init"])
+        session_status = resolve_tag_key("session.status")
+        session_status_tag_values = resolve_many_weak(["crashed", "init"])
         snuba_filter = entity_subscription.build_snuba_filter("", None, None)
         assert snuba_filter
         assert snuba_filter.aggregations == [["sum(value)", None, "value"]]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", metric_id(org_id, SessionMetricKey.SESSION)],
+            ["metric_id", "=", resolve(SessionMetricKey.SESSION)],
             [session_status, "IN", session_status_tag_values],
         ]
         assert snuba_filter.groupby == groupby

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -1,6 +1,7 @@
 from sentry.exceptions import InvalidQuerySubscription, UnsupportedQuerySubscription
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.sessions import SessionMetricKey
+from sentry.sentry_metrics.utils import resolve, resolve_many_weak, resolve_tag_key
 from sentry.snuba.dataset import EntityKey
 from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
@@ -11,7 +12,6 @@ from sentry.snuba.entity_subscription import (
     TransactionsEntitySubscription,
     get_entity_subscription_for_dataset,
 )
-from sentry.snuba.metrics import resolve, resolve_many_weak, resolve_tag_key
 from sentry.snuba.models import QueryDatasets
 from sentry.testutils import TestCase
 
@@ -114,7 +114,7 @@ class EntitySubscriptionTestCase(TestCase):
         assert snuba_filter
         assert snuba_filter.aggregations == [["uniq(value)", None, "value"]]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", resolve(SessionMetricKey.USER)],
+            ["metric_id", "=", resolve(SessionMetricKey.USER.value)],
             [session_status, "IN", session_status_tag_values],
         ]
         assert snuba_filter.groupby == groupby
@@ -145,7 +145,7 @@ class EntitySubscriptionTestCase(TestCase):
         assert snuba_filter
         assert snuba_filter.aggregations == [["sum(value)", None, "value"]]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", resolve(SessionMetricKey.SESSION)],
+            ["metric_id", "=", resolve(SessionMetricKey.SESSION.value)],
             [session_status, "IN", session_status_tag_values],
         ]
         assert snuba_filter.groupby == groupby

--- a/tests/sentry/snuba/test_metrics.py
+++ b/tests/sentry/snuba/test_metrics.py
@@ -91,12 +91,11 @@ MOCK_NOW = datetime(2021, 8, 25, 23, 59, tzinfo=pytz.utc)
         ('transaction:"/bar/:orgId/"', [Condition(Column(name="tags[17]"), Op.EQ, rhs=18)]),
     ],
 )
-@mock.patch("sentry.snuba.metrics.indexer")
-def test_parse_query(mock_indexer, query_string, expected):
+def test_parse_query(monkeypatch, query_string, expected):
     local_indexer = MockIndexer()
     for s in ("", "myapp@2.0.0", "transaction", "/bar/:orgId/"):
         local_indexer.record(s)
-    mock_indexer.resolve = local_indexer.resolve
+    monkeypatch.setattr("sentry.sentry_metrics.indexer.resolve", local_indexer.resolve)
     parsed = _resolve_tags(parse_query(query_string))
     assert parsed == expected
 
@@ -166,12 +165,10 @@ def test_timestamps():
     assert interval == 12 * 60 * 60
 
 
-@mock.patch("sentry.snuba.metrics.indexer")
 @mock.patch("sentry.snuba.sessions_v2.get_now", return_value=MOCK_NOW)
 @mock.patch("sentry.api.utils.timezone.now", return_value=MOCK_NOW)
-def test_build_snuba_query(mock_now, mock_now2, mock_indexer):
-
-    mock_indexer.resolve = MockIndexer().resolve
+def test_build_snuba_query(mock_now, mock_now2, monkeypatch):
+    monkeypatch.setattr("sentry.sentry_metrics.indexer.resolve", MockIndexer().resolve)
     # Your typical release health query querying everything
     query_params = MultiValueDict(
         {
@@ -238,12 +235,10 @@ def test_build_snuba_query(mock_now, mock_now2, mock_indexer):
     }
 
 
-@mock.patch("sentry.snuba.metrics.indexer")
 @mock.patch("sentry.snuba.sessions_v2.get_now", return_value=MOCK_NOW)
 @mock.patch("sentry.api.utils.timezone.now", return_value=MOCK_NOW)
-def test_build_snuba_query_orderby(mock_now, mock_now2, mock_indexer):
-
-    mock_indexer.resolve = MockIndexer().resolve
+def test_build_snuba_query_orderby(mock_now, mock_now2, monkeypatch):
+    monkeypatch.setattr("sentry.sentry_metrics.indexer.resolve", MockIndexer().resolve)
     query_params = MultiValueDict(
         {
             "query": [
@@ -288,11 +283,12 @@ def test_build_snuba_query_orderby(mock_now, mock_now2, mock_indexer):
     )
 
 
-@mock.patch("sentry.snuba.metrics.indexer")
 @mock.patch("sentry.snuba.sessions_v2.get_now", return_value=MOCK_NOW)
 @mock.patch("sentry.api.utils.timezone.now", return_value=MOCK_NOW)
-def test_translate_results(_1, _2, mock_indexer):
-    mock_indexer.reverse_resolve = MockIndexer().reverse_resolve
+def test_translate_results(_1, _2, monkeypatch):
+    monkeypatch.setattr(
+        "sentry.sentry_metrics.indexer.reverse_resolve", MockIndexer().reverse_resolve
+    )
 
     query_params = MultiValueDict(
         {
@@ -447,11 +443,12 @@ def test_translate_results(_1, _2, mock_indexer):
     ]
 
 
-@mock.patch("sentry.snuba.metrics.indexer")
 @mock.patch("sentry.snuba.sessions_v2.get_now", return_value=MOCK_NOW)
 @mock.patch("sentry.api.utils.timezone.now", return_value=MOCK_NOW)
-def test_translate_results_missing_slots(_1, _2, mock_indexer):
-    mock_indexer.reverse_resolve = MockIndexer().reverse_resolve
+def test_translate_results_missing_slots(_1, _2, monkeypatch):
+    monkeypatch.setattr(
+        "sentry.sentry_metrics.indexer.reverse_resolve", MockIndexer().reverse_resolve
+    )
     query_params = MultiValueDict(
         {
             "field": [

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -8,13 +8,13 @@ import responses
 from django.utils import timezone
 from exam import patcher
 
-from sentry.release_health.metrics import get_tag_values_list, metric_id, tag_key, tag_value
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.sessions import SessionMetricKey
 from sentry.snuba.entity_subscription import (
     apply_dataset_query_conditions,
     get_entity_subscription_for_dataset,
 )
+from sentry.snuba.metrics import resolve, resolve_many_weak, resolve_tag_key, resolve_weak
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.tasks import (
     SUBSCRIPTION_STATUS_MAX_AGE,
@@ -306,13 +306,12 @@ class BuildSnubaFilterTest(TestCase):
             query="",
             environment=None,
         )
-        org_id = self.organization.id
-        session_status = tag_key(org_id, "session.status")
-        session_status_tag_values = get_tag_values_list(org_id, ["crashed", "init"])
+        session_status = resolve_tag_key("session.status")
+        session_status_tag_values = resolve_many_weak(["crashed", "init"])
         assert snuba_filter
         assert snuba_filter.aggregations == [["sum(value)", None, "value"]]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", metric_id(org_id, SessionMetricKey.SESSION)],
+            ["metric_id", "=", resolve(SessionMetricKey.SESSION)],
             [session_status, "IN", session_status_tag_values],
         ]
         assert snuba_filter.groupby == [session_status]
@@ -331,13 +330,12 @@ class BuildSnubaFilterTest(TestCase):
             query="",
             environment=None,
         )
-        org_id = self.organization.id
-        session_status = tag_key(org_id, "session.status")
-        session_status_tag_values = get_tag_values_list(org_id, ["crashed", "init"])
+        session_status = resolve_tag_key("session.status")
+        session_status_tag_values = resolve_many_weak(["crashed", "init"])
         assert snuba_filter
         assert snuba_filter.aggregations == [["uniq(value)", None, "value"]]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", metric_id(org_id, SessionMetricKey.USER)],
+            ["metric_id", "=", resolve(SessionMetricKey.USER)],
             [session_status, "IN", session_status_tag_values],
         ]
         assert snuba_filter.groupby == [session_status]
@@ -407,19 +405,18 @@ class BuildSnubaFilterTest(TestCase):
             query="release:ahmed@12.2",
             environment=env,
         )
-        org_id = self.organization.id
         assert snuba_filter
         assert snuba_filter.aggregations == [["sum(value)", None, "value"]]
-        assert snuba_filter.groupby == [tag_key(org_id, "session.status")]
+        assert snuba_filter.groupby == [resolve_tag_key("session.status")]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", metric_id(org_id, SessionMetricKey.SESSION)],
+            ["metric_id", "=", resolve(SessionMetricKey.SESSION)],
             [
-                tag_key(org_id, "session.status"),
+                resolve_tag_key("session.status"),
                 "IN",
-                get_tag_values_list(org_id, ["crashed", "init"]),
+                resolve_many_weak(["crashed", "init"]),
             ],
-            [tag_key(org_id, "environment"), "=", tag_value(org_id, "development")],
-            [tag_key(org_id, "release"), "=", tag_value(org_id, "ahmed@12.2")],
+            [resolve_tag_key("environment"), "=", resolve_weak("development")],
+            [resolve_tag_key("release"), "=", resolve_weak("ahmed@12.2")],
         ]
 
     def test_query_and_environment_users(self):
@@ -473,19 +470,18 @@ class BuildSnubaFilterTest(TestCase):
             query="release:ahmed@12.2",
             environment=env,
         )
-        org_id = self.organization.id
         assert snuba_filter
         assert snuba_filter.aggregations == [["uniq(value)", None, "value"]]
-        assert snuba_filter.groupby == [tag_key(org_id, "session.status")]
+        assert snuba_filter.groupby == [resolve_tag_key("session.status")]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", metric_id(org_id, SessionMetricKey.USER)],
+            ["metric_id", "=", resolve(SessionMetricKey.USER)],
             [
-                tag_key(org_id, "session.status"),
+                resolve_tag_key("session.status"),
                 "IN",
-                get_tag_values_list(org_id, ["crashed", "init"]),
+                resolve_many_weak(["crashed", "init"]),
             ],
-            [tag_key(org_id, "environment"), "=", tag_value(org_id, "development")],
-            [tag_key(org_id, "release"), "=", tag_value(org_id, "ahmed@12.2")],
+            [resolve_tag_key("environment"), "=", resolve_weak("development")],
+            [resolve_tag_key("release"), "=", resolve_weak("ahmed@12.2")],
         ]
 
     def test_aliased_query_transactions(self):

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -10,11 +10,11 @@ from exam import patcher
 
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.sessions import SessionMetricKey
+from sentry.sentry_metrics.utils import resolve, resolve_many_weak, resolve_tag_key, resolve_weak
 from sentry.snuba.entity_subscription import (
     apply_dataset_query_conditions,
     get_entity_subscription_for_dataset,
 )
-from sentry.snuba.metrics import resolve, resolve_many_weak, resolve_tag_key, resolve_weak
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.tasks import (
     SUBSCRIPTION_STATUS_MAX_AGE,
@@ -311,7 +311,7 @@ class BuildSnubaFilterTest(TestCase):
         assert snuba_filter
         assert snuba_filter.aggregations == [["sum(value)", None, "value"]]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", resolve(SessionMetricKey.SESSION)],
+            ["metric_id", "=", resolve(SessionMetricKey.SESSION.value)],
             [session_status, "IN", session_status_tag_values],
         ]
         assert snuba_filter.groupby == [session_status]
@@ -335,7 +335,7 @@ class BuildSnubaFilterTest(TestCase):
         assert snuba_filter
         assert snuba_filter.aggregations == [["uniq(value)", None, "value"]]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", resolve(SessionMetricKey.USER)],
+            ["metric_id", "=", resolve(SessionMetricKey.USER.value)],
             [session_status, "IN", session_status_tag_values],
         ]
         assert snuba_filter.groupby == [session_status]
@@ -409,7 +409,7 @@ class BuildSnubaFilterTest(TestCase):
         assert snuba_filter.aggregations == [["sum(value)", None, "value"]]
         assert snuba_filter.groupby == [resolve_tag_key("session.status")]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", resolve(SessionMetricKey.SESSION)],
+            ["metric_id", "=", resolve(SessionMetricKey.SESSION.value)],
             [
                 resolve_tag_key("session.status"),
                 "IN",
@@ -474,7 +474,7 @@ class BuildSnubaFilterTest(TestCase):
         assert snuba_filter.aggregations == [["uniq(value)", None, "value"]]
         assert snuba_filter.groupby == [resolve_tag_key("session.status")]
         assert snuba_filter.conditions == [
-            ["metric_id", "=", resolve(SessionMetricKey.USER)],
+            ["metric_id", "=", resolve(SessionMetricKey.USER.value)],
             [
                 resolve_tag_key("session.status"),
                 "IN",


### PR DESCRIPTION
Consolidate all the helper functions that have evolved around string
indexer, and fix string indexer to produce valid typing information for
mypy.

Notable changes include:

* All APIs now throw `MetricIndexNotFound`
* `MetricIndexNotFound` is now a subclass of `InvalidParams` because there is code in metrics_sessions_v2 that appears to make use of that.

Looping in S&S so they're aware what ingest team is doing with
index_value=0, and which patterns have evolved around string indexer.