### PR TITLE
test(metrics): Run snuba integration tests unconditionally [INGEST-854]

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -112,7 +112,7 @@ from . import assert_status_code
 from .factories import Factories
 from .fixtures import Fixtures
 from .helpers import AuthProvider, Feature, TaskRunner, override_options, parse_queries
-from .skips import requires_snuba, requires_snuba_metrics
+from .skips import requires_snuba
 
 DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
 
@@ -967,7 +967,6 @@ class SnubaTestCase(BaseTestCase):
         )
 
 
-@requires_snuba_metrics
 class SessionMetricsTestCase(SnubaTestCase):
     """Store metrics instead of sessions"""
 

--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -3,7 +3,6 @@ import socket
 from urllib.parse import urlparse
 
 import pytest
-import requests
 from django.conf import settings
 
 _service_status = {}
@@ -24,19 +23,6 @@ def snuba_is_available():
 
 requires_snuba = pytest.mark.skipif(
     not snuba_is_available(), reason="requires snuba server running"
-)
-
-
-def snuba_metrics_available():
-    try:
-        return requests.get(settings.SENTRY_SNUBA + "/metrics/snql").status_code == 200
-    except requests.ConnectionError:
-        return False
-
-
-requires_snuba_metrics = pytest.mark.skipif(
-    not snuba_is_available() or not snuba_metrics_available(),
-    reason="requires snuba server running with metrics enabled",
 )
 
 

--- a/src/sentry/utils/pytest/fixtures.py
+++ b/src/sentry/utils/pytest/fixtures.py
@@ -385,12 +385,8 @@ def reset_snuba(call_snuba):
         "/tests/groupedmessage/drop",
         "/tests/transactions/drop",
         "/tests/sessions/drop",
+        "/tests/metrics/drop",
     ]
-
-    from sentry.testutils.skips import snuba_metrics_available
-
-    if snuba_metrics_available():
-        init_endpoints.append("/tests/metrics/drop")
 
     assert all(
         response.status_code == 200


### PR DESCRIPTION
When the metrics dataset was not enabled by default in snuba, it was necessary to skip metrics-based integration tests in CI. For unknown reasons, these tests were still skipped in sentry CI _after_ the necessary snuba dataset was enabled.

This PR removes the faulty check if metrics are enabled, so that the desired tests are now executed.