### PR TITLE
fix(org-stats): fixed /stats_v2/ endpoint returns zero for a lot of time slices

### DIFF
--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -509,7 +509,7 @@ def massage_sessions_result(
         for row in rows:
             row[ts_col] = row[ts_col][:19] + "Z"
 
-        rows = list(reversed(rows))  # Time series was ordered DESC
+        rows.sort(key=lambda row: row[ts_col])
         fields = [(name, field, list()) for name, field in query.fields.items()]
         group_index = 0
 


### PR DESCRIPTION
problem: https://getsentry.atlassian.net/browse/ER-913

The reason why this was happening was in `make_timeseries`, how the rows was sorted was changed. Tbjs caused the `row[ts_col] == ts` to not match in most cases. In turn this set row to `None` which resulted in a 0 in the series field for the date that it was compared to. 

The fix is to revert it back to how the rows were being sorted before. 
![image](https://user-images.githubusercontent.com/22259802/150608458-ac4e16da-4eb3-4771-8ba0-cf6828dc9e59.png)
![image](https://user-images.githubusercontent.com/22259802/150608471-38c8ff51-82f1-4263-87f8-adffcf927080.png)
