### PR TITLE
fix(ui): Prevent suspect span table from displaying frequencies above 100%

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
@@ -47,8 +47,10 @@ export default function SuspectSpansTable(props: Props) {
     description: suspectSpan.description,
     totalCount: suspectSpan.count,
     frequency:
+      // Due to how Clickhouse retrieves data via approximations, sometimes the frequency value can exceed the total number of spans.
+      // This can result in a ratio greater than 1, so use Math.min here to avoid those cases
       defined(suspectSpan.frequency) && defined(totals?.count)
-        ? suspectSpan.frequency / totals!.count
+        ? Math.min(1, suspectSpan.frequency / totals!.count)
         : null,
     avgOccurrences: suspectSpan.avgOccurrences,
     p50ExclusiveTime: suspectSpan.p50ExclusiveTime,

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
@@ -47,8 +47,8 @@ export default function SuspectSpansTable(props: Props) {
     description: suspectSpan.description,
     totalCount: suspectSpan.count,
     frequency:
-      // Due to how Clickhouse retrieves data via approximations, sometimes the frequency value can exceed the total number of spans.
-      // This can result in a ratio greater than 1, so use Math.min here to avoid those cases
+      // Frequency is computed using the `uniq` function in ClickHouse.
+      // Because it is an approximation, it can occasionally exceed the number of events.
       defined(suspectSpan.frequency) && defined(totals?.count)
         ? Math.min(1, suspectSpan.frequency / totals!.count)
         : null,

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -133,7 +133,7 @@ function makeExample(opt: ExampleOpt): ExampleTransaction {
   };
 }
 
-function makeSuspectSpan(opt: SuspectOpt): SuspectSpan {
+export function makeSuspectSpan(opt: SuspectOpt): SuspectSpan {
   const {op, group, description, examples} = opt;
   return {
     op,

--- a/tests/js/spec/views/performance/transactionSpans/suspectSpansTable.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/suspectSpansTable.spec.tsx
@@ -1,0 +1,43 @@
+import {
+  initializeData as _initializeData,
+  makeSuspectSpan,
+  SAMPLE_SPANS,
+} from 'sentry-test/performance/initializePerformanceData';
+import {act, mountWithTheme, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import SuspectSpansTable from 'sentry/views/performance/transactionSummary/transactionSpans/suspectSpansTable';
+import {SpanSortOthers} from 'sentry/views/performance/transactionSummary/transactionSpans/types';
+
+const initializeData = () => {
+  const data = _initializeData({
+    features: ['performance-view', 'performance-suspect-spans-view'],
+  });
+
+  act(() => ProjectsStore.loadInitialData(data.organization.projects));
+  return data;
+};
+
+describe('SuspectSpansTable', () => {
+  it('should not calculate frequency percentages above 100%', async () => {
+    const initialData = initializeData();
+    const suspectSpan = makeSuspectSpan(SAMPLE_SPANS[0]);
+    suspectSpan.frequency = 120;
+
+    mountWithTheme(
+      <SuspectSpansTable
+        location={initialData.router.location}
+        organization={initialData.organization}
+        transactionName="Test Transaction"
+        isLoading={false}
+        suspectSpans={[suspectSpan]}
+        totals={{count: 100}}
+        sort={SpanSortOthers.COUNT}
+      />,
+      {context: initialData.routerContext}
+    );
+
+    const frequencyHeader = await screen.findByTestId('grid-editable');
+    expect(await within(frequencyHeader).findByText('100%')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
In some rare cases, the frequency value in the suspect spans table displays percentages above 100%. This change accounts for those rare cases and ensures that percentages above 100% will not be shown.

Fixes VIS-1391