### PR TITLE
fix(dashboards): Fixed mapErrors to also support string errors

### DIFF
--- a/static/app/views/dashboardsV2/widget/eventWidget/utils.tsx
+++ b/static/app/views/dashboardsV2/widget/eventWidget/utils.tsx
@@ -10,7 +10,7 @@ import {Widget} from 'sentry/views/dashboardsV2/types';
 import {DisplayType} from '../utils';
 
 type ValidationError = {
-  [key: string]: string[] | ValidationError[] | ValidationError;
+  [key: string]: string | string[] | ValidationError[] | ValidationError;
 };
 
 type FlatValidationError = {
@@ -23,6 +23,10 @@ export function mapErrors(
 ): FlatValidationError {
   Object.keys(data).forEach((key: string) => {
     const value = data[key];
+    if (typeof value === 'string') {
+      update[key] = value;
+      return;
+    }
     // Recurse into nested objects.
     if (Array.isArray(value) && typeof value[0] === 'string') {
       update[key] = value[0];

--- a/tests/js/spec/views/dashboardsV2/widget/eventWidget/utils.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widget/eventWidget/utils.spec.tsx
@@ -1,0 +1,19 @@
+import {mapErrors} from 'sentry/views/dashboardsV2/widget/eventWidget/utils';
+
+describe('eventWidget utils', function () {
+  describe('mapErrors', function () {
+    it('able to handle string and string[] validation errors', () => {
+      const flatValidation = mapErrors(
+        {
+          queries: [{fields: 'just a string'}],
+          another: [{fields: ['another string']}],
+        },
+        {}
+      );
+      expect(flatValidation).toEqual({
+        queries: [{fields: 'just a string'}],
+        another: [{fields: 'another string'}],
+      });
+    });
+  });
+});


### PR DESCRIPTION
Some validation errors already come flattened as string. `mapErrors` assumes these errors only come in arrays, which is causing infinite recursion. Updated to support string errors.