### PR TITLE
fix(ui): Correct alignment of numbers in ProgressRing

### DIFF
--- a/static/app/components/progressRing.tsx
+++ b/static/app/components/progressRing.tsx
@@ -58,7 +58,6 @@ const Text = styled('div')<Omit<TextProps, 'theme'>>`
   width: 100%;
   color: ${p => p.theme.chartLabel};
   font-size: ${p => p.theme.fontSizeExtraSmall};
-  padding-top: 1px;
   transition: color 100ms;
   ${p => p.textCss && p.textCss(p)}
 `;


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1421724/151309317-2de62f85-76ca-45d2-bb4a-9cb7fc06d564.png)

After
![image](https://user-images.githubusercontent.com/1421724/151309365-1fa37b0d-713a-4013-b6da-a9a5b03eee0b.png)

