### PR TITLE
Fix metric alert grammar for 1 minute

### DIFF
--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.urls import reverse
+from django.utils.translation import ugettext_lazy as _
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL, get_incident_aggregates
@@ -76,7 +77,7 @@ def incident_attachment_info(incident, metric_value=None, action=None, method=No
 
     interval = "minute" if time_window == 1 else "minutes"
 
-    text = f"{metric_and_agg_text} in the last {time_window} {interval}"
+    text = _(f"{metric_and_agg_text} in the last {time_window} {interval}")
     if alert_rule.snuba_query.query != "":
         text += f"\nFilter: {alert_rule.snuba_query.query}"
 

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -74,7 +74,9 @@ def incident_attachment_info(incident, metric_value=None, action=None, method=No
     else:
         metric_and_agg_text = f"{metric_value} {agg_text}"
 
-    text = f"{metric_and_agg_text} in the last {time_window} minutes"
+    interval = "minute" if time_window == 1 else "minutes"
+
+    text = f"{metric_and_agg_text} in the last {time_window} {interval}"
     if alert_rule.snuba_query.query != "":
         text += f"\nFilter: {alert_rule.snuba_query.query}"
 

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL, get_incident_aggregates
@@ -76,8 +76,11 @@ def incident_attachment_info(incident, metric_value=None, action=None, method=No
         metric_and_agg_text = f"{metric_value} {agg_text}"
 
     interval = "minute" if time_window == 1 else "minutes"
-
-    text = _(f"{metric_and_agg_text} in the last {time_window} {interval}")
+    text = _("%(metric_and_agg_text)s in the last %(time_window)d %(interval)s") % {
+        "metric_and_agg_text": metric_and_agg_text,
+        "time_window": time_window,
+        "interval": interval,
+    }
     if alert_rule.snuba_query.query != "":
         text += f"\nFilter: {alert_rule.snuba_query.query}"
 


### PR DESCRIPTION
This fixes the text of a metric alert so that if something happened in the last minute, it will say "... in the last 1 minute" instead of "... in the last 1 minutes". 