### PR TITLE
fix(ui): Remove -webkit focus outline on radio inputs

### DIFF
--- a/static/app/components/radio.tsx
+++ b/static/app/components/radio.tsx
@@ -38,8 +38,8 @@ const Radio = styled('input')<Props>`
   /* TODO(bootstrap): Our bootstrap CSS adds this, we can remove when we remove that */
   margin: 0 !important;
 
-  &&:focus,
-  &&.focus-visible {
+  &:focus,
+  &.focus-visible {
     outline: none;
     border-color: ${p => p.theme.focusBorder};
     box-shadow: ${p => p.theme.focusBorder} 0 0 0 1px;

--- a/static/app/components/radio.tsx
+++ b/static/app/components/radio.tsx
@@ -38,8 +38,8 @@ const Radio = styled('input')<Props>`
   /* TODO(bootstrap): Our bootstrap CSS adds this, we can remove when we remove that */
   margin: 0 !important;
 
-  &:focus,
-  &.focus-visible {
+  &&:focus,
+  &&.focus-visible {
     outline: none;
     border-color: ${p => p.theme.focusBorder};
     box-shadow: ${p => p.theme.focusBorder} 0 0 0 1px;

--- a/static/less/shared/forms.less
+++ b/static/less/shared/forms.less
@@ -170,13 +170,6 @@ select[size] {
   height: auto;
 }
 
-// Focus for file, radio, and checkbox
-input[type='file']:focus,
-input[type='radio']:focus,
-input[type='checkbox']:focus {
-  .tab-focus();
-}
-
 // Adjust output element
 output {
   display: block;


### PR DESCRIPTION
Before:
<img width="207" alt="Screen Shot 2022-01-12 at 11 29 03 AM" src="https://user-images.githubusercontent.com/44172267/149208843-70a6bee9-9df3-4dd1-955c-157dab7b32bf.png">

After:
<img width="207" alt="Screen Shot 2022-01-12 at 11 29 26 AM" src="https://user-images.githubusercontent.com/44172267/149208863-1d467974-8785-412f-b7bc-ef04f172bd07.png">

