### PR TITLE
fix(Dashboards): Limits Top N widget to single query when switching visualization display type

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -323,6 +323,10 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       const newState = cloneDeep(prevState);
       const displayType = prevState.displayType as Widget['displayType'];
       const normalized = normalizeQueries(displayType, prevState.queries);
+      if (displayType === DisplayType.TOP_N) {
+        // TOP N display should only allow a single query
+        normalized.splice(1);
+      }
 
       if (!prevState.userHasModified) {
         // If the Widget is an issue widget,
@@ -333,10 +337,6 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
           set(newState, 'queries', widget.queries);
           set(newState, 'widgetType', WidgetType.ISSUE);
           return {...newState, errors: undefined};
-        }
-        if (displayType === DisplayType.TOP_N) {
-          // TOP N display should only allow a single query
-          normalized.splice(1);
         }
 
         // Default widget provided by Add to Dashboard from Discover

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -334,6 +334,10 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
           set(newState, 'widgetType', WidgetType.ISSUE);
           return {...newState, errors: undefined};
         }
+        if (displayType === DisplayType.TOP_N) {
+          // TOP N display should only allow a single query
+          normalized.splice(1);
+        }
 
         // Default widget provided by Add to Dashboard from Discover
         if (defaultWidgetQuery && defaultTableColumns) {

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -1064,6 +1064,35 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     wrapper.unmount();
   });
 
+  it('limits TopN display to one query when switching from another visualization', async () => {
+    reactMountWithTheme(
+      <AddDashboardWidgetModal
+        Header={stubEl}
+        Body={stubEl}
+        Footer={stubEl}
+        CloseButton={stubEl}
+        organization={initialData.organization}
+        onAddWidget={() => undefined}
+        onUpdateWidget={() => undefined}
+        widget={initialData.widget}
+        closeModal={() => void 0}
+        source={types.DashboardWidgetSource.DASHBOARDS}
+      />
+    );
+    userEvent.click(screen.getByText('Table'));
+    userEvent.click(await screen.findByText('Bar Chart'));
+    userEvent.click(screen.getByText('Add Query'));
+    userEvent.click(screen.getByText('Add Query'));
+    expect(
+      screen.getAllByPlaceholderText('Search for events, users, tags, and more').length
+    ).toEqual(3);
+    userEvent.click(screen.getByText('Bar Chart'));
+    userEvent.click(await screen.findByText('Top 5 Events'));
+    expect(
+      screen.getAllByPlaceholderText('Search for events, users, tags, and more').length
+    ).toEqual(1);
+  });
+
   describe('Issue Widgets', function () {
     function mountModalWithRtl({onAddWidget, onUpdateWidget, widget, source}) {
       return reactMountWithTheme(


### PR DESCRIPTION
https://github.com/getsentry/sentry/issues/31080

Fixes a bug where the user can create a TopN widget with more than one query by switching from a visualization with multiple queries to TopN