### PR TITLE
fix(echarts): Use default echarts bar series type

### DIFF
--- a/static/app/components/charts/series/barSeries.tsx
+++ b/static/app/components/charts/series/barSeries.tsx
@@ -2,25 +2,9 @@ import 'echarts/lib/chart/bar';
 
 import type {BarSeriesOption} from 'echarts';
 
-/**
- * TODO(ts): Bar chart can accept multiple values with an object, currently defined types are incorrect
- * See https://echarts.apache.org/en/option.html#series-bar.data
- */
-type BarChartDataObject = Omit<BarSeriesOption['data'], 'value'> & {
-  value: (string | number) | (string | number)[];
-};
-
-type Props = Omit<BarSeriesOption, 'data'> & {
-  data?:
-    | (string | number | void | BarChartDataObject | (string | number)[])[]
-    | (string | number | void | BarChartDataObject)[][]
-    | undefined;
-};
-
-function barSeries({data, ...rest}: Props): BarSeriesOption {
+function barSeries(props: BarSeriesOption): BarSeriesOption {
   return {
-    ...rest,
-    data: data as BarSeriesOption['data'],
+    ...props,
     type: 'bar',
   };
 }


### PR DESCRIPTION
I think we made a type because the old types were incorrect