### PR TITLE
fix(relay): Actually emit right format for disabled DSN [INGEST-852]

### DIFF
--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -16,7 +16,7 @@ from sentry.ingest.inbound_filters import (
     get_filter_key,
 )
 from sentry.interfaces.security import DEFAULT_DISALLOWED_SOURCES
-from sentry.models import Project, ProjectKeyStatus
+from sentry.models import Project
 from sentry.relay.utils import to_camel_case_name
 from sentry.utils.http import get_origins
 from sentry.utils.sdk import configure_scope
@@ -54,8 +54,6 @@ def get_public_key_configs(project, full_config, project_keys=None):
     public_keys = []
 
     for project_key in project_keys or ():
-        if project_key.status != ProjectKeyStatus.ACTIVE:
-            continue
         key = {
             "publicKey": project_key.public_key,
             "numericId": project_key.id,

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -217,7 +217,7 @@ def test_projectkeys(default_project, task_runner, redis_cache):
         pk.status = ProjectKeyStatus.INACTIVE
         pk.save()
 
-    assert not redis_cache.get(pk.public_key)["publicKeys"]
+    assert redis_cache.get(pk.public_key)["disabled"]
 
     with task_runner():
         pk.delete()


### PR DESCRIPTION
For a project without DSNs, the current code recently was changed to `{"disabled": False,
"publicKeys": []}`, and that was entirely intentional, but it turns out
that we actually intended to consolidate all such disabled states to
`{"disabled": True}`. Relay prints a warning about this at
https://github.com/getsentry/relay/blob/7ee898dfce656279dded87dbde1baea182ffdc3e/relay-server/src/actors/project.rs#L400-L403
(and luckily still does the right thing)
