### PR TITLE
Fix/dashboard grid layout new widget in edit ignores new layout on commit

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -368,7 +368,7 @@ class DashboardDetail extends Component<Props, State> {
       i: constructGridItemKey(newWidgets[index]),
     }));
     saveDashboardLayout(organizationId, dashboardId, newLayout);
-    this.setState({layout: newLayout});
+    return newLayout;
   };
 
   onCommit = () => {
@@ -383,6 +383,7 @@ class DashboardDetail extends Component<Props, State> {
           createDashboard(api, organization.slug, modifiedDashboard, this.isPreview).then(
             (newDashboard: DashboardDetails) => {
               if (organization.features.includes('dashboard-grid-layout')) {
+                // Redirect occurs so no need to update layout state
                 this.saveLayoutWithNewWidgets(
                   organization.id,
                   newDashboard.id,
@@ -435,11 +436,14 @@ class DashboardDetail extends Component<Props, State> {
               }
 
               if (organization.features.includes('dashboard-grid-layout')) {
-                this.saveLayoutWithNewWidgets(
+                const newLayout = this.saveLayoutWithNewWidgets(
                   organization.id,
                   newDashboard.id,
                   newDashboard.widgets
                 );
+                // Unset modifiedDashboard and set newLayout at the same time
+                // to render newLayout with updated dashboard prop
+                this.setState({layout: newLayout, modifiedDashboard: null});
               }
               addSuccessMessage(t('Dashboard updated'));
               trackAnalyticsEvent({

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -435,15 +435,13 @@ class DashboardDetail extends Component<Props, State> {
                 onDashboardUpdate(newDashboard);
               }
 
+              let newLayout;
               if (organization.features.includes('dashboard-grid-layout')) {
-                const newLayout = this.saveLayoutWithNewWidgets(
+                newLayout = this.saveLayoutWithNewWidgets(
                   organization.id,
                   newDashboard.id,
                   newDashboard.widgets
                 );
-                // Unset modifiedDashboard and set newLayout at the same time
-                // to render newLayout with updated dashboard prop
-                this.setState({layout: newLayout, modifiedDashboard: null});
               }
               addSuccessMessage(t('Dashboard updated'));
               trackAnalyticsEvent({
@@ -454,6 +452,7 @@ class DashboardDetail extends Component<Props, State> {
               this.setState({
                 dashboardState: DashboardState.VIEW,
                 modifiedDashboard: null,
+                layout: newLayout ?? layout,
               });
 
               if (dashboard && newDashboard.id !== dashboard.id) {

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.action_chains import ActionChains
+
 from sentry.models import (
     Dashboard,
     DashboardWidget,
@@ -14,6 +16,8 @@ FEATURE_NAMES = [
 ]
 
 EDIT_FEATURE = ["organizations:dashboards-edit"]
+
+GRID_LAYOUT_FEATURE = ["organizations:dashboard-grid-layout"]
 
 
 class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
@@ -98,6 +102,38 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
             self.browser.element('[data-test-id="widget-library-card-2"]').click()
 
             self.browser.snapshot("dashboards - widget library")
+
+    def test_add_and_move_new_widget_on_existing_dashboard(self):
+        with self.feature(FEATURE_NAMES + EDIT_FEATURE + GRID_LAYOUT_FEATURE):
+            # Create a new dashboard
+            self.browser.get(f"/organizations/{self.organization.slug}/dashboards/new/")
+            self.wait_until_loaded()
+
+            # Save this dashboard
+            button = self.browser.element('[data-test-id="dashboard-commit"]')
+            button.click()
+
+            # Go to edit mode.
+            button = self.browser.element('[data-test-id="dashboard-edit"]')
+            button.click()
+
+            # Add a widget
+            button = self.browser.element('[data-test-id="widget-add"]')
+            button.click()
+            title_input = self.browser.element('input[data-test-id="widget-title-input"]')
+            title_input.send_keys("New Widget")
+            button = self.browser.element('[data-test-id="add-widget"]')
+            button.click()
+
+            dragHandle = self.browser.element(".widget-drag")
+            # Drag to the right
+            action = ActionChains(self.browser.driver)
+            action.drag_and_drop_by_offset(dragHandle, 1000, 0).perform()
+
+            button = self.browser.element('[data-test-id="dashboard-commit"]')
+            button.click()
+
+            self.browser.snapshot("dashboards - save new widget layout in custom dashboard")
 
 
 class OrganizationDashboardsManageAcceptanceTest(AcceptanceTestCase):


### PR DESCRIPTION
We have to set the `newLayout` AND unset `modifiedDashboard` at the same time or else there will be an in-between render where the layout is the `newLayout`, but the widgets rendered with `modifiedDashboard` don't match. This is because `newLayout` uses the widget IDs of the POST response and `modifiedDashboard` only has `tempId`s

Also added an acceptance test to drag a widget to the right and show that it's saved in the correct position.