### PR TITLE
feat(profiling): add cursor renderer

### DIFF
--- a/static/app/utils/profiling/renderers/cursorRenderer.tsx
+++ b/static/app/utils/profiling/renderers/cursorRenderer.tsx
@@ -20,7 +20,7 @@ class CursorRenderer {
   draw(configSpaceCursor: vec2, physicalSpace: Rect, configToPhysicalSpace: mat3): void {
     const physicalSpaceCursor = vec2.transformMat3(
       vec2.create(),
-      vec2.fromValues(configSpaceCursor[0], configSpaceCursor[1]),
+     configSpaceCursor,
       configToPhysicalSpace
     );
 

--- a/static/app/utils/profiling/renderers/cursorRenderer.tsx
+++ b/static/app/utils/profiling/renderers/cursorRenderer.tsx
@@ -20,7 +20,7 @@ class CursorRenderer {
   draw(configSpaceCursor: vec2, physicalSpace: Rect, configToPhysicalSpace: mat3): void {
     const physicalSpaceCursor = vec2.transformMat3(
       vec2.create(),
-     configSpaceCursor,
+      configSpaceCursor,
       configToPhysicalSpace
     );
 

--- a/static/app/utils/profiling/renderers/cursorRenderer.tsx
+++ b/static/app/utils/profiling/renderers/cursorRenderer.tsx
@@ -1,7 +1,7 @@
 import {mat3, vec2} from 'gl-matrix';
 
-import {FlamegraphTheme} from '../FlamegraphTheme';
-import {Rect, resizeCanvasToDisplaySize} from '../gl/utils';
+import {FlamegraphTheme} from '../flamegraph/FlamegraphTheme';
+import {getContext, Rect, resizeCanvasToDisplaySize} from '../gl/utils';
 
 class CursorRenderer {
   canvas: HTMLCanvasElement;
@@ -12,13 +12,8 @@ class CursorRenderer {
   constructor(canvas: HTMLCanvasElement, theme: FlamegraphTheme) {
     this.canvas = canvas;
     this.theme = theme;
-    const ctx = canvas.getContext('2d');
+    this.context = getContext(canvas, '2d');
 
-    if (!ctx) {
-      throw new Error('Could not initialize canvas context for CursorRenderer');
-    }
-
-    this.context = ctx;
     resizeCanvasToDisplaySize(canvas);
   }
 

--- a/static/app/utils/profiling/renderers/cursorRenderer.tsx
+++ b/static/app/utils/profiling/renderers/cursorRenderer.tsx
@@ -1,0 +1,44 @@
+import {mat3, vec2} from 'gl-matrix';
+
+import {FlamegraphTheme} from '../FlamegraphTheme';
+import {Rect, resizeCanvasToDisplaySize} from '../gl/utils';
+
+class CursorRenderer {
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+
+  theme: FlamegraphTheme;
+
+  constructor(canvas: HTMLCanvasElement, theme: FlamegraphTheme) {
+    this.canvas = canvas;
+    this.theme = theme;
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) {
+      throw new Error('Could not initialize canvas context for CursorRenderer');
+    }
+
+    this.context = ctx;
+    resizeCanvasToDisplaySize(canvas);
+  }
+
+  draw(configSpaceCursor: vec2, physicalSpace: Rect, configToPhysicalSpace: mat3): void {
+    const physicalSpaceCursor = vec2.transformMat3(
+      vec2.create(),
+      vec2.fromValues(configSpaceCursor[0], configSpaceCursor[1]),
+      configToPhysicalSpace
+    );
+
+    this.context.beginPath();
+    this.context.moveTo(physicalSpaceCursor[0], 0);
+    this.context.lineTo(physicalSpaceCursor[0], physicalSpace.height);
+
+    this.context.moveTo(0, physicalSpaceCursor[1]);
+    this.context.lineTo(physicalSpace.width, physicalSpaceCursor[1]);
+
+    this.context.strokeStyle = this.theme.COLORS.CURSOR_CROSSHAIR;
+    this.context.stroke();
+  }
+}
+
+export {CursorRenderer};

--- a/tests/js/spec/utils/profiling/renderers/cursorRenderer.spec.tsx
+++ b/tests/js/spec/utils/profiling/renderers/cursorRenderer.spec.tsx
@@ -1,0 +1,45 @@
+import {vec2} from 'gl-matrix';
+
+import {LightFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/FlamegraphTheme';
+import {Rect, Transform} from 'sentry/utils/profiling/gl/utils';
+import {CursorRenderer} from 'sentry/utils/profiling/renderers/cursorRenderer';
+
+describe('CursorRenderer', () => {
+  it('renders cursor in center screen', () => {
+    const context = {
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      strokeStyle: undefined,
+      stroke: jest.fn(),
+    };
+    const canvasMock = {
+      getContext: jest.fn().mockReturnValue(context),
+    } as unknown as HTMLCanvasElement;
+
+    const renderer = new CursorRenderer(canvasMock, LightFlamegraphTheme);
+
+    const cursor = vec2.fromValues(0.5, 0.5);
+    const physicalSpace = new Rect(0, 0, 1000, 1000);
+
+    const configToPhysicalSpace = Transform.betweenRect(
+      new Rect(0, 0, 1, 1),
+      physicalSpace
+    );
+
+    renderer.draw(cursor, physicalSpace, configToPhysicalSpace.toMatrix());
+
+    expect(context.beginPath).toHaveBeenCalled();
+
+    // Draws vertical line
+    expect(context.moveTo.mock.calls[0]).toEqual([500, 0]);
+    expect(context.lineTo.mock.calls[0]).toEqual([500, 1000]);
+
+    // Draws horizontal line
+    expect(context.moveTo.mock.calls[1]).toEqual([0, 500]);
+    expect(context.lineTo.mock.calls[1]).toEqual([1000, 500]);
+
+    expect(context.strokeStyle).toBe(LightFlamegraphTheme.COLORS.CURSOR_CROSSHAIR);
+    expect(context.stroke).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
First in the series of canvas renderers. Each renderer has the ability to draw on a canvas that we to it, this renderer renders a sort of crosshair cursor on a canvas. The renderers do not make any draw calls by themselves, so in a sense they are sort of like controlled components. It is useful to split them as it makes for easier control of the rendering logic and order of draw ops to the canvas.