### PR TITLE
fix(relay): Omit disabled keys [ISSUE-1383]

### DIFF
--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -59,6 +59,12 @@ def get_public_key_configs(project, full_config, project_keys=None):
         key = {
             "publicKey": project_key.public_key,
             "numericId": project_key.id,
+            # Disabled keys are omitted from the config, this is just there so
+            # old Relays don't break (we haven't investigated whether there are
+            # actual relays relying on this value)
+            #
+            # Removed that value in https://github.com/getsentry/relay/pull/778/files#diff-e66f275002251930fbfc361b4cca64ab41ff2435029f65c2fd6ffb729129909dL372
+            "isEnabled": True,
         }
 
         if full_config:

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -54,10 +54,11 @@ def get_public_key_configs(project, full_config, project_keys=None):
     public_keys = []
 
     for project_key in project_keys or ():
+        if project_key.status != ProjectKeyStatus.ACTIVE:
+            continue
         key = {
             "publicKey": project_key.public_key,
             "numericId": project_key.id,
-            "isEnabled": project_key.status == ProjectKeyStatus.ACTIVE,
         }
 
         if full_config:

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -112,6 +112,7 @@ def test_generate(
     assert cfg["projectId"] == default_project.id
     assert cfg["publicKeys"] == [
         {
+            "isEnabled": True,
             "publicKey": default_projectkey.public_key,
             "numericId": default_projectkey.id,
             "quotas": [],

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from sentry.models import ProjectKey, ProjectOption
+from sentry.models import ProjectKey, ProjectKeyStatus, ProjectOption
 from sentry.relay.projectconfig_cache.redis import RedisProjectConfigCache
 from sentry.relay.projectconfig_debounce_cache.redis import RedisProjectConfigDebounceCache
 from sentry.tasks.relay import schedule_update_config_cache
@@ -113,7 +113,6 @@ def test_generate(
     assert cfg["publicKeys"] == [
         {
             "publicKey": default_projectkey.public_key,
-            "isEnabled": True,
             "numericId": default_projectkey.id,
             "quotas": [],
         }
@@ -212,7 +211,12 @@ def test_projectkeys(default_project, task_runner, redis_cache):
 
     (pk_json,) = redis_cache.get(pk.public_key)["publicKeys"]
     assert pk_json["publicKey"] == pk.public_key
-    assert pk_json["isEnabled"]
+
+    with task_runner():
+        pk.status = ProjectKeyStatus.INACTIVE
+        pk.save()
+
+    assert not redis_cache.get(pk.public_key)["publicKeys"]
 
     with task_runner():
         pk.delete()


### PR DESCRIPTION
Relay does not define or use the isEnabled field in the DSN struct at all, and therefore treats enabled and disabled keys the same.

https://github.com/getsentry/sentry/pull/30868 has recently started emitting all DSNs even when they were disabled, because the assumption was that the isEnabled flag meant anything to Relay.

This PR removes any mention of isEnabled and restores the old behavior where disabled DSNs are omitted from the config.

There will be an accompanying PR for the Relay testsuite that removes any mention of isEnabled as well.