### PR TITLE
ref(webhooks): Handle unexpected webhook responses

### DIFF
--- a/src/sentry/plugins/sentry_webhooks/client.py
+++ b/src/sentry/plugins/sentry_webhooks/client.py
@@ -18,4 +18,5 @@ class WebhookApiClient(ApiClient):
             json=True,
             timeout=5,
             allow_text=True,
+            ignore_webhook_errors=True,
         )

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -68,6 +68,7 @@ class BaseApiClient(TrackResponseMixin):
         allow_text=None,
         allow_redirects=None,
         timeout=None,
+        ignore_webhook_errors=False,
     ):
 
         if allow_text is None:
@@ -141,7 +142,9 @@ class BaseApiClient(TrackResponseMixin):
             if resp.status_code == 204:
                 return {}
 
-            return BaseApiResponse.from_response(resp, allow_text=allow_text)
+            return BaseApiResponse.from_response(
+                resp, allow_text=allow_text, ignore_webhook_errors=ignore_webhook_errors
+            )
 
     # subclasses should override ``request``
     def request(self, *args, **kwargs):

--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -31,7 +31,7 @@ class BaseApiResponse:
         return {item["rel"]: item["url"] for item in requests.utils.parse_header_links(link_header)}
 
     @classmethod
-    def from_response(self, response, allow_text=False):
+    def from_response(self, response, allow_text=False, ignore_webhook_errors=False):
         from sentry.shared_integrations.response import (
             MappingApiResponse,
             SequenceApiResponse,
@@ -74,4 +74,6 @@ class BaseApiResponse:
         elif isinstance(data, (list, tuple)):
             return SequenceApiResponse(data, response.headers, response.status_code)
         else:
+            if ignore_webhook_errors:
+                return
             raise NotImplementedError


### PR DESCRIPTION
Users' webhooks may respond with things we don't expect, but this isn't really a problem, so we don't want to raise an error in this case.

Fixes [SENTRY-T3H](https://sentry.io/organizations/sentry/issues/2930778489/)