### PR TITLE
fix(notifications): Truncate version in Regression notification

### DIFF
--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from sentry_relay import parse_release
+
+from sentry.models import Activity
 from sentry.utils.html import escape
 from sentry.utils.http import absolute_uri
 
@@ -11,36 +14,33 @@ from .base import GroupActivityNotification
 class RegressionActivityNotification(GroupActivityNotification):
     referrer_base = "regression-activity"
 
+    def __init__(self, activity: Activity) -> None:
+        super().__init__(activity)
+        self.version = self.activity.data.get("version")
+        self.version_parsed = parse_release(self.version)["description"]
+
     def get_activity_name(self) -> str:
         return "Regression"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
-        data = self.activity.data
+        message, params, html_params = "{author} marked {an issue} as a regression", {}, {}
 
-        if data.get("version"):
-            version_url = "/organizations/{}/releases/{}/".format(
-                self.organization.slug, data["version"]
+        if self.version:
+            version_url = absolute_uri(
+                f"/organizations/{self.organization.slug}/releases/{self.version_parsed}/"
             )
 
-            return (
-                "{author} marked {an issue} as a regression in {version}",
-                {"version": data["version"]},
-                {
-                    "version": '<a href="{}">{}</a>'.format(
-                        absolute_uri(version_url), escape(data["version"])
-                    )
-                },
-            )
+            message += " in {version}"
+            params["version"] = self.version_parsed
+            html_params["version"] = f'<a href="{version_url}">{escape(self.version_parsed)}</a>'
 
-        return "{author} marked {an issue} as a regression", {}, {}
+        return message, params, html_params
 
     def get_category(self) -> str:
         return "regression_activity_email"
 
     def get_notification_title(self) -> str:
-        data = self.activity.data
-        release = data.get("version")
         text = "Issue marked as regression"
-        if release:
-            text += f" in release {release}"
+        if self.version:
+            text += f" in release {self.version_parsed}"
         return text

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -16,7 +16,7 @@ class RegressionActivityNotification(GroupActivityNotification):
 
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity)
-        self.version = self.activity.data.get("version")
+        self.version = self.activity.data.get("version", "")
         self.version_parsed = parse_release(self.version)["description"]
 
     def get_activity_name(self) -> str:


### PR DESCRIPTION
Regression notifications use the full version name (e.g. `frontend@0625c034e76ff98873e8f7b27627d6dfcb5d9465`) in the message title. We should use the truncated version we show on the Releases page.

<img width="511" alt="Screen Shot 2022-01-20 at 2 45 13 PM" src="https://user-images.githubusercontent.com/31750075/150434265-702e3c4f-9a30-4c12-85f7-554654bd2af9.png">