### PR TITLE
fix(webhooks): Return issue_id as string

### DIFF
--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -70,7 +70,7 @@ def _webhook_event_data(event, group_id, project_id):
     # a valid URL (it can't know which option to pick). We have to manually
     # create this URL for, that reason.
     event_context["issue_url"] = absolute_uri(f"/api/0/issues/{group_id}/")
-    event_context["issue_id"] = group_id
+    event_context["issue_id"] = str(group_id)
     return event_context
 
 

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -153,7 +153,7 @@ class TestSendAlertEvent(TestCase):
                         )
                     ),
                     issue_url=absolute_uri(f"/api/0/issues/{group.id}/"),
-                    issue_id=group.id,
+                    issue_id=str(group.id),
                 ),
                 "triggered_rule": self.rule.label,
             },
@@ -307,7 +307,7 @@ class TestProcessResourceChange(TestCase):
         assert data["action"] == "created"
         assert data["installation"]["uuid"] == install.uuid
         assert data["data"]["error"]["event_id"] == event.event_id
-        assert data["data"]["error"]["issue_id"] == event.group_id
+        assert data["data"]["error"]["issue_id"] == str(event.group_id)
         assert faux(safe_urlopen).kwargs_contain("headers.Content-Type")
         assert faux(safe_urlopen).kwargs_contain("headers.Request-ID")
         assert faux(safe_urlopen).kwargs_contain("headers.Sentry-Hook-Resource")


### PR DESCRIPTION
## Objective:
Followup to https://github.com/getsentry/sentry/pull/31222

We want to return ids as strings for consistency.