### PR TITLE
feat(dashboards): Only trigger widget defaults if the display type actually changes

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -368,6 +368,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
 
   handleFieldChange = (field: string) => (value: string) => {
     const {organization, source} = this.props;
+    const {displayType} = this.state;
     this.setState(prevState => {
       const newState = cloneDeep(prevState);
       set(newState, field, value);
@@ -383,7 +384,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       return {...newState, errors: undefined};
     });
 
-    if (field === 'displayType') {
+    if (field === 'displayType' && value !== displayType) {
       this.handleDefaultFields();
     }
   };


### PR DESCRIPTION
We shouldn't call `handleDefaultFields` unless the `displayType` actually changes. This caused a bug where selecting `table` display type again on an issue widget would reset the widget to a discover widget.

![image](https://user-images.githubusercontent.com/83961295/149805759-f63dca2d-27e0-4cf2-a26c-99d09f893c71.png)
