### PR TITLE
fix(insights): Exclude ignored issues from initial unresolved counts in all unresolved issues endpoint

### DIFF
--- a/src/sentry/api/endpoints/team_all_unresolved_issues.py
+++ b/src/sentry/api/endpoints/team_all_unresolved_issues.py
@@ -2,7 +2,17 @@ import copy
 from datetime import timedelta
 from itertools import chain
 
-from django.db.models import Count, ExpressionWrapper, F, IntegerField, Min, OuterRef, Q, Subquery
+from django.db.models import (
+    Count,
+    Exists,
+    ExpressionWrapper,
+    F,
+    IntegerField,
+    Min,
+    OuterRef,
+    Q,
+    Subquery,
+)
 from django.db.models.functions import Coalesce, TruncDay
 from django.utils import timezone
 from rest_framework.request import Request
@@ -12,7 +22,7 @@ from sentry import features
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.utils import get_date_range_from_params
-from sentry.models import Group, GroupHistory, GroupHistoryStatus, Project, Team
+from sentry.models import Group, GroupHistory, GroupHistoryStatus, GroupStatus, Project, Team
 from sentry.models.grouphistory import RESOLVED_STATUSES, UNRESOLVED_STATUSES
 
 OPEN_STATUSES = UNRESOLVED_STATUSES + (GroupHistoryStatus.UNIGNORED,)
@@ -70,7 +80,37 @@ class TeamAllUnresolvedIssuesEndpoint(TeamEndpoint, EnvironmentMixin):  # type: 
                 )
             )
         }
-        # TODO: Could get ignored counts from `GroupSnooze` too
+
+        project_ignored = {
+            r["project"]: r["total"]
+            for r in (
+                Group.objects.filter_to_team(team)
+                .annotate(
+                    ignored_exists=Exists(
+                        GroupHistory.objects.filter(
+                            group_id=OuterRef("id"),
+                            status__in=[GroupHistoryStatus.IGNORED, GroupHistoryStatus.UNIGNORED],
+                        ),
+                    ),
+                )
+                .filter(ignored_exists=False, status=GroupStatus.IGNORED)
+                .values("project")
+                .annotate(
+                    total=Count("id"),
+                )
+            )
+        }
+        for project, ignored in project_ignored.items():
+            if project not in project_unresolved:
+                # This shouldn't be able to happen since the project should already be included,
+                # but just being defensive.
+                continue
+            project_unresolved[project] = max(project_unresolved[project] - ignored, 0)
+
+        # TODO: We could write a query to fetch any unignored GroupHistory rows that don't have
+        # a corresponding ignored row. This would imply that the Group was ignored before we had
+        # history of it happening, and we could use that to help determine initial ignored count.
+        # Might not be as important as the general ignored detection above.
 
         prev_status_sub_qs = Coalesce(
             Subquery(

--- a/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
+++ b/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from django.utils.timezone import now
 from freezegun import freeze_time
 
-from sentry.models import GroupAssignee, GroupHistory, GroupHistoryStatus
+from sentry.models import GroupAssignee, GroupHistory, GroupHistoryStatus, GroupStatus
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 
@@ -24,11 +24,16 @@ class TeamIssueBreakdownTest(APITestCase):
             project=project1, first_seen=before_now(days=40), resolved_at=before_now(days=9)
         )
         group1_5 = self.create_group(project=project1, first_seen=before_now(days=40))
+        # Should be excluded from counts even though it has no group history row
+        group1_6 = self.create_group(
+            project=project1, first_seen=before_now(days=41), status=GroupStatus.IGNORED
+        )
         GroupAssignee.objects.assign(group1_1, self.user)
         GroupAssignee.objects.assign(group1_2, self.user)
         GroupAssignee.objects.assign(group1_3, self.user)
         GroupAssignee.objects.assign(group1_4, self.user)
         GroupAssignee.objects.assign(group1_5, self.user)
+        GroupAssignee.objects.assign(group1_6, self.user)
         GroupHistory.objects.all().delete()
 
         self.create_group_history(


### PR DESCRIPTION
Since we've only been writing to `GroupHistory` in the last few months it doesn't have a full
history going back to when all groups were created.

Currently, if a group was ignored before we started writing `GroupHistory` rows then it is included
in the total counts, which throws off our daily numbers. This pr tries to detect these rows, by
filtering to groups that are ignored and have no relevant rows in `GroupHistory`.

Unfortunately we can't use `GroupSnooze` for this, since it has no `date_added` field.