### PR TITLE
ref(webhooks): Use ApiClient

### DIFF
--- a/src/sentry/plugins/sentry_webhooks/client.py
+++ b/src/sentry/plugins/sentry_webhooks/client.py
@@ -1,0 +1,21 @@
+from sentry_plugins.client import ApiClient
+
+
+class WebhookApiClient(ApiClient):
+    plugin_name = "webhook"
+    allow_redirects = False
+    datadog_prefix = "integrations.webhook"
+
+    def __init__(self, data):
+        self.data = data
+        super().__init__(verify_ssl=False)
+
+    def request(self, url):
+        return self._request(
+            path=url,
+            method="post",
+            data=self.data,
+            json=True,
+            timeout=5,
+            allow_text=True,
+        )

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -7,11 +7,12 @@ from requests.exceptions import ConnectionError, ReadTimeout
 
 import sentry
 from sentry.exceptions import PluginError
-from sentry.http import is_valid_url, safe_urlopen
+from sentry.http import is_valid_url
 from sentry.integrations import FeatureDescription, IntegrationFeatures
 from sentry.plugins.bases import notify
 from sentry.utils.compat import filter
-from sentry.utils.safe import safe_execute
+
+from .client import WebhookApiClient
 
 DESCRIPTION = """
 Trigger outgoing HTTP POST requests from Sentry.
@@ -118,17 +119,19 @@ class WebHooksPlugin(notify.NotificationPlugin):
     def get_webhook_urls(self, project):
         return split_urls(self.get_option("urls", project))
 
-    def send_webhook(self, url, payload):
-        return safe_urlopen(url=url, json=payload, timeout=self.timeout, verify_ssl=False)
+    def get_client(self, payload):
+        return WebhookApiClient(payload)
 
     def notify_users(self, group, event, triggering_rules, fail_silently=False, **kwargs):
         payload = self.get_group_data(group, event, triggering_rules)
+        client = self.get_client(payload)
         for url in self.get_webhook_urls(group.project):
-            # TODO: Use API client with raise_error
-            safe_execute(
-                self.send_webhook,
-                url,
-                payload,
-                _with_transaction=False,
-                expected_errors=(ReadTimeout, ConnectionError),
-            )
+            try:
+                client.request(
+                    url,
+                )
+            except Exception as exc:
+                if isinstance(exc, (ReadTimeout, ConnectionError)):
+                    pass
+                else:
+                    raise (exc)

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -127,11 +127,6 @@ class WebHooksPlugin(notify.NotificationPlugin):
         client = self.get_client(payload)
         for url in self.get_webhook_urls(group.project):
             try:
-                client.request(
-                    url,
-                )
-            except Exception as exc:
-                if isinstance(exc, (ReadTimeout, ConnectionError)):
-                    pass
-                else:
-                    raise (exc)
+                client.request(url)
+            except (ReadTimeout, ConnectionError):
+                pass

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -38,7 +38,7 @@ class WebHooksPluginTest(TestCase):
 
     def test_webhook_validation(self):
         # Test that you can't sneak a bad domain into the list of webhooks
-        # without it being validated by delmiting with \r instead of \n
+        # without it being validated by delimiting with \r instead of \n
         bad_urls = "http://example.com\rftp://baddomain.com"
         form = WebHooksOptionsForm(data={"urls": bad_urls})
         form.is_valid()


### PR DESCRIPTION
This PR refactors the webhook plugin to the the `ApiClient` - this allows us to get free instrumentation to Datadog and Sentry.