### PR TITLE
fix(workflow): Remove `project:` query on create from discover

### DIFF
--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -270,13 +270,21 @@ function CreateAlertFromViewButton({
     hasYAxisError,
   };
   const project = projects.find(p => p.id === `${eventView.project[0]}`);
+  const queryParams = eventView.generateQueryStringObject();
+  if (queryParams.query?.includes(`project:${project?.slug}`)) {
+    queryParams.query = (queryParams.query as string).replace(
+      `project:${project?.slug}`,
+      ''
+    );
+  }
+
   const hasErrors = Object.values(errors).some(x => x);
   const to = hasErrors
     ? undefined
     : {
         pathname: `/organizations/${organization.slug}/alerts/${project?.slug}/new/`,
         query: {
-          ...eventView.generateQueryStringObject(),
+          ...queryParams,
           createFromDiscover: true,
           referrer,
         },

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -319,6 +319,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                     'release.stage',
                     'release.package',
                     'release.build',
+                    'project',
                   ]}
                   disabled={disabled}
                   useFormWrapper={false}

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -17,7 +17,7 @@ function generateWrappedComponent(organization, eventView) {
       location={location}
       organization={organization}
       eventView={eventView}
-      projects={[]}
+      projects={[TestStubs.Project()]}
       onIncompatibleQuery={onIncompatibleQueryMock}
       onSuccess={onSuccessMock}
     />,
@@ -243,6 +243,24 @@ describe('CreateAlertFromViewButton', () => {
 
     expect(wrapper.find('Button').props().to).toBe(
       `/organizations/org-slug/alerts/proj-slug/wizard/`
+    );
+  });
+
+  it('removes a duplicate project filter', async () => {
+    const eventView = EventView.fromSavedQuery({
+      ...DEFAULT_EVENT_VIEW,
+      query: 'event.type:error project:project-slug',
+      projects: [2],
+    });
+    const wrapper = generateWrappedComponent(organization, eventView);
+
+    expect(wrapper.find('Button').props().to).toEqual(
+      expect.objectContaining({
+        pathname: `/organizations/org-slug/alerts/project-slug/new/`,
+        query: expect.objectContaining({
+          query: 'event.type:error ',
+        }),
+      })
     );
   });
 });


### PR DESCRIPTION
We enforce project selection from the global selection header, if it happens to also be in the query we can remove it