### PR TITLE
fix(dashboards): remove beta badge from dataset selector

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -15,7 +15,6 @@ import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import IssueWidgetQueriesForm from 'sentry/components/dashboards/issueWidgetQueriesForm';
 import WidgetQueriesForm from 'sentry/components/dashboards/widgetQueriesForm';
-import FeatureBadge from 'sentry/components/featureBadge';
 import SelectControl from 'sentry/components/forms/selectControl';
 import {PanelAlert} from 'sentry/components/panels';
 import {t, tct} from 'sentry/locale';
@@ -636,7 +635,6 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
             state.displayType === DisplayType.TABLE && (
               <React.Fragment>
                 <StyledFieldLabel>{t('Data Set')}</StyledFieldLabel>
-                <FeatureBadge type="beta" />
                 <StyledRadioGroup
                   style={{flex: 1}}
                   choices={DATASET_CHOICES}


### PR DESCRIPTION
Removes the beta badge from the widget dataset selector
![image](https://user-images.githubusercontent.com/83961295/151212200-564068ec-3752-4a98-9737-8bca7d7b24ac.png)
