### PR TITLE
fix(ui): Use `size="zero"` for SDK alert buttons

### DIFF
--- a/static/app/components/globalSdkUpdateAlert.tsx
+++ b/static/app/components/globalSdkUpdateAlert.tsx
@@ -125,6 +125,7 @@ class InnerGlobalSdkSuggestions extends React.Component<Props, State> {
     const showBroadcastsPanel = (
       <Button
         priority="link"
+        size="zero"
         onClick={() => {
           SidebarPanelActions.activatePanel(SidebarPanelKey.Broadcasts);
           recordAnalyticsClicked({organization});
@@ -143,6 +144,7 @@ class InnerGlobalSdkSuggestions extends React.Component<Props, State> {
           <Actions>
             <Button
               priority="link"
+              size="zero"
               title={t('Dismiss for the next two weeks')}
               onClick={this.snoozePrompt}
             >


### PR DESCRIPTION
Before:
<img width="1253" alt="Screen Shot 2022-01-25 at 12 24 40 PM" src="https://user-images.githubusercontent.com/44172267/151054024-5bb67ffc-6542-43ed-84bf-3ae02ed3d756.png">

After:
<img width="1253" alt="Screen Shot 2022-01-25 at 12 24 56 PM" src="https://user-images.githubusercontent.com/44172267/151054039-dd3cc5de-b001-4ffa-8fc2-9b1fa81eb061.png">

