### PR TITLE
fix(metrics-indexer): Dont hardcode cluster name

### DIFF
--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -65,8 +65,9 @@ def get_metrics():  # type: ignore
 
 
 def get_config(topic: str, group_id: str, auto_offset_reset: str) -> MutableMapping[Any, Any]:
+    cluster_name: str = settings.KAFKA_TOPICS[topic]["cluster"]
     consumer_config: MutableMapping[Any, Any] = kafka_config.get_kafka_consumer_cluster_options(
-        "default",
+        cluster_name,
         override_params={
             "enable.auto.commit": False,
             "enable.auto.offset.store": False,


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/30462 I [hardcoded](https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_metrics/multiprocess.py#L69) the cluster name to be `"default"` which doesn't exist in prod 🤦‍♀️ 