### PR TITLE
ref(js): Do not export updateParams

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -286,7 +286,7 @@ export function pinFilter(filter: PinnedPageFilter, pin: boolean) {
  * @param [router] React router object
  * @param [options] Options object
  */
-export function updateParams(obj: PageFiltersUpdate, router?: Router, options?: Options) {
+function updateParams(obj: PageFiltersUpdate, router?: Router, options?: Options) {
   // Allow another component to handle routing
   if (!router) {
     return;

--- a/tests/js/spec/actionCreators/pageFilters.spec.jsx
+++ b/tests/js/spec/actionCreators/pageFilters.spec.jsx
@@ -2,7 +2,6 @@ import {
   initializeUrlState,
   updateDateTime,
   updateEnvironments,
-  updateParams,
   updateProjects,
 } from 'sentry/actionCreators/pageFilters';
 import PageFiltersActions from 'sentry/actions/pageFiltersActions';
@@ -203,6 +202,64 @@ describe('PageFilters ActionCreators', function () {
       updateProjects(['1']);
       expect(PageFiltersActions.updateProjects).not.toHaveBeenCalled();
     });
+
+    it('updates history when queries are different', function () {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {project: '2'},
+        },
+      });
+      // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
+      // however react-router will treat it as a string if there is only one param
+      updateProjects([1], router);
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {project: ['1']},
+      });
+    });
+    it('does not update history when queries are the same', function () {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {project: '1'},
+        },
+      });
+      // this can be passed w/ `project` as an array (e.g. multiple projects
+      // being selected) however react-router will treat it as a string if
+      // there is only one param
+      updateProjects([1], router);
+
+      expect(router.push).not.toHaveBeenCalled();
+    });
+
+    it('updates history when queries are different with replace', function () {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {project: '2'},
+        },
+      });
+      updateProjects([1], router, {replace: true});
+
+      expect(router.replace).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {project: ['1']},
+      });
+    });
+
+    it('does not update history when queries are the same with replace', function () {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {project: '1'},
+        },
+      });
+      updateProjects([1], router, {replace: true});
+
+      expect(router.replace).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateEnvironments()', function () {
@@ -302,70 +359,6 @@ describe('PageFilters ActionCreators', function () {
           end: '2020-04-21T00:53:38',
         },
       });
-    });
-  });
-
-  describe('updateParams()', function () {
-    it('updates history when queries are different', function () {
-      const router = TestStubs.router({
-        location: {
-          pathname: '/test/',
-          query: {project: '2'},
-        },
-      });
-      // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
-      // however react-router will treat it as a string if there is only one param
-      updateParams({project: [1]}, router);
-
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {project: ['1']},
-      });
-    });
-    it('does not update history when queries are the same', function () {
-      const router = TestStubs.router({
-        location: {
-          pathname: '/test/',
-          query: {project: '1'},
-        },
-      });
-      // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
-      // however react-router will treat it as a string if there is only one param
-      updateParams({project: [1]}, router);
-
-      expect(router.push).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('updateParams(..., {replace: true})', function () {
-    it('updates history when queries are different', function () {
-      const router = TestStubs.router({
-        location: {
-          pathname: '/test/',
-          query: {project: '2'},
-        },
-      });
-      // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
-      // however react-router will treat it as a string if there is only one param
-      updateParams({project: [1]}, router, {replace: true});
-
-      expect(router.replace).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {project: ['1']},
-      });
-    });
-    it('does not update history when queries are the same', function () {
-      const router = TestStubs.router({
-        location: {
-          pathname: '/test/',
-          query: {project: '1'},
-        },
-      });
-      // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
-      // however react-router will treat it as a string if there is only one param
-      updateParams({project: [1]}, router, {replace: true});
-
-      expect(router.replace).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -57,7 +57,6 @@ describe('GlobalSelectionHeader', function () {
     jest.spyOn(globalActions, 'updateDateTime');
     jest.spyOn(globalActions, 'updateEnvironments');
     jest.spyOn(globalActions, 'updateProjects');
-    jest.spyOn(globalActions, 'updateParams');
   });
 
   beforeEach(function () {
@@ -78,7 +77,6 @@ describe('GlobalSelectionHeader', function () {
       globalActions.updateDateTime,
       globalActions.updateProjects,
       globalActions.updateEnvironments,
-      globalActions.updateParams,
       router.push,
       router.replace,
       getItem,


### PR DESCRIPTION
Simplifies the API of the pageFilter actions a bit more.