### PR TITLE
ref(rate limits): Remove rate_limit_endpoint decorator

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -15,7 +15,6 @@ from sentry.api.helpers.group_index import (
     delete_group_list,
     get_first_last_release,
     prep_search,
-    rate_limit_endpoint,
     update_groups,
 )
 from sentry.api.serializers import GroupSerializer, GroupSerializerSnuba, serialize
@@ -32,6 +31,7 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 
 
 class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(5, 1),
@@ -113,7 +113,6 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             PluginSerializer(project),
         )
 
-    @rate_limit_endpoint(limit=5, window=1)
     def get(self, request: Request, group) -> Response:
         """
         Retrieve an Issue
@@ -228,7 +227,6 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             )
             raise
 
-    @rate_limit_endpoint(limit=5, window=1)
     def put(self, request: Request, group) -> Response:
         """
         Update an Issue
@@ -297,7 +295,6 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         except Exception:
             raise
 
-    @rate_limit_endpoint(limit=5, window=5)
     def delete(self, request: Request, group) -> Response:
         """
         Remove an Issue

--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -4,12 +4,12 @@ from rest_framework.response import Response
 from sentry.api import client
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
-from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class GroupEventsLatestEndpoint(GroupEndpoint):
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(15, 1),
@@ -18,7 +18,6 @@ class GroupEventsLatestEndpoint(GroupEndpoint):
         }
     }
 
-    @rate_limit_endpoint(limit=15, window=1)
     def get(self, request: Request, group) -> Response:
         """
         Retrieve the Latest Event for an Issue

--- a/src/sentry/api/endpoints/group_first_last_release.py
+++ b/src/sentry/api/endpoints/group_first_last_release.py
@@ -3,11 +3,12 @@ from rest_framework.response import Response
 
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
-from sentry.api.helpers.group_index import get_first_last_release, rate_limit_endpoint
+from sentry.api.helpers.group_index import get_first_last_release
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class GroupFirstLastReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(5, 1),
@@ -16,7 +17,6 @@ class GroupFirstLastReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
         }
     }
 
-    @rate_limit_endpoint(limit=5, window=1)
     def get(self, request: Request, group) -> Response:
         """Get the first and last release for a group.
 

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -4,7 +4,6 @@ from rest_framework.response import Response
 from sentry import eventstore
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import serialize
 from sentry.models import Project
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -12,7 +11,7 @@ from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
 
 
 class EventIdLookupEndpoint(OrganizationEndpoint):
-
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(1, 1),
@@ -21,7 +20,6 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
         }
     }
 
-    @rate_limit_endpoint(limit=1, window=1)
     def get(self, request: Request, organization, event_id) -> Response:
         """
         Resolve an Event ID

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -16,7 +16,6 @@ from sentry.api.helpers.group_index import (
     calculate_stats_period,
     delete_groups,
     get_by_short_id,
-    rate_limit_endpoint,
     track_slo_response,
     update_groups,
 )
@@ -138,6 +137,7 @@ def inbox_search(
 
 class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
     permission_classes = (OrganizationEventPermission,)
+    enforce_rate_limit = True
 
     rate_limits = {
         "GET": {
@@ -176,7 +176,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         return result, query_kwargs
 
     @track_slo_response("workflow")
-    @rate_limit_endpoint(limit=10, window=1)
     def get(self, request: Request, organization) -> Response:
         """
         List an Organization's Issues
@@ -350,7 +349,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         return response
 
     @track_slo_response("workflow")
-    @rate_limit_endpoint(limit=5, window=5)
     def put(self, request: Request, organization) -> Response:
         """
         Bulk Mutate a List of Issues
@@ -433,7 +431,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         )
 
     @track_slo_response("workflow")
-    @rate_limit_endpoint(limit=5, window=5)
     def delete(self, request: Request, organization) -> Response:
         """
         Bulk Remove a List of Issues

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -4,11 +4,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases import OrganizationEventPermission, OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_group_index import ERR_INVALID_STATS_PERIOD
-from sentry.api.helpers.group_index import (
-    build_query_params_from_request,
-    calculate_stats_period,
-    rate_limit_endpoint,
-)
+from sentry.api.helpers.group_index import build_query_params_from_request, calculate_stats_period
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import InvalidParams, get_date_range_from_params
@@ -19,6 +15,7 @@ from sentry.utils.compat import map
 
 class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
     permission_classes = (OrganizationEventPermission,)
+    enforce_rate_limit = True
 
     rate_limits = {
         "GET": {
@@ -28,7 +25,6 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
         }
     }
 
-    @rate_limit_endpoint(limit=10, window=1)
     def get(self, request: Request, organization) -> Response:
         """
         Get the stats on an Organization's Issues

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -4,11 +4,7 @@ from rest_framework.response import Response
 
 from sentry import features, search
 from sentry.api.bases import OrganizationEventsEndpointBase
-from sentry.api.helpers.group_index import (
-    ValidationError,
-    rate_limit_endpoint,
-    validate_search_filter_permissions,
-)
+from sentry.api.helpers.group_index import ValidationError, validate_search_filter_permissions
 from sentry.api.issue_search import convert_query_values, parse_search_query
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.snuba import discover
@@ -21,6 +17,7 @@ ISSUES_COUNT_MAX_HITS_LIMIT = 100
 
 
 class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(10, 1),
@@ -53,7 +50,6 @@ class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
         result = search.query(**query_kwargs)
         return result.hits
 
-    @rate_limit_endpoint(limit=10, window=1)
     def get(self, request: Request, organization) -> Response:
         stats_period = request.GET.get("groupStatsPeriod")
         try:

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -6,7 +6,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
-from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.search.utils import InvalidQuery
 from sentry.snuba.outcomes import (
@@ -20,7 +19,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
-
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(20, 1),
@@ -29,7 +28,6 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
         }
     }
 
-    @rate_limit_endpoint(limit=20, window=1)
     def get(self, request: Request, organization) -> Response:
         with self.handle_query_errors():
             with sentry_sdk.start_span(op="outcomes.endpoint", description="build_outcomes_query"):

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -7,13 +7,12 @@ from rest_framework.response import Response
 
 from sentry import eventstore, features
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectEventsEndpoint(ProjectEndpoint):
-
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(5, 1),
@@ -22,7 +21,6 @@ class ProjectEventsEndpoint(ProjectEndpoint):
         }
     }
 
-    @rate_limit_endpoint(limit=5, window=1)
     def get(self, request: Request, project) -> Response:
         """
         List a Project's Events

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -11,7 +11,6 @@ from sentry.api.helpers.group_index import (
     delete_groups,
     get_by_short_id,
     prep_search,
-    rate_limit_endpoint,
     track_slo_response,
     update_groups,
 )
@@ -28,6 +27,7 @@ ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', a
 
 class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
     permission_classes = (ProjectEventPermission,)
+    enforce_rate_limit = True
 
     rate_limits = {
         "GET": {
@@ -38,7 +38,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
     }
 
     @track_slo_response("workflow")
-    @rate_limit_endpoint(limit=3, window=1)
     def get(self, request: Request, project) -> Response:
         """
         List a Project's Issues

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -4,14 +4,13 @@ from rest_framework.response import Response
 from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.app import tsdb
 from sentry.models import Environment, Group
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
-
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(20, 1),
@@ -20,7 +19,6 @@ class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
         }
     }
 
-    @rate_limit_endpoint(limit=20, window=1)
     def get(self, request: Request, project) -> Response:
         try:
             environment_id = self._get_environment_id_from_request(request, project.organization_id)

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -8,13 +8,12 @@ from sentry import tsdb
 from sentry.api.base import StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.models import ProjectKey
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
-
+    enforce_rate_limit = True
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(20, 1),
@@ -23,7 +22,6 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
         }
     }
 
-    @rate_limit_endpoint(limit=20, window=1)
     def get(self, request: Request, project, key_id) -> Response:
         try:
             key = ProjectKey.objects.get(

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -9,7 +9,6 @@ from sentry import features
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.helpers.group_index.index import rate_limit_endpoint
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.discover.utils import transform_aliases_and_query
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -27,6 +26,7 @@ class DiscoverQueryPermission(OrganizationPermission):
 
 class DiscoverQueryEndpoint(OrganizationEndpoint):
     permission_classes = (DiscoverQueryPermission,)
+    enforce_rate_limit = True
 
     rate_limits = {
         "POST": {
@@ -115,7 +115,6 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
                 self.handle_results(snuba_results, requested_query, projects), status=200
             )
 
-    @rate_limit_endpoint(limit=4)
     def post(self, request: Request, organization) -> Response:
         if not self.has_feature(request, organization):
             return Response(status=404)

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -4,14 +4,12 @@ from django.http import QueryDict
 
 from sentry.api.helpers.group_index import (
     ValidationError,
-    build_rate_limit_key,
     update_groups,
     validate_search_filter_permissions,
 )
 from sentry.api.issue_search import parse_search_query
 from sentry.models import GroupInbox, GroupInboxReason, GroupStatus, add_group_to_inbox
 from sentry.testutils import TestCase
-from sentry.utils.hashlib import md5_text
 
 
 class ValidateSearchFilterPermissionsTest(TestCase):
@@ -171,13 +169,3 @@ class UpdateGroupsTest(TestCase):
 
         assert not GroupInbox.objects.filter(group=group).exists()
         assert send_robust.called
-
-
-class BuildRateLimitKeyTest(TestCase):
-    def some_function(self):
-        pass
-
-    def test(self):
-        request = self.make_request()
-        expected = f"rate_limit_endpoint:{md5_text('BuildRateLimitKeyTest.some_function').hexdigest()}:{request.META['REMOTE_ADDR']}"
-        assert build_rate_limit_key(self.some_function, request) == expected


### PR DESCRIPTION
Remove the `rate_limit_endpoint` decorator in favor of using `enforce_rate_limit = True` in the class.