### PR TITLE
feat(dashboard): Default display type to Table when creating a new widget

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -132,7 +132,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     if (!widget) {
       this.state = {
         title: defaultTitle ?? '',
-        displayType: displayType ?? DisplayType.LINE,
+        displayType: displayType ?? DisplayType.TABLE,
         interval: '5m',
         queries: [defaultWidgetQuery ? {...defaultWidgetQuery} : {...newQuery}],
         errors: undefined,

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -256,6 +256,9 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       onAddWidget: data => (widget = data),
     });
 
+    // Select Line chart display
+    selectByLabel(wrapper, 'Line Chart', {name: 'displayType', at: 0, control: true});
+
     // Click the add button
     const add = wrapper.find('button[aria-label="Add Overlay"]');
     add.simulate('click');
@@ -279,6 +282,9 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       initialData,
       onAddWidget: data => (widget = data),
     });
+
+    // Select Line chart display
+    selectByLabel(wrapper, 'Line Chart', {name: 'displayType', at: 0, control: true});
 
     // Click the add button
     const add = wrapper.find('button[aria-label="Add an Equation"]');
@@ -316,6 +322,9 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       initialData,
       onAddWidget: data => (widget = data),
     });
+
+    // Select Line chart display
+    selectByLabel(wrapper, 'Line Chart', {name: 'displayType', at: 0, control: true});
 
     // Click the add button
     const add = wrapper.find('button[aria-label="Add Overlay"]');
@@ -379,6 +388,9 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       initialData,
       onAddWidget: data => (widget = data),
     });
+
+    // Select Line chart display
+    selectByLabel(wrapper, 'Line Chart', {name: 'displayType', at: 0, control: true});
 
     // Set first query search conditions
     await setSearchConditions(
@@ -717,6 +729,9 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       initialData,
       onAddWidget: data => (widget = data),
     });
+    // Select Line chart display
+    selectByLabel(wrapper, 'Line Chart', {name: 'displayType', at: 0, control: true});
+
     // No delete button as there is only one field.
     expect(wrapper.find('IconDelete')).toHaveLength(0);
 
@@ -1073,8 +1088,6 @@ describe('Modals -> AddDashboardWidgetModal', function () {
         onAddWidget: onAdd,
         onUpdateWidget: () => undefined,
       });
-      userEvent.click(screen.getByText('Line Chart'));
-      userEvent.click(screen.getByText('Table'));
       userEvent.click(screen.getByText('Issues (States, Assignment, Time, etc.)'));
       userEvent.click(screen.getByTestId('add-widget'));
 
@@ -1105,8 +1118,8 @@ describe('Modals -> AddDashboardWidgetModal', function () {
         source: types.DashboardWidgetSource.DISCOVERV2,
       });
       await tick();
-      userEvent.click(screen.getByText('Line Chart'));
       userEvent.click(screen.getByText('Table'));
+      userEvent.click(screen.getByText('Line Chart'));
       expect(screen.queryByText('Data Set')).not.toBeInTheDocument();
       wrapper.unmount();
     });
@@ -1117,8 +1130,6 @@ describe('Modals -> AddDashboardWidgetModal', function () {
         onUpdateWidget: () => undefined,
         source: types.DashboardWidgetSource.DASHBOARDS,
       });
-      userEvent.click(screen.getByText('Line Chart'));
-      userEvent.click(screen.getByText('Table'));
 
       expect(screen.getByText('Data Set')).toBeInTheDocument();
       wrapper.unmount();

--- a/tests/js/spec/views/dashboardsV2/gridLayout/create.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/create.spec.tsx
@@ -56,6 +56,10 @@ describe('Dashboards > Create', function () {
         method: 'GET',
         body: [],
       });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/eventsv2/',
+        body: {data: []},
+      });
     });
 
     afterEach(function () {


### PR DESCRIPTION
This change is to improve the visibility of the Data Set selector since the selector only appears in Table widgets.
![image](https://user-images.githubusercontent.com/83961295/149019388-ef171524-e225-4d1c-9c75-b4dc6591c3e1.png)
