### PR TITLE
feat(alert-rule): Requester response message is optional

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -207,9 +207,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                 )
 
                 if not result["success"]:
-                    raise serializers.ValidationError(
-                        {"sentry_app": f'{install.sentry_app.name}: {result["message"]}'}
-                    )
+                    raise serializers.ValidationError({"sentry_app": result["message"]})
 
                 del attrs["sentry_app_installation_uuid"]
 

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -41,8 +41,9 @@ class AlertRuleActionRequester(Mediator):
                 method=self.http_method,
                 data=self.body,
             )
-            body = safe_urlread(req)
-            response = {"success": True, "message": "", "body": json.loads(body)}
+            body = safe_urlread(req).decode() if safe_urlread(req) else None
+            message = f"{self.sentry_app.name}: {body or 'Success!'}"
+            return {"success": True, "message": message}
         except Exception as e:
             logger.info(
                 "alert_rule_action.error",
@@ -53,10 +54,9 @@ class AlertRuleActionRequester(Mediator):
                     "error_message": str(e),
                 },
             )
+            message = f"{self.sentry_app.name}: {str(e.response.text) or 'Something went wrong!'}"
             # Bubble up error message from Sentry App to the UI for the user.
-            response = {"success": False, "message": str(e.response.text), "body": {}}
-
-        return response
+            return {"success": False, "message": message}
 
     def _build_headers(self):
         request_uuid = uuid4().hex


### PR DESCRIPTION
Fixes SENTRY-SDP

## Objective: 
We want to allow Alert Rule Requester accept 200 responses without a JSON message. Alert Rule Requester will propagate the messages from responses >400  to the user. Error messages will have a default so that user knows that the issue is on the SentryApp's side.