### PR TITLE
feat(perf): Improve Trace View when there are only errors and no transactions

### DIFF
--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -14,8 +14,6 @@ import * as ScrollbarManager from 'sentry/components/events/interfaces/spans/scr
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
-import List from 'sentry/components/list';
-import ListItem from 'sentry/components/list/listItem';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {MessageRow} from 'sentry/components/performance/waterfall/messageRow';
@@ -25,6 +23,12 @@ import {
   VirtualScrollbar,
   VirtualScrollbarGrip,
 } from 'sentry/components/performance/waterfall/miniHeader';
+import {
+  ErrorDot,
+  ErrorLevel,
+  ErrorMessageContent,
+  ErrorTitle,
+} from 'sentry/components/performance/waterfall/rowDetails';
 import {pickBarColor, toPercent} from 'sentry/components/performance/waterfall/utils';
 import TimeSince from 'sentry/components/timeSince';
 import {IconInfo} from 'sentry/icons';
@@ -109,6 +113,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
         {kind: 'field', field: 'project'},
         {kind: 'field', field: 'title'},
         {kind: 'field', field: 'issue.id'},
+        {kind: 'field', field: 'level'},
       ]);
       errorsEventView.query = `trace:${traceSlug} !event.type:transaction `;
 
@@ -143,22 +148,21 @@ class TraceDetailsContent extends React.Component<Props, State> {
                   {t('The trace cannot be shown when all events are errors.')}
                 </ErrorLabel>
 
-                <List symbol="bullet" data-test-id="trace-view-errors-list">
+                <ErrorMessageContent data-test-id="trace-view-errors">
                   {tableData.data.map(data => (
-                    <ListItem key={data.id}>
-                      {tct('[link]: [title]', {
-                        link: (
-                          <Link
-                            to={`/organizations/${organization.slug}/issues/${data['issue.id']}/events/${data.id}`}
-                          >
-                            {data.project}
-                          </Link>
-                        ),
-                        title: data.title,
-                      })}
-                    </ListItem>
+                    <React.Fragment key={data.id}>
+                      <ErrorDot level={data.level} />
+                      <ErrorLevel>{data.level}</ErrorLevel>
+                      <ErrorTitle>
+                        <Link
+                          to={`/organizations/${organization.slug}/issues/${data['issue.id']}/events/${data.id}`}
+                        >
+                          {data.title}
+                        </Link>
+                      </ErrorTitle>
+                    </React.Fragment>
                   ))}
-                </List>
+                </ErrorMessageContent>
               </Alert>
             );
           }}

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -140,7 +140,17 @@ class TraceDetailsContent extends React.Component<Props, State> {
                 return (
                   <List symbol="bullet" data-test-id="trace-view-errors-list">
                     {tableData.data.map(data => (
-                      <ListItem key={data.id}>{data.title}</ListItem>
+                      <ListItem key={data.id}>
+                        {tct(`[link]: ${data.title}`, {
+                          link: (
+                            <Link
+                              to={`/organizations/${organization.slug}/discover/${data.project}:${data.id}`}
+                            >
+                              {data.project}
+                            </Link>
+                          ),
+                        })}
+                      </ListItem>
                     ))}
                   </List>
                 );

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -138,7 +138,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
                 }
 
                 return (
-                  <List symbol="bullet">
+                  <List symbol="bullet" data-test-id="trace-view-errors-list">
                     {tableData.data.map(data => (
                       <ListItem key={data.id}>{data.title}</ListItem>
                     ))}

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -101,7 +101,9 @@ class TraceDetailsContent extends React.Component<Props, State> {
 
     if (transactions === 0 && errors > 0) {
       return (
-        <LoadingError message={t('The trace you are looking contains only errors.')} />
+        <LoadingError
+          message={t('The trace cannot be shown when all events are errors.')}
+        />
       );
     }
 

--- a/tests/js/spec/views/performance/traceDetails/content.spec.tsx
+++ b/tests/js/spec/views/performance/traceDetails/content.spec.tsx
@@ -8,8 +8,8 @@ import TraceDetailsContent from 'sentry/views/performance/traceDetails/content';
 
 const SAMPLE_ERROR_DATA = {
   data: [
-    {id: '1', title: 'Test error 1', project: 'sentry'},
-    {id: '2', title: 'Test error 2', project: 'sentry'},
+    {id: '1', level: 'error', title: 'Test error 1', project: 'sentry'},
+    {id: '2', level: 'fatal', title: 'Test error 2', project: 'sentry'},
   ],
 };
 
@@ -62,6 +62,13 @@ describe('TraceDetailsContent', () => {
       ).toBeInTheDocument();
       expect(
         await within(errorList).findByText(SAMPLE_ERROR_DATA.data[1].title)
+      ).toBeInTheDocument();
+
+      expect(
+        await within(errorList).findByText(SAMPLE_ERROR_DATA.data[0].level)
+      ).toBeInTheDocument();
+      expect(
+        await within(errorList).findByText(SAMPLE_ERROR_DATA.data[1].level)
       ).toBeInTheDocument();
     });
   });

--- a/tests/js/spec/views/performance/traceDetails/content.spec.tsx
+++ b/tests/js/spec/views/performance/traceDetails/content.spec.tsx
@@ -1,0 +1,68 @@
+import {initializeData as _initializeData} from 'sentry-test/performance/initializePerformanceData';
+import {act, mountWithTheme, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import EventView from 'sentry/utils/discover/eventView';
+import {DEFAULT_EVENT_VIEW} from 'sentry/views/eventsV2/data';
+import TraceDetailsContent from 'sentry/views/performance/traceDetails/content';
+
+const SAMPLE_ERROR_DATA = {
+  data: [
+    {id: '1', title: 'Test error 1'},
+    {id: '2', title: 'Test error 2'},
+  ],
+};
+
+const initializeData = () => {
+  const data = _initializeData({
+    features: ['performance-view'],
+  });
+
+  act(() => ProjectsStore.loadInitialData(data.organization.projects));
+  return data;
+};
+
+describe('TraceDetailsContent', () => {
+  describe('Without Transactions', () => {
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/eventsv2/',
+        body: SAMPLE_ERROR_DATA,
+      });
+    });
+
+    afterEach(function () {
+      MockApiClient.clearMockResponses();
+      ProjectsStore.reset();
+    });
+
+    it('should render a list of errors when a trace contains only error events', async () => {
+      const initialData = initializeData();
+      const eventView = EventView.fromSavedQuery(DEFAULT_EVENT_VIEW);
+      const meta = {errors: 2, projects: 1, transactions: 0};
+
+      mountWithTheme(
+        <TraceDetailsContent
+          location={initialData.location}
+          organization={initialData.organization}
+          traceSlug="123"
+          params={{traceSlug: '123'}}
+          traceEventView={eventView}
+          dateSelected
+          isLoading={false}
+          error={null}
+          traces={null}
+          meta={meta}
+        />
+      );
+
+      const errorList = await screen.findByTestId('trace-view-errors-list');
+      expect(
+        await within(errorList).findByText(SAMPLE_ERROR_DATA.data[0].title)
+      ).toBeInTheDocument();
+      expect(
+        await within(errorList).findByText(SAMPLE_ERROR_DATA.data[1].title)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/js/spec/views/performance/traceDetails/content.spec.tsx
+++ b/tests/js/spec/views/performance/traceDetails/content.spec.tsx
@@ -8,8 +8,8 @@ import TraceDetailsContent from 'sentry/views/performance/traceDetails/content';
 
 const SAMPLE_ERROR_DATA = {
   data: [
-    {id: '1', title: 'Test error 1'},
-    {id: '2', title: 'Test error 2'},
+    {id: '1', title: 'Test error 1', project: 'sentry'},
+    {id: '2', title: 'Test error 2', project: 'sentry'},
   ],
 };
 
@@ -58,10 +58,10 @@ describe('TraceDetailsContent', () => {
 
       const errorList = await screen.findByTestId('trace-view-errors-list');
       expect(
-        await within(errorList).findByText(SAMPLE_ERROR_DATA.data[0].title)
+        await within(errorList).findByText(`: ${SAMPLE_ERROR_DATA.data[0].title}`)
       ).toBeInTheDocument();
       expect(
-        await within(errorList).findByText(SAMPLE_ERROR_DATA.data[1].title)
+        await within(errorList).findByText(`: ${SAMPLE_ERROR_DATA.data[1].title}`)
       ).toBeInTheDocument();
     });
   });

--- a/tests/js/spec/views/performance/traceDetails/content.spec.tsx
+++ b/tests/js/spec/views/performance/traceDetails/content.spec.tsx
@@ -15,7 +15,7 @@ const SAMPLE_ERROR_DATA = {
 
 const initializeData = () => {
   const data = _initializeData({
-    features: ['performance-view'],
+    features: ['performance-view', 'trace-view'],
   });
 
   act(() => ProjectsStore.loadInitialData(data.organization.projects));

--- a/tests/js/spec/views/performance/traceDetails/content.spec.tsx
+++ b/tests/js/spec/views/performance/traceDetails/content.spec.tsx
@@ -58,10 +58,10 @@ describe('TraceDetailsContent', () => {
 
       const errorList = await screen.findByTestId('trace-view-errors-list');
       expect(
-        await within(errorList).findByText(`: ${SAMPLE_ERROR_DATA.data[0].title}`)
+        await within(errorList).findByText(SAMPLE_ERROR_DATA.data[0].title)
       ).toBeInTheDocument();
       expect(
-        await within(errorList).findByText(`: ${SAMPLE_ERROR_DATA.data[1].title}`)
+        await within(errorList).findByText(SAMPLE_ERROR_DATA.data[1].title)
       ).toBeInTheDocument();
     });
   });

--- a/tests/js/spec/views/performance/traceDetails/content.spec.tsx
+++ b/tests/js/spec/views/performance/traceDetails/content.spec.tsx
@@ -56,7 +56,7 @@ describe('TraceDetailsContent', () => {
         />
       );
 
-      const errorList = await screen.findByTestId('trace-view-errors-list');
+      const errorList = await screen.findByTestId('trace-view-errors');
       expect(
         await within(errorList).findByText(SAMPLE_ERROR_DATA.data[0].title)
       ).toBeInTheDocument();


### PR DESCRIPTION
On the trace view, it is sometimes possible that a trace can contain only errors and no transactions. In those cases, an alert that says "The trace you are looking for only contains errors." is rendered. This PR improves the trace view in these cases, by rewording this message, and listing the error events in the trace with links to view them.

### Before
![image](https://user-images.githubusercontent.com/16740047/151253729-68809926-e5f2-468e-a93f-a08b9e1dc919.png)



### After
![image](https://user-images.githubusercontent.com/16740047/151253554-af5201f2-e343-49c0-9211-2136a6741b02.png)


Fixes VIS-1385