### PR TITLE
fix(copy): title of issue alert notifications page

### DIFF
--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -13,7 +13,7 @@ export type FineTuneField = {
 // TODO: clean up unused fields
 export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
   alerts: {
-    title: 'Project Alerts',
+    title: 'Issue Alert Notifications',
     description: t(
       'Notifications from Alert Rules that your team has setup. You’ll always receive notifications from Alerts configured to be sent directly to you.'
     ),


### PR DESCRIPTION
"Project Alerts" is a super confusing title for this page. It should be "Issue Alert Notifications" since it only applies to them and also it’s the link you click to get here

## Before
![CleanShot 2022-01-19 at 12 35 37](https://user-images.githubusercontent.com/1900676/150210349-e13068f4-e7a0-476e-9e33-1e174c5a1d96.png)

## After
![CleanShot 2022-01-19 at 12 35 50](https://user-images.githubusercontent.com/1900676/150210368-9b6e7385-748c-4faa-99ee-113d697bb3f5.png)


