### PR TITLE
fix(release_health): Cast float of sum() to int for comparison [INGEST-784]

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1773,7 +1773,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             query, referrer="release_health.metrics.get_num_sessions_per_project"
         )["data"]
 
-        return [(row["project_id"], row["value"]) for row in rows]
+        return [(row["project_id"], int(row["value"])) for row in rows]
 
     def get_project_releases_by_stability(
         self,

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1714,7 +1714,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             "data"
         ]
 
-        ret_val: int = rows[0]["value"] if rows else 0
+        ret_val: int = int(rows[0]["value"]) if rows else 0
         return ret_val
 
     def get_num_sessions_per_project(


### PR DESCRIPTION
the duplex backend will throw an error if the type is not exactly the
same, and for correctness we should return an int anyway