### PR TITLE
feat(dashboards): Added counts and timestamp fields to Issue Widgets

### DIFF
--- a/static/app/views/dashboardsV2/widget/issueWidget/fields.tsx
+++ b/static/app/views/dashboardsV2/widget/issueWidget/fields.tsx
@@ -18,6 +18,12 @@ enum FieldKey {
   IS_BOOKMARKED = 'isBookmarked',
   IS_SUBSCRIBED = 'isSubscribed',
   IS_HANDLED = 'isHandled',
+  COUNT = 'count',
+  USER_COUNT = 'userCount',
+  LAST_SEEN = 'lastSeen',
+  FIRST_SEEN = 'firstSeen',
+  LIFETIME_COUNT = 'lifetimeCount',
+  LIFETIME_USER_COUNT = 'lifetimeUserCount',
 }
 
 export const ISSUE_FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
@@ -31,4 +37,10 @@ export const ISSUE_FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
   [FieldKey.IS_BOOKMARKED]: 'boolean',
   [FieldKey.IS_SUBSCRIBED]: 'boolean',
   [FieldKey.IS_HANDLED]: 'boolean',
+  [FieldKey.COUNT]: 'string',
+  [FieldKey.USER_COUNT]: 'string',
+  [FieldKey.LAST_SEEN]: 'string',
+  [FieldKey.FIRST_SEEN]: 'string',
+  [FieldKey.LIFETIME_COUNT]: 'string',
+  [FieldKey.LIFETIME_USER_COUNT]: 'string',
 };

--- a/tests/js/spec/views/dashboardsV2/widget/issueWidget/utils.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widget/issueWidget/utils.spec.tsx
@@ -5,15 +5,21 @@ describe('generateIssueWidgetFieldOptions', function () {
     const issueFields = generateIssueWidgetFieldOptions();
     expect(Object.keys(issueFields)).toEqual([
       'field:assignee',
+      'field:count',
+      'field:firstSeen',
       'field:isBookmarked',
       'field:isHandled',
       'field:isSubscribed',
       'field:issue',
+      'field:lastSeen',
       'field:level',
+      'field:lifetimeCount',
+      'field:lifetimeUserCount',
       'field:permalink',
       'field:platform',
       'field:status',
       'field:title',
+      'field:userCount',
     ]);
   });
   it('returns supplied issue fields', () => {

--- a/tests/js/spec/views/dashboardsV2/widgetCard/issueWidgetQueries.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard/issueWidgetQueries.spec.tsx
@@ -25,12 +25,17 @@ describe('IssueWidgetQueries', function () {
           project: {
             id: '3',
           },
+          status: 'unresolved',
           owners: [
             {
               type: 'ownershipRule',
               owner: 'user:2',
             },
           ],
+          lifetime: {count: 10, userCount: 5},
+          count: 6,
+          userCount: 3,
+          firstSeen: '2022-01-01T13:04:02Z',
         },
       ],
     });
@@ -76,7 +81,18 @@ describe('IssueWidgetQueries', function () {
     await tick();
     expect(mockFunction).toHaveBeenCalledWith(
       expect.objectContaining({
-        transformedResults: [expect.objectContaining({title: 'Error: Failed'})],
+        transformedResults: [
+          expect.objectContaining({
+            id: '1',
+            title: 'Error: Failed',
+            status: 'unresolved',
+            lifetimeCount: 10,
+            lifetimeUserCount: 5,
+            count: 6,
+            userCount: 3,
+            firstSeen: '2022-01-01T13:04:02Z',
+          }),
+        ],
       })
     );
   });


### PR DESCRIPTION
Added count, userCount, lastSeen, firstSeen, lifetimeCount, lifetimeUserCount as fields to Issue Widgets.
Currently just renders as plain text and timestamps. Update to `fieldRenderers` coming in future pr to improve field displays. `totalCount` to be used in the future PR for Big Number visualization

![image](https://user-images.githubusercontent.com/83961295/149004195-50b8ff52-338f-4823-9bb6-ff98f4ad75c0.png)
![image](https://user-images.githubusercontent.com/83961295/149004258-0654a6b9-1dfb-4f3e-9c0a-e11503fb3742.png)