### PR TITLE
ref(ui): Update <SmartSearchBar />'s focus state

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1361,7 +1361,11 @@ class SmartSearchBar extends React.Component<Props, State> {
     const cursor = this.cursorPosition;
 
     return (
-      <Container ref={this.containerRef} className={className} isOpen={inputHasFocus}>
+      <Container
+        ref={this.containerRef}
+        className={className}
+        inputHasFocus={inputHasFocus}
+      >
         <SearchLabel htmlFor="smart-search-input" aria-label={t('Search events')}>
           <IconSearch />
           {inlineLabel}
@@ -1450,7 +1454,7 @@ export default withApi(withRouter(withOrganization(SmartSearchBarContainer)));
 
 export {SmartSearchBar};
 
-const Container = styled('div')<{isOpen: boolean}>`
+const Container = styled('div')<{inputHasFocus: boolean}>`
   border: 1px solid ${p => p.theme.border};
   box-shadow: inset ${p => p.theme.dropShadowLight};
   background: ${p => p.theme.background};
@@ -1461,14 +1465,18 @@ const Container = styled('div')<{isOpen: boolean}>`
   gap: ${space(1)};
   align-items: start;
 
-  border-radius: ${p =>
-    p.isOpen
-      ? `${p.theme.borderRadius} ${p.theme.borderRadius} 0 0`
-      : p.theme.borderRadius};
+  border-radius: ${p => p.theme.borderRadius};
 
   .show-sidebar & {
     background: ${p => p.theme.backgroundSecondary};
   }
+
+  ${p =>
+    p.inputHasFocus &&
+    `
+    border-color: ${p.theme.focusBorder};
+    box-shadow: 0 0 0 1px ${p.theme.focusBorder};
+  `}
 `;
 
 const SearchLabel = styled('label')`

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -115,10 +115,11 @@ const StyledSearchDropdown = styled('div')`
   right: -1px;
   z-index: ${p => p.theme.zIndex.dropdown};
   overflow: hidden;
+  margin-top: ${space(1)};
   background: ${p => p.theme.background};
-  box-shadow: ${p => p.theme.dropShadowLight};
+  box-shadow: ${p => p.theme.dropShadowHeavy};
   border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadiusBottom};
+  border-radius: ${p => p.theme.borderRadius};
 `;
 
 const LoadingWrapper = styled('div')`


### PR DESCRIPTION
With a focus ring and detached dropdown menu design.

**Before:**
<img width="866" alt="Screen Shot 2022-01-13 at 12 03 15 PM" src="https://user-images.githubusercontent.com/44172267/149401090-2508f1cf-11a3-4061-86ff-5023cd5e2845.png">


**After:**
<img width="866" alt="Screen Shot 2022-01-13 at 12 03 33 PM" src="https://user-images.githubusercontent.com/44172267/149401137-1d75e70e-acd9-4553-9c80-0b5b6fdb0bc6.png">

