### PR TITLE
ref(Vercel): Handle configuration redirect

### DIFF
--- a/src/sentry/integrations/vercel/redirect.py
+++ b/src/sentry/integrations/vercel/redirect.py
@@ -1,5 +1,3 @@
-from urllib.parse import parse_qsl, urlparse
-
 from django.http import HttpResponseRedirect
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,12 +8,17 @@ from sentry.utils.http import absolute_uri
 
 
 class VercelConfigurationRedirect(Endpoint):
-    def redirect(self, request: Request) -> Response:
-        configuration_id = dict(parse_qsl(urlparse(request).query))["configurationId"]
+
+    authentication_classes = ()
+    permission_classes = ()
+    provider = "vercel"
+
+    def get(self, request: Request) -> Response:
+        configuration_id = request.query_params["configurationId"]
         integration = Integration.objects.get(
-            provider="vercel", metadata__contains=configuration_id
+            provider=self.provider, metadata__contains=configuration_id
         )
         organizations = integration.organizations.all()
         return HttpResponseRedirect(
-            absolute_uri(f"/settings/{organizations[0].slug}/integrations/vercel/")
+            absolute_uri(f"/settings/{organizations[0].slug}/integrations/{self.provider}/")
         )

--- a/src/sentry/integrations/vercel/redirect.py
+++ b/src/sentry/integrations/vercel/redirect.py
@@ -1,0 +1,21 @@
+from urllib.parse import parse_qsl, urlparse
+
+from django.http import HttpResponseRedirect
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+from sentry.models import Integration
+from sentry.utils.http import absolute_uri
+
+
+class VercelConfigurationRedirect(Endpoint):
+    def redirect(self, request: Request) -> Response:
+        configuration_id = dict(parse_qsl(urlparse(request).query))["configurationId"]
+        integration = Integration.objects.get(
+            provider="vercel", metadata__contains=configuration_id
+        )
+        organizations = integration.organizations.all()
+        return HttpResponseRedirect(
+            absolute_uri(f"/settings/{organizations[0].slug}/integrations/vercel/")
+        )

--- a/src/sentry/integrations/vercel/urls.py
+++ b/src/sentry/integrations/vercel/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from sentry.web.frontend.vercel_extension_configuration import VercelExtensionConfigurationView
 
 from .generic_webhook import VercelGenericWebhookEndpoint
+from .redirect import VercelConfigurationRedirect
 from .webhook import VercelWebhookEndpoint
 
 urlpatterns = [
@@ -18,5 +19,10 @@ urlpatterns = [
         r"^delete/$",
         VercelGenericWebhookEndpoint.as_view(),
         name="sentry-extensions-vercel-generic-webhook",
+    ),
+    url(
+        r"^redirect/$",
+        VercelConfigurationRedirect.as_view(),
+        name="sentry-extensions-vercel-redirect",
     ),
 ]

--- a/src/sentry/web/frontend/vercel_extension_configuration.py
+++ b/src/sentry/web/frontend/vercel_extension_configuration.py
@@ -1,6 +1,25 @@
+from urllib.parse import parse_qsl, urlparse
+
+from django.http import HttpResponseRedirect
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.models import Integration
+from sentry.utils.http import absolute_uri
+
 from .integration_extension_configuration import IntegrationExtensionConfigurationView
 
 
 class VercelExtensionConfigurationView(IntegrationExtensionConfigurationView):
     provider = "vercel"
     external_provider_key = "vercel"
+
+    def redirect(self, request: Request) -> Response:
+        configuration_id = dict(parse_qsl(urlparse(request).query))["configurationId"]
+        integration = Integration.objects.get(
+            provider="vercel", metadata__contains=configuration_id
+        )
+        organizations = integration.organizations.all()
+        return HttpResponseRedirect(
+            absolute_uri(f"/settings/{organizations[0].slug}/integrations/vercel/")
+        )

--- a/src/sentry/web/frontend/vercel_extension_configuration.py
+++ b/src/sentry/web/frontend/vercel_extension_configuration.py
@@ -1,25 +1,6 @@
-from urllib.parse import parse_qsl, urlparse
-
-from django.http import HttpResponseRedirect
-from rest_framework.request import Request
-from rest_framework.response import Response
-
-from sentry.models import Integration
-from sentry.utils.http import absolute_uri
-
 from .integration_extension_configuration import IntegrationExtensionConfigurationView
 
 
 class VercelExtensionConfigurationView(IntegrationExtensionConfigurationView):
     provider = "vercel"
     external_provider_key = "vercel"
-
-    def redirect(self, request: Request) -> Response:
-        configuration_id = dict(parse_qsl(urlparse(request).query))["configurationId"]
-        integration = Integration.objects.get(
-            provider="vercel", metadata__contains=configuration_id
-        )
-        organizations = integration.organizations.all()
-        return HttpResponseRedirect(
-            absolute_uri(f"/settings/{organizations[0].slug}/integrations/vercel/")
-        )

--- a/tests/sentry/integrations/vercel/test_redirect.py
+++ b/tests/sentry/integrations/vercel/test_redirect.py
@@ -1,0 +1,32 @@
+from sentry.models import Integration, OrganizationIntegration
+from sentry.testutils import IntegrationTestCase
+
+
+class VercelConfigurationRedirectTest(IntegrationTestCase):
+    @property
+    def path(self):
+        return "/extensions/vercel/redirect/?configurationId=my_config_id"
+
+    def setUp(self):
+        self.integration = Integration.objects.create(
+            provider="vercel",
+            external_id="abc123",
+            name="hellboy",
+            metadata={
+                "access_token": "ogUp6j3AxpQnJUoBFdMn2qZM",
+                "installation_id": "my_config_id",
+                "installation_type": "team",
+            },
+            status=0,
+        )
+        self.oi = OrganizationIntegration.objects.create(
+            organization=self.organization, integration=self.integration
+        )
+
+    def test_simple(self):
+        self.login_as(self.user)
+
+        resp = self.client.get(self.path)
+
+        assert resp.status_code == 302
+        assert f"/settings/{self.organization.slug}/integrations/vercel/" in resp.url


### PR DESCRIPTION
Vercel has the option to provide a [configuration URL](https://vercel.com/docs/integrations#creating-your-integration/integration-settings/configuration-url) for users to be taken to the configuration page in Sentry from Vercel after installing the integration. This PR grabs the configuration ID sent from Vercel, looks up the integration's organization, and redirects the user to their Vercel config page in Sentry.


This is obviously my local app, but if you don't set a configuration URL it will default to linking to your company site. 
<img width="1044" alt="Screen Shot 2022-01-13 at 1 33 20 PM" src="https://user-images.githubusercontent.com/29959063/149412447-a956fccd-bc2d-4332-adcc-0acd6ec178ee.png">
