### PR TITLE
feat(metrics): Add pagination to OrganizationMetricsDataEndpoint [INGEST-851]

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -117,8 +117,10 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
 
         def data_fn(offset: int, limit: int):
             try:
-                query = QueryDefinition(request.GET)
-                data = get_datasource(request).get_series(projects, query, offset, limit)
+                query = QueryDefinition(
+                    request.GET, paginator_kwargs={"limit": limit, "offset": offset}
+                )
+                data = get_datasource(request).get_series(projects, query)
             except (InvalidField, InvalidParams) as exc:
                 raise (ParseError(detail=str(exc)))
             return data

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.paginator import GenericOffsetPaginator
 from sentry.snuba.metrics import (
     InvalidField,
     InvalidParams,
@@ -12,6 +13,7 @@ from sentry.snuba.metrics import (
     QueryDefinition,
     SnubaDataSource,
 )
+from sentry.utils.cursors import Cursor, CursorResult
 
 
 def get_datasource(request):
@@ -112,10 +114,38 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
             return Response(status=404)
 
         projects = self.get_projects(request, organization)
-        try:
-            query = QueryDefinition(request.GET)
-            data = get_datasource(request).get_series(projects, query)
-        except (InvalidField, InvalidParams) as exc:
-            raise (ParseError(detail=str(exc)))
 
-        return Response(data, status=200)
+        def data_fn(offset: int, limit: int):
+            try:
+                query = QueryDefinition(request.GET)
+                data = get_datasource(request).get_series(projects, query, offset, limit)
+            except (InvalidField, InvalidParams) as exc:
+                raise (ParseError(detail=str(exc)))
+            return data
+
+        return self.paginate(
+            request,
+            paginator=MetricsDataSeriesPaginator(data_fn=data_fn),
+            default_per_page=50,
+            max_per_page=100,
+        )
+
+
+class MetricsDataSeriesPaginator(GenericOffsetPaginator):
+    def get_result(self, limit, cursor=None):
+        assert limit > 0
+        offset = cursor.offset if cursor is not None else 0
+        data = self.data_fn(offset=offset, limit=limit + 1)
+
+        if isinstance(data.get("groups"), list):
+            has_more = len(data["groups"]) == limit + 1
+            if has_more:
+                data["groups"].pop()
+        else:
+            raise NotImplementedError
+
+        return CursorResult(
+            data,
+            prev=Cursor(0, max(0, offset - limit), True, offset > 0),
+            next=Cursor(0, max(0, offset + limit), False, has_more),
+        )

--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -200,15 +200,8 @@ class QueryDefinition:
         return (op, metric_name), direction
 
     def _parse_limit(self, query_params, paginator_kwargs):
-        limit = query_params.get("limit", None)
-        if self.orderby:
-            paginator_limit = paginator_kwargs.get("limit")
-            if paginator_limit is not None:
-                return paginator_limit
-        else:
-            if limit is not None:
-                raise InvalidParams("'limit' is only supported in combination with 'orderBy'")
-
+        limit = paginator_kwargs.get("limit")
+        if not self.orderby:
             per_page = query_params.get("per_page")
             if per_page is not None:
                 # If order by is not None, it means we will have a `series` query which cannot be

--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -221,6 +221,12 @@ class QueryDefinition:
 
     def _parse_offset(self, query_params, paginator_kwargs):
         if not self.orderby:
+            cursor = query_params.get("cursor")
+            if cursor is not None:
+                # If order by is not None, it means we will have a `series` query which cannot be
+                # paginated, and passing a `per_page` url param to paginate the results is not
+                # possible
+                raise InvalidParams("'cursor' is only supported in combination with 'orderBy'")
             return None
         return paginator_kwargs.get("offset")
 

--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -1194,8 +1194,8 @@ class SnubaDataSource(DataSource):
                         ]
                     snuba_query = snuba_query.set_where(where)
                     # Set the limit of the second query to be the provided limits multiplied by
-                    # the number of the metrics requested in the query
-                    snuba_query = snuba_query.set_limit(limit * len(query.fields))
+                    # the number of the metrics requested in the query in this specific entity
+                    snuba_query = snuba_query.set_limit(limit * len(snuba_query.select))
 
                     snuba_query_res = raw_snql_query(
                         snuba_query, use_cache=False, referrer="api.metrics.totals.second_query"

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -374,6 +374,25 @@ class OrganizationMetricDataTest(APITestCase):
         )
 
     @with_feature(FEATURE_FLAG)
+    def test_pagination_offset_without_orderby(self):
+        """
+        Test that ensures an exception is raised when pagination `per_page` parameter is sent
+        without order by being set
+        """
+        response = self.get_response(
+            self.organization.slug,
+            field="count(sentry.transactions.measurements.lcp)",
+            datasource="snuba",
+            groupBy="transaction",
+            cursor=Cursor(0, 1),
+        )
+        assert response.status_code == 400
+        print(response.json())
+        assert response.json()["detail"] == (
+            "'cursor' is only supported in combination with 'orderBy'"
+        )
+
+    @with_feature(FEATURE_FLAG)
     def test_statsperiod_invalid(self):
         response = self.get_response(
             self.project.organization.slug,

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -356,25 +356,6 @@ class OrganizationMetricDataTest(APITestCase):
         assert response.status_code == 400
 
     @with_feature(FEATURE_FLAG)
-    def test_limit_without_orderby(self):
-        response = self.get_response(
-            self.project.organization.slug,
-            field="sum(sentry.sessions.session)",
-            limit=3,
-        )
-        assert response.status_code == 400
-
-    @with_feature(FEATURE_FLAG)
-    def test_limit_invalid(self):
-        for limit in (-1, 0, "foo"):
-            response = self.get_response(
-                self.project.organization.slug,
-                field="sum(sentry.sessions.session)",
-                limit=limit,
-            )
-            assert response.status_code == 400
-
-    @with_feature(FEATURE_FLAG)
     def test_statsperiod_invalid(self):
         response = self.get_response(
             self.project.organization.slug,

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -402,6 +402,23 @@ class OrganizationMetricIntegrationTest(SessionMetricsTestCase, APITestCase):
         assert count_sessions(project_id=self.project2.id) == 1
 
     @with_feature(FEATURE_FLAG)
+    def test_pagination_without_orderby(self):
+        """
+        Test that ensures an exception is raised when pagination
+        """
+        response = self.get_response(
+            self.organization.slug,
+            field="count(sentry.transactions.measurements.lcp)",
+            datasource="snuba",
+            groupBy="transaction",
+            per_page=2,
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "'per_page' is only supported in combination with 'orderBy'"
+        )
+
+    @with_feature(FEATURE_FLAG)
     def test_orderby(self):
         # Record some strings
         metric_id = indexer.record("sentry.transactions.measurements.lcp")

--- a/tests/sentry/snuba/test_metrics.py
+++ b/tests/sentry/snuba/test_metrics.py
@@ -249,10 +249,9 @@ def test_build_snuba_query_orderby(mock_now, mock_now2, monkeypatch):
                 "sum(sentry.sessions.session)",
             ],
             "orderBy": ["-sum(sentry.sessions.session)"],
-            "limit": [3],
         }
     )
-    query_definition = QueryDefinition(query_params)
+    query_definition = QueryDefinition(query_params, paginator_kwargs={"limit": 3})
     snuba_queries = SnubaQueryBuilder([PseudoProject(1, 1)], query_definition).get_snuba_queries()
 
     counter_queries = snuba_queries.pop("metrics_counters")


### PR DESCRIPTION
This PR:
- Adds new paginator class `MetricsDataSeriesPaginator` which inherits from `GenericOffsetPaginator` to add pagination to the response of api requests made to `OrganizationMetricsDataEndpoint` specifically the `groups` key in the response
- Adds a default of 50 elements per page and a max of 100 elements
- `limit` parameter sent in the request no longer serves a purpose, and is overridden the paginator