### PR TITLE
feat(dev): Fix `jest --watch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "jest-circus": "27.0.6",
     "jest-fetch-mock": "^3.0.3",
     "jest-junit": "^9.0.0",
-    "jest-sentry-environment": "1.2.0",
+    "jest-sentry-environment": "1.3.0",
     "prettier": "2.3.2",
     "react-refresh": "^0.8.3",
     "react-select-event": "5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9652,10 +9652,10 @@ jest-runtime@^27.0.6:
     strip-bom "^4.0.0"
     yargs "^16.0.3"
 
-jest-sentry-environment@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/jest-sentry-environment/-/jest-sentry-environment-1.2.0.tgz#ccc0537cbf48e788b08eabb859ed2bf26a911fea"
-  integrity sha512-QeZ7FHpBJHMZngaiqHoFL3ddbEuZXzgAcc0auRBBkKk/4MLIcI/3wxLLx4w8pKVnmrvTBmmctZlkvuBxurjObA==
+jest-sentry-environment@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/jest-sentry-environment/-/jest-sentry-environment-1.3.0.tgz#7e2586e75ccaea99d495ea9af00aa49ef4ab4faa"
+  integrity sha512-bGYZUZ4ZNrLsisqrb8PG4E0S4OeIISbUrHvqwzZxL6IbKredOl+WCwldjqUVQjt7IPIPCpgqH6adB5M2l1qeIw==
 
 jest-serializer@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
Upgrades `jest-sentry-environment` which disables jest instrumentation in `watch` mode.