### PR TITLE
Fix(dashboards): Widget modal use the updated select option component to match new style

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {browserHistory} from 'react-router';
-import {components, OptionProps} from 'react-select';
+import {OptionProps} from 'react-select';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
@@ -57,6 +57,7 @@ import RadioGroup from 'sentry/views/settings/components/forms/controls/radioGro
 import Field from 'sentry/views/settings/components/forms/field';
 import FieldLabel from 'sentry/views/settings/components/forms/field/fieldLabel';
 
+import Option from '../forms/selectOption';
 import Tooltip from '../tooltip';
 
 import {TAB, TabsButtonBar} from './dashboardWidgetLibraryModal/tabsButtonBar';
@@ -516,11 +517,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
                   containerDisplayMode="block"
                   position="right"
                 >
-                  <components.Option
-                    label={label}
-                    data={data}
-                    {...(optionProps as any)}
-                  />
+                  <Option label={label} data={data} {...(optionProps as any)} />
                 </Tooltip>
               ),
             }}


### PR DESCRIPTION
Fixes selector to use newer option style
Before
![image](https://user-images.githubusercontent.com/83961295/150424515-d83b4aa2-0f9a-4fb2-a288-994946f9e64f.png)
After
![image](https://user-images.githubusercontent.com/83961295/150424479-e845fa3e-12f8-41ac-b148-8cf509188a17.png)
