### PR TITLE
fix(tests): Fix flakey test for External Mappings

### DIFF
--- a/tests/acceptance/test_organization_integration_configuration_tabs.py
+++ b/tests/acceptance/test_organization_integration_configuration_tabs.py
@@ -122,7 +122,6 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
             self.browser.click('[aria-label="Save Changes"]')
             self.browser.wait_until_not('[aria-label="Save Changes"]')
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
-            self.browser.wait_until_not(".loading-indicator")
             self.browser.snapshot("integrations - one external team mapping")
 
     def test_settings_tab(self):

--- a/tests/acceptance/test_organization_integration_configuration_tabs.py
+++ b/tests/acceptance/test_organization_integration_configuration_tabs.py
@@ -85,6 +85,7 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
 
             # List View
             self.browser.click('[aria-label="Save Changes"]')
+            self.browser.wait_until_not('[aria-label="Save Changes"]')
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("integrations - one external user mapping")
 
@@ -119,7 +120,9 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
 
             # List View
             self.browser.click('[aria-label="Save Changes"]')
+            self.browser.wait_until_not('[aria-label="Save Changes"]')
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
+            self.browser.wait_until_not(".loading-indicator")
             self.browser.snapshot("integrations - one external team mapping")
 
     def test_settings_tab(self):


### PR DESCRIPTION
## Objective:
Probs a race condition or some network latency issues causing this test to be flakey. Hopefully adding a check helps. Test passes locally multiple times, but only time will tell if the acceptance test has become consistent.