### PR TITLE
feat(ui): Show error count on bar chart in issue stream

### DIFF
--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -53,6 +53,11 @@ type Props = Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'> & {
   markers?: Marker[];
 
   /**
+   * Whether not we show a MarkLine label
+   */
+  showMarkLineLabel?: boolean;
+
+  /**
    * Whether timestamps are should be shown in UTC or local timezone.
    */
   utc?: boolean;
@@ -86,6 +91,7 @@ function MiniBarChart({
   colors,
   stacked = false,
   labelYAxisExtents = false,
+  showMarkLineLabel = false,
   height,
   ...props
 }: Props) {
@@ -203,7 +209,7 @@ function MiniBarChart({
       // default size.
       top: labelYAxisExtents ? 6 : 0,
       bottom: markers || labelYAxisExtents ? 4 : 0,
-      left: markers ? 8 : 4,
+      left: showMarkLineLabel ? 35 : markers ? 8 : 4,
       right: markers ? 4 : 0,
     },
     xAxis: {

--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -208,8 +208,8 @@ function MiniBarChart({
       // Offset to ensure there is room for the marker symbols at the
       // default size.
       top: labelYAxisExtents ? 6 : 0,
-      bottom: markers || labelYAxisExtents ? 4 : 0,
-      left: showMarkLineLabel ? 35 : markers ? 8 : 4,
+      bottom: markers || labelYAxisExtents || showMarkLineLabel ? 4 : 0,
+      left: markers ? 8 : showMarkLineLabel ? 35 : 4,
       right: markers ? 4 : 0,
     },
     xAxis: {

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -751,7 +751,7 @@ const MenuItemText = styled('div')`
 `;
 
 const ChartWrapper = styled('div')`
-  width: 190px;
+  width: 200px;
   margin: 0 ${space(2)};
   align-self: center;
 `;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -420,6 +420,7 @@ class StreamGroup extends React.Component<Props, State> {
                 statsPeriod={statsPeriod!}
                 data={data}
                 showSecondaryPoints={showSecondaryPoints}
+                showMarkline
               />
             )}
           </ChartWrapper>

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -420,7 +420,7 @@ class StreamGroup extends React.Component<Props, State> {
                 statsPeriod={statsPeriod!}
                 data={data}
                 showSecondaryPoints={showSecondaryPoints}
-                showMarkline
+                showMarkLine
               />
             )}
           </ChartWrapper>

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -750,7 +750,7 @@ const MenuItemText = styled('div')`
 `;
 
 const ChartWrapper = styled('div')`
-  width: 160px;
+  width: 190px;
   margin: 0 ${space(2)};
   align-self: center;
 `;

--- a/static/app/components/stream/groupChart.tsx
+++ b/static/app/components/stream/groupChart.tsx
@@ -13,7 +13,7 @@ type Props = {
   data: Group;
   height?: number;
   showSecondaryPoints?: boolean;
-  showMarkline?: boolean;
+  showMarkLine?: boolean;
 };
 
 function GroupChart({
@@ -21,7 +21,7 @@ function GroupChart({
   statsPeriod,
   showSecondaryPoints = false,
   height = 24,
-  showMarkline = false,
+  showMarkLine = false,
 }: Props) {
   const stats: TimeseriesValue[] = statsPeriod
     ? data.filtered
@@ -59,30 +59,26 @@ function GroupChart({
     series.push({
       seriesName: t('Events'),
       data: stats.map(point => ({name: point[0] * 1000, value: point[1]})),
-    });
-    if (showMarkline) {
-      series.push({
-        seriesName: t('Events'),
-        data: stats.map(point => ({name: point[0] * 1000, value: point[1]})),
-        markLine: MarkLine({
-          silent: true,
-          lineStyle: {color: theme.gray200, type: 'solid', width: 1},
-          data: [
-            {
-              type: 'max',
+      markLine: showMarkLine
+        ? MarkLine({
+            silent: true,
+            lineStyle: {color: theme.gray200, type: 'solid', width: 1},
+            data: [
+              {
+                type: 'max',
+              },
+            ],
+            label: {
+              show: true,
+              position: 'start',
+              color: `${theme.gray200}`,
+              fontFamily: 'Rubik',
+              fontSize: 10,
+              formatter: `${formattedMarkLine}`,
             },
-          ],
-          label: {
-            show: true,
-            position: 'start',
-            color: `${theme.gray200}`,
-            fontFamily: 'Rubik',
-            fontSize: 10,
-            formatter: `${formattedMarkLine}`,
-          },
-        }),
-      });
-    }
+          })
+        : undefined,
+    });
   }
 
   return (
@@ -95,7 +91,7 @@ function GroupChart({
         colors={colors}
         emphasisColors={emphasisColors}
         hideDelay={50}
-        showMarkLineLabel={showMarkline}
+        showMarkLineLabel={showMarkLine}
       />
     </LazyLoad>
   );

--- a/static/app/components/stream/groupChart.tsx
+++ b/static/app/components/stream/groupChart.tsx
@@ -1,9 +1,11 @@
 import LazyLoad from 'react-lazyload';
 
+import MarkLine from 'sentry/components/charts/components/markLine';
 import MiniBarChart from 'sentry/components/charts/miniBarChart';
 import {t} from 'sentry/locale';
 import {Group, TimeseriesValue} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import theme from 'sentry/utils/theme';
 
 type Props = {
@@ -32,6 +34,8 @@ function GroupChart({
     return null;
   }
 
+  const markLinePoint = stats.map(point => point[1]);
+  const formattedMarkLine = formatAbbreviatedNumber(Math.max(...markLinePoint));
   let colors: string[] | undefined = undefined;
   let emphasisColors: string[] | undefined = undefined;
 
@@ -53,6 +57,23 @@ function GroupChart({
     series.push({
       seriesName: t('Events'),
       data: stats.map(point => ({name: point[0] * 1000, value: point[1]})),
+      markLine: MarkLine({
+        silent: true,
+        lineStyle: {color: theme.gray200, type: 'solid', width: 1},
+        data: [
+          {
+            type: 'max',
+          },
+        ],
+        label: {
+          show: true,
+          position: 'start',
+          color: `${theme.gray200}`,
+          fontFamily: 'Rubik',
+          fontSize: 10,
+          formatter: `${formattedMarkLine}`,
+        },
+      }),
     });
   }
 
@@ -66,6 +87,7 @@ function GroupChart({
         colors={colors}
         emphasisColors={emphasisColors}
         hideDelay={50}
+        grid={{left: 35}}
       />
     </LazyLoad>
   );

--- a/static/app/components/stream/groupChart.tsx
+++ b/static/app/components/stream/groupChart.tsx
@@ -38,6 +38,7 @@ function GroupChart({
 
   const markLinePoint = stats.map(point => point[1]);
   const formattedMarkLine = formatAbbreviatedNumber(Math.max(...markLinePoint));
+
   let colors: string[] | undefined = undefined;
   let emphasisColors: string[] | undefined = undefined;
 
@@ -82,9 +83,9 @@ function GroupChart({
   }
 
   return (
-    <LazyLoad debounce={50} height={height}>
+    <LazyLoad debounce={50} height={showMarkLine ? 30 : height}>
       <MiniBarChart
-        height={height}
+        height={showMarkLine ? 30 : height}
         isGroupedByDate
         showTimeInTooltip
         series={series}

--- a/static/app/components/stream/groupChart.tsx
+++ b/static/app/components/stream/groupChart.tsx
@@ -13,6 +13,7 @@ type Props = {
   data: Group;
   height?: number;
   showSecondaryPoints?: boolean;
+  showMarkline?: boolean;
 };
 
 function GroupChart({
@@ -20,6 +21,7 @@ function GroupChart({
   statsPeriod,
   showSecondaryPoints = false,
   height = 24,
+  showMarkline = false,
 }: Props) {
   const stats: TimeseriesValue[] = statsPeriod
     ? data.filtered
@@ -57,24 +59,30 @@ function GroupChart({
     series.push({
       seriesName: t('Events'),
       data: stats.map(point => ({name: point[0] * 1000, value: point[1]})),
-      markLine: MarkLine({
-        silent: true,
-        lineStyle: {color: theme.gray200, type: 'solid', width: 1},
-        data: [
-          {
-            type: 'max',
-          },
-        ],
-        label: {
-          show: true,
-          position: 'start',
-          color: `${theme.gray200}`,
-          fontFamily: 'Rubik',
-          fontSize: 10,
-          formatter: `${formattedMarkLine}`,
-        },
-      }),
     });
+    if (showMarkline) {
+      series.push({
+        seriesName: t('Events'),
+        data: stats.map(point => ({name: point[0] * 1000, value: point[1]})),
+        markLine: MarkLine({
+          silent: true,
+          lineStyle: {color: theme.gray200, type: 'solid', width: 1},
+          data: [
+            {
+              type: 'max',
+            },
+          ],
+          label: {
+            show: true,
+            position: 'start',
+            color: `${theme.gray200}`,
+            fontFamily: 'Rubik',
+            fontSize: 10,
+            formatter: `${formattedMarkLine}`,
+          },
+        }),
+      });
+    }
   }
 
   return (
@@ -87,7 +95,7 @@ function GroupChart({
         colors={colors}
         emphasisColors={emphasisColors}
         hideDelay={50}
-        grid={{left: 35}}
+        grid={{left: showMarkline ? 35 : 0}}
       />
     </LazyLoad>
   );

--- a/static/app/components/stream/groupChart.tsx
+++ b/static/app/components/stream/groupChart.tsx
@@ -95,7 +95,7 @@ function GroupChart({
         colors={colors}
         emphasisColors={emphasisColors}
         hideDelay={50}
-        grid={{left: showMarkline ? 35 : 0}}
+        showMarkLineLabel={showMarkline}
       />
     </LazyLoad>
   );


### PR DESCRIPTION
Show error count on the bar chart in issue stream.

[FIXES WOR-349](https://getsentry.atlassian.net/browse/WOR-349)

# Before
<img width="1213" alt="Screen Shot 2022-01-26 at 5 30 16 PM" src="https://user-images.githubusercontent.com/20312973/151275181-bc85b3e9-d99d-4b80-a431-a43397e64315.png">
<img width="194" alt="Screen Shot 2022-01-26 at 5 30 29 PM" src="https://user-images.githubusercontent.com/20312973/151275192-ac61d526-314e-4c94-b0da-797f8e68c654.png">

# After
<img width="1220" alt="Screen Shot 2022-01-27 at 2 47 08 PM" src="https://user-images.githubusercontent.com/20312973/151457232-e232b164-71da-4f52-9b41-c7d7434a24a4.png">
<img width="216" alt="Screen Shot 2022-01-27 at 2 59 12 PM" src="https://user-images.githubusercontent.com/20312973/151457307-87b9f402-c2a1-4e4c-8dd3-2af93d45acb4.png">

