### PR TITLE
ref(hovercard): refactor to fc and use react testing library

### DIFF
--- a/docs-ui/stories/components/hovercard.stories.js
+++ b/docs-ui/stories/components/hovercard.stories.js
@@ -1,4 +1,4 @@
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 
 export default {
   title: 'Components/Tooltips/Hovercard',
@@ -7,14 +7,17 @@ export default {
     header: 'Header',
     body: 'Body',
     position: 'top',
-    show: true,
   },
   argTypes: {
     tipColor: {control: 'color'},
+    show: {
+      type: 'select',
+      options: [undefined, false, true],
+    },
   },
 };
 
-export const _Hovercard = ({...args}) => (
+export const _OldHovercard = ({...args}) => (
   <div
     style={{
       height: 300,
@@ -26,7 +29,8 @@ export const _Hovercard = ({...args}) => (
     <Hovercard {...args}>Hover over me</Hovercard>
   </div>
 );
-_Hovercard.parameters = {
+
+_OldHovercard.parameters = {
   docs: {
     description: {
       story:

--- a/docs-ui/stories/components/hovercard.stories.js
+++ b/docs-ui/stories/components/hovercard.stories.js
@@ -17,7 +17,7 @@ export default {
   },
 };
 
-export const _OldHovercard = ({...args}) => (
+export const _Hovercard = ({...args}) => (
   <div
     style={{
       height: 300,
@@ -30,7 +30,7 @@ export const _OldHovercard = ({...args}) => (
   </div>
 );
 
-_OldHovercard.parameters = {
+_Hovercard.parameters = {
   docs: {
     description: {
       story:

--- a/static/app/components/assistant/guideAnchor.tsx
+++ b/static/app/components/assistant/guideAnchor.tsx
@@ -13,7 +13,7 @@ import {
 } from 'sentry/actionCreators/guides';
 import {Guide} from 'sentry/components/assistant/types';
 import Button from 'sentry/components/button';
-import Hovercard, {Body as HovercardBody} from 'sentry/components/hovercard';
+import {Body as HovercardBody, Hovercard} from 'sentry/components/hovercard';
 import {t, tct} from 'sentry/locale';
 import GuideStore, {GuideStoreState} from 'sentry/stores/guideStore';
 import space from 'sentry/styles/space';

--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/react';
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import CommitLink from 'sentry/components/commitLink';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import Link from 'sentry/components/links/link';
 import {PanelItem} from 'sentry/components/panels';
 import TextOverflow from 'sentry/components/textOverflow';

--- a/static/app/components/discover/discoverFeature.tsx
+++ b/static/app/components/discover/discoverFeature.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import {t} from 'sentry/locale';
 
 type Props = {

--- a/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
@@ -5,7 +5,7 @@ import forOwn from 'lodash/forOwn';
 import isNil from 'lodash/isNil';
 import isObject from 'lodash/isObject';
 
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Pill from 'sentry/components/pill';
 import Pills from 'sentry/components/pills';

--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -30,6 +30,12 @@ type Props = {
    * if the actor is not suggested based on ownership rules.
    */
   rules?: any[] | null;
+
+  /**
+   * Children are required, as they are passed to the hovercard component, without it,
+   * we will not be able to trigger any hovercard actions
+   */
+  children: React.ReactNode;
 };
 
 type State = {

--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -6,7 +6,7 @@ import {openInviteMembersModal} from 'sentry/actionCreators/modal';
 import Alert from 'sentry/components/alert';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import Button from 'sentry/components/button';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import Link from 'sentry/components/links/link';
 import {IconCommit, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';

--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -21,21 +21,21 @@ type Props = {
    */
   actor: Actor;
   /**
+   * Children are required, as they are passed to the hovercard component, without it,
+   * we will not be able to trigger any hovercard actions
+   */
+  children: React.ReactNode;
+  /**
    * The list of commits the actor is suggested for. May be left blank if the
    * actor is not suggested for commits.
    */
   commits?: Commit[];
+
   /**
    * The list of ownership rules the actor is suggested for. May be left blank
    * if the actor is not suggested based on ownership rules.
    */
   rules?: any[] | null;
-
-  /**
-   * Children are required, as they are passed to the hovercard component, without it,
-   * we will not be able to trigger any hovercard actions
-   */
-  children: React.ReactNode;
 };
 
 type State = {

--- a/static/app/components/group/suggestedOwners/ownershipRules.tsx
+++ b/static/app/components/group/suggestedOwners/ownershipRules.tsx
@@ -8,7 +8,7 @@ import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeatureBadge from 'sentry/components/featureBadge';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import {Panel} from 'sentry/components/panels';
 import {IconClose, IconQuestion} from 'sentry/icons';
 import {t} from 'sentry/locale';

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -171,7 +171,7 @@ function Hovercard(props: HovercardProps): React.ReactElement {
             }
 
             return (
-              <div style={style}>
+              <HovercardContainer style={style}>
                 <SlideInAnimation visible={isVisible} placement={placement}>
                   <StyledHovercard
                     ref={ref}
@@ -195,7 +195,7 @@ function Hovercard(props: HovercardProps): React.ReactElement {
                     />
                   </StyledHovercard>
                 </SlideInAnimation>
-              </div>
+              </HovercardContainer>
             );
           }}
         </Popper>,
@@ -269,6 +269,11 @@ function getTipDirection(
   return (prefix || 'top') as 'top' | 'bottom' | 'left' | 'right';
 }
 
+const HovercardContainer = styled('div')`
+  /* Some hovercards overlap the toplevel header and sidebar, and we need to appear on top */
+  z-index: ${p => p.theme.zIndex.hovercard};
+`;
+
 type StyledHovercardProps = {
   placement: PopperProps['placement'];
   offset?: string;
@@ -279,8 +284,6 @@ const StyledHovercard = styled('div')<StyledHovercardProps>`
   text-align: left;
   padding: 0;
   line-height: 1;
-  /* Some hovercards overlap the toplevel header and sidebar, and we need to appear on top */
-  z-index: ${p => p.theme.zIndex.hovercard};
   white-space: initial;
   color: ${p => p.theme.textColor};
   border: 1px solid ${p => p.theme.border};

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -256,7 +256,7 @@ function SlideInAnimation({
   );
 }
 
-const getTipDirection = (p: HovercardArrowProps): string => {
+function getTipDirection(p: HovercardArrowProps): string {
   const placement = p.placement;
 
   if (!placement) {
@@ -268,7 +268,7 @@ const getTipDirection = (p: HovercardArrowProps): string => {
   });
 
   return prefix || 'top';
-};
+}
 
 type StyledHovercardProps = {
 <<<<<<< HEAD

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -1,19 +1,28 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {Manager, Popper, PopperProps, Reference} from 'react-popper';
-import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
+import {motion} from 'framer-motion';
 
-import {fadeIn} from 'sentry/styles/animations';
 import space from 'sentry/styles/space';
 import {domId} from 'sentry/utils/domId';
 
-const VALID_DIRECTIONS = ['top', 'bottom', 'left', 'right'] as const;
+function findOrCreatePortal(): HTMLElement {
+  let portal = document.getElementById('hovercard-portal');
 
-type Direction = typeof VALID_DIRECTIONS[number];
+  if (portal) {
+    return portal;
+  }
 
-type DefaultProps = {
+  portal = document.createElement('div');
+  portal.setAttribute('id', 'hovercard-portal');
+  document.body.appendChild(portal);
+
+  return portal;
+}
+
+interface HovercardProps {
   /**
    * Time in ms until hovercard is hidden
    */
@@ -21,10 +30,7 @@ type DefaultProps = {
   /**
    * Position tooltip should take relative to the child element
    */
-  position: Direction;
-};
-
-type Props = DefaultProps & {
+  position: PopperProps['placement'];
   /**
    * Element to display in the body
    */
@@ -67,80 +73,41 @@ type Props = DefaultProps & {
   tipColor?: string;
 };
 
-type State = {
-  visible: boolean;
-};
+function Hovercard(props: HovercardProps): React.ReactElement {
+  const [visible, setVisible] = React.useState(false);
 
-class Hovercard extends React.Component<Props, State> {
-  static defaultProps: DefaultProps = {
-    displayTimeout: 100,
-    position: 'top',
-  };
+  const inTimeout = React.useRef<number | null>(null);
+  const scheduleUpdateRef = React.useRef<(() => void) | null>(null);
 
-  constructor(args: Props) {
-    super(args);
+  const portalEl = React.useMemo(() => findOrCreatePortal(), []);
+  const tooltipId = React.useMemo(() => domId('hovercard-'), []);
 
-    let portal = document.getElementById('hovercard-portal');
-    if (!portal) {
-      portal = document.createElement('div');
-      portal.setAttribute('id', 'hovercard-portal');
-      document.body.appendChild(portal);
+  React.useEffect(() => {
+    // We had a problem with popper not recalculating position when body/header changed while hovercard still opened.
+    // This can happen for example when showing a loading spinner in a hovercard and then changing it to the actual content once fetch finishes.
+    if (scheduleUpdateRef.current) {
+      scheduleUpdateRef.current();
     }
-    this.portalEl = portal;
-    this.tooltipId = domId('hovercard-');
-    this.scheduleUpdate = null;
-  }
+  }, [props.body, props.header]);
 
-  state: State = {
-    visible: false,
-  };
+  const toggleHovercard = React.useCallback(
+    (value: boolean) => {
+      // If a previous timeout is set, then clear it
+      if (typeof inTimeout.current === 'number') {
+        clearTimeout(inTimeout.current);
+      }
 
-  componentDidUpdate(prevProps: Props) {
-    const {body, header} = this.props;
+      // Else enqueue a new timeout
+      inTimeout.current = window.setTimeout(
+        () => setVisible(value),
+        props.displayTimeout
+      );
+    },
+    [props.displayTimeout]
+  );
 
-    if (body !== prevProps.body || header !== prevProps.header) {
-      // We had a problem with popper not recalculating position when body/header changed while hovercard still opened.
-      // This can happen for example when showing a loading spinner in a hovercard and then changing it to the actual content once fetch finishes.
-      this.scheduleUpdate?.();
-    }
-  }
-
-  portalEl: HTMLElement;
-  tooltipId: string;
-  hoverWait: number | null = null;
-  scheduleUpdate: (() => void) | null;
-
-  handleToggleOn = () => this.toggleHovercard(true);
-  handleToggleOff = () => this.toggleHovercard(false);
-
-  toggleHovercard = (visible: boolean) => {
-    const {displayTimeout} = this.props;
-
-    if (this.hoverWait) {
-      clearTimeout(this.hoverWait);
-    }
-
-    this.hoverWait = window.setTimeout(() => this.setState({visible}), displayTimeout);
-  };
-
-  render() {
-    const {
-      bodyClassName,
-      containerClassName,
-      className,
-      header,
-      body,
-      position,
-      show,
-      tipColor,
-      tipBorderColor,
-      offset,
-      modifiers,
-    } = this.props;
-
-    // Maintain the hovercard class name for BC with less styles
-    const cx = classNames('hovercard', className);
-    const popperModifiers: PopperProps['modifiers'] = {
+  const popperModifiers = React.useMemo(() => {
+    const modifiers: PopperProps['modifiers'] = {
       hide: {
         enabled: false,
       },
@@ -149,91 +116,163 @@ class Hovercard extends React.Component<Props, State> {
         enabled: true,
         boundariesElement: 'viewport',
       },
-      ...(modifiers || {}),
+      ...(props.modifiers || {}),
     };
+    return modifiers;
+  }, [props.modifiers]);
 
-    const visible = show !== undefined ? show : this.state.visible;
-    const hoverProps =
-      show !== undefined
-        ? {}
-        : {onMouseEnter: this.handleToggleOn, onMouseLeave: this.handleToggleOff};
+  const isVisible = React.useMemo(() => {
+    // If show is not set, then visibility state is uncontrolled
+    if (props.show === undefined) {
+      return visible;
+    }
+    return props.show;
+  }, [props.show, visible]);
 
-    return (
-      <Manager>
-        <Reference>
-          {({ref}) => (
-            <span
-              ref={ref}
-              aria-describedby={this.tooltipId}
-              className={containerClassName}
-              {...hoverProps}
-            >
-              {this.props.children}
-            </span>
-          )}
-        </Reference>
-        {visible &&
-          (header || body) &&
-          ReactDOM.createPortal(
-            <Popper placement={position} modifiers={popperModifiers}>
-              {({ref, style, placement, arrowProps, scheduleUpdate}) => {
-                this.scheduleUpdate = scheduleUpdate;
-                return (
-                  <StyledHovercard
-                    id={this.tooltipId}
-                    visible={visible}
-                    ref={ref}
-                    style={style}
-                    placement={placement as Direction}
-                    offset={offset}
-                    className={cx}
-                    {...hoverProps}
-                  >
-                    {header && <Header>{header}</Header>}
-                    {body && <Body className={bodyClassName}>{body}</Body>}
-                    <HovercardArrow
-                      ref={arrowProps.ref}
-                      style={arrowProps.style}
-                      placement={placement as Direction}
-                      tipColor={tipColor}
-                      tipBorderColor={tipBorderColor}
-                    />
-                  </StyledHovercard>
-                );
-              }}
-            </Popper>,
-            this.portalEl
-          )}
-      </Manager>
-    );
-  }
+  const hoverProps = React.useMemo((): Pick<
+    React.HTMLProps<HTMLDivElement>,
+    'onMouseEnter' | 'onMouseLeave'
+  > => {
+    // If show is not set, then visibility state is controlled by mouse events
+    if (props.show === undefined) {
+      return {
+        onMouseEnter: () => toggleHovercard(true),
+        onMouseLeave: () => toggleHovercard(false),
+      };
+    }
+    return {};
+  }, [props.show, toggleHovercard]);
+
+  return (
+    <Manager>
+      <Reference>
+        {({ref}) => (
+          <span
+            ref={ref}
+            aria-describedby={tooltipId}
+            className={props.containerClassName}
+            {...hoverProps}
+          >
+            {props.children}
+          </span>
+        )}
+      </Reference>
+      {ReactDOM.createPortal(
+        <Popper placement={props.position} modifiers={popperModifiers}>
+          {({ref, style, placement, arrowProps, scheduleUpdate}) => {
+            // Nothing to render
+            if (!props.body && !props.header) {
+              return null;
+            }
+
+            // Element is not visible in neither controlled and uncontrolled state (show prop is not passed and card is not hovered)
+            if (!isVisible) {
+              return null;
+            }
+
+            scheduleUpdateRef.current = scheduleUpdate;
+            return (
+              <SlideInAnimation visible={visible} placement={placement} style={style}>
+                <StyledHovercard
+                  ref={ref}
+                  id={tooltipId}
+                  placement={placement}
+                  offset={props.offset}
+                  // Maintain the hovercard class name for BC with less styles
+                  className={classNames('hovercard', props.className)}
+                  style={style}
+                  {...hoverProps}
+                >
+                  {props.header ? <Header>{props.header}</Header> : null}
+                  {props.body ? (
+                    <Body className={props.bodyClassName}>{props.body}</Body>
+                  ) : null}
+                  <HovercardArrow
+                    ref={arrowProps.ref}
+                    style={arrowProps.style}
+                    placement={placement}
+                    tipColor={props.tipColor}
+                    tipBorderColor={props.tipBorderColor}
+                  />
+                </StyledHovercard>
+              </SlideInAnimation>
+            );
+          }}
+        </Popper>,
+        portalEl
+      )}
+    </Manager>
+  );
 }
 
-// Slide in from the same direction as the placement
-// so that the card pops into place.
-const slideIn = (p: StyledHovercardProps) => keyframes`
-  from {
-    ${p.placement === 'top' ? 'top: -10px;' : ''}
-    ${p.placement === 'bottom' ? 'top: 10px;' : ''}
-    ${p.placement === 'left' ? 'left: -10px;' : ''}
-    ${p.placement === 'right' ? 'left: 10px;' : ''}
-  }
-  to {
-    ${p.placement === 'top' ? 'top: 0;' : ''}
-    ${p.placement === 'bottom' ? 'top: 0;' : ''}
-    ${p.placement === 'left' ? 'left: 0;' : ''}
-    ${p.placement === 'right' ? 'left: 0;' : ''}
-  }
-`;
+const SLIDE_DISTANCE = 10;
 
-const getTipDirection = (p: HovercardArrowProps) =>
-  VALID_DIRECTIONS.includes(p.placement) ? p.placement : 'top';
+function SlideInAnimation({
+  visible,
+  placement,
+  children,
+  style,
+}: {
+  visible: boolean;
+  placement: PopperProps['placement'];
+  children: React.ReactNode;
+  style: React.CSSProperties;
+}): React.ReactElement {
+  const narrowedPlacement = getTipDirection({placement});
 
-const getOffset = (p: StyledHovercardProps) => p.offset ?? space(2);
+  return (
+    <motion.div
+      initial="hidden"
+      variants={{
+        hidden: {
+          opacity: 0,
+        },
+        visible: {
+          opacity: [0, 1],
+          x:
+            narrowedPlacement === 'left'
+              ? [-SLIDE_DISTANCE, 0]
+              : narrowedPlacement === 'right'
+              ? [SLIDE_DISTANCE, 0]
+              : [0, 0],
+          y:
+            narrowedPlacement === 'top'
+              ? [-SLIDE_DISTANCE, 0]
+              : narrowedPlacement === 'bottom'
+              ? [SLIDE_DISTANCE, 0]
+              : [0, 0],
+        },
+      }}
+      animate={visible ? 'visible' : 'hidden'}
+      transition={{duration: 0.1, ease: 'easeInOut'}}
+      style={style}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+const getTipDirection = (p: HovercardArrowProps): string => {
+  const placement = p.placement;
+
+  if (!placement) {
+    return 'top';
+  }
+
+  const prefix = ['top', 'bottom', 'left', 'right'].find(pl => {
+    return placement.startsWith(pl);
+  });
+
+  return prefix || 'top';
+};
 
 type StyledHovercardProps = {
+<<<<<<< HEAD
   placement: Direction;
   visible: boolean;
+=======
+  placement: PopperProps['placement'];
+>>>>>>> fbe177b829 (ref(hovercard): refactor to fc)
   offset?: string;
 };
 
@@ -255,17 +294,11 @@ const StyledHovercard = styled('div')<StyledHovercardProps>`
   /* The hovercard may appear in different contexts, don't inherit fonts */
   font-family: ${p => p.theme.text.family};
 
-  position: absolute;
-  visibility: ${p => (p.visible ? 'visible' : 'hidden')};
-
-  animation: ${fadeIn} 100ms, ${slideIn} 100ms ease-in-out;
-  animation-play-state: ${p => (p.visible ? 'running' : 'paused')};
-
   /* Offset for the arrow */
-  ${p => (p.placement === 'top' ? `margin-bottom: ${getOffset(p)}` : '')};
-  ${p => (p.placement === 'bottom' ? `margin-top: ${getOffset(p)}` : '')};
-  ${p => (p.placement === 'left' ? `margin-right: ${getOffset(p)}` : '')};
-  ${p => (p.placement === 'right' ? `margin-left: ${getOffset(p)}` : '')};
+  ${p => (p.placement === 'top' ? `margin-bottom: ${p.offset ?? space(2)}` : '')};
+  ${p => (p.placement === 'bottom' ? `margin-top: ${p.offset ?? space(2)}` : '')};
+  ${p => (p.placement === 'left' ? `margin-right: ${p.offset ?? space(2)}` : '')};
+  ${p => (p.placement === 'right' ? `margin-left: ${p.offset ?? space(2)}` : '')};
 `;
 
 const Header = styled('div')`
@@ -284,7 +317,12 @@ const Body = styled('div')`
 `;
 
 type HovercardArrowProps = {
+<<<<<<< HEAD
   placement: Direction;
+=======
+  placement: PopperProps['placement'];
+  tipColor?: string;
+>>>>>>> fbe177b829 (ref(hovercard): refactor to fc)
   tipBorderColor?: string;
   tipColor?: string;
 };
@@ -316,18 +354,16 @@ const HovercardArrow = styled('span')<HovercardArrowProps>`
   &::before {
     top: 1px;
     border: 10px solid transparent;
-    border-${getTipDirection}-color: ${p =>
-  p.tipBorderColor || p.tipColor || p.theme.border};
-
-    ${p => (p.placement === 'bottom' ? 'top: -1px' : '')};
-    ${p => (p.placement === 'left' ? 'top: 0; left: 1px;' : '')};
-    ${p => (p.placement === 'right' ? 'top: 0; left: -1px' : '')};
-  }
-  &::after {
-    border: 10px solid transparent;
-    border-${getTipDirection}-color: ${p => p.tipColor ?? p.theme.background};
-  }
+    border-${getTipDirection}-color:
+      ${p => p.tipBorderColor || p.tipColor || p.theme.border};
+      ${p => (p.placement === 'bottom' ? 'top: -1px' : '')};
+      ${p => (p.placement === 'left' ? 'top: 0; left: 1px;' : '')};
+      ${p => (p.placement === 'right' ? 'top: 0; left: -1px' : '')};
+    }
+    &::after {
+      border: 10px solid transparent;
+      border-${getTipDirection}-color: ${p => p.tipColor ?? p.theme.background};
+    }
 `;
 
 export {Body, Header, Hovercard};
-export default Hovercard;

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -207,6 +207,8 @@ function Hovercard(props: HovercardProps): React.ReactElement {
   );
 }
 
+export {Hovercard};
+
 const SLIDE_DISTANCE = 10;
 
 function SlideInAnimation({
@@ -313,10 +315,14 @@ const Header = styled('div')`
   padding: ${space(1.5)};
 `;
 
+export {Header};
+
 const Body = styled('div')`
   padding: ${space(2)};
   min-height: 30px;
 `;
+
+export {Body};
 
 type HovercardArrowProps = {
 <<<<<<< HEAD
@@ -367,5 +373,3 @@ const HovercardArrow = styled('span')<HovercardArrowProps>`
       border-${getTipDirection}-color: ${p => p.tipColor ?? p.theme.background};
     }
 `;
-
-export {Body, Header, Hovercard};

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -44,6 +44,7 @@ interface HovercardProps {
   /**
    * Classname to apply to the hovercard
    */
+  children: React.ReactNode;
   className?: string;
   /**
    * Classname to apply to the hovercard container
@@ -73,7 +74,7 @@ interface HovercardProps {
    * Color of the arrow tip
    */
   tipColor?: string;
-};
+}
 
 function Hovercard(props: HovercardProps): React.ReactElement {
   const [visible, setVisible] = React.useState(false);
@@ -269,12 +270,7 @@ function getTipDirection(
 }
 
 type StyledHovercardProps = {
-<<<<<<< HEAD
-  placement: Direction;
-  visible: boolean;
-=======
   placement: PopperProps['placement'];
->>>>>>> fbe177b829 (ref(hovercard): refactor to fc)
   offset?: string;
 };
 
@@ -323,12 +319,7 @@ const Body = styled('div')`
 export {Body};
 
 type HovercardArrowProps = {
-<<<<<<< HEAD
-  placement: Direction;
-=======
   placement: PopperProps['placement'];
-  tipColor?: string;
->>>>>>> fbe177b829 (ref(hovercard): refactor to fc)
   tipBorderColor?: string;
   tipColor?: string;
 };

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -123,13 +123,8 @@ function Hovercard(props: HovercardProps): React.ReactElement {
     return modifiers;
   }, [props.modifiers]);
 
-  const isVisible = React.useMemo(() => {
-    // If show is not set, then visibility state is uncontrolled
-    if (props.show === undefined) {
-      return visible;
-    }
-    return props.show;
-  }, [props.show, visible]);
+  // If show is not set, then visibility state is uncontrolled
+  const isVisible = props.show === undefined ? visible : props.show;
 
   const hoverProps = React.useMemo((): Pick<
     React.HTMLProps<HTMLDivElement>,

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -26,13 +26,9 @@ function findOrCreatePortal(): HTMLElement {
 
 interface HovercardProps {
   /**
-   * Position tooltip should take relative to the child element
+   * Classname to apply to the hovercard
    */
-  position?: PopperProps['placement'];
-  /**
-   * Time in ms until hovercard is hidden
-   */
-  displayTimeout?: number;
+  children: React.ReactNode;
   /**
    * Element to display in the body
    */
@@ -41,15 +37,15 @@ interface HovercardProps {
    * Classname to apply to body container
    */
   bodyClassName?: string;
-  /**
-   * Classname to apply to the hovercard
-   */
-  children: React.ReactNode;
   className?: string;
   /**
    * Classname to apply to the hovercard container
    */
   containerClassName?: string;
+  /**
+   * Time in ms until hovercard is hidden
+   */
+  displayTimeout?: number;
   /**
    * Element to display in the header
    */
@@ -62,6 +58,10 @@ interface HovercardProps {
    * Offset for the arrow
    */
   offset?: string;
+  /**
+   * Position tooltip should take relative to the child element
+   */
+  position?: PopperProps['placement'];
   /**
    * If set, is used INSTEAD OF the hover action to determine whether the hovercard is shown
    */
@@ -214,9 +214,9 @@ function SlideInAnimation({
   placement,
   children,
 }: {
-  visible: boolean;
-  placement: PopperProps['placement'];
   children: React.ReactNode;
+  placement: PopperProps['placement'];
+  visible: boolean;
 }): React.ReactElement {
   const narrowedPlacement = getTipDirection(placement);
 

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -8,15 +8,17 @@ import {motion} from 'framer-motion';
 import space from 'sentry/styles/space';
 import {domId} from 'sentry/utils/domId';
 
+export const HOVERCARD_PORTAL_ID = 'hovercard-portal';
+
 function findOrCreatePortal(): HTMLElement {
-  let portal = document.getElementById('hovercard-portal');
+  let portal = document.getElementById(HOVERCARD_PORTAL_ID);
 
   if (portal) {
     return portal;
   }
 
   portal = document.createElement('div');
-  portal.setAttribute('id', 'hovercard-portal');
+  portal.setAttribute('id', HOVERCARD_PORTAL_ID);
   document.body.appendChild(portal);
 
   return portal;
@@ -24,13 +26,13 @@ function findOrCreatePortal(): HTMLElement {
 
 interface HovercardProps {
   /**
-   * Time in ms until hovercard is hidden
-   */
-  displayTimeout: number;
-  /**
    * Position tooltip should take relative to the child element
    */
-  position: PopperProps['placement'];
+  position?: PopperProps['placement'];
+  /**
+   * Time in ms until hovercard is hidden
+   */
+  displayTimeout?: number;
   /**
    * Element to display in the body
    */
@@ -100,7 +102,7 @@ function Hovercard(props: HovercardProps): React.ReactElement {
       // Else enqueue a new timeout
       inTimeout.current = window.setTimeout(
         () => setVisible(value),
-        props.displayTimeout
+        props.displayTimeout ?? 100
       );
     },
     [props.displayTimeout]
@@ -158,7 +160,7 @@ function Hovercard(props: HovercardProps): React.ReactElement {
         )}
       </Reference>
       {ReactDOM.createPortal(
-        <Popper placement={props.position} modifiers={popperModifiers}>
+        <Popper placement={props.position ?? 'top'} modifiers={popperModifiers}>
           {({ref, style, placement, arrowProps, scheduleUpdate}) => {
             // Nothing to render
             if (!props.body && !props.header) {

--- a/static/app/components/issueLink.tsx
+++ b/static/app/components/issueLink.tsx
@@ -6,7 +6,7 @@ import Count from 'sentry/components/count';
 import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
 import EventAnnotation from 'sentry/components/events/eventAnnotation';
 import EventMessage from 'sentry/components/events/eventMessage';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import Link from 'sentry/components/links/link';
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';

--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -3,7 +3,7 @@ import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 import capitalize from 'lodash/capitalize';
 
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import {IconAdd, IconClose} from 'sentry/icons';
 import space from 'sentry/styles/space';
 import {callIfFunction} from 'sentry/utils/callIfFunction';

--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -23,17 +23,6 @@ type Props = {
 };
 
 class IssueSyncListElement extends React.Component<Props> {
-  componentDidUpdate(nextProps) {
-    if (
-      this.props.showHoverCard !== nextProps.showHoverCard &&
-      nextProps.showHoverCard === undefined
-    ) {
-      this.hoverCardRef.current && this.hoverCardRef.current.handleToggleOff();
-    }
-  }
-
-  hoverCardRef = React.createRef<Hovercard>();
-
   isLinked(): boolean {
     return !!(this.props.externalIssueLink && this.props.externalIssueId);
   }
@@ -103,7 +92,6 @@ class IssueSyncListElement extends React.Component<Props> {
         <ClassNames>
           {({css}) => (
             <Hovercard
-              ref={this.hoverCardRef}
               containerClassName={css`
                 display: flex;
                 align-items: center;

--- a/static/app/components/organizations/projectSelector/selectorItem.tsx
+++ b/static/app/components/organizations/projectSelector/selectorItem.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import Highlight from 'sentry/components/highlight';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
 import PageFilterRow from 'sentry/components/organizations/pageFilterRow';

--- a/static/app/components/stacktracePreview.tsx
+++ b/static/app/components/stacktracePreview.tsx
@@ -6,7 +6,7 @@ import StackTraceContent from 'sentry/components/events/interfaces/crashContent/
 import StackTraceContentV2 from 'sentry/components/events/interfaces/crashContent/stackTrace/contentV2';
 import StackTraceContentV3 from 'sentry/components/events/interfaces/crashContent/stackTrace/contentV3';
 import {isStacktraceNewestFirst} from 'sentry/components/events/interfaces/utils';
-import Hovercard, {Body} from 'sentry/components/hovercard';
+import {Body, Hovercard} from 'sentry/components/hovercard';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';

--- a/static/app/components/versionHoverCard.tsx
+++ b/static/app/components/versionHoverCard.tsx
@@ -5,7 +5,7 @@ import {Client} from 'sentry/api';
 import AvatarList from 'sentry/components/avatar/avatarList';
 import Button from 'sentry/components/button';
 import Clipboard from 'sentry/components/clipboard';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import LastCommit from 'sentry/components/lastCommit';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -6,7 +6,7 @@ import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import CreateAlertButton from 'sentry/components/createAlertButton';
 import FeatureBadge from 'sentry/components/featureBadge';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';

--- a/static/app/views/dashboardsV2/controls.tsx
+++ b/static/app/views/dashboardsV2/controls.tsx
@@ -6,7 +6,7 @@ import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import Confirm from 'sentry/components/confirm';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import Tooltip from 'sentry/components/tooltip';
 import {IconAdd, IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -14,7 +14,7 @@ import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
 import DropdownControl from 'sentry/components/dropdownControl';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import {IconDelete, IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';

--- a/static/app/views/eventsV2/table/tableActions.tsx
+++ b/static/app/views/eventsV2/table/tableActions.tsx
@@ -6,7 +6,7 @@ import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Button from 'sentry/components/button';
 import DataExport, {ExportQueryType} from 'sentry/components/dataExport';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import {IconDownload, IconStack, IconTag} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';

--- a/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -10,7 +10,7 @@ import Checkbox from 'sentry/components/checkbox';
 import Count from 'sentry/components/count';
 import EventOrGroupExtraDetails from 'sentry/components/eventOrGroupExtraDetails';
 import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import {PanelItem} from 'sentry/components/panels';
 import ScoreBar from 'sentry/components/scoreBar';
 import SimilarScoreCard from 'sentry/components/similarScoreCard';

--- a/static/app/views/organizationGroupDetails/quickTrace/configureDistributedTracing.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/configureDistributedTracing.tsx
@@ -9,7 +9,7 @@ import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import {Panel} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -3,7 +3,7 @@ import {Location} from 'history';
 import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import Placeholder from 'sentry/components/placeholder';

--- a/static/app/views/settings/components/dataScrubbing/modals/form/sourceSuggestionExamples.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/sourceSuggestionExamples.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import {IconQuestion} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -5,7 +5,7 @@ import Access from 'sentry/components/acl/access';
 import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import Button from 'sentry/components/button';
-import Hovercard from 'sentry/components/hovercard';
+import {Hovercard} from 'sentry/components/hovercard';
 import {PanelItem} from 'sentry/components/panels';
 import Tag from 'sentry/components/tag';
 import {IconLock} from 'sentry/icons';

--- a/tests/js/spec/components/commitRow.spec.tsx
+++ b/tests/js/spec/components/commitRow.spec.tsx
@@ -9,8 +9,9 @@ import {Commit, Repository, User} from 'sentry/types';
 
 jest.mock('sentry/components/hovercard', () => {
   return {
-    __esModule: true,
-    default: ({body}) => {
+    Header: ({children}: {children: React.ReactNode}) => children,
+    Body: ({children}: {children: React.ReactNode}) => children,
+    Hovercard: ({body}) => {
       return body;
     },
   };

--- a/tests/js/spec/components/hovercard.spec.tsx
+++ b/tests/js/spec/components/hovercard.spec.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react';
+import {act, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {mountWithTheme} from 'sentry-test/reactTestingLibrary';
+
+import {Hovercard, HOVERCARD_PORTAL_ID} from 'sentry/components/hovercard';
+
+describe('Hovercard', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('reuses portal', () => {
+    mountWithTheme(
+      <React.Fragment>
+        <Hovercard
+          position="top"
+          body="Hovercard Body"
+          header="Hovercard Header"
+          displayTimeout={0}
+        >
+          Hovercard Trigger
+        </Hovercard>
+        <Hovercard
+          position="top"
+          body="Hovercard Body"
+          header="Hovercard Header"
+          displayTimeout={0}
+        >
+          Hovercard Trigger
+        </Hovercard>
+      </React.Fragment>
+    );
+
+    // eslint-disable-next-line
+    expect(document.querySelectorAll(`#${HOVERCARD_PORTAL_ID}`)).toHaveLength(1);
+  });
+  it('Displays card', async () => {
+    mountWithTheme(
+      <Hovercard
+        position="top"
+        body="Hovercard Body"
+        header="Hovercard Header"
+        displayTimeout={0}
+      >
+        Hovercard Trigger
+      </Hovercard>
+    );
+
+    userEvent.hover(screen.getByText('Hovercard Trigger'));
+
+    expect(await screen.findByText(/Hovercard Body/)).toBeInTheDocument();
+    expect(await screen.findByText(/Hovercard Header/)).toBeInTheDocument();
+  });
+
+  it('Does not display card', async () => {
+    mountWithTheme(
+      <Hovercard
+        position="top"
+        body="Hovercard Body"
+        header="Hovercard Header"
+        displayTimeout={0}
+        show={false}
+      >
+        Hovercard Trigger
+      </Hovercard>
+    );
+
+    userEvent.hover(screen.getByText('Hovercard Trigger'));
+    jest.runAllTimers();
+
+    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
+  });
+
+  it('Always displays card', async () => {
+    mountWithTheme(
+      <Hovercard
+        position="top"
+        body="Hovercard Body"
+        header="Hovercard Header"
+        displayTimeout={0}
+        show
+      >
+        Hovercard Trigger
+      </Hovercard>
+    );
+
+    expect(screen.getByText(/Hovercard Body/)).toBeInTheDocument();
+    expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
+  });
+
+  it('Respects displayTimeout displays card', async () => {
+    mountWithTheme(
+      <Hovercard
+        position="top"
+        body="Hovercard Body"
+        header="Hovercard Header"
+        displayTimeout={100}
+      >
+        Hovercard Trigger
+      </Hovercard>
+    );
+
+    userEvent.hover(screen.getByText('Hovercard Trigger'));
+
+    act(() => {
+      jest.advanceTimersByTime(99);
+    });
+
+    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(screen.getByText(/Hovercard Body/)).toBeInTheDocument();
+    expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
+  });
+
+  it('Doesnt leak timeout', async () => {
+    mountWithTheme(
+      <Hovercard
+        position="top"
+        body="Hovercard Body"
+        header="Hovercard Header"
+        displayTimeout={100}
+      >
+        Hovercard Trigger
+      </Hovercard>
+    );
+
+    userEvent.hover(screen.getByText('Hovercard Trigger'));
+
+    act(() => {
+      jest.advanceTimersByTime(99);
+    });
+
+    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
+
+    userEvent.unhover(screen.getByText('Hovercard Trigger'));
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
+  });
+});

--- a/tests/js/spec/components/hovercard.spec.tsx
+++ b/tests/js/spec/components/hovercard.spec.tsx
@@ -94,13 +94,14 @@ describe('Hovercard', () => {
     expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
   });
 
-  it('Respects displayTimeout displays card', () => {
+  it('Respects displayTimeout displays card', async () => {
+    const DISPLAY_TIMEOUT = 100;
     mountWithTheme(
       <Hovercard
         position="top"
         body="Hovercard Body"
         header="Hovercard Header"
-        displayTimeout={100}
+        displayTimeout={DISPLAY_TIMEOUT}
       >
         Hovercard Trigger
       </Hovercard>
@@ -109,17 +110,14 @@ describe('Hovercard', () => {
     userEvent.hover(screen.getByText('Hovercard Trigger'));
 
     act(() => {
-      jest.advanceTimersByTime(99);
+      jest.advanceTimersByTime(DISPLAY_TIMEOUT - 1);
     });
 
     expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
 
-    act(() => {
-      jest.advanceTimersByTime(1);
-    });
-    expect(screen.getByText(/Hovercard Body/)).toBeInTheDocument();
-    expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
+    expect(await screen.findByText(/Hovercard Body/)).toBeInTheDocument();
+    expect(await screen.findByText(/Hovercard Header/)).toBeInTheDocument();
   });
 
   it('Doesnt leak timeout', () => {

--- a/tests/js/spec/components/hovercard.spec.tsx
+++ b/tests/js/spec/components/hovercard.spec.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import {act, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import {mountWithTheme} from 'sentry-test/reactTestingLibrary';
+import {act, mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Hovercard, HOVERCARD_PORTAL_ID} from 'sentry/components/hovercard';
 
@@ -58,7 +57,7 @@ describe('Hovercard', () => {
     expect(await screen.findByText(/Hovercard Header/)).toBeInTheDocument();
   });
 
-  it('Does not display card', async () => {
+  it('Does not display card', () => {
     mountWithTheme(
       <Hovercard
         position="top"
@@ -78,7 +77,7 @@ describe('Hovercard', () => {
     expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
   });
 
-  it('Always displays card', async () => {
+  it('Always displays card', () => {
     mountWithTheme(
       <Hovercard
         position="top"
@@ -95,7 +94,7 @@ describe('Hovercard', () => {
     expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
   });
 
-  it('Respects displayTimeout displays card', async () => {
+  it('Respects displayTimeout displays card', () => {
     mountWithTheme(
       <Hovercard
         position="top"
@@ -123,7 +122,7 @@ describe('Hovercard', () => {
     expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
   });
 
-  it('Doesnt leak timeout', async () => {
+  it('Doesnt leak timeout', () => {
     mountWithTheme(
       <Hovercard
         position="top"


### PR DESCRIPTION
There is a subtle change where we now keep the Popper controller renderer (the DOM output is the same as before) and control the child body/header rendering which hopefully leaves popper less work to do when actually mounting the component. Something that doesnt play nicely together is that the container component receives translate style props from popper props + we have the animation which uses it's own translate values that assume [0,0]. I assume it works because browsers handle it for us somehow andI'm not sure what's a better way around it so keeping as-is (besides parsing translate values from popper props and adding/subtracting the slide difference to compute final position)

Requires [jb/ref/hovercard](https://github.com/getsentry/getsentry/pull/6970)