### PR TITLE
fix(snuba-tests): wrap tag key in Column

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -320,7 +320,7 @@ def _get_snuba_query(
             continue
 
         try:
-            groupby[field] = resolve_tag_key(field)
+            groupby[field] = Column(resolve_tag_key(field))
         except MetricIndexNotFound:
             # exclude unresolved keys from groupby
             pass


### PR DESCRIPTION
Changes in https://github.com/getsentry/sentry/pull/31051 caused the following errors in [snuba CI](https://github.com/getsentry/snuba/runs/4819610231?check_suite_focus=true) sentry tests. 

```  File "/Users/meredith/sentry/src/sentry/utils/snuba.py", line 905, in _raw_snql_query
    body = query.snuba()
  File "/Users/meredith/sentry/.venv/lib/python3.8/site-packages/snuba_sdk/query.py", line 205, in snuba
    self.validate()
  File "/Users/meredith/sentry/.venv/lib/python3.8/site-packages/snuba_sdk/query.py", line 194, in validate
    VALIDATOR.visit(self)
  File "/Users/meredith/sentry/.venv/lib/python3.8/site-packages/snuba_sdk/query_visitors.py", line 91, in visit
    returns[field] = getattr(self, f"_visit_{field}")(getattr(query, field))
  File "/Users/meredith/sentry/.venv/lib/python3.8/site-packages/snuba_sdk/query_visitors.py", line 507, in _visit_groupby
    self.__list_validate(groupby)
  File "/Users/meredith/sentry/.venv/lib/python3.8/site-packages/snuba_sdk/query_visitors.py", line 497, in __list_validate
    v.validate()
AttributeError: 'str' object has no attribute 'validate'
``` 
The offending query's  groupby looked like `groupby=['tags[5]']` instead of being wrapped as a column like `Column(name='tags[5]', entity=None, subscriptable='tags', key='5')]` hence there being no `validate` attribute on the string `"tags[5]"`