### PR TITLE
fix(dashboards): Deduplicate yAxis before opening widget in discover

### DIFF
--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
@@ -44,9 +44,9 @@ class DashboardWidgetQuerySelectorModal extends React.Component<Props> {
       const discoverLocation = eventView.getResultsViewUrlTarget(organization.slug);
       // Pull a max of 3 valid Y-Axis from the widget
       const yAxisOptions = eventView.getYAxisOptions().map(({value}) => value);
-      discoverLocation.query.yAxis = query.fields
-        .filter(field => yAxisOptions.includes(field))
-        .slice(0, 3);
+      discoverLocation.query.yAxis = [
+        ...new Set(query.fields.filter(field => yAxisOptions.includes(field))),
+      ].slice(0, 3);
       switch (widget.displayType) {
         case DisplayType.BAR:
           discoverLocation.query.display = DisplayModes.BAR;

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -81,9 +81,11 @@ function WidgetCardContextMenu({
       if (isAllowWidgetsToDiscover()) {
         // Pull a max of 3 valid Y-Axis from the widget
         const yAxisOptions = eventView.getYAxisOptions().map(({value}) => value);
-        discoverLocation.query.yAxis = widget.queries[0].fields
-          .filter(field => yAxisOptions.includes(field))
-          .slice(0, 3);
+        discoverLocation.query.yAxis = [
+          ...new Set(
+            widget.queries[0].fields.filter(field => yAxisOptions.includes(field))
+          ),
+        ].slice(0, 3);
         switch (widget.displayType) {
           case DisplayType.WORLD_MAP:
             discoverLocation.query.display = DisplayModes.WORLDMAP;
@@ -114,9 +116,6 @@ function WidgetCardContextMenu({
           fields.unshift(term);
         }
       });
-
-      // Deduplicate yAxis
-      discoverLocation.query.yAxis = [...new Set(discoverLocation.query.yAxis)];
 
       const discoverPath = `${discoverLocation.pathname}?${qs.stringify({
         ...discoverLocation.query,

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -115,6 +115,9 @@ function WidgetCardContextMenu({
         }
       });
 
+      // Deduplicate yAxis
+      discoverLocation.query.yAxis = [...new Set(discoverLocation.query.yAxis)];
+
       const discoverPath = `${discoverLocation.pathname}?${qs.stringify({
         ...discoverLocation.query,
       })}`;

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -95,6 +95,8 @@ function WidgetCardContextMenu({
             break;
           case DisplayType.TOP_N:
             discoverLocation.query.display = DisplayModes.TOP5;
+            discoverLocation.query.yAxis =
+              widget.queries[0].fields[widget.queries[0].fields.length - 1];
             break;
           default:
             break;


### PR DESCRIPTION
Opening in discover with a widget with duplicate yAxis will break discover. Deduplicates yAxis before redirecting when clicking Open in Discover