### PR TITLE
fix(release_health): Adjust granularity to be bug-compatible with sessions [INGEST-784]

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1066,7 +1066,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             conditions.append(Condition(Column(environment_key), Op.IN, environment_values))
 
         def query_stats(end: datetime) -> CrashFreeBreakdown:
-            def _get_data(entity_key: EntityKey, metric_key: MetricKey) -> Tuple[int, int]:
+            def _get_data(
+                entity_key: EntityKey, metric_key: MetricKey, referrer: str
+            ) -> Tuple[int, int]:
                 total = 0
                 crashed = 0
                 metric_id = indexer.resolve(metric_key.value)
@@ -1092,7 +1094,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                             where=where,
                             groupby=[Column(status_key)],
                         ),
-                        referrer="release_health.metrics.crash-free-breakdown.session",
+                        referrer=referrer,
                     )["data"]
                     for row in data:
                         if row[status_key] == status_init:
@@ -1103,9 +1105,15 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 return total, crashed
 
             sessions_total, sessions_crashed = _get_data(
-                EntityKey.MetricsCounters, MetricKey.SESSION
+                EntityKey.MetricsCounters,
+                MetricKey.SESSION,
+                referrer="release_health.metrics.crash-free-breakdown.session",
             )
-            users_total, users_crashed = _get_data(EntityKey.MetricsSets, MetricKey.USER)
+            users_total, users_crashed = _get_data(
+                EntityKey.MetricsSets,
+                MetricKey.USER,
+                referrer="release_health.metrics.crash-free-breakdown.users",
+            )
 
             return {
                 "date": end,

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1364,6 +1364,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                         Function("quantiles(0.5, 0.90)", [Column("value")], alias="quantiles"),
                     ],
                     groupby=[Column("bucketed_time")],
+                    referrer="release_health.metrics.get_project_release_stats_durations",
                 )
             )["data"]
             for row in duration_series_data:

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -444,21 +444,15 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
             )
         )
 
-        if isinstance(self.backend, MetricsReleaseHealthBackend):
-            truncation = {"second": 0}
-        else:
-            truncation = {"minute": 0}
-
         expected_formatted_lower_bound = (
             datetime.utcfromtimestamp(self.session_started - 3600 * 2)
-            .replace(**truncation)
+            .replace(minute=0)
             .isoformat()[:19]
             + "Z"
         )
 
         expected_formatted_upper_bound = (
-            datetime.utcfromtimestamp(self.session_started).replace(**truncation).isoformat()[:19]
-            + "Z"
+            datetime.utcfromtimestamp(self.session_started).replace(minute=0).isoformat()[:19] + "Z"
         )
 
         # Test for self.session_release


### PR DESCRIPTION
https://github.com/getsentry/snuba/blob/6f92898b37c89d5d41a1894b313726d85ede0170/snuba/query/processors/timeseries_processor.py#L238-L249
https://github.com/getsentry/snuba/blob/6f92898b37c89d5d41a1894b313726d85ede0170/snuba/datasets/entities/sessions.py#L230-L231

The above code shows that snuba selects the hourly vs raw table based on the `groupby` of the query. If there is no groupby, or if the groupby does not contain any timestamp-related data, the granularity defaults to 1h. In order to make comparisons easier, @jjbayer and I went through each sessions-table query, and considered whether those queries would run with default granularity. If they did, we added a granularity of 1h to the corresponding metrics query.

Once comparison is over, we can undo/tweak this change.

Additionally I fixed some missing referrers in queries.