### PR TITLE
fix(dashboard): Set line height on BigNumber to avoid clipping

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -354,6 +354,7 @@ const LoadingPlaceholder = styled(Placeholder)`
 
 const BigNumber = styled('div')`
   font-size: 32px;
+  line-height: 1;
   padding: ${space(1)} ${space(3)} ${space(3)} ${space(3)};
   * {
     text-align: left !important;


### PR DESCRIPTION
Before:
<img width="200" alt="Screen Shot 2022-01-14 at 11 24 26 AM" src="https://user-images.githubusercontent.com/22846452/149550002-d7aafcde-4282-4f1e-88c5-c2040f79c381.png">

After:
<img width="231" alt="Screen Shot 2022-01-14 at 11 26 05 AM" src="https://user-images.githubusercontent.com/22846452/149550017-9fbb0c17-a0b0-4a47-9716-2cf640008e5b.png">

The line-height was set to `24px` before, but the font-size here is `32px`, resulting in some clipping on both sides. `line-height: 1` makes the line height match the BigNumber `32px` font size.