### PR TITLE
fix(suspect-spans): Use non aggregate variant of span examples query

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -111,36 +111,31 @@ class OrganizationEventsSpansEndpointTestBase(APITestCase, SnubaTestCase):
     def suspect_span_examples_snuba_results(self, op, event):
         results = {
             "project.id": self.project.id,
-            "project": self.project.slug,
             "id": event.event_id,
-            "array_join_spans_op": op,
         }
 
         if op == "http.server":
             results.update(
                 {
-                    "array_join_spans_group": "ab" * 8,
-                    "count": 1,
-                    "sumArray_spans_exclusive_time": 4.0,
-                    "maxArray_spans_exclusive_time": 4.0,
+                    "count_span_time": 1,
+                    "sum_span_time": 4.0,
+                    "max_span_time": 4.0,
                 }
             )
         elif op == "django.middleware":
             results.update(
                 {
-                    "array_join_spans_group": "cd" * 8,
-                    "count": 2,
-                    "sumArray_spans_exclusive_time": 6.0,
-                    "maxArray_spans_exclusive_time": 3.0,
+                    "count_span_time": 2,
+                    "sum_span_time": 6.0,
+                    "max_span_time": 3.0,
                 }
             )
         elif op == "django.view":
             results.update(
                 {
-                    "array_join_spans_group": "ef" * 8,
-                    "count": 3,
-                    "sumArray_spans_exclusive_time": 3.0,
-                    "maxArray_spans_exclusive_time": 1.0,
+                    "count_span_time": 3,
+                    "sum_span_time": 3.0,
+                    "max_span_time": 1.0,
                 }
             )
         else:


### PR DESCRIPTION
The original span examples query uses an array join with an group by on the
event id. This creates too many groupings, 1 per event id, which leads to slow
query performance. This changes the query to do the same without using array
join or any aggregates.