### PR TITLE
fix(arithmetic): Raise error when arithmetic doesn't have operators

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -302,6 +302,8 @@ def parse_arithmetic(
         raise ArithmeticValidationError("Cannot mix functions and fields in arithmetic")
     if visitor.terms <= 1:
         raise ArithmeticValidationError("Arithmetic expression must contain at least 2 terms")
+    if visitor.operators == 0:
+        raise ArithmeticValidationError("Arithmetic expression must contain at least 1 operator")
     return result, list(visitor.fields), list(visitor.functions)
 
 

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -287,6 +287,7 @@ def test_unparseable_arithmetic(equation):
         "12",
         "p50(transaction.duration)",
         "measurements.lcp",
+        "(measurements.lcp)",
     ],
 )
 def test_invalid_arithmetic(equation):


### PR DESCRIPTION
- This fixes a bug where we would error when an equation only contained
  a single term in brackets eg. `(transaction.duration)`
  - This is a quick fix to resolve the error, but need to dig deeper
    into seeing if we can correct the number of terms in the equation
- Fixes SENTRY-T4E