### PR TITLE
ref(hook): allow usePrevious to initialize with value and add tests

### DIFF
--- a/static/app/utils/usePrevious.tsx
+++ b/static/app/utils/usePrevious.tsx
@@ -8,7 +8,7 @@ import {useEffect, useRef} from 'react';
  * @returns 'ref.current' and therefore should not be used as a dependency of useEffect.
  * Mutable values like 'ref.current' are not valid dependencies of useEffect because changing them does not re-render the component.
  */
-function usePrevious<T>(value: T) {
+function usePrevious<T>(value: T): T {
   // The ref object is a generic container whose current property is mutable ...
   // ... and can hold any value, similar to an instance property on a class
   const ref = useRef<T>(value);

--- a/static/app/utils/usePrevious.tsx
+++ b/static/app/utils/usePrevious.tsx
@@ -11,7 +11,7 @@ import {useEffect, useRef} from 'react';
 function usePrevious<T>(value: T) {
   // The ref object is a generic container whose current property is mutable ...
   // ... and can hold any value, similar to an instance property on a class
-  const ref = useRef<T>();
+  const ref = useRef<T>(value);
   // Store current value in ref
   useEffect(() => {
     ref.current = value;

--- a/tests/js/spec/utils/usePrevious.spec.jsx
+++ b/tests/js/spec/utils/usePrevious.spec.jsx
@@ -1,0 +1,31 @@
+import {renderHook} from '@testing-library/react-hooks';
+
+import usePrevious from 'sentry/utils/usePrevious';
+
+describe('usePrevious', () => {
+  it('stores initial value', () => {
+    const {result} = renderHook(() => usePrevious('Initial Value'));
+    expect(result.current).toBe('Initial Value');
+  });
+
+  it('provides initial value', () => {
+    const {result} = renderHook(value => usePrevious(value), {
+      initialProps: 'Initial Value',
+    });
+
+    expect(result.current).toBe('Initial Value');
+  });
+
+  it('provides previous value', () => {
+    const {result, rerender} = renderHook(value => usePrevious(value), {
+      initialProps: undefined,
+    });
+
+    rerender('New Value');
+    // We did not pass anything under initialProps
+    expect(result.current).toBe(undefined);
+    rerender('New New Value');
+    // Result should point to old value
+    expect(result.current).toBe('New Value');
+  });
+});

--- a/tests/js/spec/utils/usePrevious.spec.tsx
+++ b/tests/js/spec/utils/usePrevious.spec.tsx
@@ -17,9 +17,12 @@ describe('usePrevious', () => {
   });
 
   it('provides previous value', () => {
-    const {result, rerender} = renderHook(value => usePrevious(value), {
-      initialProps: undefined,
-    });
+    const {result, rerender} = renderHook(
+      (value: string | undefined) => usePrevious(value),
+      {
+        initialProps: undefined,
+      }
+    );
 
     rerender('New Value');
     // We did not pass anything under initialProps


### PR DESCRIPTION
Gives our `usePrevious` hook some extra flexibility by allowing the initial value passed to `useRef` to be initialized. This is useful for cases where you can initialize usePrevious with a value