### PR TITLE
test(org-stats): Test for make_timeseries() 

### DIFF
--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -327,8 +327,6 @@ def test_massage_simple_timeseries():
 
 @freeze_time("2020-12-18T11:14:17.105Z")
 def test_massage_unordered_timeseries():
-    """A timeseries is filled up when it only receives partial data"""
-
     query = _make_query("statsPeriod=1d&interval=6h&field=sum(session)")
     result_totals = [{"sessions": 10}]
     # snuba returns the datetimes as strings for now


### PR DESCRIPTION
problem: org-stats broke due to the timestamps not matching the ordered timestamp as they way of sorting timestamps was changed. it was then fixed in https://github.com/getsentry/sentry/pull/31296. This test checks if the time stamps are being sorted and matched properly so the correct data is being filled

https://getsentry.atlassian.net/browse/ER-915