### PR TITLE
feat(metrics): Support multi-field orderby for performance [INGEST-805]

### DIFF
--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -4,6 +4,7 @@ import random
 import re
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
+from copy import copy
 from datetime import datetime, timedelta
 from operator import itemgetter
 from typing import (
@@ -182,42 +183,6 @@ class QueryDefinition:
         elif len(orderby) > 1:
             raise InvalidParams("Only one 'orderBy' is supported")
 
-        if len(self.fields) != 1:
-            # If we were to allow multiple fields when `orderBy` is set,
-            # we would require two snuba queries: one to get the sorted metric,
-            # And one to get the fields that we are not currently sorting by.
-            #
-            # For example, the query
-            #
-            #   ?field=sum(foo)&field=sum(bar)&groupBy=tag1&orderBy=sum(foo)&limit=1
-            #
-            # with snuba entries (simplified)
-            #
-            #   | metric | tag1 | sum(value) |
-            #   |----------------------------|
-            #   | foo    | val1 |          2 |
-            #   | foo    | val2 |          1 |
-            #   | bar    | val1 |          3 |
-            #   | bar    | val2 |          4 |
-            #
-            # Would require a query (simplified)
-            #
-            #   SELECT sum(value) BY tag1 WHERE metric = foo ORDER BY sum(value)
-            #
-            # ->
-            #
-            #   {tag1: val2, sum(value): 1}
-            #
-            # and then
-            #
-            #   SELECT sum(value) BY metric, tag WHERE metric in [bar] and tag1 in [val2]
-            #
-            # to get the values for the other requested field(s).
-            #
-            # Since we do not have a requirement for ordered multi-field results (yet),
-            # let's keep it simple and only allow a single field when `orderBy` is set.
-            #
-            raise InvalidParams("Cannot provide multiple 'field's when 'orderBy' is given")
         orderby = orderby[0]
         direction = Direction.ASC
         if orderby[0] == "-":
@@ -1112,16 +1077,167 @@ class SnubaDataSource(DataSource):
         """Get time series for the given query"""
         intervals = list(get_intervals(query))
 
-        snuba_queries = SnubaQueryBuilder(projects, query).get_snuba_queries()
-        results = {
-            entity: {
-                # TODO: Should we use cache?
-                key: raw_snql_query(query, use_cache=False, referrer=f"api.metrics.{key}")
-                for key, query in queries.items()
-                if query is not None
+        if query.orderby is not None and len(query.fields) > 1:
+            # Multi-field select with order by functionality. Currently only supports the
+            # performance table.
+            original_query_fields = copy(query.fields)
+
+            # This check is necessary as we only support this multi-field select with one field
+            # order by functionality only for the performance table. The reason behind this is
+            # that since we make two queries, where we use the results of the first query to
+            # filter down the results of the second query, if the field used to order by has no
+            # values for certain transactions, we might end up showing less transactions than
+            # there actually are if we choose to order by it. However, we are certain that this
+            # won't happen with the performance table because all the metrics in the table are
+            # always extracted from transactions.
+            for _, field_name in list(original_query_fields.values()):
+                if not (field_name.startswith("sentry.transactions")):
+                    raise InvalidParams(
+                        f"Multi-field select order by queries is not supported "
+                        f"for metric {field_name}"
+                    )
+
+            # The initial query has to contain only one field which is the same as the order by
+            # field
+            orderby_field = [
+                key for key, value in query.fields.items() if value == query.orderby[0]
+            ][0]
+            query.fields = {orderby_field: parse_field(orderby_field)}
+
+            snuba_queries = SnubaQueryBuilder(projects, query).get_snuba_queries()
+            if len(snuba_queries) > 1:
+                # Currently accepting an order by field that spans multiple entities is not
+                # supported, but it might change in the future. Even then, it might be better
+                # handled on the snuba side of things
+                raise InvalidParams(
+                    "Order by queries over multiple entities are not supported in "
+                    "multi-field select with order by clause queries"
+                )
+
+            # This query contains an order by clause, and so we are only interested in the
+            # "totals" query
+            initial_snuba_query = next(iter(snuba_queries.values()))["totals"]
+            # ToDo(ahmed): Change this to accept the limit from the api request with a fallback to
+            #  50 elements if more than 50 elements are to be requested
+            initial_snuba_query = initial_snuba_query.set_limit(50)
+
+            initial_query_results = raw_snql_query(
+                initial_snuba_query, use_cache=False, referrer="api.metrics.totals"
+            )
+
+            # We no longer want the order by in the 2nd query because we already have the order of
+            # the group by tags from the first query so we basically remove the order by columns,
+            # and reset the query fields to the original fields because in the second query,
+            # we want to query for all the metrics in the request api call
+            query.orderby = None
+            query.fields = original_query_fields
+
+            snuba_queries = SnubaQueryBuilder(projects, query).get_snuba_queries()
+
+            results = {entity: {"totals": {"data": []}} for entity in snuba_queries.keys()}
+
+            # If we do not get any results from the first query, then there is no point in making
+            # the second query
+            if len(initial_query_results["data"]) > 0:
+                # Translate the groupby fields of the query into their tag keys because these fields
+                # will be used to filter down and order the results of the 2nd query.
+                # For example, (project_id, transaction) is translated to (project_id, tags[3])
+                groupby_tags = [
+                    resolve_tag_key(field) if field not in _ALLOWED_GROUPBY_COLUMNS else field
+                    for field in query.groupby
+                ]
+
+                # Dictionary that contains the conditions that are required to be added to the where
+                # clause of the second query. In addition to filtering down on the tuple combination
+                # of the fields in the group by columns, we need a separate condition for each of
+                # the columns in the group by with their respective values so Clickhouse can
+                # filter the results down before checking for the group by column combinations.
+                ordered_tag_conditions = {
+                    col: list({data_elem[col] for data_elem in initial_query_results["data"]})
+                    for col in groupby_tags
+                }
+                ordered_tag_conditions[tuple(col for col in groupby_tags)] = [
+                    tuple(data_elem[col] for col in groupby_tags)
+                    for data_elem in initial_query_results["data"]
+                ]
+
+                for entity, queries in snuba_queries.items():
+                    # This loop has constant time complexity as it will always have a maximum of
+                    # three queries corresponding to the three available entities
+                    # ["metrics_sets", "metrics_distributions", "metrics_counters"]
+                    snuba_query = queries["totals"]
+
+                    # If query is grouped by project_id, then we should remove the original
+                    # condition project_id cause it might be more relaxed than the project_id
+                    # condition in the second query
+                    where = []
+                    if "project_id" in groupby_tags:
+                        for condition in snuba_query.where:
+                            if not (
+                                isinstance(condition.lhs, Column)
+                                and condition.lhs.name == "project_id"
+                            ):
+                                where += [condition]
+
+                    # Adds the conditions obtained from the previous query
+                    for condition_key, condition_value in ordered_tag_conditions.items():
+                        lhs_condition = (
+                            Function("tuple", [Column(col) for col in condition_key])
+                            if isinstance(condition_key, tuple)
+                            else Column(condition_key)
+                        )
+                        where += [
+                            Condition(lhs_condition, Op.IN, Function("tuple", condition_value))
+                        ]
+                    snuba_query = snuba_query.set_where(where)
+
+                    snuba_query_res = raw_snql_query(
+                        snuba_query, use_cache=False, referrer="api.metrics.totals"
+                    )
+                    # Create a dictionary that has keys representing the ordered by tuples from the
+                    # initial query, so that we are able to order it easily in the next code block
+                    # If for example, we are grouping by (project_id, transaction) -> then this
+                    # logic will output a dictionary that looks something like, where `tags[1]`
+                    # represents transaction
+                    # {
+                    #     (3, 2): [{"metric_id": 4, "project_id": 3, "tags[1]": 2, "p50": [11.0]}],
+                    #     (3, 3): [{"metric_id": 4, "project_id": 3, "tags[1]": 3, "p50": [5.0]}],
+                    # }
+                    snuba_query_data_dict = {}
+                    for data_elem in snuba_query_res["data"]:
+                        snuba_query_data_dict.setdefault(
+                            tuple(data_elem[col] for col in groupby_tags), []
+                        ).append(data_elem)
+
+                    # Order the results according to the results of the initial query, so that when
+                    # the results dict is passed on to `SnubaResultsConverter`, it comes out ordered
+                    # Ordered conditions might for example look something like this
+                    # {..., ('project_id', 'tags[1]'): [(3, 3), (3, 2)]}, then we end up with
+                    # {
+                    #     "totals": {
+                    #         "data": [
+                    #             {
+                    #               "metric_id": 5, "project_id": 3, "tags[1]": 3, "count_unique": 5
+                    #             },
+                    #             {
+                    #               "metric_id": 5, "project_id": 3, "tags[1]": 2, "count_unique": 1
+                    #             },
+                    #         ]
+                    #     }
+                    # }
+                    for group_tuple in ordered_tag_conditions[tuple(col for col in groupby_tags)]:
+                        results[entity]["totals"]["data"] += snuba_query_data_dict[group_tuple]
+        else:
+            snuba_queries = SnubaQueryBuilder(projects, query).get_snuba_queries()
+            results = {
+                entity: {
+                    # TODO: Should we use cache?
+                    key: raw_snql_query(query, use_cache=False, referrer=f"api.metrics.{key}")
+                    for key, query in queries.items()
+                    if query is not None
+                }
+                for entity, queries in snuba_queries.items()
             }
-            for entity, queries in snuba_queries.items()
-        }
 
         assert projects
         converter = SnubaResultConverter(projects[0].organization_id, query, intervals, results)

--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -1122,7 +1122,7 @@ class SnubaDataSource(DataSource):
             initial_snuba_query = initial_snuba_query.set_limit(50)
 
             initial_query_results = raw_snql_query(
-                initial_snuba_query, use_cache=False, referrer="api.metrics.totals"
+                initial_snuba_query, use_cache=False, referrer="api.metrics.totals.initial_query"
             )
 
             # We no longer want the order by in the 2nd query because we already have the order of
@@ -1142,10 +1142,10 @@ class SnubaDataSource(DataSource):
                 # Translate the groupby fields of the query into their tag keys because these fields
                 # will be used to filter down and order the results of the 2nd query.
                 # For example, (project_id, transaction) is translated to (project_id, tags[3])
-                groupby_tags = [
+                groupby_tags = tuple(
                     resolve_tag_key(field) if field not in _ALLOWED_GROUPBY_COLUMNS else field
                     for field in query.groupby
-                ]
+                )
 
                 # Dictionary that contains the conditions that are required to be added to the where
                 # clause of the second query. In addition to filtering down on the tuple combination
@@ -1156,7 +1156,7 @@ class SnubaDataSource(DataSource):
                     col: list({data_elem[col] for data_elem in initial_query_results["data"]})
                     for col in groupby_tags
                 }
-                ordered_tag_conditions[tuple(col for col in groupby_tags)] = [
+                ordered_tag_conditions[groupby_tags] = [
                     tuple(data_elem[col] for col in groupby_tags)
                     for data_elem in initial_query_results["data"]
                 ]
@@ -1192,7 +1192,7 @@ class SnubaDataSource(DataSource):
                     snuba_query = snuba_query.set_where(where)
 
                     snuba_query_res = raw_snql_query(
-                        snuba_query, use_cache=False, referrer="api.metrics.totals"
+                        snuba_query, use_cache=False, referrer="api.metrics.totals.second_query"
                     )
                     # Create a dictionary that has keys representing the ordered by tuples from the
                     # initial query, so that we are able to order it easily in the next code block
@@ -1225,7 +1225,7 @@ class SnubaDataSource(DataSource):
                     #         ]
                     #     }
                     # }
-                    for group_tuple in ordered_tag_conditions[tuple(col for col in groupby_tags)]:
+                    for group_tuple in ordered_tag_conditions[groupby_tags]:
                         results[entity]["totals"]["data"] += snuba_query_data_dict[group_tuple]
         else:
             snuba_queries = SnubaQueryBuilder(projects, query).get_snuba_queries()

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -338,13 +338,13 @@ class OrganizationMetricDataTest(APITestCase):
 
     @with_feature(FEATURE_FLAG)
     def test_orderby_2(self):
-        """Only one field is supported with order by"""
+        """Support for more than one field is supported with order by"""
         response = self.get_response(
             self.project.organization.slug,
             field=["sum(sentry.sessions.session)", "count_unique(sentry.sessions.user)"],
             orderBy=["sum(sentry.sessions.session)"],
         )
-        assert response.status_code == 400
+        assert response.status_code == 200
 
     @with_feature(FEATURE_FLAG)
     def test_orderby_percentile(self):
@@ -529,6 +529,243 @@ class OrganizationMetricIntegrationTest(SessionMetricsTestCase, APITestCase):
             assert group["by"] == {"tag1": expected_tag_value}
             totals = group["totals"]
             assert totals == {"p50(sentry.transactions.measurements.lcp)": expected_count}
+
+    @with_feature(FEATURE_FLAG)
+    def test_orderby_percentile_with_many_fields_non_transactions_supported_fields(self):
+        """
+        Test that contains a field in the `select` that is not performance related should return
+        a 400
+        """
+        response = self.get_response(
+            self.organization.slug,
+            field=[
+                "p50(sentry.transactions.measurements.lcp)",
+                "sum(sentry.sessions.session)",
+            ],
+            statsPeriod="1h",
+            interval="1h",
+            datasource="snuba",
+            groupBy=["project_id", "transaction"],
+            orderBy="p50(sentry.transactions.measurements.lcp)",
+        )
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]
+            == "Multi-field select order by queries is not supported for metric "
+            "sentry.sessions.session"
+        )
+
+    @with_feature(FEATURE_FLAG)
+    def test_orderby_percentile_with_many_fields_transactions_unsupported_fields(self):
+        """
+        Test that contains a field in the `select` that is performance related but currently
+        not supported should return a 400
+        """
+        response = self.get_response(
+            self.organization.slug,
+            field=[
+                "p50(sentry.transactions.measurements.lcp)",
+                "sum(user_misery)",
+            ],
+            statsPeriod="1h",
+            interval="1h",
+            datasource="snuba",
+            groupBy=["project_id", "transaction"],
+            orderBy="p50(sentry.transactions.measurements.lcp)",
+        )
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]
+            == "Multi-field select order by queries is not supported for metric user_misery"
+        )
+
+    @with_feature(FEATURE_FLAG)
+    def test_orderby_percentile_with_many_fields_one_entity_no_data(self):
+        """
+        Test that ensures that when metrics data is available then an empty response is returned
+        gracefully
+        """
+        for metric in [
+            "sentry.transactions.measurements.lcp",
+            "sentry.transactions.measurements.fcp",
+            "transaction",
+        ]:
+            indexer.record(metric)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=[
+                "p50(sentry.transactions.measurements.lcp)",
+                "p50(sentry.transactions.measurements.fcp)",
+            ],
+            statsPeriod="1h",
+            interval="1h",
+            datasource="snuba",
+            groupBy=["project_id", "transaction"],
+            orderBy="p50(sentry.transactions.measurements.lcp)",
+        )
+        groups = response.data["groups"]
+        assert len(groups) == 0
+
+    @with_feature(FEATURE_FLAG)
+    def test_orderby_percentile_with_many_fields_one_entity(self):
+        """
+        Test that ensures when transactions are ordered correctly when all the fields requested
+        are from the same entity
+        """
+        metric_id = indexer.record("sentry.transactions.measurements.lcp")
+        metric_id_fcp = indexer.record("sentry.transactions.measurements.fcp")
+        transaction_id = indexer.record("transaction")
+        transaction_1 = indexer.record("/foo/")
+        transaction_2 = indexer.record("/bar/")
+
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": metric_id,
+                    "timestamp": int(time.time()),
+                    "type": "d",
+                    "value": numbers,
+                    "tags": {tag: value},
+                    "retention_days": 90,
+                }
+                for tag, value, numbers in (
+                    (transaction_id, transaction_1, [10, 11, 12]),
+                    (transaction_id, transaction_2, [4, 5, 6]),
+                )
+            ],
+            entity="metrics_distributions",
+        )
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": metric_id_fcp,
+                    "timestamp": int(time.time()),
+                    "type": "d",
+                    "value": numbers,
+                    "tags": {tag: value},
+                    "retention_days": 90,
+                }
+                for tag, value, numbers in (
+                    (transaction_id, transaction_1, [1, 2, 3]),
+                    (transaction_id, transaction_2, [13, 14, 15]),
+                )
+            ],
+            entity="metrics_distributions",
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=[
+                "p50(sentry.transactions.measurements.lcp)",
+                "p50(sentry.transactions.measurements.fcp)",
+            ],
+            statsPeriod="1h",
+            interval="1h",
+            datasource="snuba",
+            groupBy=["project_id", "transaction"],
+            orderBy="p50(sentry.transactions.measurements.lcp)",
+        )
+        groups = response.data["groups"]
+        assert len(groups) == 2
+
+        expected = [
+            ("/bar/", 5.0, 14.0),
+            ("/foo/", 11.0, 2.0),
+        ]
+        for (expected_tag_value, expected_lcp_count, expected_fcp_count), group in zip(
+            expected, groups
+        ):
+            # With orderBy, you only get totals:
+            assert "series" not in group
+            assert group["by"] == {"transaction": expected_tag_value, "project_id": self.project.id}
+            totals = group["totals"]
+            assert totals == {
+                "p50(sentry.transactions.measurements.lcp)": expected_lcp_count,
+                "p50(sentry.transactions.measurements.fcp)": expected_fcp_count,
+            }
+
+    @with_feature(FEATURE_FLAG)
+    def test_orderby_percentile_with_many_fields_multiple_entities(self):
+        """
+        Test that ensures when transactions are ordered correctly when all the fields requested
+        are from multiple entities
+        """
+        transaction_id = indexer.record("transaction")
+        transaction_1 = indexer.record("/foo/")
+        transaction_2 = indexer.record("/bar/")
+
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": indexer.record("sentry.transactions.measurements.lcp"),
+                    "timestamp": int(time.time()),
+                    "type": "d",
+                    "value": numbers,
+                    "tags": {tag: value},
+                    "retention_days": 90,
+                }
+                for tag, value, numbers in (
+                    (transaction_id, transaction_1, [10, 11, 12]),
+                    (transaction_id, transaction_2, [4, 5, 6]),
+                )
+            ],
+            entity="metrics_distributions",
+        )
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": indexer.record("sentry.transactions.user"),
+                    "timestamp": int(time.time()),
+                    "tags": {tag: value},
+                    "type": "s",
+                    "value": numbers,
+                    "retention_days": 90,
+                }
+                for tag, value, numbers in (
+                    (transaction_id, transaction_1, list(range(1))),
+                    (transaction_id, transaction_2, list(range(5))),
+                )
+            ],
+            entity="metrics_sets",
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=[
+                "p50(sentry.transactions.measurements.lcp)",
+                "count_unique(sentry.transactions.user)",
+            ],
+            statsPeriod="1h",
+            interval="1h",
+            datasource="snuba",
+            groupBy=["project_id", "transaction"],
+            orderBy="p50(sentry.transactions.measurements.lcp)",
+        )
+        groups = response.data["groups"]
+        assert len(groups) == 2
+
+        expected = [
+            ("/bar/", 5.0, 5),
+            ("/foo/", 11.0, 1),
+        ]
+        for (expected_tag_value, expected_lcp_count, users), group in zip(expected, groups):
+            # With orderBy, you only get totals:
+            assert "series" not in group
+            assert group["by"] == {"transaction": expected_tag_value, "project_id": self.project.id}
+            totals = group["totals"]
+            assert totals == {
+                "p50(sentry.transactions.measurements.lcp)": expected_lcp_count,
+                "count_unique(sentry.transactions.user)": users,
+            }
 
     @with_feature(FEATURE_FLAG)
     def test_groupby_project(self):


### PR DESCRIPTION
Adds support for the performance table to the metrics organization data endpoint

This PR involves the following: 
- A new logic branch for multi-field order by queries when we have one order by field but multi fields in the select
- Runs an initial query with just the field in the order by in the select statement to get the ordering for which the group by columns are in
- If there are results from that initial query, then we use the results tags/group by to filter down the second query (required to get all the values of the fields from the original query)
- Once we get those results, we re-order them according to the order of the tags from the first query, and then the results are returned in the API 
- Currently, this is only supported for the Perfomance table but can be easily abstracted to any other use case