### PR TITLE
fix(vital-detail-metrics): Fix p75 all transactions [INGEST-545]

### DIFF
--- a/static/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/static/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -24,6 +24,7 @@ type Props = ViewProps & {
   location: Location;
   vital: WebVital | WebVital[];
   orgSlug: Organization['slug'];
+  isLoading?: boolean;
   hideBar?: boolean;
   hideStates?: boolean;
   hideVitalPercentNames?: boolean;
@@ -41,6 +42,7 @@ function VitalInfo({
   environment,
   vital,
   location,
+  isLoading,
   hideBar,
   hideStates,
   hideVitalPercentNames,
@@ -76,7 +78,7 @@ function VitalInfo({
         query={new MutableSearch(query).formatString()} // TODO(metrics): not all tags will be compatible with metrics
         groupBy={['measurement_rating']}
       >
-        {({loading: isLoading, response}) => {
+        {({loading, response}) => {
           const data = vitals.reduce((acc, v, index) => {
             acc[v] = getVitalData({
               field: fields[index],
@@ -89,15 +91,25 @@ function VitalInfo({
             data[vital].p75 = p75AllTransactions ?? 0;
           }
 
-          return <VitalBar {...contentCommonProps} isLoading={isLoading} data={data} />;
+          return (
+            <VitalBar
+              {...contentCommonProps}
+              isLoading={isLoading || loading}
+              data={data}
+            />
+          );
         }}
       </MetricsRequest>
     );
   }
   return (
     <VitalsCardDiscoverQuery location={location} vitals={vitals}>
-      {({isLoading, vitalsData}) => (
-        <VitalBar {...contentCommonProps} data={vitalsData} isLoading={isLoading} />
+      {({isLoading: loading, vitalsData}) => (
+        <VitalBar
+          {...contentCommonProps}
+          isLoading={isLoading || loading}
+          data={vitalsData}
+        />
       )}
     </VitalsCardDiscoverQuery>
   );

--- a/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
+++ b/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
@@ -300,7 +300,7 @@ describe('Performance > VitalDetail', function () {
 
     // It shows the vital card
     expect(
-      screen.getByText(textWithMarkupMatcher('The p75 for all transactions is 51293ms'))
+      screen.getByText(textWithMarkupMatcher('The p75 for all transactions is 534ms'))
     ).toBeInTheDocument();
 
     expect(screen.getByText('Good 28%')).toBeInTheDocument();
@@ -503,7 +503,7 @@ describe('Performance > VitalDetail', function () {
     expect(await screen.findByText('Cumulative Layout Shift')).toBeInTheDocument();
 
     expect(
-      screen.getByText(textWithMarkupMatcher('The p75 for all transactions is 51292.95'))
+      screen.getByText(textWithMarkupMatcher('The p75 for all transactions is 534.30'))
     ).toBeInTheDocument();
 
     // The table is still a TODO
@@ -599,7 +599,7 @@ describe('Performance > VitalDetail', function () {
     expect(await screen.findByText('Largest Contentful Paint')).toBeInTheDocument();
 
     expect(
-      screen.getByText(textWithMarkupMatcher('The p75 for all transactions is 51293ms'))
+      screen.getByText(textWithMarkupMatcher('The p75 for all transactions is 534ms'))
     ).toBeInTheDocument();
 
     // The table is still a TODO


### PR DESCRIPTION
The calculation of the p75 was wrong in the vital details (metrics version) and this PR fixes it by using the `dataMean` of the function `transformMetricsToArea`


**Before:**

![image](https://user-images.githubusercontent.com/29228205/149301126-235715ab-a8f5-4796-a06b-bc2e2ecccc51.png)



**After:**


![image](https://user-images.githubusercontent.com/29228205/149300999-bc148251-7087-452b-8505-379f901d4a33.png)
