### PR TITLE
fix(metrics-api): Add transaction user to hard coded list of metrics [INGEST-544] [INGEST-804]

### DIFF
--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -422,11 +422,17 @@ _SESSION_TAGS = dict(
     },
 )
 
-_MEASUREMENT_TAGS = dict(
+_TRANSACTION_TAGS = dict(
     _BASE_TAGS,
     **{
-        "measurement_rating": ["good", "meh", "poor"],
         "transaction": ["/foo/:orgId/", "/bar/:orgId/"],
+    },
+)
+
+_MEASUREMENT_TAGS = dict(
+    _TRANSACTION_TAGS,
+    **{
+        "measurement_rating": ["good", "meh", "poor"],
     },
 )
 
@@ -456,7 +462,7 @@ _METRICS = {
         "type": "distribution",
         "operations": _AVAILABLE_OPERATIONS["metrics_distributions"],
         "tags": {
-            **_MEASUREMENT_TAGS,
+            **_TRANSACTION_TAGS,
             "transaction.status": [
                 # Subset of possible states:
                 # https://develop.sentry.dev/sdk/event-payloads/transaction/
@@ -465,6 +471,11 @@ _METRICS = {
                 "aborted",
             ],
         },
+    },
+    "sentry.transactions.user": {
+        "type": "set",
+        "operations": _AVAILABLE_OPERATIONS["metrics_sets"],
+        "tags": _TRANSACTION_TAGS,
     },
 }
 

--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -424,16 +424,12 @@ _SESSION_TAGS = dict(
 
 _TRANSACTION_TAGS = dict(
     _BASE_TAGS,
-    **{
-        "transaction": ["/foo/:orgId/", "/bar/:orgId/"],
-    },
+    transaction=["/foo/:orgId/", "/bar/:orgId/"],
 )
 
 _MEASUREMENT_TAGS = dict(
     _TRANSACTION_TAGS,
-    **{
-        "measurement_rating": ["good", "meh", "poor"],
-    },
+    measurement_rating=["good", "meh", "poor"],
 )
 
 _METRICS = {

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -552,12 +552,12 @@ class OrganizationMetricIntegrationTest(SessionMetricsTestCase, APITestCase):
             group["by"].keys() == {"project_id", "session.status"} for group in groups
         )
 
-        expected = [
-            ({"project_id": self.project2.id, "session.status": "init"}, 1),
-            ({"project_id": self.project.id, "session.status": "init"}, 2),
-        ]
-        for (expected_groupby, expected_count), group in zip(expected, groups):
-            assert group["by"] == expected_groupby
+        expected = {
+            self.project2.id: 1,
+            self.project.id: 2,
+        }
+        for group in groups:
+            expected_count = expected[group["by"]["project_id"]]
             totals = group["totals"]
             assert totals == {"sum(sentry.sessions.session)": expected_count}
 


### PR DESCRIPTION
Make sure the new transaction user metric is queryable.
This PR also fixed a flaky integration test.