### PR TITLE
fix(sessions): Prevent query mutation behavior in `_prepare_query_params`

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -488,6 +488,9 @@ def get_query_params_to_update_for_organizations(query_params):
 
 
 def _prepare_query_params(query_params):
+    kwargs = deepcopy(query_params.kwargs)
+    query_params_conditions = deepcopy(query_params.conditions)
+
     # convert to naive UTC datetimes, as Snuba only deals in UTC
     # and this avoids offset-naive and offset-aware issues
     start = naiveify_datetime(query_params.start)
@@ -516,14 +519,14 @@ def _prepare_query_params(query_params):
             "No strategy found for getting an organization for the given dataset."
         )
 
-    query_params.kwargs.update(params_to_update)
+    kwargs.update(params_to_update)
 
     for col, keys in forward(deepcopy(query_params.filter_keys)).items():
         if keys:
             if len(keys) == 1 and None in keys:
-                query_params.conditions.append((col, "IS NULL", None))
+                query_params_conditions.append((col, "IS NULL", None))
             else:
-                query_params.conditions.append((col, "IN", keys))
+                query_params_conditions.append((col, "IN", keys))
 
     expired, start = outside_retention_with_modified_start(
         start, end, Organization(organization_id)
@@ -547,18 +550,18 @@ def _prepare_query_params(query_params):
     if start > end:
         raise QueryOutsideGroupActivityError
 
-    query_params.kwargs.update(
+    kwargs.update(
         {
             "dataset": query_params.dataset.value,
             "from_date": start.isoformat(),
             "to_date": end.isoformat(),
             "groupby": query_params.groupby,
-            "conditions": query_params.conditions,
+            "conditions": query_params_conditions,
             "aggregations": query_params.aggregations,
             "granularity": query_params.rollup,  # TODO name these things the same
         }
     )
-    kwargs = {k: v for k, v in query_params.kwargs.items() if v is not None}
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
     kwargs.update(OVERRIDE_OPTIONS)
     return kwargs, forward, reverse


### PR DESCRIPTION
Fixes the behavior of `_prepare_query_params`
that mutates the conditions passed from the query.

Example:
Lets take the following code snippet https://github.com/getsentry/sentry/blob/849626fdd4a8ed40111745dfc11e43950db5f312/src/sentry/snuba/sessions_v2.py#L424-L455

Because the original query object was mutated at https://github.com/getsentry/sentry/blob/c5bc53fb5070453c742f1ce19aa0aa757aa9b189/src/sentry/utils/snuba.py#L524-L529

The second query in the first snippet will have conditions that look like 
```
[[['or', [['equals', ['release', "'foo@1.1.0'"]], ['equals', ['release', "'foo@1.2.0'"]]]], '=', 1], ('project_id', 'IN', [4, 3, 2]), ('project_id', 'IN', [4, 3, 2])]
```
As you can see, the `project_id` condition is there twice, because it was added once from the first call to the `raw_query` and then another time when the second call to `raw_query` was made.