### PR TITLE
ref(ratelimits): Add a killswitch to optionmanager

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -103,7 +103,7 @@ class Endpoint(APIView):
     # Default Rate Limit Values, override in subclass
     # Should be of format: { <http function>: { <category>: RateLimit(limit, window) } }
     rate_limits: Mapping[str, Mapping[RateLimitCategory | str, RateLimit]] = {}
-    enforce_rate_limit: bool = settings.SENTRY_RATELIMITER_ENABLED
+    enforce_rate_limit: bool = False
 
     def build_cursor_link(self, request: Request, name, cursor):
         querystring = None

--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -27,6 +27,8 @@ class RelayProjectConfigsEndpoint(Endpoint):
     authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)
 
+    enforce_rate_limit = False
+
     def post(self, request: Request) -> Response:
         with start_transaction(
             op="http.server", name="RelayProjectConfigsEndpoint", sampled=_sample_apm()

--- a/src/sentry/api/endpoints/relay_register.py
+++ b/src/sentry/api/endpoints/relay_register.py
@@ -113,6 +113,8 @@ class RelayRegisterResponseEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
 
+    enforce_rate_limit = False
+
     def post(self, request: Request) -> Response:
         """
         Registers a Relay

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1335,7 +1335,6 @@ SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE_OPTIONS = {}
 
 # Rate limiting backend
 SENTRY_RATELIMITER = "sentry.ratelimits.base.RateLimiter"
-SENTRY_RATELIMITER_ENABLED = False
 SENTRY_RATELIMITER_OPTIONS = {}
 # These values were determined from analysis on one week of api access logs
 SENTRY_RATELIMITER_DEFAULT_IP = 620

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -389,4 +389,4 @@ register("store.save-transactions-ingest-consumer-rate", default=0.0)
 register("reprocessing2.drop-delete-old-primary-hash", default=[])
 
 # Killswitch for API Rate limiter
-register("api.rate-limiter-activated", default=True, type=Bool)
+register("api.rate-limiter-deactivated", default=False, type=Bool, ttl=60)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -387,3 +387,6 @@ register("store.save-transactions-ingest-consumer-rate", default=0.0)
 
 # Drop delete_old_primary_hash messages for a particular project.
 register("reprocessing2.drop-delete-old-primary-hash", default=[])
+
+# Killswitch for API Rate limiter
+register("api.rate-limiter-activated", default=True, type=Bool)

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, options
+from sentry import features
 from sentry.types.ratelimit import RateLimit, RateLimitCategory, RateLimitMeta
 from sentry.utils.hashlib import md5_text
 
@@ -28,10 +28,8 @@ DEFAULT_CONFIG = {
 
 
 def can_be_ratelimited(request: Request, view_func: EndpointFunction) -> bool:
-    return (
-        options.get("api.rate-limiter-activated")
-        and hasattr(view_func, "view_class")
-        and not request.path_info.startswith(settings.ANONYMOUS_STATIC_PREFIXES)
+    return hasattr(view_func, "view_class") and not request.path_info.startswith(
+        settings.ANONYMOUS_STATIC_PREFIXES
     )
 
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import features, options
 from sentry.types.ratelimit import RateLimit, RateLimitCategory, RateLimitMeta
 from sentry.utils.hashlib import md5_text
 
@@ -28,8 +28,10 @@ DEFAULT_CONFIG = {
 
 
 def can_be_ratelimited(request: Request, view_func: EndpointFunction) -> bool:
-    return hasattr(view_func, "view_class") and not request.path_info.startswith(
-        settings.ANONYMOUS_STATIC_PREFIXES
+    return (
+        options.get("api.rate-limiter-activated")
+        and hasattr(view_func, "view_class")
+        and not request.path_info.startswith(settings.ANONYMOUS_STATIC_PREFIXES)
     )
 
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -88,7 +88,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         )
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 35
+        expected_queries = 36
 
         # TODO(mgaeta): Extra query while we're "dual reading" from UserOptions and NotificationSettings.
         expected_queries += 1

--- a/tests/sentry/ratelimits/utils/test_enforce_rate_limit.py
+++ b/tests/sentry/ratelimits/utils/test_enforce_rate_limit.py
@@ -56,7 +56,7 @@ class TestKillswitch(APITestCase):
     def test_killswitch_override(self):
         """Ensure that an activated killswitch overrides any other local enforcement"""
         self.endpoint = "enforced-endpoint"
-        options.set("api.rate-limiter-activated", False)
+        options.set("api.rate-limiter-deactivated", True)
         with freeze_time("2000-01-01"):
             self.get_success_response()
             self.get_success_response()
@@ -64,7 +64,7 @@ class TestKillswitch(APITestCase):
     def test_killswitch_disabled(self):
         """Ensure that an deactivated killswitch doesn't affect local enforcement"""
         self.endpoint = "enforced-endpoint"
-        options.set("api.rate-limiter-activated", True)
+        options.set("api.rate-limiter-deactivated", False)
         with freeze_time("2000-01-01"):
             self.get_success_response()
             self.get_error_response()


### PR DESCRIPTION
`api.rate-limiter-activated` is a kill-switch for the global rate limiter. Disabling it will stop ALL rate limit enforcement, even if the endpoint flag `enforce_rate_limit` is True, the kill switch overrides it.
```
 killswitch | enforce_rate_limit | enforced?
--------------------------------------------
   True     |      False         |  False
   True     |       True         |   True
  False     |      False         |  False
  False     |       True         |  False
```