### PR TITLE
ref(pageFilters): Constrict types on updateParams better

### DIFF
--- a/static/app/components/organizations/pageFilters/utils.tsx
+++ b/static/app/components/organizations/pageFilters/utils.tsx
@@ -7,7 +7,7 @@ import pickBy from 'lodash/pickBy';
 
 import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/constants/pageFilters';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
-import {Environment, PageFilters} from 'sentry/types';
+import {PageFilters} from 'sentry/types';
 import localStorage from 'sentry/utils/localStorage';
 
 import {normalizeDateTimeParams} from './parse';
@@ -85,8 +85,8 @@ function makeLocalStorageKey(orgSlug: string) {
 }
 
 type UpdateData = {
-  project?: Array<string | number> | string | number | null;
-  environment?: Environment['id'][] | null;
+  project?: string[] | null;
+  environment?: string[] | null;
 };
 
 /**
@@ -116,17 +116,9 @@ export function setPageFiltersStorage(
     return;
   }
 
-  const {project, environment} = update;
-  const validatedProject = project
-    ? (Array.isArray(project) ? project : [project])
-        .map(Number)
-        .filter(value => !isNaN(value))
-    : undefined;
-  const validatedEnvironment = environment;
-
   const dataToSave = {
-    projects: validatedProject || current.projects,
-    environments: validatedEnvironment || current.environments,
+    projects: update.project || current.projects,
+    environments: update.environment || current.environments,
   };
 
   const localStorageKey = makeLocalStorageKey(org.slug);

--- a/tests/js/spec/actionCreators/pageFilters.spec.jsx
+++ b/tests/js/spec/actionCreators/pageFilters.spec.jsx
@@ -46,7 +46,7 @@ describe('PageFilters ActionCreators', function () {
         expect.objectContaining({
           query: {
             environment: [],
-            project: [1],
+            project: ['1'],
           },
         })
       );
@@ -126,7 +126,7 @@ describe('PageFilters ActionCreators', function () {
         expect.objectContaining({
           query: {
             cursor: undefined,
-            project: [1],
+            project: ['1'],
             environment: [],
             statsPeriod: '1h',
           },
@@ -153,7 +153,7 @@ describe('PageFilters ActionCreators', function () {
         expect.objectContaining({
           query: {
             cursor: undefined,
-            project: [1],
+            project: ['1'],
             environment: [],
             start: '2020-03-22T00:53:38',
             end: '2020-04-21T00:53:38',
@@ -186,7 +186,7 @@ describe('PageFilters ActionCreators', function () {
         expect.objectContaining({
           query: {
             environment: [],
-            project: [1],
+            project: ['1'],
           },
         })
       );
@@ -336,7 +336,7 @@ describe('PageFilters ActionCreators', function () {
 
       expect(router.push).toHaveBeenCalledWith({
         pathname: '/test/',
-        query: {project: [1]},
+        query: {project: ['1']},
       });
     });
     it('does not update history when queries are the same', function () {
@@ -368,7 +368,7 @@ describe('PageFilters ActionCreators', function () {
 
       expect(router.replace).toHaveBeenCalledWith({
         pathname: '/test/',
-        query: {project: [1]},
+        query: {project: ['1']},
       });
     });
     it('does not update history when queries are the same', function () {

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -7,6 +7,7 @@ import * as globalActions from 'sentry/actionCreators/pageFilters';
 import OrganizationActions from 'sentry/actions/organizationActions';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import ConfigStore from 'sentry/stores/configStore';
+import OrganizationsStore from 'sentry/stores/organizationsStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {getItem} from 'sentry/utils/localStorage';
@@ -62,6 +63,7 @@ describe('GlobalSelectionHeader', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     ProjectsStore.loadInitialData(organization.projects);
+    OrganizationsStore.add(organization);
 
     getItem.mockImplementation(() => null);
     MockApiClient.addMockResponse({
@@ -139,6 +141,54 @@ describe('GlobalSelectionHeader', function () {
       },
       environments: [],
       projects: [],
+    });
+  });
+
+  it('can change environments with a project selected', async function () {
+    wrapper = mountWithTheme(
+      <PageFiltersContainer
+        organization={organization}
+        projects={organization.projects}
+      />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    mockRouterPush(wrapper, router);
+
+    // Open dropdown and select one project
+    wrapper.find('MultipleProjectSelector HeaderItem').simulate('click');
+    wrapper.find('MultipleProjectSelector CheckboxFancy').at(1).simulate('click');
+    wrapper.find('MultipleProjectSelector HeaderItem').simulate('click');
+
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('MultipleProjectSelector Content').text()).toBe('project-3');
+
+    // Select environment
+    wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');
+    wrapper.find('MultipleEnvironmentSelector CheckboxFancy').at(0).simulate('click');
+    wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');
+    await tick();
+
+    expect(wrapper.find('MultipleEnvironmentSelector Content').text()).toBe('prod');
+
+    expect(PageFiltersStore.getState().selection).toEqual({
+      datetime: {
+        period: '14d',
+        utc: null,
+        start: null,
+        end: null,
+      },
+      environments: ['prod'],
+      projects: [3],
+    });
+    const query = wrapper.prop('location').query;
+    expect(query).toEqual({
+      environment: 'prod',
+      project: '3',
     });
   });
 
@@ -225,7 +275,7 @@ describe('GlobalSelectionHeader', function () {
         {id: 2, slug: 'prod-project', environments: ['prod']},
       ],
       router: {
-        location: {query: {project: [1]}},
+        location: {query: {project: ['1']}},
         params: {orgId: 'org-slug'},
       },
     });
@@ -406,7 +456,7 @@ describe('GlobalSelectionHeader', function () {
       expect.objectContaining({
         query: {
           environment: ['staging'],
-          project: [3],
+          project: ['3'],
         },
       })
     );
@@ -425,7 +475,7 @@ describe('GlobalSelectionHeader', function () {
         // we need this to be set to make sure org in context is same as
         // current org in URL
         params: {orgId: 'org-slug'},
-        location: {query: {project: [1, 2]}},
+        location: {query: {project: ['1', '2']}},
       },
     });
 
@@ -451,7 +501,7 @@ describe('GlobalSelectionHeader', function () {
         // we need this to be set to make sure org in context is same as
         // current org in URL
         params: {orgId: 'org-slug'},
-        location: {query: {project: [1, 2]}},
+        location: {query: {project: ['1', '2']}},
       },
     });
 
@@ -527,7 +577,7 @@ describe('GlobalSelectionHeader', function () {
           // we need this to be set to make sure org in context is same as
           // current org in URL
           params: {orgId: 'org-slug'},
-          location: {query: {project: [1]}},
+          location: {query: {project: ['1']}},
         },
       });
 
@@ -575,7 +625,7 @@ describe('GlobalSelectionHeader', function () {
 
       expect(initialData.router.replace).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          query: {environment: [], project: [123]},
+          query: {environment: [], project: ['123']},
         })
       );
     });
@@ -586,7 +636,7 @@ describe('GlobalSelectionHeader', function () {
           // we need this to be set to make sure org in context is same as
           // current org in URL
           params: {orgId: 'org-slug'},
-          location: {query: {project: [1, 2]}},
+          location: {query: {project: ['1', '2']}},
         },
       });
 
@@ -597,7 +647,7 @@ describe('GlobalSelectionHeader', function () {
 
       expect(initializationObj.router.replace).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {environment: [], project: [1]},
+          query: {environment: [], project: ['1']},
         })
       );
     });
@@ -623,7 +673,7 @@ describe('GlobalSelectionHeader', function () {
 
       expect(initializationObj.router.replace).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {environment: [], project: [3]},
+          query: {environment: [], project: ['3']},
         })
       );
     });
@@ -717,7 +767,7 @@ describe('GlobalSelectionHeader', function () {
         // be the first project
         expect(initialData.router.replace).toHaveBeenLastCalledWith({
           pathname: undefined,
-          query: {cursor: undefined, environment: [], project: [2]},
+          query: {cursor: undefined, environment: [], project: ['2']},
         });
       });
 
@@ -738,7 +788,7 @@ describe('GlobalSelectionHeader', function () {
 
         expect(initialData.router.replace).toHaveBeenLastCalledWith({
           pathname: undefined,
-          query: {environment: [], project: [1]},
+          query: {environment: [], project: ['1']},
         });
 
         expect(initialData.router.replace).toHaveBeenCalledTimes(1);
@@ -754,7 +804,7 @@ describe('GlobalSelectionHeader', function () {
             location: {
               ...initialData.router.location,
               query: {
-                project: 321,
+                project: '321',
               },
             },
           },
@@ -779,7 +829,7 @@ describe('GlobalSelectionHeader', function () {
 
         expect(initialData.router.replace).toHaveBeenLastCalledWith({
           pathname: undefined,
-          query: {environment: [], project: [1]},
+          query: {environment: [], project: ['1']},
         });
       });
     });
@@ -826,7 +876,7 @@ describe('GlobalSelectionHeader', function () {
 
         expect(initialData.router.replace).toHaveBeenLastCalledWith({
           pathname: undefined,
-          query: {environment: [], project: [1], statsPeriod: '90d'},
+          query: {environment: [], project: ['1'], statsPeriod: '90d'},
         });
       });
     });
@@ -908,7 +958,7 @@ describe('GlobalSelectionHeader', function () {
 
         expect(initialData.router.replace).toHaveBeenLastCalledWith({
           pathname: undefined,
-          query: {environment: [], project: [1]},
+          query: {environment: [], project: ['1']},
         });
 
         expect(initialData.router.replace).toHaveBeenCalledTimes(1);

--- a/tests/js/spec/components/projectPageFilter.spec.tsx
+++ b/tests/js/spec/components/projectPageFilter.spec.tsx
@@ -56,7 +56,7 @@ describe('ProjectPageFilter', function () {
 
     // Verify we were redirected
     expect(router.push).toHaveBeenCalledWith(
-      expect.objectContaining({query: {environment: [], project: [2]}})
+      expect.objectContaining({query: {environment: [], project: ['2']}})
     );
   });
 });


### PR DESCRIPTION
This narrows the types on the updateParams function call to better reflect what is actually going on

 - The UrlParams type has been renamed to  `UpdateParams` and `PageFilterQuery`, which better reflect how the parameters are transformed when being shuttled between query parameters and more structured 'state' objects.

   This is especially important when passing these parameters to the `setPageFiltersStorage` function which now specifically always wants the `project` parameters to be a string array.

 - Add a test case to cover the regression that occurred in 0bbbfaba84, where we could not call `.map` on a string, which typescript failed to catch since the types in the pageFilters actionCreators were too wide and in some cases incorrect.

   This test would have failed in 0bbbfaba84.