### PR TITLE
ref(ui): Use light text for release projects panel's header

### DIFF
--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -135,7 +135,7 @@ class ReleaseCard extends Component<Props> {
         </ReleaseInfo>
 
         <ReleaseProjects>
-          <ReleaseProjectsHeader>
+          <ReleaseProjectsHeader lightText>
             <ReleaseProjectsLayout showReleaseAdoptionStages={showReleaseAdoptionStages}>
               <ReleaseProjectColumn>{t('Project Name')}</ReleaseProjectColumn>
               {showReleaseAdoptionStages && (


### PR DESCRIPTION
**Before:**
<img width="980" alt="Screen Shot 2022-01-24 at 12 33 45 PM" src="https://user-images.githubusercontent.com/44172267/150860264-26a2a512-6966-415d-9c32-bbe741df0ec6.png">

**After:**
<img width="980" alt="Screen Shot 2022-01-24 at 12 34 13 PM" src="https://user-images.githubusercontent.com/44172267/150860307-12bac844-cd90-4499-bd2f-5106ad7f269b.png">

