### PR TITLE
fix(integrations): Send oversized messages for SQS

### DIFF
--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -183,7 +183,7 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
 
             message = json.dumps(payload)
 
-            if len(message) > 256 * 1024:
+            if len(message) > 256 * 1024 and not s3_bucket:
                 logger.info("sentry_plugins.amazon_sqs.skip_oversized", extra=logging_params)
                 return False
 


### PR DESCRIPTION
Fixes bug (wrong placed condition) that prevents oversized messages from being sent to SQS queue.