### PR TITLE
feat(workflow): Show disabled create ownership rule button

### DIFF
--- a/static/app/components/group/suggestedOwners/ownershipRules.tsx
+++ b/static/app/components/group/suggestedOwners/ownershipRules.tsx
@@ -45,11 +45,19 @@ const OwnershipRules = ({
 
   const createRuleButton = (
     <Access access={['project:write']}>
-      <GuideAnchor target="owners" position="bottom" offset={space(3)}>
-        <Button onClick={handleOpenCreateOwnershipRule} size="small">
-          {t('Create Ownership Rule')}
-        </Button>
-      </GuideAnchor>
+      {({hasAccess}) => (
+        <GuideAnchor target="owners" position="bottom" offset={space(3)}>
+          <Button
+            onClick={handleOpenCreateOwnershipRule}
+            size="small"
+            disabled={!hasAccess}
+            title={t("You don't have permission to create ownership rules.")}
+            tooltipProps={{disabled: hasAccess}}
+          >
+            {t('Create Ownership Rule')}
+          </Button>
+        </GuideAnchor>
+      )}
     </Access>
   );
 
@@ -73,7 +81,7 @@ const OwnershipRules = ({
         <SetupButton
           size="small"
           priority="primary"
-          href={`/settings/${organization.slug}/projects/${project.slug}/ownership/`}
+          to={`/settings/${organization.slug}/projects/${project.slug}/ownership/`}
           onClick={() =>
             trackIntegrationAnalytics('integrations.code_owners_cta_setup_clicked', {
               view: 'stacktrace_issue_details',
@@ -82,7 +90,7 @@ const OwnershipRules = ({
             })
           }
         >
-          {t('Set It Up')}
+          {t('Setup')}
         </SetupButton>
         <Button
           size="small"
@@ -118,6 +126,7 @@ const OwnershipRules = ({
                       )}
                     </p>
                     <Button
+                      external
                       href="https://docs.sentry.io/workflow/issue-owners/"
                       priority="primary"
                     >


### PR DESCRIPTION
Before, the button was completely gone and the section was empty.

preview of button with disabled tooltip
![image](https://user-images.githubusercontent.com/1400464/150213055-97044334-8f7e-4034-bc1b-5c541ba1facc.png)

- fixes issue with setup button link reloading entire app and adjusts copy @robinrendle
- fixes docs button not being external