### PR TITLE
feat(discover): Label breakdown & measurements as fields

### DIFF
--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -517,12 +517,12 @@ class QueryField extends React.Component<Props> {
         tagType = 'success';
         break;
       case FieldValueKind.MEASUREMENT:
-        text = 'measure';
-        tagType = 'info';
+        text = 'field';
+        tagType = 'highlight';
         break;
       case FieldValueKind.BREAKDOWN:
-        text = 'breakdown';
-        tagType = 'error';
+        text = 'field';
+        tagType = 'highlight';
         break;
       case FieldValueKind.TAG:
         text = kind;

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -489,23 +489,6 @@ export function generateFieldOptions({
     };
   });
 
-  if (tagKeys !== undefined && tagKeys !== null) {
-    tagKeys.sort();
-    tagKeys.forEach(tag => {
-      const tagValue =
-        fields.hasOwnProperty(tag) || AGGREGATIONS.hasOwnProperty(tag)
-          ? `tags[${tag}]`
-          : tag;
-      fieldOptions[`tag:${tag}`] = {
-        label: tag,
-        value: {
-          kind: FieldValueKind.TAG,
-          meta: {name: tagValue, dataType: 'string'},
-        },
-      };
-    });
-  }
-
   if (measurementKeys !== undefined && measurementKeys !== null) {
     measurementKeys.sort();
     measurementKeys.forEach(measurement => {
@@ -527,6 +510,23 @@ export function generateFieldOptions({
         value: {
           kind: FieldValueKind.BREAKDOWN,
           meta: {name: breakdownField, dataType: 'duration'},
+        },
+      };
+    });
+  }
+
+  if (tagKeys !== undefined && tagKeys !== null) {
+    tagKeys.sort();
+    tagKeys.forEach(tag => {
+      const tagValue =
+        fields.hasOwnProperty(tag) || AGGREGATIONS.hasOwnProperty(tag)
+          ? `tags[${tag}]`
+          : tag;
+      fieldOptions[`tag:${tag}`] = {
+        label: tag,
+        value: {
+          kind: FieldValueKind.TAG,
+          meta: {name: tagValue, dataType: 'string'},
         },
       };
     });


### PR DESCRIPTION
- This is cause they're effectively fields, even though they're more specific fields and to try to avoid additional confusion
- This also reorders the dropdowns so measurements & breakdowns appear before tags, rather than after them