### PR TITLE
feat(apidocs) demo of response serializer autodoc based on TypedDicts

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -237,9 +237,6 @@
     "/api/0/organizations/{organization_slug}/scim/v2/Users": {
       "$ref": "paths/scim/member_index.json"
     },
-    "/api/0/organizations/{organization_slug}/scim/v2/Users/{member_id}": {
-      "$ref": "paths/scim/member_details.json"
-    },
     "/api/0/organizations/{organization_slug}/scim/v2/Groups": {
       "$ref": "paths/scim/team_index.json"
     },

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "build-acceptance": "IS_ACCEPTANCE_TEST=1 NODE_ENV=production yarn webpack --mode development",
     "build-production": "NODE_ENV=production yarn webpack --mode production",
     "build": "NODE_OPTIONS=--max-old-space-size=4096 yarn webpack",
-    "validate-api-examples": "cd api-docs && yarn openapi-examples-validator ./openapi.json --no-additional-properties",
+    "validate-api-examples": "cd api-docs && yarn openapi-examples-validator ../tests/apidocs/openapi-derefed.json --no-additional-properties",
     "mkcert-localhost": "mkcert -key-file config/localhost-key.pem -cert-file config/localhost.pem localhost"
   },
   "browserslist": {

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,6 +62,7 @@ statsd==3.3
 structlog==21.1.0
 symbolic==8.3.2
 toronado==0.1.0
+typing-extensions==3.10.0.2
 ua-parser==0.10.0
 unidiff==0.6.0
 urllib3==1.24.2

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
-from typing import Any, List, Mapping, MutableMapping, Optional, Sequence, Set, TypedDict
+from typing import Any, List, Mapping, MutableMapping, Optional, Sequence, Set
+
+from typing_extensions import TypedDict
 
 from sentry import roles
 from sentry.api.serializers import Serializer, register, serialize
@@ -219,7 +221,13 @@ class OrganizationMemberSCIMSerializerRequired(TypedDict):
 class OrganizationMemberSCIMSerializerResponse(
     OrganizationMemberSCIMSerializerRequired, total=False
 ):
+    """
+    Conforming to the SCIM RFC, this represents a Sentry Org Member
+    as a SCIM user object.
+    """
+
     active: bool
+    """Sentry doesn't use this field but is expected by SCIM"""
 
 
 class OrganizationMemberSCIMSerializer(Serializer):  # type: ignore

--- a/src/sentry/apidocs/extensions.py
+++ b/src/sentry/apidocs/extensions.py
@@ -3,8 +3,9 @@ from typing import Any, Optional
 
 from drf_spectacular.extensions import OpenApiAuthenticationExtension, OpenApiSerializerExtension
 from drf_spectacular.openapi import AutoSchema
-from drf_spectacular.plumbing import resolve_type_hint
 from drf_spectacular.utils import Direction
+
+from sentry.apidocs.spectacular_ports import resolve_type_hint
 
 
 class TokenAuthExtension(OpenApiAuthenticationExtension):

--- a/src/sentry/apidocs/extensions.py
+++ b/src/sentry/apidocs/extensions.py
@@ -1,4 +1,10 @@
-from drf_spectacular.extensions import OpenApiAuthenticationExtension
+import inspect
+from typing import Any, Optional
+
+from drf_spectacular.extensions import OpenApiAuthenticationExtension, OpenApiSerializerExtension
+from drf_spectacular.openapi import AutoSchema
+from drf_spectacular.plumbing import resolve_type_hint
+from drf_spectacular.utils import Direction
 
 
 class TokenAuthExtension(OpenApiAuthenticationExtension):
@@ -16,3 +22,44 @@ class TokenAuthExtension(OpenApiAuthenticationExtension):
                 permissions.add(p)
 
         return {self.name: list(permissions)}
+
+
+# TODO: map things in registry?
+# add docstring as description
+# excluded attributes?
+# optional/required in responses
+class SentryResponseSerializerExtension(OpenApiSerializerExtension):  # type: ignore
+    priority = 0
+    target_class = "sentry.api.serializers.base.Serializer"
+    match_subclasses = True
+
+    def get_name(self) -> Optional[str]:
+        name: str = self.target.__name__
+        return name
+
+    def map_serializer(self, auto_schema: AutoSchema, direction: Direction) -> Any:
+        serializer_signature = inspect.signature(self.target.serialize)
+        return resolve_type_hint(serializer_signature.return_annotation)
+
+
+# class SentryInlineResponseSerializerExtension(OpenApiSerializerExtension):  # type: ignore
+#     priority = 0
+#     target_class = "sentry.apidocs.schemaserializer.RawSchema"
+#     match_subclasses = True
+
+#     def get_name(self) -> Optional[str]:
+#         name: str = self.target.__name__
+#         return name
+
+#     def map_serializer(self, auto_schema: AutoSchema, direction: Direction) -> Any:
+#         return resolve_type_hint(self.target.typeSchema)
+
+
+class RawSchema:
+    def __init__(self, t: type) -> None:
+        self.typeSchema = t
+
+
+def inline_sentry_response_serializer(name: str, t: type) -> type:
+    serializer_class = type(name, (RawSchema,), {"typeSchema": t})
+    return serializer_class

--- a/src/sentry/apidocs/spectacular_ports.py
+++ b/src/sentry/apidocs/spectacular_ports.py
@@ -1,0 +1,110 @@
+import collections
+import inspect
+import typing
+from collections import OrderedDict, defaultdict
+from enum import Enum
+from typing import Literal, Union, get_type_hints
+
+from drf_spectacular.drainage import get_override
+from drf_spectacular.plumbing import (
+    UnableToProceedError,
+    build_array_type,
+    build_basic_type,
+    build_object_type,
+    is_basic_type,
+)
+from drf_spectacular.types import OpenApiTypes
+from typing_extensions import _TypedDictMeta
+
+# Until we're on 3.9 we have to use the typing extention TypedDict as
+# we are unable to tell optional fields at run time via the regular 3.8
+# implementation
+
+
+# This function is ported from the drf-spectacular library method here:
+# https://github.com/tfranzel/drf-spectacular/blob/03d315ced245db71cef1e45fd05a082b7dedc7aa/drf_spectacular/plumbing.py#L1100
+# with modifications to support our use case:
+#   grabbing description from a TypedDict __doc__
+#   support for TypedDict required fields
+#   support for excluded fields via @extend_schema_serializer
+#   warning about using typing_extension TypedDict
+
+# TODO:
+#   figure out solution for field descriptions
+#   support deprecated fields via extension
+
+
+def _get_type_hint_origin(hint):
+    return typing.get_origin(hint), typing.get_args(hint)
+
+
+def resolve_type_hint(hint):
+    """drf-spectacular library method modified to add descriptions to TypedDict"""
+    origin, args = _get_type_hint_origin(hint)
+
+    if origin is None and is_basic_type(hint, allow_none=False):
+        return build_basic_type(hint)
+    elif origin is None and inspect.isclass(hint) and issubclass(hint, tuple):
+        # a convoluted way to catch NamedTuple. suggestions welcome.
+        if get_type_hints(hint):
+            properties = {k: resolve_type_hint(v) for k, v in get_type_hints(hint).items()}
+        else:
+            properties = {k: build_basic_type(OpenApiTypes.ANY) for k in hint._fields}
+        return build_object_type(properties=properties, required=properties.keys())
+    elif origin is list or hint is list:
+        return build_array_type(
+            resolve_type_hint(args[0]) if args else build_basic_type(OpenApiTypes.ANY)
+        )
+    elif origin is tuple:
+        return build_array_type(
+            schema=build_basic_type(args[0]),
+            max_length=len(args),
+            min_length=len(args),
+        )
+    elif origin is dict or origin is defaultdict or origin is OrderedDict:
+        schema = build_basic_type(OpenApiTypes.OBJECT)
+        if args and args[1] is not typing.Any:
+            schema["additionalProperties"] = resolve_type_hint(args[1])
+        return schema
+    elif origin is set:
+        return build_array_type(resolve_type_hint(args[0]))
+    elif origin is frozenset:
+        return build_array_type(resolve_type_hint(args[0]))
+    elif origin is Literal:
+        # Literal only works for python >= 3.8 despite typing_extensions, because it
+        # behaves slightly different w.r.t. __origin__
+        schema = {"enum": list(args)}
+        if all(type(args[0]) is type(choice) for choice in args):
+            schema.update(build_basic_type(type(args[0])))
+        return schema
+    elif inspect.isclass(hint) and issubclass(hint, Enum):
+        schema = {"enum": [item.value for item in hint]}
+        mixin_base_types = [t for t in hint.__mro__ if is_basic_type(t)]
+        if mixin_base_types:
+            schema.update(build_basic_type(mixin_base_types[0]))
+        return schema
+    elif isinstance(hint, _TypedDictMeta):
+        return build_object_type(
+            properties={
+                k: resolve_type_hint(v)
+                for k, v in get_type_hints(hint).items()
+                if k not in get_override(hint, "exclude_fields", [])
+            },
+            description=inspect.cleandoc(hint.__doc__ or ""),
+            required=hint.__required_keys__,
+        )
+    elif origin is Union:
+        type_args = [arg for arg in args if arg is not type(None)]  # noqa: E721
+        if len(type_args) > 1:
+            schema = {"oneOf": [resolve_type_hint(arg) for arg in type_args]}
+        else:
+            schema = resolve_type_hint(type_args[0])
+        if type(None) in args:
+            schema["nullable"] = True
+        return schema
+    elif origin is collections.abc.Iterable:
+        return build_array_type(resolve_type_hint(args[0]))
+    elif isinstance(hint, typing._TypedDictMeta):
+        raise UnableToProceedError("Wrong TypedDict class, please use typing_extensions.TypedDict")
+    else:
+        raise UnableToProceedError()

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -893,7 +893,8 @@ if os.environ.get("OPENAPIGENERATE", False):
     SPECTACULAR_SETTINGS = {
         "PREPROCESSING_HOOKS": ["sentry.apidocs.preprocessor.custom_preprocessing_hook"],
         "DISABLE_ERRORS_AND_WARNINGS": False,
-        "COMPONENT_SPLIT_REQUEST": True,
+        "COMPONENT_SPLIT_REQUEST": False,
+        "COMPONENT_SPLIT_PATCH": False,
         "AUTHENTICATION_WHITELIST": ["sentry.api.authentication.TokenAuthentication"],
         "TAGS": OPENAPI_TAGS,
         "TITLE": "API Reference",
@@ -903,6 +904,7 @@ if os.environ.get("OPENAPIGENERATE", False):
         "LICENSE": {"name": "Apache 2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0.html"},
         "VERSION": "v0",
         "SERVERS": [{"url": "https://sentry.io/"}],
+        "PARSER_WHITELIST": ["rest_framework.parsers.JSONParser"],
         "APPEND_PATHS": get_old_json_paths(OLD_OPENAPI_JSON_PATH),
     }
 

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -155,6 +155,11 @@ def configure(ctx, py, yaml, skip_service_validation=False):
         skip_service_validation=skip_service_validation,
     )
 
+    if os.environ.get("OPENAPIGENERATE", False):
+        # TODO: is this the best place for this import?
+        # see https://drf-spectacular.readthedocs.io/en/latest/customization.html#step-5-extensions
+        from sentry.apidocs import extensions  # NOQA
+
     __installed = True
 
 

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -108,6 +108,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
                     "active": True,
                     "meta": {"resourceType": "User"},
                 },
+                status_codes=["200"],
             ),
         ],
     )

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -1,8 +1,7 @@
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
-from drf_spectacular.utils import OpenApiExample, extend_schema, inline_serializer
-from rest_framework import serializers
+from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -92,24 +91,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         parameters=[GLOBAL_PARAMS.ORG_SLUG, SCIM_PARAMS.MEMBER_ID],
         request=None,
         responses={
-            200: inline_serializer(
-                "SCIMMember",
-                fields={
-                    "schemas": serializers.CharField(),
-                    "id": serializers.CharField(),
-                    "userName": serializers.CharField(),
-                    "emails": inline_serializer(
-                        "SCIMMemberEmails",
-                        fields={
-                            "primary": serializers.BooleanField(),
-                            "value": serializers.CharField(),
-                            "type": serializers.CharField(),
-                        },
-                        many=True,
-                    ),
-                },
-                many=True,
-            ),
+            200: OrganizationMemberSCIMSerializer,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOTFOUND,


### PR DESCRIPTION
This PR demos a potential solution for documenting our response serializer, following up on #30040.

### It works by:
- creating a custom serializer extension that is registered to our response serializers.  
- this extension will look at the return type of the respective `serialize` functions and pass it to the drf-spectacular library function `resolve_type_hint`, which will turn the return type annotation into OpenAPI schema.

### To use this, we would:
- Take any endpoint we'd like to make public, and type the serializer function with a `TypedDict`.
- Use the serializer in the `extend_schema` response, or use the `serialize` return type in an inline definition.


### Alternatives:
- Performance issues with DRF's serializers still exist, so converting over to them was ruled out.
  - see [here](https://hakibenita.com/django-rest-framework-slow#fixing-django-rest-framework), even with tuning and recent fixes applied, a simple serializer is still an order of magnitude faster than DRFs.
-  Any combination of ours and DRF's serializers where we'd still have to define the fields on our class seems like it would introduce extra boilerplate that isn't that helpful. Typing the serializer with a `TypedDict` seems like it is somewhat helpful, simple to do, and requires no change on the part of the developer besides typing the function return.

### Limitations:
- Defining required vs non-required fields in TypedDicts isn't super elegant right now. It is possible, via defining a base with the required keys, and an extension of it with the optional ones. [PEP 655](https://www.python.org/dev/peps/pep-0655/#id6) addresses this and will be in 3.11.
- When I originally prototyped this I was having issues with nested serializers, but this current implementation handles them fine.
   

## TODO:
- try to find cases where this could break down or is unwieldy. I have tried other endpoints off branch but so far, so good.