### PR TITLE
fix(ui): Handle project selection when logger clicked 

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import EventAnnotation from 'sentry/components/events/eventAnnotation';
+import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import InboxReason from 'sentry/components/group/inboxBadges/inboxReason';
 import InboxShortId from 'sentry/components/group/inboxBadges/shortId';
 import TimesTag from 'sentry/components/group/inboxBadges/timesTag';
@@ -89,17 +90,16 @@ function EventOrGroupExtraDetails({
       )}
       {logger && (
         <LoggerAnnotation>
-          <Link
+          <GlobalSelectionLink
             to={{
               pathname: issuesPath,
               query: {
                 query: `logger:${logger}`,
-                project: [project.id],
               },
             }}
           >
             {logger}
-          </Link>
+          </GlobalSelectionLink>
         </LoggerAnnotation>
       )}
       {annotations?.map((annotation, key) => (

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -94,7 +94,7 @@ function EventOrGroupExtraDetails({
               pathname: issuesPath,
               query: {
                 query: `logger:${logger}`,
-                project: project.id,
+                project: [project.id],
               },
             }}
           >

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -94,6 +94,7 @@ function EventOrGroupExtraDetails({
               pathname: issuesPath,
               query: {
                 query: `logger:${logger}`,
+                project: project.id,
               },
             }}
           >


### PR DESCRIPTION
Fix issue where when you click the logger from the Issue Stream, it would go to the Custom Search tab but remove the project from the global header. If you don't have the multiple project feature, it would display an error. This fix should persist the selected project.

[FIXES ISSUE-1381](https://getsentry.atlassian.net/browse/ISSUE-1381)

# Before
<img width="1214" alt="Screen Shot 2022-01-24 at 2 55 48 AM" src="https://user-images.githubusercontent.com/20312973/150773479-44133502-0090-4a7c-9a73-89da7145fc2d.png">
<img width="1217" alt="Screen Shot 2022-01-24 at 2 56 00 AM" src="https://user-images.githubusercontent.com/20312973/150773588-ea203f45-0a8e-4155-a95f-fddf08cb1141.png">

# After
<img width="1220" alt="Screen Shot 2022-01-24 at 2 54 58 AM" src="https://user-images.githubusercontent.com/20312973/150773624-a345f38e-b87c-4db2-9827-e26a1b69bf8c.png">
<img width="1219" alt="Screen Shot 2022-01-24 at 2 55 12 AM" src="https://user-images.githubusercontent.com/20312973/150773640-75d23d63-7893-43b9-b506-35acba0d4599.png">

