### PR TITLE
fix(dashboard): Fix widget edit/delete edge cases

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -238,7 +238,7 @@ class Dashboard extends Component<Props, State> {
     }
   };
 
-  handleDeleteWidget = (widgetToDelete: Widget) => () => {
+  handleDeleteWidget = (widgetToDelete: Widget, index: number) => () => {
     const {layouts} = this.state;
     const {
       dashboard,
@@ -249,7 +249,8 @@ class Dashboard extends Component<Props, State> {
       handleUpdateWidgetList,
     } = this.props;
 
-    const nextList = dashboard.widgets.filter(widget => widget !== widgetToDelete);
+    const nextList = [...dashboard.widgets];
+    nextList.splice(index, 1);
     onUpdate(nextList);
 
     if (organization.features.includes('dashboard-grid-layout')) {
@@ -346,7 +347,7 @@ class Dashboard extends Component<Props, State> {
       widget,
       isEditing,
       widgetLimitReached,
-      onDelete: this.handleDeleteWidget(widget),
+      onDelete: this.handleDeleteWidget(widget, index),
       onEdit: this.handleEditWidget(widget, index),
       onDuplicate: this.handleDuplicateWidget(widget, index),
       isPreview,

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -228,17 +228,18 @@ class Dashboard extends Component<Props, State> {
     });
   };
 
-  handleUpdateComplete = (prevWidget: Widget, index: number) => (nextWidget: Widget) => {
+  handleUpdateComplete = (prevWidget: Widget) => (nextWidget: Widget) => {
     const {isEditing, handleUpdateWidgetList} = this.props;
     const nextList = [...this.props.dashboard.widgets];
-    nextList[index] = {...nextWidget, tempId: prevWidget.tempId};
+    const updateIndex = nextList.indexOf(prevWidget);
+    nextList[updateIndex] = {...nextWidget, tempId: prevWidget.tempId};
     this.props.onUpdate(nextList);
     if (!!!isEditing) {
       handleUpdateWidgetList(nextList);
     }
   };
 
-  handleDeleteWidget = (widgetToDelete: Widget, index: number) => () => {
+  handleDeleteWidget = (widgetToDelete: Widget) => () => {
     const {layouts} = this.state;
     const {
       dashboard,
@@ -249,8 +250,7 @@ class Dashboard extends Component<Props, State> {
       handleUpdateWidgetList,
     } = this.props;
 
-    const nextList = [...dashboard.widgets];
-    nextList.splice(index, 1);
+    const nextList = dashboard.widgets.filter(widget => widget !== widgetToDelete);
     onUpdate(nextList);
 
     if (organization.features.includes('dashboard-grid-layout')) {
@@ -321,7 +321,7 @@ class Dashboard extends Component<Props, State> {
       widget,
       selection,
       onAddWidget: handleAddCustomWidget,
-      onUpdateWidget: this.handleUpdateComplete(widget, index),
+      onUpdateWidget: this.handleUpdateComplete(widget),
     };
     openAddDashboardWidgetModal({
       ...modalProps,
@@ -347,7 +347,7 @@ class Dashboard extends Component<Props, State> {
       widget,
       isEditing,
       widgetLimitReached,
-      onDelete: this.handleDeleteWidget(widget, index),
+      onDelete: this.handleDeleteWidget(widget),
       onEdit: this.handleEditWidget(widget, index),
       onDuplicate: this.handleDuplicateWidget(widget, index),
       isPreview,

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -341,7 +341,6 @@ class DashboardDetail extends Component<Props, State> {
     openAddDashboardWidgetModal({
       organization,
       dashboard,
-      onAddWidget: (widget: Widget) => this.handleAddCustomWidget(widget),
       onAddLibraryWidget: (widgets: Widget[]) => this.handleUpdateWidgetList(widgets),
       source: DashboardWidgetSource.LIBRARY,
     });

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -4,7 +4,6 @@ import {withRouter, WithRouterProps} from 'react-router';
 import {useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import isEqual from 'lodash/isEqual';
 
 import {Client} from 'sentry/api';
 import ErrorPanel from 'sentry/components/charts/errorPanel';
@@ -13,7 +12,6 @@ import {HeaderTitle} from 'sentry/components/charts/styles';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {isSelectionEqual} from 'sentry/components/organizations/pageFilters/utils';
 import {Panel} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import {IconDelete, IconEdit, IconGrabbable, IconWarning} from 'sentry/icons';
@@ -64,21 +62,6 @@ type Props = WithRouterProps & {
 };
 
 class WidgetCard extends React.Component<Props> {
-  shouldComponentUpdate(nextProps: Props): boolean {
-    if (
-      !isEqual(nextProps.widget, this.props.widget) ||
-      !isSelectionEqual(nextProps.selection, this.props.selection) ||
-      this.props.isEditing !== nextProps.isEditing ||
-      this.props.isSorting !== nextProps.isSorting ||
-      this.props.hideToolbar !== nextProps.hideToolbar ||
-      this.props.widgetLimitReached !== nextProps.widgetLimitReached ||
-      this.props.hideDragHandle !== nextProps.hideDragHandle
-    ) {
-      return true;
-    }
-    return false;
-  }
-
   isAllowWidgetsToDiscover() {
     const {organization} = this.props;
     return organization.features.includes('connect-discover-and-dashboards');


### PR DESCRIPTION
Widgets were behaving weirdly when you add,
edit and delete them multiple times without 
refreshing the page and when you try deleting
widgets in edit mode. This is because we were
only checking equality on widget props when 
re-rendering the widgets but reference changes
were not triggering re-renders. We are using
widget references to figure out which widgets
to update or delete so it seemed like these widgets
didn't exist because the references didn't get updated
correctly. Removing the componentShouldUpdate
to just trigger re-render every time, so trading off
some optimizations there (not sure why they were
introduced).