### PR TITLE
Disable subtasks result collection for reports prepare

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -570,6 +570,7 @@ backend = RedisReportBackend(redis.clusters.get("default"), 60 * 60 * 3)
     queue="reports.prepare",
     max_retries=5,
     acks_late=True,
+    trail=False,
 )
 def prepare_reports(dry_run=False, *args, **kwargs):
     timestamp, duration = _fill_default_parameters(*args, **kwargs)


### PR DESCRIPTION
This PR disables the accumulation of results of tasks spawned from `prepare_reports`. 

https://github.com/celery/celery/blob/d50c6cfc448e9e31384190b23f285254cb44e8a2/celery/app/task.py#L195-L198