### PR TITLE
fix(sentry apps): Render saved form fields

### DIFF
--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -22,6 +22,7 @@ export type FieldFromSchema = Omit<Field, 'choices' | 'type'> & {
   depends_on?: string[];
   choices?: Array<[any, string]>;
   async?: boolean;
+  skip_load_on_open?: boolean;
 };
 
 export type SchemaFormConfig = {
@@ -252,10 +253,16 @@ export class SentryAppExternalForm extends Component<Props, State> {
 
     if (fieldToPass.type === 'select') {
       // find the options from state to pass down
-      const defaultOptions = (field.choices || []).map(([value, label]) => ({
+      let defaultOptions = (field.choices || []).map(([value, label]) => ({
         value,
         label,
       }));
+      // there are no choices if skip_load_on_open is set, just use what's in the defaultResetValue
+      if (field.skip_load_on_open === true) {
+        defaultOptions = [
+          {value: defaultResetValues[field.name], label: defaultResetValues[field.name]},
+        ];
+      }
       const options = this.state.optionsByField.get(field.name) || defaultOptions;
       const allowClear = !required;
       // filter by what the user is typing
@@ -295,7 +302,6 @@ export class SentryAppExternalForm extends Component<Props, State> {
         fieldToPass = {...fieldToPass, disabled: true};
       }
     }
-
     // if we have a uri, we need to set extra parameters
     const extraProps = field.uri
       ? {


### PR DESCRIPTION
If a user made a sentry app that uses alert rule UI components and one (or more) of the select fields uses the `skip_load_on_open` option in the schema (see the [docs](https://docs.sentry.io/product/integrations/integration-platform/ui-components/#attributes), it won't make an API call to the defined sentry app uri until the user begins typing, so the options aren't automatically there on page load), when an alert rule action is created for that app, the saved values for the fields that have `skip_load_on_open` won't appear on edit.

**Before:**
<img width="572" alt="Screen Shot 2022-01-18 at 12 03 59 PM" src="https://user-images.githubusercontent.com/29959063/150036838-76b9881d-3ca6-499a-80e3-e4d70ee47fa6.png">
**After:**
<img width="592" alt="Screen Shot 2022-01-18 at 12 04 14 PM" src="https://user-images.githubusercontent.com/29959063/150036842-47575aaf-5738-477c-873a-8212952e85fe.png">
