### PR TITLE
feat(alert-rule-action): Optional description for alert-rule-settings

### DIFF
--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -134,6 +134,7 @@ SCHEMA = {
             "type": "object",
             "properties": {
                 "type": {"type": "string", "enum": ["alert-rule-settings"]},
+                "description": {"type": "string", "maxLength": 140, "minLength": 1},
                 "uri": {"$ref": "#/definitions/uri"},
                 "required_fields": {"$ref": "#/definitions/fieldset"},
                 "optional_fields": {"$ref": "#/definitions/fieldset"},

--- a/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
@@ -1,7 +1,9 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
 import {closeModal, ModalRenderProps} from 'sentry/actionCreators/modal';
 import {tct} from 'sentry/locale';
+import space from 'sentry/styles/space';
 import SentryAppExternalForm, {
   SchemaFormConfig,
 } from 'sentry/views/organizationIntegrations/sentryAppExternalForm';
@@ -24,7 +26,10 @@ const SentryAppRuleModal = ({
   onSubmitSuccess,
 }: Props) => (
   <Fragment>
-    <Header closeButton>{tct('[name] Settings', {name: appName})}</Header>
+    <Header closeButton>
+      <div>{tct('[name] Settings', {name: appName})}</div>
+      {config.description && <Description>{config.description}</Description>}
+    </Header>
     <Body>
       <SentryAppExternalForm
         sentryAppInstallationUuid={sentryAppInstallationUuid}
@@ -41,5 +46,10 @@ const SentryAppRuleModal = ({
     </Body>
   </Fragment>
 );
+
+const Description = styled('div')`
+  padding-top: ${space(0)};
+  color: ${p => p.theme.subText};
+`;
 
 export default SentryAppRuleModal;

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -28,10 +28,11 @@ export type SchemaFormConfig = {
   uri: string;
   required_fields?: FieldFromSchema[];
   optional_fields?: FieldFromSchema[];
+  description: string | null;
 };
 
 // only need required_fields and optional_fields
-type State = Omit<SchemaFormConfig, 'uri'> & {
+type State = Omit<SchemaFormConfig, 'uri' | 'description'> & {
   optionsByField: Map<string, Array<{label: string; value: any}>>;
 };
 

--- a/tests/sentry/api/validators/sentry_apps/test_alert_rule_action.py
+++ b/tests/sentry/api/validators/sentry_apps/test_alert_rule_action.py
@@ -11,6 +11,7 @@ class TestAlertRuleActionSchemaValidation(TestCase):
             "title": "Create Task",
             "settings": {
                 "type": "alert-rule-settings",
+                "description": "This integration allows you to create a task.",
                 "uri": "/sentry/alert-rule",
                 "required_fields": [{"type": "text", "name": "channel", "label": "Channel"}],
                 "optional_fields": [{"type": "text", "name": "prefix", "label": "Prefix"}],


### PR DESCRIPTION
## Objective:
Allow SentryApp to provide a description above the form for Alert Rule Action. This will be optional. The description should be above the divider of the form and below the title. Will limit the description to 140 characters.

![alert-rule-action-optional-description](https://user-images.githubusercontent.com/10491193/150592191-2f748edc-cd21-4ad2-a709-1f486a6922b0.png)
