### PR TITLE
feat(ui): Remove thirds body sidebar for screens < 1200px

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -13,12 +13,15 @@ export const Body = styled('div')`
   background-color: ${p => p.theme.background};
   flex-grow: 1;
 
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    padding: ${space(3)} ${space(4)};
+  }
+
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
     display: grid;
+    grid-template-columns: minmax(100px, auto) 325px;
     align-content: start;
     gap: ${space(3)};
-    padding: ${space(3)} ${space(4)};
-    grid-template-columns: minmax(100px, auto) 325px;
   }
 `;
 

--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -13,15 +13,11 @@ export const Body = styled('div')`
   background-color: ${p => p.theme.background};
   flex-grow: 1;
 
-  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
     display: grid;
-    grid-template-columns: 66% auto;
     align-content: start;
     gap: ${space(3)};
     padding: ${space(3)} ${space(4)};
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints[2]}) {
     grid-template-columns: minmax(100px, auto) 325px;
   }
 `;


### PR DESCRIPTION
Removes a breakpoint from the thirds layout. Fixes an issue with text overflow on the issues stream.
Now there will not be a sidebar on some pages until 1200px.

This is used on a bunch of pages, notably the issues stream and performance pages.

Issues stream overflow
![image](https://user-images.githubusercontent.com/1400464/150233881-66a3284e-bb1c-4553-a7b9-9abc1cb250fc.png)

BEFORE 995px some overflow
![image](https://user-images.githubusercontent.com/1400464/150232176-6bb21839-9d26-4d32-9135-7236a8995833.png)

BEFORE 995px with sidebar open. Page overflow on the right side
![image](https://user-images.githubusercontent.com/1400464/150233087-c5601111-aa12-4038-bed0-0d25e1eb377c.png)


AFTER sidebar is down below, like on smaller screens
![image](https://user-images.githubusercontent.com/1400464/150232924-0af49f67-9539-4aa8-9507-88ae73c931e0.png)

