### PR TITLE
ref(dashboard-templates): Switch the Preview & Add buttons

### DIFF
--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -355,6 +355,9 @@ const TemplateContainer = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints[3]}) {
     grid-template-columns: repeat(2, 1fr);
   }
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: repeat(1, 1fr);
+  }
   gap: ${space(2)};
   padding-bottom: ${space(4)};
 `;

--- a/static/app/views/dashboardsV2/manage/templateCard.tsx
+++ b/static/app/views/dashboardsV2/manage/templateCard.tsx
@@ -26,16 +26,16 @@ function TemplateCard({title, widgetCount, onPreview, onAdd}: Props) {
         </CardText>
       </Header>
       <ButtonContainer>
-        <StyledButton priority="default" onClick={onPreview} label={t('Preview')}>
-          {t('Preview')}
-        </StyledButton>
         <StyledButton
-          priority="primary"
+          priority="default"
           onClick={onAdd}
           icon={<IconAdd size="xs" isCircled />}
           label={t('Add Dashboard')}
         >
           {t('Add Dashboard')}
+        </StyledButton>
+        <StyledButton priority="primary" onClick={onPreview} label={t('Preview')}>
+          {t('Preview')}
         </StyledButton>
       </ButtonContainer>
     </StyledCard>
@@ -80,7 +80,7 @@ const StyledButton = styled(Button)<{priority: string}>`
 
   ${p =>
     p.priority === 'default' &&
-    `width: 50%;
+    `width: 100%;
     margin-right: ${space(2)};`};
 `;
 


### PR DESCRIPTION
- This is so that preview is the primary button instead, since it allows
  the user to see what's in the dashboard more easily
- Also adds a mobile breakpoint to the template Container


### Preview
![image](https://user-images.githubusercontent.com/4205004/149829474-5779f019-3e17-4696-b2de-03c041bee487.png)

