### PR TITLE
feat(alert-rule-action): New data structure for alert-rule-action settings

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -128,7 +128,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
             if attrs.get("sentry_app_config"):
                 if attrs.get("sentry_app_installation_uuid") is None:
                     raise serializers.ValidationError(
-                        {"sentry_app": "Missing paramater: sentry_app_installation_uuid"}
+                        {"sentry_app": "Missing parameter: sentry_app_installation_uuid"}
                     )
 
                 try:

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -33,7 +33,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
     id = serializers.IntegerField(required=False)
     type = serializers.CharField()
     target_type = serializers.CharField()
-    sentry_app_config = serializers.JSONField(required=False)
+    sentry_app_config = serializers.JSONField(required=False)  # array of dicts
     sentry_app_installation_uuid = serializers.CharField(required=False)
 
     class Meta:

--- a/src/sentry/mediators/alert_rule_actions/creator.py
+++ b/src/sentry/mediators/alert_rule_actions/creator.py
@@ -6,7 +6,7 @@ from sentry.utils.cache import memoize
 
 class AlertRuleActionCreator(Mediator):
     install = Param("sentry.models.SentryAppInstallation")
-    fields = Param(object)
+    fields = Param(object, default=[])  # array of dicts
 
     def call(self):
         uri = self._fetch_sentry_app_uri()

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -23,7 +23,7 @@ class AlertRuleActionRequester(Mediator):
 
     install = Param("sentry.models.SentryAppInstallation")
     uri = Param((str,))
-    fields = Param(object, required=False, default={})
+    fields = Param(object, required=False, default=[])
     http_method = Param(str, required=False, default="POST")
 
     def call(self):

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -76,13 +76,12 @@ class AlertRuleActionRequester(Mediator):
 
     @memoize
     def body(self):
-        return json.dumps({
-            "fields": {
-                field["name"]: field["value"]
-                for field in self.fields
-            },
-            "installationId": self.install.uuid
-        })
+        return json.dumps(
+            {
+                "fields": {field["name"]: field["value"] for field in self.fields},
+                "installationId": self.install.uuid,
+            }
+        )
 
     @memoize
     def sentry_app(self):

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -76,13 +76,13 @@ class AlertRuleActionRequester(Mediator):
 
     @memoize
     def body(self):
-        body = {"fields": {}}
-        for name, value in self.fields.items():
-            body["fields"][name] = value
-
-        body["installationId"] = self.install.uuid
-
-        return json.dumps(body)
+        return json.dumps({
+            "fields": {
+                field["name"]: field["value"]
+                for field in self.fields
+            },
+            "installationId": self.install.uuid
+        })
 
     @memoize
     def sentry_app(self):

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -78,7 +78,7 @@ class AlertRuleActionRequester(Mediator):
     def body(self):
         return json.dumps(
             {
-                "fields": {field["name"]: field["value"] for field in self.fields},
+                "fields": self.fields,
                 "installationId": self.install.uuid,
             }
         )

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -23,7 +23,7 @@ class AlertRuleActionRequester(Mediator):
 
     install = Param("sentry.models.SentryAppInstallation")
     uri = Param((str,))
-    fields = Param(object, required=False, default=[])
+    fields = Param(list, required=False, default=[])
     http_method = Param(str, required=False, default="POST")
 
     def call(self):

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -102,7 +102,14 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
         schema = alert_rule_component.schema.get("settings")
         for required_field in schema.get("required_fields", []):
             field_name = required_field.get("name")
-            field_value = incoming_settings.get(field_name)
+            field_value = next(
+                (
+                    setting["value"]
+                    for setting in incoming_settings
+                    if setting["name"] == field_name
+                ),
+                None,
+            )
             if not field_value:
                 raise ValidationError(
                     f"{sentry_app.name} is missing required settings field: '{field_name}'"
@@ -113,12 +120,19 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
         # Ensure optional fields are valid
         for optional_field in schema.get("optional_fields", []):
             field_name = optional_field.get("name")
-            field_value = incoming_settings.get(field_name)
+            field_value = next(
+                (
+                    setting["value"]
+                    for setting in incoming_settings
+                    if setting["name"] == field_name
+                ),
+                None,
+            )
             validate_field(field_value, optional_field, sentry_app.name)
             valid_fields.add(field_name)
 
         # Ensure the payload we send matches the expectations set in the schema
-        extra_keys = incoming_settings.keys() - valid_fields
+        extra_keys = set([setting["name"] for setting in incoming_settings]) - valid_fields
         if extra_keys:
             extra_keys_string = ", ".join(extra_keys)
             raise ValidationError(

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -132,7 +132,7 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
             valid_fields.add(field_name)
 
         # Ensure the payload we send matches the expectations set in the schema
-        extra_keys = set([setting["name"] for setting in incoming_settings]) - valid_fields
+        extra_keys = {setting["name"] for setting in incoming_settings} - valid_fields
         if extra_keys:
             extra_keys_string = ", ".join(extra_keys)
             raise ValidationError(

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -54,7 +54,7 @@ type Props = {
   /**
    * Object containing reset values for fields if previously entered, in case this form is unmounted
    */
-  resetValues?: {[key: string]: any};
+  resetValues?: {[key: string]: any; settings?: {name: string; value: any}[]};
   /**
    * Function to provide fields with pre-written data if a default is specified
    */
@@ -249,7 +249,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
 
     // async only used for select components
     const isAsync = typeof field.async === 'undefined' ? true : !!field.async; // default to true
-    const defaultResetValues = (this.props.resetValues || {}).settings || {};
+    const defaultResetValues = (this.props.resetValues || {}).settings || [];
 
     if (fieldToPass.type === 'select') {
       // find the options from state to pass down
@@ -259,12 +259,18 @@ export class SentryAppExternalForm extends Component<Props, State> {
       }));
       const options = this.state.optionsByField.get(field.name) || defaultOptions;
       const allowClear = !required;
+      const defaultValue = defaultResetValues.reduce((acc, curr) => {
+        if (curr.name === field.name) {
+          acc = curr.value;
+        }
+        return acc;
+      }, undefined);
       // filter by what the user is typing
       const filterOption = createFilter({});
       fieldToPass = {
         ...fieldToPass,
         options,
-        defaultValue: defaultResetValues[field.name],
+        defaultValue,
         defaultOptions,
         filterOption,
         allowClear,

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -325,7 +325,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
     if (this.model.validateForm()) {
       onSubmitSuccess({
         // The form data must be nested in 'settings' to ensure they don't overlap with any other field names.
-        settings: formData,
+        settings: Object.entries(formData).map(([name, value]) => ({name, value})),
         sentryAppInstallationUuid,
         // Used on the backend to explicitly associate with a different rule than those without a custom form.
         hasSchemaFormConfig: true,

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -44,11 +44,11 @@ type Props = {
   action: 'create' | 'link';
   element: 'issue-link' | 'alert-rule-action';
   /**
-   * Addtional form data to submit with the request
+   * Additional form data to submit with the request
    */
   extraFields?: {[key: string]: any};
   /**
-   * Addtional body parameters to submit with the request
+   * Additional body parameters to submit with the request
    */
   extraRequestBody?: {[key: string]: any};
   /**

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -822,7 +822,10 @@ class UpdateProjectRuleTest(APITestCase):
         actions = [
             {
                 "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
-                "settings": {"title": "Team Rocket", "summary": "We're blasting off again."},
+                "settings": [
+                    {"name": "title", "value": "Team Rocket"},
+                    {"name": "summary", "value": "We're blasting off again."},
+                ],
                 "sentryAppInstallationUuid": install.uuid,
                 "hasSchemaFormConfig": True,
             },

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -502,7 +502,10 @@ class CreateProjectRuleTest(APITestCase):
         actions = [
             {
                 "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
-                "settings": {"title": "Team Rocket", "summary": "We're blasting off again."},
+                "settings": [
+                    {"name": "title", "value": "Team Rocket"},
+                    {"name": "summary", "value": "We're blasting off again."},
+                ],
                 "sentryAppInstallationUuid": install.uuid,
                 "hasSchemaFormConfig": True,
             },

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -993,7 +993,7 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
                 "sentry_app": self.sentry_app.id,
                 "sentry_app_config": {"tag": "asdfasdfads"},
             },
-            {"sentryApp": ["Missing paramater: sentry_app_installation_uuid"]},
+            {"sentryApp": ["Missing parameter: sentry_app_installation_uuid"]},
         )
 
     @responses.activate

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -675,12 +675,13 @@ class SentryAppAlerRuleUIComponentActionHandlerTest(FireTest, TestCase):
             type=AlertRuleTriggerAction.Type.SENTRY_APP,
             target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
             sentry_app=self.sentry_app,
-            sentry_app_config={
-                "channel": "#santry",
-                "workspace": "santrysantrysantry",
-                "tag": "triage",
-                "assignee": "Nisanthan Nanthakumar",
-            },
+            sentry_app_config=[
+                {"name": "channel", "value": "#santry"},
+                {"name": "workspace_name", "value": "santrysantrysantry"},
+                {"name": "tag", "value": "triage"},
+                {"name": "assignee", "value": "Nisanthan Nanthakumar"},
+                {"name": "teamId", "value": 1},
+            ],
         )
 
         responses.add(
@@ -700,12 +701,13 @@ class SentryAppAlerRuleUIComponentActionHandlerTest(FireTest, TestCase):
         # Check that the Alert Rule UI Component settings are returned
         assert json.loads(data)["data"]["metric_alert"]["alert_rule"]["triggers"][0]["actions"][0][
             "settings"
-        ] == {
-            "channel": "#santry",
-            "workspace": "santrysantrysantry",
-            "tag": "triage",
-            "assignee": "Nisanthan Nanthakumar",
-        }
+        ] == [
+            {"name": "channel", "value": "#santry"},
+            {"name": "workspace_name", "value": "santrysantrysantry"},
+            {"name": "tag", "value": "triage"},
+            {"name": "assignee", "value": "Nisanthan Nanthakumar"},
+            {"name": "teamId", "value": 1},
+        ]
 
     def test_fire_metric_alert(self):
         self.run_fire_test()

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -54,11 +54,14 @@ class TestAlertRuleActionRequester(TestCase):
         request = responses.calls[0].request
 
         data = {
-            "fields": {
-                "title": "An Alert",
-                "description": "threshold reached",
-                "assignee_id": "user-1",
-            },
+            "fields": [
+                {"name": "title", "value": "An Alert"},
+                {"name": "description", "value": "threshold reached"},
+                {
+                    "name": "assignee_id",
+                    "value": "user-1",
+                },
+            ],
             "installationId": self.install.uuid,
         }
         payload = json.loads(request.body)
@@ -95,11 +98,14 @@ class TestAlertRuleActionRequester(TestCase):
         request = responses.calls[0].request
 
         data = {
-            "fields": {
-                "title": "An Alert",
-                "description": "threshold reached",
-                "assignee_id": "user-1",
-            },
+            "fields": [
+                {"name": "title", "value": "An Alert"},
+                {"name": "description", "value": "threshold reached"},
+                {
+                    "name": "assignee_id",
+                    "value": "user-1",
+                },
+            ],
             "installationId": self.install.uuid,
         }
         payload = json.loads(request.body)
@@ -135,11 +141,14 @@ class TestAlertRuleActionRequester(TestCase):
         request = responses.calls[0].request
 
         data = {
-            "fields": {
-                "title": "An Alert",
-                "description": "threshold reached",
-                "assignee_id": "user-1",
-            },
+            "fields": [
+                {"name": "title", "value": "An Alert"},
+                {"name": "description", "value": "threshold reached"},
+                {
+                    "name": "assignee_id",
+                    "value": "user-1",
+                },
+            ],
             "installationId": self.install.uuid,
         }
         payload = json.loads(request.body)

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -28,10 +28,14 @@ class TestAlertRuleActionRequester(TestCase):
         self.install = self.create_sentry_app_installation(
             slug="foo", organization=self.org, user=self.user
         )
+        self.fields = [
+            {"name": "title", "value": "An Alert"},
+            {"name": "description", "value": "threshold reached"},
+            {"name": "assignee_id", "value": "user-1"},
+        ]
 
     @responses.activate
     def test_makes_successful_request(self):
-        fields = {"title": "An Alert", "description": "threshold reached", "assignee": "user-1"}
 
         responses.add(
             method=responses.POST,
@@ -43,7 +47,7 @@ class TestAlertRuleActionRequester(TestCase):
         result = AlertRuleActionRequester.run(
             install=self.install,
             uri="/sentry/alert-rule",
-            fields=fields,
+            fields=self.fields,
         )
         assert result["success"]
         assert result["message"] == 'foo: "Saved information"'
@@ -53,7 +57,7 @@ class TestAlertRuleActionRequester(TestCase):
             "fields": {
                 "title": "An Alert",
                 "description": "threshold reached",
-                "assignee": "user-1",
+                "assignee_id": "user-1",
             },
             "installationId": self.install.uuid,
         }
@@ -73,7 +77,6 @@ class TestAlertRuleActionRequester(TestCase):
 
     @responses.activate
     def test_makes_failed_request(self):
-        fields = {"title": "An Alert", "description": "threshold reached", "assignee": "user-1"}
 
         responses.add(
             method=responses.POST,
@@ -85,7 +88,7 @@ class TestAlertRuleActionRequester(TestCase):
         result = AlertRuleActionRequester.run(
             install=self.install,
             uri="/sentry/alert-rule",
-            fields=fields,
+            fields=self.fields,
         )
         assert not result["success"]
         assert result["message"] == 'foo: "Channel not found!"'
@@ -95,7 +98,7 @@ class TestAlertRuleActionRequester(TestCase):
             "fields": {
                 "title": "An Alert",
                 "description": "threshold reached",
-                "assignee": "user-1",
+                "assignee_id": "user-1",
             },
             "installationId": self.install.uuid,
         }
@@ -115,7 +118,6 @@ class TestAlertRuleActionRequester(TestCase):
 
     @responses.activate
     def test_makes_failed_request_returning_only_status(self):
-        fields = {"title": "An Alert", "description": "threshold reached", "assignee": "user-1"}
 
         responses.add(
             method=responses.POST,
@@ -126,7 +128,7 @@ class TestAlertRuleActionRequester(TestCase):
         result = AlertRuleActionRequester.run(
             install=self.install,
             uri="/sentry/alert-rule",
-            fields=fields,
+            fields=self.fields,
         )
         assert not result["success"]
         assert result["message"] == "foo: Something went wrong!"
@@ -136,7 +138,7 @@ class TestAlertRuleActionRequester(TestCase):
             "fields": {
                 "title": "An Alert",
                 "description": "threshold reached",
-                "assignee": "user-1",
+                "assignee_id": "user-1",
             },
             "installationId": self.install.uuid,
         }

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -13,7 +13,10 @@ SENTRY_APP_ALERT_ACTION = "sentry.rules.actions.notify_event_sentry_app.NotifyEv
 
 class NotifyEventSentryAppActionTest(RuleTestCase):
     rule_cls = NotifyEventSentryAppAction
-    schema_data = {"title": "Squid Game", "summary": "circle triangle square"}
+    schema_data = [
+        {"name": "title", "value": "Squid Game"},
+        {"name": "summary", "value": "circle triangle square"},
+    ]
 
     @before
     def create_schema(self):
@@ -143,7 +146,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
             data={
                 "hasSchemaFormConfig": True,
                 "sentryAppInstallationUuid": self.install.uuid,
-                "settings": {"title": "Lamy"},
+                "settings": [{"name": "title", "value": "Lamy"}],
             }
         )
         with self.assertRaises(ValidationError):
@@ -154,7 +157,11 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
             data={
                 "hasSchemaFormConfig": True,
                 "sentryAppInstallationUuid": self.install.uuid,
-                "settings": {"title": "Lamy", "summary": "Safari", "invalidField": "Invalid Value"},
+                "settings": [
+                    {"name": "title", "value": "Lamy"},
+                    {"name": "summary", "value": "Safari"},
+                    {"name": "invalidField", "value": "Invalid Value"},
+                ],
             }
         )
         with self.assertRaises(ValidationError):
@@ -165,11 +172,11 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
             data={
                 "hasSchemaFormConfig": True,
                 "sentryAppInstallationUuid": self.install.uuid,
-                "settings": {
-                    "title": "Lamy",
-                    "summary": "Safari",
-                    "points": "Invalid Select Value",
-                },
+                "settings": [
+                    {"name": "title", "value": "Lamy"},
+                    {"name": "summary", "value": "Safari"},
+                    {"name": "points", "value": "Invalid Select Value"},
+                ],
             }
         )
         with self.assertRaises(ValidationError):

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -181,11 +181,14 @@ class TestSendAlertEvent(TestCase):
     @patch("sentry.tasks.sentry_apps.safe_urlopen", return_value=MockResponseInstance)
     def test_send_alert_event_with_additional_payload(self, safe_urlopen):
         event = self.store_event(data={}, project_id=self.project.id)
-        settings = {
-            "alert_prefix": "[Not Good]",
-            "channel": "#ignored-errors",
-            "best_emoji": ":fire:",
-        }
+        settings = [
+            {"name": "alert_prefix", "value": "[Not Good]"},
+            {"name": "channel", "value": "#ignored-errors"},
+            {"name": "best_emoji", "value": ":fire:"},
+            {"name": "teamId", "value": 1},
+            {"name": "assigneeId", "value": 3},
+        ]
+
         rule_future = RuleFuture(
             rule=self.rule,
             kwargs={"sentry_app": self.sentry_app, "schema_defined_settings": settings},


### PR DESCRIPTION
## Objective:
Originally the issue was with serializing the settings field for alert webhooks and fighting with the serializers. Instead we decided to convert the dictionary to an array of dictionaries with keys `name` and `value`.

We will need to delete the existing records with the legacy data structure. 
We have SQL queries to determine the records to delete. https://github.com/getsentry/sentry/pull/31409 
Since the total number of records is small, we can delete manually.
We will send an email to the partner org before deleting the records.