### PR TITLE
ref(ui): Use translucent borders & dark backdrop for <GlobalModal />

### DIFF
--- a/static/app/components/globalModal/components.tsx
+++ b/static/app/components/globalModal/components.tsx
@@ -31,6 +31,8 @@ const CloseButton = styled(Button)`
   right: 0;
   transform: translate(50%, -50%);
   border-radius: 50%;
+  border: none;
+  box-shadow: 0 0 0 1px ${p => p.theme.translucentBorder};
   background: ${p => p.theme.background};
   height: 24px;
   width: 24px;

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -214,7 +214,7 @@ const fullPageCss = css`
 const Backdrop = styled('div')`
   ${fullPageCss};
   z-index: ${p => p.theme.zIndex.modal};
-  background: ${p => p.theme.gray500};
+  background: ${p => p.theme.black};
   will-change: opacity;
   transition: opacity 200ms;
   pointer-events: none;
@@ -250,8 +250,7 @@ const Content = styled('div')`
   padding: ${space(4)};
   background: ${p => p.theme.background};
   border-radius: 8px;
-  border: ${p => p.theme.modalBorder};
-  box-shadow: ${p => p.theme.modalBoxShadow};
+  box-shadow: 0 0 0 1px ${p => p.theme.translucentBorder}, ${(p) => p.theme.dropShadowHeavy};
 `;
 
 type State = {

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -250,7 +250,7 @@ const Content = styled('div')`
   padding: ${space(4)};
   background: ${p => p.theme.background};
   border-radius: 8px;
-  box-shadow: 0 0 0 1px ${p => p.theme.translucentBorder}, ${(p) => p.theme.dropShadowHeavy};
+  box-shadow: 0 0 0 1px ${p => p.theme.translucentBorder}, ${p => p.theme.dropShadowHeavy};
 `;
 
 type State = {

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -192,16 +192,6 @@ const generateAliases = (colors: BaseColors) => ({
   translucentInnerBorder: colors.translucentGray100,
 
   /**
-   * Border around modals
-   */
-  modalBorder: 'none',
-
-  /**
-   * Box shadow on the modal
-   */
-  modalBoxShadow: 'none',
-
-  /**
    * A color that denotes a "success", or something good
    */
   success: colors.green300,


### PR DESCRIPTION
For `<GlobalModal />`, use translucent borders for the main dialog content and the dismiss button, since they are both overlays that appear on top of the app's main UI. Also, for the backdrop, use `black`, which is dark in both light and dark mode, instead of `gray500`, which becomes white in dark mode.

Before:
<img width="727" alt="Screen Shot 2022-01-12 at 2 14 16 PM" src="https://user-images.githubusercontent.com/44172267/149231432-2a0d5740-6ad4-48f6-9ff8-201c3d210600.png">
<img width="727" alt="Screen Shot 2022-01-12 at 2 14 27 PM" src="https://user-images.githubusercontent.com/44172267/149231446-f7fb3048-95d3-4cd0-b765-8588a46d3e4b.png">

After:
<img width="721" alt="Screen Shot 2022-01-12 at 2 14 56 PM" src="https://user-images.githubusercontent.com/44172267/149231499-f1e3a36f-be0c-4a5e-9d7b-d81c10d5cf6a.png">
<img width="721" alt="Screen Shot 2022-01-12 at 2 15 04 PM" src="https://user-images.githubusercontent.com/44172267/149231516-713e231d-7173-41f7-8ff1-914bba0daea5.png">

