### PR TITLE
feat(dashboard-layout): Change placeholder colour to purple200

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -666,6 +666,10 @@ const GridLayout = styled(WidthProvider(Responsive))`
   .react-grid-item > .react-resizable-handle::after {
     border: none;
   }
+
+  .react-grid-item.react-grid-placeholder {
+    background: ${p => p.theme.purple200};
+  }
 `;
 
 const ResizeHandle = styled('div')`


### PR DESCRIPTION
The original placeholder was red, which makes people think "this is an invalid placement". Change it to our purple200 to match our theme and avoid that feeling.

After:
![Screen Shot 2022-01-28 at 1 14 11 PM (2)](https://user-images.githubusercontent.com/22846452/151602754-f5c2524a-f1eb-4741-9ff1-31ca19c1f81e.png)

![Screen Shot 2022-01-28 at 1 12 31 PM (2)](https://user-images.githubusercontent.com/22846452/151602765-3f6ff35d-9263-4ba5-b31f-f87dbb41c2e8.png)

