### PR TITLE
feat(analytics): adds analytics for project selector

### DIFF
--- a/static/app/components/organizations/multipleProjectSelector.tsx
+++ b/static/app/components/organizations/multipleProjectSelector.tsx
@@ -16,7 +16,7 @@ import {t, tct} from 'sentry/locale';
 import {growIn} from 'sentry/styles/animations';
 import space from 'sentry/styles/space';
 import {MinimalProject, Organization, Project} from 'sentry/types';
-import {analytics} from 'sentry/utils/analytics';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 
 import ProjectSelector from './projectSelector';
@@ -86,11 +86,10 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
    * Should perform an "update" callback
    */
   handleQuickSelect = (selected: Pick<Project, 'id'>) => {
-    analytics('projectselector.direct_selection', {
+    trackAdvancedAnalyticsEvent('projectselector.direct_selection', {
       path: getRouteStringFromRoutes(this.props.router.routes),
-      org_id: parseInt(this.props.organization.id, 10),
+      organization: this.props.organization,
     });
-
     const value = selected.id === null ? [] : [parseInt(selected.id, 10)];
     this.props.onChange(value);
     this.doUpdate();
@@ -108,10 +107,11 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
     }
 
     const {value} = this.props;
-    analytics('projectselector.update', {
+
+    trackAdvancedAnalyticsEvent('projectselector.update', {
       count: value.length,
       path: getRouteStringFromRoutes(this.props.router.routes),
-      org_id: parseInt(this.props.organization.id, 10),
+      organization: this.props.organization,
       multi: this.multi,
     });
 
@@ -124,9 +124,9 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
    * Should perform an "update" callback
    */
   handleClear = () => {
-    analytics('projectselector.clear', {
+    trackAdvancedAnalyticsEvent('projectselector.clear', {
       path: getRouteStringFromRoutes(this.props.router.routes),
-      org_id: parseInt(this.props.organization.id, 10),
+      organization: this.props.organization,
     });
 
     this.props.onChange([]);
@@ -141,10 +141,10 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
   handleMultiSelect = (selected: Project[]) => {
     const {onChange, value} = this.props;
 
-    analytics('projectselector.toggle', {
+    trackAdvancedAnalyticsEvent('projectselector.toggle', {
       action: selected.length > value.length ? 'added' : 'removed',
       path: getRouteStringFromRoutes(this.props.router.routes),
-      org_id: parseInt(this.props.organization.id, 10),
+      organization: this.props.organization,
     });
 
     const selectedList = selected.map(({id}) => parseInt(id, 10)).filter(i => i);
@@ -272,10 +272,20 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
                 onShowAllProjects={() => {
                   this.handleQuickSelect({id: ALL_ACCESS_PROJECTS.toString()});
                   actions.close();
+                  trackAdvancedAnalyticsEvent('projectselector.multi_button_clicked', {
+                    button_type: 'all',
+                    path: getRouteStringFromRoutes(this.props.router.routes),
+                    organization,
+                  });
                 }}
                 onShowMyProjects={() => {
                   this.handleClear();
                   actions.close();
+                  trackAdvancedAnalyticsEvent('projectselector.multi_button_clicked', {
+                    button_type: 'my',
+                    path: getRouteStringFromRoutes(this.props.router.routes),
+                    organization,
+                  });
                 }}
                 message={footerMessage}
               />

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -7,6 +7,7 @@ type SearchEventBase = {
 type OpenEvent = {};
 type SelectEvent = {result_type: string; source_type: string; query?: string};
 type QueryEvent = {query: string};
+type ProjectSelectorEvent = {path: string};
 
 export type SearchEventParameters = {
   'search.searched': SearchEventBase & {search_source?: string};
@@ -24,6 +25,18 @@ export type SearchEventParameters = {
   'settings_search.query': QueryEvent;
   'command_palette.query': QueryEvent;
   'sidebar_help.query': QueryEvent;
+  'projectselector.direct_selection': ProjectSelectorEvent;
+  'projectselector.update': ProjectSelectorEvent & {
+    count: number;
+    multi: boolean;
+  };
+  'projectselector.clear': ProjectSelectorEvent;
+  'projectselector.toggle': ProjectSelectorEvent & {
+    action: 'added' | 'removed';
+  };
+  'projectselector.multi_button_clicked': ProjectSelectorEvent & {
+    button_type: 'all' | 'my';
+  };
 };
 
 export type SearchEventKey = keyof SearchEventParameters;
@@ -42,4 +55,8 @@ export const searchEventMap: Record<SearchEventKey, string | null> = {
   'settings_search.query': 'settings_search Query',
   'command_palette.query': 'command_palette Query',
   'sidebar_help.query': 'sidebar_help Query',
+  'projectselector.direct_selection': 'Project Selector: Direct Selection',
+  'projectselector.update': 'Project Selector: Update',
+  'projectselector.clear': 'Project Selector: Clear',
+  'projectselector.multi_button_clicked': 'Project Selector: Multi Button Clicked',
 };

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -58,5 +58,6 @@ export const searchEventMap: Record<SearchEventKey, string | null> = {
   'projectselector.direct_selection': 'Project Selector: Direct Selection',
   'projectselector.update': 'Project Selector: Update',
   'projectselector.clear': 'Project Selector: Clear',
+  'projectselector.toggle': 'Project Selector: Toggle',
   'projectselector.multi_button_clicked': 'Project Selector: Multi Button Clicked',
 };


### PR DESCRIPTION
This PR adds a new analytics event (`projectselector.multi_button_clicked`) when a user clicks `Select All Projects` or `Select My Projects`. I also converted the other analytics for this file.