### PR TITLE
test(ui): Fix lint errors from updated lint rules

### DIFF
--- a/tests/js/spec/components/avatar.spec.tsx
+++ b/tests/js/spec/components/avatar.spec.tsx
@@ -211,7 +211,7 @@ describe('Avatar', function () {
       avatar2.unmount();
 
       mountWithTheme(<AvatarComponent sentryApp={sentryApp} isDefault />);
-      expect(screen.queryByTestId('default-sentry-app-avatar')).toBeInTheDocument();
+      expect(screen.getByTestId('default-sentry-app-avatar')).toBeInTheDocument();
     });
 
     it('renders the correct fallbacks for SentryAppAvatars', async function () {
@@ -220,7 +220,7 @@ describe('Avatar', function () {
 
       // No existing avatars
       const avatar1 = mountWithTheme(<AvatarComponent sentryApp={sentryApp} isColor />);
-      expect(screen.queryByTestId('default-sentry-app-avatar')).toBeInTheDocument();
+      expect(screen.getByTestId('default-sentry-app-avatar')).toBeInTheDocument();
       avatar1.unmount();
 
       // No provided `isColor` attribute
@@ -235,7 +235,7 @@ describe('Avatar', function () {
       // avatarType of `default`
       sentryApp.avatars[0].avatarType = 'default';
       mountWithTheme(<AvatarComponent sentryApp={sentryApp} isColor />);
-      expect(screen.queryByTestId('default-sentry-app-avatar')).toBeInTheDocument();
+      expect(screen.getByTestId('default-sentry-app-avatar')).toBeInTheDocument();
     });
   });
 });

--- a/tests/js/spec/components/bulkController/index.spec.tsx
+++ b/tests/js/spec/components/bulkController/index.spec.tsx
@@ -4,7 +4,7 @@ import {shallow} from 'sentry-test/enzyme';
 
 import BulkController from 'sentry/components/bulkController';
 
-function renderedComponent(
+function mountComponent(
   renderProp: Function,
   pageIds: string[],
   defaultSelectedIds?: string[]
@@ -54,7 +54,7 @@ describe('BulkController', function () {
 
   describe('renders', function () {
     beforeEach(function () {
-      wrapper = renderedComponent(renderProp, pageIds);
+      wrapper = mountComponent(renderProp, pageIds);
       toggleRow = wrapper.find('[data-test-id="toggleRow"]');
       selectPage = wrapper.find('[data-test-id="selectPage"]');
       deselectPage = wrapper.find('[data-test-id="deselectPage"]');
@@ -101,18 +101,18 @@ describe('BulkController', function () {
 
   describe('with default selectIds', function () {
     it('sets the defaults', function () {
-      wrapper = renderedComponent(renderProp, pageIds, ['2']);
+      wrapper = mountComponent(renderProp, pageIds, ['2']);
       expect(renderProp).toHaveBeenLastCalledWith(false, false, ['2']);
     });
 
     it('page is selected by default', function () {
-      wrapper = renderedComponent(renderProp, pageIds, pageIds);
+      wrapper = mountComponent(renderProp, pageIds, pageIds);
       expect(renderProp).toHaveBeenLastCalledWith(false, true, pageIds);
     });
 
     it('toggle the last unchecked option, should change button selectAll to true', function () {
       const defaultSelectedIds = ['1', '3'];
-      wrapper = renderedComponent(renderProp, pageIds, defaultSelectedIds);
+      wrapper = mountComponent(renderProp, pageIds, defaultSelectedIds);
       expect(renderProp).toHaveBeenLastCalledWith(false, false, defaultSelectedIds);
       toggleRow.simulate('click');
       expect(renderProp).toHaveBeenLastCalledWith(false, true, [

--- a/tests/js/spec/components/dashboards/widgetQueryFields.spec.tsx
+++ b/tests/js/spec/components/dashboards/widgetQueryFields.spec.tsx
@@ -100,7 +100,7 @@ describe('WidgetQueryFields', function () {
     const organization = TestStubs.Organization();
     let fields: QueryFieldValue[];
 
-    const rerender = () =>
+    const mountComponent = () =>
       reactMountWithTheme(
         <WidgetQueryFields
           widgetType={WidgetType.ISSUE}
@@ -146,7 +146,7 @@ describe('WidgetQueryFields', function () {
           field: 'assignee',
         },
       ];
-      rerender();
+      mountComponent();
     });
     it('renders issue and assignee columns', function () {
       expect(screen.getByText('issue')).toBeInTheDocument();
@@ -162,12 +162,12 @@ describe('WidgetQueryFields', function () {
       expect(screen.queryByText('assignee')).not.toBeInTheDocument();
       expect(screen.getByText('Add a Column')).toBeInTheDocument();
       userEvent.click(screen.getByText('Add a Column'));
-      rerender();
+      mountComponent();
       expect(screen.getByText('(Required)')).toBeInTheDocument();
       userEvent.click(screen.getByText('(Required)'));
-      rerender();
+      mountComponent();
       userEvent.click(screen.getByText('assignee'));
-      rerender();
+      mountComponent();
       expect(screen.getByText('assignee')).toBeInTheDocument();
     });
   });

--- a/tests/js/spec/components/events/interfaces/threadsV2.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/threadsV2.spec.tsx
@@ -257,7 +257,7 @@ describe('ThreadsV2', function () {
         mountWithTheme(<ThreadsV2 {...props} />, {organization: org});
 
         expect(
-          within(screen.queryAllByTestId('stack-trace-frame')[0]).getByText(
+          within(screen.getAllByTestId('stack-trace-frame')[0]).getByText(
             'sentry/controllers/welcome_controller.rb'
           )
         ).toBeInTheDocument();
@@ -279,7 +279,7 @@ describe('ThreadsV2', function () {
         ).toBeInTheDocument();
 
         expect(
-          within(screen.queryAllByTestId('stack-trace-frame')[0]).getByText(
+          within(screen.getAllByTestId('stack-trace-frame')[0]).getByText(
             'puma (3.12.6) lib/puma/server.rb'
           )
         ).toBeInTheDocument();
@@ -914,7 +914,7 @@ describe('ThreadsV2', function () {
         mountWithTheme(<ThreadsV2 {...props} />, {organization: org});
 
         expect(
-          within(screen.queryAllByTestId('stack-trace-frame')[0]).getByText(
+          within(screen.getAllByTestId('stack-trace-frame')[0]).getByText(
             '-[SentryClient crash]'
           )
         ).toBeInTheDocument();
@@ -936,7 +936,7 @@ describe('ThreadsV2', function () {
         ).toBeInTheDocument();
 
         expect(
-          within(screen.queryAllByTestId('stack-trace-frame')[0]).getByText('UIKit')
+          within(screen.getAllByTestId('stack-trace-frame')[0]).getByText('UIKit')
         ).toBeInTheDocument();
 
         userEvent.click(screen.getByRole('button', {name: 'Sort By Recent last'}));
@@ -1003,7 +1003,7 @@ describe('ThreadsV2', function () {
 
         // Check Verbose Function Names
         expect(
-          within(screen.queryAllByTestId('stack-trace-frame')[1]).getByText(
+          within(screen.getAllByTestId('stack-trace-frame')[1]).getByText(
             'ViewController.causeCrash'
           )
         ).toBeInTheDocument();
@@ -1012,14 +1012,14 @@ describe('ThreadsV2', function () {
         expect(within(displayOption3).getByRole('checkbox')).toBeChecked();
 
         expect(
-          within(screen.queryAllByTestId('stack-trace-frame')[1]).getByText(
+          within(screen.getAllByTestId('stack-trace-frame')[1]).getByText(
             'ViewController.causeCrash(Any) -> ()'
           )
         ).toBeInTheDocument();
 
         // Check Absolute Path Names
         expect(
-          within(screen.queryAllByTestId('stack-trace-frame')[1]).getByText('+0x085ac')
+          within(screen.getAllByTestId('stack-trace-frame')[1]).getByText('+0x085ac')
         ).toBeInTheDocument();
 
         userEvent.click(screen.queryAllByLabelText('Display option')[1]);
@@ -1028,7 +1028,7 @@ describe('ThreadsV2', function () {
         ).toBeChecked();
 
         expect(
-          within(screen.queryAllByTestId('stack-trace-frame')[1]).getByText('0x10008c5ac')
+          within(screen.getAllByTestId('stack-trace-frame')[1]).getByText('0x10008c5ac')
         ).toBeInTheDocument();
 
         // Check Full Stack Trace

--- a/tests/js/spec/components/modals/dashboardWidgetLibraryModal.spec.jsx
+++ b/tests/js/spec/components/modals/dashboardWidgetLibraryModal.spec.jsx
@@ -55,14 +55,14 @@ describe('Modals -> DashboardWidgetLibraryModal', function () {
     // Checking initial modal states
     container = mountModal({initialData});
 
-    expect(screen.queryByText('Duration Distribution')).toBeInTheDocument();
-    expect(screen.queryByText('High Throughput Transactions')).toBeInTheDocument();
-    expect(screen.queryByText('LCP by Country')).toBeInTheDocument();
-    expect(screen.queryByText('Miserable Users')).toBeInTheDocument();
-    expect(screen.queryByText('Slow vs Fast Transactions')).toBeInTheDocument();
-    expect(screen.queryByText('Latest Unresolved Issues')).toBeInTheDocument();
-    expect(screen.queryByText('Top Unhandled Error Types')).toBeInTheDocument();
-    expect(screen.queryByText('Users Affected by Errors')).toBeInTheDocument();
+    expect(screen.getByText('Duration Distribution')).toBeInTheDocument();
+    expect(screen.getByText('High Throughput Transactions')).toBeInTheDocument();
+    expect(screen.getByText('LCP by Country')).toBeInTheDocument();
+    expect(screen.getByText('Miserable Users')).toBeInTheDocument();
+    expect(screen.getByText('Slow vs Fast Transactions')).toBeInTheDocument();
+    expect(screen.getByText('Latest Unresolved Issues')).toBeInTheDocument();
+    expect(screen.getByText('Top Unhandled Error Types')).toBeInTheDocument();
+    expect(screen.getByText('Users Affected by Errors')).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {name: 'Widget Library beta', current: true})

--- a/tests/js/spec/components/modals/reprocessEventModal.spec.tsx
+++ b/tests/js/spec/components/modals/reprocessEventModal.spec.tsx
@@ -15,7 +15,7 @@ const organization = TestStubs.Organization({
   features: ['reprocessing-v2'],
 });
 
-async function renderComponent() {
+async function mountComponent() {
   const modal = await mountGlobalModal();
 
   openReprocessEventModal({organization, groupId: group.id});
@@ -31,7 +31,7 @@ describe('ReprocessEventModal', function () {
   let wrapper: any;
 
   beforeEach(async function () {
-    wrapper = await renderComponent();
+    wrapper = await mountComponent();
   });
 
   it('modal is open', () => {

--- a/tests/js/spec/components/modals/sentryAppDetailsModal.spec.jsx
+++ b/tests/js/spec/components/modals/sentryAppDetailsModal.spec.jsx
@@ -12,7 +12,7 @@ describe('SentryAppDetailsModal', function () {
   const installButton = 'Button[data-test-id="install"]';
   let sentryAppInteractionRequest;
 
-  function render() {
+  function mount() {
     return mountWithTheme(
       <SentryAppDetailsModal
         sentryApp={sentryApp}
@@ -45,7 +45,7 @@ describe('SentryAppDetailsModal', function () {
       body: {},
     });
 
-    wrapper = render();
+    wrapper = mount();
   });
 
   it('renders', () => {
@@ -81,7 +81,7 @@ describe('SentryAppDetailsModal', function () {
   describe('when the User does not have permission to install Integrations', () => {
     beforeEach(() => {
       org = {...org, access: []};
-      wrapper = render();
+      wrapper = mount();
     });
 
     it('does not display the Install button', () => {
@@ -92,7 +92,7 @@ describe('SentryAppDetailsModal', function () {
   describe('when the Integration is installed', () => {
     beforeEach(() => {
       isInstalled = true;
-      wrapper = render();
+      wrapper = mount();
     });
 
     it('disabled the Install button', () => {
@@ -103,7 +103,7 @@ describe('SentryAppDetailsModal', function () {
   describe('when the Integration requires no permissions', () => {
     beforeEach(() => {
       sentryApp = {...sentryApp, scopes: []};
-      wrapper = render();
+      wrapper = mount();
     });
 
     it('does not render permissions', () => {

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -139,7 +139,7 @@ describe('Sidebar', function () {
 
       rerender(getElement({location: {...router.location, pathname: 'new-path-name'}}));
 
-      await waitForElementToBeRemoved(() => screen.getByText("What's new in Sentry"));
+      await waitForElementToBeRemoved(() => screen.queryByText("What's new in Sentry"));
     });
 
     it('can have onboarding feature', async function () {
@@ -173,7 +173,7 @@ describe('Sidebar', function () {
 
       // Close the sidebar
       userEvent.click(screen.getByText("What's new"));
-      await waitForElementToBeRemoved(() => screen.getByText("What's new in Sentry"));
+      await waitForElementToBeRemoved(() => screen.queryByText("What's new in Sentry"));
     });
 
     it('can display Broadcasts panel and mark as seen', async function () {
@@ -205,7 +205,7 @@ describe('Sidebar', function () {
 
       // Close the sidebar
       userEvent.click(screen.getByText("What's new"));
-      await waitForElementToBeRemoved(() => screen.getByText("What's new in Sentry"));
+      await waitForElementToBeRemoved(() => screen.queryByText("What's new in Sentry"));
     });
 
     it('can unmount Sidebar (and Broadcasts) and kills Broadcast timers', async function () {
@@ -250,7 +250,7 @@ describe('Sidebar', function () {
     userEvent.click(screen.getByTestId('sidebar-collapse'));
 
     // Check that the organization name is no longer visible
-    await waitForElementToBeRemoved(() => screen.getByText(organization.name));
+    await waitForElementToBeRemoved(() => screen.queryByText(organization.name));
 
     // Un-collapse he sidebar and make sure the org name is visible again
     userEvent.click(screen.getByTestId('sidebar-collapse'));

--- a/tests/js/spec/components/tooltip.spec.jsx
+++ b/tests/js/spec/components/tooltip.spec.jsx
@@ -37,7 +37,7 @@ describe('Tooltip', function () {
     expect(screen.getByText('bar')).toBeInTheDocument();
 
     userEvent.unhover(screen.getByText('My Button'));
-    await waitForElementToBeRemoved(() => screen.getByText('bar'));
+    await waitForElementToBeRemoved(() => screen.queryByText('bar'));
   });
 
   it('disables and does not render', function () {

--- a/tests/js/spec/utils/withConfig.spec.jsx
+++ b/tests/js/spec/utils/withConfig.spec.jsx
@@ -13,6 +13,6 @@ describe('withConfig HoC', function () {
 
     act(() => void ConfigStore.set('test', 'foo'));
 
-    expect(screen.queryByText('foo')).toBeInTheDocument();
+    expect(screen.getByText('foo')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/issueList/tagFilter.spec.tsx
+++ b/tests/js/spec/views/issueList/tagFilter.spec.tsx
@@ -57,7 +57,7 @@ describe('IssueListTagFilter', function () {
     userEvent.type(input, 'foo');
 
     // waits for the loading indicator to disappear
-    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     // the result has a length of 2, because when performing a search,
     // an element containing the same value is present in the rendered HTML markup

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -185,10 +185,10 @@ describe('groupDetails', () => {
     expect(screen.queryByText('Group Details Mock')).not.toBeInTheDocument();
     await waitFor(() => {
       expect(browserHistory.push).toHaveBeenCalledTimes(1);
-      expect(browserHistory.push).toHaveBeenCalledWith(
-        '/organizations/org-slug/issues/new-id/?foo=bar#hash'
-      );
     });
+    expect(browserHistory.push).toHaveBeenCalledWith(
+      '/organizations/org-slug/issues/new-id/?foo=bar#hash'
+    );
   });
 
   it('renders issue event error', async function () {

--- a/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
@@ -226,7 +226,7 @@ describe('TeamInsightsOverview', () => {
 
   it('defaults to first team', async () => {
     createWrapper();
-    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     expect(screen.getByText('#backend')).toBeInTheDocument();
     expect(screen.getByText('Key transaction')).toBeInTheDocument();
@@ -234,7 +234,7 @@ describe('TeamInsightsOverview', () => {
 
   it('allows team switching', async () => {
     createWrapper();
-    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     expect(screen.getByText('#backend')).toBeInTheDocument();
     userEvent.type(screen.getByText('#backend'), '{mouseDown}');

--- a/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
@@ -85,7 +85,7 @@ describe('TeamMisery', () => {
       {context: routerContext}
     );
 
-    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     expect(weekMisery).toHaveBeenCalledTimes(1);
     expect(periodMisery).toHaveBeenCalledTimes(1);
@@ -137,7 +137,7 @@ describe('TeamMisery', () => {
       {context: routerContext}
     );
 
-    await waitForElementToBeRemoved(screen.getByTestId('loading-indicator'));
+    await waitForElementToBeRemoved(screen.queryByTestId('loading-indicator'));
 
     expect(screen.getByText('There was an error loading data.')).toBeInTheDocument();
   });

--- a/tests/js/spec/views/performance/transactionDetails/index.spec.jsx
+++ b/tests/js/spec/views/performance/transactionDetails/index.spec.jsx
@@ -27,7 +27,7 @@ describe('EventDetails', () => {
       />,
       {context: routerContext}
     );
-    expect(screen.queryByText(alertText)).toBeInTheDocument();
+    expect(screen.getByText(alertText)).toBeInTheDocument();
   });
 
   it('does not reender alert if already received transaction', () => {

--- a/tests/js/spec/views/performance/transactionSummary.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.tsx
@@ -341,7 +341,7 @@ describe('Performance > TransactionSummary', function () {
     );
 
     // Ensure create alert from discover is shown with metric alerts
-    expect(screen.queryByRole('button', {name: 'Create Alert'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Create Alert'})).toBeInTheDocument();
   });
 
   it('renders Web Vitals widget', async function () {

--- a/tests/js/spec/views/settings/projectFiltersAndSampling/errors.spec.tsx
+++ b/tests/js/spec/views/settings/projectFiltersAndSampling/errors.spec.tsx
@@ -180,7 +180,7 @@ describe('Filters and Sampling - Error rule', function () {
     userEvent.click(saveRuleButtonEnabled);
 
     // Modal will close
-    await waitForElementToBeRemoved(() => screen.getByText('Edit Error Sampling Rule'));
+    await waitForElementToBeRemoved(() => screen.queryByText('Edit Error Sampling Rule'));
 
     // Error rules panel is updated
     expect(screen.getByText('Errors only')).toBeInTheDocument();
@@ -298,7 +298,7 @@ describe('Filters and Sampling - Error rule', function () {
 
     // Confirmation modal will close
     await waitForElementToBeRemoved(() =>
-      screen.getByText('Are you sure you wish to delete this dynamic sampling rule?')
+      screen.queryByText('Are you sure you wish to delete this dynamic sampling rule?')
     );
 
     // Error rules panel is updated
@@ -335,7 +335,9 @@ describe('Filters and Sampling - Error rule', function () {
 
       // Close Modal
       userEvent.click(screen.getByLabelText('Close Modal'));
-      await waitForElementToBeRemoved(() => screen.getByText('Add Error Sampling Rule'));
+      await waitForElementToBeRemoved(() =>
+        screen.queryByText('Add Error Sampling Rule')
+      );
     });
 
     it('condition options', async function () {
@@ -363,7 +365,9 @@ describe('Filters and Sampling - Error rule', function () {
 
       // Close Modal
       userEvent.click(screen.getByLabelText('Close Modal'));
-      await waitForElementToBeRemoved(() => screen.getByText('Add Error Sampling Rule'));
+      await waitForElementToBeRemoved(() =>
+        screen.queryByText('Add Error Sampling Rule')
+      );
     });
 
     it('save rule', async function () {
@@ -452,7 +456,9 @@ describe('Filters and Sampling - Error rule', function () {
       userEvent.click(saveRuleButtonEnabled);
 
       // Modal will close
-      await waitForElementToBeRemoved(() => screen.getByText('Add Error Sampling Rule'));
+      await waitForElementToBeRemoved(() =>
+        screen.queryByText('Add Error Sampling Rule')
+      );
 
       // Error rules panel is updated
       expect(

--- a/tests/js/spec/views/settings/projectFiltersAndSampling/transactions.spec.tsx
+++ b/tests/js/spec/views/settings/projectFiltersAndSampling/transactions.spec.tsx
@@ -190,7 +190,7 @@ describe('Filters and Sampling - Transaction rule', function () {
 
       // Modal will close
       await waitForElementToBeRemoved(() =>
-        screen.getByText('Edit Transaction Sampling Rule')
+        screen.queryByText('Edit Transaction Sampling Rule')
       );
 
       // Error rules panel is updated
@@ -259,7 +259,7 @@ describe('Filters and Sampling - Transaction rule', function () {
         // Close Modal
         userEvent.click(screen.getByLabelText('Close Modal'));
         await waitForElementToBeRemoved(() =>
-          screen.getByText('Add Transaction Sampling Rule')
+          screen.queryByText('Add Transaction Sampling Rule')
         );
       });
 
@@ -304,7 +304,7 @@ describe('Filters and Sampling - Transaction rule', function () {
         // Close Modal
         userEvent.click(screen.getByLabelText('Close Modal'));
         await waitForElementToBeRemoved(() =>
-          screen.getByText('Add Transaction Sampling Rule')
+          screen.queryByText('Add Transaction Sampling Rule')
         );
       });
 
@@ -400,7 +400,7 @@ describe('Filters and Sampling - Transaction rule', function () {
 
           // Modal will close
           await waitForElementToBeRemoved(() =>
-            screen.getByText('Add Transaction Sampling Rule')
+            screen.queryByText('Add Transaction Sampling Rule')
           );
 
           // Transaction rules panel is updated
@@ -503,7 +503,7 @@ describe('Filters and Sampling - Transaction rule', function () {
 
             // Modal will close
             await waitForElementToBeRemoved(() =>
-              screen.getByText('Add Transaction Sampling Rule')
+              screen.queryByText('Add Transaction Sampling Rule')
             );
 
             // Transaction rules panel is updated
@@ -630,7 +630,7 @@ describe('Filters and Sampling - Transaction rule', function () {
 
             // Modal will close
             await waitForElementToBeRemoved(() =>
-              screen.getByText('Add Transaction Sampling Rule')
+              screen.queryByText('Add Transaction Sampling Rule')
             );
 
             // Transaction rules panel is updated
@@ -828,7 +828,7 @@ describe('Filters and Sampling - Transaction rule', function () {
 
       // Modal will close
       await waitForElementToBeRemoved(() =>
-        screen.getByText('Edit Transaction Sampling Rule')
+        screen.queryByText('Edit Transaction Sampling Rule')
       );
 
       // Error rules panel is updated


### PR DESCRIPTION
fixes lint errors before #31152 is merged

[this rule](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-render-in-setup.md) seems kinda dumb in that it looks for any "render" function being called in beforeEach