### PR TITLE
feat(suspect-spans): Add avg occurrences to span details

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsTable.tsx
@@ -173,7 +173,7 @@ const COLUMN_TYPE: Omit<
 const SPANS_TABLE_COLUMN_ORDER: TableColumn[] = [
   {
     key: 'id',
-    name: t('Example Transaction'),
+    name: t('Event ID'),
     width: COL_WIDTH_UNDEFINED,
   },
   {

--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -192,7 +192,7 @@ export const SPAN_SORT_TO_FIELDS: Record<SpanSort, string[]> = {
     'percentileArray(spans_exclusive_time, 0.75)',
     'count()',
     'count_unique(id)',
-    'equation|count()/count_unique(id)',
+    'equation|count() / count_unique(id)',
     'sumArray(spans_exclusive_time)',
   ],
   [SpanSortOthers.COUNT]: [

--- a/tests/js/spec/views/performance/transactionSpans/spanDetails.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/spanDetails.spec.tsx
@@ -200,7 +200,15 @@ describe('Performance > Transaction Spans > Span Details', function () {
 
       const frequencyHeader = await screen.findByTestId('header-frequency');
       expect(await within(frequencyHeader).findByText('100%')).toBeInTheDocument();
-      expect(await within(frequencyHeader).findByText('1 event')).toBeInTheDocument();
+      expect(
+        await within(frequencyHeader).findByText((_content, element) =>
+          Boolean(
+            element &&
+              element.tagName === 'DIV' &&
+              element.textContent === '1.00 times per event'
+          )
+        )
+      ).toBeInTheDocument();
 
       const totalExclusiveTimeHeader = await screen.findByTestId(
         'header-total-exclusive-time'
@@ -208,7 +216,13 @@ describe('Performance > Transaction Spans > Span Details', function () {
       expect(
         await within(totalExclusiveTimeHeader).findByText('5.00ms')
       ).toBeInTheDocument();
-      // TODO: add an expect for the TBD
+      expect(
+        await within(totalExclusiveTimeHeader).findByText((_content, element) =>
+          Boolean(
+            element && element.tagName === 'DIV' && element.textContent === '1 events'
+          )
+        )
+      ).toBeInTheDocument();
     });
 
     it('renders chart', async function () {
@@ -236,7 +250,7 @@ describe('Performance > Transaction Spans > Span Details', function () {
         organization: data.organization,
       });
 
-      expect(await screen.findByText('Example Transaction')).toBeInTheDocument();
+      expect(await screen.findByText('Event ID')).toBeInTheDocument();
       expect(await screen.findByText('Timestamp')).toBeInTheDocument();
       expect(await screen.findByText('Span Duration')).toBeInTheDocument();
       expect(await screen.findByText('Count')).toBeInTheDocument();


### PR DESCRIPTION
This moves the event count to where the TBD was and replaces it with the avg
occurrences.