### PR TITLE
fix(dashboards): TopN widgets Open in Discover opens with TopN display type

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -89,6 +89,9 @@ function WidgetCardContextMenu({
           case DisplayType.BAR:
             discoverLocation.query.display = DisplayModes.BAR;
             break;
+          case DisplayType.TOP_N:
+            discoverLocation.query.display = DisplayModes.TOP5;
+            break;
           default:
             break;
         }

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -156,6 +156,39 @@ describe('Dashboards > WidgetCard', function () {
     );
   });
 
+  it('Opens in Discover with Top N', async function () {
+    mountWithTheme(
+      <WidgetCard
+        api={api}
+        organization={initialData.organization}
+        widget={{
+          ...multipleQueryWidget,
+          displayType: DisplayType.TOP_N,
+          queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
+        }}
+        selection={selection}
+        isEditing={false}
+        onDelete={() => undefined}
+        onEdit={() => undefined}
+        onDuplicate={() => undefined}
+        renderErrorMessage={() => undefined}
+        isSorting={false}
+        currentWidgetDragging={false}
+        showContextMenu
+        widgetLimitReached={false}
+      />
+    );
+
+    await tick();
+
+    userEvent.click(screen.getByTestId('context-menu'));
+    expect(screen.getByText('Open in Discover')).toBeInTheDocument();
+    expect(screen.getByText('Open in Discover').closest('a')).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/discover/results/?display=top5&environment=prod&field=count%28%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29'
+    );
+  });
+
   it('calls onDuplicate when Duplicate Widget is clicked', async function () {
     const mock = jest.fn();
     mountWithTheme(


### PR DESCRIPTION
Fixes TopN widgets not opening in Discover in TopN display type when clicking open in discover
![image](https://user-images.githubusercontent.com/83961295/149407886-99d70dda-460e-4c88-b84e-1da6c7d40737.png)
![image](https://user-images.githubusercontent.com/83961295/149407916-f1bd6f46-ba19-499d-ba16-fe550af2bd63.png)
