### PR TITLE
fix(ui): Remove eCharts tooltip border

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -584,7 +584,7 @@ const ChartContainer = styled('div')<{autoHeightResize: boolean}>`
     border-radius: ${p => p.theme.borderRadiusBottom};
   }
   .tooltip-arrow {
-    top: calc(100% + 1px);
+    top: 100%;
     left: 50%;
     position: absolute;
     pointer-events: none;

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -274,6 +274,7 @@ export default function Tooltip({
     show: true,
     trigger: 'item',
     backgroundColor: `${theme.backgroundElevated}`,
+    borderWidth: 0,
     extraCssText: `box-shadow: 0 0 0 1px ${theme.translucentBorder}, ${theme.dropShadowHeavy}`,
     transitionDuration: 0,
     padding: 0,


### PR DESCRIPTION
Remove eChart's default tooltip border in favor of our own translucent border (implemented as a `box-shadow`).

Before:
<img width="236" alt="Screen Shot 2022-01-18 at 1 05 58 PM" src="https://user-images.githubusercontent.com/44172267/150018737-ca80cbbe-fadd-4a84-aad6-f94cebc67d6c.png">

After:
<img width="443" alt="Screen Shot 2022-01-18 at 1 08 07 PM" src="https://user-images.githubusercontent.com/44172267/150019101-475c635e-e754-4e24-859a-5fa403eabb54.png">

