### PR TITLE
ref(ts): Allow `period` to be null on PageFilters

### DIFF
--- a/docs-ui/stories/features/streamGroup.stories.js
+++ b/docs-ui/stories/features/streamGroup.stories.js
@@ -15,7 +15,7 @@ const selection = {
   datetime: {
     start: '2019-10-09T11:18:59',
     end: '2019-09-09T11:18:59',
-    period: '',
+    period: null,
     utc: true,
   },
 };

--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -19,7 +19,7 @@ type Options = {
   project?: Readonly<number[]>;
   environment?: Readonly<string[]>;
   team?: Readonly<string | string[]>;
-  period?: string;
+  period?: string | null;
   start?: DateString;
   end?: DateString;
   interval?: string;

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -138,7 +138,7 @@ export function initializeUrlState({
 
   // Do not set a period if we have absolute start and end
   if (pageFilters.datetime.start && pageFilters.datetime.end) {
-    pageFilters.datetime.period = '';
+    pageFilters.datetime.period = null;
   }
 
   if (hasProjectOrEnvironmentInUrl) {

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -256,7 +256,7 @@ type Props = {
   /**
    * optional, used to determine how xAxis is formatted if `isGroupedByDate == true`
    */
-  period?: string;
+  period?: string | null;
   /**
    * Formats dates as UTC?
    */

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -25,7 +25,7 @@ const getDate = date =>
   date ? moment.utc(date).format(moment.HTML5_FMT.DATETIME_LOCAL_SECONDS) : null;
 
 type Period = {
-  period: string;
+  period: string | null;
   start: DateString;
   end: DateString;
 };
@@ -57,7 +57,7 @@ type Props = {
   xAxisIndex?: number | number[];
   start?: DateString;
   end?: DateString;
-  period?: string;
+  period?: string | null;
   utc?: boolean | null;
   onChartReady?: EChartChartReadyHandler;
   onDataZoom?: EChartDataZoomHandler;

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -348,7 +348,7 @@ export type EventsChartProps = {
   /**
    * Relative datetime expression. eg. 14d
    */
-  period?: string;
+  period?: string | null;
   /**
    * Absolute start date.
    */

--- a/static/app/components/charts/eventsGeoRequest.tsx
+++ b/static/app/components/charts/eventsGeoRequest.tsx
@@ -34,7 +34,7 @@ const EventsGeoRequest = ({
   query: string;
   orderby?: string;
   projects: number[];
-  period?: string;
+  period?: string | null;
   start: DateString;
   end: DateString;
   environments: string[];

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -58,7 +58,7 @@ type DefaultProps = {
    *
    * e.g. 24h, 7d, 30d
    */
-  period?: string;
+  period?: string | null;
   /**
    * Absolute start date for query
    */

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -32,7 +32,7 @@ type ReleaseConditions = {
   end: DateString;
   project: Readonly<number[]>;
   environment: Readonly<string[]>;
-  statsPeriod?: string;
+  statsPeriod?: string | null;
   cursor?: string;
   query?: string;
 };
@@ -71,7 +71,7 @@ type Props = WithRouterProps & {
   environments: Readonly<string[]>;
   start: DateString;
   end: DateString;
-  period?: string;
+  period?: string | null;
   utc?: boolean | null;
   releases?: ReleaseMetaBasic[] | null;
   tooltip?: Exclude<Parameters<typeof MarkLine>[0], undefined>['tooltip'];

--- a/static/app/components/charts/sessionsRequest.tsx
+++ b/static/app/components/charts/sessionsRequest.tsx
@@ -26,7 +26,7 @@ type Props = {
   field: SessionField[];
   project?: number[];
   environment?: string[];
-  statsPeriod?: string;
+  statsPeriod?: string | null;
   start?: string;
   end?: string;
   query?: string;

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -156,7 +156,7 @@ const MAX_PERIOD_HOURS_INCLUDE_PREVIOUS = 45 * 24;
 
 export function canIncludePreviousPeriod(
   includePrevious: boolean | undefined,
-  period: string | undefined
+  period: string | null | undefined
 ) {
   if (!includePrevious) {
     return false;

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -76,7 +76,7 @@ export type DashboardWidgetModalOptions = {
   source: DashboardWidgetSource;
   start?: DateString;
   end?: DateString;
-  statsPeriod?: string;
+  statsPeriod?: string | null;
   selectedWidgets?: WidgetTemplate[];
   onAddLibraryWidget?: (widgets: Widget[]) => void;
 };
@@ -549,7 +549,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     const querySelection: PageFilters = statsPeriod
       ? {...selection, datetime: {start: null, end: null, period: statsPeriod, utc: null}}
       : start && end
-      ? {...selection, datetime: {start, end, period: '', utc: null}}
+      ? {...selection, datetime: {start, end, period: null, utc: null}}
       : selection;
     const fieldOptions = (measurementKeys: string[]) =>
       generateFieldOptions({

--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -171,7 +171,7 @@ type InputParams = {
 type ParsedParams = {
   start?: string;
   end?: string;
-  statsPeriod?: string;
+  statsPeriod?: string | null;
   utc?: string;
   [others: string]: Location['query'][string];
 };
@@ -187,7 +187,7 @@ type DateTimeNormalizeOptions = {
    * Include this default statsPeriod in the resulting parsed parameters when
    * no stats period is provided (or if it is an invalid stats period)
    */
-  defaultStatsPeriod?: string;
+  defaultStatsPeriod?: string | null;
   /**
    * Parse absolute date time (`start` / `end`) from the input parameters. When
    * set to false the start and end will always be `null`.
@@ -241,7 +241,8 @@ export function normalizeDateTimeParams(
   let coercedPeriod =
     getStatsPeriodValue(pageStatsPeriod) ||
     getStatsPeriodValue(statsPeriod) ||
-    getStatsPeriodValue(period);
+    getStatsPeriodValue(period) ||
+    null;
 
   const dateTimeStart = allowAbsoluteDatetime
     ? allowAbsolutePageDatetime
@@ -260,8 +261,8 @@ export function normalizeDateTimeParams(
 
   const object = {
     statsPeriod: coercedPeriod,
-    start: coercedPeriod ? null : dateTimeStart,
-    end: coercedPeriod ? null : dateTimeEnd,
+    start: coercedPeriod ? null : dateTimeStart ?? null,
+    end: coercedPeriod ? null : dateTimeEnd ?? null,
     // coerce utc into a string (it can be both: a string representation from
     // router, or a boolean from time range picker)
     utc: getUtcValue(pageUtc ?? utc),

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -102,7 +102,7 @@ type Props = WithRouterProps & {
   /**
    * Relative date value
    */
-  relative: string;
+  relative: string | null;
 
   /**
    * Override defaults from DEFAULT_RELATIVE_PERIODS

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -93,7 +93,7 @@ export type PageFilters = {
   datetime: {
     start: DateString;
     end: DateString;
-    period: string;
+    period: string | null;
     utc: boolean | null;
   };
 };

--- a/static/app/utils/dates.tsx
+++ b/static/app/utils/dates.tsx
@@ -209,9 +209,9 @@ export function parsePeriodToHours(str: string): number {
 }
 
 export function statsPeriodToDays(
-  statsPeriod: string | undefined,
-  start: DateString | undefined,
-  end: DateString | undefined
+  statsPeriod?: string | null,
+  start?: DateString,
+  end?: DateString
 ) {
   if (statsPeriod && statsPeriod.endsWith('d')) {
     return parseInt(statsPeriod.slice(0, -1), 10);

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -58,11 +58,11 @@ export type MetaType = Record<string, ColumnType>;
 export type EventData = Record<string, any>;
 
 export type LocationQuery = {
-  start?: string | string[];
-  end?: string | string[];
-  utc?: string | string[];
-  statsPeriod?: string | string[];
-  cursor?: string | string[];
+  start?: string | string[] | null;
+  end?: string | string[] | null;
+  utc?: string | string[] | null;
+  statsPeriod?: string | string[] | null;
+  cursor?: string | string[] | null;
 };
 
 const DATETIME_QUERY_STRING_KEYS = ['start', 'end', 'utc', 'statsPeriod'] as const;
@@ -580,10 +580,10 @@ class EventView {
       datetime: {
         start: this.start ?? null,
         end: this.end ?? null,
-        period: this.statsPeriod ?? '',
-        // TODO(tony) Add support for the Use UTC option from
-        // the global headers, currently, that option is not
-        // supported and all times are assumed to be UTC
+        period: this.statsPeriod ?? null,
+        // TODO(tony) Add support for the Use UTC option from the global
+        // headers, currently, that option is not supported and all times are
+        // assumed to be UTC
         utc: true,
       },
     };

--- a/static/app/utils/getPeriod.tsx
+++ b/static/app/utils/getPeriod.tsx
@@ -8,7 +8,7 @@ type DateObject = {
   /**
    * Relative period string in format "<int><unit>" (e.g. 4d for 4 days)
    */
-  period?: string;
+  period?: string | null;
   /**
    * Starting date object
    */

--- a/static/app/utils/metrics/metricsRequest.tsx
+++ b/static/app/utils/metrics/metricsRequest.tsx
@@ -45,7 +45,7 @@ type Props = DefaultProps & {
   children?: (renderProps: MetricsRequestRenderProps) => React.ReactNode;
   project?: Readonly<number[]>;
   environment?: Readonly<string[]>;
-  statsPeriod?: string;
+  statsPeriod?: string | null;
   start?: DateString;
   end?: DateString;
   query?: string;

--- a/static/app/utils/performance/quickTrace/types.tsx
+++ b/static/app/utils/performance/quickTrace/types.tsx
@@ -71,7 +71,7 @@ export type TraceProps = {
   traceId: string;
   start?: string;
   end?: string;
-  statsPeriod?: string;
+  statsPeriod?: string | null;
 };
 
 export type TraceRequestProps = DiscoverQueryProps & TraceProps;

--- a/static/app/utils/performance/quickTrace/utils.tsx
+++ b/static/app/utils/performance/quickTrace/utils.tsx
@@ -240,7 +240,7 @@ export function makeEventView({
 }: {
   start?: string;
   end?: string;
-  statsPeriod?: string;
+  statsPeriod?: string | null;
 }) {
   return EventView.fromSavedQuery({
     id: undefined,
@@ -254,7 +254,7 @@ export function makeEventView({
     environment: [],
     start,
     end,
-    range: statsPeriod,
+    range: statsPeriod ?? undefined,
   });
 }
 

--- a/static/app/views/dashboardsV2/utils.tsx
+++ b/static/app/views/dashboardsV2/utils.tsx
@@ -51,7 +51,7 @@ export function eventViewFromWidget(
     query: conditions,
     orderby: query.orderby,
     projects,
-    range: statsPeriod,
+    range: statsPeriod ?? undefined,
     start: start ? getUtcDateString(start) : undefined,
     end: end ? getUtcDateString(end) : undefined,
     environment: environments,

--- a/static/app/views/dashboardsV2/widget/metricWidget/statsRequest.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/statsRequest.tsx
@@ -32,7 +32,7 @@ type RequestQuery = {
   query?: string;
   start?: string;
   end?: string;
-  period?: string;
+  period?: string | null;
   utc?: string;
 };
 

--- a/static/app/views/dashboardsV2/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/issueWidgetQueries.tsx
@@ -29,8 +29,8 @@ type EndpointParams = Partial<PageFilters['datetime']> & {
   environment: string[];
   query?: string;
   sort?: string;
-  statsPeriod?: string;
-  groupStatsPeriod?: string;
+  statsPeriod?: string | null;
+  groupStatsPeriod?: string | null;
   cursor?: string;
   page?: number | string;
   display?: string;
@@ -177,7 +177,7 @@ class IssueWidgetQueries extends React.Component<Props, State> {
         transformedTableResult.start = getUtcDateString(start);
         transformedTableResult.end = getUtcDateString(end);
       }
-      transformedTableResult.period = period;
+      transformedTableResult.period = period ?? '';
       transformedTableResults.push(transformedTableResult);
     });
     return transformedTableResults;

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -128,8 +128,8 @@ type EndpointParams = Partial<PageFilters['datetime']> & {
   environment: string[];
   query?: string;
   sort?: string;
-  statsPeriod?: string;
-  groupStatsPeriod?: string;
+  statsPeriod?: string | null;
+  groupStatsPeriod?: string | null;
   cursor?: string;
   page?: number | string;
   display?: string;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -190,7 +190,7 @@ export class OrganizationStats extends Component<Props> {
   setStateOnUrl = (
     nextState: {
       dataCategory?: DataCategory;
-      pageStatsPeriod?: string;
+      pageStatsPeriod?: string | null;
       pageStart?: DateString;
       pageEnd?: DateString;
       pageUtc?: boolean | null;

--- a/static/app/views/organizationStats/teamInsights/overview.tsx
+++ b/static/app/views/organizationStats/teamInsights/overview.tsx
@@ -107,7 +107,7 @@ function TeamInsightsOverview({location, router}: Props) {
   }
 
   function setStateOnUrl(nextState: {
-    pageStatsPeriod?: string;
+    pageStatsPeriod?: string | null;
     pageStart?: DateString;
     pageEnd?: DateString;
     pageUtc?: boolean | null;

--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -33,7 +33,7 @@ type TeamMiseryProps = {
   periodTableData: TableData | null;
   weekTableData: TableData | null;
   isLoading: boolean;
-  period?: string;
+  period?: string | null;
   error?: Error | null;
 };
 
@@ -190,7 +190,7 @@ type Props = AsyncComponent['props'] & {
   teamId: string;
   projects: Project[];
   location: Location;
-  period?: string;
+  period?: string | null;
   start?: string;
   end?: string;
 } & DateTimeObject;
@@ -237,7 +237,7 @@ function TeamMiseryWrapper({
   const periodEventView = EventView.fromSavedQuery({
     ...commonEventView,
     name: 'periodMisery',
-    range: period,
+    range: period ?? undefined,
     start,
     end,
   });

--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -33,7 +33,7 @@ import {groupByTrend} from './utils';
 type Props = AsyncComponent['props'] & {
   organization: Organization;
   projects: Project[];
-  period?: string;
+  period?: string | null;
 } & DateTimeObject;
 
 type State = AsyncComponent['state'] & {

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -37,7 +37,7 @@ type Props = {
   chartTransform?: string;
   handleChangeState: (state: {
     dataCategory?: DataCategory;
-    pagePeriod?: string;
+    pagePeriod?: string | null;
     transform?: ChartDataTransform;
   }) => void;
 } & AsyncComponent['props'];

--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -15,7 +15,7 @@ type Props = {
   data: Series[];
   previousData?: Series[];
   router: InjectedRouter;
-  statsPeriod: string | undefined;
+  statsPeriod: string | null | undefined;
   start: DateString;
   end: DateString;
   utc: boolean;

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -57,7 +57,7 @@ export type QueryFC<T extends WidgetDataConstraint> = React.FC<
   QueryChildren & {
     fields?: string | string[];
     yAxis?: string | string[];
-    period?: string;
+    period?: string | null;
     start?: DateString;
     end?: DateString;
     project?: Readonly<number[]>;

--- a/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
@@ -23,7 +23,7 @@ type Props = {
   organization: OrganizationSummary;
   location: Location;
   transaction: string;
-  statsPeriod?: string;
+  statsPeriod?: string | null;
   start?: string;
   end?: string;
 };

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -58,7 +58,7 @@ type Props = Pick<
     chartOptions: Record<string, any>;
     series: React.ComponentProps<typeof LineChart>['series'];
   };
-  statsPeriod?: string;
+  statsPeriod?: string | null;
   start?: Date;
   end?: Date;
 };

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -35,7 +35,7 @@ type Props = WithRouterProps & {
   value: React.ReactNode;
   diff: React.ReactNode;
   organization: Organization;
-  period?: string;
+  period?: string | null;
   start?: string;
   end?: string;
   utc?: boolean;

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -52,7 +52,7 @@ type Props = {
   diff: React.ReactNode;
   loading: boolean;
   reloading: boolean;
-  period?: string;
+  period?: string | null;
   start?: string;
   end?: string;
   utc?: boolean;

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -2797,7 +2797,7 @@ describe('EventView.getPageFilters()', function () {
       datetime: {
         start: null,
         end: null,
-        period: '',
+        period: null,
 
         // event views currently do not support the utc option,
         // see comment in EventView.getPageFilters


### PR DESCRIPTION
This was the only parameter, that for whatever reason couldn't be set to null, even though it's possible for this value to be empty, you had to set it to ''.

There were also various places we were overriding the type to allow null, so :shrug: