### PR TITLE
fix(dashboards): lazyload widgets into view when deleting upper widget

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -266,7 +266,7 @@ class Dashboard extends Component<Props, State> {
     // Force check lazyLoad elements that might have shifted into view after deleting an upper widget
     // Unfortunately need to use setTimeout since React Grid Layout animates widgets into view when layout changes
     // RGL doesn't provide a handler for post animation layout change
-    setTimeout(() => {
+    setTimeout(forceCheck, 400);
       forceCheck();
     }, 400);
   };

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -267,8 +267,6 @@ class Dashboard extends Component<Props, State> {
     // Unfortunately need to use setTimeout since React Grid Layout animates widgets into view when layout changes
     // RGL doesn't provide a handler for post animation layout change
     setTimeout(forceCheck, 400);
-      forceCheck();
-    }, 400);
   };
 
   handleDuplicateWidget = (widget: Widget, index: number) => () => {

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -3,6 +3,7 @@ import 'react-resizable/css/styles.css';
 
 import {Component} from 'react';
 import {Layouts, Responsive, WidthProvider} from 'react-grid-layout';
+import {forceCheck} from 'react-lazyload';
 import {InjectedRouter} from 'react-router';
 import {closestCenter, DndContext} from '@dnd-kit/core';
 import {arrayMove, rectSortingStrategy, SortableContext} from '@dnd-kit/sortable';
@@ -262,6 +263,12 @@ class Dashboard extends Component<Props, State> {
     if (!!!isEditing) {
       handleUpdateWidgetList(nextList);
     }
+    // Force check lazyLoad elements that might have shifted into view after deleting an upper widget
+    // Unfortunately need to use setTimeout since React Grid Layout animates widgets into view when layout changes
+    // RGL doesn't provide a handler for post animation layout change
+    setTimeout(() => {
+      forceCheck();
+    }, 400);
   };
 
   handleDuplicateWidget = (widget: Widget, index: number) => () => {


### PR DESCRIPTION
Fixes this scenario:
![image](https://user-images.githubusercontent.com/83961295/151399578-0df01ae2-70fc-444a-beec-3ef2ca4f1f7c.png)

When deleting a widget in a dashboard, the layout will shift to fill in the deleted widget gap. This can cause widgets that were previously out of view to come into view after layout shift. Our lazyload lib doesn't flag this event to check for lazyloading so we need to manually check by calling `forceCheck()`. Unfortunately we also have to use a `setTimeout` because RGL has an animation when changing layout (which doesn't seem to be configurable). RGL also doesn't have a handle for post animation layout changes so we don't have a more elegant way to schedule the `forceCheck()`.