### PR TITLE
fix(ui): columns in alerts table

### DIFF
--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -361,7 +361,7 @@ const StyledPanelTable = styled(PanelTable)`
     overflow: initial;
   }
 
-  grid-template-columns: auto 1.5fr 1fr 1fr 1fr auto;
+  grid-template-columns: 4fr auto 140px 60px 110px auto;
   white-space: nowrap;
   font-size: ${p => p.theme.fontSizeMedium};
 `;

--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -186,7 +186,9 @@ function RuleListRow({
         </FlexCenter>
         <AlertNameAndStatus>
           <AlertName>{alertLink}</AlertName>
-          {!isIssueAlert(rule) && renderLastIncidentDate()}
+          <AlertIncidentDate>
+            {!isIssueAlert(rule) && renderLastIncidentDate()}
+          </AlertIncidentDate>
         </AlertNameAndStatus>
       </AlertNameWrapper>
       <FlexCenter>{renderAlertRuleStatus()}</FlexCenter>
@@ -329,6 +331,10 @@ const AlertName = styled('div')`
   }
 `;
 
+const AlertIncidentDate = styled('div')`
+  color: ${p => p.theme.gray300};
+`;
+
 const ProjectBadgeContainer = styled('div')`
   width: 100%;
 `;
@@ -339,6 +345,7 @@ const ProjectBadge = styled(IdBadge)`
 
 const StyledDateTime = styled(DateTime)`
   font-variant-numeric: tabular-nums;
+  color: ${p => p.theme.gray300};
 `;
 
 const TriggerText = styled('div')`


### PR DESCRIPTION
Made the column with the alert name take up more space so it’s easier to scan each item and overall it just looks a lot cleaner. Also fixed the color of text in other columns to be less prevalent.

### Before

![CleanShot 2022-01-12 at 08 58 46](https://user-images.githubusercontent.com/1900676/149186300-a08a3070-643d-4d3d-b63b-68b960d0ff8c.png)



### After

![CleanShot 2022-01-11 at 16 51 23](https://user-images.githubusercontent.com/1900676/149044376-e7321e63-8a83-40a2-bfcd-0d286bd88162.png)

