### PR TITLE
fix(dashboards): Fixed incorrect widget card for Top N widgets when creating from Discover

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -161,7 +161,6 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     if (this.omitDashboardProp) {
       this.fetchDashboards();
     }
-    this.handleDefaultFields();
   }
 
   get omitDashboardProp() {
@@ -317,13 +316,12 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     }
   };
 
-  handleDefaultFields = () => {
-    const {defaultWidgetQuery, defaultTableColumns, widget} = this.props;
+  handleDefaultFields = (newDisplayType: DisplayType) => {
+    const {displayType, defaultWidgetQuery, defaultTableColumns, widget} = this.props;
     this.setState(prevState => {
       const newState = cloneDeep(prevState);
-      const displayType = prevState.displayType as Widget['displayType'];
-      const normalized = normalizeQueries(displayType, prevState.queries);
-      if (displayType === DisplayType.TOP_N) {
+      const normalized = normalizeQueries(newDisplayType, prevState.queries);
+      if (newDisplayType === DisplayType.TOP_N) {
         // TOP N display should only allow a single query
         normalized.splice(1);
       }
@@ -331,7 +329,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       if (!prevState.userHasModified) {
         // If the Widget is an issue widget,
         if (
-          displayType === DisplayType.TABLE &&
+          newDisplayType === DisplayType.TABLE &&
           widget?.widgetType === WidgetType.ISSUE
         ) {
           set(newState, 'queries', widget.queries);
@@ -342,19 +340,16 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
         // Default widget provided by Add to Dashboard from Discover
         if (defaultWidgetQuery && defaultTableColumns) {
           // If switching to Table visualization, use saved query fields for Y-Axis if user has not made query changes
-          if (displayType === DisplayType.TABLE) {
+          // This is so the widget can reflect the same columns as the table in Discover without requiring additional user input
+          if (newDisplayType === DisplayType.TABLE) {
             normalized.forEach(query => {
               query.fields = [...defaultTableColumns];
             });
-          } else if (displayType === DisplayType.TOP_N) {
-            normalized.forEach(query => {
-              // Append Y-Axis to query.fields since TOP_N view assumes the last field is the Y-Axis
-              query.fields = [...defaultTableColumns, defaultWidgetQuery.fields[0]];
-              query.orderby = defaultWidgetQuery.orderby;
-            });
-          } else {
+          } else if (newDisplayType === displayType) {
+            // When switching back to original display type, default fields back to the fields provided from the discover query
             normalized.forEach(query => {
               query.fields = [...defaultWidgetQuery.fields];
+              query.orderby = defaultWidgetQuery.orderby;
             });
           }
         }
@@ -385,7 +380,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     });
 
     if (field === 'displayType' && value !== displayType) {
-      this.handleDefaultFields();
+      this.handleDefaultFields(value as DisplayType);
     }
   };
 

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -915,16 +915,16 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     const wrapper = mountModal({
       initialData,
       onAddWidget: data => (widget = data),
+      displayType: types.DisplayType.TOP_N,
       defaultTableColumns: ['title', 'count()', 'count_unique(user)', 'epm()'],
       defaultWidgetQuery: {
         name: '',
-        fields: ['count()'],
+        fields: ['title', 'count()', 'count_unique(user)', 'epm()', 'count()'],
         conditions: 'tag:value',
         orderby: '',
       },
     });
     // Select Top n display
-    selectByLabel(wrapper, 'Top 5 Events', {name: 'displayType', at: 0, control: true});
     expect(getDisplayType(wrapper).props().value).toEqual('top_n');
 
     // No delete button as there is only one field.
@@ -1002,7 +1002,10 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       onUpdateWidget: () => undefined,
       source: types.DashboardWidgetSource.DISCOVERV2,
       displayType: types.DisplayType.TOP_N,
-      defaultWidgetQuery: {fields: ['count_unique(user)'], orderby: '-count_unique_user'},
+      defaultWidgetQuery: {
+        fields: ['title', 'count()', 'count_unique(user)'],
+        orderby: '-count_unique_user',
+      },
       defaultTableColumns: ['title', 'count()'],
     });
 


### PR DESCRIPTION
- fixed issues with widget card in widget modal not querying proper fields when attempting to add top n widget from discover. Top N discover queries need to pass their selected columns and yaxis in the Widget's `field` attribute due to how Top N widgets are implemented.

- fixed issue with widget fields sometimes entering broken states when switching display types from Discover. Refactored code area around Widget Modal from discover.