### PR TITLE
feat(gsh): Environment filter pinning functionality

### DIFF
--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -24,7 +24,7 @@ type Props = {
 function EnvironmentPageFilter({router, resetParamsOnChange = []}: Props) {
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const organization = useOrganization();
-  const {selection, isReady} = useLegacyStore(PageFiltersStore);
+  const {selection, pinnedFilters, isReady} = useLegacyStore(PageFiltersStore);
 
   const [selectedEnvironments, setSelectedEnvironments] = useState<string[] | null>(null);
 
@@ -71,6 +71,7 @@ function EnvironmentPageFilter({router, resetParamsOnChange = []}: Props) {
       onUpdate={handleUpdateEnvironments}
       customDropdownButton={customDropdownButton}
       customLoadingIndicator={customLoadingIndicator}
+      pinned={pinnedFilters.has('environments')}
     />
   );
 }

--- a/static/app/components/organizations/multipleEnvironmentSelector.tsx
+++ b/static/app/components/organizations/multipleEnvironmentSelector.tsx
@@ -4,7 +4,7 @@ import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 import uniq from 'lodash/uniq';
 
-import PageFiltersActions from 'sentry/actions/pageFiltersActions';
+import {pinFilter} from 'sentry/actionCreators/pageFilters';
 import {Client} from 'sentry/api';
 import Button from 'sentry/components/button';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
@@ -226,7 +226,7 @@ class MultipleEnvironmentSelector extends React.PureComponent<Props, State> {
   }
 
   handlePinClick = () => {
-    PageFiltersActions.pin('environments', !this.props.pinned);
+    pinFilter('environments', !this.props.pinned);
   };
 
   render() {

--- a/tests/js/spec/components/environmentPageFilter.spec.tsx
+++ b/tests/js/spec/components/environmentPageFilter.spec.tsx
@@ -9,7 +9,7 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('EnvironmentPageFilter', function () {
   const {organization, router, routerContext} = initializeOrg({
-    organization: {features: ['global-views']},
+    organization: {features: ['global-views', 'selection-filters-v2']},
     project: undefined,
     projects: [
       {
@@ -55,6 +55,39 @@ describe('EnvironmentPageFilter', function () {
     // Verify we were redirected
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({query: {environment: ['prod']}})
+    );
+  });
+
+  it('can pin environment', async function () {
+    mountWithTheme(
+      <OrganizationContext.Provider value={organization}>
+        <EnvironmentPageFilter />
+      </OrganizationContext.Provider>,
+      {
+        context: routerContext,
+      }
+    );
+    // Confirm no filters are pinned
+    expect(PageFiltersStore.getState()).toEqual(
+      expect.objectContaining({
+        pinnedFilters: new Set(),
+      })
+    );
+
+    // Open the environment dropdown
+    expect(screen.getByText('All Environments')).toBeInTheDocument();
+    userEvent.click(screen.getByText('All Environments'));
+
+    // Click the pin button
+    const pinButton = screen.getByRole('button', {name: 'Pin'});
+    userEvent.click(pinButton);
+
+    await screen.findByRole('button', {name: 'Pin', pressed: true});
+
+    expect(PageFiltersStore.getState()).toEqual(
+      expect.objectContaining({
+        pinnedFilters: new Set(['environments']),
+      })
     );
   });
 });


### PR DESCRIPTION
Adding a pin button which when pressed will 'pin' the environment selection, persisting it between page navigations. (In the future the default behavior will be that page filter selections are not persisted)

![image](https://user-images.githubusercontent.com/9372512/151281237-5402a387-c1d7-497f-bf1b-4766a198999c.png)
