### PR TITLE
ref(tsc): improve locale types

### DIFF
--- a/static/app/components/group/inboxBadges/inboxReason.tsx
+++ b/static/app/components/group/inboxBadges/inboxReason.tsx
@@ -92,7 +92,7 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
   function getReasonDetails(): {
     reasonBadgeText: string;
     tagType: React.ComponentProps<typeof Tag>['type'];
-    tooltipDescription?: string | React.ReactElement;
+    tooltipDescription?: string | React.ReactNode;
     tooltipText?: string;
   } {
     switch (reason) {

--- a/static/app/components/group/sentryAppExternalIssueActions.tsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.tsx
@@ -116,7 +116,7 @@ class SentryAppExternalIssueActions extends React.Component<Props, State> {
     const name = sentryAppComponent.sentryApp.name;
 
     let url = '#';
-    let displayName: React.ReactElement | string = tct('Link [name] Issue', {name});
+    let displayName: React.ReactNode | string = tct('Link [name] Issue', {name});
 
     if (externalIssue) {
       url = externalIssue.webUrl;

--- a/static/app/components/pagination.tsx
+++ b/static/app/components/pagination.tsx
@@ -24,7 +24,7 @@ export type CursorHandler = (
 ) => void;
 
 type Props = WithRouterProps & {
-  caption?: React.ReactElement;
+  caption?: React.ReactNode;
   className?: string;
   disabled?: boolean;
   onCursor?: CursorHandler;

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as Sentry from '@sentry/react';
 import Jed from 'jed';
-import isArray from 'lodash/isArray';
 import isObject from 'lodash/isObject';
 import isString from 'lodash/isString';
 import {sprintf} from 'sprintf-js';
@@ -41,7 +40,7 @@ export function toggleLocaleDebug() {
 /**
  * Global Jed locale object loaded with translations via setLocale
  */
-let i18n: any = null;
+let i18n: Jed | null = null;
 
 /**
  * Set the current application locale.
@@ -68,7 +67,7 @@ type FormatArg = ComponentMap | React.ReactNode;
  * Helper to return the i18n client, and initialize for the default locale (English)
  * if it has otherwise not been initialized.
  */
-function getClient() {
+function getClient(): Jed | null {
   if (!i18n) {
     // If this happens, it could mean that an import was added/changed where
     // locale initialization does not happen soon enough.
@@ -84,7 +83,7 @@ function getClient() {
 /**
  * printf style string formatting which render as react nodes.
  */
-function formatForReact(formatString: string, args: FormatArg[]) {
+function formatForReact(formatString: string, args: FormatArg[]): React.ReactNode[] {
   const nodes: React.ReactNodeArray = [];
   let cursor = 0;
 
@@ -125,7 +124,7 @@ function formatForReact(formatString: string, args: FormatArg[]) {
 /**
  * Determine if any arguments include React elements.
  */
-function argsInvolveReact(args: FormatArg[]) {
+function argsInvolveReact(args: FormatArg[]): boolean {
   if (args.some(React.isValidElement)) {
     return true;
   }
@@ -169,7 +168,7 @@ type ComponentMap = {[group: string]: React.ReactNode};
  * The top level group will be keyed as `root`. All other group names will have
  * been extracted from the template string.
  */
-export function parseComponentTemplate(template: string) {
+export function parseComponentTemplate(template: string): ParsedTemplate {
   const parsed: ParsedTemplate = {};
 
   function process(startPos: number, group: string, inGroup: boolean) {
@@ -230,7 +229,10 @@ export function parseComponentTemplate(template: string) {
  * Renders a parsed template into a React tree given a ComponentMap to use for
  * the parsed groups.
  */
-export function renderTemplate(template: ParsedTemplate, components: ComponentMap) {
+export function renderTemplate(
+  template: ParsedTemplate,
+  components: ComponentMap
+): React.ReactNode {
   let idx = 0;
 
   function renderGroup(groupKey: string) {
@@ -269,30 +271,29 @@ export function renderTemplate(template: ParsedTemplate, components: ComponentMa
  * NOTE: This is a no-op and will return the node if LOCALE_DEBUG is not
  * currently enabled. See setLocaleDebug and toggleLocaleDebug.
  */
-function mark<T>(node: T): T {
+function mark(node: string | React.ReactNode): string {
   if (!LOCALE_DEBUG) {
-    return node;
+    return node as string;
   }
 
   // TODO(epurkhiser): Explain why we manually create a react node and assign
   // the toString function. This could likely also use better typing, but will
   // require some understanding of reacts internal types.
-  const proxy: any = {
+  const proxy: React.ReactNode = {
     $$typeof: Symbol.for('react.element'),
     type: 'span',
     key: null,
     ref: null,
     props: {
       style: markerStyles,
-      children: isArray(node) ? node : [node],
+      children: Array.isArray(node) ? node : [node],
     },
     _owner: null,
     _store: {},
   };
 
   proxy.toString = () => '✅' + node + '✅';
-
-  return proxy;
+  return proxy as string;
 }
 
 /**
@@ -303,7 +304,10 @@ function mark<T>(node: T): T {
  *
  * [0]: https://github.com/alexei/sprintf.js
  */
-export function format(formatString: string, args: FormatArg[]) {
+export function format(
+  formatString: string,
+  args: FormatArg[]
+): string | React.ReactNode {
   if (argsInvolveReact(args)) {
     return formatForReact(formatString, args);
   }
@@ -319,7 +323,7 @@ export function format(formatString: string, args: FormatArg[]) {
  *
  * [0]: https://github.com/alexei/sprintf.js
  */
-export function gettext(string: string, ...args: FormatArg[]) {
+export function gettext(string: string, ...args: FormatArg[]): string {
   const val: string = getClient().gettext(string);
 
   if (args.length === 0) {
@@ -329,7 +333,7 @@ export function gettext(string: string, ...args: FormatArg[]) {
   // XXX(ts): It IS possible to use gettext in such a way that it will return a
   // React.ReactNodeArray, however we currently rarely (if at all) use it in
   // this way, and usually just expect strings back.
-  return mark(format(val, args) as string);
+  return mark(format(val, args));
 }
 
 /**
@@ -342,7 +346,7 @@ export function gettext(string: string, ...args: FormatArg[]) {
  *
  * [0]: https://github.com/alexei/sprintf.js
  */
-export function ngettext(singular: string, plural: string, ...args: FormatArg[]) {
+export function ngettext(singular: string, plural: string, ...args: FormatArg[]): string {
   let countArg = 0;
 
   if (args.length > 0) {
@@ -379,7 +383,10 @@ export function ngettext(singular: string, plural: string, ...args: FormatArg[])
  *
  * You may recursively nest additional groups within the grouped string values.
  */
-export function gettextComponentTemplate(template: string, components: ComponentMap) {
+export function gettextComponentTemplate(
+  template: string,
+  components: ComponentMap
+): React.ReactNode {
   const tmpl = parseComponentTemplate(getClient().gettext(template));
   return mark(renderTemplate(tmpl, components));
 }

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -271,7 +271,7 @@ export function renderTemplate(
  * NOTE: This is a no-op and will return the node if LOCALE_DEBUG is not
  * currently enabled. See setLocaleDebug and toggleLocaleDebug.
  */
-function mark(node: string | React.ReactNode): string {
+function mark(node: React.ReactNode): string {
   if (!LOCALE_DEBUG) {
     return node as string;
   }
@@ -279,7 +279,7 @@ function mark(node: string | React.ReactNode): string {
   // TODO(epurkhiser): Explain why we manually create a react node and assign
   // the toString function. This could likely also use better typing, but will
   // require some understanding of reacts internal types.
-  const proxy: React.ReactNode = {
+  const proxy = {
     $$typeof: Symbol.for('react.element'),
     type: 'span',
     key: null,
@@ -293,7 +293,7 @@ function mark(node: string | React.ReactNode): string {
   };
 
   proxy.toString = () => '✅' + node + '✅';
-  return proxy as string;
+  return proxy as unknown as string;
 }
 
 /**
@@ -304,10 +304,7 @@ function mark(node: string | React.ReactNode): string {
  *
  * [0]: https://github.com/alexei/sprintf.js
  */
-export function format(
-  formatString: string,
-  args: FormatArg[]
-): string | React.ReactNode {
+export function format(formatString: string, args: FormatArg[]): React.ReactNode {
   if (argsInvolveReact(args)) {
     return formatForReact(formatString, args);
   }
@@ -386,9 +383,9 @@ export function ngettext(singular: string, plural: string, ...args: FormatArg[])
 export function gettextComponentTemplate(
   template: string,
   components: ComponentMap
-): React.ReactNode {
-  const tmpl = parseComponentTemplate(getClient().gettext(template));
-  return mark(renderTemplate(tmpl, components));
+): string {
+  const parsedTemplate = parseComponentTemplate(getClient().gettext(template));
+  return mark(renderTemplate(parsedTemplate, components));
 }
 
 /**

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -22,7 +22,7 @@ import {BULK_LIMIT, BULK_LIMIT_STR, ConfirmAction} from './utils';
 type Props = {
   allResultsVisible: boolean;
   api: Client;
-  displayCount: React.ReactElement;
+  displayCount: React.ReactNode;
   displayReprocessingActions: boolean;
   groupIds: string[];
   onDelete: () => void;

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -200,7 +200,7 @@ const adoptionStagesLink = (
 
 export const ADOPTION_STAGE_LABELS: Record<
   string,
-  {name: string; tooltipTitle: JSX.Element; type: keyof Theme['tag']}
+  {name: string; tooltipTitle: React.ReactNode; type: keyof Theme['tag']}
 > = {
   low_adoption: {
     name: t('Low Adoption'),


### PR DESCRIPTION
Improve locale types by adding strict fn return type to eval perf wins. It's a bit hard to quantify how much a single return type helps, because it depends on how often it is used and how complex the inference is, but as discussed in the TSC, there's also the nice dev experience of being able to just see what a fn returns from it's signature w/o having to have to hover it.

I've ran the tests on before/after this change and while compile time varied it was always in the few second range (decrease). I've also ran this on an M1 cpu, so idk how representative of Sentry's eng machines this is, but it may be worth trying to run this on an intel based machine and see if the gains are larger.

TS diagnostics diff
```
Files: 4060 0
Lines: 655431 +4.00
Nodes: 2520402 +39.00
Identifiers: 820463 +18.00
Symbols: 2655099 -279.00
Types: 879026 -178.00
Instantiations: 3095640 -620.00
Memory used: 231998K -13280.00K
I/O read: 0.2s +0.10s
I/O write: 0s 0s
Parse time: 2.5s +0.10s
Bind time: 1.1s +0.20s
Check time: 24.8s -5.10s
Emit time: 0s 0s
Total time: 28.5s -4.90s
```

Requires https://github.com/getsentry/getsentry/pull/6882