### PR TITLE
ref(notifications): adds recipient to slack methods for notifications

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -37,9 +37,9 @@ class SlackNotificationsMessageBuilder(SlackMessageBuilder):
     def build(self) -> SlackBody:
         callback_id_raw = self.notification.get_callback_data()
         return self._build(
-            title=self.notification.build_attachment_title(),
-            title_link=self.notification.get_title_link(),
-            text=self.notification.get_message_description(),
+            title=self.notification.build_attachment_title(self.recipient),
+            title_link=self.notification.get_title_link(self.recipient),
+            text=self.notification.get_message_description(self.recipient),
             footer=self.notification.build_notification_footer(self.recipient),
             actions=self.notification.get_message_actions(self.recipient),
             callback_id=json.dumps(callback_id_raw) if callback_id_raw else None,

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -184,12 +184,12 @@ class GroupActivityNotification(ActivityNotification, ABC):
 
         return mark_safe(description.format(**context))
 
-    def get_title_link(self) -> str | None:
+    def get_title_link(self, recipient: Team | User) -> str | None:
         from sentry.integrations.slack.message_builder.issues import get_title_link
 
         return get_title_link(self.group, None, False, True, self)
 
-    def build_attachment_title(self) -> str:
+    def build_attachment_title(self, recipient: Team | User) -> str:
         from sentry.integrations.slack.message_builder.issues import build_attachment_title
 
         return build_attachment_title(self.group)

--- a/src/sentry/notifications/notifications/activity/new_processing_issues.py
+++ b/src/sentry/notifications/notifications/activity/new_processing_issues.py
@@ -32,7 +32,7 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
             for provider, participants in participants_by_provider.items()
         }
 
-    def get_message_description(self) -> str:
+    def get_message_description(self, recipient: Team | User) -> str:
         return f"Some events failed to process in your project {self.project.slug}"
 
     def get_context(self) -> MutableMapping[str, Any]:
@@ -64,8 +64,8 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
         )
         return f"Processing issues on <{self.project.slug}|{project_url}"
 
-    def build_attachment_title(self) -> str:
+    def build_attachment_title(self, recipient: Team | User) -> str:
         return self.get_subject()
 
-    def get_title_link(self) -> str | None:
+    def get_title_link(self, recipient: Team | User) -> str | None:
         return None

--- a/src/sentry/notifications/notifications/activity/note.py
+++ b/src/sentry/notifications/notifications/activity/note.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
 from .base import GroupActivityNotification
+
+if TYPE_CHECKING:
+    from sentry.models import Team, User
 
 
 class NoteActivityNotification(GroupActivityNotification):
@@ -28,5 +31,5 @@ class NoteActivityNotification(GroupActivityNotification):
     def get_notification_title(self) -> str:
         return self.get_title()
 
-    def get_message_description(self) -> Any:
+    def get_message_description(self, recipient: Team | User) -> Any:
         return self.get_context()["text_description"]

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -148,10 +148,10 @@ class ReleaseActivityNotification(ActivityNotification):
                 ]
         return []
 
-    def build_attachment_title(self) -> str:
+    def build_attachment_title(self, recipient: Team | User) -> str:
         return ""
 
-    def get_title_link(self) -> str | None:
+    def get_title_link(self, recipient: Team | User) -> str | None:
         return None
 
     def build_notification_footer(self, recipient: Team | User) -> str:

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -88,16 +88,16 @@ class BaseNotification(abc.ABC):
     def get_notification_title(self) -> str:
         raise NotImplementedError
 
-    def get_title_link(self) -> str | None:
+    def get_title_link(self, recipient: Team | User) -> str | None:
         raise NotImplementedError
 
-    def build_attachment_title(self) -> str:
+    def build_attachment_title(self, recipient: Team | User) -> str:
         raise NotImplementedError
 
     def build_notification_footer(self, recipient: Team | User) -> str:
         raise NotImplementedError
 
-    def get_message_description(self) -> Any:
+    def get_message_description(self, recipient: Team | User) -> Any:
         context = getattr(self, "context", None)
         return context["text_description"] if context else None
 

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -68,10 +68,10 @@ class DigestNotification(ProjectNotification):
         # This shouldn't be possible but adding a message just in case.
         return "Digest Report"
 
-    def get_title_link(self) -> str | None:
+    def get_title_link(self, recipient: Team | User) -> str | None:
         return None
 
-    def build_attachment_title(self) -> str:
+    def build_attachment_title(self, recipient: Team | User) -> str:
         return ""
 
     def get_reference(self) -> Any:

--- a/src/sentry/notifications/notifications/integration_nudge.py
+++ b/src/sentry/notifications/notifications/integration_nudge.py
@@ -71,7 +71,7 @@ class IntegrationNudgeNotification(BaseNotification):
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return ""
 
-    def get_message_description(self) -> Any:
+    def get_message_description(self, recipient: Team | User) -> Any:
         return MESSAGE_LIBRARY[self.seed].format(provider=self.provider.name.capitalize())
 
     def get_message_actions(self, recipient: Team | User) -> Sequence[MessageAction]:
@@ -89,10 +89,10 @@ class IntegrationNudgeNotification(BaseNotification):
     def get_notification_title(self) -> str:
         return ""
 
-    def get_title_link(self) -> str | None:
+    def get_title_link(self, recipient: Team | User) -> str | None:
         return None
 
-    def build_attachment_title(self) -> str:
+    def build_attachment_title(self, recipient: Team | User) -> str:
         return ""
 
     def get_filename(self) -> str:

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -51,7 +51,7 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
             settings_url, recipient
         )
 
-    def get_title_link(self) -> str | None:
+    def get_title_link(self, recipient: Team | User) -> str | None:
         return None
 
     def get_log_params(self, recipient: Team | User) -> MutableMapping[str, Any]:

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -81,10 +81,10 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
     def get_type(self) -> str:
         return "organization.integration.request"
 
-    def build_attachment_title(self) -> str:
+    def build_attachment_title(self, recipient: Team | User) -> str:
         return "Request to Install"
 
-    def get_message_description(self) -> str:
+    def get_message_description(self, recipient: Team | User) -> str:
         requester_name = self.requester.get_display_name()
         optional_message = (
             f" They've included this message `{self.message}`" if self.message else ""

--- a/src/sentry/notifications/notifications/organization_request/invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/invite_request.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .abstract_invite_request import AbstractInviteRequestNotification
+
+if TYPE_CHECKING:
+    from sentry.models import Team, User
 
 
 class InviteRequestNotification(AbstractInviteRequestNotification):
@@ -8,9 +15,9 @@ class InviteRequestNotification(AbstractInviteRequestNotification):
     def get_filename(self) -> str:
         return "organization-invite-request"
 
-    def build_attachment_title(self) -> str:
+    def build_attachment_title(self, recipient: Team | User) -> str:
         return "Request to Invite"
 
-    def get_message_description(self) -> str:
+    def get_message_description(self, recipient: Team | User) -> str:
         requester_name = self.requester.get_display_name()
         return f"{requester_name} is requesting to invite {self.pending_member.email} into {self.organization.name}"

--- a/src/sentry/notifications/notifications/organization_request/join_request.py
+++ b/src/sentry/notifications/notifications/organization_request/join_request.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .abstract_invite_request import AbstractInviteRequestNotification
+
+if TYPE_CHECKING:
+    from sentry.models import Team, User
 
 
 class JoinRequestNotification(AbstractInviteRequestNotification):
@@ -8,8 +15,8 @@ class JoinRequestNotification(AbstractInviteRequestNotification):
     def get_filename(self) -> str:
         return "organization-join-request"
 
-    def build_attachment_title(self) -> str:
+    def build_attachment_title(self, recipient: Team | User) -> str:
         return "Request to Join"
 
-    def get_message_description(self) -> str:
+    def get_message_description(self, recipient: Team | User) -> str:
         return f"{self.pending_member.email} is requesting to join {self.organization.name}"

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -11,13 +11,13 @@ from sentry.utils import json
 
 
 class DummyNotification(BaseNotification):
-    def build_attachment_title(self):
+    def build_attachment_title(self, *args):
         return "My Title"
 
-    def get_title_link(self):
+    def get_title_link(self, *args):
         return None
 
-    def get_notification_title(self):
+    def get_notification_title(self, *args):
         return "Notification Title"
 
     def record_notification_sent(self, *args):


### PR DESCRIPTION
This PR adds the `recipient` to all methods for Slack payload generation to support recipient-dependent content. This is needed to support quota notifications where a user may choose to opt-out of receiving alerts for a specific type of event (ex: transactions). 