### PR TITLE
chore(codeowners): Restrict the configuration pages to non-members

### DIFF
--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -30,6 +30,7 @@ import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHea
 
 type RouteParams = {
   orgId: string;
+  providerKey: string;
   integrationId: string;
 };
 type Props = RouteComponentProps<RouteParams, {}> & {
@@ -54,7 +55,18 @@ class ConfigureIntegration extends AsyncView<Props, State> {
   }
 
   componentDidMount() {
-    const {location} = this.props;
+    const {
+      location,
+      router,
+      organization,
+      params: {orgId, providerKey},
+    } = this.props;
+    // This page should not be accessible by members
+    if (!organization.access.includes('org:integrations')) {
+      router.push({
+        pathname: `/settings/${orgId}/integrations/${providerKey}/`,
+      });
+    }
     const value =
       (['codeMappings', 'userMappings', 'teamMappings'] as const).find(
         tab => tab === location.query.tab


### PR DESCRIPTION
See [API-2386](https://getsentry.atlassian.net/browse/API-2386)

This PR will restrict the entire configuration pages to non-members only. Prior to this PR if you happened to know the configuration ID of your integration you could access its page even if your permissions wouldn't let you do so in the UI. 

For example: Member's can view `/settings/{org}/integrations/github/`. Here the 'Configure' button is disabled. But if they know the id, they can go to `/settings/{org}/integrations/github/{configId}/` and view the configurations. They can't make changes but can still view mappings, repos, etc.

Now, trying to go to `/settings/{org}/integrations/github/{configId}/` will redirect members to the last page they had access to, `/settings/{org}/integrations/github/`.