### PR TITLE
feat(pageFilters): Add pinned state to store

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -21,6 +21,7 @@ import {
   MinimalProject,
   Organization,
   PageFilters,
+  PinnedPageFilter,
   Project,
 } from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -292,6 +293,12 @@ export function updateEnvironments(
 ) {
   PageFiltersActions.updateEnvironments(environment);
   updateParams({environment}, router, options);
+}
+
+export function pinFilter(filter: PinnedPageFilter, pin: boolean) {
+  PageFiltersActions.pin(filter, pin);
+
+  // TODO: Persist into storage
 }
 
 /**

--- a/static/app/actions/pageFiltersActions.tsx
+++ b/static/app/actions/pageFiltersActions.tsx
@@ -7,6 +7,7 @@ const PageFiltersActions = Reflux.createActions([
   'updateProjects',
   'updateDateTime',
   'updateEnvironments',
+  'pin',
 ]);
 
 export default PageFiltersActions;

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -80,6 +80,11 @@ export const DataCategoryName = {
 export type RelativePeriod = keyof typeof DEFAULT_RELATIVE_PERIODS;
 export type IntervalPeriod = ReturnType<typeof getInterval>;
 
+/**
+ * Represents a pinned page filter sentinel value
+ */
+export type PinnedPageFilter = 'projects' | 'environments' | 'datetime';
+
 export type PageFilters = {
   /**
    * Currently selected Project IDs

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -313,6 +313,7 @@ describe('GlobalSelectionHeader', function () {
     expect(PageFiltersStore.getState()).toEqual({
       organization,
       isReady: true,
+      pinnedFilters: new Set(),
       selection: {
         datetime: {
           period: '14d',
@@ -341,6 +342,7 @@ describe('GlobalSelectionHeader', function () {
     expect(PageFiltersStore.getState()).toEqual({
       organization,
       isReady: true,
+      pinnedFilters: new Set(),
       selection: {
         datetime: {
           period: '14d',
@@ -368,6 +370,7 @@ describe('GlobalSelectionHeader', function () {
     expect(PageFiltersStore.getState()).toEqual({
       organization,
       isReady: true,
+      pinnedFilters: new Set(),
       selection: {
         datetime: {
           period: '14d',
@@ -414,6 +417,7 @@ describe('GlobalSelectionHeader', function () {
     expect(PageFiltersStore.getState()).toEqual({
       organization,
       isReady: true,
+      pinnedFilters: new Set(),
       selection: {
         datetime: {
           period: '7d',

--- a/tests/js/spec/stores/pageFiltersStore.spec.jsx
+++ b/tests/js/spec/stores/pageFiltersStore.spec.jsx
@@ -1,4 +1,5 @@
 import {
+  pinFilter,
   updateDateTime,
   updateEnvironments,
   updateProjects,
@@ -19,6 +20,7 @@ describe('PageFiltersStore', function () {
     expect(PageFiltersStore.getState()).toEqual({
       organization: null,
       isReady: false,
+      pinnedFilters: new Set(),
       selection: {
         projects: [],
         environments: [],
@@ -83,5 +85,22 @@ describe('PageFiltersStore', function () {
     updateEnvironments(['alpha']);
     await tick();
     expect(PageFiltersStore.getState().selection.environments).toEqual(['alpha']);
+  });
+
+  it('can mark filters as pinned', async function () {
+    expect(PageFiltersStore.getState().pinnedFilters).toEqual(new Set());
+    pinFilter('projects', true);
+    await tick();
+    expect(PageFiltersStore.getState().pinnedFilters).toEqual(new Set(['projects']));
+
+    pinFilter('environments', true);
+    await tick();
+    expect(PageFiltersStore.getState().pinnedFilters).toEqual(
+      new Set(['projects', 'environments'])
+    );
+
+    pinFilter('projects', false);
+    await tick();
+    expect(PageFiltersStore.getState().pinnedFilters).toEqual(new Set(['environments']));
   });
 });


### PR DESCRIPTION
This can be used to check if a particular page filter is currently
pinned.

A upcoming PR will persist the pinned value into local storage