### PR TITLE
ref(pageFilters): Don't handle merging page filter when persisting

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -8,10 +8,7 @@ import * as qs from 'query-string';
 
 import PageFiltersActions from 'sentry/actions/pageFiltersActions';
 import {getStateFromQuery} from 'sentry/components/organizations/pageFilters/parse';
-import {
-  PageFiltersStringified,
-  PageFiltersUpdate,
-} from 'sentry/components/organizations/pageFilters/types';
+import {PageFiltersStringified} from 'sentry/components/organizations/pageFilters/types';
 import {
   getDefaultSelection,
   getPageFilterStorage,
@@ -21,6 +18,7 @@ import {URL_PARAM} from 'sentry/constants/pageFilters';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {
+  DateString,
   Environment,
   MinimalProject,
   Organization,
@@ -54,6 +52,19 @@ type Options = {
    * Use Location.replace instead of push when updating the URL query state
    */
   replace?: boolean;
+};
+
+/**
+ * This is the 'update' object used for updating the page filters. The types
+ * here are a bit wider to allow for easy updates.
+ */
+type PageFiltersUpdate = {
+  project?: Array<string | number> | null;
+  environment?: string[] | null;
+  start?: DateString;
+  end?: DateString;
+  utc?: string | boolean | null;
+  period?: string | null;
 };
 
 /**
@@ -209,6 +220,10 @@ export function initializeUrlState({
   });
 }
 
+function isProjectsValid(projects: ProjectId[]) {
+  return Array.isArray(projects) && projects.every(project => isInteger(project));
+}
+
 /**
  * Updates store and  selection URL param if `router` is supplied
  *
@@ -231,29 +246,7 @@ export function updateProjects(
 
   PageFiltersActions.updateProjects(projects, options?.environments);
   updateParams({project: projects, environment: options?.environments}, router, options);
-}
-
-function isProjectsValid(projects: ProjectId[]) {
-  return Array.isArray(projects) && projects.every(project => isInteger(project));
-}
-
-/**
- * Updates store and global datetime selection URL param if `router` is supplied
- *
- * @param {Object} datetime Object with start, end, range keys
- * @param {Object} [router] Router object
- * @param {Object} [options] Options object
- * @param {String[]} [options.resetParams] List of parameters to remove when changing URL params
- */
-export function updateDateTime(
-  datetime: DateTimeUpdate,
-  router?: Router,
-  options?: Options
-) {
-  PageFiltersActions.updateDateTime(datetime);
-  // We only save projects/environments to local storage, do not
-  // save anything when date changes.
-  updateParams(datetime, router, {...options, save: false});
+  persistPageFilters(options);
 }
 
 /**
@@ -271,6 +264,27 @@ export function updateEnvironments(
 ) {
   PageFiltersActions.updateEnvironments(environment);
   updateParams({environment}, router, options);
+  persistPageFilters(options);
+}
+
+/**
+ * Updates store and global datetime selection URL param if `router` is supplied
+ *
+ * @param {Object} datetime Object with start, end, range keys
+ * @param {Object} [router] Router object
+ * @param {Object} [options] Options object
+ * @param {String[]} [options.resetParams] List of parameters to remove when changing URL params
+ */
+export function updateDateTime(
+  datetime: DateTimeUpdate,
+  router?: Router,
+  options?: Options
+) {
+  PageFiltersActions.updateDateTime(datetime);
+  updateParams(datetime, router, options);
+
+  // We only save projects/environments to local storage, do not
+  // save anything when date changes.
 }
 
 export function pinFilter(filter: PinnedPageFilter, pin: boolean) {
@@ -299,17 +313,34 @@ function updateParams(obj: PageFiltersUpdate, router?: Router, options?: Options
     return;
   }
 
-  if (options?.save) {
-    const {organization} = OrganizationStore.getState();
-    const {selection} = PageFiltersStore.getState();
-    const orgSlug = organization?.slug ?? null;
-
-    setPageFiltersStorage(orgSlug, selection, newQuery);
-  }
-
   const routerAction = options?.replace ? router.replace : router.push;
 
   routerAction({pathname: router.location.pathname, query: newQuery});
+}
+
+/**
+ * Save the current page filters to local storage
+ */
+async function persistPageFilters(options?: Options) {
+  if (!options?.save) {
+    return;
+  }
+
+  // XXX(epurkhiser): Since this is called immediately after updating the
+  // store, wait for a tick since stores are not updated fully synchronously..
+  // a bit goofy, but it works fine.
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  const {organization} = OrganizationStore.getState();
+  const {selection} = PageFiltersStore.getState();
+  const orgSlug = organization?.slug ?? null;
+
+  // Can't do anything if we don't have an organization
+  if (orgSlug === null) {
+    return;
+  }
+
+  setPageFiltersStorage(orgSlug, selection);
 }
 
 /**

--- a/static/app/components/organizations/pageFilters/types.tsx
+++ b/static/app/components/organizations/pageFilters/types.tsx
@@ -1,5 +1,3 @@
-import {DateString} from 'sentry/types';
-
 /**
  * A flat object of stringified page filter data
  *
@@ -25,17 +23,4 @@ export type PageFiltersState = {
   start: Date | null;
   end: Date | null;
   utc: boolean | null;
-};
-
-/**
- * This is the 'update' object used for updating the page filters. The types
- * here are a bit wider to allow for easy updates.
- */
-export type PageFiltersUpdate = {
-  project?: Array<string | number> | null;
-  environment?: string[] | null;
-  start?: DateString;
-  end?: DateString;
-  utc?: string | boolean | null;
-  period?: string | null;
 };

--- a/static/app/components/organizations/pageFilters/utils.tsx
+++ b/static/app/components/organizations/pageFilters/utils.tsx
@@ -7,11 +7,8 @@ import pickBy from 'lodash/pickBy';
 
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/constants/pageFilters';
-import OrganizationsStore from 'sentry/stores/organizationsStore';
 import {PageFilters} from 'sentry/types';
 import localStorage from 'sentry/utils/localStorage';
-
-import {PageFiltersStringified} from './types';
 
 /**
  * Make a default page filters object
@@ -98,29 +95,14 @@ type RetrievedData = {
  * However, if user then changes environment, it should...? Currently it will
  * save the current project alongside environment to local storage. It's
  * debatable if this is the desired behavior.
- *
- * This will be a no-op if a inaccessible organization slug is passed.
  */
-export function setPageFiltersStorage(
-  orgSlug: string | null,
-  current: PageFilters,
-  newQuery: PageFiltersStringified
-) {
-  const org = orgSlug && OrganizationsStore.get(orgSlug);
-
-  // Do nothing if no org is loaded or user is not an org member. Only
-  // organizations that a user has membership in will be available via the
-  // organizations store
-  if (!org) {
-    return;
-  }
-
+export function setPageFiltersStorage(orgSlug: string, selection: PageFilters) {
   const dataToSave = {
-    projects: newQuery.project || current.projects,
-    environments: newQuery.environment || current.environments,
+    projects: selection.projects,
+    environments: selection.environments,
   };
 
-  const localStorageKey = makeLocalStorageKey(org.slug);
+  const localStorageKey = makeLocalStorageKey(orgSlug);
 
   try {
     localStorage.setItem(localStorageKey, JSON.stringify(dataToSave));


### PR DESCRIPTION
Prior to this change, the query object was being used to update the page filter values in local storage. Instead of doing that, just persist the current PageFilter object stored in the PageFiltersStore when calling persistPageFilters

This should simplify the understanding of what the persist function does