### PR TITLE
feat(workflow): Add unignored GroupHistory via expired_snoozes

### DIFF
--- a/src/sentry/tasks/clear_expired_snoozes.py
+++ b/src/sentry/tasks/clear_expired_snoozes.py
@@ -1,6 +1,7 @@
 from django.utils import timezone
 
 from sentry.models import Group, GroupSnooze, GroupStatus
+from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.signals import issue_unignored
 from sentry.tasks.base import instrumented_task
 
@@ -19,6 +20,7 @@ def clear_expired_snoozes():
     GroupSnooze.objects.filter(group__in=group_list).delete()
 
     for group in ignored_groups:
+        record_group_history(group, GroupHistoryStatus.UNIGNORED)
         issue_unignored.send_robust(
             project=group.project,
             user=None,

--- a/tests/sentry/tasks/test_clear_expired_snoozes.py
+++ b/tests/sentry/tasks/test_clear_expired_snoozes.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from django.utils import timezone
 
 from sentry.models import Group, GroupSnooze, GroupStatus
+from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 from sentry.tasks.clear_expired_snoozes import clear_expired_snoozes
 from sentry.testutils import TestCase
 
@@ -25,5 +26,12 @@ class ClearExpiredSnoozesTest(TestCase):
         assert Group.objects.get(id=group1.id).status == GroupStatus.UNRESOLVED
 
         assert Group.objects.get(id=group2.id).status == GroupStatus.IGNORED
+
+        assert GroupHistory.objects.filter(
+            group=group1, status=GroupHistoryStatus.UNIGNORED
+        ).exists()
+        assert not GroupHistory.objects.filter(
+            group=group2, status=GroupHistoryStatus.UNIGNORED
+        ).exists()
 
         assert send_robust.called


### PR DESCRIPTION
when clearing expired snoozes, adds a GroupHistory entry

Fixes [WOR-993](https://getsentry.atlassian.net/browse/WOR-993)