### PR TITLE
feat(profiling): add text renderer

### DIFF
--- a/static/app/utils/profiling/flamegraph/FlamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/FlamegraphTheme.tsx
@@ -5,6 +5,8 @@ const MONOSPACE_FONT = `ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI 
 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro', 'Fira Mono', 'Droid Sans Mono',
 'Courier New', monospace`;
 
+const FRAME_FONT = `"Source Code Pro", Courier, monospace`;
+
 // Luma chroma hue settings
 export interface LCH {
   C_0: number;
@@ -85,6 +87,7 @@ export interface FlamegraphTheme {
   };
   FONTS: {
     FONT: string;
+    FRAME_FONT: string;
   };
 }
 
@@ -155,6 +158,7 @@ export const LightFlamegraphTheme: FlamegraphTheme = {
   },
   FONTS: {
     FONT: MONOSPACE_FONT,
+    FRAME_FONT,
   },
 };
 
@@ -210,5 +214,6 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
   },
   FONTS: {
     FONT: MONOSPACE_FONT,
+    FRAME_FONT,
   },
 };

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -198,13 +198,13 @@ export class Rect {
     return this.x;
   }
   get right(): number {
-    return this.x + this.width;
+    return this.left + this.width;
   }
   get top(): number {
     return this.y;
   }
   get bottom(): number {
-    return this.y + this.height;
+    return this.top + this.height;
   }
 
   toMatrix(): mat3 {

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -198,13 +198,13 @@ export class Rect {
     return this.x;
   }
   get right(): number {
-    return this.left + this.width;
+    return this.x + this.width;
   }
   get top(): number {
     return this.y;
   }
   get bottom(): number {
-    return this.top + this.height;
+    return this.y + this.height;
   }
 
   toMatrix(): mat3 {

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -383,3 +383,30 @@ function getContext(canvas: HTMLCanvasElement, context: string): RenderingContex
 }
 
 export {getContext};
+
+/** Find closest min and max value to target */
+export function findRangeBinarySearch(
+  {low, high}: {low: number; high: number},
+  fn: (val: number) => number,
+  target: number,
+  precision = 1
+): [number, number] {
+  if (target < low || target > high) {
+    throw new Error(
+      `Target value needs to be in low-high range, got ${target} for [${low}, ${high}]`
+    );
+  }
+  // eslint-disable-next-line
+  while (true) {
+    if (high - low <= precision) {
+      return [low, high];
+    }
+
+    const mid = (high + low) / 2;
+    if (fn(mid) < target) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+  }
+}

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -410,3 +410,20 @@ export function findRangeBinarySearch(
     }
   }
 }
+
+export const ELLIPSIS = '\u2026';
+export function trimTextCenter(text: string, low: number) {
+  if (low > text.length) {
+    return text;
+  }
+
+  const prefixLength = Math.floor(low / 2);
+  // Use 1 character less than the low value to account for ellipsis
+  // and favor displaying the prefix
+  const postfixLength = low - prefixLength - 1;
+
+  return `${text.substring(0, prefixLength)}${ELLIPSIS}${text.substring(
+    text.length - postfixLength,
+    text.length
+  )}`;
+}

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -14,22 +14,7 @@ import {
 
 export function isOutsideView(frame: Rect, view: Rect, inverted: boolean): boolean {
   // Frame is outside of the view on the left
-  if (frame.right <= view.left) {
-    return true;
-  }
-
-  // Frame is outside of the view on the right
-  if (frame.left >= view.right) {
-    return true;
-  }
-
-  // Frame is above the view
-  if (frame.bottom <= view.top) {
-    return true;
-  }
-
-  // Frame is below the view
-  if (frame.top >= view.bottom) {
+  if (!frame.overlaps(view)) {
     return true;
   }
 
@@ -74,14 +59,14 @@ class TextRenderer {
   }
 
   draw(configViewSpace: Rect, configSpace: Rect, configToPhysicalSpace: mat3): void {
-    this.context.font = `${
-      this.theme.SIZES.BAR_FONT_SIZE * window.devicePixelRatio
-    }px "Source Code Pro", Courier, monospace`;
+    this.context.font = `${this.theme.SIZES.BAR_FONT_SIZE * window.devicePixelRatio}px ${
+      this.theme.FONTS.FRAME_FONT
+    }`;
 
     this.context.textBaseline = 'alphabetic';
     this.context.fillStyle = this.theme.COLORS.LABEL_FONT_COLOR;
 
-    const minWidth = this.measureText(this.context, `${ELLIPSIS}`);
+    const minWidth = this.measureText(this.context, ELLIPSIS);
 
     let frame: FlamegraphFrame;
     let i: number;

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -1,10 +1,37 @@
 import {mat3} from 'gl-matrix';
 
-import {Flamegraph} from '../Flamegraph';
+import {Flamegraph} from '../flamegraph';
 import {FlamegraphTheme} from '../flamegraph/FlamegraphTheme';
-import {getContext, Rect, resizeCanvasToDisplaySize} from '../gl/utils';
+import {FlamegraphFrame} from '../flamegraphFrame';
+import {
+  ELLIPSIS,
+  findRangeBinarySearch,
+  getContext,
+  Rect,
+  resizeCanvasToDisplaySize,
+  trimTextCenter,
+} from '../gl/utils';
 
-const ELLIPSIS = '\u2026';
+function isOutsideView(frame: Rect, configView: Rect, inverted: boolean): boolean {
+  if (frame.right < configView.left) {
+    return true;
+  }
+  if (frame.left > configView.right) {
+    return true;
+  }
+
+  if (inverted) {
+    if (frame.top - 1 > configView.bottom) {
+      return true;
+    }
+  }
+
+  if (frame.bottom < configView.top - 1) {
+    return true;
+  }
+
+  return false;
+}
 
 class TextRenderer {
   textCache: Record<string, number> = {};
@@ -32,23 +59,32 @@ class TextRenderer {
     if (this.textCache[text]) {
       return this.textCache[text];
     }
-    const metrics = context.measureText(text);
-    this.textCache[text] = metrics.width;
-    return metrics.width;
+    this.textCache[text] = context.measureText(text).width;
+    return this.textCache[text];
   }
 
   draw(configViewSpace: Rect, configSpace: Rect, configToPhysicalSpace: mat3): void {
     this.context.font = `${
       this.theme.SIZES.BAR_FONT_SIZE * window.devicePixelRatio
     }px "Source Code Pro", Courier, monospace`;
+
     this.context.textBaseline = 'alphabetic';
-    this.context.fillStyle = this.theme.COLORS.BAR_LABEL_FONT_COLOR;
+    this.context.fillStyle = this.theme.COLORS.LABEL_FONT_COLOR;
 
     const minWidth = this.measureText(this.context, `${ELLIPSIS}`);
 
-    for (const frame of this.flamegraph.frames) {
+    let frame: FlamegraphFrame;
+    let i: number;
+    const length: number = this.flamegraph.frames.length;
+
+    // We currently iterate over all frames, but we could optimize this to only iterate over visible frames.
+    // This could be achieved by querying the flamegraph tree (as an interval tree). This would still run in O(n), but
+    // would improve our best case performance (e.g. when users) zoom into the flamegraph
+    for (i = 0; i < length; i++) {
+      frame = this.flamegraph.frames[i];
       const text = frame.frame.name;
 
+      // This rect gets discarded after each render which is wasteful
       const frameInConfigSpace = new Rect(
         frame.start,
         this.flamegraph.inverted ? configSpace.height - frame.depth + 1 : frame.depth + 1,
@@ -56,26 +92,18 @@ class TextRenderer {
         1
       );
 
-      if (frameInConfigSpace.right < configViewSpace.left) {
-        continue;
-      }
-      if (frameInConfigSpace.left > configViewSpace.right) {
+      // Check if our rect overlaps with the current viewport and skip it
+      if (
+        isOutsideView(frameInConfigSpace, configViewSpace, !!this.flamegraph.inverted)
+      ) {
         continue;
       }
 
-      if (this.flamegraph.inverted) {
-        if (frameInConfigSpace.top - 1 > configViewSpace.bottom) {
-          continue;
-        }
-      } else {
-        if (frameInConfigSpace.bottom < configViewSpace.top - 1) {
-          continue;
-        }
-      }
-
+      // We pin the start and end of the frame, so scrolling around keeps text pinned to the left or right side of the viewport
       const pinnedStart = Math.max(frame.start, configViewSpace.left);
       const pinnedEnd = Math.min(frame.end, configViewSpace.right);
 
+      // This rect gets discarded after each render which is wasteful
       const offsetFrame = new Rect(
         pinnedStart,
         frameInConfigSpace.y,
@@ -83,8 +111,11 @@ class TextRenderer {
         1
       );
 
+      // Transform frame to physical space coordinates
       const frameInPhysicalSpace = offsetFrame.transformRect(configToPhysicalSpace);
 
+      // Since the text is not exactly aligned to the left/right bounds of the frame, we need to subtract the padding
+      // from the total width, so that we can truncate the center of the text accurately.
       const paddedWidth =
         frameInPhysicalSpace.width -
         2 * (this.theme.SIZES.BAR_PADDING * window.devicePixelRatio);
@@ -92,31 +123,30 @@ class TextRenderer {
       const y =
         frameInPhysicalSpace.y -
         (this.theme.SIZES.BAR_FONT_SIZE / 2) * window.devicePixelRatio;
+
       const x =
         frameInPhysicalSpace.x + this.theme.SIZES.BAR_PADDING * window.devicePixelRatio;
 
+      // If the width of the text is greater than the minimum width to render, we should render it
       if (paddedWidth >= minWidth) {
-        if (this.measureText(this.context, text) > paddedWidth) {
-          const [low] = findValueBisect(
-            0,
-            text.length,
-            n => this.measureText(this.context, text.substring(0, n)),
-            paddedWidth
-          );
+        const width = this.measureText(this.context, text);
 
-          const prefixLength = Math.floor(low / 2);
-          const postfixLength = low - prefixLength - 1;
-
-          const string = `${text.substr(0, prefixLength)}${ELLIPSIS}${text.substr(
-            text.length - postfixLength,
-            postfixLength
-          )}`;
-
-          this.context.fillStyle = this.theme.COLORS.LABEL_FONT_COLOR;
-          this.context.fillText(string, x, y);
-        } else {
-          this.context.fillStyle = this.theme.COLORS.LABEL_FONT_COLOR;
+        if (width < paddedWidth) {
           this.context.fillText(text, x, y);
+          continue;
+        } else {
+          this.context.fillText(
+            trimTextCenter(
+              text,
+              findRangeBinarySearch(
+                {low: 0, high: text.length},
+                n => this.measureText(this.context, text.substring(0, n)),
+                paddedWidth
+              )[0]
+            ),
+            x,
+            y
+          );
         }
       }
     }

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -1,0 +1,126 @@
+import {mat3} from 'gl-matrix';
+
+import {Flamegraph} from '../Flamegraph';
+import {FlamegraphTheme} from '../flamegraph/FlamegraphTheme';
+import {getContext, Rect, resizeCanvasToDisplaySize} from '../gl/utils';
+
+const ELLIPSIS = '\u2026';
+
+class TextRenderer {
+  textCache: Record<string, number> = {};
+
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+  theme: FlamegraphTheme;
+  flamegraph: Flamegraph;
+
+  constructor(canvas: HTMLCanvasElement, flamegraph: Flamegraph, theme: FlamegraphTheme) {
+    this.canvas = canvas;
+    this.theme = theme;
+    this.flamegraph = flamegraph;
+
+    this.context = getContext(canvas, '2d');
+
+    resizeCanvasToDisplaySize(canvas);
+  }
+
+  clearCache(): void {
+    this.textCache = {};
+  }
+
+  measureText(context: CanvasRenderingContext2D, text: string): number {
+    if (this.textCache[text]) {
+      return this.textCache[text];
+    }
+    const metrics = context.measureText(text);
+    this.textCache[text] = metrics.width;
+    return metrics.width;
+  }
+
+  draw(configViewSpace: Rect, configSpace: Rect, configToPhysicalSpace: mat3): void {
+    this.context.font = `${
+      this.theme.SIZES.BAR_FONT_SIZE * window.devicePixelRatio
+    }px "Source Code Pro", Courier, monospace`;
+    this.context.textBaseline = 'alphabetic';
+    this.context.fillStyle = this.theme.COLORS.BAR_LABEL_FONT_COLOR;
+
+    const minWidth = this.measureText(this.context, `${ELLIPSIS}`);
+
+    for (const frame of this.flamegraph.frames) {
+      const text = frame.frame.name;
+
+      const frameInConfigSpace = new Rect(
+        frame.start,
+        this.flamegraph.inverted ? configSpace.height - frame.depth + 1 : frame.depth + 1,
+        frame.end - frame.start,
+        1
+      );
+
+      if (frameInConfigSpace.right < configViewSpace.left) {
+        continue;
+      }
+      if (frameInConfigSpace.left > configViewSpace.right) {
+        continue;
+      }
+
+      if (this.flamegraph.inverted) {
+        if (frameInConfigSpace.top - 1 > configViewSpace.bottom) {
+          continue;
+        }
+      } else {
+        if (frameInConfigSpace.bottom < configViewSpace.top - 1) {
+          continue;
+        }
+      }
+
+      const pinnedStart = Math.max(frame.start, configViewSpace.left);
+      const pinnedEnd = Math.min(frame.end, configViewSpace.right);
+
+      const offsetFrame = new Rect(
+        pinnedStart,
+        frameInConfigSpace.y,
+        pinnedEnd - pinnedStart,
+        1
+      );
+
+      const frameInPhysicalSpace = offsetFrame.transformRect(configToPhysicalSpace);
+
+      const paddedWidth =
+        frameInPhysicalSpace.width -
+        2 * (this.theme.SIZES.BAR_PADDING * window.devicePixelRatio);
+
+      const y =
+        frameInPhysicalSpace.y -
+        (this.theme.SIZES.BAR_FONT_SIZE / 2) * window.devicePixelRatio;
+      const x =
+        frameInPhysicalSpace.x + this.theme.SIZES.BAR_PADDING * window.devicePixelRatio;
+
+      if (paddedWidth >= minWidth) {
+        if (this.measureText(this.context, text) > paddedWidth) {
+          const [low] = findValueBisect(
+            0,
+            text.length,
+            n => this.measureText(this.context, text.substring(0, n)),
+            paddedWidth
+          );
+
+          const prefixLength = Math.floor(low / 2);
+          const postfixLength = low - prefixLength - 1;
+
+          const string = `${text.substr(0, prefixLength)}${ELLIPSIS}${text.substr(
+            text.length - postfixLength,
+            postfixLength
+          )}`;
+
+          this.context.fillStyle = this.theme.COLORS.LABEL_FONT_COLOR;
+          this.context.fillText(string, x, y);
+        } else {
+          this.context.fillStyle = this.theme.COLORS.LABEL_FONT_COLOR;
+          this.context.fillText(text, x, y);
+        }
+      }
+    }
+  }
+}
+
+export {TextRenderer};

--- a/tests/js/spec/utils/profiling/gl/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/gl/utils.spec.tsx
@@ -3,6 +3,7 @@ import {mat3, vec2} from 'gl-matrix';
 import {
   createProgram,
   createShader,
+  findRangeBinarySearch,
   getContext,
   makeProjectionMatrix,
   Rect,
@@ -302,5 +303,54 @@ describe('Rect', () => {
         vec2.fromValues(2, 2)
       );
     });
+  });
+});
+
+describe('findRangeBinarySearch', () => {
+  it('throws if target is out of range', () => {
+    expect(() =>
+      findRangeBinarySearch({low: 1, high: 2}, () => 0, 0, Number.MIN_SAFE_INTEGER)
+    ).toThrow('Target value needs to be in low-high range, got 0 for [1, 2]');
+  });
+
+  it('finds in single iteration', () => {
+    const text = new Array(10)
+      .fill(0)
+      .map((_, i) => String.fromCharCode(i + 97))
+      .join('');
+
+    const fn = jest.fn().mockImplementation(n => {
+      return text.substring(0, n).length;
+    });
+
+    const target = 2;
+    const precision = 1;
+
+    // First iteration will halve 1+3, next iteration will compare 2-1 <= 1 and return [1,2]
+    const [low, high] = findRangeBinarySearch({low: 1, high: 3}, fn, target, precision);
+
+    expect([low, high]).toEqual([1, 2]);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(text.substring(0, low)).toBe('a');
+  });
+
+  it('finds closest range', () => {
+    const text = new Array(10)
+      .fill(0)
+      .map((_, i) => String.fromCharCode(i + 97))
+      .join('');
+
+    const fn = jest.fn().mockImplementation(n => {
+      return text.substring(0, n).length;
+    });
+
+    const target = 4;
+    const precision = 1;
+
+    const [low, high] = findRangeBinarySearch({low: 0, high: 10}, fn, target, precision);
+
+    expect([low, high]).toEqual([3.75, 4.375]);
+    expect(fn).toHaveBeenCalledTimes(4);
+    expect(text.substring(0, low)).toBe('abc');
   });
 });

--- a/tests/js/spec/utils/profiling/gl/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/gl/utils.spec.tsx
@@ -3,11 +3,13 @@ import {mat3, vec2} from 'gl-matrix';
 import {
   createProgram,
   createShader,
+  ELLIPSIS,
   findRangeBinarySearch,
   getContext,
   makeProjectionMatrix,
   Rect,
   Transform,
+  trimTextCenter,
 } from 'sentry/utils/profiling/gl/utils';
 
 describe('makeProjectionMatrix', () => {
@@ -352,5 +354,17 @@ describe('findRangeBinarySearch', () => {
     expect([low, high]).toEqual([3.75, 4.375]);
     expect(fn).toHaveBeenCalledTimes(4);
     expect(text.substring(0, low)).toBe('abc');
+  });
+});
+
+describe('trimTextCenter', () => {
+  it('trims nothing if low > length', () => {
+    expect(trimTextCenter('abc', 4)).toBe('abc');
+  });
+  it('trims center perfectly', () => {
+    expect(trimTextCenter('abcdef', 5)).toBe(`ab${ELLIPSIS}ef`);
+  });
+  it('favors prefix length', () => {
+    expect(trimTextCenter('abcdef', 4)).toBe(`ab${ELLIPSIS}f`);
   });
 });

--- a/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
+++ b/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
@@ -31,10 +31,10 @@ describe('TextRenderer', () => {
   it('skips drawing if the text is outside the view', () => {
     const view = new Rect(0, 0, 1, 1);
 
-    const frameLeftOutsideOfView = new Rect(-1, 0, 1, 1);
-    const frameRightOutsideOfView = new Rect(1, 1, 1, 1);
-    const frameAboveView = new Rect(0, -1, 1, 1);
-    const frameBelowView = new Rect(0, 1, 1, 1);
+    const frameLeftOutsideOfView = new Rect(-1.1, 0, 1, 1);
+    const frameRightOutsideOfView = new Rect(1, 1.1, 1, 1);
+    const frameAboveView = new Rect(0, -1.1, 1, 1);
+    const frameBelowView = new Rect(0, 1.1, 1, 1);
 
     expect(isOutsideView(frameLeftOutsideOfView, view, false)).toBe(true);
     expect(isOutsideView(frameRightOutsideOfView, view, false)).toBe(true);

--- a/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
+++ b/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
@@ -1,6 +1,227 @@
+import {mat3} from 'gl-matrix';
+
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {LightFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/FlamegraphTheme';
+import {Rect, trimTextCenter} from 'sentry/utils/profiling/gl/utils';
+import {EventedProfile} from 'sentry/utils/profiling/profile/eventedProfile';
+import {isOutsideView, TextRenderer} from 'sentry/utils/profiling/renderers/textRenderer';
+
+const makeBaseFlamegraph = (): Flamegraph => {
+  const profile = EventedProfile.FromProfile({
+    name: 'profile',
+    startValue: 0,
+    endValue: 1000,
+    unit: 'milliseconds',
+    type: 'evented',
+    events: [
+      {type: 'O', at: 0, frame: 0},
+      {type: 'O', at: 1, frame: 1},
+      {type: 'C', at: 2, frame: 1},
+      {type: 'C', at: 3, frame: 0},
+    ],
+    shared: {
+      frames: [{name: 'f0'}, {name: 'f1'}],
+    },
+  });
+
+  return new Flamegraph(profile, 0, false, false);
+};
+
 describe('TextRenderer', () => {
-  it.todo('measures text');
-  it.todo('uses cached measurements');
-  it.todo('skips rendering node if it is not visible');
-  it.todo("trims output text if it doesn't fit");
+  it('skips drawing if the text is outside the view', () => {
+    const view = new Rect(0, 0, 1, 1);
+
+    const frameLeftOutsideOfView = new Rect(-1, 0, 1, 1);
+    const frameRightOutsideOfView = new Rect(1, 1, 1, 1);
+    const frameAboveView = new Rect(0, -1, 1, 1);
+    const frameBelowView = new Rect(0, 1, 1, 1);
+
+    expect(isOutsideView(frameLeftOutsideOfView, view, false)).toBe(true);
+    expect(isOutsideView(frameRightOutsideOfView, view, false)).toBe(true);
+    expect(isOutsideView(frameAboveView, view, false)).toBe(true);
+    expect(isOutsideView(frameBelowView, view, false)).toBe(true);
+  });
+  it('caches measure text', () => {
+    const context: Partial<CanvasRenderingContext2D> = {
+      measureText: jest.fn().mockReturnValue({width: 10}),
+    };
+
+    const canvas: Partial<HTMLCanvasElement> = {
+      getContext: jest.fn().mockReturnValue(context),
+    };
+
+    const textRenderer = new TextRenderer(
+      canvas as HTMLCanvasElement,
+      makeBaseFlamegraph(),
+      LightFlamegraphTheme
+    );
+    textRenderer.measureText(context as CanvasRenderingContext2D, 'text');
+    textRenderer.measureText(context as CanvasRenderingContext2D, 'text');
+    expect(context.measureText).toHaveBeenCalledTimes(1);
+  });
+  it('skips rendering node if it is not visible', () => {
+    // Flamegraph looks like this
+    // f0----f0 f2
+    //    f1
+    const profile = EventedProfile.FromProfile({
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'O', at: 100, frame: 1},
+        {type: 'C', at: 200, frame: 1},
+        {type: 'C', at: 300, frame: 0},
+        {type: 'O', at: 300, frame: 2},
+        {type: 'C', at: 400, frame: 2},
+      ],
+      shared: {
+        frames: [{name: 'f0'}, {name: 'f1'}, {name: 'f2'}],
+      },
+    });
+
+    const flamegraph = new Flamegraph(profile, 0, false, false);
+
+    const context: Partial<CanvasRenderingContext2D> = {
+      measureText: jest.fn().mockReturnValue({width: 10}),
+      fillText: jest.fn(),
+    };
+
+    const canvas: Partial<HTMLCanvasElement> = {
+      getContext: jest.fn().mockReturnValue(context),
+    };
+
+    const textRenderer = new TextRenderer(
+      canvas as HTMLCanvasElement,
+      flamegraph,
+      LightFlamegraphTheme
+    );
+
+    textRenderer.draw(
+      new Rect(0, 1.1, 200, 2),
+      flamegraph.configSpace,
+      mat3.identity(mat3.create())
+    );
+
+    expect(context.fillText).toHaveBeenCalledTimes(1);
+    expect(context.fillText).toHaveBeenCalledWith(
+      'f1',
+      100 + LightFlamegraphTheme.SIZES.BAR_PADDING,
+      1 - LightFlamegraphTheme.SIZES.BAR_FONT_SIZE / 2 // center text vertically inside the rect
+    );
+  });
+  it("trims output text if it doesn't fit", () => {
+    const longFrameName =
+      'very long frame name that needs to be truncated to fit the rect';
+    const profile = EventedProfile.FromProfile({
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'C', at: longFrameName.length, frame: 0},
+      ],
+      shared: {
+        frames: [{name: longFrameName}],
+      },
+    });
+
+    const flamegraph = new Flamegraph(profile, 0, false, false);
+
+    const context: Partial<CanvasRenderingContext2D> = {
+      measureText: jest.fn().mockImplementation(n => {
+        return {width: n.length};
+      }),
+      fillText: jest.fn(),
+    };
+
+    const canvas: Partial<HTMLCanvasElement> = {
+      getContext: jest.fn().mockReturnValue(context),
+    };
+
+    const textRenderer = new TextRenderer(
+      canvas as HTMLCanvasElement,
+      flamegraph,
+      LightFlamegraphTheme
+    );
+
+    textRenderer.draw(
+      new Rect(0, 0, Math.floor(longFrameName.length / 2), 10),
+      flamegraph.configSpace,
+      mat3.identity(mat3.create())
+    );
+
+    expect(context.fillText).toHaveBeenCalledTimes(1);
+    expect(context.fillText).toHaveBeenCalledWith(
+      trimTextCenter(
+        longFrameName,
+        Math.floor(longFrameName.length / 2) - LightFlamegraphTheme.SIZES.BAR_PADDING * 2
+      ),
+      LightFlamegraphTheme.SIZES.BAR_PADDING,
+      -LightFlamegraphTheme.SIZES.BAR_FONT_SIZE / 2 // center text vertically inside the rect
+    );
+  });
+  it('pins text to left and respects right boundary', () => {
+    const longFrameName =
+      'very long frame name that needs to be truncated to fit the rect';
+    const profile = EventedProfile.FromProfile({
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'C', at: longFrameName.length, frame: 0},
+      ],
+      shared: {
+        frames: [{name: longFrameName}],
+      },
+    });
+
+    const flamegraph = new Flamegraph(profile, 0, false, false);
+
+    const context: Partial<CanvasRenderingContext2D> = {
+      measureText: jest.fn().mockImplementation(n => {
+        return {width: n.length};
+      }),
+      fillText: jest.fn(),
+    };
+
+    const canvas: Partial<HTMLCanvasElement> = {
+      getContext: jest.fn().mockReturnValue(context),
+    };
+
+    const textRenderer = new TextRenderer(
+      canvas as HTMLCanvasElement,
+      flamegraph,
+      LightFlamegraphTheme
+    );
+
+    textRenderer.draw(
+      new Rect(
+        Math.floor(longFrameName.length / 2),
+        0,
+        Math.floor(longFrameName.length / 2 / 2),
+        10
+      ),
+      flamegraph.configSpace,
+      mat3.identity(mat3.create())
+    );
+
+    expect(context.fillText).toHaveBeenCalledTimes(1);
+    expect(context.fillText).toHaveBeenCalledWith(
+      trimTextCenter(
+        longFrameName,
+        Math.floor(longFrameName.length / 2 / 2) -
+          LightFlamegraphTheme.SIZES.BAR_PADDING * 2
+      ),
+      Math.floor(longFrameName.length / 2) + LightFlamegraphTheme.SIZES.BAR_PADDING,
+      -LightFlamegraphTheme.SIZES.BAR_FONT_SIZE / 2 // center text vertically inside the rect
+    );
+  });
 });

--- a/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
+++ b/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
@@ -1,0 +1,6 @@
+describe('TextRenderer', () => {
+  it.todo('measures text');
+  it.todo('uses cached measurements');
+  it.todo('skips rendering node if it is not visible');
+  it.todo("trims output text if it doesn't fit");
+});


### PR DESCRIPTION
TextRenderer class for rendering text on the canvas.

Since WebGL doesnt have very nice support for text rendering and we dont want to mess around with glyphs, we use an overlay canvas that draws text onto the rectangles.

https://user-images.githubusercontent.com/9317857/149897883-d54c3eae-8a5a-4b9d-b356-393e45b8fc97.mp4
