### PR TITLE
feat(notifications): change analytics params and make recipient optional

### DIFF
--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -113,6 +113,12 @@ class BaseNotification(abc.ABC):
             "actor_id": recipient.actor_id,
         }
 
+    def get_custom_analytics_params(self, recipient: Team | User) -> Mapping[str, Any]:
+        """
+        Returns a mapping of params used to record the event associated with analytics_event
+        """
+        return self.get_log_params(recipient)
+
     def get_message_actions(self, recipient: Team | User) -> Sequence[MessageAction]:
         return []
 
@@ -134,10 +140,9 @@ class BaseNotification(abc.ABC):
             self.record_analytics(
                 self.analytics_event,
                 providers=provider.name.lower(),
-                **self.get_log_params(recipient),
+                **self.get_custom_analytics_params(recipient),
             )
 
-    # TODO: make recipient required
     def get_referrer(
         self, provider: ExternalProviders, recipient: Optional[Team | User] = None
     ) -> str:
@@ -147,7 +152,9 @@ class BaseNotification(abc.ABC):
             referrer += "-" + recipient.__class__.__name__.lower()
         return referrer
 
-    def get_sentry_query_params(self, provider: ExternalProviders, recipient: Team | User) -> str:
+    def get_sentry_query_params(
+        self, provider: ExternalProviders, recipient: Optional[Team | User]
+    ) -> str:
         return f"?referrer={self.get_referrer(provider, recipient)}"
 
     def get_settings_url(self, recipient: Team | User, provider: ExternalProviders) -> str:

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -115,7 +115,8 @@ class BaseNotification(abc.ABC):
 
     def get_custom_analytics_params(self, recipient: Team | User) -> Mapping[str, Any]:
         """
-        Returns a mapping of params used to record the event associated with analytics_event
+        Returns a mapping of params used to record the event associated with self.analytics_event.
+        By default, use the log params.
         """
         return self.get_log_params(recipient)
 

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -156,6 +156,11 @@ class BaseNotification(abc.ABC):
     def get_sentry_query_params(
         self, provider: ExternalProviders, recipient: Optional[Team | User] = None
     ) -> str:
+        """
+        Returns the query params that allow us to track clicks into Sentry links.
+        If the recipient is not necessarily a user (ex: sending to an email address associated with an account),
+        The recipient may be omitted.
+        """
         return f"?referrer={self.get_referrer(provider, recipient)}"
 
     def get_settings_url(self, recipient: Team | User, provider: ExternalProviders) -> str:

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -153,7 +153,7 @@ class BaseNotification(abc.ABC):
         return referrer
 
     def get_sentry_query_params(
-        self, provider: ExternalProviders, recipient: Optional[Team | User]
+        self, provider: ExternalProviders, recipient: Optional[Team | User] = None
     ) -> str:
         return f"?referrer={self.get_referrer(provider, recipient)}"
 


### PR DESCRIPTION
This PR makes two changes that will help with quota notifications being added in getsentry

1. This makes the `recipient` optional for `get_sentry_query_params`. The purpose is that quota emails could go to a floating email not to tied to a specific recipient.
2. Adds a new method called ` get_custom_analytics_params` which passes in params just to the custom analytics event. The purpose here is so we can pass a field to analytics that doesn't belong in logging (ex: the full subscription object which analytics will decompose).