### PR TITLE
feat(dashboards): Add an event when adding previewed template

### DIFF
--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -38,6 +38,7 @@ export type DashboardsEventParameters = {
   };
   'dashboards_manage.templates.add': {
     dashboard_id: string;
+    was_previewed: boolean;
   };
   'dashboards_manage.templates.preview': {
     dashboard_id: string;

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -23,6 +23,7 @@ import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -350,6 +351,13 @@ class DashboardDetail extends Component<Props, State> {
       case DashboardState.PREVIEW:
       case DashboardState.CREATE: {
         if (modifiedDashboard) {
+          if (this.isPreview) {
+            trackAdvancedAnalyticsEvent('dashboards_manage.templates.add', {
+              organization,
+              dashboard_id: dashboard.id,
+              was_previewed: true,
+            });
+          }
           createDashboard(api, organization.slug, modifiedDashboard, this.isPreview).then(
             (newDashboard: DashboardDetails) => {
               addSuccessMessage(t('Dashboard created'));

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -229,6 +229,7 @@ class ManageDashboards extends AsyncView<Props, State> {
     trackAdvancedAnalyticsEvent('dashboards_manage.templates.add', {
       organization,
       dashboard_id: dashboard.id,
+      was_previewed: false,
     });
 
     await createDashboard(api, organization.slug, dashboard, true);


### PR DESCRIPTION
- This adds an additional event when a previewed dashboard template is
  added to the list of dashboards
  - along with an additional property so we can distinguish between the
    management page and the preview page