### PR TITLE
fix(dashboards): remove last field from topn fields when opening in discover

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -95,8 +95,10 @@ function WidgetCardContextMenu({
             break;
           case DisplayType.TOP_N:
             discoverLocation.query.display = DisplayModes.TOP5;
+            // Last field is used as the yAxis
             discoverLocation.query.yAxis =
               widget.queries[0].fields[widget.queries[0].fields.length - 1];
+            discoverLocation.query.field = widget.queries[0].fields.slice(0, -1);
             break;
           default:
             break;

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -203,7 +203,9 @@ describe('Dashboards > WidgetCard', function () {
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.TOP_N,
-          queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
+          queries: [
+            {...multipleQueryWidget.queries[0], fields: ['transaction', 'count()']},
+          ],
         }}
         selection={selection}
         isEditing={false}
@@ -224,7 +226,7 @@ describe('Dashboards > WidgetCard', function () {
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     expect(screen.getByText('Open in Discover').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/discover/results/?display=top5&environment=prod&field=count%28%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29'
+      '/organizations/org-slug/discover/results/?display=top5&environment=prod&field=transaction&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29'
     );
   });
 


### PR DESCRIPTION
Removes the last field from Top N Widget fields when clicking `Open In Discover`. This is because the last field for Top N widgets is used as the Y Axis, so we remove it before passing to discover, otherwise discover would render the Y Axis as an extra column in the table display.