### PR TITLE
fix(ratelimit): Don't rate limit system requests

### DIFF
--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -27,6 +27,9 @@ class RelayProjectConfigsEndpoint(Endpoint):
     authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)
 
+    # Relay requests are internal and shouldn't be rate limited
+    enforce_rate_limit = False
+
     def post(self, request: Request) -> Response:
         with start_transaction(
             op="http.server", name="RelayProjectConfigsEndpoint", sampled=_sample_apm()

--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -27,9 +27,6 @@ class RelayProjectConfigsEndpoint(Endpoint):
     authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)
 
-    # Relay requests are internal and shouldn't be rate limited
-    enforce_rate_limit = False
-
     def post(self, request: Request) -> Response:
         with start_transaction(
             op="http.server", name="RelayProjectConfigsEndpoint", sampled=_sample_apm()

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -51,7 +51,12 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
 
     from django.contrib.auth.models import AnonymousUser
 
+    from sentry.auth.system import SystemToken
     from sentry.models import ApiKey, ApiToken
+
+    # Don't Rate Limit System Token Requests
+    if isinstance(request_auth, SystemToken):
+        return None
 
     if isinstance(request_auth, ApiToken):
 

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -1,6 +1,7 @@
 from django.test import RequestFactory
 
 from sentry.api.endpoints.organization_group_index import OrganizationGroupIndexEndpoint
+from sentry.auth.system import SystemToken
 from sentry.mediators.token_exchange import GrantExchanger
 from sentry.models import User
 from sentry.ratelimits import get_rate_limit_key
@@ -28,6 +29,10 @@ class GetRateLimitKeyTest(TestCase):
             get_rate_limit_key(self.view, self.request)
             == "ip:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
         )
+
+    def test_system_token(self):
+        self.request.auth = SystemToken()
+        assert get_rate_limit_key(self.view, self.request) is None
 
     def test_users(self):
         user = User(id=1)


### PR DESCRIPTION
As the title says, we rate limit internal requests right now. We shouldn't.