### PR TITLE
feat(codeowners): Display mappings suggestions from codeowners

### DIFF
--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -4,9 +4,14 @@ import capitalize from 'lodash/capitalize';
 
 import {SelectAsyncControlProps} from 'sentry/components/forms/selectAsyncControl';
 import {t, tct} from 'sentry/locale';
-import {ExternalActorMapping, Integration} from 'sentry/types';
+import {
+  ExternalActorMapping,
+  ExternalActorMappingOrSuggestion,
+  Integration,
+} from 'sentry/types';
 import {
   getExternalActorEndpointDetails,
+  isExternalActorMapping,
   sentryNameToOption,
 } from 'sentry/utils/integrationUtil';
 import {FieldFromConfig} from 'sentry/views/settings/components/forms';
@@ -17,9 +22,9 @@ import {Field} from 'sentry/views/settings/components/forms/type';
 type Props = Pick<Form['props'], 'onCancel' | 'onSubmitSuccess' | 'onSubmitError'> &
   Pick<SelectAsyncControlProps, 'defaultOptions'> & {
     integration: Integration;
-    mapping?: ExternalActorMapping;
+    mapping?: ExternalActorMappingOrSuggestion;
     type: 'user' | 'team';
-    getBaseFormEndpoint: (mapping?: ExternalActorMapping) => string;
+    getBaseFormEndpoint: (mapping?: ExternalActorMappingOrSuggestion) => string;
     sentryNamesMapper: (v: any) => {id: string; name: string}[];
     dataEndpoint: string;
     onResults?: (data: any, mappingKey?: string) => void;
@@ -39,13 +44,13 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
     };
   }
 
-  getDefaultOptions(mapping?: ExternalActorMapping) {
+  getDefaultOptions(mapping?: ExternalActorMappingOrSuggestion) {
     const {defaultOptions, type} = this.props;
     if (typeof defaultOptions === 'boolean') {
       return defaultOptions;
     }
     const options = [...(defaultOptions ?? [])];
-    if (!mapping) {
+    if (!mapping || !isExternalActorMapping(mapping)) {
       return options;
     }
     // For organizations with >100 entries, we want to make sure their

--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -50,15 +50,17 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
       return defaultOptions;
     }
     const options = [...(defaultOptions ?? [])];
-    if (!mapping || !isExternalActorMapping(mapping)) {
+    if (!mapping || !isExternalActorMapping(mapping) || !mapping.sentryName) {
       return options;
     }
     // For organizations with >100 entries, we want to make sure their
     // saved mapping gets populated in the results if it wouldn't have
     // been in the initial 100 API results, which is why we add it here
     const mappingId = mapping[`${type}Id`];
-    const mappingOption = options.find(({value}) => mappingId && value === mappingId);
-    return !!mappingOption
+    const isMappingInOptionsAlready = options.some(
+      ({value}) => mappingId && value === mappingId
+    );
+    return isMappingInOptionsAlready
       ? options
       : [{value: mappingId, label: mapping.sentryName}, ...options];
   }

--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -116,12 +116,15 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
 
   // This function is necessary since the endpoint we submit to changes depending on the value selected
   updateModel() {
-    const mapping = this.model.getData() as ExternalActorMapping;
-    const {getBaseFormEndpoint} = this.props;
-    if (mapping) {
+    const {getBaseFormEndpoint, mapping} = this.props;
+    const updatedMapping: ExternalActorMapping = {
+      ...mapping,
+      ...(this.model.getData() as ExternalActorMapping),
+    };
+    if (updatedMapping) {
       const endpointDetails = getExternalActorEndpointDetails(
-        getBaseFormEndpoint(mapping),
-        mapping
+        getBaseFormEndpoint(updatedMapping),
+        updatedMapping
       );
       this.model.setFormOptions({...this.model.options, ...endpointDetails});
     }

--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -83,7 +83,7 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
 
   get isFirstPage(): boolean {
     const {cursor} = this.props.location.query;
-    return cursor && (cursor.split(':')[1] === '0' ?? false);
+    return cursor ? cursor?.split(':')[1] === '0' : true;
   }
 
   get unassociatedMappings(): ExternalActorSuggestion[] {

--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -226,7 +226,7 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
                         icon={<IconAdd size="xs" isCircled />}
                         disabled={!hasAccess}
                       >
-                        {tct('Add [type] Mapping', {type})}
+                        <ButtonText>{tct('Add [type] Mapping', {type})}</ButtonText>
                       </AddButton>
                     </Tooltip>
                   </ButtonColumn>
@@ -275,6 +275,11 @@ export default withRouter(IntegrationExternalMappings);
 
 const AddButton = styled(Button)`
   text-transform: capitalize;
+  height: inherit;
+`;
+
+const ButtonText = styled('div')`
+  white-space: break-spaces;
 `;
 
 const Layout = styled('div')`
@@ -283,7 +288,7 @@ const Layout = styled('div')`
   padding: ${space(1)};
   width: 100%;
   align-items: center;
-  grid-template-columns: 2.5fr 50px 2.5fr 1fr;
+  grid-template-columns: 2.25fr 50px 2.75fr 100px;
   grid-template-areas: 'external-name arrow sentry-name button';
 `;
 
@@ -302,6 +307,7 @@ const IconEllipsisVertical = styled(IconEllipsis)`
 `;
 
 const StyledPluginIcon = styled(PluginIcon)`
+  min-width: ${p => p.size}px;
   margin-right: ${space(2)};
 `;
 

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -31,6 +31,16 @@ export type ExternalActorMapping = {
   sentryName: string;
 };
 
+export type ExternalActorSuggestion = {
+  externalName: string;
+  userId?: string;
+  teamId?: string;
+};
+
+export type ExternalActorMappingOrSuggestion =
+  | ExternalActorMapping
+  | ExternalActorSuggestion;
+
 export type ExternalUser = {
   id: string;
   memberId: string;

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -16,6 +16,7 @@ import {
   AppOrProviderOrPlugin,
   DocIntegration,
   ExternalActorMapping,
+  ExternalActorMappingOrSuggestion,
   Integration,
   IntegrationFeature,
   IntegrationInstallationStatus,
@@ -150,6 +151,12 @@ export function isDocIntegration(
   return integration.hasOwnProperty('isDraft');
 }
 
+export function isExternalActorMapping(
+  mapping: ExternalActorMappingOrSuggestion
+): mapping is ExternalActorMapping {
+  return mapping.hasOwnProperty('id');
+}
+
 export const getIntegrationType = (
   integration: AppOrProviderOrPlugin
 ): IntegrationType => {
@@ -234,14 +241,14 @@ export const getAlertText = (integrations?: Integration[]): string | undefined =
 /**
  * Uses the mapping and baseEndpoint to derive the details for the mappings request.
  * @param baseEndpoint Must have a trailing slash, since the id is appended for PUT requests!
- * @param mapping The mapping being sent to the endpoint
+ * @param mapping The mapping or suggestion being sent to the endpoint
  * @returns An object containing the request method (apiMethod), and final endpoint (apiEndpoint)
  */
 export const getExternalActorEndpointDetails = (
   baseEndpoint: string,
-  mapping?: ExternalActorMapping
+  mapping?: ExternalActorMappingOrSuggestion
 ): {apiMethod: 'POST' | 'PUT'; apiEndpoint: string} => {
-  const isValidMapping = !!mapping?.id;
+  const isValidMapping = mapping && isExternalActorMapping(mapping);
   return {
     apiMethod: isValidMapping ? 'PUT' : 'POST',
     apiEndpoint: isValidMapping ? `${baseEndpoint}${mapping.id}/` : baseEndpoint,

--- a/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
@@ -15,7 +15,7 @@ import {
   Organization,
   Team,
 } from 'sentry/types';
-import {isExternalActorMapping, sentryNameToOption} from 'sentry/utils/integrationUtil';
+import {sentryNameToOption} from 'sentry/utils/integrationUtil';
 import withOrganization from 'sentry/utils/withOrganization';
 
 type Props = AsyncComponent['props'] &
@@ -112,7 +112,7 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
   }
 
   getBaseFormEndpoint(mapping?: ExternalActorMappingOrSuggestion) {
-    if (!mapping || !isExternalActorMapping(mapping)) {
+    if (!mapping) {
       return '';
     }
     const {organization} = this.props;

--- a/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
@@ -8,8 +8,14 @@ import AsyncComponent from 'sentry/components/asyncComponent';
 import IntegrationExternalMappingForm from 'sentry/components/integrationExternalMappingForm';
 import IntegrationExternalMappings from 'sentry/components/integrationExternalMappings';
 import {t} from 'sentry/locale';
-import {ExternalActorMapping, Integration, Organization, Team} from 'sentry/types';
-import {sentryNameToOption} from 'sentry/utils/integrationUtil';
+import {
+  ExternalActorMapping,
+  ExternalActorMappingOrSuggestion,
+  Integration,
+  Organization,
+  Team,
+} from 'sentry/types';
+import {isExternalActorMapping, sentryNameToOption} from 'sentry/utils/integrationUtil';
 import withOrganization from 'sentry/utils/withOrganization';
 
 type Props = AsyncComponent['props'] &
@@ -105,8 +111,8 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
     return this.sentryNamesMapper(initialResults).map(sentryNameToOption);
   }
 
-  getBaseFormEndpoint(mapping?: ExternalActorMapping) {
-    if (!mapping) {
+  getBaseFormEndpoint(mapping?: ExternalActorMappingOrSuggestion) {
+    if (!mapping || !isExternalActorMapping(mapping)) {
       return '';
     }
     const {organization} = this.props;
@@ -150,7 +156,7 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
     }
   };
 
-  openModal = (mapping?: ExternalActorMapping) => {
+  openModal = (mapping?: ExternalActorMappingOrSuggestion) => {
     const {integration} = this.props;
     openModal(({Body, Header, closeModal}) => (
       <Fragment>

--- a/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -9,6 +9,7 @@ import IntegrationExternalMappings from 'sentry/components/integrationExternalMa
 import {t} from 'sentry/locale';
 import {
   ExternalActorMapping,
+  ExternalActorMappingOrSuggestion,
   ExternalUser,
   Integration,
   Member,
@@ -107,7 +108,7 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
       });
   }
 
-  openModal = (mapping?: ExternalActorMapping) => {
+  openModal = (mapping?: ExternalActorMappingOrSuggestion) => {
     const {integration} = this.props;
     openModal(({Body, Header, closeModal}) => (
       <Fragment>

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -30,6 +30,7 @@ import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHea
 
 type RouteParams = {
   orgId: string;
+  providerKey: string;
   integrationId: string;
 };
 type Props = RouteComponentProps<RouteParams, {}> & {
@@ -54,7 +55,18 @@ class ConfigureIntegration extends AsyncView<Props, State> {
   }
 
   componentDidMount() {
-    const {location} = this.props;
+    const {
+      location,
+      router,
+      organization,
+      params: {orgId, providerKey},
+    } = this.props;
+    // This page should not be accessible by members
+    if (!organization.access.includes('org:integrations')) {
+      router.push({
+        pathname: `/settings/${orgId}/integrations/${providerKey}/`,
+      });
+    }
     const value =
       (['codeMappings', 'userMappings', 'teamMappings'] as const).find(
         tab => tab === location.query.tab


### PR DESCRIPTION
See [API-2386](https://getsentry.atlassian.net/browse/API-2386)

This PR will add suggestions to the first page of the team/user mappings pages. The suggestions come from codeowners and are specific to the provider page that the user is currently viewing (i.e. viewing the gitlab mappings should not show github account suggestions)


### Demo

Regular demo:

https://user-images.githubusercontent.com/35509934/151269243-70a11ae3-db20-4446-960c-e16a601a8e7a.mov

With `limit  = 3` pagintion: 

https://user-images.githubusercontent.com/35509934/151270491-9f8817d8-0bc8-46ee-9a28-91719237ef07.mov


