### PR TITLE
chore(suspect-spans): Remove unused referrer on spans stats

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeChart.tsx
@@ -104,7 +104,6 @@ export default function ExclusiveTimeChart(props: Props) {
             yAxis={yAxis}
             partial
             withoutZerofill={withoutZerofill}
-            referrer="api.performance.transaction-summary.duration-chart"
             queryExtras={{span: `${spanSlug.op}:${spanSlug.group}`}}
             generatePathname={org => `/organizations/${org.slug}/events-spans-stats/`}
           >


### PR DESCRIPTION
The backend already has a referrer set on this endpoint. This referrer on the
frontend is not used.