### PR TITLE
test(acceptance): Use data-test-id or loading indicators

### DIFF
--- a/tests/acceptance/page_objects/base.py
+++ b/tests/acceptance/page_objects/base.py
@@ -9,7 +9,7 @@ class BasePage:
         return self.browser.driver
 
     def wait_until_loaded(self):
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
 
 class BaseElement:

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -32,7 +32,7 @@ class IssueDetailsPage(BasePage):
     def go_to_subtab(self, name):
         tabs = self.browser.find_element_by_css_selector(".group-detail .nav-tabs")
         tabs.find_element_by_partial_link_text(name).click()
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def open_issue_errors(self):
         self.browser.click(".errors-toggle")
@@ -67,7 +67,7 @@ class IssueDetailsPage(BasePage):
         assert len(options) > 0, "No assignees could be found."
         options[0].click()
 
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def find_comment_form(self):
         return self.browser.find_element_by_css_selector('[data-test-id="note-input-form"]')
@@ -77,7 +77,7 @@ class IssueDetailsPage(BasePage):
         return text in element.text
 
     def wait_until_loaded(self):
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_test_id("event-entries-loading-false")
         self.browser.wait_until_test_id("linked-issues")
         self.browser.wait_until_test_id("loaded-device-name")

--- a/tests/acceptance/page_objects/transaction_summary.py
+++ b/tests/acceptance/page_objects/transaction_summary.py
@@ -3,5 +3,5 @@ from .base import BasePage
 
 class TransactionSummaryPage(BasePage):
     def wait_until_loaded(self):
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_not('[data-test-id="loading-placeholder"]')

--- a/tests/acceptance/sentry_plugins/test_amazon_sqs.py
+++ b/tests/acceptance/sentry_plugins/test_amazon_sqs.py
@@ -14,6 +14,6 @@ class AmazonSQSTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("amazon sqs settings")
         assert self.browser.element_exists(".ref-plugin-config-amazon-sqs")

--- a/tests/acceptance/sentry_plugins/test_asana.py
+++ b/tests/acceptance/sentry_plugins/test_asana.py
@@ -14,6 +14,6 @@ class AsanaTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("asana settings")
         assert self.browser.element_exists(".ref-plugin-config-asana")

--- a/tests/acceptance/sentry_plugins/test_bitbucket.py
+++ b/tests/acceptance/sentry_plugins/test_bitbucket.py
@@ -14,6 +14,6 @@ class BitbucketTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("bitbucket settings")
         assert self.browser.element_exists(".ref-plugin-config-bitbucket")

--- a/tests/acceptance/sentry_plugins/test_github.py
+++ b/tests/acceptance/sentry_plugins/test_github.py
@@ -14,6 +14,6 @@ class GitHubTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("github settings")
         assert self.browser.element_exists(".ref-plugin-config-github")

--- a/tests/acceptance/sentry_plugins/test_gitlab.py
+++ b/tests/acceptance/sentry_plugins/test_gitlab.py
@@ -14,6 +14,6 @@ class GitLabTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("gitlab settings")
         assert self.browser.element_exists(".ref-plugin-config-gitlab")

--- a/tests/acceptance/sentry_plugins/test_jira.py
+++ b/tests/acceptance/sentry_plugins/test_jira.py
@@ -14,6 +14,6 @@ class JIRATest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("jira settings")
         assert self.browser.element_exists(".ref-plugin-config-jira")

--- a/tests/acceptance/sentry_plugins/test_pagerduty.py
+++ b/tests/acceptance/sentry_plugins/test_pagerduty.py
@@ -14,6 +14,6 @@ class PagerDutyTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("pagerduty settings")
         assert self.browser.element_exists(".ref-plugin-config-pagerduty")

--- a/tests/acceptance/sentry_plugins/test_phabricator.py
+++ b/tests/acceptance/sentry_plugins/test_phabricator.py
@@ -14,6 +14,6 @@ class PhabricatorTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("phabricator settings")
         assert self.browser.element_exists(".ref-plugin-config-phabricator")

--- a/tests/acceptance/sentry_plugins/test_pivotal.py
+++ b/tests/acceptance/sentry_plugins/test_pivotal.py
@@ -14,6 +14,6 @@ class PivotalTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("pivotal settings")
         assert self.browser.element_exists(".ref-plugin-config-pivotal")

--- a/tests/acceptance/sentry_plugins/test_pushover.py
+++ b/tests/acceptance/sentry_plugins/test_pushover.py
@@ -14,6 +14,6 @@ class PushoverTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("pushover settings")
         assert self.browser.element_exists(".ref-plugin-config-pushover")

--- a/tests/acceptance/sentry_plugins/test_segment.py
+++ b/tests/acceptance/sentry_plugins/test_segment.py
@@ -14,6 +14,6 @@ class SegmentTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("segment settings")
         assert self.browser.element_exists(".ref-plugin-config-segment")

--- a/tests/acceptance/sentry_plugins/test_sessionstack.py
+++ b/tests/acceptance/sentry_plugins/test_sessionstack.py
@@ -14,6 +14,6 @@ class SessionStackTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("sessionstack settings")
         assert self.browser.element_exists(".ref-plugin-config-sessionstack")

--- a/tests/acceptance/sentry_plugins/test_slack.py
+++ b/tests/acceptance/sentry_plugins/test_slack.py
@@ -14,6 +14,6 @@ class SlackTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("slack settings")
         assert self.browser.element_exists(".ref-plugin-config-slack")

--- a/tests/acceptance/sentry_plugins/test_splunk.py
+++ b/tests/acceptance/sentry_plugins/test_splunk.py
@@ -14,6 +14,6 @@ class SplunkTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("splunk settings")
         assert self.browser.element_exists(".ref-plugin-config-splunk")

--- a/tests/acceptance/sentry_plugins/test_victorops.py
+++ b/tests/acceptance/sentry_plugins/test_victorops.py
@@ -14,6 +14,6 @@ class VictorOpsTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("victorops settings")
         assert self.browser.element_exists(".ref-plugin-config-victorops")

--- a/tests/acceptance/test_account_settings.py
+++ b/tests/acceptance/test_account_settings.py
@@ -29,89 +29,89 @@ class AccountSettingsTest(AcceptanceTestCase):
         with self.feature("organizations:onboarding"):
             path = "/account/settings/"
             self.browser.get(path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account settings")
 
             self.browser.click('[href="/settings/account/security/"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account security settings")
 
             self.browser.click('[href="/settings/account/notifications/"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account notification settings")
 
             self.browser.click_when_visible("#Alerts a")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot('account notification - fine tune "Alerts"')
 
             self.browser.click('[href="/settings/account/emails/"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account emails settings")
 
             self.browser.click('[href="/settings/account/subscriptions/"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account subscriptions settings")
 
             self.browser.click('[href="/settings/account/authorizations/"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account authorizations settings")
 
             self.browser.click('[href="/settings/account/identities/"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account identities settings")
 
             self.browser.click('[href="/settings/account/close-account/"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account settings - close account")
 
     def test_account_appearance_settings(self):
         with self.feature("organizations:onboarding"):
             self.browser.get("/account/settings/appearance/")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account appearance settings")
 
     def test_account_security_settings(self):
         with self.feature("organizations:onboarding"):
             self.browser.get("/account/settings/security/")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account security settings")
 
     def test_account_notifications(self):
         with self.feature("organizations:onboarding"):
             self.browser.get("/account/settings/notifications/")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account notification settings")
 
             self.browser.click_when_visible('[data-test-id="fine-tuning"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot('account notification - fine tune "Alerts"')
 
     def test_account_emails_settings(self):
         with self.feature("organizations:onboarding"):
             self.browser.get("/account/settings/emails/")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account emails settings")
 
     def test_account_subscriptions_settings(self):
         with self.feature("organizations:onboarding"):
             self.browser.get("/account/settings/subscriptions/")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account subscriptions settings")
 
     def test_account_authorizations_settings(self):
         with self.feature("organizations:onboarding"):
             self.browser.get("/account/authorizations/")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account authorizations settings")
 
     def test_account_identities_settings(self):
         with self.feature("organizations:onboarding"):
             self.browser.get("/account/settings/identities/")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account identities settings")
 
     def test_close_account(self):
         with self.feature("organizations:onboarding"):
             self.browser.get("/account/remove/")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("account settings - close account")

--- a/tests/acceptance/test_dashboard.py
+++ b/tests/acceptance/test_dashboard.py
@@ -66,7 +66,7 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
     def test_project_with_no_first_event(self):
         self.project.update(first_event=None)
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_test_id("resources")
         self.browser.wait_until(".echarts-for-react path", timeout=10000)
         self.browser.snapshot("org dash no first event")
@@ -74,16 +74,16 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
     def test_one_issue(self):
         self.create_sample_event()
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until(".echarts-for-react path", timeout=100000)
         self.browser.snapshot("org dash one issue")
 
     def test_rename_team_and_navigate_back(self):
         self.create_sample_event()
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.click('[data-test-id="badge-display-name"]')
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.click(".nav-tabs li:nth-child(4) a")
         self.browser.wait_until('input[name="slug"]')
         self.browser.element('input[name="slug"]').send_keys("-new-slug")
@@ -93,7 +93,7 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
 
         # Go to projects
         self.browser.click(f'[href="/organizations/{self.organization.slug}/projects/"]')
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
         assert self.browser.element('[data-test-id="badge-display-name"]').text == "#foo-new-slug"
 
@@ -106,5 +106,5 @@ class EmptyDashboardTest(AcceptanceTestCase):
 
     def test_new_dashboard_empty(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("new dashboard empty")

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -18,7 +18,7 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
     def test_empty_incidents(self):
         with self.feature(FEATURE_NAME):
             self.browser.get(self.path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("incidents - empty state")
 
     def test_incidents_list(self):
@@ -35,14 +35,14 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
         features = {feature: True for feature in FEATURE_NAME}
         with self.feature(features):
             self.browser.get(self.path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
             self.browser.snapshot("incidents - list")
 
             details_url = f'[href="/organizations/{self.organization.slug}/alerts/rules/details/{alert_rule.id}/?alert={incident.id}'
             self.browser.wait_until(details_url)
             self.browser.click(details_url)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.wait_until_test_id("incident-rule-title")
 
             self.browser.wait_until_not('[data-test-id="loading-placeholder"]')

--- a/tests/acceptance/test_member_list.py
+++ b/tests/acceptance/test_member_list.py
@@ -22,7 +22,7 @@ class ListOrganizationMembersTest(AcceptanceTestCase):
 
     def test_list(self):
         self.browser.get(f"/organizations/{self.org.slug}/members/")
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot(name="list organization members")
         assert self.browser.element_exists_by_test_id("email-invite")
         assert self.browser.element_exists_by_aria_label("Resend invite")

--- a/tests/acceptance/test_new_settings.py
+++ b/tests/acceptance/test_new_settings.py
@@ -16,5 +16,5 @@ class NewSettingsTest(AcceptanceTestCase):
     def test_settings_index(self):
         with self.feature("organizations:onboarding"):
             self.browser.get(self.path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("new settings index")

--- a/tests/acceptance/test_organization_activity.py
+++ b/tests/acceptance/test_organization_activity.py
@@ -33,5 +33,5 @@ class OrganizationActivityTest(AcceptanceTestCase):
 
     def test_empty(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("organization activity feed - empty")

--- a/tests/acceptance/test_organization_alert_rules.py
+++ b/tests/acceptance/test_organization_alert_rules.py
@@ -16,7 +16,7 @@ class OrganizationAlertRulesListTest(AcceptanceTestCase, SnubaTestCase):
     def test_empty_alert_rules(self):
         with self.feature(FEATURE_NAME):
             self.browser.get(self.path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("alert rules - empty state")
 
     def test_alert_rules_list(self):
@@ -29,7 +29,7 @@ class OrganizationAlertRulesListTest(AcceptanceTestCase, SnubaTestCase):
 
         with self.feature(FEATURE_NAME):
             self.browser.get(self.path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("alert rules - list")
 
     def test_alert_rules_alert_list(self):
@@ -60,5 +60,5 @@ class OrganizationAlertRulesListTest(AcceptanceTestCase, SnubaTestCase):
 
         with self.feature(["organizations:incidents"]):
             self.browser.get(self.path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("alert rules - alert list")

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -28,7 +28,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
         self.login_as(self.user)
 
     def wait_until_loaded(self):
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
 
     def test_view_dashboard(self):
@@ -131,7 +131,7 @@ class OrganizationDashboardsManageAcceptanceTest(AcceptanceTestCase):
         self.default_path = f"/organizations/{self.organization.slug}/dashboards/"
 
     def wait_until_loaded(self):
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
 
     def test_dashboard_manager(self):

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -18,7 +18,7 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
 
     def load_page(self, url):
         self.browser.get(url)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def test_create_new_public_integration(self):
         self.load_page(self.org_developer_settings_path)
@@ -69,7 +69,7 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
 
     def load_page(self, url):
         self.browser.get(url)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def test_edit_integration_schema(self):
         self.load_page(self.org_developer_settings_path)
@@ -85,7 +85,7 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
         link = self.browser.find_element_by_link_text("Tesla App")
         link.click()
 
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
         schema = self.browser.element('textarea[name="schema"]')
         assert schema.text == ""

--- a/tests/acceptance/test_organization_document_integration_detailed_view.py
+++ b/tests/acceptance/test_organization_document_integration_detailed_view.py
@@ -17,7 +17,7 @@ class OrganizationDocumentIntegrationDetailView(AcceptanceTestCase):
     def load_page(self, slug):
         url = f"/settings/{self.organization.slug}/document-integrations/{slug}/"
         self.browser.get(url)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def test_view_doc(self):
         self.load_page(self.doc.slug)

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -144,7 +144,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         self.result_path = f"/organizations/{self.org.slug}/discover/results/"
 
     def wait_until_loaded(self):
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
 
     def test_events_default_landing(self):

--- a/tests/acceptance/test_organization_integration_configuration_tabs.py
+++ b/tests/acceptance/test_organization_integration_configuration_tabs.py
@@ -33,7 +33,7 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
         if configuration_tab:
             url += "?tab=configurations"
         self.browser.get(url)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def test_external_user_mappings(self):
         # create `auth_user` records to differentiate `user_id` and `organization_member_id`
@@ -65,9 +65,9 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
             self.browser.get(
                 f"/settings/{self.organization.slug}/integrations/{self.provider}/{self.integration.id}/"
             )
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.click(".nav-tabs li:nth-child(3) a")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
             # Empty state
             self.browser.snapshot("integrations - empty external user mappings")
@@ -85,7 +85,7 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
 
             # List View
             self.browser.click('[aria-label="Save Changes"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("integrations - one external user mapping")
 
     def test_external_team_mappings(self):
@@ -99,9 +99,9 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
             self.browser.get(
                 f"/settings/{self.organization.slug}/integrations/{self.provider}/{self.integration.id}/"
             )
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.click(".nav-tabs li:nth-child(4) a")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
             # Empty state
             self.browser.snapshot("integrations - empty external team mappings")
@@ -119,7 +119,7 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
 
             # List View
             self.browser.click('[aria-label="Save Changes"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("integrations - one external team mapping")
 
     def test_settings_tab(self):
@@ -143,9 +143,9 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
             self.browser.get(
                 f"/settings/{self.organization.slug}/integrations/{provider}/{integration.id}/"
             )
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.click(".nav-tabs li:nth-child(1) a")
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
             name = self.browser.find_element_by_name("name")
             name.clear()

--- a/tests/acceptance/test_organization_integration_detail_view.py
+++ b/tests/acceptance/test_organization_integration_detail_view.py
@@ -25,7 +25,7 @@ class OrganizationIntegrationDetailView(AcceptanceTestCase):
         if configuration_tab:
             url += "?tab=configurations"
         self.browser.get(url)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def test_example_installation(self):
         self.provider = mock.Mock()

--- a/tests/acceptance/test_organization_integration_directory.py
+++ b/tests/acceptance/test_organization_integration_directory.py
@@ -9,5 +9,5 @@ class OrganizationIntegrationDirectoryTest(AcceptanceTestCase):
     def test_all_integrations_list(self):
         path = f"/settings/{self.organization.slug}/integrations/"
         self.browser.get(path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("integrations - integration directory")

--- a/tests/acceptance/test_organization_plugin_detail_view.py
+++ b/tests/acceptance/test_organization_plugin_detail_view.py
@@ -24,7 +24,7 @@ class OrganizationPluginDetailedView(AcceptanceTestCase):
         if configuration_tab:
             url += "?tab=configurations"
         self.browser.get(url)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def test_opsgenie_add_to_project(self):
         self.load_page("opsgenie")
@@ -35,7 +35,7 @@ class OrganizationPluginDetailedView(AcceptanceTestCase):
 
         self.browser.click('[role="dialog"] [id$="option-0-0"]')
         # check if we got to the configuration page with the form
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_test_id("plugin-config")
         self.browser.snapshot("integrations - plugin config form")
 

--- a/tests/acceptance/test_organization_rate_limits.py
+++ b/tests/acceptance/test_organization_rate_limits.py
@@ -20,7 +20,7 @@ class OrganizationRateLimitsTest(AcceptanceTestCase):
     def test_with_rate_limits(self):
         self.project.update(first_event=timezone.now())
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_test_id("rate-limit-editor")
         self.browser.snapshot("organization rate limits with quota")
         assert self.browser.element_exists_by_test_id("rate-limit-editor")
@@ -29,7 +29,7 @@ class OrganizationRateLimitsTest(AcceptanceTestCase):
     def test_without_rate_limits(self):
         self.project.update(first_event=timezone.now())
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_test_id("rate-limit-editor")
         self.browser.snapshot("organization rate limits without quota")
         assert self.browser.element_exists_by_test_id("rate-limit-editor")

--- a/tests/acceptance/test_organization_security_privacy.py
+++ b/tests/acceptance/test_organization_security_privacy.py
@@ -11,7 +11,7 @@ class OrganizationSecurityAndPrivacyTest(AcceptanceTestCase):
         self.path = f"/settings/{self.org.slug}/security-and-privacy/"
 
     def load_organization_helper(self, snapshot_name=None):
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         if snapshot_name is not None:
             self.browser.snapshot("organization settings security and privacy -- " + snapshot_name)
         assert self.browser.wait_until(
@@ -36,7 +36,7 @@ class OrganizationSecurityAndPrivacyTest(AcceptanceTestCase):
 
     def test_setting_2fa_without_2fa_enabled(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         assert not self.browser.element_exists(
             '[data-test-id="organization-settings-security-and-privacy"] .error'
         )
@@ -49,7 +49,7 @@ class OrganizationSecurityAndPrivacyTest(AcceptanceTestCase):
 
     def test_renders_advanced_data_scrubbing_without_rule(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         assert self.browser.wait_until('[data-test-id="advanced-data-scrubbing"]')
         self.load_organization_helper("advanced-data-scrubbing-without-rule")
 
@@ -68,14 +68,14 @@ class OrganizationSecurityAndPrivacyTest(AcceptanceTestCase):
         )
         self.org.update_option("sentry:relay_pii_config", relayPiiConfig)
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         assert self.browser.wait_until('[data-test-id="advanced-data-scrubbing"]')
         assert self.browser.wait_until('[data-test-id="advanced-data-scrubbing-rules"]')
         self.load_organization_helper("advanced-data-scrubbing-with-rules")
 
     def test_renders_advanced_data_scrubbing_add_rule_modal(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         assert self.browser.wait_until('[data-test-id="advanced-data-scrubbing"]')
         self.browser.click_when_visible("[aria-label='Add Rule']")
         self.load_organization_helper("advanced-data-scrubbing-add-rule-modal")

--- a/tests/acceptance/test_organization_sentry_app.py
+++ b/tests/acceptance/test_organization_sentry_app.py
@@ -34,7 +34,7 @@ class OrganizationSentryAppAcceptanceTestCase(AcceptanceTestCase):
 
     def load_page(self, url):
         self.browser.get(url)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     # def test_install_sentry_app(self):
     #     self.load_page(self.org_integration_settings_path)

--- a/tests/acceptance/test_organization_sentry_app_detailed_view.py
+++ b/tests/acceptance/test_organization_sentry_app_detailed_view.py
@@ -20,7 +20,7 @@ class OrganizationSentryAppDetailedView(AcceptanceTestCase):
     def load_page(self, slug):
         url = f"/settings/{self.organization.slug}/sentry-apps/{slug}/"
         self.browser.get(url)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def test_add_sentry_app(self):
         self.load_page(self.sentry_app.slug)

--- a/tests/acceptance/test_organization_stats.py
+++ b/tests/acceptance/test_organization_stats.py
@@ -18,5 +18,5 @@ class OrganizationStatsTest(AcceptanceTestCase):
     def test_simple(self):
         self.project.update(first_event=timezone.now())
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("organization stats")

--- a/tests/acceptance/test_organization_switch.py
+++ b/tests/acceptance/test_organization_switch.py
@@ -32,7 +32,7 @@ class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
         def navigate_to_issues_page(org_slug):
             issues_url = OrganizationSwitchTest.url_creator("issues", org_slug)
             self.browser.get(issues_url)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
         @TimedRetryPolicy.wrap(timeout=20, exceptions=(TimeoutException,))
         def open_project_selector():
@@ -66,7 +66,7 @@ class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
                 )
 
                 self.browser.get(transition_url)
-                self.browser.wait_until_not(".loading-indicator")
+                self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
                 navigate_to_issues_page(self.secondary_organization.slug)
                 open_project_selector()

--- a/tests/acceptance/test_organization_user_feedback.py
+++ b/tests/acceptance/test_organization_user_feedback.py
@@ -19,16 +19,16 @@ class OrganizationUserFeedbackTest(AcceptanceTestCase):
     def test(self):
         self.create_userreport(date_added=timezone.now(), group=self.group, project=self.project)
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until('[data-test-id="user-feedback-list"]')
         self.browser.snapshot("organization user feedback")
 
     def test_empty(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("organization user feedback - empty")
 
     def test_no_access(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("organization user feedback - no access")

--- a/tests/acceptance/test_performance_trace_detail.py
+++ b/tests/acceptance/test_performance_trace_detail.py
@@ -193,6 +193,6 @@ class PerformanceTraceDetailTest(AcceptanceTestCase, SnubaTestCase):
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.elements('[data-test-id="transaction-row-title"]')[1].click()
             self.browser.snapshot("performance trace view - with data")

--- a/tests/acceptance/test_project_alert_settings.py
+++ b/tests/acceptance/test_project_alert_settings.py
@@ -44,12 +44,12 @@ class ProjectAlertSettingsTest(AcceptanceTestCase):
 
     def test_settings_load(self):
         self.browser.get(self.path1)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("project alert settings")
         self.browser.wait_until(".ref-plugin-enable-webhooks")
         self.browser.click(".ref-plugin-enable-webhooks")
         self.browser.wait_until(".ref-plugin-config-webhooks")
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
         # flakey Toast animation being snapshotted in CI
         # click it to clear it before snapshotting

--- a/tests/acceptance/test_project_all_integrations_settings.py
+++ b/tests/acceptance/test_project_all_integrations_settings.py
@@ -15,5 +15,5 @@ class ProjectAllIntegrationsSettingsTest(AcceptanceTestCase):
     def test_all_integrations_list(self):
         path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/"
         self.browser.get(path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("project settings - all integrations")

--- a/tests/acceptance/test_project_data_forwarding_settings.py
+++ b/tests/acceptance/test_project_data_forwarding_settings.py
@@ -15,6 +15,6 @@ class ProjectDataForwardingSettingsTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("project data forwarding settings")
         self.browser.wait_until_test_id("data-forwarding-settings")

--- a/tests/acceptance/test_project_debug_symbols_settings.py
+++ b/tests/acceptance/test_project_debug_symbols_settings.py
@@ -15,5 +15,5 @@ class ProjectSavedSearchesSettingsTest(AcceptanceTestCase):
     def test_saved_searches(self):
         path = f"/{self.org.slug}/{self.project.slug}/settings/debug-symbols/"
         self.browser.get(path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("project settings - debug symbols")

--- a/tests/acceptance/test_project_detail.py
+++ b/tests/acceptance/test_project_detail.py
@@ -69,11 +69,11 @@ class ProjectDetailTest(AcceptanceTestCase):
     def test_simple(self):
         with self.feature(FEATURE_NAME):
             self.browser.get(self.path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
             self.browser.snapshot("project detail")
 
     def test_no_feature(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("project detail no feature")

--- a/tests/acceptance/test_project_general_settings.py
+++ b/tests/acceptance/test_project_general_settings.py
@@ -15,7 +15,7 @@ class ProjectGeneralSettingsTest(AcceptanceTestCase):
     def test_saved_searches(self):
         path = f"/{self.org.slug}/{self.project.slug}/settings/"
         self.browser.get(path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("project settings - general settings")
 
     def test_mobile_menu(self):
@@ -26,7 +26,7 @@ class ProjectGeneralSettingsTest(AcceptanceTestCase):
 
         with self.browser.mobile_viewport():
             self.browser.get(path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
             self.browser.click('[aria-label="Open the menu"]')
             self.browser.wait_until("body.scroll-lock")

--- a/tests/acceptance/test_project_keys.py
+++ b/tests/acceptance/test_project_keys.py
@@ -28,7 +28,7 @@ class ProjectKeysTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_test_id("project-keys")
         self.browser.snapshot("project keys")
 
@@ -55,7 +55,7 @@ class ProjectKeyDetailsTest(AcceptanceTestCase):
 
     def test_simple(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_test_id("key-details")
         self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
         self.browser.snapshot("project key details")

--- a/tests/acceptance/test_project_release_tracking_settings.py
+++ b/tests/acceptance/test_project_release_tracking_settings.py
@@ -25,5 +25,5 @@ class ProjectReleaseTrackingSettingsTest(AcceptanceTestCase, SnubaTestCase):
             project_id=self.project.id,
         )
         self.browser.get(self.path1)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("project settings - release tracking")

--- a/tests/acceptance/test_project_servicehooks.py
+++ b/tests/acceptance/test_project_servicehooks.py
@@ -18,19 +18,19 @@ class ProjectServiceHooksTest(AcceptanceTestCase):
     def test_simple(self):
         with self.feature("projects:servicehooks"):
             self.browser.get(self.list_hooks_path)
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("project settings - service hooks - empty list")
             # click "New"
             self.browser.click('[data-test-id="new-service-hook"]')
 
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             assert self.browser.current_url == f"{self.browser.live_server_url}{self.new_hook_path}"
             self.browser.snapshot("project settings - service hooks - create")
             self.browser.element('input[name="url"]').send_keys("https://example.com/hook")
             # click "Save Changes"
             self.browser.click('form [data-test-id="form-submit"]')
 
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             assert (
                 self.browser.current_url == f"{self.browser.live_server_url}{self.list_hooks_path}"
             )
@@ -42,7 +42,7 @@ class ProjectServiceHooksTest(AcceptanceTestCase):
 
             # hopefully click the first service hook
             self.browser.click('[data-test-id="project-service-hook"]')
-            self.browser.wait_until_not(".loading-indicator")
+            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             assert self.browser.current_url == "{}{}".format(
                 self.browser.live_server_url,
                 f"/settings/{self.org.slug}/projects/{self.project.slug}/hooks/{hook.guid}/",

--- a/tests/acceptance/test_project_tags_settings.py
+++ b/tests/acceptance/test_project_tags_settings.py
@@ -36,7 +36,7 @@ class ProjectTagsSettingsTest(AcceptanceTestCase, SnubaTestCase):
         )
 
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("project settings - tags")
 
         self.browser.wait_until_test_id("tag-row")

--- a/tests/acceptance/test_shared_issue.py
+++ b/tests/acceptance/test_shared_issue.py
@@ -21,6 +21,6 @@ class SharedIssueTest(AcceptanceTestCase):
         GroupShare.objects.create(project_id=event.group.project_id, group=event.group)
 
         self.browser.get(f"/share/issue/{event.group.get_share_id()}/")
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_test_id("event-entries-loading-false")
         self.browser.snapshot("shared issue python")

--- a/tests/acceptance/test_sidebar.py
+++ b/tests/acceptance/test_sidebar.py
@@ -27,7 +27,7 @@ class SidebarTest(AcceptanceTestCase):
 
     def test_help_search(self):
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
         self.browser.wait_until_test_id("help-sidebar")
         self.browser.click('[data-test-id="help-sidebar"]')

--- a/tests/acceptance/test_teams_list.py
+++ b/tests/acceptance/test_teams_list.py
@@ -18,21 +18,21 @@ class TeamsListTest(AcceptanceTestCase):
     def test_simple(self):
         self.project.update(first_event=timezone.now())
         self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_test_id("team-list")
         self.browser.snapshot("organization teams list")
 
         # team details link
         self.browser.click('[data-test-id="team-list"] a[href]:first-child')
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("organization team - members list")
 
         # Click projects tab
         self.browser.click(".nav-tabs li:nth-child(2) a")
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("organization team - projects list")
 
         # Click projects tab
         self.browser.click(".nav-tabs li:nth-child(3) a")
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.snapshot("organization team - settings")


### PR DESCRIPTION
Updating this so we can split out the loading indicator components and not use. the `.loading` class on some of them.

They will always have a `data-test-id` though