### PR TITLE
fix(teamStats): Adjust gap between bar charts

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -144,6 +144,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
                 seriesName: t('Alerts Triggered'),
                 data: seriesData,
                 silent: true,
+                barCategoryGap: '10%',
               },
             ]}
           />

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -144,7 +144,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
                 seriesName: t('Alerts Triggered'),
                 data: seriesData,
                 silent: true,
-                barCategoryGap: '10%',
+                barCategoryGap: '5%',
               },
             ]}
           />

--- a/static/app/views/organizationStats/teamInsights/teamIssuesAge.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesAge.tsx
@@ -130,7 +130,7 @@ class TeamIssuesAge extends AsyncComponent<Props, State> {
                   seriesName: t('Unresolved Issues'),
                   silent: true,
                   data: seriesData,
-                  barCategoryGap: '10%',
+                  barCategoryGap: '5%',
                 },
               ]}
             />

--- a/static/app/views/organizationStats/teamInsights/teamIssuesAge.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesAge.tsx
@@ -130,6 +130,7 @@ class TeamIssuesAge extends AsyncComponent<Props, State> {
                   seriesName: t('Unresolved Issues'),
                   silent: true,
                   data: seriesData,
+                  barCategoryGap: '10%',
                 },
               ]}
             />

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
@@ -149,6 +149,7 @@ class TeamIssuesBreakdown extends AsyncComponent<Props, State> {
         animationDuration: 500,
         animationDelay: idx * 500,
         silent: true,
+        barCategoryGap: '10%',
       })
     );
 

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
@@ -149,7 +149,7 @@ class TeamIssuesBreakdown extends AsyncComponent<Props, State> {
         animationDuration: 500,
         animationDelay: idx * 500,
         silent: true,
-        barCategoryGap: '10%',
+        barCategoryGap: '5%',
       })
     );
 

--- a/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
@@ -142,7 +142,7 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
                   silent: true,
                   animationDuration: 500,
                   animationDelay: 0,
-                  barCategoryGap: '10%',
+                  barCategoryGap: '5%',
                 },
                 {
                   seriesName: t('Not Reviewed'),
@@ -150,7 +150,7 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
                   silent: true,
                   animationDuration: 500,
                   animationDelay: 500,
-                  barCategoryGap: '10%',
+                  barCategoryGap: '5%',
                 },
               ]}
             />

--- a/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
@@ -142,6 +142,7 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
                   silent: true,
                   animationDuration: 500,
                   animationDelay: 0,
+                  barCategoryGap: '10%',
                 },
                 {
                   seriesName: t('Not Reviewed'),
@@ -149,6 +150,7 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
                   silent: true,
                   animationDuration: 500,
                   animationDelay: 500,
+                  barCategoryGap: '10%',
                 },
               ]}
             />

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -219,6 +219,7 @@ class TeamReleases extends AsyncComponent<Props, State> {
                     show: false,
                   },
                 }),
+                barCategoryGap: '10%',
               },
             ]}
             tooltip={{

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -219,7 +219,7 @@ class TeamReleases extends AsyncComponent<Props, State> {
                     show: false,
                   },
                 }),
-                barCategoryGap: '10%',
+                barCategoryGap: '5%',
               },
             ]}
             tooltip={{

--- a/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
@@ -96,7 +96,7 @@ class TeamResolutionTime extends AsyncComponent<Props, State> {
               seriesName: t('Time to Resolution'),
               data: seriesData,
               silent: true,
-              barCategoryGap: '10%',
+              barCategoryGap: '5%',
             },
           ]}
         />

--- a/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
@@ -96,6 +96,7 @@ class TeamResolutionTime extends AsyncComponent<Props, State> {
               seriesName: t('Time to Resolution'),
               data: seriesData,
               silent: true,
+              barCategoryGap: '10%',
             },
           ]}
         />

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
@@ -172,7 +172,7 @@ class TeamUnresolvedIssues extends AsyncComponent<Props, State> {
                   seriesName: t('Unresolved Issues'),
                   silent: true,
                   data: seriesData,
-                  barCategoryGap: '10%',
+                  barCategoryGap: '5%',
                 },
               ]}
             />

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
@@ -172,6 +172,7 @@ class TeamUnresolvedIssues extends AsyncComponent<Props, State> {
                   seriesName: t('Unresolved Issues'),
                   silent: true,
                   data: seriesData,
+                  barCategoryGap: '10%',
                 },
               ]}
             />


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/1400464/149419806-988d260c-835f-4bee-af3f-72aeaf7d43e0.png)

after
![image](https://user-images.githubusercontent.com/1400464/149419843-dbdd55c6-ab6e-41f4-a573-ecf37179b64e.png)
