### PR TITLE
fix(ui): Remove unnecessary condition in query string for transaction summaries

### DIFF
--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -25,6 +25,7 @@ export function generateTransactionSummaryRoute({orgSlug}: {orgSlug: String}): s
 function cleanTransactionSummaryFilter(query: string): string {
   const filterParams = new MutableSearch(query);
   filterParams.removeFilter('transaction');
+  filterParams.removeFilter('event.type');
   return filterParams.formatString();
 }
 

--- a/tests/js/spec/views/performance/content.spec.jsx
+++ b/tests/js/spec/views/performance/content.spec.jsx
@@ -385,7 +385,7 @@ describe('Performance > Content', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           transaction: '/apple/cart',
-          query: 'sentry:yes transaction.duration:<15m event.type:transaction',
+          query: 'sentry:yes transaction.duration:<15m',
         }),
       })
     );

--- a/tests/js/spec/views/performance/table.spec.jsx
+++ b/tests/js/spec/views/performance/table.spec.jsx
@@ -181,7 +181,7 @@ describe('Performance > Table', function () {
         statsPeriod: '14d',
         start: '2019-10-01T00:00:00',
         end: '2019-10-02T00:00:00',
-        query: 'event.type:transaction', // drops 'transaction:/api*' from the query
+        query: '', // drops 'transaction:/api*' and 'event.type:transaction' from the query
         unselectedSeries: 'p100()',
         showTransactions: undefined,
         display: undefined,


### PR DESCRIPTION
When drilling down from the Performance landing page to transaction summary page, event.type:transaction gets added to the query, but this is unnecessary since it is already implied. This change removes this from the query string.

Fixes VIS-1308