### PR TITLE
fix(perf): Set overflow to auto for performance widget container

### DIFF
--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -134,12 +134,12 @@ function _DataDisplay<T extends WidgetDataConstraint>(
             />
           </ContentContainer>
         ))}
-        loadingComponent={<Placeholder height={`${totalHeight}px`} />}
+        loadingComponent={<PerformanceWidgetPlaceholder height={`${totalHeight}px`} />}
         emptyComponent={
           EmptyComponent ? (
             <EmptyComponent />
           ) : (
-            <Placeholder height={`${totalHeight}px`} />
+            <PerformanceWidgetPlaceholder height={`${totalHeight}px`} />
           )
         }
       />
@@ -168,6 +168,12 @@ const ContentContainer = styled('div')<{noPadding?: boolean; bottomPadding?: boo
   padding-left: ${p => (p.noPadding ? space(0) : space(2))};
   padding-right: ${p => (p.noPadding ? space(0) : space(2))};
   padding-bottom: ${p => (p.bottomPadding ? space(1) : space(0))};
+`;
+
+const PerformanceWidgetPlaceholder = styled(Placeholder)`
+  border-color: transparent;
+  border-bottom-right-radius: inherit;
+  border-bottom-left-radius: inherit;
 `;
 
 GenericPerformanceWidget.defaultProps = {

--- a/static/app/views/performance/landing/widgets/components/performanceWidgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidgetContainer.tsx
@@ -8,8 +8,11 @@ export type PerformanceWidgetContainerTypes = 'panel' | 'inline';
 const StyledPanel = styled(Panel)`
   padding-top: ${space(2)};
   margin-bottom: 0;
+  overflow: auto;
 `;
-const Div = styled('div')``;
+const Div = styled('div')`
+  overflow: auto;
+`;
 
 const getPerformanceWidgetContainer = ({
   containerType,

--- a/static/app/views/performance/landing/widgets/components/performanceWidgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidgetContainer.tsx
@@ -8,11 +8,8 @@ export type PerformanceWidgetContainerTypes = 'panel' | 'inline';
 const StyledPanel = styled(Panel)`
   padding-top: ${space(2)};
   margin-bottom: 0;
-  overflow: auto;
 `;
-const Div = styled('div')`
-  overflow: auto;
-`;
+const Div = styled('div')``;
 
 const getPerformanceWidgetContainer = ({
   containerType,


### PR DESCRIPTION
Set container overflow to auto so that `Placeholder` component's overflow does not clip containers bottom border.

Before:
<img width="686" alt="Screen Shot 2022-01-28 at 11 46 34 AM" src="https://user-images.githubusercontent.com/23648387/151589796-fd478bf2-fbea-4452-8bba-091c48f00f2a.png">

After:
<img width="321" alt="Screen Shot 2022-01-28 at 11 50 03 AM" src="https://user-images.githubusercontent.com/23648387/151589800-1de84713-2e2c-44a5-968d-02b6cb1719a3.png">
