### PR TITLE
fix(api): Fix OrganizationTagKeyValuesEndpoint to support passing environment

### DIFF
--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -23,9 +23,12 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
             paginator = SequencePaginator([])
         else:
             with self.handle_query_errors():
+                environment_ids = None
+                if "environment_objects" in filter_params:
+                    environment_ids = [env.id for env in filter_params["environment_objects"]]
                 paginator = tagstore.get_tag_value_paginator_for_projects(
                     filter_params["project_id"],
-                    filter_params.get("environment"),
+                    environment_ids,
                     key,
                     filter_params["start"],
                     filter_params["end"],


### PR DESCRIPTION
We pass in environment name to `get_tag_value_paginator_for_projects`, but we actually require an id
here. When passing an environment name we actually error here when we attempt to translate the
environment filter param.

This fix just changes the code to pass environment ids rather than names.