### PR TITLE
feat(trends): Implicitly set trend parameter as filter value in query

### DIFF
--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -5,8 +5,10 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import {NewQuery, Organization, Project, SelectValue} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
+import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {getCurrentTrendParameter} from 'sentry/views/performance/trends/utils';
 
 import {getCurrentLandingDisplay, LandingDisplayField} from './landing/utils';
 import {
@@ -454,6 +456,13 @@ function generateGenericPerformanceEventView(
   // in case the metric switch is disabled (for now).
   if (!isMetricsData) {
     eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
+  }
+
+  if (query.trendParameter) {
+    const trendParameter = getCurrentTrendParameter(location);
+    if (Boolean(WEB_VITAL_DETAILS[trendParameter.column])) {
+      eventView.additionalConditions.addFilterValues('has', [trendParameter.column]);
+    }
   }
 
   return eventView;

--- a/tests/js/spec/views/performance/trends/index.spec.jsx
+++ b/tests/js/spec/views/performance/trends/index.spec.jsx
@@ -5,6 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
+import {WebVital} from 'sentry/utils/discover/fields';
 import TrendsIndex from 'sentry/views/performance/trends/';
 import {
   DEFAULT_MAX_DURATION,
@@ -407,6 +408,56 @@ describe('Performance > Trends', function () {
           trendParameter: parameter.label,
         }),
       });
+    }
+  }, 10000);
+
+  it('choosing a web vitals parameter adds it as an additional condition to the query', async function () {
+    const projects = [TestStubs.Project()];
+    const data = initializeTrendsData(projects, {project: ['-1']});
+
+    wrapper = mountWithTheme(
+      <TrendsIndex organization={data.organization} location={data.router.location} />,
+      data.routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    for (const parameter of TRENDS_PARAMETERS) {
+      if (Object.values(WebVital).includes(parameter.column)) {
+        trendsStatsMock.mockReset();
+
+        wrapper.setProps({
+          location: {query: {...trendsViewQuery, trendParameter: parameter.label}},
+        });
+
+        wrapper.update();
+        await tick();
+
+        expect(trendsStatsMock).toHaveBeenCalledTimes(2);
+
+        // Improved transactions call
+        expect(trendsStatsMock).toHaveBeenNthCalledWith(
+          1,
+          expect.anything(),
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query: expect.stringContaining(`has:${parameter.column}`),
+            }),
+          })
+        );
+
+        // Regression transactions call
+        expect(trendsStatsMock).toHaveBeenNthCalledWith(
+          2,
+          expect.anything(),
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query: expect.stringContaining(`has:${parameter.column}`),
+            }),
+          })
+        );
+      }
     }
   }, 10000);
 


### PR DESCRIPTION
For the performance trends view, add current trend parameter field value as an additional condition filter to the query