### PR TITLE
feat(notifications): overage slack notifications backend

### DIFF
--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -73,6 +73,11 @@ class NotificationSetting(Model):
             (NotificationSettingTypes.ISSUE_ALERTS, "issue"),
             (NotificationSettingTypes.WORKFLOW, "workflow"),
             (NotificationSettingTypes.APPROVAL, "approval"),
+            (NotificationSettingTypes.QUOTA, "quota"),
+            (NotificationSettingTypes.QUOTA_ERRORS, "quotaErrors"),
+            (NotificationSettingTypes.QUOTA_TRANSACTIONS, "quotaTransactions"),
+            (NotificationSettingTypes.QUOTA_ATTACHMENTS, "quotaAttacments"),
+            (NotificationSettingTypes.QUOTA_WARNINGS, "quotaWarnings"),
         ),
         null=False,
     )

--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -13,6 +13,11 @@ NOTIFICATION_SETTINGS_ALL_SOMETIMES = {
     NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.ALWAYS,
     NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
     NotificationSettingTypes.APPROVAL: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.QUOTA: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.QUOTA_ERRORS: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.QUOTA_TRANSACTIONS: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.QUOTA_ATTACHMENTS: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.QUOTA_WARNINGS: NotificationSettingOptionValues.ALWAYS,
 }
 
 NOTIFICATION_SETTINGS_SLACK = {
@@ -20,6 +25,11 @@ NOTIFICATION_SETTINGS_SLACK = {
     NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.NEVER,
     NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.NEVER,
     NotificationSettingTypes.APPROVAL: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.QUOTA: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.QUOTA_ERRORS: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.QUOTA_TRANSACTIONS: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.QUOTA_ATTACHMENTS: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.QUOTA_WARNINGS: NotificationSettingOptionValues.ALWAYS,
 }
 
 NOTIFICATION_SETTING_DEFAULTS = {

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -225,13 +225,23 @@ def validate(type: NotificationSettingTypes, value: NotificationSettingOptionVal
 
 def get_scope_type(type: NotificationSettingTypes) -> NotificationScopeType:
     """In which scope (proj or org) can a user set more specific settings?"""
-    if type in [NotificationSettingTypes.DEPLOY, NotificationSettingTypes.APPROVAL]:
+    if type in [
+        NotificationSettingTypes.DEPLOY,
+        NotificationSettingTypes.APPROVAL,
+        NotificationSettingTypes.QUOTA,
+        NotificationSettingTypes.QUOTA_ERRORS,
+        NotificationSettingTypes.QUOTA_TRANSACTIONS,
+        NotificationSettingTypes.QUOTA_ATTACHMENTS,
+        NotificationSettingTypes.QUOTA_WARNINGS,
+    ]:
         return NotificationScopeType.ORGANIZATION
 
     if type in [NotificationSettingTypes.WORKFLOW, NotificationSettingTypes.ISSUE_ALERTS]:
         return NotificationScopeType.PROJECT
 
-    raise Exception(f"type {type}, must be alerts, deploy, workflow, or approval")
+    raise Exception(
+        f"type {type}, must be alerts, deploy, workflow, approval, quota, quotaErrors, quotaTransactions, quotaAttachments, quotaWarnings"
+    )
 
 
 def get_scope(

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -46,6 +46,17 @@ class NotificationSettingTypes(Enum):
     # Notifications that require approval like a request to invite a member
     APPROVAL = 40
 
+    # Notifications about quotas
+    QUOTA = 50
+
+    # Sub category of quotas for each event category
+    QUOTA_ERRORS = 51
+    QUOTA_TRANSACTIONS = 52
+    QUOTA_ATTACHMENTS = 53
+
+    # Sub category of quotas
+    QUOTA_WARNINGS = 54
+
 
 NOTIFICATION_SETTING_TYPES = {
     NotificationSettingTypes.DEFAULT: "default",
@@ -53,6 +64,11 @@ NOTIFICATION_SETTING_TYPES = {
     NotificationSettingTypes.ISSUE_ALERTS: "alerts",
     NotificationSettingTypes.WORKFLOW: "workflow",
     NotificationSettingTypes.APPROVAL: "approval",
+    NotificationSettingTypes.QUOTA: "quota",
+    NotificationSettingTypes.QUOTA_ERRORS: "quotaErrors",
+    NotificationSettingTypes.QUOTA_TRANSACTIONS: "quotaTransactions",
+    NotificationSettingTypes.QUOTA_ATTACHMENTS: "quotaAttachments",
+    NotificationSettingTypes.QUOTA_WARNINGS: "quotaWarnings",
 }
 
 
@@ -109,6 +125,7 @@ class FineTuningAPIKey(Enum):
     APPROVAL = "approval"
     DEPLOY = "deploy"
     EMAIL = "email"
+    QUOTA = "quota"
     REPORTS = "reports"
     WORKFLOW = "workflow"
 
@@ -120,6 +137,7 @@ class UserOptionsSettingsKey(Enum):
     SUBSCRIBE_BY_DEFAULT = "subscribeByDefault"
     WORKFLOW = "workflowNotifications"
     APPROVAL = "approvalNotifications"
+    QUOTA = "quotaNotifications"
 
 
 VALID_VALUES_FOR_KEY = {
@@ -133,6 +151,26 @@ VALID_VALUES_FOR_KEY = {
         NotificationSettingOptionValues.NEVER,
     },
     NotificationSettingTypes.ISSUE_ALERTS: {
+        NotificationSettingOptionValues.ALWAYS,
+        NotificationSettingOptionValues.NEVER,
+    },
+    NotificationSettingTypes.QUOTA: {
+        NotificationSettingOptionValues.ALWAYS,
+        NotificationSettingOptionValues.NEVER,
+    },
+    NotificationSettingTypes.QUOTA_ERRORS: {
+        NotificationSettingOptionValues.ALWAYS,
+        NotificationSettingOptionValues.NEVER,
+    },
+    NotificationSettingTypes.QUOTA_TRANSACTIONS: {
+        NotificationSettingOptionValues.ALWAYS,
+        NotificationSettingOptionValues.NEVER,
+    },
+    NotificationSettingTypes.QUOTA_ATTACHMENTS: {
+        NotificationSettingOptionValues.ALWAYS,
+        NotificationSettingOptionValues.NEVER,
+    },
+    NotificationSettingTypes.QUOTA_WARNINGS: {
         NotificationSettingOptionValues.ALWAYS,
         NotificationSettingOptionValues.NEVER,
     },

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -54,7 +54,7 @@ class NotificationSettingTypes(Enum):
     QUOTA_TRANSACTIONS = 52
     QUOTA_ATTACHMENTS = 53
 
-    # Sub category of quotas
+    # Sub category of quotas for warnings before hitting the actual limit
     QUOTA_WARNINGS = 54
 
 


### PR DESCRIPTION
This PR adds backend support for the quota category and quota sub-categories (`quotaErrors`, `quotaTransactions`,`quotaAttachments`,`quotaWarnings`). The idea is that on one page a user could modify all the quota related settings together rather than having multiple different pages. Note that a front-end PR will have to be added to start using the fields. These new fields will enable us move quota notifications to the notification platform so we can add Slack messages.