### PR TITLE
fix(insights): Improve counts for final bucket in all unresolved endpoint.

### DIFF
--- a/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
+++ b/tests/sentry/api/endpoints/test_team_all_unresolved_issues.py
@@ -18,10 +18,16 @@ class TeamIssueBreakdownTest(APITestCase):
         group1_1 = self.create_group(project=project1, first_seen=before_now(days=40))
         group1_2 = self.create_group(project=project1, first_seen=before_now(days=5))
         group1_3 = self.create_group(
-            project=project1, first_seen=before_now(days=40), resolved_at=before_now(days=35)
+            project=project1,
+            first_seen=before_now(days=40),
+            status=GroupStatus.RESOLVED,
+            resolved_at=before_now(days=35),
         )
         group1_4 = self.create_group(
-            project=project1, first_seen=before_now(days=40), resolved_at=before_now(days=9)
+            project=project1,
+            first_seen=before_now(days=40),
+            status=GroupStatus.RESOLVED,
+            resolved_at=before_now(days=9),
         )
         group1_5 = self.create_group(project=project1, first_seen=before_now(days=40))
         # Should be excluded from counts even though it has no group history row
@@ -31,6 +37,11 @@ class TeamIssueBreakdownTest(APITestCase):
         # Should be excluded from initial counts because it has a regressed status without a
         # corresponding resolved status
         group1_7 = self.create_group(project=project1, first_seen=before_now(days=40))
+        # This group is unresolved, but we have a resolved record for it. This should correctly
+        # show up as unresolved in the last bucket.
+        group1_8 = self.create_group(
+            project=project1, first_seen=before_now(days=40), status=GroupStatus.UNRESOLVED
+        )
         GroupAssignee.objects.assign(group1_1, self.user)
         GroupAssignee.objects.assign(group1_2, self.user)
         GroupAssignee.objects.assign(group1_3, self.user)
@@ -38,6 +49,7 @@ class TeamIssueBreakdownTest(APITestCase):
         GroupAssignee.objects.assign(group1_5, self.user)
         GroupAssignee.objects.assign(group1_6, self.user)
         GroupAssignee.objects.assign(group1_7, self.user)
+        GroupAssignee.objects.assign(group1_8, self.user)
         GroupHistory.objects.all().delete()
 
         self.create_group_history(
@@ -83,8 +95,15 @@ class TeamIssueBreakdownTest(APITestCase):
             date_added=before_now(days=1),
             status=GroupHistoryStatus.REGRESSED,
         )
+        self.create_group_history(
+            group=group1_8,
+            date_added=before_now(days=8, hours=0),
+            status=GroupHistoryStatus.RESOLVED,
+        )
         project2 = self.create_project(teams=[self.team])
-        group2_1 = self.create_group(project=project2, first_seen=before_now(days=40))
+        group2_1 = self.create_group(
+            project=project2, first_seen=before_now(days=40), status=GroupStatus.RESOLVED
+        )
         GroupAssignee.objects.assign(group2_1, self.user)
         self.create_group_history(
             group=group2_1, date_added=before_now(days=6), status=GroupHistoryStatus.RESOLVED
@@ -111,7 +130,9 @@ class TeamIssueBreakdownTest(APITestCase):
         )
 
         project3 = self.create_project(teams=[self.team])
-        group3_1 = self.create_group(project=project3, first_seen=before_now(days=5))
+        group3_1 = self.create_group(
+            project=project3, first_seen=before_now(days=5), status=GroupStatus.RESOLVED
+        )
         GroupAssignee.objects.assign(group3_1, self.user)
         self.create_group_history(
             group=group3_1, date_added=before_now(days=4), status=GroupHistoryStatus.RESOLVED
@@ -150,7 +171,7 @@ class TeamIssueBreakdownTest(APITestCase):
             }
             assert expected == response.data[project.id]
 
-        compare_response(response, project1, [2, 2, 2, 3, 3, 4, 4])
+        compare_response(response, project1, [2, 2, 2, 3, 3, 4, 5])
         compare_response(response, project2, [0, 1, 0, 1, 0, 1, 0])
         compare_response(response, project3, [0, 1, 0, 0, 0, 0, 0])
 


### PR DESCRIPTION
Due to the way we calculate the daily history here we will likely always have at least a little
inaccuracy. To help counter this, on the last bucket we query for the current unresolved counts and
use those, so that at least the final bucket will always be correct.