### PR TITLE
ref(vsts): Make email not case sensitive

### DIFF
--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -73,7 +73,7 @@ def sync_group_assignee_inbound(
             GroupAssignee.objects.deassign(group)
         return affected_groups
 
-    users = User.objects.get_for_email(email)
+    users = User.objects.get_for_email(email.lower())
     users_by_id = {user.id: user for user in users}
     projects_by_user = Project.objects.get_by_users(users)
 

--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -73,7 +73,7 @@ def sync_group_assignee_inbound(
             GroupAssignee.objects.deassign(group)
         return affected_groups
 
-    users = User.objects.get_for_email(email.lower())
+    users = User.objects.get_for_email(email, case_sensitive=False)
     users_by_id = {user.id: user for user in users}
     projects_by_user = Project.objects.get_by_users(users)
 

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -99,12 +99,13 @@ class UserManager(BaseManager, DjangoUserManager):
             .filter(row_count=1)
         )
 
-    def get_for_email(self, email: str) -> Sequence["User"]:
-        return self.filter(
-            emails__email=email,
-            emails__is_verified=True,
-            is_active=True,
-        )
+    def get_for_email(self, email: str, case_sensitive: bool = True) -> Sequence["User"]:
+        if not case_sensitive:
+            kwargs = dict(emails__email__iexact=email)
+        else:
+            kwargs = dict(emails__email=email)
+
+        return self.filter(emails__is_verified=True, is_active=True, **kwargs)
 
 
 class User(BaseModel, AbstractBaseUser):

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -259,6 +259,16 @@ class GroupAssigneeTestCase(TestCase):
                 project=group.project, group=group, user=user_w_access, team__isnull=True
             ).exists()
 
+            # confirm capitalization doesn't affect syncing
+            groups_updated = sync_group_assignee_inbound(
+                integration, user_w_access.email.title(), "APP-123"
+            )
+
+            assert groups_updated[0] == group
+            assert GroupAssignee.objects.filter(
+                project=group.project, group=group, user=user_w_access, team__isnull=True
+            ).exists()
+
     def test_assignee_sync_inbound_deassign(self):
         group = self.group
         integration = Integration.objects.create(provider="example", external_id="123456")


### PR DESCRIPTION
If a Sentry user's email is "colleen@sentry.io" but for some reason in Azure DevOps it's "Colleen@sentry.io", when you try to sync assignment from Azure to Sentry, we will fail to find the matching email address in Sentry because of the case. This PR makes the email address lowercase to avoid the issue.