### PR TITLE
fix(discover): Incorrect tag name cause of - vs _

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -421,7 +421,7 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
         if not self.has_feature(organization, request):
             return Response(status=404)
         use_snql = self.has_snql_feature(organization, request)
-        sentry_sdk.set_tag("discover.use-snql", use_snql)
+        sentry_sdk.set_tag("discover.use_snql", use_snql)
 
         try:
             params = self.get_snuba_params(request, organization)


### PR DESCRIPTION
- This tag is `discover.use_snql` everywhere else, and was accidentally `discover.use-snql` on the trends endpoint