### PR TITLE
feat(cra-metrics): Replace UI autocomplete backend

### DIFF
--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -34,6 +34,7 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
                     filter_params["end"],
                     query=request.GET.get("query"),
                     include_transactions=request.GET.get("includeTransactions") == "1",
+                    include_sessions=request.GET.get("includeSessions") == "1",
                 )
 
         return self.paginate(


### PR DESCRIPTION
Replaces the autocomplete release tag values for
crash rate alerts backend with the Release model on
postgres
DACI: https://www.notion.so/sentry/Auto-complete-UI-for-Crash-Rate-Alerts-9328791b2582484e92dec0c533e266ad