### PR TITLE
Revert "fix/perf-home-truncate (#31163)"

### DIFF
--- a/static/app/components/truncate.tsx
+++ b/static/app/components/truncate.tsx
@@ -117,7 +117,6 @@ class Truncate extends React.Component<Props, State> {
 }
 
 const Wrapper = styled('span')`
-  display: block;
   position: relative;
 `;
 

--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -161,7 +161,7 @@ const defaultGrid = {
   left: space(0),
   right: space(0),
   top: space(2),
-  bottom: space(1),
+  bottom: space(0),
 };
 
 const ContentContainer = styled('div')<{noPadding?: boolean; bottomPadding?: boolean}>`
@@ -169,7 +169,6 @@ const ContentContainer = styled('div')<{noPadding?: boolean; bottomPadding?: boo
   padding-right: ${p => (p.noPadding ? space(0) : space(2))};
   padding-bottom: ${p => (p.bottomPadding ? space(1) : space(0))};
 `;
-
 GenericPerformanceWidget.defaultProps = {
   containerType: 'panel',
   chartHeight: 200,

--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -57,15 +57,14 @@ export const RightAlignedCell = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 ${space(1)};
 `;
 
 export const Subtitle = styled('span')`
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeMedium};
+  min-height: 24px;
   display: inline-block;
 `;
-
 export const GrowLink = styled(Link)`
   flex-grow: 1;
 `;
@@ -79,14 +78,16 @@ export function ListClose(props: {
   setSelectListIndex: (n: number) => void;
 }) {
   return (
-    <StyledTooltip title={t('Exclude from search filter')}>
-      <StyledIconClose
-        onClick={() => {
-          props.onClick();
-          props.setSelectListIndex(0);
-        }}
-      />
-    </StyledTooltip>
+    <CloseContainer>
+      <StyledTooltip title={t('Exclude this transaction from the search filter.')}>
+        <StyledIconClose
+          onClick={() => {
+            props.onClick();
+            props.setSelectListIndex(0);
+          }}
+        />
+      </StyledTooltip>
+    </CloseContainer>
   );
 }
 
@@ -96,9 +97,20 @@ const StyledTooltip = styled(Tooltip)`
   justify-content: center;
 `;
 
+const CloseContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: ${space(1)};
+`;
+
 const StyledIconClose = styled(IconClose)`
   cursor: pointer;
   color: ${p => p.theme.gray200};
+
+  &:hover {
+    color: ${p => p.theme.gray300};
+  }
 `;
 
 const StyledEmptyStateWarning = styled(EmptyStateWarning)`
@@ -108,6 +120,7 @@ const StyledEmptyStateWarning = styled(EmptyStateWarning)`
 
 const ListItemContainer = styled('div')`
   display: flex;
+
   border-top: 1px solid ${p => p.theme.border};
   padding: ${space(1)} ${space(2)};
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
 import MenuItem from 'sentry/components/menuItem';
@@ -208,8 +209,17 @@ export const WidgetContainerActions = ({
     );
   }
 
-  return <ContextMenu>{menuOptions}</ContextMenu>;
+  return (
+    <ChartActionContainer>
+      <ContextMenu>{menuOptions}</ContextMenu>
+    </ChartActionContainer>
+  );
 };
+
+const ChartActionContainer = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+`;
 
 const WidgetContainer = withOrganization(_WidgetContainer);
 

--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -17,15 +17,18 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
   return (
     <WidgetHeaderContainer>
       <TitleContainer>
-        <StyledHeaderTitleLegend data-test-id="performance-widget-title">
-          <div>{title}</div>
-          <QuestionTooltip position="top" size="sm" title={titleTooltip} />
-        </StyledHeaderTitleLegend>
-        {Subtitle ? <Subtitle {...props} /> : null}
+        <div>
+          <StyledHeaderTitleLegend data-test-id="performance-widget-title">
+            <div className="truncate">{title}</div>
+            <QuestionTooltip position="top" size="sm" title={titleTooltip} />
+          </StyledHeaderTitleLegend>
+        </div>
+        <div>{Subtitle ? <Subtitle {...props} /> : null}</div>
       </TitleContainer>
+
       {HeaderActions && (
         <HeaderActionsContainer>
-          <HeaderActions {...props} />
+          {HeaderActions && <HeaderActions {...props} />}
         </HeaderActionsContainer>
       )}
     </WidgetHeaderContainer>
@@ -40,14 +43,12 @@ const StyledHeaderTitleLegend = styled(HeaderTitleLegend)`
 const TitleContainer = styled('div')`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
 `;
 
 const WidgetHeaderContainer = styled('div')`
   display: flex;
   justify-content: space-between;
 `;
-
 const HeaderActionsContainer = styled('div')`
   display: flex;
   gap: ${space(1)};

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -257,7 +257,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                   case PerformanceWidgetSetting.MOST_RELATED_ISSUES:
                     return (
                       <Fragment>
-                        <GrowLink to={transactionTarget}>
+                        <GrowLink to={transactionTarget} className="truncate">
                           <Truncate value={transaction} maxLength={40} />
                         </GrowLink>
                         <RightAlignedCell>
@@ -278,7 +278,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                   case PerformanceWidgetSetting.MOST_RELATED_ERRORS:
                     return (
                       <Fragment>
-                        <GrowLink to={transactionTarget}>
+                        <GrowLink to={transactionTarget} className="truncate">
                           <Truncate value={transaction} maxLength={40} />
                         </GrowLink>
                         <RightAlignedCell>
@@ -296,7 +296,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                     if (typeof rightValue === 'number') {
                       return (
                         <Fragment>
-                          <GrowLink to={transactionTarget}>
+                          <GrowLink to={transactionTarget} className="truncate">
                             <Truncate value={transaction} maxLength={40} />
                           </GrowLink>
                           <RightAlignedCell>
@@ -313,7 +313,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                     }
                     return (
                       <Fragment>
-                        <GrowLink to={transactionTarget}>
+                        <GrowLink to={transactionTarget} className="truncate">
                           <Truncate value={transaction} maxLength={40} />
                         </GrowLink>
                         <RightAlignedCell>{rightValue}</RightAlignedCell>

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidgetMetrics.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidgetMetrics.tsx
@@ -183,7 +183,7 @@ export function LineChartListWidgetMetrics(props: PerformanceWidgetProps) {
 
                 return (
                   <Fragment>
-                    <GrowLink to={transactionTarget}>
+                    <GrowLink to={transactionTarget} className="truncate">
                       <Truncate value={transaction} maxLength={40} />
                     </GrowLink>
                     <RightAlignedCell>


### PR DESCRIPTION
This reverts commit 51b16332c63636c9483ae7c12d90b079697523ee which is https://github.com/getsentry/sentry/pull/31163

Looks like these changes are having unintended visual changes across the app
- eg. the orderby arrow appearing below the text in discover
<img width="117" alt="image" src="https://user-images.githubusercontent.com/4205004/149839906-4acaf82a-fb1e-40bb-bf90-414079a19278.png">
- or stacktrace headers like these being split up into many lines
<img width="362" alt="image" src="https://user-images.githubusercontent.com/4205004/149839932-1490d468-a3a7-4a6c-add5-a165d181955b.png">
