### PR TITLE
fix(metrics): Accept tuples in `_translate_conditions` [INGEST-767]

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -690,5 +690,5 @@ def _translate_conditions(org_id: int, input_: Any) -> Any:
     if isinstance(input_, (int, float)):
         return input_
 
-    assert isinstance(input_, list), input_
+    assert isinstance(input_, (tuple, list)), input_
     return [_translate_conditions(org_id, item) for item in input_]

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -685,6 +685,24 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
 
         assert seen == {"abnormal", "crashed", "errored", "healthy"}
 
+    @freeze_time("2021-01-14T12:27:28.303Z")
+    def test_environment_filter_not_present_in_query(self):
+        self.create_environment(name="abc")
+        response = self.do_request(
+            {
+                "project": [-1],
+                "statsPeriod": "1d",
+                "interval": "1d",
+                "field": ["sum(session)"],
+                "environment": ["development", "abc"],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert result_sorted(response.data)["groups"] == [
+            {"by": {}, "series": {"sum(session)": [1]}, "totals": {"sum(session)": 1}}
+        ]
+
 
 @patch("sentry.api.endpoints.organization_sessions.release_health", MetricsReleaseHealthBackend())
 class OrganizationSessionsEndpointMetricsTest(


### PR DESCRIPTION
Fixes SENTRY-SX8