### PR TITLE
fix(ui): Show markline at > 0 events on bar chart in issue stream

### DIFF
--- a/static/app/components/stream/groupChart.tsx
+++ b/static/app/components/stream/groupChart.tsx
@@ -60,25 +60,26 @@ function GroupChart({
     series.push({
       seriesName: t('Events'),
       data: stats.map(point => ({name: point[0] * 1000, value: point[1]})),
-      markLine: showMarkLine
-        ? MarkLine({
-            silent: true,
-            lineStyle: {color: theme.gray200, type: 'solid', width: 1},
-            data: [
-              {
-                type: 'max',
+      markLine:
+        showMarkLine && Math.max(...markLinePoint) > 0
+          ? MarkLine({
+              silent: true,
+              lineStyle: {color: theme.gray200, type: 'solid', width: 1},
+              data: [
+                {
+                  type: 'max',
+                },
+              ],
+              label: {
+                show: true,
+                position: 'start',
+                color: `${theme.gray200}`,
+                fontFamily: 'Rubik',
+                fontSize: 10,
+                formatter: `${formattedMarkLine}`,
               },
-            ],
-            label: {
-              show: true,
-              position: 'start',
-              color: `${theme.gray200}`,
-              fontFamily: 'Rubik',
-              fontSize: 10,
-              formatter: `${formattedMarkLine}`,
-            },
-          })
-        : undefined,
+            })
+          : undefined,
     });
   }
 


### PR DESCRIPTION
Show markline at > 0 events on bar chart in issue stream.

[FIXES WOR-1579](https://getsentry.atlassian.net/browse/WOR-1579)

# Before
<img width="210" alt="Screen Shot 2022-01-28 at 1 44 13 AM" src="https://user-images.githubusercontent.com/20312973/151525215-853a47b9-09d6-4385-91aa-36e9bfab4b26.png">

# After
<img width="197" alt="Screen Shot 2022-01-28 at 1 44 50 AM" src="https://user-images.githubusercontent.com/20312973/151525241-d2b25370-6918-4644-b73c-b54eb2b3a777.png">

