### PR TITLE
feat(storybook): Use storybook-dark-mode plugin

### DIFF
--- a/.storybook/globalStyles.tsx
+++ b/.storybook/globalStyles.tsx
@@ -3,7 +3,7 @@ import {css, Global} from '@emotion/react';
 import space from 'sentry/styles/space';
 import {Theme} from 'sentry/utils/theme';
 
-const styles = (theme: Theme) => css`
+const docsStyles = (theme: Theme) => css`
   html,
   body {
     font-family: ${theme.text.family};
@@ -25,6 +25,9 @@ const styles = (theme: Theme) => css`
     display: flex;
     justify-content: center;
     background: ${theme.background};
+  }
+  body.sb-show-main {
+    background: ${theme.background} !important;
   }
   .sbdocs.sbdocs-wrapper {
     padding: calc(${space(4)} * 3) calc(${space(4)} * 2);
@@ -164,8 +167,16 @@ const styles = (theme: Theme) => css`
   }
 `;
 
-const PreviewGlobalStyles = ({theme}: {theme: Theme}) => (
-  <Global styles={styles(theme)} />
+export const DocsGlobalStyles = ({theme}: {theme: Theme}) => (
+  <Global styles={docsStyles(theme)} />
 );
 
-export default PreviewGlobalStyles;
+const storyStyles = (theme: Theme) => css`
+  body.sb-show-main {
+    background: ${theme.background} !important;
+  }
+`;
+
+export const StoryGlobalStyles = ({theme}: {theme: Theme}) => (
+  <Global styles={storyStyles(theme)} />
+);

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,6 +21,7 @@ const config: StorybookConfig = {
     },
     '@storybook/addon-a11y',
     '@storybook/addon-links',
+    'storybook-dark-mode',
   ],
 
   // For whatever reason the `babel` config override is not present in

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,17 +1,6 @@
 import {addons} from '@storybook/addons';
-import {create} from '@storybook/theming';
-
-const theme = create({
-  base: 'light',
-  brandTitle: 'Sentry UI System',
-  brandUrl: '#',
-  fontBase: '"Rubik", sans-serif',
-  // To control appearance:
-  // brandImage: 'http://url.of/some.svg',
-});
 
 addons.setConfig({
   showRoots: true,
   panelPosition: 'bottom',
-  theme,
 });

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,6 +4,7 @@ import 'docs-ui/index.js';
 import {Fragment} from 'react';
 import {DocsContainer, Meta} from '@storybook/addon-docs';
 import {addDecorator, addParameters, DecoratorFn, Parameters} from '@storybook/react';
+import {themes} from '@storybook/theming';
 import Code from 'docs-ui/components/code';
 import ColorChip from 'docs-ui/components/colorChip';
 import DocsLinks from 'docs-ui/components/docsLinks';
@@ -11,15 +12,16 @@ import DoDont from 'docs-ui/components/doDont';
 import Sample from 'docs-ui/components/sample';
 import TableOfContents from 'docs-ui/components/tableOfContents';
 import {ThemeProvider} from 'emotion-theming';
+import {useDarkMode} from 'storybook-dark-mode';
 
 import GlobalStyles from 'sentry/styles/global';
-import {darkTheme, lightTheme} from 'sentry/utils/theme';
+import {darkTheme, lightTheme, Theme} from 'sentry/utils/theme';
 
-import PreviewGlobalStyles from './previewGlobalStyles';
+import {DocsGlobalStyles, StoryGlobalStyles} from './globalStyles';
 
 // Theme decorator for stories
 const withThemeStory: DecoratorFn = (Story, context) => {
-  const isDark = context.globals.theme === 'dark';
+  const isDark = useDarkMode();
   const currentTheme = isDark ? darkTheme : lightTheme;
 
   // Set @storybook/addon-backgrounds current color based on theme
@@ -30,6 +32,7 @@ const withThemeStory: DecoratorFn = (Story, context) => {
   return (
     <ThemeProvider theme={currentTheme}>
       <GlobalStyles isDark={isDark} theme={currentTheme} />
+      <StoryGlobalStyles theme={currentTheme} />
       <Story {...context} />
     </ThemeProvider>
   );
@@ -39,7 +42,7 @@ addDecorator(withThemeStory);
 
 // Theme decorator for MDX Docs
 const withThemeDocs: DecoratorFn = ({children, context}) => {
-  const isDark = context.globals.theme === 'dark';
+  const isDark = useDarkMode();
   const currentTheme = isDark ? darkTheme : lightTheme;
 
   // Set @storybook/addon-backgrounds current color based on theme
@@ -53,7 +56,7 @@ const withThemeDocs: DecoratorFn = ({children, context}) => {
     <Fragment>
       <DocsContainer context={context}>
         <GlobalStyles isDark={isDark} theme={currentTheme} />
-        <PreviewGlobalStyles theme={currentTheme} />
+        <DocsGlobalStyles theme={currentTheme} />
         <ThemeProvider theme={currentTheme}>{children}</ThemeProvider>
       </DocsContainer>
       <ThemeProvider theme={currentTheme}>
@@ -190,40 +193,37 @@ addParameters({
   },
 });
 
-export const globalTypes = {
-  theme: {
-    name: 'Theme',
-    description: 'Global theme for components',
-    defaultValue: 'light',
-    toolbar: {
-      icon: 'circlehollow',
-      // array of plain string values or MenuItem shape (see below)
-      items: [
-        {value: 'light', icon: 'circlehollow', title: 'light'},
-        {value: 'dark', icon: 'circle', title: 'dark'},
-      ],
-    },
-  },
+const commonTheme = {
+  brandTitle: 'Sentry UI System',
+  brandUrl: '#',
+  fontBase: '"Rubik", sans-serif',
 };
 
+const getThemeColors = (theme: Theme) => ({
+  appBg: theme.bodyBackground,
+  appContentBg: theme.background,
+  appBorderColor: theme.innerBorder,
+  textColor: theme.textColor,
+  textInverseColor: theme.white,
+  barTextColor: theme.subText,
+  barSelectedColor: theme.active,
+  barBg: theme.background,
+  inputBg: theme.backgroundElevated,
+  inputBorder: theme.border,
+  inputTextColor: theme.textColor,
+});
+
 export const parameters: Parameters = {
-  /**
-   * @storybook/addon-backgrounds background is controlled via theme
-   */
-  backgrounds: {
-    grid: {
-      disable: true,
+  darkMode: {
+    dark: {
+      ...themes.dark,
+      ...commonTheme,
+      ...getThemeColors(darkTheme),
     },
-    default: 'light',
-    values: [
-      {
-        name: 'light',
-        value: lightTheme.background,
-      },
-      {
-        name: 'dark',
-        value: darkTheme.background,
-      },
-    ],
+    light: {
+      ...themes.normal,
+      ...commonTheme,
+      ...getThemeColors(lightTheme),
+    },
   },
 };

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "react-test-renderer": "17.0.2",
     "size-limit": "^5.0.5",
     "speed-measure-webpack-plugin": "^1.5.0",
+    "storybook-dark-mode": "^1.0.8",
     "stylelint": "13.13.1",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-recommended": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7373,7 +7373,7 @@ extract-zip@2.0.1:
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.0.0, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -13844,6 +13844,14 @@ storybook-addon-outline@^1.4.1:
     "@storybook/components" "^6.3.0"
     "@storybook/core-events" "^6.3.0"
     ts-dedent "^2.1.1"
+
+storybook-dark-mode@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/storybook-dark-mode/-/storybook-dark-mode-1.0.8.tgz#bbd64b382fd62d38685fdd769e2cac4e32ec293d"
+  integrity sha512-uY6yTSd1vYE0YwlON50u+iIoNF/fmMj59ww1cpd/naUcmOmCjwawViKFG5YjichwdR/yJ5ybWRUF0tnRQfaSiw==
+  dependencies:
+    fast-deep-equal "^3.0.0"
+    memoizerific "^1.11.3"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Add support for dark mode (for Storybook's entire UI in addition to the just the story/docs contents).

[Preview.](https://storybook-3ul0tk5l0.sentry.dev/?path=/story/components-buttons--overview)

**Before - when theme is set to `dark`:**

<img width="1512" alt="Screen Shot 2022-01-13 at 11 33 41 AM" src="https://user-images.githubusercontent.com/44172267/149397094-45fe9cb5-4337-45a3-811a-c342adb18a0c.png">

**After:**

<img width="1512" alt="Screen Shot 2022-01-13 at 11 34 00 AM" src="https://user-images.githubusercontent.com/44172267/149397132-357310dd-a2e7-4de3-a6fb-dde17dc3dc07.png">

