### PR TITLE
feat(billing): Update on-demand audit log to support new on-demand budgets

### DIFF
--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -391,7 +391,7 @@ class AuditLogEntry(Model):
             if "prev_ondemand" in self.data:
                 prev_ondemand_budget = format_ondemand_budget(self.data["prev_ondemand"])
                 return f"changed on-demand budget from {prev_ondemand_budget} to {next_ondemand_budget}"
-            return f"changed on-demand max spend to {next_ondemand_budget}"
+            return f"changed on-demand budget spend to {next_ondemand_budget}"
         elif self.event == AuditLogEntryEvent.TRIAL_STARTED:
             return "started trial"
         elif self.event == AuditLogEntryEvent.PLAN_CHANGED:

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -389,11 +389,8 @@ class AuditLogEntry(Model):
                 return "changed on-demand spend to unlimited"
             next_ondemand_budget = format_ondemand_budget(self.data["ondemand"])
             if "prev_ondemand" in self.data:
-                ondemand_label = "on-demand max spend"
-                if type(self.data["ondemand"]) is dict or type(self.data["prev_ondemand"]) is dict:
-                    ondemand_label = "on-demand budget"
                 prev_ondemand_budget = format_ondemand_budget(self.data["prev_ondemand"])
-                return f"changed {ondemand_label} from {prev_ondemand_budget} to {next_ondemand_budget}"
+                return f"changed on-demand budget from {prev_ondemand_budget} to {next_ondemand_budget}"
             return f"changed on-demand max spend to {next_ondemand_budget}"
         elif self.event == AuditLogEntryEvent.TRIAL_STARTED:
             return "started trial"

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -13,6 +13,24 @@ from sentry.utils.strings import truncatechars
 MAX_ACTOR_LABEL_LENGTH = 64
 
 
+def format_ondemand_budget(ondemand_data):
+    if type(ondemand_data) is dict:
+        budget_mode = ondemand_data.get("budgetMode", None)
+        if budget_mode == "shared":
+            shared_budget = ondemand_data.get("sharedMaxBudget", 0)
+            return f"shared on-demand of {format_ondemand_max_spend(shared_budget)}"
+        else:
+            errors_budget = format_ondemand_max_spend(ondemand_data.get("errorsBudget", 0))
+            transactions_budget = format_ondemand_max_spend(
+                ondemand_data.get("transactionsBudget", 0)
+            )
+            attachments_budget = format_ondemand_max_spend(
+                ondemand_data.get("attachmentsBudget", 0)
+            )
+            return f"split on-demand (errors at {errors_budget}, transactions at {transactions_budget}, and attachments at {attachments_budget})"
+    return format_ondemand_max_spend(ondemand_data)
+
+
 def format_ondemand_max_spend(max_spend_in_cents):
     ondemand_max_spend = max_spend_in_cents / 100
     has_cents = (ondemand_max_spend % 1) != 0
@@ -369,11 +387,14 @@ class AuditLogEntry(Model):
         elif self.event == AuditLogEntryEvent.SET_ONDEMAND:
             if self.data["ondemand"] == -1:
                 return "changed on-demand spend to unlimited"
-            next_ondemand_max_spend = format_ondemand_max_spend(self.data["ondemand"])
+            next_ondemand_budget = format_ondemand_budget(self.data["ondemand"])
             if "prev_ondemand" in self.data:
-                prev_ondemand_max_spend = format_ondemand_max_spend(self.data["prev_ondemand"])
-                return f"changed on-demand max spend from {prev_ondemand_max_spend} to {next_ondemand_max_spend}"
-            return f"changed on-demand max spend to {next_ondemand_max_spend}"
+                ondemand_label = "on-demand max spend"
+                if type(self.data["ondemand"]) is dict or type(self.data["prev_ondemand"]) is dict:
+                    ondemand_label = "on-demand budget"
+                prev_ondemand_budget = format_ondemand_budget(self.data["prev_ondemand"])
+                return f"changed {ondemand_label} from {prev_ondemand_budget} to {next_ondemand_budget}"
+            return f"changed on-demand max spend to {next_ondemand_budget}"
         elif self.event == AuditLogEntryEvent.TRIAL_STARTED:
             return "started trial"
         elif self.event == AuditLogEntryEvent.PLAN_CHANGED:

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -16,10 +16,7 @@ MAX_ACTOR_LABEL_LENGTH = 64
 def format_ondemand_budget(ondemand_data):
     if type(ondemand_data) is dict:
         budget_mode = ondemand_data.get("budgetMode", None)
-        if budget_mode == "shared":
-            shared_budget = ondemand_data.get("sharedMaxBudget", 0)
-            return f"shared on-demand of {format_ondemand_max_spend(shared_budget)}"
-        else:
+        if budget_mode == "per_category":
             errors_budget = format_ondemand_max_spend(ondemand_data.get("errorsBudget", 0))
             transactions_budget = format_ondemand_max_spend(
                 ondemand_data.get("transactionsBudget", 0)
@@ -28,6 +25,9 @@ def format_ondemand_budget(ondemand_data):
                 ondemand_data.get("attachmentsBudget", 0)
             )
             return f"split on-demand (errors at {errors_budget}, transactions at {transactions_budget}, and attachments at {attachments_budget})"
+        else:
+            shared_budget = ondemand_data.get("sharedMaxBudget", 0)
+            return f"shared on-demand of {format_ondemand_max_spend(shared_budget)}"
     return format_ondemand_max_spend(ondemand_data)
 
 

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -391,7 +391,7 @@ class AuditLogEntry(Model):
             if "prev_ondemand" in self.data:
                 prev_ondemand_budget = format_ondemand_budget(self.data["prev_ondemand"])
                 return f"changed on-demand budget from {prev_ondemand_budget} to {next_ondemand_budget}"
-            return f"changed on-demand budget spend to {next_ondemand_budget}"
+            return f"changed on-demand budget to {next_ondemand_budget}"
         elif self.event == AuditLogEntryEvent.TRIAL_STARTED:
             return "started trial"
         elif self.event == AuditLogEntryEvent.PLAN_CHANGED:


### PR DESCRIPTION
The new on-demand audit log entries will be generated in https://github.com/getsentry/getsentry/pull/6926 (and later in the AM checkout endpoint).

New audit log entries with on-demand budget support, and current on-demand audit log entries that was added in https://github.com/getsentry/sentry/pull/30054

<img width="1186" alt="Screen Shot 2022-01-27 at 7 43 49 PM" src="https://user-images.githubusercontent.com/139499/151467152-ce91fdb7-a315-44c4-a35e-528a553c046b.png">


Legacy on-demand audit log entry is still supported for backwards compatibility (prior to https://github.com/getsentry/sentry/pull/30054):

<img width="1175" alt="Screen Shot 2022-01-27 at 11 01 12 PM" src="https://user-images.githubusercontent.com/139499/151485175-4a83e812-8548-43d1-825a-38b465c20484.png">
