### PR TITLE
ref(dashboards): Prebuilt issue widget remove assignee_or_suggested condition and fixed count field

### DIFF
--- a/static/app/views/dashboardsV2/widgetLibrary/data.tsx
+++ b/static/app/views/dashboardsV2/widgetLibrary/data.tsx
@@ -104,8 +104,8 @@ export const DEFAULT_WIDGETS: Readonly<Array<WidgetTemplate>> = [
     queries: [
       {
         name: '',
-        conditions: 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
-        fields: ['issue', 'assignee', 'count', 'title'],
+        conditions: 'is:unresolved is:for_review',
+        fields: ['issue', 'assignee', 'events', 'title'],
         orderby: 'date',
       },
     ],


### PR DESCRIPTION
Feedback on prebuilt issue widget, we want Issues to be cross team so removing the assignee_or_suggested condition for now

Also changed the count field to events (new name)