### PR TITLE
fix(suspect-spans): All columns must be explicitly specified

### DIFF
--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -449,30 +449,15 @@ def query_suspect_span_groups(
     ] + [
         "array_join(spans_op)",
         "array_join(spans_group)",
-        "count()",
-        "count_unique(id)",
         # want a single event id to fetch from nodestore for the span description
         "any(id)",
     ]
 
     equations: List[str] = [
         strip_equation(column)
-        for column in suspect_span_columns.suspect_op_group_columns
+        for column in suspect_span_columns.suspect_op_group_columns + fields
         if is_equation(column)
     ]
-
-    # TODO: This adds all the possible fields to the query by default. However,
-    # due to the way shards aggregate the rows, this can be slow. As an
-    # optimization, allow the fields to be user specified to only get the
-    # necessary aggregations.
-    #
-    # As part of the transition, continue to add all possible fields when its
-    # not specified, but this should be removed in the future.
-    if not fields:
-        for column in SPAN_PERFORMANCE_COLUMNS.values():
-            for col in column.suspect_op_group_sort:
-                if not col.startswith("equation["):
-                    selected_columns.append(col)
 
     builder = QueryBuilder(
         dataset=Dataset.Discover,

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -491,7 +491,18 @@ class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndp
         with self.feature(self.FEATURES):
             response = self.client.get(
                 self.url,
-                data={"project": self.project.id},
+                data={
+                    "project": self.project.id,
+                    "field": [
+                        "percentileArray(spans_exclusive_time, 0.50)",
+                        "percentileArray(spans_exclusive_time, 0.75)",
+                        "percentileArray(spans_exclusive_time, 0.95)",
+                        "percentileArray(spans_exclusive_time, 0.99)",
+                        "count()",
+                        "count_unique(id)",
+                        "sumArray(spans_exclusive_time)",
+                    ],
+                },
                 format="json",
             )
 


### PR DESCRIPTION
Previously, some columns were still being added automatically with a default of
adding every column. This change ensures that all the desired columns must be
explicitly specified or it won't be returned.