### PR TITLE
fix(insights): Filter out groups with a last seen older than 90 days from unresolved issue age and old groups endpoints

### DIFF
--- a/src/sentry/api/endpoints/team_groups_old.py
+++ b/src/sentry/api/endpoints/team_groups_old.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,7 +17,10 @@ class TeamGroupsOldEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignore
         limit = min(100, int(request.GET.get("limit", 10)))
         group_list = list(
             Group.objects.filter_to_team(team)
-            .filter(status=GroupStatus.UNRESOLVED)
+            .filter(
+                status=GroupStatus.UNRESOLVED,
+                last_seen__gt=datetime.now() - timedelta(days=90),
+            )
             .order_by("first_seen")[:limit]
         )
 

--- a/src/sentry/api/endpoints/team_unresolved_issue_age.py
+++ b/src/sentry/api/endpoints/team_unresolved_issue_age.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django.db.models import Case, Count, TextField, Value, When
 from django.utils import timezone
@@ -33,7 +33,10 @@ class TeamUnresolvedIssueAgeEndpoint(TeamEndpoint):  # type: ignore
         current_time = timezone.now()
         unresolved_ages = list(
             Group.objects.filter_to_team(team)
-            .filter(status=GroupStatus.UNRESOLVED)
+            .filter(
+                status=GroupStatus.UNRESOLVED,
+                last_seen__gt=datetime.now() - timedelta(days=90),
+            )
             .annotate(
                 bucket=Case(
                     *[

--- a/tests/sentry/api/endpoints/test_team_groups_old.py
+++ b/tests/sentry/api/endpoints/test_team_groups_old.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.utils import timezone
 
@@ -39,6 +39,14 @@ class TeamGroupsOldTest(APITestCase):
             project=project2,
             first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
         )
+
+        # Should be excluded since it hasn't been seen for over 90 days.
+        last_seen_too_old_group = self.create_group(
+            project=project1,
+            first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+            last_seen=datetime.now() - timedelta(days=91),
+        )
+        GroupAssignee.objects.assign(last_seen_too_old_group, self.user)
 
         self.login_as(user=self.user)
         response = self.get_success_response(self.organization.slug, self.team.slug)

--- a/tests/sentry/api/endpoints/test_team_unresolved_issue_age.py
+++ b/tests/sentry/api/endpoints/test_team_unresolved_issue_age.py
@@ -32,10 +32,13 @@ class TeamUnresolvedIssueAgeEndpointTest(APITestCase):
         assigned_other_team = self.create_group(
             project=project2, status=GroupStatus.RESOLVED, first_seen=before_now(weeks=60)
         )
+        # This group shouldn't be counted since it hasn't been seen for more than 90 days
+        last_seen_too_old_group = self.create_group(project=project1, last_seen=before_now(days=91))
         GroupAssignee.objects.assign(group1, self.user)
         GroupAssignee.objects.assign(group2, self.user)
         GroupAssignee.objects.assign(group3, self.team)
         GroupAssignee.objects.assign(group4, self.user)
+        GroupAssignee.objects.assign(last_seen_too_old_group, self.user)
         GroupAssignee.objects.assign(resolved_group, self.user)
         GroupAssignee.objects.assign(assigned_other_user, other_user)
         GroupAssignee.objects.assign(assigned_other_team, other_team)


### PR DESCRIPTION
Incinerator is currently broken, which means old groups are hanging around forever and appearing in
these reports. To filter them out we remove any groups with a last seen older than 90 days ago.