### PR TITLE
fix(u2f): showing error on first load for u2f devices on safari

### DIFF
--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -286,8 +286,8 @@ class U2fInterface extends React.Component<Props, State> {
     );
     if (
       this.state.failCount === 1 &&
-      navigator.userAgent.indexOf('Safari') !== -1 &&
-      navigator.userAgent.indexOf('Chrome') === -1
+      navigator.userAgent.includes('Safari') &&
+      !navigator.userAgent.includes('Chrome')
     ) {
       return this.renderSafariWebAuthn();
     }
@@ -342,8 +342,8 @@ class U2fInterface extends React.Component<Props, State> {
           (this.state.hasBeenTapped ? ' tapped' : '') +
           (this.state.deviceFailure
             ? this.state.failCount === 1 &&
-              navigator.userAgent.indexOf('Safari') !== -1 &&
-              navigator.userAgent.indexOf('Chrome') === -1
+              navigator.userAgent.includes('Safari') &&
+              !navigator.userAgent.includes('Chrome')
               ? ' loading-dots'
               : ' device-failure'
             : '')

--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -60,7 +60,7 @@ class U2fInterface extends React.Component<Props, State> {
     if (isSafari) {
       // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({
-        deviceFailure: 'safari error',
+        deviceFailure: 'safari: requires interaction',
         isSafari,
         hasBeenTapped: false,
       });

--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -274,17 +274,12 @@ class U2fInterface extends React.Component<Props, State> {
     return this.state.deviceFailure !== 'BAD_APPID';
   }
 
-  get buttonMessage() {
-    if (this.props.flowMode === 'enroll') {
-      return t('Enroll with WebAuthn');
-    }
-    return t('Sign in with WebAuthn');
-  }
-
   renderSafariWebAuthn = () => {
     return (
       <a onClick={this.onTryAgain} className="btn btn-primary">
-        {this.buttonMessage}
+        {this.props.flowMode === 'enroll'
+          ? t('Enroll with WebAuthn')
+          : t('Sign in with WebAuthn')}
       </a>
     );
   };


### PR DESCRIPTION
Problem: Upon going through the U2F flow on Safari, it will display an error due to https://support.yubico.com/hc/en-us/articles/360022004600-No-reaction-when-using-WebAuthn-on-macOS-iOS-and-iPadOS.

As a result, the user will see this screen once loaded to the 2fa screen 
![image](https://user-images.githubusercontent.com/22259802/149222633-8456452a-3800-489b-badd-11a112eed29a.png)

Solution: added a failCounter, if the fail counter is 1 and the browser is safari, instead of rendering the previously shown error screen, we show the following instead:
Authentication:
![image](https://user-images.githubusercontent.com/22259802/149223152-47ab595b-fe6e-4007-a163-8b37f5940bf2.png)

Registration: 
![image](https://user-images.githubusercontent.com/22259802/149223072-8868e10d-cfee-468b-8597-aae6670e82a8.png)
