### PR TITLE
feat(dashboards): Fill out the remaining dashboard templates

### DIFF
--- a/static/app/views/dashboardsV2/data.tsx
+++ b/static/app/views/dashboardsV2/data.tsx
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 import {uniqueId} from 'sentry/utils/guid';
 
-import {DashboardDetails, DisplayType} from './types';
+import {DashboardDetails, DisplayType, WidgetType} from './types';
 
 export const EMPTY_DASHBOARD: DashboardDetails = {
   id: '',
@@ -13,7 +13,6 @@ export const EMPTY_DASHBOARD: DashboardDetails = {
 
 export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
   {
-    // This also exists in the backend at sentry/models/dashboard.py
     id: 'default-template',
     dateCreated: '',
     createdBy: undefined,
@@ -26,11 +25,12 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         queries: [
           {
             name: '',
-            conditions: '!event.type:transaction',
             fields: ['count()'],
+            conditions: '!event.type:transaction',
             orderby: 'count()',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -40,11 +40,12 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         queries: [
           {
             name: '',
-            conditions: '!event.type:transaction',
             fields: ['count_unique(issue)'],
+            conditions: '!event.type:transaction',
             orderby: 'count_unique(issue)',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -54,11 +55,12 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         queries: [
           {
             name: t('Events'),
-            conditions: '!event.type:transaction',
             fields: ['count()'],
+            conditions: '!event.type:transaction',
             orderby: 'count()',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -68,17 +70,18 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         queries: [
           {
             name: t('Known Users'),
-            conditions: 'has:user.email !event.type:transaction',
             fields: ['count_unique(user)'],
+            conditions: 'has:user.email !event.type:transaction',
             orderby: 'count_unique(user)',
           },
           {
             name: t('Anonymous Users'),
-            conditions: '!has:user.email !event.type:transaction',
             fields: ['count_unique(user)'],
+            conditions: '!has:user.email !event.type:transaction',
             orderby: 'count_unique(user)',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -88,17 +91,18 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         queries: [
           {
             name: t('Handled'),
-            conditions: 'error.handled:true',
             fields: ['count()'],
+            conditions: 'error.handled:true',
             orderby: 'count()',
           },
           {
             name: t('Unhandled'),
-            conditions: 'error.handled:false',
             fields: ['count()'],
+            conditions: 'error.handled:false',
             orderby: 'count()',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -108,11 +112,27 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         queries: [
           {
             name: t('Error counts'),
-            conditions: '!event.type:transaction has:geo.country_code',
             fields: ['count()'],
+            conditions: '!event.type:transaction has:geo.country_code',
             orderby: 'count()',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('High Throughput Transactions'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['count()', 'transaction'],
+            conditions: '!event.type:error',
+            orderby: '-count',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -122,11 +142,72 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         queries: [
           {
             name: '',
-            conditions: '!event.type:transaction has:browser.name',
             fields: ['browser.name', 'count()'],
+            conditions: '!event.type:transaction has:browser.name',
             orderby: '-count',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Overall User Misery'),
+        displayType: DisplayType.BIG_NUMBER,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['user_misery(300)'],
+            conditions: '',
+            orderby: '',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('High Throughput Transactions'),
+        displayType: DisplayType.TOP_N,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['transaction', 'count()'],
+            conditions: '!event.type:error',
+            orderby: '-count',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Issues assigned to Me or My Team'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['assignee', 'issue', 'title'],
+            conditions: 'assigned:me is:unresolved',
+            orderby: 'priority',
+          },
+        ],
+        widgetType: WidgetType.ISSUE,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Transactions Ordered by Misery'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['transaction', 'user_misery(300)'],
+            conditions: '',
+            orderby: '-user_misery_300',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
     ],
@@ -138,17 +219,187 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
     createdBy: undefined,
     widgets: [
       {
+        title: t('Top 5 Issues by Unique Users over Time'),
+        displayType: DisplayType.TOP_N,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['issue', 'count_unique(user)'],
+            conditions: '',
+            orderby: '-count_unique_user',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Errors by Browser as Percentage'),
+        displayType: DisplayType.AREA,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: [
+              'equation|count_if(browser.name,equals,Chrome)/count() * 100',
+              'equation|count_if(browser.name,equals,Firefox)/count() * 100',
+              'equation|count_if(browser.name,equals,Safari)/count() * 100',
+            ],
+            conditions: 'has:browser.name',
+            orderby: '',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Issues assigned to Me or My Team'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['issue', 'assignee', 'title'],
+            conditions: 'assigned:me',
+            orderby: 'priority',
+          },
+        ],
+        widgetType: WidgetType.ISSUE,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Top 5 Issues by Unique Users'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['issue', 'count_unique(user)', 'title'],
+            conditions: '',
+            orderby: '-count_unique_user',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Urls grouped by issue'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['http.url', 'issue', 'count_unique(user)'],
+            conditions: 'event.type:error',
+            orderby: '-count_unique_user',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Transactions 404ing'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['transaction', 'count()'],
+            conditions: 'transaction.status:not_found',
+            orderby: '-count',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Layout Shift over Time'),
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['p75(measurements.cls)'],
+            conditions: '',
+            orderby: '',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('LCP by Country'),
+        displayType: DisplayType.WORLD_MAP,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['p75(measurements.lcp)'],
+            conditions: 'has:geo.country_code',
+            orderby: '',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Page Load over Time'),
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['p75(measurements.lcp)', 'p75(measurements.fcp)'],
+            conditions: 'transaction.op:pageload',
+            orderby: '',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Slowest Pageloads'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['transaction', 'count()'],
+            conditions: 'transaction.op:pageload p75(measurements.lcp):>4s',
+            orderby: '-count',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
         title: t('Overall LCP'),
         displayType: DisplayType.BIG_NUMBER,
         interval: '5m',
         queries: [
           {
             name: '',
-            conditions: 'event.type:transaction',
             fields: ['p75(measurements.lcp)'],
-            orderby: 'measurements.lcp',
+            conditions: '',
+            orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Slow Page Navigations'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['transaction', 'count()'],
+            conditions: 'transaction.duration:>2s',
+            orderby: '-count',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -158,67 +409,12 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         queries: [
           {
             name: '',
-            conditions: 'event.type:transaction',
             fields: ['p75(measurements.fcp)'],
-            orderby: 'measurements.fcp',
+            conditions: '',
+            orderby: '',
           },
         ],
-        tempId: uniqueId(),
-      },
-      {
-        title: t('Overall FID'),
-        displayType: DisplayType.BIG_NUMBER,
-        interval: '5m',
-        queries: [
-          {
-            name: '',
-            conditions: 'event.type:transaction',
-            fields: ['p75(measurements.fid)'],
-            orderby: 'measurements.fid',
-          },
-        ],
-        tempId: uniqueId(),
-      },
-      {
-        title: t('LCP over time'),
-        displayType: DisplayType.LINE,
-        interval: '5m',
-        queries: [
-          {
-            name: t('LCP'),
-            conditions: 'event.type:transaction',
-            fields: ['p75(measurements.lcp)'],
-            orderby: 'measurements.lcp',
-          },
-        ],
-        tempId: uniqueId(),
-      },
-      {
-        title: t('FCP over time'),
-        displayType: DisplayType.LINE,
-        interval: '5m',
-        queries: [
-          {
-            name: t('FCP'),
-            conditions: 'event.type:transaction',
-            fields: ['p75(measurements.fcp)'],
-            orderby: 'measurements.fcp',
-          },
-        ],
-        tempId: uniqueId(),
-      },
-      {
-        title: t('FID over time'),
-        displayType: DisplayType.LINE,
-        interval: '5m',
-        queries: [
-          {
-            name: t('FID'),
-            conditions: 'event.type:transaction',
-            fields: ['p75(measurements.fid)'],
-            orderby: 'measurements.fid',
-          },
-        ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
     ],
@@ -230,87 +426,210 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
     createdBy: undefined,
     widgets: [
       {
+        title: t('Top 5 Issues by Unique Users over Time'),
+        displayType: DisplayType.TOP_N,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['issue', 'count_unique(user)'],
+            conditions: '',
+            orderby: '-count_unique_user',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Transactions Erroring Over Time'),
+        displayType: DisplayType.TOP_N,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['transaction', 'count()'],
+            conditions: 'transaction.status:internal_error',
+            orderby: '-count',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Erroring Transactions by Percentage'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: [
+              'equation|count_if(transaction.status,equals,internal_error) / count() * 100',
+              'transaction',
+              'count_if(transaction.status,equals,internal_error)',
+              'count()',
+            ],
+            conditions: 'count():>100',
+            orderby: '-equation[0]',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Top 5 Issues by Unique Users'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['issue', 'count_unique(user)', 'title'],
+            conditions: '',
+            orderby: '-count_unique_user',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Transactions Erroring'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['count()', 'transaction'],
+            conditions: 'transaction.status:internal_error',
+            orderby: '-count',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Issues assigned to Me or My Team'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['assignee', 'issue', 'title'],
+            conditions: 'assigned:me',
+            orderby: 'priority',
+          },
+        ],
+        widgetType: WidgetType.ISSUE,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('p75(duration)'),
+        displayType: DisplayType.WORLD_MAP,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['p75(transaction.duration)'],
+            conditions: '',
+            orderby: '',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('p75 Over Time'),
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['p75(transaction.duration)'],
+            conditions: '',
+            orderby: '',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Throughput (Transactions Per Minute)'),
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [
+          {
+            name: 'Transactions',
+            fields: ['epm()'],
+            conditions: 'event.type:transaction',
+            orderby: '',
+          },
+          {
+            name: 'Errors',
+            fields: ['epm()'],
+            conditions: 'event.type:error',
+            orderby: '',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('Tasks Transactions with poor Apdex'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['count()', 'transaction'],
+            conditions: 'apdex():<0.5 transaction.op:*task*',
+            orderby: '-count',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
+        title: t('HTTP Transactions with poor Apdex'),
+        displayType: DisplayType.TABLE,
+        interval: '5m',
+        queries: [
+          {
+            name: '',
+            fields: ['epm()', 'http.method', 'http.status_code', 'transaction'],
+            conditions:
+              'apdex():<0.5 transaction.op:*http* has:http.method has:http.status_code',
+            orderby: '-epm',
+          },
+        ],
+        widgetType: WidgetType.DISCOVER,
+        tempId: uniqueId(),
+      },
+      {
         title: t('Overall Apdex'),
         displayType: DisplayType.BIG_NUMBER,
         interval: '5m',
         queries: [
           {
             name: '',
-            conditions: 'event.type:transaction',
-            fields: ['apdex()'],
-            orderby: 'apdex',
+            fields: ['apdex(300)'],
+            conditions: '',
+            orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
-        title: t('Failing Transactions'),
+        title: t('Overal P75'),
         displayType: DisplayType.BIG_NUMBER,
         interval: '5m',
         queries: [
           {
             name: '',
-            conditions: 'event.type:transaction',
-            fields: ['failure_count()'],
-            orderby: 'failure_count',
+            fields: ['p75(transaction.duration)'],
+            conditions: '',
+            orderby: '',
           },
         ],
-        tempId: uniqueId(),
-      },
-      {
-        title: t('Overall Misery'),
-        displayType: DisplayType.BIG_NUMBER,
-        interval: '5m',
-        queries: [
-          {
-            name: '',
-            conditions: 'event.type:transaction',
-            fields: ['user_misery()'],
-            orderby: 'user_misery',
-          },
-        ],
-        tempId: uniqueId(),
-      },
-      {
-        title: t('Apdex over time'),
-        displayType: DisplayType.LINE,
-        interval: '5m',
-        queries: [
-          {
-            name: t('Apdex'),
-            conditions: 'event.type:transaction',
-            fields: ['apdex()'],
-            orderby: 'apdex',
-          },
-        ],
-        tempId: uniqueId(),
-      },
-      {
-        title: t('Failure Transactions over time'),
-        displayType: DisplayType.LINE,
-        interval: '5m',
-        queries: [
-          {
-            name: t('Failing Transactions'),
-            conditions: 'event.type:transaction',
-            fields: ['failure_count()'],
-            orderby: 'failure_count',
-          },
-        ],
-        tempId: uniqueId(),
-      },
-      {
-        title: t('Misery over time'),
-        displayType: DisplayType.LINE,
-        interval: '5m',
-        queries: [
-          {
-            name: t('Miserable Users'),
-            conditions: 'event.type:transaction',
-            fields: ['user_misery()'],
-            orderby: 'user_misery',
-          },
-        ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
     ],
@@ -333,6 +652,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -347,6 +667,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -361,6 +682,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -375,6 +697,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '-count_unique_user',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -389,6 +712,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -403,6 +727,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '-count',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -417,6 +742,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -431,6 +757,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -445,6 +772,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -459,6 +787,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -473,6 +802,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -487,6 +817,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -501,6 +832,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
       {
@@ -515,6 +847,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
             orderby: '-p75_measurements_frames_frozen_rate',
           },
         ],
+        widgetType: WidgetType.DISCOVER,
         tempId: uniqueId(),
       },
     ],

--- a/static/app/views/dashboardsV2/data.tsx
+++ b/static/app/views/dashboardsV2/data.tsx
@@ -181,14 +181,14 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         tempId: uniqueId(),
       },
       {
-        title: t('Issues assigned to Me or My Team'),
+        title: t('Issues Assigned to Me or My Teams'),
         displayType: DisplayType.TABLE,
         interval: '5m',
         queries: [
           {
             name: '',
             fields: ['assignee', 'issue', 'title'],
-            conditions: 'assigned:me is:unresolved',
+            conditions: 'assigned_or_suggested:me is:unresolved',
             orderby: 'priority',
           },
         ],
@@ -253,14 +253,14 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         tempId: uniqueId(),
       },
       {
-        title: t('Issues assigned to Me or My Team'),
+        title: t('Issues Assigned to Me or My Teams'),
         displayType: DisplayType.TABLE,
         interval: '5m',
         queries: [
           {
             name: '',
-            fields: ['issue', 'assignee', 'title'],
-            conditions: 'assigned:me',
+            fields: ['assignee', 'issue', 'title'],
+            conditions: 'assigned_or_suggested:me is:unresolved',
             orderby: 'priority',
           },
         ],
@@ -283,7 +283,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         tempId: uniqueId(),
       },
       {
-        title: t('Urls grouped by issue'),
+        title: t('Urls grouped by Issue'),
         displayType: DisplayType.TABLE,
         interval: '5m',
         queries: [
@@ -506,14 +506,14 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         tempId: uniqueId(),
       },
       {
-        title: t('Issues assigned to Me or My Team'),
+        title: t('Issues Assigned to Me or My Teams'),
         displayType: DisplayType.TABLE,
         interval: '5m',
         queries: [
           {
             name: '',
             fields: ['assignee', 'issue', 'title'],
-            conditions: 'assigned:me',
+            conditions: 'assigned_or_suggested:me is:unresolved',
             orderby: 'priority',
           },
         ],
@@ -551,7 +551,7 @@ export const DASHBOARDS_TEMPLATES: DashboardDetails[] = [
         tempId: uniqueId(),
       },
       {
-        title: t('Throughput (Transactions Per Minute)'),
+        title: t('Throughput (Events Per Minute)'),
         displayType: DisplayType.LINE,
         interval: '5m',
         queries: [


### PR DESCRIPTION
Dupe of https://github.com/getsentry/sentry/pull/31220
- This updates the Default, Backend, Frontend templates with actual
  widgets
- This changes the default template on the frontend, but hasn't updated
  the backend version of it, will update that in a separate PR