### PR TITLE
ref(notifications): adds analytics instance 

### DIFF
--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -129,7 +129,7 @@ class BaseNotification(abc.ABC):
     @property
     def analytics_instance(self) -> Any | None:
         """
-        Returns on instance for that can be used for analytics such as an organization or project
+        Returns an instance for that can be used for analytics such as an organization or project
         """
         return None
 

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -129,7 +129,7 @@ class BaseNotification(abc.ABC):
     @property
     def analytics_instance(self) -> Any | None:
         """
-        Returns on instance for that can be used for analytics
+        Returns on instance for that can be used for analytics such as an organization or project
         """
         return None
 

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -126,8 +126,15 @@ class BaseNotification(abc.ABC):
     def get_callback_data(self) -> Mapping[str, Any] | None:
         return None
 
-    def record_analytics(self, event_name: str, **kwargs: Any) -> None:
-        analytics.record(event_name, **kwargs)
+    @property
+    def analytics_instance(self) -> Any | None:
+        """
+        Returns on instance for that can be used for analytics
+        """
+        return None
+
+    def record_analytics(self, event_name: str, *args: Any, **kwargs: Any) -> None:
+        analytics.record(event_name, *args, **kwargs)
 
     def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
         # may want to explicitly pass in the parameters for this event
@@ -140,6 +147,7 @@ class BaseNotification(abc.ABC):
         if self.analytics_event:
             self.record_analytics(
                 self.analytics_event,
+                self.analytics_instance,
                 providers=provider.name.lower(),
                 **self.get_custom_analytics_params(recipient),
             )


### PR DESCRIPTION
This PR adds an optional instance for notification analytics corresponding to the signature here: https://github.com/getsentry/sentry/blob/master/src/sentry/analytics/base.py#L20

The idea is instead of the caller function decomposing an object (say a subscription) into all the fields we want, we pass in the instance to analytics and let it pull the fields from that instance.