### PR TITLE
feat(profiling): add position indicator renderer

### DIFF
--- a/static/app/utils/profiling/renderers/positionIndicatorRenderer.tsx
+++ b/static/app/utils/profiling/renderers/positionIndicatorRenderer.tsx
@@ -1,0 +1,55 @@
+import {mat3} from 'gl-matrix';
+
+import {FlamegraphTheme} from '../flamegraph/FlamegraphTheme';
+import {getContext, Rect} from '../gl/utils';
+
+class PositionIndicatorRenderer {
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+  theme: FlamegraphTheme;
+
+  constructor(canvas: HTMLCanvasElement, theme: FlamegraphTheme) {
+    this.canvas = canvas;
+    this.theme = theme;
+
+    this.context = getContext(this.canvas, '2d');
+  }
+
+  draw(configView: Rect, configSpace: Rect, configToPhysicalSpace: mat3): void {
+    if (configView.equals(configSpace)) {
+      // User is not zoomed in, so we dont need to draw anything.
+      return;
+    }
+
+    // Transform both views to their respective physical spaces
+    const physicalConfigViewRect =
+      Rect.From(configView).transformRect(configToPhysicalSpace);
+    const physicalConfigRect =
+      Rect.From(configSpace).transformRect(configToPhysicalSpace);
+
+    const offsetRectForBorderWidth: [number, number, number, number] = [
+      physicalConfigViewRect.x - this.theme.SIZES.MINIMAP_POSITION_OVERLAY_BORDER_WIDTH,
+      physicalConfigViewRect.y,
+      physicalConfigViewRect.width +
+        this.theme.SIZES.MINIMAP_POSITION_OVERLAY_BORDER_WIDTH,
+      physicalConfigViewRect.height,
+    ];
+
+    // What we do to draw the "window" that the user is currently watching is we draw two rectangles, the
+    // zoomed in view and the zoomed out view. The zoomed out view is the full view of the flamegraph, and the zoom
+    // in view is whatever the user is currently looking at. Because the zoomed in view is a subset of the zoomed,
+    // we just need to use the evenodd fill rule to paint inbetween the two rectangles.
+    this.context.fillStyle = this.theme.COLORS.MINIMAP_POSITION_OVERLAY_COLOR;
+    this.context.strokeStyle = this.theme.COLORS.MINIMAP_POSITION_OVERLAY_BORDER_COLOR;
+    this.context.lineWidth = this.theme.SIZES.MINIMAP_POSITION_OVERLAY_BORDER_WIDTH;
+
+    this.context.beginPath();
+    this.context.rect(0, 0, physicalConfigRect.width, physicalConfigRect.height);
+    this.context.rect(...offsetRectForBorderWidth);
+
+    this.context.fill('evenodd');
+    this.context.strokeRect(...offsetRectForBorderWidth);
+  }
+}
+
+export {PositionIndicatorRenderer};

--- a/tests/js/spec/utils/profiling/renderers/positionIndicatorRenderer.spec.tsx
+++ b/tests/js/spec/utils/profiling/renderers/positionIndicatorRenderer.spec.tsx
@@ -1,0 +1,75 @@
+import {mat3, vec2} from 'gl-matrix';
+
+import {LightFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/FlamegraphTheme';
+import {Rect} from 'sentry/utils/profiling/gl/utils';
+import {PositionIndicatorRenderer} from 'sentry/utils/profiling/renderers/positionIndicatorRenderer';
+
+describe('PositionIndicatorRenderer', () => {
+  it('draws nothing if view is not zoomed', () => {
+    const configView = new Rect(0, 0, 100, 100);
+    const configSpace = new Rect(0, 0, 100, 100);
+
+    const context: Partial<CanvasRenderingContext2D> = {
+      beginPath: jest.fn(),
+      rect: jest.fn(),
+      fill: jest.fn(),
+      strokeRect: jest.fn(),
+      fillStyle: undefined,
+      strokeStyle: undefined,
+      lineWidth: undefined,
+    };
+
+    const canvas: Partial<HTMLCanvasElement> = {
+      getContext: jest.fn().mockReturnValue(context),
+    };
+
+    const renderer = new PositionIndicatorRenderer(
+      canvas as HTMLCanvasElement,
+      LightFlamegraphTheme
+    );
+    renderer.draw(configView, configSpace, mat3.identity(mat3.create()));
+
+    expect(context.beginPath).not.toHaveBeenCalled();
+  });
+
+  it('draws if view is not zoomed', () => {
+    const configView = new Rect(40, 40, 20, 100);
+    const configSpace = new Rect(0, 0, 100, 100);
+
+    const context: Partial<CanvasRenderingContext2D> = {
+      beginPath: jest.fn(),
+      rect: jest.fn(),
+      fill: jest.fn(),
+      strokeRect: jest.fn(),
+      fillStyle: undefined,
+      strokeStyle: undefined,
+      lineWidth: undefined,
+    };
+
+    const canvas: Partial<HTMLCanvasElement> = {
+      getContext: jest.fn().mockReturnValue(context),
+    };
+
+    const renderer = new PositionIndicatorRenderer(
+      canvas as HTMLCanvasElement,
+      LightFlamegraphTheme
+    );
+    renderer.draw(
+      configView,
+      configSpace,
+      mat3.fromScaling(mat3.create(), vec2.fromValues(2, 2))
+    );
+
+    expect(context.beginPath).toHaveBeenCalled();
+    // @ts-ignore this is a mock
+    expect(context.rect.mock.calls[0]).toEqual([0, 0, 200, 200]);
+    // @ts-ignore this is a mock
+    // We offset x by width of the border be
+    expect(context.rect.mock.calls[1]).toEqual([
+      80 - LightFlamegraphTheme.SIZES.MINIMAP_POSITION_OVERLAY_BORDER_WIDTH,
+      80,
+      40 + LightFlamegraphTheme.SIZES.MINIMAP_POSITION_OVERLAY_BORDER_WIDTH,
+      200,
+    ]);
+  });
+});


### PR DESCRIPTION
Adds the renderer that draws the current view so that it's easy to understand what part of the flamegraph you are viewing

https://user-images.githubusercontent.com/9317857/150178824-0f442596-77dc-4890-a80f-e830a0ceae5d.mp4
