### PR TITLE
fix(worker): Pass remaining options to run_worker

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -247,7 +247,7 @@ def worker(ignore_unknown_queues, **options):
     if options["autoreload"]:
         from django.utils import autoreload
 
-        autoreload.run_with_reloader(run_worker, kwargs=options)
+        autoreload.run_with_reloader(run_worker, **options)
     else:
         run_worker(**options)
 


### PR DESCRIPTION
Fix the issue that options is not past to run_worker properly.

Issues：

When you execute `sentry run worker -c 1 --autoreload`, the actual number of worker subprocess is not 1 as expected.