### PR TITLE
fix(snql): Add aggregations to select in auto_aggregation

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
-from snuba_sdk.conditions import And, Condition, Op, Or
+from snuba_sdk.conditions import And, BooleanCondition, Condition, Op, Or
 from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import Granularity, Limit, Offset, Turbo
 from snuba_sdk.function import CurriedFunction, Function
@@ -114,18 +114,43 @@ class QueryBuilder(QueryFilter):  # type: ignore
         Skipped if auto_aggregations are enabled, and at least one other aggregate is selected
         This is so we don't change grouping suddenly
         """
-        if self.auto_aggregations and self.aggregates:
-            return
-        error_extra = ", and could not be automatically added" if self.auto_aggregations else ""
+        # construct the list of each condition, this is so many steps cause self.having can be a mix of
+        # BooleanConditions and Conditions.
+        to_check: List[Condition] = []
+        boolean_conditions: List[BooleanCondition] = []
         for condition in self.having:
-            lhs = condition.lhs
-            if lhs not in self.columns:
-                raise InvalidSearchQuery(
-                    "Aggregate {} used in a condition but is not a selected column{}.".format(
-                        lhs.alias,
-                        error_extra,
+            if isinstance(condition, Condition):
+                to_check.append(condition)
+            elif isinstance(condition, BooleanCondition):
+                boolean_conditions.append(condition)
+
+        while len(boolean_conditions) > 0:
+            boolean_condition = boolean_conditions.pop()
+            for condition in boolean_condition.conditions:
+                if isinstance(condition, Condition):
+                    to_check.append(condition)
+                elif isinstance(condition, BooleanCondition):
+                    boolean_conditions.append(condition)
+
+        if self.auto_aggregations and self.aggregates:
+            for condition in to_check:
+                lhs = condition.lhs
+                if isinstance(lhs, CurriedFunction) and lhs not in self.columns:
+                    self.columns.append(lhs)
+                    self.aggregates.append(lhs)
+            return
+        # If auto aggregations is disabled or aggregations aren't present in the first place we throw an error
+        else:
+            error_extra = ", and could not be automatically added" if self.auto_aggregations else ""
+            for condition in to_check:
+                lhs = condition.lhs
+                if lhs not in self.columns:
+                    raise InvalidSearchQuery(
+                        "Aggregate {} used in a condition but is not a selected column{}.".format(
+                            lhs.alias,
+                            error_extra,
+                        )
                     )
-                )
 
     def get_snql_query(self) -> Query:
         self.validate_having_clause()

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -485,3 +485,82 @@ class QueryBuilderTest(TestCase):
         snql_query = query.get_snql_query()
         snql_query.validate()
         assert snql_query.turbo.value
+
+    def test_auto_aggregation(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            "count_unique(user):>10",
+            selected_columns=[
+                "count()",
+            ],
+            auto_aggregations=True,
+            use_aggregate_conditions=True,
+        )
+        snql_query = query.get_snql_query()
+        snql_query.validate()
+        self.assertCountEqual(
+            snql_query.having,
+            [
+                Condition(Function("uniq", [Column("user")], "count_unique_user"), Op.GT, 10),
+            ],
+        )
+        self.assertCountEqual(
+            snql_query.select,
+            [
+                Function("uniq", [Column("user")], "count_unique_user"),
+                Function("count", [], "count"),
+            ],
+        )
+
+    def test_auto_aggregation_with_boolean(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            # Nonsense query but doesn't matter
+            "count_unique(user):>10 OR count_unique(user):<10",
+            selected_columns=[
+                "count()",
+            ],
+            auto_aggregations=True,
+            use_aggregate_conditions=True,
+        )
+        snql_query = query.get_snql_query()
+        snql_query.validate()
+        self.assertCountEqual(
+            snql_query.having,
+            [
+                Or(
+                    [
+                        Condition(
+                            Function("uniq", [Column("user")], "count_unique_user"), Op.GT, 10
+                        ),
+                        Condition(
+                            Function("uniq", [Column("user")], "count_unique_user"), Op.LT, 10
+                        ),
+                    ]
+                )
+            ],
+        )
+        self.assertCountEqual(
+            snql_query.select,
+            [
+                Function("uniq", [Column("user")], "count_unique_user"),
+                Function("count", [], "count"),
+            ],
+        )
+
+    def test_disable_auto_aggregation(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            "count_unique(user):>10",
+            selected_columns=[
+                "count()",
+            ],
+            auto_aggregations=False,
+            use_aggregate_conditions=True,
+        )
+        # With count_unique only in a condition and no auto_aggregations this should raise a invalid search query
+        with self.assertRaises(InvalidSearchQuery):
+            query.get_snql_query()


### PR DESCRIPTION
- This is to fix an issue for queries that have the uniq aggregation in
  the HAVING clause, and is not selected.
  - Previously we would not add the aggregation to the select clause in
    these cases
  - Now anything in the having clause will get added to the select
    clause as well if auto_aggregation is enabled
  - if its disabled we raise an invalid search query error
- This also fixes a bug where this having validation wasn't working
  correctly for boolean conditions