### PR TITLE
fix(eventsv2): Raise permission deined for teams

### DIFF
--- a/src/sentry/api/helpers/teams.py
+++ b/src/sentry/api/helpers/teams.py
@@ -1,3 +1,5 @@
+from rest_framework.exceptions import PermissionDenied
+
 from sentry.api.utils import InvalidParams
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import Team, TeamStatus
@@ -32,7 +34,7 @@ def get_teams(request, organization, teams=None):
             continue
 
         if not request.access.has_team_access(team):
-            raise InvalidParams(
+            raise PermissionDenied(
                 f"Error: You do not have permission to access {team.name}",
             )
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -856,7 +856,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
-        assert response.status_code == 400
+        assert response.status_code == 403
 
     def test_name_filter(self):
         self.setup_project_and_rules()

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -730,8 +730,10 @@ class TeamKeyTransactionListTest(TeamKeyTransactionTestBase):
                 format="json",
             )
 
-        assert response.status_code == 400, response.content
-        assert response.data == f"Error: You do not have permission to access {other_team.name}"
+        assert response.status_code == 403, response.content
+        assert response.data == {
+            "detail": f"Error: You do not have permission to access {other_team.name}"
+        }
 
     def test_get_key_transaction_list_my_teams(self):
         with self.feature(self.features):


### PR DESCRIPTION
The get_teams api helper currently returns 500
on permissions error on the eventsv2 endpoint,
updated to return a 403 Forbidden. every time
since it's an access based error.

Fixes: SENTRY-T1W