### PR TITLE
fix(auth): remove saml expiry logic

### DIFF
--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -1,11 +1,9 @@
-from datetime import datetime
 from urllib.parse import urlparse
 
 from django.contrib import messages
 from django.contrib.auth import logout
 from django.http import HttpResponse, HttpResponseServerError
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -150,14 +148,6 @@ class SAML2ACSView(AuthView):
             return helper.error(ERR_SAML_FAILED.format(reason=auth.get_last_error_reason()))
 
         helper.bind_state("auth_attributes", auth.get_attributes())
-
-        # Not all providers send a session expiration value, but if they do,
-        # we should respect it and set session cookies to expire at the given time.
-        if auth.get_session_expiration() is not None:
-            session_expiration = datetime.fromtimestamp(auth.get_session_expiration()).replace(
-                tzinfo=timezone.utc
-            )
-            request.session.set_expiry(session_expiration)
 
         return helper.next_step()
 

--- a/tests/sentry/auth/providers/test_saml2.py
+++ b/tests/sentry/auth/providers/test_saml2.py
@@ -1,13 +1,9 @@
-import types
-from datetime import datetime
 from unittest import mock
 
 import pytest
-from django.utils import timezone
 
 from sentry.auth.exceptions import IdentityNotValid
-from sentry.auth.helper import AuthHelper
-from sentry.auth.providers.saml2.provider import Attributes, SAML2ACSView, SAML2Provider
+from sentry.auth.providers.saml2.provider import Attributes, SAML2Provider
 from sentry.models import AuthProvider
 from sentry.testutils import TestCase
 
@@ -72,40 +68,3 @@ class SAML2ProviderTest(TestCase):
         assert identity["id"] == "123"
         assert identity["email"] == "valid@example.com"
         assert identity["name"] == "Morty Smith"
-
-
-@mock.patch("sentry.auth.providers.saml2.provider.build_auth")
-class SAML2ACSViewTest(TestCase):
-    def test_set_session_expiration(self, mock_auth):
-        self.org = self.create_organization()
-        self.auth_provider = AuthProvider.objects.create(provider="saml2", organization=self.org)
-        self.provider = SAML2Provider(key=self.auth_provider.provider)
-        self.provider.config = dummy_provider_config
-        self.auth_provider.get_provider = mock.MagicMock(return_value=self.provider)
-        super().setUp()
-
-        request = self.make_request(user=None)
-        request.META = {
-            "PATH_INFO": "/",
-        }
-
-        test_view = SAML2ACSView()
-        helper = AuthHelper(
-            request, self.org, AuthHelper.FLOW_LOGIN, auth_provider=self.auth_provider
-        )
-
-        def mock_next_step(self):
-            return
-
-        helper.next_step = types.MethodType(mock_next_step, helper)
-
-        instance = mock_auth.return_value
-        instance.get_errors.return_value = None
-        instance.get_attributes.return_value = {}
-        instance.get_session_expiration.return_value = 1591044492
-
-        test_view.dispatch(request, helper)
-
-        assert request.session.get_expiry_date() == datetime.fromtimestamp(1591044492).replace(
-            tzinfo=timezone.utc
-        )


### PR DESCRIPTION
This PR reverts https://github.com/getsentry/sentry/pull/19125

Reasons as follows:
- As per[ Django source code](https://github.com/django/django/blob/77d0fe5868a34200c74d4fc45b1fb5f88824345c/django/contrib/sessions/backends/signed_cookies.py#L18), session expiry is not supported if using SignedCookieBackend, so this logic never actually expired sessions as intended.
- In #29422 We defaulted SSO expiry to 20 hours, which should be sufficient going forward
- The serialized datetime being set is causing issues in our work to transition to the JSONSerializer from PickleSerializer. (https://github.com/getsentry/sentry/pull/31153)

