### PR TITLE
feat(page-filters): Project page filter pin functionality

### DIFF
--- a/static/app/components/organizations/multipleProjectSelector.tsx
+++ b/static/app/components/organizations/multipleProjectSelector.tsx
@@ -42,6 +42,7 @@ type Props = WithRouterProps & {
     isOpen: boolean;
   }) => React.ReactElement;
   customLoadingIndicator?: React.ReactNode;
+  pinned?: boolean;
 };
 
 type State = {
@@ -204,6 +205,7 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
       footerMessage,
       customDropdownButton,
       customLoadingIndicator,
+      pinned,
     } = this.props;
     const selectedProjectIds = new Set(value);
     const multi = this.multi;
@@ -280,6 +282,7 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
                 message={footerMessage}
               />
             )}
+            pinned={pinned}
           >
             {({getActorProps, selectedProjects, isOpen}) => {
               if (customDropdownButton) {

--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
-import PageFiltersActions from 'sentry/actions/pageFiltersActions';
+import {pinFilter} from 'sentry/actionCreators/pageFilters';
 import Button from 'sentry/components/button';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
 import {IconAdd, IconPin} from 'sentry/icons';
@@ -161,7 +161,7 @@ const ProjectSelector = ({
   };
 
   const handlePinClick = () => {
-    PageFiltersActions.pin('projects', !pinned);
+    pinFilter('projects', !pinned);
   };
 
   const hasProjects = !!projects?.length || !!nonMemberProjects?.length;

--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
+import PageFiltersActions from 'sentry/actions/pageFiltersActions';
 import Button from 'sentry/components/button';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
-import {IconAdd} from 'sentry/icons';
+import {IconAdd, IconPin} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
@@ -59,6 +60,7 @@ type Props = {
    * Calls back with (projects[], event)
    */
   onMultiSelect?: (projects: Array<Project>, event: React.MouseEvent) => void;
+  pinned?: boolean;
 } & Pick<
   DropdownAutoCompleteProps,
   'menuFooter' | 'onScroll' | 'onClose' | 'rootClassName' | 'className'
@@ -80,6 +82,7 @@ const ProjectSelector = ({
   onMultiSelect,
   multi = false,
   selectedProjects = [],
+  pinned,
   ...props
 }: Props) => {
   const getProjects = () => {
@@ -157,9 +160,14 @@ const ProjectSelector = ({
     ];
   };
 
+  const handlePinClick = () => {
+    PageFiltersActions.pin('projects', !pinned);
+  };
+
   const hasProjects = !!projects?.length || !!nonMemberProjects?.length;
   const newProjectUrl = `/organizations/${organization.slug}/projects/new/`;
   const hasProjectWrite = organization.access.includes('project:write');
+  const hasPageFilters = organization.features.includes('selection-filters-v2');
 
   return (
     <DropdownAutoComplete
@@ -180,17 +188,31 @@ const ProjectSelector = ({
       virtualizedLabelHeight={theme.headerSelectorLabelHeight}
       emptyHidesInput={!paginated}
       inputActions={
-        <AddButton
-          disabled={!hasProjectWrite}
-          to={newProjectUrl}
-          size="xsmall"
-          icon={<IconAdd size="xs" isCircled />}
-          title={
-            !hasProjectWrite ? t("You don't have permission to add a project") : undefined
-          }
-        >
-          {t('Project')}
-        </AddButton>
+        <InputActions>
+          <AddButton
+            aria-label={t('Add Project')}
+            disabled={!hasProjectWrite}
+            to={newProjectUrl}
+            size="xsmall"
+            icon={<IconAdd size="xs" isCircled />}
+            title={
+              !hasProjectWrite
+                ? t("You don't have permission to add a project")
+                : undefined
+            }
+          >
+            {hasPageFilters ? '' : t('Project')}
+          </AddButton>
+          {hasPageFilters && (
+            <PinButton
+              aria-pressed={pinned}
+              aria-label={t('Pin')}
+              onClick={handlePinClick}
+              size="xsmall"
+              icon={<IconPin size="xs" isSolid={pinned} />}
+            />
+          )}
+        </InputActions>
       }
       menuFooter={renderProps => {
         const renderedFooter =
@@ -231,7 +253,14 @@ const Label = styled('div')`
 
 const AddButton = styled(Button)`
   display: block;
-  margin: 0 ${space(1)};
+  color: ${p => p.theme.gray300};
+  :hover {
+    color: ${p => p.theme.subText};
+  }
+`;
+
+const PinButton = styled(Button)`
+  display: block;
   color: ${p => p.theme.gray300};
   :hover {
     color: ${p => p.theme.subText};
@@ -242,4 +271,12 @@ const CreateProjectButton = styled(Button)`
   display: block;
   text-align: center;
   margin: ${space(0.5)} 0;
+`;
+
+const InputActions = styled('div')`
+  display: grid;
+  margin: 0 ${space(1)};
+  gap: ${space(1)};
+  grid-auto-flow: column;
+  grid-auto-columns: auto;
 `;

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -68,7 +68,7 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
   );
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const organization = useOrganization();
-  const {selection, isReady} = useLegacyStore(PageFiltersStore);
+  const {selection, pinnedFilters, isReady} = useLegacyStore(PageFiltersStore);
 
   const handleChangeProjects = (newProjects: number[] | null) => {
     setCurrentSelectedProjects(newProjects);
@@ -140,6 +140,7 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
       onUpdate={handleUpdateProjects}
       customDropdownButton={customProjectDropdown}
       customLoadingIndicator={customLoadingIndicator}
+      pinned={pinnedFilters.has('projects')}
       {...otherProps}
     />
   );

--- a/tests/js/spec/components/organizations/projectSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/projectSelector.spec.jsx
@@ -48,6 +48,7 @@ describe('ProjectSelector', function () {
           id: 'org',
           slug: 'org-slug',
           access: [],
+          features: [],
         }}
       />,
       routerContext
@@ -68,6 +69,7 @@ describe('ProjectSelector', function () {
           id: 'org',
           slug: 'org-slug',
           access: ['project:write'],
+          features: [],
         }}
       />,
       routerContext

--- a/tests/js/spec/components/projectPageFilter.spec.tsx
+++ b/tests/js/spec/components/projectPageFilter.spec.tsx
@@ -9,7 +9,7 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('ProjectPageFilter', function () {
   const {organization, router, routerContext} = initializeOrg({
-    organization: {features: ['global-views']},
+    organization: {features: ['global-views', 'selection-filters-v2']},
     project: undefined,
     projects: [
       {
@@ -57,6 +57,33 @@ describe('ProjectPageFilter', function () {
     // Verify we were redirected
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({query: {environment: [], project: ['2']}})
+    );
+  });
+
+  it('can pin selection', async function () {
+    mountWithTheme(
+      <OrganizationContext.Provider value={organization}>
+        <ProjectPageFilter />
+      </OrganizationContext.Provider>,
+      {
+        context: routerContext,
+      }
+    );
+
+    // Open the project dropdown
+    expect(screen.getByText('My Projects')).toBeInTheDocument();
+    userEvent.click(screen.getByText('My Projects'));
+
+    // Click the pin button
+    const pinButton = screen.getByRole('button', {name: 'Pin'});
+    userEvent.click(pinButton);
+
+    await screen.findByRole('button', {name: 'Pin', pressed: true});
+
+    expect(PageFiltersStore.getState()).toEqual(
+      expect.objectContaining({
+        pinnedFilters: new Set(['projects']),
+      })
     );
   });
 });


### PR DESCRIPTION
Added a pin button alongside the new project button in the multipleProjectSelector which when pressed will persist the selection of projects in the store.

![image](https://user-images.githubusercontent.com/9372512/151278901-01959d50-c27d-45db-8575-33118cdf2c23.png)

![image](https://user-images.githubusercontent.com/9372512/151278941-d78bdc73-e8d7-4e84-a953-4d5e26a64eab.png)
