### PR TITLE
feat(webhooks): Add issue_id to event_alert and error.created webhooks

### DIFF
--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -70,7 +70,7 @@ def _webhook_event_data(event, group_id, project_id):
     # a valid URL (it can't know which option to pick). We have to manually
     # create this URL for, that reason.
     event_context["issue_url"] = absolute_uri(f"/api/0/issues/{group_id}/")
-
+    event_context["issue_id"] = group_id
     return event_context
 
 

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -307,6 +307,7 @@ class TestProcessResourceChange(TestCase):
         assert data["action"] == "created"
         assert data["installation"]["uuid"] == install.uuid
         assert data["data"]["error"]["event_id"] == event.event_id
+        assert data["data"]["error"]["issue_id"] == event.group_id
         assert faux(safe_urlopen).kwargs_contain("headers.Content-Type")
         assert faux(safe_urlopen).kwargs_contain("headers.Request-ID")
         assert faux(safe_urlopen).kwargs_contain("headers.Sentry-Hook-Resource")

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -153,6 +153,7 @@ class TestSendAlertEvent(TestCase):
                         )
                     ),
                     issue_url=absolute_uri(f"/api/0/issues/{group.id}/"),
+                    issue_id=group.id,
                 ),
                 "triggered_rule": self.rule.label,
             },


### PR DESCRIPTION
Objective:
Currently for an Issue Alert (event_alert) I have to parse the issue_url to get ahold of an issue_id. 
We want to provide that directly instead.