### PR TITLE
fix(ui): Use theme.headingColor for dashboard widget numbers

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -355,6 +355,7 @@ const LoadingPlaceholder = styled(Placeholder)`
 const BigNumber = styled('div')`
   font-size: 32px;
   line-height: 1;
+  color: ${p => p.theme.headingColor};
   padding: ${space(1)} ${space(3)} ${space(3)} ${space(3)};
   * {
     text-align: left !important;


### PR DESCRIPTION
The big numbers in dashboard widgets should use the darker `headingColor`, not the default `textColor`.

**Before:**
<img width="1246" alt="Screen Shot 2022-01-20 at 10 02 45 AM" src="https://user-images.githubusercontent.com/44172267/150395811-bb1df49d-c23e-4b0c-8960-e4409f249073.png">

**After:**
<img width="1246" alt="Screen Shot 2022-01-20 at 10 02 56 AM" src="https://user-images.githubusercontent.com/44172267/150395844-d51d3254-1e78-4540-a88a-0718fdc0aedc.png">

