### PR TITLE
ref(codeowners): Only fetch codeowners from specific locations

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -64,6 +64,9 @@ FEATURES = [
     ),
 ]
 
+# The order determines which location takes precidence when fetching CODEOWNERS files
+CODEOWNERS_LOCATIONS = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
+
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
     features=FEATURES,
@@ -89,25 +92,10 @@ def build_repository_query(metadata: Mapping[str, Any], name: str, query: str) -
 
 class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMixin):  # type: ignore
     repo_search = True
+    codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 
     def get_client(self) -> GitHubClientMixin:
         return GitHubAppsClient(integration=self.model)
-
-    def get_codeowner_file(
-        self, repo: Repository, ref: str | None = None
-    ) -> Mapping[str, Any] | None:
-        try:
-            files = self.get_client().search_file(repo.name, "CODEOWNERS")
-            # TODO(mgaeta): Pull this logic out of the try/catch.
-            for f in files["items"]:
-                if f["name"] == "CODEOWNERS":
-                    filepath = f["path"]
-                    html_url = f["html_url"]
-                    contents = self.get_client().get_file(repo.name, filepath)
-                    return {"filepath": filepath, "html_url": html_url, "raw": contents}
-        except ApiError:
-            return None
-        return None
 
     def get_repositories(self, query: str | None = None) -> Sequence[Mapping[str, Any]]:
         if not query:

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -64,9 +64,6 @@ FEATURES = [
     ),
 ]
 
-# The order determines which location takes precidence when fetching CODEOWNERS files
-CODEOWNERS_LOCATIONS = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
-
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
     features=FEATURES,

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -82,6 +82,7 @@ metadata = IntegrationMetadata(
 
 class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMixin):
     repo_search = True
+    codeowners_locations = ["CODEOWNERS", ".gitlab/CODEOWNERS", "docs/CODEOWNERS"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -95,19 +96,6 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
             self.default_identity = self.get_default_identity()
 
         return GitLabApiClient(self)
-
-    def get_codeowner_file(self, repo, ref=None):
-        filepath_options = ["CODEOWNERS", ".gitlab/CODEOWNERS", "docs/CODEOWNERS"]
-        for filepath in filepath_options:
-            try:
-                contents = self.get_client().get_file(repo, filepath, ref)
-            except ApiError:
-                continue
-
-            html_url = self.format_source_url(repo, filepath, ref)
-            return {"filepath": filepath, "html_url": html_url, "raw": contents}
-
-        return None
 
     def get_repositories(self, query=None):
         # Note: gitlab projects are the same things as repos everywhere else

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -109,7 +109,9 @@ class RepositoryMixin:
     def has_repo_access(self, repo: Repository) -> bool:
         raise NotImplementedError
 
-    def get_codeowner_file(self, repo: Repository, ref: str | None = None) -> Mapping[str, str]:
+    def get_codeowner_file(
+        self, repo: Repository, ref: str | None = None
+    ) -> Mapping[str, str] | None:
         """
         Find and get the contents of a CODEOWNERS file.
 

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -112,7 +112,6 @@ class RepositoryMixin:
     def get_codeowner_file(self, repo: Repository, ref: str | None = None) -> Mapping[str, str]:
         """
         Find and get the contents of a CODEOWNERS file.
-        Should use client().get_file to get and decode the contents.
 
         args:
          * repo - Repository object
@@ -123,4 +122,15 @@ class RepositoryMixin:
          * filepath - full path of the file i.e. CODEOWNERS, .github/CODEOWNERS, docs/CODEOWNERS
          * raw - the decoded raw contents of the codeowner file
         """
-        raise NotImplementedError
+        if self.codeowners_locations is None:
+            raise Exception("Implement self.codeowners_locations to use this method.")
+
+        for filepath in self.codeowners_locations:
+            html_url = self.check_file(repo, filepath, ref)
+            if html_url:
+                try:
+                    contents = self.get_client().get_file(repo.name, filepath)
+                except ApiError:
+                    continue
+                return {"filepath": filepath, "html_url": html_url, "raw": contents}
+        return None


### PR DESCRIPTION
See [API-2278](https://getsentry.atlassian.net/browse/API-2278)

This PR changes the way we fetch CODEOWNERS for github to more similarly resemble the way we do it for gitlab, checking specific locations only. Since they're so similar, I moved the method up to the base class mixin, and made the clients just a bit lighter.

**Demo**

Now, we fetch CODEOWNERS from `/` first, then `.github/`, then `docs/`. If there is no result at any of those locations, we check the next, and if nothing is found we return `None`.

In the demo you can see the returned value is from root (`/`) since that's first in github's `self.codeowners_locations` list.

https://user-images.githubusercontent.com/35509934/151467616-1a893d06-d1e7-4779-a7cb-6208ba58810b.mov

