### PR TITLE
ref(pagerduty): Add logging for resolving metric alerts

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1027,6 +1027,8 @@ SENTRY_FEATURES = {
     # Prefix host with organization ID when giving users DSNs (can be
     # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE)
     "organizations:org-subdomains": False,
+    # Enable logging for select organizations
+    "organizations:pagerduty-metric-alert-resolve-logging": False,
     # Display a global dashboard notification for this org
     "organizations:prompt-dashboards": False,
     # Enable views for ops breakdown

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -120,6 +120,9 @@ default_manager.add("organizations:native-stack-trace-v2", OrganizationFeature, 
 default_manager.add("organizations:notification-all-recipients", OrganizationFeature, True)
 default_manager.add("organizations:onboarding", OrganizationFeature)
 default_manager.add("organizations:org-subdomains", OrganizationFeature)
+default_manager.add(
+    "organizations:pagerduty-metric-alert-resolve-logging", OrganizationFeature, True
+)
 default_manager.add("organizations:performance-chart-interpolation", OrganizationFeature, True)
 default_manager.add("organizations:performance-events-page", OrganizationFeature, True)
 default_manager.add("organizations:performance-landing-widgets", OrganizationFeature, True)

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -1,6 +1,11 @@
+import logging
+
+from sentry import features
 from sentry.api.serializers import ExternalEventSerializer, serialize
 from sentry.eventstore.models import Event
 from sentry.integrations.client import ApiClient
+
+logger = logging.getLogger("sentry.integrations.pagerduty")
 
 LEVEL_SEVERITY_MAP = {
     "debug": "info",
@@ -26,7 +31,7 @@ class PagerDutyClient(ApiClient):
 
         return self._request(method, path, headers=headers, data=data, params=params)
 
-    def send_trigger(self, data):
+    def send_trigger(self, data, organization, method):
         # expected payload: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
         if isinstance(data, Event):
             source = data.transaction or data.culprit or "<unknown>"
@@ -58,7 +63,19 @@ class PagerDutyClient(ApiClient):
             # the payload is for a metric alert
             payload = data
 
-        return self.post("/", data=payload)
+        response = self.post("/", data=payload)
+        if (
+            features.has("organizations:pagerduty-metric-alert-resolve-logging", organization)
+            and method == "resolve"
+            and response.status_code == 202
+        ):
+            logger.info(
+                "resolve.received.pagerduty_metric_alert",
+                extra={
+                    "organization_id": organization.id,
+                },
+            )
+        return response
 
     def send_acknowledge(self, data):
         pass

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -67,13 +67,10 @@ class PagerDutyClient(ApiClient):
         if (
             features.has("organizations:pagerduty-metric-alert-resolve-logging", organization)
             and method == "resolve"
-            and response.status_code == 202
         ):
             logger.info(
                 "resolve.received.pagerduty_metric_alert",
-                extra={
-                    "organization_id": organization.id,
-                },
+                extra={"organization_id": organization.id, "status_code": response.status_code},
             )
         return response
 

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -31,7 +31,7 @@ class PagerDutyClient(ApiClient):
 
         return self._request(method, path, headers=headers, data=data, params=params)
 
-    def send_trigger(self, data, organization, method):
+    def send_trigger(self, data, organization=None, method="fire"):
         # expected payload: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
         if isinstance(data, Event):
             source = data.transaction or data.culprit or "<unknown>"
@@ -65,7 +65,8 @@ class PagerDutyClient(ApiClient):
 
         response = self.post("/", data=payload)
         if (
-            features.has("organizations:pagerduty-metric-alert-resolve-logging", organization)
+            organization
+            and features.has("organizations:pagerduty-metric-alert-resolve-logging", organization)
             and method == "resolve"
         ):
             logger.info(

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("sentry.integrations.pagerduty")
 def build_incident_attachment(action, incident, integration_key, metric_value=None, method=None):
     data = incident_attachment_info(incident, metric_value, action=action, method=method)
     incident_status = incident_status_info(incident, metric_value, action=action, method=method)
-    severity = ""
+    severity = "info"
     if incident_status == IncidentStatus.CRITICAL:
         severity = "critical"
     elif incident_status == IncidentStatus.WARNING:


### PR DESCRIPTION
There is an open customer issue where they have a long delay in resolving PagerDuty metric alerts that I have not been able to reproduce. My idea with this logging is to get confirmation when we send the request to resolve the incident as well as the response, so we can see if the response had any issue. If it responds with a 202 and the customer still says it isn't resolved in PagerDuty, that would point to the problem not being us. I am open to suggestions on debugging this!