### PR TITLE
feat(redis): Introduce single-host redis client with retry logic to survive failovers

### DIFF
--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -20,6 +20,7 @@ from sentry import options
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import warnings
 from sentry.utils.compat import map
+from sentry.utils.imports import import_string
 from sentry.utils.versioning import Version, check_versions
 from sentry.utils.warnings import DeprecatedSettingWarning
 
@@ -240,7 +241,11 @@ class _RedisCluster:
             else:
                 host = hosts[0].copy()
                 host["decode_responses"] = True
-                return StrictRedis(**host)
+                return (
+                    import_string(config["client_class"])
+                    if "client_class" in config
+                    else StrictRedis
+                )(**host)
 
         return SimpleLazyObject(cluster_factory)
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -146,19 +146,19 @@ class FailoverRedis(StrictRedis):
     def __init__(
         self,
         *args,
-        _retries: int = 5,
+        _retries: int = 10,
         _backoff_min: float = 0.2,
-        _backoff_max: int = 2,
+        _backoff_max: int = 5,
         _backoff_multiplier: float = 2,
         **kwargs,
     ):
         if _retries < 0:
-            raise ValueError(f"Number of retries must be positive integer: _retries={_retries}")
+            raise ValueError(f"Number of retries must non negative integer: _retries={_retries}")
         self._retries = _retries
 
         if _backoff_min < 0.0:
             raise ValueError(
-                f"Minimal backoff must be positive number: _backoff_min={_backoff_min}"
+                f"Minimal backoff must be non negative number: _backoff_min={_backoff_min}"
             )
         self._backoff_min = _backoff_min
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -1,6 +1,8 @@
 import functools
 import logging
 import posixpath
+import random
+import time
 from copy import deepcopy
 from threading import Lock
 
@@ -9,7 +11,8 @@ from django.utils.functional import SimpleLazyObject
 from pkg_resources import resource_string
 from redis.client import Script, StrictRedis
 from redis.connection import ConnectionPool, Encoder
-from redis.exceptions import BusyLoadingError, ConnectionError
+from redis.exceptions import BusyLoadingError, ConnectionError, ReadOnlyError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 from rediscluster import RedisCluster
 from rediscluster.exceptions import ClusterError
 
@@ -96,6 +99,110 @@ class RetryingRedisCluster(RedisCluster):
         ):
             self.connection_pool.nodes.reset()
             return super(self.__class__, self).execute_command(*args, **kwargs)
+
+
+class FailoverRedis(StrictRedis):
+    """
+    Single host redis client implementation with retry logic intended to
+    survive failover events. Retry logic uses capped exponential backoff with
+    jitter.
+
+    https://redis.io/commands/failover
+
+    Failover sequence:
+
+    1. The primary will internally start a CLIENT PAUSE WRITE, which will pause
+    incoming writes and prevent the accumulation of new data in the replication
+    stream. From this point all writes to the primary instance fails with
+    ReadOnlyError.
+
+    2. The primary will monitor its replicas, waiting for a replica to indicate
+    that it has fully consumed the replication stream. If the primary has
+    multiple replicas, it will only wait for the first replica to catch up.
+
+    3. The primary will then demote itself to a replica. This is done to
+    prevent any dual master scenarios.
+
+    4. The previous primary will send a special PSYNC request to the target
+    replica, PSYNC FAILOVER, instructing the target replica to become a
+    primary.
+
+    5. Once the previous primary receives acknowledgement the PSYNC FAILOVER
+    was accepted it will unpause its clients.
+
+    In addition, the Memorystore for Redis, which is the main target of this implementation states:
+
+    When the primary node fails over to the replica, existing connections to
+    the primary endpoint of the instance are dropped. The instance is
+    unavailable for a few seconds while the new primary reconnects. On
+    reconnect, your application is automatically redirected to the new primary
+    node using the same connection string or IP address. You do not need to
+    update your application after a failover.
+
+    https://cloud.google.com/memorystore/docs/redis/high-availability#how_a_failover_affects_your_application
+
+    """
+
+    def __init__(
+        self,
+        *args,
+        _retries: int = 5,
+        _backoff_min: float = 0.2,
+        _backoff_max: int = 2,
+        _backoff_multiplier: float = 2,
+        **kwargs,
+    ):
+        if _retries < 0:
+            raise ValueError(f"Number of retries must be positive integer: _retries={_retries}")
+        self._retries = _retries
+
+        if _backoff_min < 0.0:
+            raise ValueError(
+                f"Minimal backoff must be positive number: _backoff_min={_backoff_min}"
+            )
+        self._backoff_min = _backoff_min
+
+        if _backoff_max < _backoff_min:
+            raise ValueError(
+                f"Maximal backoff must be at least equal to the minimal ({_backoff_min}): _backoff_max={_backoff_max}"
+            )
+        self._backoff_max = _backoff_max
+
+        if _backoff_multiplier <= 0:
+            raise ValueError(
+                f"Backoff multiplier must be positive number: _backoff_multiplier={_backoff_multiplier}"
+            )
+        self._backoff_multiplier = _backoff_multiplier
+        super().__init__(*args, **kwargs)
+
+    def execute_command(self, *args, **kwargs):
+        retries = 0
+        while True:
+            try:
+                return super().execute_command(*args, **kwargs)
+            except (
+                # Caught during the inital phase of failver when writes are
+                # paused on primary
+                ReadOnlyError,
+                # When the connection to primary is dropped and the one to the
+                # replica is not ready yet.
+                # ConnectionError with the errno ETIMEDOUT = 110
+                ConnectionError,
+                # When the client is initiated with socket_timeout or
+                # socket_connect_timeout, during the reconnect it throws
+                # redis.exceptions.TimeoutError instead of ConnectionError
+                RedisTimeoutError,
+            ):
+                if retries >= self._retries:
+                    raise
+                time.sleep(
+                    min(
+                        self._backoff_max,
+                        (self._backoff_min * (self._backoff_multiplier ** retries))
+                        * (1 + random.random()),
+                    )
+                )
+                retries += 1
 
 
 class _RedisCluster:

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -4,8 +4,11 @@ from unittest import TestCase, mock
 
 import pytest
 from django.utils.functional import SimpleLazyObject
+from redis.exceptions import ConnectionError, ReadOnlyError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from sentry.exceptions import InvalidConfiguration
+from sentry.utils import imports
 from sentry.utils.redis import (
     ClusterManager,
     _RedisCluster,
@@ -24,12 +27,19 @@ make_manager = functools.partial(
             "foo": {"hosts": {0: {"db": 0}}},
             "bar": {"hosts": {0: {"db": 0}, 1: {"db": 1}}},
             "baz": {"is_redis_cluster": True, "hosts": {0: {}}},
+            "failover": {
+                "client_class": "sentry.utils.redis.FailoverRedis",
+                "hosts": {0: {"db": 0}},
+            },
         }
     },
 )
 
 
 class ClusterManagerTestCase(TestCase):
+    def setUp(self):
+        imports._cache.clear()
+
     def test_get(self):
         manager = make_manager()
         assert manager.get("foo") is manager.get("foo")
@@ -40,14 +50,17 @@ class ClusterManagerTestCase(TestCase):
 
     @mock.patch("sentry.utils.redis.RetryingRedisCluster")
     @mock.patch("sentry.utils.redis.StrictRedis")
-    def test_specific_cluster(self, StrictRedis, RetryingRedisCluster):
+    @mock.patch("sentry.utils.redis.FailoverRedis")
+    def test_specific_cluster(self, FailoverRedis, StrictRedis, RetryingRedisCluster):
         manager = make_manager(cluster_type=_RedisCluster)
 
         # We wrap the cluster in a Simple Lazy Object, force creation of the
         # object to verify it's correct.
 
-        # cluster foo is fine since it's a single node
+        # cluster foo is fine since it's a single node, without specific client_class
         assert manager.get("foo")._setupfunc() is StrictRedis.return_value
+        # failover cluster is single host and specifies client_class to FailoverRedis
+        assert manager.get("failover")._setupfunc() is FailoverRedis.return_value
         # baz works becasue it's explicitly is_redis_cluster
         assert manager.get("baz")._setupfunc() is RetryingRedisCluster.return_value
 
@@ -99,3 +112,66 @@ def test_get_cluster_from_options():
             {"hosts": {0: {"db": 0}}, "cluster": "foo", "foo": "bar"},
             cluster_manager=manager,
         )
+
+
+class TestFailoverRedis(TestCase):
+    def setUp(self):
+        # clear previously cached FailoverRedis mock from import cache
+        imports._cache.clear()
+
+    def _get_client(self, **kwargs):
+        return ClusterManager(
+            {
+                "redis.clusters": {
+                    "c": {
+                        "client_class": "sentry.utils.redis.FailoverRedis",
+                        "hosts": {0: {"db": 0, **kwargs}},
+                    }
+                }
+            },
+            cluster_type=_RedisCluster,
+        ).get("c")
+
+    @mock.patch("sentry.utils.redis.StrictRedis.execute_command")
+    @mock.patch("sentry.utils.redis.time.sleep")
+    def test_retries(self, time_sleep, execute_command):
+        client = self._get_client(_retries=5)
+        assert client._retries == 5
+        execute_command.side_effect = ConnectionError()
+        with pytest.raises(ConnectionError):
+            client.get("key")
+        assert time_sleep.call_count == 5
+
+    @mock.patch("sentry.utils.redis.StrictRedis.execute_command")
+    @mock.patch("sentry.utils.redis.time.sleep")
+    def test_recover(self, time_sleep, execute_command):
+        client = self._get_client(_retries=5)
+        assert client._retries == 5
+        execute_command.side_effect = [
+            ConnectionError(),
+            RedisTimeoutError(),
+            ReadOnlyError(),
+            "value",
+        ]
+        assert client.get("key") == "value"
+        assert time_sleep.call_count == 3
+
+    @mock.patch("sentry.utils.redis.StrictRedis.execute_command")
+    @mock.patch("sentry.utils.redis.time.sleep")
+    def test_fixed_backoff(self, time_sleep, execute_command):
+        client = self._get_client(_backoff_max=1.0, _backoff_min=1.0)
+        assert client._retries == 10
+        execute_command.side_effect = ConnectionError()
+        with pytest.raises(ConnectionError):
+            client.get("key")
+        assert time_sleep.call_args_list == 10 * [((1.0,), {})]
+
+    @mock.patch("sentry.utils.redis.StrictRedis.execute_command")
+    @mock.patch("sentry.utils.redis.time.sleep")
+    def test_max_backoff(self, time_sleep, execute_command):
+        client = self._get_client(_backoff_max=1.0, _backoff_min=0.5)
+        assert client._retries == 10
+        execute_command.side_effect = ConnectionError()
+        with pytest.raises(ConnectionError):
+            client.get("key")
+        assert all(a[0][0] <= 1.0 for a in time_sleep.call_args_list)


### PR DESCRIPTION
In multiple places, we use Redis as a temporary store (as opposed to cache), and is important that single-host clients can survive eventual failover events without losing data or crashing processing tasks.

This client implementation was tested and defaults are configured so it can survive the GCP Redis Memorystore failover sequence.