### PR TITLE
fix(ratelimit): Store header info with request

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-before_after=1.0.1
+before_after==1.0.1
 docker>=3.7.0,<3.8.0
 exam>=0.5.1
 freezegun==1.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+before_after=1.0.1
 docker>=3.7.0,<3.8.0
 exam>=0.5.1
 freezegun==1.1.0

--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -1,5 +1,3 @@
-import time
-
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -31,8 +29,6 @@ class GroupEventsLatestEndpoint(GroupEndpoint):
         :pparam string group_id: the ID of the issue
         """
         environments = [e.name for e in get_environments(request, group.project.organization)]
-
-        time.sleep(10)
 
         event = group.get_latest_event_for_environments(environments)
 

--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -1,3 +1,5 @@
+import time
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -29,6 +31,8 @@ class GroupEventsLatestEndpoint(GroupEndpoint):
         :pparam string group_id: the ID of the issue
         """
         environments = [e.name for e in get_environments(request, group.project.organization)]
+
+        time.sleep(10)
 
         event = group.get_latest_event_for_environments(environments)
 

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -27,7 +27,6 @@ class RatelimitMiddleware(MiddlewareMixin):
         request.will_be_rate_limited = False
         request.rate_limit_category = None
 
-        # If rate_limit_metadata isn't none, then some other request established it first
         if not can_be_ratelimited(request, view_func):
             return
 
@@ -45,39 +44,25 @@ class RatelimitMiddleware(MiddlewareMixin):
         if rate_limit is None:
             return
 
-        rate_limit_metadata = above_rate_limit_check(key, rate_limit)
-        request.rate_limit_limit = rate_limit_metadata.limit
-        request.rate_limit_current_count = rate_limit_metadata.current
-        request.rate_limit_reset = rate_limit_metadata.reset_time
+        request.rate_limit_metadata = above_rate_limit_check(key, rate_limit)
 
-        if rate_limit_metadata.is_limited:
+        if request.rate_limit_metadata.is_limited:
             request.will_be_rate_limited = True
             enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
             if enforce_rate_limit:
                 return HttpResponse(
                     {
                         "detail": DEFAULT_ERROR_MESSAGE.format(
-                            limit=rate_limit_metadata.limit,
-                            window=rate_limit_metadata.window,
+                            limit=request.rate_limit_metadata.limit,
+                            window=request.rate_limit_metadata.window,
                         )
                     },
                     status=429,
                 )
 
     def process_response(self, request: Request, response: Response) -> Response:
-        if all(
-            (
-                hasattr(request, "rate_limit_limit"),
-                hasattr(request, "rate_limit_current_count"),
-                hasattr(request, "rate_limit_reset"),
-            )
-        ):
-            remaining_count = (
-                request.rate_limit_limit - request.rate_limit_current_count
-                if request.rate_limit_limit > request.rate_limit_current_count
-                else 0
-            )
-            response["X-Sentry-Rate-Limit-Remaining"] = remaining_count
-            response["X-Sentry-Rate-Limit-Limit"] = request.rate_limit_limit
-            response["X-Sentry-Rate-Limit-Reset"] = request.rate_limit_reset
+        if hasattr(request, "rate_limit_metadata"):
+            response["X-Sentry-Rate-Limit-Remaining"] = request.rate_limit_metadata.remaining
+            response["X-Sentry-Rate-Limit-Limit"] = request.rate_limit_metadata.limit
+            response["X-Sentry-Rate-Limit-Reset"] = request.rate_limit_metadata.reset_time
         return response

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -11,7 +11,7 @@ from sentry.ratelimits import (
     get_rate_limit_key,
     get_rate_limit_value,
 )
-from sentry.types.ratelimit import RateLimitCategory, RateLimitMeta
+from sentry.types.ratelimit import RateLimitCategory
 
 DEFAULT_ERROR_MESSAGE = (
     "You are attempting to use this endpoint too frequently. Limit is "
@@ -22,13 +22,12 @@ DEFAULT_ERROR_MESSAGE = (
 class RatelimitMiddleware(MiddlewareMixin):
     """Middleware that applies a rate limit to every endpoint."""
 
-    rate_limit_metadata: RateLimitMeta | None = None
-
     def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response | None:
         """Check if the endpoint call will violate."""
         request.will_be_rate_limited = False
         request.rate_limit_category = None
 
+        # If rate_limit_metadata isn't none, then some other request established it first
         if not can_be_ratelimited(request, view_func):
             return
 
@@ -46,29 +45,40 @@ class RatelimitMiddleware(MiddlewareMixin):
         if rate_limit is None:
             return
 
-        self.rate_limit_metadata = above_rate_limit_check(key, rate_limit)
-        if self.rate_limit_metadata.is_limited:
+        rate_limit_metadata = above_rate_limit_check(key, rate_limit)
+        request.rate_limit_limit = rate_limit_metadata.limit
+        request.rate_limit_current_count = rate_limit_metadata.current
+        request.rate_limit_reset = rate_limit_metadata.reset_time
+
+        if rate_limit_metadata.is_limited:
             request.will_be_rate_limited = True
             enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
             if enforce_rate_limit:
                 return HttpResponse(
                     {
                         "detail": DEFAULT_ERROR_MESSAGE.format(
-                            limit=self.rate_limit_metadata.limit,
-                            window=self.rate_limit_metadata.window,
+                            limit=rate_limit_metadata.limit,
+                            window=rate_limit_metadata.window,
                         )
                     },
                     status=429,
                 )
 
     def process_response(self, request: Request, response: Response) -> Response:
-        if self.rate_limit_metadata is not None:
+        if all(
+            (
+                hasattr(request, "rate_limit_limit"),
+                hasattr(request, "rate_limit_current_count"),
+                request,
+                "rate_limit_reset",
+            )
+        ):
             remaining_count = (
-                self.rate_limit_metadata.limit - self.rate_limit_metadata.current
-                if not self.rate_limit_metadata.is_limited
+                request.rate_limit_limit - request.rate_limit_current_count
+                if request.rate_limit_limit > request.rate_limit_current_count
                 else 0
             )
             response["X-Sentry-Rate-Limit-Remaining"] = remaining_count
-            response["X-Sentry-Rate-Limit-Limit"] = self.rate_limit_metadata.limit
-            response["X-Sentry-Rate-Limit-Reset"] = self.rate_limit_metadata.reset_time
+            response["X-Sentry-Rate-Limit-Limit"] = request.rate_limit_limit
+            response["X-Sentry-Rate-Limit-Reset"] = request.rate_limit_reset
         return response

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -69,8 +69,7 @@ class RatelimitMiddleware(MiddlewareMixin):
             (
                 hasattr(request, "rate_limit_limit"),
                 hasattr(request, "rate_limit_current_count"),
-                request,
-                "rate_limit_reset",
+                hasattr(request, "rate_limit_reset"),
             )
         ):
             remaining_count = (

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -128,12 +128,14 @@ def above_rate_limit_check(key: str, rate_limit: RateLimit) -> RateLimitMeta:
     is_limited, current, reset_time = ratelimiter.is_limited_with_value(
         key, limit=rate_limit.limit, window=rate_limit.window
     )
+    remaining = rate_limit.limit - current if not is_limited else 0
     return RateLimitMeta(
         is_limited=is_limited,
         current=current,
         limit=rate_limit.limit,
         window=rate_limit.window,
         reset_time=reset_time,
+        remaining=remaining,
     )
 
 

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -31,6 +31,7 @@ class RateLimitMeta:
     Attributes:
         is_limited (bool): request is rate limited
         current (int): number of requests done in the current window
+        remaining (int): number of requests left in the current window
         limit (int): max number of requests per window
         window (int): window size in seconds
         reset_time (int): UTC Epoch time in seconds when the current window expires
@@ -38,6 +39,7 @@ class RateLimitMeta:
 
     is_limited: bool
     current: int
+    remaining: int
     limit: int
     window: int
     reset_time: int

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -13,5 +13,20 @@ class RatelimitMiddlewareTest(TestCase):
             expected_reset_time = int(time() + 100)
             return_val = above_rate_limit_check("foo", RateLimit(10, 100))
             assert return_val == RateLimitMeta(
-                is_limited=False, current=1, limit=10, window=100, reset_time=expected_reset_time
+                is_limited=False,
+                current=1,
+                limit=10,
+                window=100,
+                reset_time=expected_reset_time,
+                remaining=9,
+            )
+            for _ in range(10):
+                return_val = above_rate_limit_check("foo", RateLimit(10, 100))
+            assert return_val == RateLimitMeta(
+                is_limited=True,
+                current=11,
+                limit=10,
+                window=100,
+                reset_time=expected_reset_time,
+                remaining=0,
             )


### PR DESCRIPTION
Previously we stored the rate limit header information in a class property of the middleware assuming that each request had it's own instance of the middleware. Turns out that a lot of the requests share the same middleware so every request was thrashing the metadata property.

Instead, I moved the header information to a property of the request. This way the correct header is tied to its request

In order to test, I added the `before_after` library for race condition testing. It allows testers to inject functions at specific points of execution to trigger race conditions. I ran the test against the old code and verified that it would've failed.