### PR TITLE
fix(ui): Add seconds to DateTime for users w/ 24 hour clock

### DIFF
--- a/static/app/components/dateTime.tsx
+++ b/static/app/components/dateTime.tsx
@@ -57,8 +57,13 @@ class DateTime extends Component<Props> {
       return 'MM/DD/YYYY';
     }
 
-    // Oct 26, 2017 11:30
     if (clock24Hours) {
+      if (seconds) {
+        // Oct 26, 2017 11:30:30
+        return 'MMM D, YYYY HH:mm:ss';
+      }
+
+      // Oct 26, 2017 11:30
       return 'MMM D, YYYY HH:mm';
     }
 

--- a/tests/js/spec/components/dateTime.spec.jsx
+++ b/tests/js/spec/components/dateTime.spec.jsx
@@ -63,7 +63,7 @@ describe('DateTime', () => {
 
     it('renders a date', () => {
       mountWithTheme(<DateTime date={new Date()} />);
-      expect(screen.getByText('Oct 16, 2017 19:41')).toBeInTheDocument();
+      expect(screen.getByText('Oct 16, 2017 19:41:20')).toBeInTheDocument();
     });
 
     it('renders timeonly', () => {
@@ -78,7 +78,7 @@ describe('DateTime', () => {
 
     it('renders date with forced utc', () => {
       mountWithTheme(<DateTime date={new Date()} utc />);
-      expect(screen.getByText('Oct 17, 2017 02:41')).toBeInTheDocument();
+      expect(screen.getByText('Oct 17, 2017 02:41:20')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Users without 24 hour clock turned on get seconds, they should both have seconds.

fixes [WOR-1563](https://getsentry.atlassian.net/browse/WOR-1563)