### PR TITLE
ref(ui): Standardize card title styles

### DIFF
--- a/static/app/components/charts/styles.tsx
+++ b/static/app/components/charts/styles.tsx
@@ -54,8 +54,8 @@ export const HeaderTitle = styled('div')`
   display: inline-grid;
   grid-auto-flow: column;
   gap: ${space(1)};
-  font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.textColor};
+  ${p => p.theme.text.cardTitle};
+  color: ${p => p.theme.headingColor};
   align-items: center;
 `;
 

--- a/static/app/components/scoreCard.tsx
+++ b/static/app/components/scoreCard.tsx
@@ -80,6 +80,7 @@ export const Score = styled('span')`
   flex-shrink: 1;
   font-size: 32px;
   line-height: 1;
+  color: ${p => p.theme.headingColor};
   white-space: nowrap;
 `;
 

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -686,6 +686,11 @@ const commonTheme = {
       letterSpacing: '-0.01em',
       lineHeight: 1.2,
     },
+    cardTitle: {
+      fontSize: '1rem',
+      fontWeight: 600,
+      lineHeight: 1.2,
+    },
   },
 
   dataCategory,

--- a/static/app/views/dashboardsV2/manage/dashboardCard.tsx
+++ b/static/app/views/dashboardsV2/manage/dashboardCard.tsx
@@ -95,7 +95,8 @@ const CardHeader = styled('div')`
 `;
 
 const Title = styled('div')`
-  color: ${p => p.theme.textColor};
+  ${p => p.theme.text.cardTitle};
+  color: ${p => p.theme.headingColor};
   ${overflowEllipsis};
 `;
 

--- a/static/app/views/eventsV2/querycard.tsx
+++ b/static/app/views/eventsV2/querycard.tsx
@@ -103,7 +103,8 @@ const QueryCardHeader = styled('div')`
 `;
 
 const QueryTitle = styled('div')`
-  color: ${p => p.theme.textColor};
+  ${p => p.theme.text.cardTitle};
+  color: ${p => p.theme.headingColor};
   ${overflowEllipsis};
 `;
 

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -311,6 +311,9 @@ const HeaderRow = styled('div')`
   grid-template-columns: 1fr auto;
   justify-content: space-between;
   align-items: center;
+
+  ${p => p.theme.text.cardTitle};
+  color: ${p => p.theme.headingColor};
 `;
 
 const StyledProjectCard = styled('div')`


### PR DESCRIPTION
(Follow-up to #31145) 
Add a key to the `theme` object - `theme.text.cardTitle` - to standardize card title styles.

**Before:**
<img width="422" alt="Screen Shot 2022-01-14 at 2 54 18 PM" src="https://user-images.githubusercontent.com/44172267/149595653-44d914eb-8443-4352-b196-84114070cc33.png">

**After:**
<img width="422" alt="Screen Shot 2022-01-14 at 2 53 53 PM" src="https://user-images.githubusercontent.com/44172267/149595625-a2b735ff-ebc3-41c0-8eed-6f0f91897e99.png">

