### PR TITLE
fix/dashboards-grid-margin

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -526,6 +526,8 @@ const GridItem = styled('div')`
 
 // HACK: to stack chart tooltips above other grid items
 const GridLayout = styled(WidthProvider(Responsive))`
+  margin: -${space(2)};
+
   .react-grid-item:hover {
     z-index: 10;
   }


### PR DESCRIPTION
This is a bit of a hack. The additional grid gap around the content seems to be coming from somewhere else?

Before:
![Screen Shot 2022-01-17 at 1 23 10 PM](https://user-images.githubusercontent.com/4830259/149838764-f54cbbe4-8c23-4d30-9523-f4d470057f88.png)
![Screen Shot 2022-01-17 at 1 29 24 PM](https://user-images.githubusercontent.com/4830259/149838911-44bb2dd8-b45a-4d88-a30c-437745d5dd8c.png)

After:
![Screen Shot 2022-01-17 at 1 23 23 PM](https://user-images.githubusercontent.com/4830259/149838769-75f7a33e-f47c-4870-9bc4-6ddf57ddd6af.png)
![Screen Shot 2022-01-17 at 1 29 47 PM](https://user-images.githubusercontent.com/4830259/149838917-b507565f-d1d3-465b-942b-3ce1f9fdc4b9.png)