### PR TITLE
fix(sessions): Order results by timestamp and log error if snuba limit exceeded [ISSUE-1372]

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -3,6 +3,7 @@ from the `metrics` dataset instead of `sessions`.
 
 Do not call this module directly. Use the `release_health` service instead. """
 import abc
+import logging
 from collections import defaultdict
 from dataclasses import dataclass, replace
 from datetime import datetime
@@ -22,9 +23,18 @@ from typing import (
     cast,
 )
 
-from snuba_sdk import Column, Condition, Entity, Op, Query
-from snuba_sdk.expressions import Granularity
-from snuba_sdk.function import Function
+from snuba_sdk import (
+    Column,
+    Condition,
+    Direction,
+    Entity,
+    Function,
+    Granularity,
+    Limit,
+    Op,
+    OrderBy,
+    Query,
+)
 from snuba_sdk.legacy import json_to_snql
 from snuba_sdk.query import SelectableExpression
 
@@ -45,8 +55,10 @@ from sentry.sentry_metrics.utils import (
 )
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics import TS_COL_GROUP, TS_COL_QUERY, get_intervals
-from sentry.snuba.sessions_v2 import QueryDefinition, finite_or_none
+from sentry.snuba.sessions_v2 import SNUBA_LIMIT, QueryDefinition, finite_or_none
 from sentry.utils.snuba import raw_snql_query
+
+logger = logging.getLogger(__name__)
 
 #: Referrers for snuba queries
 #: Referrers must be searchable, so no string interpolation here
@@ -326,10 +338,11 @@ def _get_snuba_query(
             pass
 
     full_groupby = set(groupby.values()) - remove_groupby
+
     if series:
         full_groupby.add(Column(TS_COL_GROUP))
 
-    return Query(
+    query_args = dict(
         dataset=Dataset.Metrics.value,
         match=Entity(entity_key.value),
         select=list(columns),
@@ -337,6 +350,13 @@ def _get_snuba_query(
         where=conditions,
         granularity=Granularity(query.rollup),
     )
+
+    if series:
+        # Set higher limit and order by to be consistent with sessions_v2
+        query_args["limit"] = Limit(SNUBA_LIMIT)
+        query_args["orderby"] = [OrderBy(Column(TS_COL_GROUP), Direction.DESC)]
+
+    return Query(**query_args)
 
 
 def _get_snuba_query_data(
@@ -369,6 +389,9 @@ def _get_snuba_query_data(
         )
         referrer = REFERRERS[metric_key][query_type]
         query_data = raw_snql_query(snuba_query, referrer=referrer)["data"]
+
+        if len(query_data) == SNUBA_LIMIT:
+            logger.error("metrics_sessions_v2.snuba_limit_exceeded")
 
         yield (metric_key, query_data)
 

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -454,7 +454,15 @@ def _run_sessions_query(query):
         referrer="sessions.timeseries",
     )
     if len(result_timeseries["data"]) == SNUBA_LIMIT:
-        logger.error("sessions_v2.snuba_limit_exceeded")
+        # We know that for every row returned by the "totals" query, we expect
+        # (end-start)/rollup rows in the "series" query:
+        expected_results = len(result_totals["data"]) * len(get_timestamps(query))
+        logger.error(
+            "sessions_v2.snuba_limit_exceeded",
+            extra={
+                "expected_num_rows": expected_results,
+            },
+        )
 
     return result_totals["data"], result_timeseries["data"]
 

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -314,11 +314,9 @@ ONE_DAY = timedelta(days=1).total_seconds()
 ONE_HOUR = timedelta(hours=1).total_seconds()
 ONE_MINUTE = timedelta(minutes=1).total_seconds()
 
-#: Time series grouped by release, environment may return more snuba rows
-#: than the snuba default limit of 1000,
+#: Snuba applies a default limit of 1000, let's make it explicit here.
 #: https://github.com/getsentry/snuba/blob/69862db3ad224b48810ac1bb3001e4c446bf0aff/snuba/query/snql/parser.py#L908-L909
-#: so lets set the maximum here
-SNUBA_LIMIT = 10000
+SNUBA_LIMIT = 1000
 
 
 class InvalidParams(Exception):
@@ -455,7 +453,6 @@ def _run_sessions_query(query):
         limit=SNUBA_LIMIT,
         referrer="sessions.timeseries",
     )
-
     if len(result_timeseries["data"]) == SNUBA_LIMIT:
         logger.error("sessions_v2.snuba_limit_exceeded")
 

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import math
 from datetime import datetime, timedelta
 from enum import Enum
@@ -10,6 +11,9 @@ from sentry.api.utils import get_date_range_from_params
 from sentry.search.events.filter import get_filter
 from sentry.utils.dates import parse_stats_period, to_datetime, to_timestamp
 from sentry.utils.snuba import Dataset, raw_query, resolve_condition
+
+logger = logging.getLogger(__name__)
+
 
 """
 The new Sessions API defines a "metrics"-like interface which is can be used in
@@ -310,6 +314,12 @@ ONE_DAY = timedelta(days=1).total_seconds()
 ONE_HOUR = timedelta(hours=1).total_seconds()
 ONE_MINUTE = timedelta(minutes=1).total_seconds()
 
+#: Time series grouped by release, environment may return more snuba rows
+#: than the snuba default limit of 1000,
+#: https://github.com/getsentry/snuba/blob/69862db3ad224b48810ac1bb3001e4c446bf0aff/snuba/query/snql/parser.py#L908-L909
+#: so lets set the maximum here
+SNUBA_LIMIT = 10000
+
 
 class InvalidParams(Exception):
     pass
@@ -426,6 +436,11 @@ def _run_sessions_query(query):
         referrer="sessions.totals",
     )
 
+    # For the time series query, we order the results by descending timestamp,
+    # such that if the maximum snuba limit is surpassed, we get consistent results
+    # for the end of the time range:
+    orderby = [f"-{TS_COL}"]
+
     result_timeseries = raw_query(
         dataset=Dataset.Sessions,
         selected_columns=[TS_COL] + query.query_columns,
@@ -436,8 +451,13 @@ def _run_sessions_query(query):
         start=query.start,
         end=query.end,
         rollup=query.rollup,
+        orderby=orderby,
+        limit=SNUBA_LIMIT,
         referrer="sessions.timeseries",
     )
+
+    if len(result_timeseries["data"]) == SNUBA_LIMIT:
+        logger.error("sessions_v2.snuba_limit_exceeded")
 
     return result_totals["data"], result_timeseries["data"]
 
@@ -484,7 +504,7 @@ def massage_sessions_result(
         for row in rows:
             row[ts_col] = row[ts_col][:19] + "Z"
 
-        rows.sort(key=lambda row: row[ts_col])
+        rows = list(reversed(rows))  # Time series was ordered DESC
         fields = [(name, field, list()) for name, field in query.fields.items()]
         group_index = 0
 

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -301,8 +301,8 @@ def test_massage_simple_timeseries():
     result_totals = [{"sessions": 4}]
     # snuba returns the datetimes as strings for now
     result_timeseries = [
-        {"sessions": 2, "bucketed_started": "2020-12-17T12:00:00+00:00"},
         {"sessions": 2, "bucketed_started": "2020-12-18T06:00:00+00:00"},
+        {"sessions": 2, "bucketed_started": "2020-12-17T12:00:00+00:00"},
     ]
 
     expected_result = {
@@ -357,8 +357,8 @@ def test_massage_exact_timeseries():
     )
     result_totals = [{"sessions": 4}]
     result_timeseries = [
-        {"sessions": 2, "bucketed_started": "2020-12-17T12:00:00+00:00"},
         {"sessions": 2, "bucketed_started": "2020-12-18T06:00:00+00:00"},
+        {"sessions": 2, "bucketed_started": "2020-12-17T12:00:00+00:00"},
     ]
 
     expected_result = {
@@ -394,17 +394,17 @@ def test_massage_groupby_timeseries():
         {
             "release": "test-example-release",
             "sessions": 2,
-            "bucketed_started": "2020-12-17T12:00:00+00:00",
-        },
-        {
-            "release": "test-example-release",
-            "sessions": 2,
             "bucketed_started": "2020-12-18T06:00:00+00:00",
         },
         {
             "release": "test-example-release-2",
             "sessions": 1,
             "bucketed_started": "2020-12-18T06:00:00+00:00",
+        },
+        {
+            "release": "test-example-release",
+            "sessions": 2,
+            "bucketed_started": "2020-12-17T12:00:00+00:00",
         },
     ]
 
@@ -457,28 +457,6 @@ def test_massage_virtual_groupby_timeseries():
     # snuba returns the datetimes as strings for now
     result_timeseries = [
         {
-            "sessions_errored": 4,
-            "users": 1,
-            "users_crashed": 0,
-            "sessions_abnormal": 4,
-            "sessions": 10,
-            "users_errored": 0,
-            "users_abnormal": 0,
-            "sessions_crashed": 3,
-            "bucketed_started": "2020-12-17T18:00:00+00:00",
-        },
-        {
-            "sessions_errored": 10,
-            "users": 1,
-            "users_crashed": 0,
-            "sessions_abnormal": 2,
-            "sessions": 15,
-            "users_errored": 0,
-            "users_abnormal": 0,
-            "sessions_crashed": 4,
-            "bucketed_started": "2020-12-18T00:00:00+00:00",
-        },
-        {
             "sessions_errored": 1,
             "users": 1,
             "users_crashed": 1,
@@ -499,6 +477,28 @@ def test_massage_virtual_groupby_timeseries():
             "users_abnormal": 0,
             "sessions_crashed": 0,
             "bucketed_started": "2020-12-18T06:00:00+00:00",
+        },
+        {
+            "sessions_errored": 10,
+            "users": 1,
+            "users_crashed": 0,
+            "sessions_abnormal": 2,
+            "sessions": 15,
+            "users_errored": 0,
+            "users_abnormal": 0,
+            "sessions_crashed": 4,
+            "bucketed_started": "2020-12-18T00:00:00+00:00",
+        },
+        {
+            "sessions_errored": 4,
+            "users": 1,
+            "users_crashed": 0,
+            "sessions_abnormal": 4,
+            "sessions": 10,
+            "users_errored": 0,
+            "users_abnormal": 0,
+            "sessions_crashed": 3,
+            "bucketed_started": "2020-12-17T18:00:00+00:00",
         },
     ]
 
@@ -553,17 +553,6 @@ def test_clamping_in_massage_sessions_results_with_groupby_timeseries():
     # snuba returns the datetimes as strings for now
     result_timeseries = [
         {
-            "sessions": 5,
-            "sessions_errored": 10,
-            "sessions_crashed": 0,
-            "sessions_abnormal": 0,
-            "users": 5,
-            "users_errored": 10,
-            "users_crashed": 0,
-            "users_abnormal": 0,
-            "bucketed_started": "2020-12-18T06:00:00+00:00",
-        },
-        {
             "sessions": 7,
             "sessions_errored": 3,
             "sessions_crashed": 2,
@@ -573,6 +562,17 @@ def test_clamping_in_massage_sessions_results_with_groupby_timeseries():
             "users_crashed": 2,
             "users_abnormal": 2,
             "bucketed_started": "2020-12-18T12:00:00+00:00",
+        },
+        {
+            "sessions": 5,
+            "sessions_errored": 10,
+            "sessions_crashed": 0,
+            "sessions_abnormal": 0,
+            "users": 5,
+            "users_errored": 10,
+            "users_crashed": 0,
+            "users_abnormal": 0,
+            "bucketed_started": "2020-12-18T06:00:00+00:00",
         },
     ]
     expected_result = {
@@ -626,14 +626,14 @@ def test_nan_duration():
     ]
     result_timeseries = [
         {
-            "duration_avg": math.nan,
-            "duration_quantiles": [math.nan, math.nan, math.nan, math.nan, math.nan, math.nan],
-            "bucketed_started": "2020-12-17T12:00:00+00:00",
-        },
-        {
             "duration_avg": math.inf,
             "duration_quantiles": [math.inf, math.inf, math.inf, math.inf, math.inf, math.inf],
             "bucketed_started": "2020-12-18T06:00:00+00:00",
+        },
+        {
+            "duration_avg": math.nan,
+            "duration_quantiles": [math.nan, math.nan, math.nan, math.nan, math.nan, math.nan],
+            "bucketed_started": "2020-12-17T12:00:00+00:00",
         },
     ]
 


### PR DESCRIPTION
As described in https://getsentry.atlassian.net/browse/ISSUE-1372, gaps occur in sessions_v2 time series when the number of releases is large, for example:

```javascript
// Results for 8 days:
"series": {
        "sum(session)": [
            0,
            105,
            3653,
            77331,
            174854,
            179608,
            174777,
            61066
        ]
    }
    
// Results for the same end time, but ~30 days:
"series": {
        "sum(session)": [
            // ...
            0,
            0,
            3653,
            77331,
            174856,
            0,
            174814,
            0
        ]
    }
```

This seems to be caused by the fact that snuba applies a default limit of 1000:

https://github.com/getsentry/snuba/blob/69862db3ad224b48810ac1bb3001e4c446bf0aff/snuba/query/snql/parser.py#L908-L909

The sessions API queries these series without an orderBy constraint, so a random subset of entries default to zero.

This PR logs an error if this limit is actually reached. Furthermore, we add an order by clause to the snuba query, such that at least the most recent part of the time series is complete.