### PR TITLE
ref(autoplayvideo): convert to functional component

### DIFF
--- a/static/app/components/autoplayVideo.tsx
+++ b/static/app/components/autoplayVideo.tsx
@@ -18,7 +18,6 @@ function AutoplayVideo(props: React.VideoHTMLAttributes<HTMLVideoElement>) {
       // We can't use the muted prop because of a react bug.
       // https://github.com/facebook/react/issues/10389
       // So we need to set the muted property then trigger play.
-      // console.log(videoRef.current);
       videoRef.current.muted = true;
 
       // non-chromium Edge and jsdom don't return a promise.

--- a/static/app/components/autoplayVideo.tsx
+++ b/static/app/components/autoplayVideo.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-type Props = React.HTMLProps<HTMLVideoElement>;
-
 /**
  * Wrapper for autoplaying video.
  *
@@ -11,40 +9,30 @@ type Props = React.HTMLProps<HTMLVideoElement>;
  * Note, video needs `muted` for `autoplay` to work on Chrome
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
  */
-class AutoplayVideo extends React.Component<Props> {
-  componentDidMount() {
-    if (this.videoRef.current) {
+function AutoplayVideo(props: React.VideoHTMLAttributes<HTMLVideoElement>) {
+  const videoRef = React.useRef<HTMLVideoElement>(null);
+
+  React.useEffect(() => {
+    if (videoRef.current) {
       // Set muted as more browsers allow autoplay with muted video.
       // We can't use the muted prop because of a react bug.
       // https://github.com/facebook/react/issues/10389
       // So we need to set the muted property then trigger play.
-      this.videoRef.current.muted = true;
-      const playPromise = this.videoRef.current.play();
+      // console.log(videoRef.current);
+      videoRef.current.muted = true;
 
       // non-chromium Edge and jsdom don't return a promise.
-      playPromise?.catch(() => {
+      videoRef.current.play()?.catch(() => {
         // Do nothing. Interrupting this playback is fine.
       });
     }
-  }
-  private videoRef = React.createRef<HTMLVideoElement>();
+  }, []);
 
-  render() {
-    const {className, src, ...props} = this.props;
-
-    return (
-      <video
-        className={className}
-        ref={this.videoRef}
-        playsInline
-        disablePictureInPicture
-        loop
-        {...props}
-      >
-        <source src={src} type="video/mp4" />
-      </video>
-    );
-  }
+  return (
+    <video ref={videoRef} playsInline disablePictureInPicture loop {...props}>
+      <source src={props.src} type="video/mp4" />
+    </video>
+  );
 }
 
-export default AutoplayVideo;
+export {AutoplayVideo};

--- a/static/app/components/autoplayVideo.tsx
+++ b/static/app/components/autoplayVideo.tsx
@@ -28,9 +28,14 @@ function AutoplayVideo(props: React.VideoHTMLAttributes<HTMLVideoElement>) {
   }, []);
 
   return (
-    <video ref={videoRef} playsInline disablePictureInPicture loop {...props}>
-      <source src={props.src} type="video/mp4" />
-    </video>
+    <video
+      ref={videoRef}
+      data-test-id="autoplay-video"
+      playsInline
+      disablePictureInPicture
+      loop
+      {...props}
+    />
   );
 }
 

--- a/static/app/components/autoplayVideo.tsx
+++ b/static/app/components/autoplayVideo.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+interface AutoplayVideoProps extends React.VideoHTMLAttributes<HTMLVideoElement> {
+  'aria-label': string;
+}
 /**
  * Wrapper for autoplaying video.
  *
@@ -9,7 +12,7 @@ import * as React from 'react';
  * Note, video needs `muted` for `autoplay` to work on Chrome
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
  */
-function AutoplayVideo(props: React.VideoHTMLAttributes<HTMLVideoElement>) {
+function AutoplayVideo(props: AutoplayVideoProps) {
   const videoRef = React.useRef<HTMLVideoElement>(null);
 
   React.useEffect(() => {
@@ -27,16 +30,7 @@ function AutoplayVideo(props: React.VideoHTMLAttributes<HTMLVideoElement>) {
     }
   }, []);
 
-  return (
-    <video
-      ref={videoRef}
-      data-test-id="autoplay-video"
-      playsInline
-      disablePictureInPicture
-      loop
-      {...props}
-    />
-  );
+  return <video ref={videoRef} playsInline disablePictureInPicture loop {...props} />;
 }
 
 export {AutoplayVideo};

--- a/static/app/views/issueList/noGroupsHandler/congratsRobots.tsx
+++ b/static/app/views/issueList/noGroupsHandler/congratsRobots.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import video from 'sentry-images/spot/congrats-robots.mp4';
 
-import AutoplayVideo from 'sentry/components/autoplayVideo';
+import {AutoplayVideo} from 'sentry/components/autoplayVideo';
 import space from 'sentry/styles/space';
 
 /**

--- a/static/app/views/issueList/noGroupsHandler/congratsRobots.tsx
+++ b/static/app/views/issueList/noGroupsHandler/congratsRobots.tsx
@@ -12,7 +12,7 @@ import space from 'sentry/styles/space';
 function CongratsRobots() {
   return (
     <AnimatedScene>
-      <StyledAutoplayVideo src={video} />
+      <StyledAutoplayVideo aria-label="Congratulations video" src={video} />
     </AnimatedScene>
   );
 }

--- a/static/app/views/issueList/noGroupsHandler/congratsRobots.tsx
+++ b/static/app/views/issueList/noGroupsHandler/congratsRobots.tsx
@@ -12,7 +12,7 @@ import space from 'sentry/styles/space';
 function CongratsRobots() {
   return (
     <AnimatedScene>
-      <StyledAutoplayVideo aria-label="Congratulations video" src={video} />
+      <StyledAutoplayVideo aria-label={t('Congratulations video')} src={video} />
     </AnimatedScene>
   );
 }

--- a/static/app/views/issueList/noGroupsHandler/congratsRobots.tsx
+++ b/static/app/views/issueList/noGroupsHandler/congratsRobots.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import video from 'sentry-images/spot/congrats-robots.mp4';
 
 import {AutoplayVideo} from 'sentry/components/autoplayVideo';
+import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 
 /**

--- a/tests/js/spec/components/autoplayVideo.spec.tsx
+++ b/tests/js/spec/components/autoplayVideo.spec.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import {render} from '@testing-library/react';
+
+import {AutoplayVideo} from 'sentry/components/autoplayVideo';
+
+jest.mock('react', () => {
+  return {
+    ...jest.requireActual('react'),
+    useRef: jest.fn(),
+  };
+});
+
+// Use a proxy to prevent <video ref={ref}/> from overriding our ref.current
+const makeProxyMock = (video: Partial<HTMLVideoElement>) => {
+  return new Proxy(
+    {current: video},
+    {
+      get(obj, prop) {
+        return obj[prop];
+      },
+      set(obj, prop) {
+        if (prop === 'current') {
+          obj.current = obj.current;
+        }
+        return true;
+      },
+    }
+  );
+};
+
+describe('autoplayVideo', () => {
+  it('sets mute and calls play', () => {
+    const mock = makeProxyMock({
+      muted: false,
+      play: jest.fn().mockReturnValue(Promise.resolve()),
+    });
+
+    // @ts-ignore we are mocking useRef
+    React.useRef.mockImplementation(() => mock);
+
+    const {container} = render(<AutoplayVideo src="https://example.com/video.mp4" />);
+
+    // Videos sadly do not have a role
+    // eslint-disable-next-line
+    expect(container.querySelector('video')).toBeInTheDocument();
+    expect(mock.current.muted).toBe(true);
+    expect(mock.current.play).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles non promise-like return from play', () => {
+    const mock = makeProxyMock({
+      muted: false,
+      play: jest.fn().mockReturnValue(null),
+    });
+
+    // @ts-ignore we are mocking useRef
+    React.useRef.mockImplementation(() => mock);
+
+    const {container} = render(<AutoplayVideo src="https://example.com/video.mp4" />);
+
+    // Videos sadly do not have a role
+    // eslint-disable-next-line
+    expect(container.querySelector('video')).toBeInTheDocument();
+    expect(mock.current.muted).toBe(true);
+    // Seems that useEffect runs, so no mocking or tick is needed.
+    // Was tested manually by removing the ?.catch safe access and the test fails
+    expect(mock.current.play).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/js/spec/components/autoplayVideo.spec.tsx
+++ b/tests/js/spec/components/autoplayVideo.spec.tsx
@@ -39,13 +39,11 @@ describe('autoplayVideo', () => {
     // @ts-ignore we are mocking useRef
     React.useRef.mockImplementation(() => mock);
 
-    const {container} = mountWithTheme(
-      <AutoplayVideo src="https://example.com/video.mp4" />
+    mountWithTheme(
+      <AutoplayVideo aria-label="video" src="https://example.com/video.mp4" />
     );
 
-    // Videos sadly do not have a role
-    // eslint-disable-next-line
-    expect(container.querySelector('video')).toBeInTheDocument();
+    expect(screen.getByLabelText('video')).toBeInTheDocument();
     expect(mock.current.muted).toBe(true);
     expect(mock.current.play).toHaveBeenCalledTimes(1);
   });
@@ -59,11 +57,11 @@ describe('autoplayVideo', () => {
     // @ts-ignore we are mocking useRef
     React.useRef.mockImplementation(() => mock);
 
-    mountWithTheme(<AutoplayVideo src="https://example.com/video.mp4" />);
+    mountWithTheme(
+      <AutoplayVideo aria-label="video" src="https://example.com/video.mp4" />
+    );
 
-    // Videos sadly do not have a role
-    // eslint-disable-next-line
-    expect(screen.getByTestId('autoplay-video')).toBeInTheDocument();
+    expect(screen.getByLabelText('video')).toBeInTheDocument();
     expect(mock.current.muted).toBe(true);
 
     // Seems that useEffect runs, so no mocking or tick is needed.

--- a/tests/js/spec/components/autoplayVideo.spec.tsx
+++ b/tests/js/spec/components/autoplayVideo.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import {render} from '@testing-library/react';
+
+import {mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
 import {AutoplayVideo} from 'sentry/components/autoplayVideo';
 
@@ -38,7 +39,9 @@ describe('autoplayVideo', () => {
     // @ts-ignore we are mocking useRef
     React.useRef.mockImplementation(() => mock);
 
-    const {container} = render(<AutoplayVideo src="https://example.com/video.mp4" />);
+    const {container} = mountWithTheme(
+      <AutoplayVideo src="https://example.com/video.mp4" />
+    );
 
     // Videos sadly do not have a role
     // eslint-disable-next-line
@@ -56,12 +59,13 @@ describe('autoplayVideo', () => {
     // @ts-ignore we are mocking useRef
     React.useRef.mockImplementation(() => mock);
 
-    const {container} = render(<AutoplayVideo src="https://example.com/video.mp4" />);
+    mountWithTheme(<AutoplayVideo src="https://example.com/video.mp4" />);
 
     // Videos sadly do not have a role
     // eslint-disable-next-line
-    expect(container.querySelector('video')).toBeInTheDocument();
+    expect(screen.getByTestId('autoplay-video')).toBeInTheDocument();
     expect(mock.current.muted).toBe(true);
+
     // Seems that useEffect runs, so no mocking or tick is needed.
     // Was tested manually by removing the ?.catch safe access and the test fails
     expect(mock.current.play).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Convert AutoplayVideo component from class component to functional component. 

I'm just going down the list of `extends React.Component` search results.