### PR TITLE
feat(gsh): Standalone time selector

### DIFF
--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -144,7 +144,7 @@ function DatePageFilter({
   const handleUpdate = (timePeriodUpdate: ChangeData) => {
     const {relative, start, end, utc} = timePeriodUpdate;
     const newTimePeriod = {
-      statsPeriod: relative,
+      period: relative,
       start,
       end,
       utc,

--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -1,0 +1,317 @@
+import React, {useState} from 'react';
+import {withRouter, WithRouterProps} from 'react-router';
+import styled from '@emotion/styled';
+import moment from 'moment';
+
+import {updateDateTime} from 'sentry/actionCreators/pageFilters';
+import Button from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import DropdownButton from 'sentry/components/dropdownButton';
+import {Content} from 'sentry/components/dropdownControl';
+import DropdownMenu from 'sentry/components/dropdownMenu';
+import HookOrDefault from 'sentry/components/hookOrDefault';
+import MultipleSelectorSubmitRow from 'sentry/components/organizations/multipleSelectorSubmitRow';
+import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
+import DateRange from 'sentry/components/organizations/timeRangeSelector/dateRange';
+import {
+  DEFAULT_RELATIVE_PERIODS_PAGE_FILTER,
+  DEFAULT_STATS_PERIOD,
+} from 'sentry/constants';
+import {t} from 'sentry/locale';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import space from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import {
+  getDateWithTimezoneInUtc,
+  getInternalDate,
+  getLocalToSystem,
+  getPeriodAgo,
+  getUserTimezone,
+  getUtcToSystem,
+  parsePeriodToHours,
+} from 'sentry/utils/dates';
+import useOrganization from 'sentry/utils/useOrganization';
+
+const DateRangeHook = HookOrDefault({
+  hookName: 'component:header-date-range',
+  defaultComponent: DateRange,
+});
+
+type DateRangeChangeData = Parameters<
+  React.ComponentProps<typeof DateRange>['onChange']
+>[0];
+
+type Props = {
+  router: WithRouterProps['router'];
+  /**
+   * Set an optional default value to prefill absolute date with
+   */
+  defaultAbsolute?: {start?: Date; end?: Date};
+  /**
+   * Override DEFAULT_STATS_PERIOD
+   */
+  defaultPeriod?: string;
+  /**
+   * The maximum number of days in the past you can pick
+   */
+  maxPickableDays?: number;
+  /**
+   * Override defaults from DEFAULT_RELATIVE_PERIODS_PAGE_FILTER
+   */
+  relativeOptions?: Record<string, React.ReactNode>;
+  /**
+   * Reset these URL params when we fire actions
+   * (custom routing only)
+   */
+  resetParamsOnChange?: string[];
+  /**
+   * Show absolute date selection
+   */
+  showAbsolute?: boolean;
+  /**
+   * Show relative date options
+   */
+  showRelative?: boolean;
+};
+
+function DatePageFilter({
+  router,
+  defaultAbsolute,
+  defaultPeriod,
+  maxPickableDays,
+  relativeOptions,
+  resetParamsOnChange = [],
+  showAbsolute = true,
+  showRelative = true,
+}: Props) {
+  const organization = useOrganization();
+  const {selection} = useLegacyStore(PageFiltersStore);
+
+  const getStartFromRelativePeriod = () => {
+    return defaultAbsolute?.start
+      ? defaultAbsolute.start
+      : getPeriodAgo(
+          'hours',
+          parsePeriodToHours(
+            selection.datetime.period || defaultPeriod || DEFAULT_STATS_PERIOD
+          )
+        ).toDate();
+  };
+
+  const getEndFromRelativePeriod = () => {
+    return defaultAbsolute?.end ? defaultAbsolute.end : new Date();
+  };
+
+  const selectionStart = selection.datetime.start;
+  const selectionEnd = selection.datetime.end;
+  // if utc is not null and not undefined, then use value of `selection.datetime.utc` (it can be false)
+  // otherwise if no value is supplied, the default should be the user's timezone preference
+  const selectionUtc = defined(selection.datetime.utc)
+    ? selection.datetime.utc
+    : getUserTimezone() === 'UTC';
+
+  // convert current selection.datetime start values into dates for the DateRange hook
+  // or generate them from the currently selected relative period
+  const startDate =
+    selectionStart && selectionEnd
+      ? getInternalDate(selectionStart, selectionUtc)
+      : getStartFromRelativePeriod();
+  const endDate =
+    selectionStart && selectionEnd
+      ? getInternalDate(selectionEnd, selectionUtc)
+      : getEndFromRelativePeriod();
+
+  const [selectedTimePeriod, setSelectedTimePeriod] = useState<ChangeData>({
+    relative: selection.datetime.period,
+    start: startDate,
+    end: endDate,
+    utc: selectionUtc,
+  });
+  const [hasChanges, setHasChanges] = useState<boolean>(false);
+  const [hasDateErrors, setHasDateErrors] = useState<boolean>(false);
+
+  const getDateSummary = () => {
+    const {relative, start, end} = selectedTimePeriod;
+    if (relative || !start || !end) {
+      return t('Custom');
+    }
+
+    const formattedStart = moment(start).local().format('MMM DD');
+    const formattedEnd = moment(end).local().format('MMM DD');
+    return `${formattedStart} - ${formattedEnd}`;
+  };
+
+  const handleUpdate = (timePeriodUpdate: ChangeData) => {
+    const {relative, start, end, utc} = timePeriodUpdate;
+    const newTimePeriod = {
+      statsPeriod: relative,
+      start,
+      end,
+      utc,
+    };
+
+    updateDateTime(newTimePeriod, router, {save: true, resetParams: resetParamsOnChange});
+    setHasChanges(false);
+  };
+
+  const handleChangeDateRange = ({
+    start,
+    end,
+    hasDateRangeErrors = false,
+  }: DateRangeChangeData) => {
+    if (hasDateRangeErrors) {
+      setHasDateErrors(hasDateRangeErrors);
+      return;
+    }
+
+    const newDateTime: ChangeData = {
+      relative: null,
+      start,
+      end,
+      utc: selectedTimePeriod.utc,
+    };
+
+    setHasChanges(true);
+    setHasDateErrors(hasDateRangeErrors);
+    setSelectedTimePeriod(newDateTime);
+  };
+
+  const handleCloseDateSelector = () => {
+    if (!hasChanges) {
+      return;
+    }
+
+    handleUpdate(selectedTimePeriod);
+  };
+
+  const handleUseUtc = () => {
+    const utc = !selectedTimePeriod.utc;
+    let {start, end} = selection.datetime;
+
+    if (!start) {
+      start = getDateWithTimezoneInUtc(selectedTimePeriod.start, utc);
+    }
+
+    if (!end) {
+      end = getDateWithTimezoneInUtc(selectedTimePeriod.end, utc);
+    }
+
+    const newDateTime = {
+      relative: null,
+      start: utc ? getLocalToSystem(start) : getUtcToSystem(start),
+      end: utc ? getLocalToSystem(end) : getUtcToSystem(end),
+      utc,
+    };
+
+    setHasChanges(true);
+    setSelectedTimePeriod(newDateTime);
+  };
+
+  const handleSelectRelative = (value: string) => {
+    const newDateTime: ChangeData = {
+      relative: value,
+      start: undefined,
+      end: undefined,
+    };
+
+    setSelectedTimePeriod(newDateTime);
+    handleUpdate(newDateTime);
+  };
+
+  return (
+    <ButtonBar merged>
+      {showRelative &&
+        Object.entries(relativeOptions ?? DEFAULT_RELATIVE_PERIODS_PAGE_FILTER).map(
+          ([value, label]) => (
+            <RelativePeriodButton
+              key={value}
+              selected={value === selection.datetime.period}
+              onClick={() => handleSelectRelative(value)}
+            >
+              {label}
+            </RelativePeriodButton>
+          )
+        )}
+      {showAbsolute && (
+        <CustomDateOption>
+          <DropdownMenu keepMenuOpen onClose={handleCloseDateSelector}>
+            {({isOpen, getActorProps, getMenuProps, actions}) => (
+              <React.Fragment>
+                <CustomPeriodButton
+                  isOpen={isOpen}
+                  {...getActorProps()}
+                  selected={!selection.datetime.period}
+                  showRelative={showRelative}
+                >
+                  {getDateSummary()}
+                </CustomPeriodButton>
+                <Content
+                  {...getMenuProps()}
+                  alignMenu="right"
+                  width="350px"
+                  isOpen={isOpen}
+                  blendCorner
+                >
+                  <DateRangeHook
+                    start={selectedTimePeriod.start ?? getStartFromRelativePeriod()}
+                    end={selectedTimePeriod.end ?? getEndFromRelativePeriod()}
+                    organization={organization}
+                    showTimePicker
+                    utc={selectedTimePeriod.utc}
+                    onChange={handleChangeDateRange}
+                    onChangeUtc={handleUseUtc}
+                    maxPickableDays={maxPickableDays}
+                  />
+                  <SubmitRow>
+                    <MultipleSelectorSubmitRow
+                      onSubmit={actions.close}
+                      disabled={!hasChanges || hasDateErrors}
+                    />
+                  </SubmitRow>
+                </Content>
+              </React.Fragment>
+            )}
+          </DropdownMenu>
+        </CustomDateOption>
+      )}
+    </ButtonBar>
+  );
+}
+
+const RelativePeriodButton = styled(Button)<{selected?: boolean}>`
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => (p.selected ? 700 : 400)};
+  color: ${p => (p.selected ? p.theme.textColor : p.theme.subText)};
+  ${p => p.selected && `background-color: ${p.theme.bodyBackground}`};
+`;
+
+const CustomPeriodButton = styled(DropdownButton)<{
+  selected?: boolean;
+  showRelative?: boolean;
+}>`
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => (p.selected ? 700 : 400)};
+  color: ${p => (p.selected ? p.theme.textColor : p.theme.subText)};
+
+  ${p =>
+    p.showRelative &&
+    `
+    border-left: none;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  `}
+`;
+
+const CustomDateOption = styled('div')`
+  display: inline-block;
+  position: relative;
+`;
+
+const SubmitRow = styled('div')`
+  padding: ${space(0.5)} ${space(1)};
+  border-top: 1px solid ${p => p.theme.innerBorder};
+  border-left: 1px solid ${p => p.theme.border};
+`;
+
+export default withRouter(DatePageFilter);

--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -61,8 +61,7 @@ type Props = {
    */
   relativeOptions?: Record<string, React.ReactNode>;
   /**
-   * Reset these URL params when we fire actions
-   * (custom routing only)
+   * Reset these URL params when we fire actions (custom routing only)
    */
   resetParamsOnChange?: string[];
   /**

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
-import moment from 'moment-timezone';
 
 import DropdownMenu from 'sentry/components/dropdownMenu';
 import HookOrDefault from 'sentry/components/hookOrDefault';
@@ -18,6 +17,8 @@ import {DateString, Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {analytics} from 'sentry/utils/analytics';
 import {
+  getDateWithTimezoneInUtc,
+  getInternalDate,
   getLocalToSystem,
   getPeriodAgo,
   getUserTimezone,
@@ -26,26 +27,6 @@ import {
 } from 'sentry/utils/dates';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
-
-// Strips timezone from local date, creates a new moment date object with timezone
-// Then returns as a Date object
-const getDateWithTimezoneInUtc = (date, utc) =>
-  moment
-    .tz(
-      moment(date).local().format('YYYY-MM-DD HH:mm:ss'),
-      utc ? 'UTC' : getUserTimezone()
-    )
-    .utc()
-    .toDate();
-
-const getInternalDate = (date, utc) => {
-  if (utc) {
-    return getUtcToSystem(date);
-  }
-  return new Date(
-    moment.tz(moment.utc(date), getUserTimezone()).format('YYYY/MM/DD HH:mm:ss')
-  );
-};
 
 const DateRangeHook = HookOrDefault({
   hookName: 'component:header-date-range',

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -209,6 +209,14 @@ export const DEFAULT_RELATIVE_PERIODS = {
   '90d': t('Last 90 days'),
 };
 
+export const DEFAULT_RELATIVE_PERIODS_PAGE_FILTER = {
+  '1h': t('1H'),
+  '24h': t('24H'),
+  '7d': t('7D'),
+  '14d': t('14D'),
+  '30d': t('30D'),
+};
+
 export const DATA_CATEGORY_NAMES = {
   [DataCategory.ERRORS]: t('Errors'),
   [DataCategory.TRANSACTIONS]: t('Transactions'),

--- a/static/app/utils/dates.tsx
+++ b/static/app/utils/dates.tsx
@@ -234,3 +234,26 @@ export function getTimeFormat({displaySeconds = false}: {displaySeconds?: boolea
 
   return displaySeconds ? 'LTS' : 'LT';
 }
+
+export function getInternalDate(date: string | Date, utc?: boolean | null) {
+  if (utc) {
+    return getUtcToSystem(date);
+  }
+  return new Date(
+    moment.tz(moment.utc(date), getUserTimezone()).format('YYYY/MM/DD HH:mm:ss')
+  );
+}
+
+/**
+ * Strips timezone from local date, creates a new moment date object with timezone
+ * returns the moment as a Date object
+ */
+export function getDateWithTimezoneInUtc(date?: Date, utc?: boolean | null) {
+  return moment
+    .tz(
+      moment(date).local().format('YYYY-MM-DD HH:mm:ss'),
+      utc ? 'UTC' : getUserTimezone()
+    )
+    .utc()
+    .toDate();
+}

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -47,6 +47,7 @@ describe('DatePageFilter', function () {
     expect(PageFiltersStore.getState()).toEqual({
       organization: null,
       isReady: true,
+      pinnedFilters: new Set(),
       selection: {
         datetime: {
           period: '7d',

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -1,0 +1,62 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import DatePageFilter from 'sentry/components/datePageFilter';
+import OrganizationStore from 'sentry/stores/organizationStore';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+describe('DatePageFilter', function () {
+  const {organization, router, routerContext} = initializeOrg({
+    organization: undefined,
+    project: undefined,
+    projects: undefined,
+    router: {
+      location: {query: {}},
+      params: {orgId: 'org-slug'},
+    },
+  });
+  OrganizationStore.onUpdate(organization, {replace: true});
+  PageFiltersStore.onInitializeUrlState({
+    projects: [],
+    environments: [],
+    datetime: {
+      period: '7d',
+      start: null,
+      end: null,
+      utc: null,
+    },
+  });
+
+  it('can change period', function () {
+    mountWithTheme(
+      <OrganizationContext.Provider value={organization}>
+        <DatePageFilter />
+      </OrganizationContext.Provider>,
+      {
+        context: routerContext,
+      }
+    );
+
+    expect(screen.getByText('7D')).toBeInTheDocument();
+    userEvent.click(screen.getByText('7D'));
+
+    expect(router.push).toHaveBeenCalledWith(
+      expect.objectContaining({query: {statsPeriod: '7d'}})
+    );
+    expect(PageFiltersStore.getState()).toEqual({
+      organization: null,
+      isReady: true,
+      selection: {
+        datetime: {
+          period: '7d',
+          utc: null,
+          start: null,
+          end: null,
+        },
+        environments: [],
+        projects: [],
+      },
+    });
+  });
+});


### PR DESCRIPTION
Added a standalone time selector according to the mocks for the new standalone page filter components. This is heavily modeled after the existing `components/organizations/timeRangeSelector`

This is how it may look in the issues page (not a final placement)
![image](https://user-images.githubusercontent.com/9372512/149211733-f845a604-202b-41dd-ad03-5a4d26a9e2a1.png)

More examples with date selection:
![image](https://user-images.githubusercontent.com/9372512/149211936-c097bf33-34d5-41f7-bd96-fa95f72e2567.png)
