### PR TITLE
fix(ui): Custom alert data source change should change the function aggregate

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -389,7 +389,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   }
 
   handleFieldChange = (name: string, value: unknown) => {
-    const {aggregate} = this.state;
+    const {aggregate: _aggregate} = this.state;
     if (
       [
         'dataset',
@@ -400,6 +400,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         'comparisonDelta',
       ].includes(name)
     ) {
+      const aggregate = name === 'aggregate' ? value : _aggregate;
       this.setState({aggregate, [name]: value});
     }
   };


### PR DESCRIPTION
This fixes an issue where the aggregate text on the custom metric alert builder wasn't changing when data source was changed.

[WOR-1562](https://getsentry.atlassian.net/browse/WOR-1562)