### PR TITLE
feat(anomalies): Add anomalies tab backed by local storage 

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1251,6 +1251,13 @@ function buildRoutes() {
           }
           component={SafeLazyLoad}
         />
+        <Route
+          path="anomalies/"
+          componentPromise={() =>
+            import('sentry/views/performance/transactionSummary/transactionAnomalies')
+          }
+          component={SafeLazyLoad}
+        />
         <Route path="spans/">
           <IndexRoute
             componentPromise={() =>

--- a/static/app/utils/performance/anomalies/anomaliesQuery.tsx
+++ b/static/app/utils/performance/anomalies/anomaliesQuery.tsx
@@ -1,0 +1,250 @@
+import {EventsStatsData} from 'sentry/types';
+import {
+  DiscoverQueryProps,
+  GenericChildrenProps,
+} from 'sentry/utils/discover/genericDiscoverQuery';
+import localStorage from 'sentry/utils/localStorage';
+import withApi from 'sentry/utils/withApi';
+
+const anomalyDevKey = 'dev.anomalyPayload';
+const transformedAnomalyDevKey = 'dev.anomalyPayload.transformed';
+
+type AnomaliesProps = {};
+
+type AnomRawField = {
+  [key: string]: number;
+};
+
+type AnomalyRawData = {
+  ds: AnomRawField;
+  yhat_lower: AnomRawField;
+  yhat_upper: AnomRawField;
+  y: AnomRawField;
+  score: AnomRawField;
+  scaled_score: AnomRawField;
+  final_score: AnomRawField;
+};
+
+type RequestProps = DiscoverQueryProps & AnomaliesProps;
+
+export type ChildrenProps = Omit<GenericChildrenProps<AnomaliesProps>, 'tableData'> & {
+  data: AnomalyPayload | null;
+};
+
+type Props = RequestProps & {
+  children: (props: ChildrenProps) => React.ReactNode;
+};
+
+type AnomalyConfidence = 'high' | 'low';
+
+type AnomalyStatsData = {
+  data: EventsStatsData;
+  start?: number;
+  end?: number;
+};
+
+type AnomArea = {
+  id: number;
+  name?: string;
+  confidence: AnomalyConfidence;
+  start: number;
+  end?: number;
+  scoreTotal: number;
+  count: number;
+};
+
+export type AnomalyInfo = {
+  confidence: AnomalyConfidence;
+  start: number;
+  end: number;
+  id: string;
+  expected: number;
+  received: number;
+};
+
+type AnomalyData = {
+  data: AnomalyInfo[];
+};
+
+export type AnomalyPayload = {
+  y: AnomalyStatsData;
+  yhat_upper: AnomalyStatsData;
+  yhat_lower: AnomalyStatsData;
+  anomalies: AnomalyData;
+};
+
+/**
+ * TODO(k-fish): Remove this after api format is stabilized.
+ */
+const generateAnomalyAreas = (anomalyData: AnomalyRawData) => {
+  const areas: AnomalyInfo[] = [];
+  let id = 0;
+  let currentArea: AnomArea | null = null;
+
+  for (const [key, value] of Object.entries(anomalyData.ds)) {
+    const y = anomalyData.y[key];
+    const lower = anomalyData.yhat_lower[key];
+    const upper = anomalyData.yhat_upper[key];
+    const score = anomalyData.final_score[key];
+
+    if (y < lower || y > upper) {
+      if (!currentArea) {
+        if (score > 0.4) {
+          id++;
+          currentArea = {
+            id,
+            name: `#${id}`,
+            start: value,
+            confidence: 'low',
+            count: 1,
+            scoreTotal: score,
+          };
+        }
+      } else {
+        currentArea.count += 1;
+        currentArea.scoreTotal += score;
+      }
+    } else {
+      if (currentArea) {
+        //
+        currentArea.end = value;
+
+        const scoreAverage = currentArea.scoreTotal / currentArea.count;
+        if (scoreAverage > 1) {
+          currentArea.confidence = 'high';
+        }
+
+        areas.push({
+          start: currentArea.start,
+          end: currentArea.end,
+          id: `${currentArea.id}`,
+          confidence: currentArea.confidence,
+          expected: 0,
+          received: 0,
+        });
+        currentArea = null;
+      }
+    }
+  }
+
+  if (currentArea) {
+    currentArea.end = Object.values(anomalyData.ds)[-1];
+
+    areas.push({
+      start: currentArea.start,
+      end: currentArea.end,
+      id: `${currentArea.id}`,
+      confidence: currentArea.confidence,
+      expected: 0,
+      received: 0,
+    });
+  }
+
+  return {data: areas};
+};
+
+/**
+ * All this code is temporary while in development so a local dev env isn't required.
+ * TODO(k-fish): Remove this after EA.
+ */
+function getLocalPayload(): AnomalyPayload | null {
+  const rawTransformed = localStorage.getItem(transformedAnomalyDevKey);
+  if (rawTransformed) {
+    const transformedData: AnomalyPayload = JSON.parse(rawTransformed || '{}');
+
+    if (transformedData) {
+      return transformedData;
+    }
+  }
+
+  localStorage.setItem(transformedAnomalyDevKey, ''); // Set the key so it shows up automatically if this feature is enabled.
+
+  const rawData = localStorage.getItem(anomalyDevKey);
+
+  if (!rawData) {
+    localStorage.setItem(anomalyDevKey, '');
+    return null;
+  }
+
+  try {
+    const data = JSON.parse(rawData || '{}');
+
+    if (data) {
+      return transformRawAnomalyData(data);
+    }
+  } catch (_) {
+    //
+  }
+
+  return null;
+}
+
+// Uses the older format with timestamps and counts in their own separate objs.
+function transformRawAnomalyData(data: AnomalyRawData): AnomalyPayload {
+  const newData: any = {
+    ds: {},
+    y: {},
+    yhat_lower: {},
+    yhat_upper: {},
+    scaled_score: {},
+    score: {},
+    final_score: {},
+  };
+
+  // Simple smoothing for raw data with high bucket counts.
+  Object.keys(data).forEach(key => {
+    const obj = data[key];
+
+    const valueArray = Object.values(obj);
+
+    const newObj = {};
+
+    let counter = 0;
+
+    for (let i = 0; i < valueArray.length; i += 6) {
+      newObj[counter] = valueArray[i];
+      counter++;
+    }
+
+    newData[key] = newObj;
+  });
+
+  const yData = Object.entries(newData.ds).map(([key, value]) => [
+    value,
+    [{count: newData.y[key]}],
+  ]) as any;
+  const yUppperData = Object.entries(newData.ds).map(([key, value]) => [
+    value,
+    [{count: newData.yhat_upper[key]}],
+  ]) as any;
+  const yLowerData = Object.entries(newData.ds).map(([key, value]) => [
+    value,
+    [{count: newData.yhat_lower[key]}],
+  ]) as any;
+
+  const payload: AnomalyPayload = {
+    y: {data: yData},
+    yhat_upper: {data: yUppperData},
+    yhat_lower: {data: yLowerData},
+    anomalies: generateAnomalyAreas(newData),
+  };
+
+  return payload;
+}
+
+function AnomaliesSeriesQuery(props: Props) {
+  const data = getLocalPayload(); // TODO(k-fish): Replace with api request when service is enabled.
+
+  return (
+    <div>
+      {props.children({
+        data,
+        isLoading: false,
+        error: null,
+        pageLinks: null,
+      })}
+    </div>
+  );
+}
+
+export default withApi(AnomaliesSeriesQuery);

--- a/static/app/utils/performance/anomalies/anomaliesQuery.tsx
+++ b/static/app/utils/performance/anomalies/anomaliesQuery.tsx
@@ -21,6 +21,7 @@ type Props = RequestProps & {
 
 type AnomalyConfidence = 'high' | 'low';
 
+// Should match events stats data in format.
 type AnomalyStatsData = {
   data: EventsStatsData;
   start?: number;
@@ -40,11 +41,12 @@ export type AnomalyPayload = {
   y: AnomalyStatsData;
   yhat_upper: AnomalyStatsData;
   yhat_lower: AnomalyStatsData;
-  anomalies: AnomalyInfo[];
+  anomalies: AnomalyInfo[]; // Anomaly info describes what the anomaly service determines is an 'anomaly area'.
 };
 
 function transformStatsTimes(stats: AnomalyStatsData) {
   stats.data.forEach(d => (d[0] = d[0] * 1000));
+  stats.data = stats.data.slice((stats.data.length * 4) / 6, stats.data.length);
   return stats;
 }
 function transformAnomaliesTimes(anoms: AnomalyInfo[]) {

--- a/static/app/utils/performance/anomalies/anomaliesQuery.tsx
+++ b/static/app/utils/performance/anomalies/anomaliesQuery.tsx
@@ -6,25 +6,9 @@ import {
 import localStorage from 'sentry/utils/localStorage';
 import withApi from 'sentry/utils/withApi';
 
-const anomalyDevKey = 'dev.anomalyPayload';
 const transformedAnomalyDevKey = 'dev.anomalyPayload.transformed';
 
 type AnomaliesProps = {};
-
-type AnomRawField = {
-  [key: string]: number;
-};
-
-type AnomalyRawData = {
-  ds: AnomRawField;
-  yhat_lower: AnomRawField;
-  yhat_upper: AnomRawField;
-  y: AnomRawField;
-  score: AnomRawField;
-  scaled_score: AnomRawField;
-  final_score: AnomRawField;
-};
-
 type RequestProps = DiscoverQueryProps & AnomaliesProps;
 
 export type ChildrenProps = Omit<GenericChildrenProps<AnomaliesProps>, 'tableData'> & {
@@ -43,16 +27,6 @@ type AnomalyStatsData = {
   end?: number;
 };
 
-type AnomArea = {
-  id: number;
-  name?: string;
-  confidence: AnomalyConfidence;
-  start: number;
-  end?: number;
-  scoreTotal: number;
-  count: number;
-};
-
 export type AnomalyInfo = {
   confidence: AnomalyConfidence;
   start: number;
@@ -62,86 +36,24 @@ export type AnomalyInfo = {
   received: number;
 };
 
-type AnomalyData = {
-  data: AnomalyInfo[];
-};
-
 export type AnomalyPayload = {
   y: AnomalyStatsData;
   yhat_upper: AnomalyStatsData;
   yhat_lower: AnomalyStatsData;
-  anomalies: AnomalyData;
+  anomalies: AnomalyInfo[];
 };
 
-/**
- * TODO(k-fish): Remove this after api format is stabilized.
- */
-const generateAnomalyAreas = (anomalyData: AnomalyRawData) => {
-  const areas: AnomalyInfo[] = [];
-  let id = 0;
-  let currentArea: AnomArea | null = null;
-
-  for (const [key, value] of Object.entries(anomalyData.ds)) {
-    const y = anomalyData.y[key];
-    const lower = anomalyData.yhat_lower[key];
-    const upper = anomalyData.yhat_upper[key];
-    const score = anomalyData.final_score[key];
-
-    if (y < lower || y > upper) {
-      if (!currentArea) {
-        if (score > 0.4) {
-          id++;
-          currentArea = {
-            id,
-            name: `#${id}`,
-            start: value,
-            confidence: 'low',
-            count: 1,
-            scoreTotal: score,
-          };
-        }
-      } else {
-        currentArea.count += 1;
-        currentArea.scoreTotal += score;
-      }
-    } else {
-      if (currentArea) {
-        //
-        currentArea.end = value;
-
-        const scoreAverage = currentArea.scoreTotal / currentArea.count;
-        if (scoreAverage > 1) {
-          currentArea.confidence = 'high';
-        }
-
-        areas.push({
-          start: currentArea.start,
-          end: currentArea.end,
-          id: `${currentArea.id}`,
-          confidence: currentArea.confidence,
-          expected: 0,
-          received: 0,
-        });
-        currentArea = null;
-      }
-    }
-  }
-
-  if (currentArea) {
-    currentArea.end = Object.values(anomalyData.ds)[-1];
-
-    areas.push({
-      start: currentArea.start,
-      end: currentArea.end,
-      id: `${currentArea.id}`,
-      confidence: currentArea.confidence,
-      expected: 0,
-      received: 0,
-    });
-  }
-
-  return {data: areas};
-};
+function transformStatsTimes(stats: AnomalyStatsData) {
+  stats.data.forEach(d => (d[0] = d[0] * 1000));
+  return stats;
+}
+function transformAnomaliesTimes(anoms: AnomalyInfo[]) {
+  anoms.forEach(a => {
+    a.start = a.start * 1000;
+    a.end = a.end * 1000;
+  });
+  return anoms;
+}
 
 /**
  * All this code is temporary while in development so a local dev env isn't required.
@@ -153,83 +65,17 @@ function getLocalPayload(): AnomalyPayload | null {
     const transformedData: AnomalyPayload = JSON.parse(rawTransformed || '{}');
 
     if (transformedData) {
+      transformedData.y = transformStatsTimes(transformedData.y);
+      transformedData.yhat_upper = transformStatsTimes(transformedData.yhat_upper);
+      transformedData.yhat_lower = transformStatsTimes(transformedData.yhat_lower);
+      transformedData.anomalies = transformAnomaliesTimes(transformedData.anomalies);
       return transformedData;
     }
   }
 
   localStorage.setItem(transformedAnomalyDevKey, ''); // Set the key so it shows up automatically if this feature is enabled.
 
-  const rawData = localStorage.getItem(anomalyDevKey);
-
-  if (!rawData) {
-    localStorage.setItem(anomalyDevKey, '');
-    return null;
-  }
-
-  try {
-    const data = JSON.parse(rawData || '{}');
-
-    if (data) {
-      return transformRawAnomalyData(data);
-    }
-  } catch (_) {
-    //
-  }
-
   return null;
-}
-
-// Uses the older format with timestamps and counts in their own separate objs.
-function transformRawAnomalyData(data: AnomalyRawData): AnomalyPayload {
-  const newData: any = {
-    ds: {},
-    y: {},
-    yhat_lower: {},
-    yhat_upper: {},
-    scaled_score: {},
-    score: {},
-    final_score: {},
-  };
-
-  // Simple smoothing for raw data with high bucket counts.
-  Object.keys(data).forEach(key => {
-    const obj = data[key];
-
-    const valueArray = Object.values(obj);
-
-    const newObj = {};
-
-    let counter = 0;
-
-    for (let i = 0; i < valueArray.length; i += 6) {
-      newObj[counter] = valueArray[i];
-      counter++;
-    }
-
-    newData[key] = newObj;
-  });
-
-  const yData = Object.entries(newData.ds).map(([key, value]) => [
-    value,
-    [{count: newData.y[key]}],
-  ]) as any;
-  const yUppperData = Object.entries(newData.ds).map(([key, value]) => [
-    value,
-    [{count: newData.yhat_upper[key]}],
-  ]) as any;
-  const yLowerData = Object.entries(newData.ds).map(([key, value]) => [
-    value,
-    [{count: newData.yhat_lower[key]}],
-  ]) as any;
-
-  const payload: AnomalyPayload = {
-    y: {data: yData},
-    yhat_upper: {data: yUppperData},
-    yhat_lower: {data: yLowerData},
-    anomalies: generateAnomalyAreas(newData),
-  };
-
-  return payload;
 }
 
 function AnomaliesSeriesQuery(props: Props) {

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -55,6 +55,10 @@ const TAB_ANALYTICS: Partial<Record<Tab, AnalyticInfo>> = {
     eventKey: 'performance_views.spans.spans_tab_clicked',
     eventName: 'Performance Views: Spans tab clicked',
   },
+  [Tab.Anomalies]: {
+    eventKey: 'performance_views.anomalies.anomalies_tab_clicked',
+    eventName: 'Performance Views: Anomalies tab clicked',
+  },
 };
 
 type Props = {

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -22,6 +22,7 @@ import Breadcrumb from 'sentry/views/performance/breadcrumb';
 import {getCurrentLandingDisplay, LandingDisplayField} from '../landing/utils';
 import {MetricsSwitch} from '../metricsSwitch';
 
+import {anomaliesRouteWithQuery} from './transactionAnomalies/utils';
 import {eventsRouteWithQuery} from './transactionEvents/utils';
 import {spansRouteWithQuery} from './transactionSpans/utils';
 import {tagsRouteWithQuery} from './transactionTags/utils';
@@ -238,6 +239,7 @@ class TransactionHeader extends React.Component<Props> {
     const tagsTarget = tagsRouteWithQuery(routeQuery);
     const eventsTarget = eventsRouteWithQuery(routeQuery);
     const spansTarget = spansRouteWithQuery(routeQuery);
+    const anomaliesTarget = anomaliesRouteWithQuery(routeQuery);
 
     return (
       <Layout.Header>
@@ -299,6 +301,21 @@ class TransactionHeader extends React.Component<Props> {
                 onClick={this.trackTabClick(Tab.Spans)}
               >
                 {t('Spans')}
+                <FeatureBadge type="alpha" noTooltip />
+              </ListLink>
+            </Feature>
+            <Feature
+              organization={organization}
+              // features={['organizations:performance-anomaly-detection-ui']} #TODO(k-fish): Remove when flag is merged
+              features={['organizations:performance-events-page']}
+            >
+              <ListLink
+                data-test-id="anomalies-tab"
+                to={anomaliesTarget}
+                isActive={() => currentTab === Tab.Anomalies}
+                onClick={this.trackTabClick(Tab.Anomalies)}
+              >
+                {t('Anomalies')}
                 <FeatureBadge type="alpha" noTooltip />
               </ListLink>
             </Feature>

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -306,8 +306,7 @@ class TransactionHeader extends React.Component<Props> {
             </Feature>
             <Feature
               organization={organization}
-              // features={['organizations:performance-anomaly-detection-ui']} #TODO(k-fish): Remove when flag is merged
-              features={['organizations:performance-events-page']}
+              features={['organizations:performance-anomaly-detection-ui']}
             >
               <ListLink
                 data-test-id="anomalies-tab"

--- a/static/app/views/performance/transactionSummary/tabs.tsx
+++ b/static/app/views/performance/transactionSummary/tabs.tsx
@@ -4,6 +4,7 @@ enum Tab {
   Tags,
   Events,
   Spans,
+  Anomalies,
 }
 
 export default Tab;

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/anomaliesTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/anomaliesTable.tsx
@@ -1,0 +1,154 @@
+import {ReactNode} from 'react';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  GridColumnOrder,
+} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
+import {t} from 'sentry/locale';
+import {Organization} from 'sentry/types';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {ColumnType, fieldAlignment} from 'sentry/utils/discover/fields';
+import {AnomalyInfo} from 'sentry/utils/performance/anomalies/anomaliesQuery';
+
+type Props = {
+  anomalies?: AnomalyInfo[];
+  location: Location;
+  organization: Organization;
+  isLoading: boolean;
+};
+
+const transformRow = (anom: AnomalyInfo): TableDataRowWithExtras => {
+  return {
+    anomaly: `#${anom.id}`,
+    confidence: anom.confidence,
+    timestamp: new Date(anom.start),
+    timeInterval: anom.end - anom.start,
+    expected: anom.expected,
+    received: anom.received,
+  };
+};
+
+export default function AnomaliesTable(props: Props) {
+  const {location, organization, isLoading, anomalies} = props;
+
+  const data: TableDataRowWithExtras[] = anomalies?.map(transformRow) || [];
+
+  return (
+    <GridEditable
+      isLoading={isLoading}
+      data={data}
+      columnOrder={Object.values(COLUMNS)}
+      columnSortBy={[]}
+      grid={{
+        renderHeadCell,
+        renderBodyCell: renderBodyCellWithMeta(location, organization),
+      }}
+      location={location}
+    />
+  );
+}
+
+function renderHeadCell(column: TableColumn, _index: number): ReactNode {
+  const align = fieldAlignment(column.key, COLUMN_TYPE[column.key]);
+  return (
+    <SortLink
+      title={column.name}
+      align={align}
+      direction={undefined}
+      canSort={false}
+      generateSortLink={() => undefined}
+    />
+  );
+}
+
+function renderBodyCellWithMeta(location: Location, organization: Organization) {
+  return (column: TableColumn, dataRow: TableDataRowWithExtras): React.ReactNode => {
+    const fieldRenderer = getFieldRenderer(column.key, COLUMN_TYPE);
+
+    if (column.key === 'confidence') {
+      return (
+        <ConfidenceCell>
+          {dataRow.confidence === 'low' ? (
+            <LowConfidence>{t('Low Confidence')}</LowConfidence>
+          ) : (
+            <HighConfidence>{t('High Confidence')}</HighConfidence>
+          )}
+        </ConfidenceCell>
+      );
+    }
+
+    return fieldRenderer(dataRow, {location, organization});
+  };
+}
+
+const LowConfidence = styled('div')`
+  color: ${p => p.theme.yellow300};
+`;
+const HighConfidence = styled('div')`
+  color: ${p => p.theme.red300};
+`;
+
+const ConfidenceCell = styled('div')`
+  text-align: left;
+  justify-self: flex-end;
+  flex-grow: 1;
+`;
+
+type TableColumnKey =
+  | 'anomaly'
+  | 'confidence'
+  | 'timeInterval'
+  | 'timestamp'
+  | 'expected'
+  | 'received';
+
+type TableColumn = GridColumnOrder<TableColumnKey>;
+
+type TableDataRow = Record<TableColumnKey, any>;
+
+type TableDataRowWithExtras = TableDataRow & {};
+
+const COLUMNS: Record<TableColumnKey, TableColumn> = {
+  anomaly: {
+    key: 'anomaly',
+    name: t('Anomaly'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  confidence: {
+    key: 'confidence',
+    name: t('Confidence'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  timeInterval: {
+    key: 'timeInterval',
+    name: t('Time Interval'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  timestamp: {
+    key: 'timestamp',
+    name: t('Timestamp'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  expected: {
+    key: 'expected',
+    name: t('Expected'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  received: {
+    key: 'received',
+    name: t('Received'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+};
+
+const COLUMN_TYPE: Record<TableColumnKey, ColumnType> = {
+  anomaly: 'string',
+  confidence: 'string',
+  timeInterval: 'duration',
+  timestamp: 'date',
+  expected: 'number',
+  received: 'number',
+};

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
@@ -4,6 +4,7 @@ import {Location} from 'history';
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import LineChart from 'sentry/components/charts/lineChart';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {t} from 'sentry/locale';
 import {DateString} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
@@ -37,7 +38,7 @@ const _AnomalyChart = (props: Props) => {
   const legend = {
     right: 10,
     top: 5,
-    data: ['High Confidence', 'Low Confidence'],
+    data: [t('High Confidence'), t('Low Confidence')],
   };
 
   const chartOptions = {

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
@@ -1,0 +1,76 @@
+import {InjectedRouter, withRouter} from 'react-router';
+import {Location} from 'history';
+
+import ChartZoom from 'sentry/components/charts/chartZoom';
+import LineChart from 'sentry/components/charts/lineChart';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {DateString} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
+import {getUtcToLocalDateObject} from 'sentry/utils/dates';
+import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
+
+type Props = {
+  data: Series[];
+  statsPeriod: string | undefined;
+  start: DateString;
+  end: DateString;
+  height?: number;
+  location: Location;
+  router: InjectedRouter;
+};
+
+const _AnomalyChart = (props: Props) => {
+  const {
+    data,
+    location,
+    statsPeriod,
+    height,
+    router,
+    start: propsStart,
+    end: propsEnd,
+  } = props;
+
+  const start = propsStart ? getUtcToLocalDateObject(propsStart) : null;
+  const end = propsEnd ? getUtcToLocalDateObject(propsEnd) : null;
+  const {utc} = normalizeDateTimeParams(location.query);
+
+  const legend = {
+    right: 10,
+    top: 5,
+    data: ['High Confidence', 'Low Confidence'],
+  };
+
+  const chartOptions = {
+    seriesOptions: {
+      showSymbol: false,
+    },
+    height,
+    tooltip: {
+      trigger: 'axis' as const,
+      valueFormatter: tooltipFormatter,
+    },
+    xAxis: undefined,
+    yAxis: {
+      axisLabel: {
+        // p50() coerces the axis to be time based
+        formatter: (value: number) => axisLabelFormatter(value, 'p50()'),
+      },
+    },
+  };
+
+  return (
+    <ChartZoom
+      router={router}
+      period={statsPeriod}
+      start={start}
+      end={end}
+      utc={utc === 'true'}
+    >
+      {zoomRenderProps => (
+        <LineChart {...zoomRenderProps} series={data} legend={legend} {...chartOptions} />
+      )}
+    </ChartZoom>
+  );
+};
+
+export const AnomalyChart = withRouter(_AnomalyChart);

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
-import color from 'color';
 import {Location} from 'history';
 import pick from 'lodash/pick';
 
@@ -120,7 +119,8 @@ const transformAnomalyData = (_: any, results: {data: AnomalyPayload}) => {
     }),
     markArea: MarkArea({
       itemStyle: {
-        color: color(theme.red300).alpha(0.2).rgb().string(),
+        color: theme.red300,
+        opacity: 0.2,
       },
       label: {
         show: false,
@@ -149,7 +149,8 @@ const transformAnomalyData = (_: any, results: {data: AnomalyPayload}) => {
     }),
     markArea: MarkArea({
       itemStyle: {
-        color: color(theme.yellow200).alpha(0.2).rgb().string(),
+        color: theme.yellow200,
+        opacity: 0.2,
       },
       label: {
         show: false,

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
@@ -84,7 +84,7 @@ const transformAnomalyData = (_: any, results: {data: AnomalyPayload}) => {
     })),
   });
 
-  const anomalies = results.data.anomalies.data;
+  const anomalies = results.data.anomalies;
   const highConfidenceAreas = anomalies
     .filter(a => a.confidence === 'high')
     .map(transformAnomalyToArea);
@@ -251,11 +251,7 @@ function AnomaliesContent(props: Props) {
           eventView={props.eventView}
         >
           {({data}) => (
-            <AnomaliesTable
-              anomalies={data?.anomalies.data}
-              {...props}
-              isLoading={false}
-            />
+            <AnomaliesTable anomalies={data?.anomalies} {...props} isLoading={false} />
           )}
         </AnomaliesQuery>
       </TableContainer>

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
@@ -1,0 +1,270 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+import color from 'color';
+import {Location} from 'history';
+import pick from 'lodash/pick';
+
+import MarkArea from 'sentry/components/charts/components/markArea';
+import MarkLine from 'sentry/components/charts/components/markLine';
+import {LineChartSeries} from 'sentry/components/charts/lineChart';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+import EventView from 'sentry/utils/discover/eventView';
+import AnomaliesQuery, {
+  AnomalyInfo,
+  AnomalyPayload,
+} from 'sentry/utils/performance/anomalies/anomaliesQuery';
+import theme from 'sentry/utils/theme';
+import _DurationChart from 'sentry/views/performance/charts/chart';
+
+import {GenericPerformanceWidget} from '../../landing/widgets/components/performanceWidget';
+import {WidgetEmptyStateWarning} from '../../landing/widgets/components/selectableList';
+import {QueryDefinition, WidgetDataResult} from '../../landing/widgets/types';
+import {
+  PerformanceWidgetSetting,
+  WIDGET_DEFINITIONS,
+} from '../../landing/widgets/widgetDefinitions';
+import {SetStateAction} from '../types';
+
+import AnomaliesTable from './anomaliesTable';
+import {AnomalyChart} from './anomalyChart';
+
+type Props = {
+  location: Location;
+  organization: Organization;
+  eventView: EventView;
+  projectId: string;
+  setError: SetStateAction<string | undefined>;
+  transactionName: string;
+};
+
+const anomalyAreaName = (anomaly: AnomalyInfo) => `#${anomaly.id}`;
+const transformAnomalyToArea = (
+  anomaly: AnomalyInfo
+): [{name: string; xAxis: number}, {xAxis: number}] => [
+  {name: anomalyAreaName(anomaly), xAxis: anomaly.start},
+  {xAxis: anomaly.end},
+];
+
+const transformAnomalyData = (_: any, results: {data: AnomalyPayload}) => {
+  const data: LineChartSeries[] = [];
+  const resultData = results.data;
+
+  if (!resultData) {
+    return {
+      isLoading: false,
+      isErrored: false,
+      data: undefined,
+      hasData: false,
+      loading: false,
+    };
+  }
+
+  data.push({
+    seriesName: 'tpm()',
+    data: resultData.y.data.map(([name, [{count}]]) => ({
+      name,
+      value: count,
+    })),
+  });
+  data.push({
+    seriesName: 'tpm() lower bound',
+    data: resultData.yhat_lower.data.map(([name, [{count}]]) => ({
+      name,
+      value: count,
+    })),
+  });
+  data.push({
+    seriesName: 'tpm() upper bound',
+    data: resultData.yhat_upper.data.map(([name, [{count}]]) => ({
+      name,
+      value: count,
+    })),
+  });
+
+  const anomalies = results.data.anomalies.data;
+  const highConfidenceAreas = anomalies
+    .filter(a => a.confidence === 'high')
+    .map(transformAnomalyToArea);
+  const highConfidenceLines = anomalies
+    .filter(a => a.confidence === 'high')
+    .map(area => ({xAxis: area.start, name: anomalyAreaName(area)}));
+
+  const lowConfidenceAreas = anomalies
+    .filter(a => a.confidence === 'low')
+    .map(transformAnomalyToArea);
+  const lowConfidenceLines = anomalies
+    .filter(a => a.confidence === 'low')
+    .map(area => ({xAxis: area.start, name: anomalyAreaName(area)}));
+
+  data.push({
+    seriesName: 'High Confidence',
+    color: theme.red300,
+    data: [],
+    silent: true,
+    markLine: MarkLine({
+      animation: false,
+      lineStyle: {color: theme.red300, type: 'solid', width: 1, opacity: 1.0},
+      data: highConfidenceLines,
+      label: {
+        show: true,
+        rotate: 90,
+        color: theme.red300,
+        position: 'insideEndBottom',
+        fontSize: '10',
+        offset: [5, 5],
+        formatter: obj => `${(obj.data as any).name}`,
+      },
+    }),
+    markArea: MarkArea({
+      itemStyle: {
+        color: color(theme.red300).alpha(0.2).rgb().string(),
+      },
+      label: {
+        show: false,
+      },
+      data: highConfidenceAreas,
+    }),
+  });
+
+  data.push({
+    seriesName: 'Low Confidence',
+    color: theme.yellow200,
+    data: [],
+    markLine: MarkLine({
+      animation: false,
+      lineStyle: {color: theme.yellow200, type: 'solid', width: 1, opacity: 1.0},
+      data: lowConfidenceLines,
+      label: {
+        show: true,
+        rotate: 90,
+        color: theme.yellow300,
+        position: 'insideEndBottom',
+        fontSize: '10',
+        offset: [5, 5],
+        formatter: obj => `${(obj.data as any).name}`,
+      },
+    }),
+    markArea: MarkArea({
+      itemStyle: {
+        color: color(theme.yellow200).alpha(0.2).rgb().string(),
+      },
+      label: {
+        show: false,
+      },
+      data: lowConfidenceAreas,
+    }),
+  });
+
+  return {
+    isLoading: false,
+    isErrored: false,
+    data,
+    hasData: true,
+    loading: false,
+  };
+};
+
+type AnomalyData = WidgetDataResult & ReturnType<typeof transformAnomalyData>;
+
+type DataType = {
+  chart: AnomalyData;
+};
+
+function Anomalies(props: Props) {
+  const height = 250;
+  const chartColor = theme.charts.colors[0];
+
+  const chart = useMemo<QueryDefinition<DataType, WidgetDataResult>>(() => {
+    return {
+      fields: '',
+      component: provided => (
+        <AnomaliesQuery
+          orgSlug={props.organization.slug}
+          location={props.location}
+          eventView={props.eventView}
+          {...pick(provided, 'children')}
+        />
+      ),
+      transform: transformAnomalyData,
+    };
+  }, []);
+
+  return (
+    <GenericPerformanceWidget<DataType>
+      {...props}
+      title={t('Transaction Count')}
+      titleTooltip={t(
+        'Represents transaction count across time, with added visualizations to highlight anomalies in your data.'
+      )}
+      fields={['']}
+      chartSetting={PerformanceWidgetSetting.TPM_AREA}
+      chartDefinition={WIDGET_DEFINITIONS[PerformanceWidgetSetting.TPM_AREA]}
+      Subtitle={() => <div />}
+      HeaderActions={() => <div />}
+      EmptyComponent={WidgetEmptyStateWarning}
+      Queries={{
+        chart,
+      }}
+      Visualizations={[
+        {
+          component: provided => {
+            const data =
+              provided.widgetData.chart.data?.map(series => {
+                if (series.seriesName !== 'tpm()') {
+                  series.lineStyle = {type: 'dashed', color: chartColor, width: 1.5};
+                }
+                if (series.seriesName === 'score') {
+                  series.lineStyle = {color: theme.red400};
+                }
+                return series;
+              }) ?? [];
+
+            return (
+              <AnomalyChart
+                {...provided}
+                data={data}
+                height={height}
+                statsPeriod={undefined}
+                start={null}
+                end={null}
+              />
+            );
+          },
+          height,
+        },
+      ]}
+    />
+  );
+}
+
+function AnomaliesContent(props: Props) {
+  return (
+    <Layout.Main fullWidth>
+      <Anomalies {...props} />
+      <TableContainer>
+        <AnomaliesQuery
+          orgSlug={props.organization.slug}
+          location={props.location}
+          eventView={props.eventView}
+        >
+          {({data}) => (
+            <AnomaliesTable
+              anomalies={data?.anomalies.data}
+              {...props}
+              isLoading={false}
+            />
+          )}
+        </AnomaliesQuery>
+      </TableContainer>
+    </Layout.Main>
+  );
+}
+
+const TableContainer = styled('div')`
+  margin-top: ${space(2)};
+`;
+
+export default AnomaliesContent;

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/index.tsx
@@ -7,9 +7,9 @@ import withProjects from 'sentry/utils/withProjects';
 
 import PageLayout from '../pageLayout';
 import Tab from '../tabs';
-import {generateSpansEventView} from '../transactionSpans/utils';
 
 import AnomaliesContent from './content';
+import {generateAnomaliesEventView} from './utils';
 
 type Props = {
   location: Location;
@@ -26,7 +26,7 @@ function TransactionAnomalies(props: Props) {
       organization={organization}
       projects={projects}
       tab={Tab.Anomalies}
-      generateEventView={generateSpansEventView} // TODO(k-fish): Fix
+      generateEventView={generateAnomaliesEventView}
       getDocumentTitle={getDocumentTitle}
       childComponent={AnomaliesContent}
     />

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/index.tsx
@@ -1,0 +1,47 @@
+import {Location} from 'history';
+
+import {t} from 'sentry/locale';
+import {Organization, Project} from 'sentry/types';
+import withOrganization from 'sentry/utils/withOrganization';
+import withProjects from 'sentry/utils/withProjects';
+
+import PageLayout from '../pageLayout';
+import Tab from '../tabs';
+import {generateSpansEventView} from '../transactionSpans/utils';
+
+import AnomaliesContent from './content';
+
+type Props = {
+  location: Location;
+  organization: Organization;
+  projects: Project[];
+};
+
+function TransactionAnomalies(props: Props) {
+  const {location, organization, projects} = props;
+
+  return (
+    <PageLayout
+      location={location}
+      organization={organization}
+      projects={projects}
+      tab={Tab.Anomalies}
+      generateEventView={generateSpansEventView} // TODO(k-fish): Fix
+      getDocumentTitle={getDocumentTitle}
+      childComponent={AnomaliesContent}
+    />
+  );
+}
+
+function getDocumentTitle(transactionName: string): string {
+  const hasTransactionName =
+    typeof transactionName === 'string' && String(transactionName).trim().length > 0;
+
+  if (hasTransactionName) {
+    return [String(transactionName).trim(), t('Performance')].join(' - ');
+  }
+
+  return [t('Summary'), t('Performance')].join(' - ');
+}
+
+export default withProjects(withOrganization(TransactionAnomalies));

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/types.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/types.tsx
@@ -1,0 +1,10 @@
+export enum AnomalyTable {
+  ANOMALY = 'anomaly',
+  CONFIDENCE = 'confidence',
+  TIME_INTERVAL = 'timeInterval',
+  TIMESTAMP = 'timestamp',
+  EXPECTED = 'expected',
+  RECEIVED = 'received',
+}
+
+export type AnomalySort = AnomalyTable;

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/utils.tsx
@@ -1,0 +1,34 @@
+import {Query} from 'history';
+
+export function generateAnomaliesRoute({orgSlug}: {orgSlug: String}): string {
+  return `/organizations/${orgSlug}/performance/summary/anomalies/`;
+}
+
+export function anomaliesRouteWithQuery({
+  orgSlug,
+  transaction,
+  projectID,
+  query,
+}: {
+  orgSlug: string;
+  transaction: string;
+  query: Query;
+  projectID?: string | string[];
+}) {
+  const pathname = generateAnomaliesRoute({
+    orgSlug,
+  });
+
+  return {
+    pathname,
+    query: {
+      transaction,
+      project: projectID,
+      environment: query.environment,
+      statsPeriod: query.statsPeriod,
+      start: query.start,
+      end: query.end,
+      query: query.query,
+    },
+  };
+}

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/utils.tsx
@@ -1,4 +1,8 @@
-import {Query} from 'history';
+import {Location, Query} from 'history';
+
+import EventView from 'sentry/utils/discover/eventView';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
 export function generateAnomaliesRoute({orgSlug}: {orgSlug: String}): string {
   return `/organizations/${orgSlug}/performance/summary/anomalies/`;
@@ -31,4 +35,31 @@ export function anomaliesRouteWithQuery({
       query: query.query,
     },
   };
+}
+
+export function generateAnomaliesEventView({
+  location,
+  transactionName,
+}: {
+  location: Location;
+  transactionName: string;
+}): EventView {
+  const query = decodeScalar(location.query.query, '');
+  const conditions = new MutableSearch(query);
+
+  conditions.setFilterValues('transaction', [transactionName]);
+
+  const eventView = EventView.fromNewQueryWithLocation(
+    {
+      id: undefined,
+      version: 2,
+      name: transactionName,
+      fields: ['tpm()'], // TODO(k-fish): Modify depending on api url later.
+      query: conditions.formatString(),
+      projects: [],
+    },
+    location
+  );
+
+  return eventView;
 }

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -9,12 +9,14 @@ import {
   SuspectSpan,
 } from 'sentry/utils/performance/suspectSpans/types';
 
-export function initializeData(settings?: {
+export interface initializeDataSettings {
   query?: {};
   features?: string[];
   projects?: Project[];
   project?: Project;
-}) {
+}
+
+export function initializeData(settings?: initializeDataSettings) {
   const _defaultProject = TestStubs.Project();
   const _settings = {
     query: {},

--- a/tests/js/spec/views/performance/transactionAnomalies/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionAnomalies/index.spec.tsx
@@ -1,0 +1,43 @@
+import {
+  initializeData as _initializeData,
+  initializeDataSettings,
+} from 'sentry-test/performance/initializePerformanceData';
+import {act, cleanup, mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+import TransactionAnomalies from 'sentry/views/performance/transactionSummary/transactionAnomalies';
+
+const initializeData = (settings: initializeDataSettings) => {
+  const data = _initializeData(settings);
+
+  act(() => void ProjectsStore.loadInitialData(data.organization.projects));
+  return data;
+};
+
+const WrappedComponent = data => {
+  return (
+    <OrganizationContext.Provider value={data.organization}>
+      <TransactionAnomalies {...data} />,
+    </OrganizationContext.Provider>
+  );
+};
+
+describe('AnomaliesTab', function () {
+  afterEach(cleanup);
+  it('renders basic UI elements with flag', async function () {
+    const initialData = initializeData({
+      features: ['performance-view', 'performance-anomaly-detection-ui'],
+      query: {project: '1', transaction: 'transaction'},
+    });
+    mountWithTheme(
+      <WrappedComponent
+        organization={initialData.organization}
+        location={initialData.router.location}
+      />,
+      {context: initialData.routerContext}
+    );
+
+    expect(await screen.findByText('Transaction Count')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Summary
This PR adds some basic UI for the upcoming anomalies feature to work behind its feature flag, and have response data supplied to it via local storage while the api is still being finalized. The local payload function will eventually be removed, but until then some small amount of transforms may happen in there.

Other:
- Has some basic tests we can expand on in the future. UI is still somewhat TBD. 