### PR TITLE
fix(consumer-lag): Remove header optimization for some cases

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -69,6 +69,8 @@ class KafkaEventStream(SnubaProtocolEventStream):
         def strip_none_values(value: Mapping[str, Optional[str]]) -> Mapping[str, str]:
             return {key: value for key, value in value.items() if value is not None}
 
+        # transaction_forwarder header is not sent if option "eventstream:kafka-headers"
+        # is not set to avoid increasing consumer lag on shared events topic.
         transaction_forwarder = True if event.group_id is None else False
 
         send_new_headers = options.get("eventstream:kafka-headers")
@@ -100,7 +102,6 @@ class KafkaEventStream(SnubaProtocolEventStream):
                     received_timestamp,
                     skip_consume,
                 ),
-                "transaction_forwarder": encode_bool(transaction_forwarder),
             }
 
     def _send(


### PR DESCRIPTION
When the header `transaction-forwarder` is present in the kafka headers,
snuba errors and transaction consumers apply an optimization where
they ignore messages which are not destined for them. But the way
they ignore it cause offsets not to be committed often if there are
only 1 type of messages on the shared topic. Removing the header if the
option "eventstream:kafka-headers" is not set. This would resolve
https://github.com/getsentry/self-hosted/issues/1204