### PR TITLE
ref(notifications): adds get_builder_args_from_context function and from_email

### DIFF
--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, MutableMapping
 
 from django.utils.encoding import force_text
 
@@ -122,7 +122,6 @@ def send_notification_as_email(
         add_users_kwargs = {}
         if isinstance(notification, ProjectNotification):
             add_users_kwargs["project"] = notification.project
-
         msg.add_users([recipient.id], **add_users_kwargs)
         msg.send_async()
         notification.record_notification_sent(recipient, ExternalProviders.EMAIL)
@@ -142,8 +141,8 @@ def get_builder_args(
 
 def get_builder_args_from_context(
     notification: BaseNotification, context: Mapping[str, Any]
-) -> Mapping[str, Any]:
-    return {
+) -> MutableMapping[str, Any]:
+    output = {
         "subject": get_subject_with_prefix(notification, context),
         "context": context,
         "template": notification.get_template(),
@@ -153,3 +152,8 @@ def get_builder_args_from_context(
         "reply_reference": notification.get_reply_reference(),
         "type": notification.get_type(),
     }
+    # add in optinal fields
+    from_email = notification.from_email
+    if from_email:
+        output["from_email"] = from_email
+    return output

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -137,6 +137,12 @@ def get_builder_args(
     # TODO: move context logic to single notification class method
     extra_context = (extra_context_by_actor_id or {}).get(recipient.actor_id, {})
     context = get_context(notification, recipient, shared_context or {}, extra_context)
+    return get_builder_args_from_context(notification, context)
+
+
+def get_builder_args_from_context(
+    notification: BaseNotification, context: Mapping[str, Any]
+) -> Mapping[str, Any]:
     return {
         "subject": get_subject_with_prefix(notification, context),
         "context": context,

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -44,6 +44,10 @@ class BaseNotification(abc.ABC):
             return None
         return get_notification_setting_type_name(self.notification_setting_type)
 
+    @property
+    def from_email(self) -> str | None:
+        return None
+
     def get_filename(self) -> str:
         raise NotImplementedError
 


### PR DESCRIPTION
This PR creates a `get_builder_args_from_context` function so we can generate email notifications that aren't tied to a particular user (specifically the billing email). It also allows a new property called `from_email` so a notification can specify a different email address such as the billing email address.