### PR TITLE
fix(gsh): Allow absolute date when navigating

### DIFF
--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -127,9 +127,11 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
 
     const oldQuery = getStateFromQuery(lastQuery.current, {
       allowEmptyPeriod: true,
+      allowAbsoluteDatetime: true,
     });
     const newQuery = getStateFromQuery(location.query, {
       allowEmptyPeriod: true,
+      allowAbsoluteDatetime: true,
     });
 
     const newEnvironments = newQuery.environment || [];


### PR DESCRIPTION
Recent changes to GSH may have introduced a bug where modifying the GSH's date through interacting with discover graphs does not seem to take effect, or only take effect when performed multiple times.

Before:
![Kapture 2022-01-21 at 16 08 29](https://user-images.githubusercontent.com/9372512/150615873-971f2ab5-2aa9-4031-bd6b-e7cda483567d.gif)

After:
![Kapture 2022-01-21 at 16 20 47](https://user-images.githubusercontent.com/9372512/150616168-57a8013f-611c-4cac-807e-f13f69265846.gif)


Not sure if this change has other side effects but it seems to make sense that we'd want to allow absolute date here.