### PR TITLE
ref(webhooks): Don't raise errors for 301s

### DIFF
--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -59,7 +59,7 @@ class BaseApiResponse:
         elif response.text.startswith("<"):
             if not allow_text:
                 raise ValueError(f"Not a valid response type: {response.text[:128]}")
-            elif response.status_code == 301 and ignore_webhook_errors:
+            elif ignore_webhook_errors and response.status_code >= 300:
                 return BaseApiResponse()
             elif response.status_code < 200 or response.status_code >= 300:
                 raise ValueError(

--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -59,6 +59,8 @@ class BaseApiResponse:
         elif response.text.startswith("<"):
             if not allow_text:
                 raise ValueError(f"Not a valid response type: {response.text[:128]}")
+            elif response.status_code == 301 and ignore_webhook_errors:
+                return
             elif response.status_code < 200 or response.status_code >= 300:
                 raise ValueError(
                     f"Received unexpected plaintext response for code {response.status_code}"

--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -60,7 +60,7 @@ class BaseApiResponse:
             if not allow_text:
                 raise ValueError(f"Not a valid response type: {response.text[:128]}")
             elif response.status_code == 301 and ignore_webhook_errors:
-                return
+                return BaseApiResponse()
             elif response.status_code < 200 or response.status_code >= 300:
                 raise ValueError(
                     f"Received unexpected plaintext response for code {response.status_code}"

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -95,3 +95,17 @@ class WebHooksPluginTest(TestCase):
 
         with pytest.raises(PluginError):
             validate_urls(form.cleaned_data.get("urls"))
+
+    @responses.activate
+    def test_moved_permanently(self):
+        """Test that we do not raise an error for 301s"""
+
+        responses.add(responses.POST, "http://example.com", body="<moved permanently", status=301)
+
+        try:
+            self.plugin.notify(self.notification)
+        except Exception:
+            assert False, "ValueError: Received unexpected plaintext response for code 301"
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].response.status_code == 301


### PR DESCRIPTION
A follow up to https://github.com/getsentry/sentry/pull/31143 to not raise 301s for webhooks, as we have no control over customers having bad settings.

Fixes [SENTRY-T3E](https://sentry.io/organizations/sentry/issues/2929617510/?project=1&referrer=slack)