### PR TITLE
fix(ui): Add padding to <ContextPickerModal />'s options

### DIFF
--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -1,11 +1,12 @@
 import {Component, Fragment} from 'react';
 import ReactDOM from 'react-dom';
-import {components, StylesConfig} from 'react-select';
+import {StylesConfig} from 'react-select';
 import styled from '@emotion/styled';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import SelectControl from 'sentry/components/forms/selectControl';
+import SelectOption from 'sentry/components/forms/selectOption';
 import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -253,14 +254,17 @@ class ContextPickerModal extends Component<Props> {
       return null;
     }
     return (
-      <components.Option label={label} {...props}>
-        <IdBadge
-          project={project}
-          avatarSize={20}
-          displayName={label}
-          avatarProps={{consistentWidth: true}}
-        />
-      </components.Option>
+      <SelectOption
+        label={
+          <IdBadge
+            project={project}
+            avatarSize={20}
+            displayName={label}
+            avatarProps={{consistentWidth: true}}
+          />
+        }
+        {...props}
+      />
     );
   };
 
@@ -334,6 +338,7 @@ class ContextPickerModal extends Component<Props> {
         components={{Option: this.customOptionProject, DropdownIndicator: null}}
         styles={selectStyles}
         menuIsOpen
+        hideCheckmarks
       />
     );
   }

--- a/static/app/components/forms/selectControl.tsx
+++ b/static/app/components/forms/selectControl.tsx
@@ -78,6 +78,12 @@ export type ControlProps<OptionType = GeneralSelectValue> = Omit<
    */
   multiple?: boolean;
   /**
+   * Optionally hide checkmarks/checkboxes. Be careful when using this prop:
+   * if a component shouldn't have checkmarks/boxes, then it's likely that
+   * a dropdown menu would be a better option.
+   */
+  hideCheckmarks?: boolean;
+  /**
    * Show line dividers between options
    */
   showDividers?: boolean;

--- a/static/app/components/forms/selectOption.tsx
+++ b/static/app/components/forms/selectOption.tsx
@@ -9,7 +9,7 @@ type Props = React.ComponentProps<typeof selectComponents.Option>;
 
 function SelectOption(props: Props) {
   const {label, data, selectProps, isMulti, isSelected, isFocused} = props;
-  const {showDividers, verticallyCenterCheckWrap} = selectProps;
+  const {showDividers, hideCheckmarks, verticallyCenterCheckWrap} = selectProps;
   const {
     details,
     leadingItems,
@@ -21,21 +21,23 @@ function SelectOption(props: Props) {
   return (
     <selectComponents.Option {...props} className="select-option">
       <InnerWrap isFocused={isFocused}>
-        <Indent isMulti={isMulti} centerCheckWrap={verticallyCenterCheckWrap}>
-          <CheckWrap isMulti={isMulti} isSelected={isSelected}>
-            {isSelected && (
-              <IconCheckmark
-                size={isMulti ? 'xs' : 'sm'}
-                color={isMulti ? 'white' : undefined}
-              />
+        {!hideCheckmarks && (
+          <Indent isMulti={isMulti} centerCheckWrap={verticallyCenterCheckWrap}>
+            <CheckWrap isMulti={isMulti} isSelected={isSelected}>
+              {isSelected && (
+                <IconCheckmark
+                  size={isMulti ? 'xs' : 'sm'}
+                  color={isMulti ? 'white' : undefined}
+                />
+              )}
+            </CheckWrap>
+            {leadingItems && (
+              <LeadingItems spanFullHeight={leadingItemsSpanFullHeight}>
+                {leadingItems}
+              </LeadingItems>
             )}
-          </CheckWrap>
-          {leadingItems && (
-            <LeadingItems spanFullHeight={leadingItemsSpanFullHeight}>
-              {leadingItems}
-            </LeadingItems>
-          )}
-        </Indent>
+          </Indent>
+        )}
         <ContentWrap
           isFocused={isFocused}
           showDividers={showDividers}


### PR DESCRIPTION
Current implementation replaces the default <SelectOption /> component with a custom component that doesn't have any padding.

**Before:**
<img width="646" alt="Screen Shot 2022-01-19 at 5 44 14 PM" src="https://user-images.githubusercontent.com/44172267/150247245-c03730e9-fd93-4c48-bf0c-70ef7839769e.png">

**After:**
<img width="646" alt="Screen Shot 2022-01-19 at 5 44 36 PM" src="https://user-images.githubusercontent.com/44172267/150247275-8f07f675-4f4a-4e6e-ae02-faef9a9b9e36.png">

