### PR TITLE
fix(ui): Team details doesn't load depending on navigation

### DIFF
--- a/static/app/views/settings/organizationTeams/teamDetails.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import {cloneElement, isValidElement, useState} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {fetchTeamDetails, joinTeam} from 'sentry/actionCreators/teams';
+import {joinTeam} from 'sentry/actionCreators/teams';
 import {Client} from 'sentry/api';
 import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
@@ -26,48 +26,23 @@ type Props = {
   organization: Organization;
 } & RouteComponentProps<{orgId: string; teamId: string}, {}>;
 
-type State = {
-  requesting: boolean;
-  team: Team | null;
-};
+function TeamDetails({api, children, ...props}: Props) {
+  const [currentTeam, setCurrentTeam] = useState(
+    TeamStore.getBySlug(props.params.teamId)
+  );
+  const [requesting, setRequesting] = useState<boolean>(false);
 
-class TeamDetails extends React.Component<Props, State> {
-  state = this.getInitialState();
-
-  getInitialState(): State {
-    const team = TeamStore.getBySlug(this.props.params.teamId);
-
-    return {
-      requesting: false,
-      team,
-    };
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    const {params} = this.props;
-
-    if (
-      prevProps.params.teamId !== params.teamId ||
-      prevProps.params.orgId !== params.orgId
-    ) {
-      this.fetchData();
-    }
-  }
-
-  handleRequestAccess = (team: Team) => {
-    const {api, params} = this.props;
+  function handleRequestAccess(team: Team) {
     if (!team) {
       return;
     }
 
-    this.setState({
-      requesting: true,
-    });
+    setRequesting(true);
 
     joinTeam(
       api,
       {
-        orgId: params.orgId,
+        orgId: props.params.orgId,
         teamId: team.slug,
       },
       {
@@ -77,9 +52,7 @@ class TeamDetails extends React.Component<Props, State> {
               team: `#${team.slug}`,
             })
           );
-          this.setState({
-            requesting: false,
-          });
+          setRequesting(false);
         },
         error: () => {
           addErrorMessage(
@@ -87,122 +60,106 @@ class TeamDetails extends React.Component<Props, State> {
               team: `#${team.slug}`,
             })
           );
-          this.setState({
-            requesting: false,
-          });
+          setRequesting(false);
         },
       }
     );
-  };
+  }
 
-  fetchData = () => {
-    fetchTeamDetails(this.props.api, this.props.params);
-  };
-
-  onTeamChange = (data: Team) => {
-    const team = this.state.team;
-    if (data.slug !== team?.slug) {
-      const orgId = this.props.params.orgId;
+  function onTeamChange(data: Team) {
+    if (currentTeam !== data) {
+      const orgId = props.params.orgId;
       browserHistory.replace(`/organizations/${orgId}/teams/${data.slug}/settings/`);
     } else {
-      this.setState({
-        team: {
-          ...team,
-          ...data,
-        },
-      });
+      setCurrentTeam({...currentTeam, ...data});
     }
-  };
-
-  render() {
-    const {children, params, routes} = this.props;
-    const {requesting} = this.state;
-
-    // `/organizations/${orgId}/teams/${teamId}`;
-    const routePrefix = recreateRoute('', {routes, params, stepBack: -1});
-
-    const navigationTabs = [
-      <ListLink key={0} to={`${routePrefix}members/`}>
-        {t('Members')}
-      </ListLink>,
-      <ListLink key={1} to={`${routePrefix}projects/`}>
-        {t('Projects')}
-      </ListLink>,
-      <ListLink key={2} to={`${routePrefix}notifications/`}>
-        {t('Notifications')}
-      </ListLink>,
-      <ListLink key={3} to={`${routePrefix}settings/`}>
-        {t('Settings')}
-      </ListLink>,
-    ];
-
-    return (
-      <Teams slugs={[params.teamId]}>
-        {({teams, initiallyLoaded}) => (
-          <div>
-            {initiallyLoaded ? (
-              teams.length ? (
-                teams.map((team, i) => {
-                  if (!team || !team.hasAccess) {
-                    return (
-                      <Alert type="warning">
-                        {team ? (
-                          <RequestAccessWrapper>
-                            {tct('You do not have access to the [teamSlug] team.', {
-                              teamSlug: <strong>{`#${team.slug}`}</strong>,
-                            })}
-                            <Button
-                              disabled={requesting || team.isPending}
-                              size="small"
-                              onClick={() => this.handleRequestAccess(team)}
-                            >
-                              {team.isPending
-                                ? t('Request Pending')
-                                : t('Request Access')}
-                            </Button>
-                          </RequestAccessWrapper>
-                        ) : (
-                          <div>{t('You do not have access to this team.')}</div>
-                        )}
-                      </Alert>
-                    );
-                  }
-                  return (
-                    <div key={i}>
-                      <SentryDocumentTitle
-                        title={t('Team Details')}
-                        orgSlug={params.orgId}
-                      />
-                      <h3>
-                        <IdBadge hideAvatar team={team} avatarSize={36} />
-                      </h3>
-
-                      <NavTabs underlined>{navigationTabs}</NavTabs>
-
-                      {React.isValidElement(children) &&
-                        React.cloneElement(children, {
-                          team,
-                          onTeamChange: this.onTeamChange,
-                        })}
-                    </div>
-                  );
-                })
-              ) : (
-                <Alert type="warning">
-                  <div>{t('You do not have access to this team.')}</div>
-                </Alert>
-              )
-            ) : (
-              <LoadingIndicator />
-            )}
-          </div>
-        )}
-      </Teams>
-    );
   }
+
+  // `/organizations/${orgId}/teams/${teamId}`;
+  const routePrefix = recreateRoute('', {
+    routes: props.routes,
+    params: props.params,
+    stepBack: -1,
+  });
+
+  const navigationTabs = [
+    <ListLink key={0} to={`${routePrefix}members/`}>
+      {t('Members')}
+    </ListLink>,
+    <ListLink key={1} to={`${routePrefix}projects/`}>
+      {t('Projects')}
+    </ListLink>,
+    <ListLink key={2} to={`${routePrefix}notifications/`}>
+      {t('Notifications')}
+    </ListLink>,
+    <ListLink key={3} to={`${routePrefix}settings/`}>
+      {t('Settings')}
+    </ListLink>,
+  ];
+
+  return (
+    <Teams slugs={[props.params.teamId]}>
+      {({teams, initiallyLoaded}) => (
+        <div>
+          {initiallyLoaded ? (
+            teams.length ? (
+              teams.map((team, i) => {
+                if (!team || !team.hasAccess) {
+                  return (
+                    <Alert type="warning">
+                      {team ? (
+                        <RequestAccessWrapper>
+                          {tct('You do not have access to the [teamSlug] team.', {
+                            teamSlug: <strong>{`#${team.slug}`}</strong>,
+                          })}
+                          <Button
+                            disabled={requesting || team.isPending}
+                            size="small"
+                            onClick={() => handleRequestAccess(team)}
+                          >
+                            {team.isPending ? t('Request Pending') : t('Request Access')}
+                          </Button>
+                        </RequestAccessWrapper>
+                      ) : (
+                        <div>{t('You do not have access to this team.')}</div>
+                      )}
+                    </Alert>
+                  );
+                }
+                return (
+                  <div key={i}>
+                    <SentryDocumentTitle
+                      title={t('Team Details')}
+                      orgSlug={props.params.orgId}
+                    />
+                    <h3>
+                      <IdBadge hideAvatar team={team} avatarSize={36} />
+                    </h3>
+
+                    <NavTabs underlined>{navigationTabs}</NavTabs>
+
+                    {isValidElement(children) &&
+                      cloneElement(children, {
+                        team,
+                        onTeamChange: () => onTeamChange(team),
+                      })}
+                  </div>
+                );
+              })
+            ) : (
+              <Alert type="warning">
+                <div>{t('You do not have access to this team.')}</div>
+              </Alert>
+            )
+          ) : (
+            <LoadingIndicator />
+          )}
+        </div>
+      )}
+    </Teams>
+  );
 }
 
-// TODO(davidenwang): change to functional component and replace withTeams with useTeams
 export default withApi(withOrganization(TeamDetails));
 
 const RequestAccessWrapper = styled('div')`


### PR DESCRIPTION
If there are more than 100 teams in an organization, the Team Details page will not load and will show an error alert for the Members tab. This fix should now load the page properly.

[FIXES WOR-1541](https://getsentry.atlassian.net/browse/WOR-1541)

# Before
<img width="996" alt="Screen Shot 2022-01-12 at 4 17 29 AM" src="https://user-images.githubusercontent.com/20312973/149139732-845f322a-7877-4a4a-9489-c13b6a5de36b.png">

# After
<img width="984" alt="Screen Shot 2022-01-12 at 4 18 00 AM" src="https://user-images.githubusercontent.com/20312973/149139753-15221038-11ba-4327-a856-74923fee7c2b.png">

