### PR TITLE
ref(codeowners): Allow associations endpoint to be limited by provider

### DIFF
--- a/src/sentry/api/endpoints/organization_codeowners_associations.py
+++ b/src/sentry/api/endpoints/organization_codeowners_associations.py
@@ -23,6 +23,11 @@ class OrganizationCodeOwnersAssociationsEndpoint(OrganizationEndpoint):
             status=ObjectStatus.VISIBLE,
         )
         project_code_owners = ProjectCodeOwners.objects.filter(project__in=projects)
+        provider = request.GET.get("provider")
+        if provider:
+            project_code_owners = project_code_owners.filter(
+                repository_project_path_config__organization_integration__integration__provider=provider
+            )
         result = {}
         for pco in project_code_owners:
             associations, errors = ProjectCodeOwners.validate_codeowners_associations(


### PR DESCRIPTION
See [API-2387](https://getsentry.atlassian.net/browse/API-2387)

This PR will introduce a query parameter option to the associations endpoint so that we limit the results based on provider. This will be useful in the team/user mappings pages since we don't want to show 'gitlab' user suggestions on the 'github' configuration page.

Tests have been added as well to ensure this feature works as expected.