### PR TITLE
fix(celery): Disable `trail` for all Celery tasks.

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -47,6 +47,10 @@ def instrumented_task(name, stat_suffix=None, **kwargs):
 
             return result
 
+        # We never use result backends in Celery. Leaving `trail=True` means that if we schedule
+        # many tasks from a parent task, each task leaks memory. This can lead to the scheduler
+        # being OOM killed.
+        kwargs["trail"] = False
         return app.task(name=name, **kwargs)(_wrapped)
 
     return wrapped

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -570,7 +570,6 @@ backend = RedisReportBackend(redis.clusters.get("default"), 60 * 60 * 3)
     queue="reports.prepare",
     max_retries=5,
     acks_late=True,
-    trail=False,
 )
 def prepare_reports(dry_run=False, *args, **kwargs):
     timestamp, duration = _fill_default_parameters(*args, **kwargs)


### PR DESCRIPTION
`trail` is enabled by default for all Celery tasks. This causes celery to keep track of all subtasks
started by a given task, which can lead to OOM kills when scheduling many (800k+) tasks from a
single scheduler.

We don't use this functionality at all since we don't use result backends, so just disabling for all
tasks.

Docs for trail here: https://docs.celeryproject.org/en/4.4.2/reference/celery.app.task.html#celery.app.task.Task.trail

Thanks to @beezz for figuring this out.