### PR TITLE
ref(ts): Remove RelativePeriod

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -24,7 +24,6 @@ import {
   DateString,
   Organization,
   PageFilters,
-  RelativePeriod,
   SelectValue,
   TagCollection,
 } from 'sentry/types';
@@ -77,7 +76,7 @@ export type DashboardWidgetModalOptions = {
   source: DashboardWidgetSource;
   start?: DateString;
   end?: DateString;
-  statsPeriod?: RelativePeriod | string;
+  statsPeriod?: string;
   selectedWidgets?: WidgetTemplate[];
   onAddLibraryWidget?: (widgets: Widget[]) => void;
 };

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -5,7 +5,7 @@
  * or used in multiple views.
  */
 import {getInterval} from 'sentry/components/charts/utils';
-import {API_ACCESS_SCOPES, DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
+import {API_ACCESS_SCOPES} from 'sentry/constants';
 
 /**
  * Visual representation of a project/team/organization/user
@@ -71,7 +71,6 @@ export enum DataCategory {
 
 export type EventType = 'error' | 'transaction' | 'attachment';
 
-export type RelativePeriod = keyof typeof DEFAULT_RELATIVE_PERIODS;
 export type IntervalPeriod = ReturnType<typeof getInterval>;
 
 /**
@@ -94,7 +93,7 @@ export type PageFilters = {
   datetime: {
     start: DateString;
     end: DateString;
-    period: RelativePeriod | string;
+    period: string;
     utc: boolean | null;
   };
 };

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -24,13 +24,7 @@ import {
 import {t} from 'sentry/locale';
 import {PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
-import {
-  DataCategory,
-  DateString,
-  Organization,
-  Project,
-  RelativePeriod,
-} from 'sentry/types';
+import {DataCategory, DateString, Organization, Project} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 import HeaderTabs from 'sentry/views/organizationStats/header';
 
@@ -181,7 +175,7 @@ export class OrganizationStats extends Component<Props> {
     }
 
     return this.setStateOnUrl({
-      pageStatsPeriod: (relative as RelativePeriod) || undefined,
+      pageStatsPeriod: relative || undefined,
       pageStart: undefined,
       pageEnd: undefined,
       pageUtc: undefined,
@@ -196,7 +190,7 @@ export class OrganizationStats extends Component<Props> {
   setStateOnUrl = (
     nextState: {
       dataCategory?: DataCategory;
-      pageStatsPeriod?: RelativePeriod;
+      pageStatsPeriod?: string;
       pageStart?: DateString;
       pageEnd?: DateString;
       pageUtc?: boolean | null;

--- a/static/app/views/organizationStats/teamInsights/overview.tsx
+++ b/static/app/views/organizationStats/teamInsights/overview.tsx
@@ -16,7 +16,7 @@ import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
 import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {DateString, RelativePeriod, TeamWithProjects} from 'sentry/types';
+import {DateString, TeamWithProjects} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import localStorage from 'sentry/utils/localStorage';
@@ -99,7 +99,7 @@ function TeamInsightsOverview({location, router}: Props) {
     }
 
     return setStateOnUrl({
-      pageStatsPeriod: (relative as RelativePeriod) || undefined,
+      pageStatsPeriod: relative || undefined,
       pageStart: undefined,
       pageEnd: undefined,
       pageUtc: undefined,
@@ -107,7 +107,7 @@ function TeamInsightsOverview({location, router}: Props) {
   }
 
   function setStateOnUrl(nextState: {
-    pageStatsPeriod?: RelativePeriod;
+    pageStatsPeriod?: string;
     pageStart?: DateString;
     pageEnd?: DateString;
     pageUtc?: boolean | null;

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -12,7 +12,7 @@ import ScoreCard from 'sentry/components/scoreCard';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {DataCategory, IntervalPeriod, Organization, RelativePeriod} from 'sentry/types';
+import {DataCategory, IntervalPeriod, Organization} from 'sentry/types';
 import {parsePeriodToHours} from 'sentry/utils/dates';
 
 import {
@@ -37,7 +37,7 @@ type Props = {
   chartTransform?: string;
   handleChangeState: (state: {
     dataCategory?: DataCategory;
-    pagePeriod?: RelativePeriod;
+    pagePeriod?: string;
     transform?: ChartDataTransform;
   }) => void;
 } & AsyncComponent['props'];


### PR DESCRIPTION
This was being always used as `RelativePeriod | string` so it always just ends up as string.. Not super helpful.