### PR TITLE
ref(ui): Use DropdownMenuV2 for ignore & resolve dropdowns

### DIFF
--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -45,22 +45,16 @@ const IgnoreActions = ({
   isIgnored = false,
 }: Props) => {
   const onIgnore = (statusDetails: ResolutionStatusDetails) => {
-    if (shouldConfirm) {
-      openConfirmModal({
-        onConfirm: () =>
-          onUpdate({
-            status: ResolutionStatus.IGNORED,
-            statusDetails: statusDetails || {},
-          }),
-        message: confirmMessage,
-        confirmText: confirmLabel,
-      });
-    } else {
-      onUpdate({
-        status: ResolutionStatus.IGNORED,
-        statusDetails: statusDetails || {},
-      });
-    }
+    openConfirmModal({
+      bypass: !shouldConfirm,
+      onConfirm: () =>
+        onUpdate({
+          status: ResolutionStatus.IGNORED,
+          statusDetails: statusDetails || {},
+        }),
+      message: confirmMessage,
+      confirmText: confirmLabel,
+    });
   };
 
   const onCustomIgnore = (statusDetails: ResolutionStatusDetails) => {

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -44,13 +44,13 @@ const IgnoreActions = ({
   confirmLabel = t('Ignore'),
   isIgnored = false,
 }: Props) => {
-  const onIgnore = (statusDetails: ResolutionStatusDetails) => {
+  const onIgnore = (statusDetails?: ResolutionStatusDetails) => {
     openConfirmModal({
       bypass: !shouldConfirm,
       onConfirm: () =>
         onUpdate({
           status: ResolutionStatus.IGNORED,
-          statusDetails: statusDetails || {},
+          statusDetails,
         }),
       message: confirmMessage,
       confirmText: confirmLabel,
@@ -59,14 +59,6 @@ const IgnoreActions = ({
 
   const onCustomIgnore = (statusDetails: ResolutionStatusDetails) => {
     onIgnore(statusDetails);
-  };
-
-  const actionLinkProps = {
-    shouldConfirm,
-    title: t('Ignore'),
-    message: confirmMessage,
-    confirmLabel,
-    disabled,
   };
 
   if (isIgnored) {
@@ -212,14 +204,14 @@ const IgnoreActions = ({
   return (
     <ButtonBar merged>
       <IgnoreButton
-        {...actionLinkProps}
         size="xsmall"
         tooltipProps={{delay: 300}}
         title={t(
           'Silences alerts for this issue and removes it from the issue stream by default.'
         )}
-        onClick={() => onUpdate({status: ResolutionStatus.IGNORED})}
         icon={<IconMute size="xs" />}
+        onClick={() => onIgnore()}
+        disabled={disabled}
       >
         {t('Ignore')}
       </IgnoreButton>

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -1,27 +1,23 @@
 import * as React from 'react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
-import ActionLink from 'sentry/components/actions/actionLink';
+import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
+import {openConfirmModal} from 'sentry/components/confirm';
 import CustomIgnoreCountModal from 'sentry/components/customIgnoreCountModal';
 import CustomIgnoreDurationModal from 'sentry/components/customIgnoreDurationModal';
-import DropdownLink from 'sentry/components/dropdownLink';
+import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
 import Duration from 'sentry/components/duration';
 import Tooltip from 'sentry/components/tooltip';
 import {IconChevron, IconMute} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
-import space from 'sentry/styles/space';
 import {
   ResolutionStatus,
   ResolutionStatusDetails,
   SelectValue,
   UpdateResolutionStatus,
 } from 'sentry/types';
-
-import ActionButton from './button';
-import MenuHeader from './menuHeader';
 
 const IGNORE_DURATIONS = [30, 120, 360, 60 * 24, 60 * 24 * 7];
 const IGNORE_COUNTS = [1, 10, 100, 1000, 10000, 100000];
@@ -49,10 +45,22 @@ const IgnoreActions = ({
   isIgnored = false,
 }: Props) => {
   const onIgnore = (statusDetails: ResolutionStatusDetails) => {
-    return onUpdate({
-      status: ResolutionStatus.IGNORED,
-      statusDetails: statusDetails || {},
-    });
+    if (shouldConfirm) {
+      openConfirmModal({
+        onConfirm: () =>
+          onUpdate({
+            status: ResolutionStatus.IGNORED,
+            statusDetails: statusDetails || {},
+          }),
+        message: confirmMessage,
+        confirmText: confirmLabel,
+      });
+    } else {
+      onUpdate({
+        status: ResolutionStatus.IGNORED,
+        statusDetails: statusDetails || {},
+      });
+    }
   };
 
   const onCustomIgnore = (statusDetails: ResolutionStatusDetails) => {
@@ -70,8 +78,9 @@ const IgnoreActions = ({
   if (isIgnored) {
     return (
       <Tooltip title={t('Change status to unresolved')}>
-        <ActionButton
+        <Button
           priority="primary"
+          size="xsmall"
           onClick={() => onUpdate({status: ResolutionStatus.UNRESOLVED})}
           aria-label={t('Unignore')}
           icon={<IconMute size="xs" />}
@@ -114,280 +123,139 @@ const IgnoreActions = ({
       />
     ));
 
+  const dropdownItems = [
+    {
+      key: 'for',
+      label: t('For\u2026'),
+      isSubmenu: true,
+      children: [
+        ...IGNORE_DURATIONS.map(duration => ({
+          key: `for-${duration}`,
+          label: <Duration seconds={duration * 60} />,
+          onAction: () => onIgnore({ignoreDuration: duration}),
+        })),
+        {
+          key: 'for-custom',
+          label: t('Custom'),
+          onAction: () => openCustomIgnoreDuration(),
+        },
+      ],
+    },
+    {
+      key: 'until-reoccur',
+      label: t('Until this occurs again\u2026'),
+      isSubmenu: true,
+      children: [
+        ...IGNORE_COUNTS.map(count => ({
+          key: `until-reoccur-${count}-times`,
+          label:
+            count === 1
+              ? t('one time\u2026') // This is intentional as unbalanced string formatters are problematic
+              : tn('%s time\u2026', '%s times\u2026', count),
+          isSubmenu: true,
+          children: [
+            {
+              key: `until-reoccur-${count}-times-from-now`,
+              label: t('from now'),
+              onAction: () => onIgnore({ignoreCount: count}),
+            },
+            ...IGNORE_WINDOWS.map(({value, label}) => ({
+              key: `until-reoccur-${count}-times-from-${label}`,
+              label,
+              onAction: () =>
+                onIgnore({
+                  ignoreCount: count,
+                  ignoreWindow: value,
+                }),
+            })),
+          ],
+        })),
+        {
+          key: 'for-custom',
+          label: t('Custom'),
+          onAction: () => openCustomIgnoreCount(),
+        },
+      ],
+    },
+    {
+      key: 'until-affect',
+      label: t('Until this affects an additional\u2026'),
+      isSubmenu: true,
+      children: [
+        ...IGNORE_COUNTS.map(count => ({
+          key: `until-affect-${count}-users`,
+          label:
+            count === 1
+              ? t('one user\u2026') // This is intentional as unbalanced string formatters are problematic
+              : tn('%s user\u2026', '%s users\u2026', count),
+          isSubmenu: true,
+          children: [
+            {
+              key: `until-affect-${count}-users-from-now`,
+              label: t('from now'),
+              onAction: () => onIgnore({ignoreUserCount: count}),
+            },
+            ...IGNORE_WINDOWS.map(({value, label}) => ({
+              key: `until-affect-${count}-users-from-${label}`,
+              label,
+              onAction: () =>
+                onIgnore({
+                  ignoreUserCount: count,
+                  ignoreUserWindow: value,
+                }),
+            })),
+          ],
+        })),
+        {
+          key: 'for-custom',
+          label: t('Custom'),
+          onAction: () => openCustomIgnoreUserCount(),
+        },
+      ],
+    },
+  ];
+
   return (
     <ButtonBar merged>
-      <Tooltip
-        disabled={actionLinkProps.disabled}
+      <IgnoreButton
+        {...actionLinkProps}
+        size="xsmall"
+        tooltipProps={{delay: 300}}
         title={t(
           'Silences alerts for this issue and removes it from the issue stream by default.'
         )}
-        delay={300}
+        onClick={() => onUpdate({status: ResolutionStatus.IGNORED})}
+        icon={<IconMute size="xs" />}
       >
-        <ActionLink
-          {...actionLinkProps}
-          type="button"
-          title={t('Ignore')}
-          onAction={() => onUpdate({status: ResolutionStatus.IGNORED})}
-          icon={<IconMute size="xs" />}
-          hasDropdown
-        >
-          {t('Ignore')}
-        </ActionLink>
-      </Tooltip>
-      <StyledDropdownLink
-        customTitle={
-          <StyledActionButton
-            disabled={disabled}
-            icon={<IconChevron direction="down" size="xs" />}
+        {t('Ignore')}
+      </IgnoreButton>
+      <DropdownMenuControlV2
+        trigger={({props: triggerProps, ref: triggerRef}) => (
+          <DropdownTrigger
+            ref={triggerRef}
+            {...triggerProps}
+            size="xsmall"
             aria-label={t('Ignore options')}
+            icon={<IconChevron direction="down" size="xs" />}
+            disabled={disabled}
           />
-        }
-        alwaysRenderMenu
-        disabled={disabled}
-      >
-        <MenuHeader>{t('Ignore')}</MenuHeader>
-
-        <DropdownMenuItem>
-          <DropdownLink
-            title={
-              <ActionSubMenu>
-                {t('For\u2026')}
-                <SubMenuChevron>
-                  <IconChevron direction="right" size="xs" />
-                </SubMenuChevron>
-              </ActionSubMenu>
-            }
-            caret={false}
-            isNestedDropdown
-            alwaysRenderMenu
-          >
-            {IGNORE_DURATIONS.map(duration => (
-              <DropdownMenuItem key={duration}>
-                <StyledForActionLink
-                  {...actionLinkProps}
-                  onAction={() => onIgnore({ignoreDuration: duration})}
-                >
-                  <ActionSubMenu>
-                    <Duration seconds={duration * 60} />
-                  </ActionSubMenu>
-                </StyledForActionLink>
-              </DropdownMenuItem>
-            ))}
-            <DropdownMenuItem>
-              <ActionSubMenu>
-                <a onClick={openCustomIgnoreDuration}>{t('Custom')}</a>
-              </ActionSubMenu>
-            </DropdownMenuItem>
-          </DropdownLink>
-        </DropdownMenuItem>
-
-        <DropdownMenuItem>
-          <DropdownLink
-            title={
-              <ActionSubMenu>
-                {t('Until this occurs again\u2026')}
-                <SubMenuChevron>
-                  <IconChevron direction="right" size="xs" />
-                </SubMenuChevron>
-              </ActionSubMenu>
-            }
-            caret={false}
-            isNestedDropdown
-            alwaysRenderMenu
-          >
-            {IGNORE_COUNTS.map(count => (
-              <DropdownMenuItem key={count}>
-                <DropdownLink
-                  title={
-                    <ActionSubMenu>
-                      {count === 1
-                        ? t('one time\u2026') // This is intentional as unbalanced string formatters are problematic
-                        : tn('%s time\u2026', '%s times\u2026', count)}
-                      <SubMenuChevron>
-                        <IconChevron direction="right" size="xs" />
-                      </SubMenuChevron>
-                    </ActionSubMenu>
-                  }
-                  caret={false}
-                  isNestedDropdown
-                  alwaysRenderMenu
-                >
-                  <DropdownMenuItem>
-                    <StyledActionLink
-                      {...actionLinkProps}
-                      onAction={() => onIgnore({ignoreCount: count})}
-                    >
-                      {t('from now')}
-                    </StyledActionLink>
-                  </DropdownMenuItem>
-                  {IGNORE_WINDOWS.map(({value, label}) => (
-                    <DropdownMenuItem key={value}>
-                      <StyledActionLink
-                        {...actionLinkProps}
-                        onAction={() =>
-                          onIgnore({
-                            ignoreCount: count,
-                            ignoreWindow: value,
-                          })
-                        }
-                      >
-                        {label}
-                      </StyledActionLink>
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownLink>
-              </DropdownMenuItem>
-            ))}
-            <DropdownMenuItem>
-              <ActionSubMenu>
-                <a onClick={openCustomIgnoreCount}>{t('Custom')}</a>
-              </ActionSubMenu>
-            </DropdownMenuItem>
-          </DropdownLink>
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <DropdownLink
-            title={
-              <ActionSubMenu>
-                {t('Until this affects an additional\u2026')}
-                <SubMenuChevron>
-                  <IconChevron direction="right" size="xs" />
-                </SubMenuChevron>
-              </ActionSubMenu>
-            }
-            caret={false}
-            isNestedDropdown
-            alwaysRenderMenu
-          >
-            {IGNORE_COUNTS.map(count => (
-              <DropdownMenuItem key={count}>
-                <DropdownLink
-                  title={
-                    <ActionSubMenu>
-                      {count === 1
-                        ? t('one user\u2026') // This is intentional as unbalanced string formatters are problematic
-                        : tn('%s user\u2026', '%s users\u2026', count)}
-                      <SubMenuChevron>
-                        <IconChevron direction="right" size="xs" />
-                      </SubMenuChevron>
-                    </ActionSubMenu>
-                  }
-                  caret={false}
-                  isNestedDropdown
-                  alwaysRenderMenu
-                >
-                  <DropdownMenuItem>
-                    <StyledActionLink
-                      {...actionLinkProps}
-                      onAction={() => onIgnore({ignoreUserCount: count})}
-                    >
-                      {t('from now')}
-                    </StyledActionLink>
-                  </DropdownMenuItem>
-                  {IGNORE_WINDOWS.map(({value, label}) => (
-                    <DropdownMenuItem key={value}>
-                      <StyledActionLink
-                        {...actionLinkProps}
-                        onAction={() =>
-                          onIgnore({
-                            ignoreUserCount: count,
-                            ignoreUserWindow: value,
-                          })
-                        }
-                      >
-                        {label}
-                      </StyledActionLink>
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownLink>
-              </DropdownMenuItem>
-            ))}
-            <DropdownMenuItem>
-              <ActionSubMenu>
-                <a onClick={openCustomIgnoreUserCount}>{t('Custom')}</a>
-              </ActionSubMenu>
-            </DropdownMenuItem>
-          </DropdownLink>
-        </DropdownMenuItem>
-      </StyledDropdownLink>
+        )}
+        menuTitle={t('Ignore')}
+        items={dropdownItems}
+      />
     </ButtonBar>
   );
 };
 
 export default IgnoreActions;
 
-const actionLinkCss = p => css`
-  color: ${p.theme.subText};
-  &:hover {
-    border-radius: ${p.theme.borderRadius};
-    background: ${p.theme.bodyBackground} !important;
-  }
-`;
-
-const StyledActionLink = styled(ActionLink)`
-  padding: 7px 10px !important;
-  ${actionLinkCss};
-`;
-
-const StyledForActionLink = styled(ActionLink)`
-  padding: ${space(0.5)} 0;
-  ${actionLinkCss};
-`;
-
-const StyledActionButton = styled(ActionButton)`
+const IgnoreButton = styled(Button)`
   box-shadow: none;
+  border-radius: ${p => p.theme.borderRadiusLeft};
 `;
 
-const StyledDropdownLink = styled(DropdownLink)`
-  transition: none;
-  border-top-left-radius: 0 !important;
-  border-bottom-left-radius: 0 !important;
-`;
-
-const DropdownMenuItem = styled('li')`
-  :not(:last-child) {
-    border-bottom: 1px solid ${p => p.theme.innerBorder};
-  }
-  > span {
-    display: block;
-    > ul {
-      border-radius: ${p => p.theme.borderRadius};
-      top: 5px;
-      left: 100%;
-      margin-top: -5px;
-      margin-left: -1px;
-      &:after,
-      &:before {
-        display: none !important;
-      }
-    }
-  }
-  &:hover > span {
-    background: ${p => p.theme.hover};
-  }
-`;
-
-const ActionSubMenu = styled('span')`
-  display: grid;
-  grid-template-columns: 200px 1fr;
-  grid-column-start: 1;
-  grid-column-end: 4;
-  gap: ${space(1)};
-  padding: ${space(0.5)} 0;
-  color: ${p => p.theme.textColor};
-  a {
-    color: ${p => p.theme.textColor};
-  }
-`;
-
-const SubMenuChevron = styled('span')`
-  display: grid;
-  align-self: center;
-  color: ${p => p.theme.gray300};
-  transition: 0.1s color linear;
-
-  &:hover,
-  &:active {
-    color: ${p => p.theme.subText};
-  }
+const DropdownTrigger = styled(Button)`
+  box-shadow: none;
+  border-radius: ${p => p.theme.borderRadiusRight};
+  border-left: none;
 `;

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -220,9 +220,6 @@ const IgnoreActions = ({
           <DropdownTrigger
             ref={triggerRef}
             {...triggerProps}
-            // to prevent prop type warning due to
-            // ConditionalAriaLabel in button.tsx
-            children={null}
             aria-label={t('Ignore options')}
             size="xsmall"
             icon={<IconChevron direction="down" size="xs" />}

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -220,8 +220,11 @@ const IgnoreActions = ({
           <DropdownTrigger
             ref={triggerRef}
             {...triggerProps}
-            size="xsmall"
+            // to prevent prop type warning due to
+            // ConditionalAriaLabel in button.tsx
+            children={null}
             aria-label={t('Ignore options')}
+            size="xsmall"
             icon={<IconChevron direction="down" size="xs" />}
             disabled={disabled}
           />

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -133,15 +133,12 @@ class ResolveActions extends React.Component<Props> {
       : '';
 
     const onActionOrConfirm = onAction => {
-      if (shouldConfirm) {
-        openConfirmModal({
-          onConfirm: onAction,
-          message: confirmMessage,
-          confirmText: confirmLabel,
-        });
-      } else {
-        onAction();
-      }
+      openConfirmModal({
+        bypass: !shouldConfirm,
+        onConfirm: onAction,
+        message: confirmMessage,
+        confirmText: confirmLabel,
+      });
     };
 
     const items = [

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
-import ActionLink from 'sentry/components/actions/actionLink';
+import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
+import {openConfirmModal} from 'sentry/components/confirm';
 import CustomResolutionModal from 'sentry/components/customResolutionModal';
-import DropdownLink from 'sentry/components/dropdownLink';
+import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
 import Tooltip from 'sentry/components/tooltip';
 import {IconCheckmark, IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -19,10 +20,6 @@ import {
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {formatVersion} from 'sentry/utils/formatters';
 import withOrganization from 'sentry/utils/withOrganization';
-
-import ActionButton from './button';
-import MenuHeader from './menuHeader';
-import MenuItemActionLink from './menuItemActionLink';
 
 const defaultProps = {
   isResolved: false,
@@ -102,8 +99,9 @@ class ResolveActions extends React.Component<Props> {
             : t('Unresolve')
         }
       >
-        <ActionButton
+        <Button
           priority="primary"
+          size="xsmall"
           icon={<IconCheckmark size="xs" />}
           aria-label={t('Unresolve')}
           disabled={isAutoResolved}
@@ -134,61 +132,62 @@ class ResolveActions extends React.Component<Props> {
       ? t('Set up release tracking in order to use this feature.')
       : '';
 
-    const actionLinkProps = {
-      shouldConfirm,
-      message: confirmMessage,
-      confirmLabel,
-      disabled: disabled || !hasRelease,
+    const onActionOrConfirm = onAction => {
+      if (shouldConfirm) {
+        openConfirmModal({
+          onConfirm: onAction,
+          message: confirmMessage,
+          confirmText: confirmLabel,
+        });
+      } else {
+        onAction();
+      }
     };
 
+    const items = [
+      {
+        key: 'next-release',
+        label: t('The next release'),
+        details: actionTitle,
+        onAction: () => onActionOrConfirm(this.handleNextReleaseResolution),
+        showDividers: !hasRelease,
+      },
+      {
+        key: 'current-release',
+        label: latestRelease
+          ? t('The current release (%s)', formatVersion(latestRelease.version))
+          : t('The current release'),
+        details: actionTitle,
+        onAction: () => onActionOrConfirm(this.handleCurrentReleaseResolution),
+        showDividers: !hasRelease,
+      },
+      {
+        key: 'another-release',
+        label: t('Another existing release\u2026'),
+        onAction: () => this.openCustomReleaseModal(),
+      },
+    ];
+
     return (
-      <DropdownLink
-        customTitle={
-          <StyledActionButton
+      <DropdownMenuControlV2
+        items={items}
+        trigger={({props: triggerProps, ref: triggerRef}) => (
+          <DropdownTrigger
+            ref={triggerRef}
+            {...triggerProps}
+            size="xsmall"
             aria-label={t('More resolve options')}
-            disabled={!projectSlug ? disabled : disableDropdown}
             icon={<IconChevron direction="down" size="xs" />}
+            disabled={!projectSlug ? disabled : disableDropdown}
           />
+        )}
+        disabledKeys={
+          disabled || !hasRelease
+            ? ['next-release', 'current-release', 'another-release']
+            : []
         }
-        caret={false}
-        alwaysRenderMenu
-        disabled={!projectSlug ? disabled : disableDropdown}
-      >
-        <MenuHeader>{t('Resolved In')}</MenuHeader>
-
-        <MenuItemActionLink
-          {...actionLinkProps}
-          title={t('The next release')}
-          onAction={this.handleNextReleaseResolution}
-        >
-          <Tooltip disabled={hasRelease} title={actionTitle}>
-            {t('The next release')}
-          </Tooltip>
-        </MenuItemActionLink>
-
-        <MenuItemActionLink
-          {...actionLinkProps}
-          title={t('The current release')}
-          onAction={this.handleCurrentReleaseResolution}
-        >
-          <Tooltip disabled={hasRelease} title={actionTitle}>
-            {latestRelease
-              ? t('The current release (%s)', formatVersion(latestRelease.version))
-              : t('The current release')}
-          </Tooltip>
-        </MenuItemActionLink>
-
-        <MenuItemActionLink
-          {...actionLinkProps}
-          title={t('Another existing release')}
-          onAction={() => hasRelease && this.openCustomReleaseModal()}
-          shouldConfirm={false}
-        >
-          <Tooltip disabled={hasRelease} title={actionTitle}>
-            {t('Another existing release')}
-          </Tooltip>
-        </MenuItemActionLink>
-      </DropdownLink>
+        menuTitle={t('Resolved In')}
+      />
     );
   }
 
@@ -232,24 +231,18 @@ class ResolveActions extends React.Component<Props> {
     return (
       <Tooltip disabled={!projectFetchError} title={t('Error fetching project')}>
         <ButtonBar merged>
-          <Tooltip
-            disabled={actionLinkProps.disabled}
+          <ResolveButton
+            {...actionLinkProps}
+            size="xsmall"
             title={t(
               'Resolves the issue. The issue will get unresolved if it happens again.'
             )}
-            delay={300}
+            tooltipProps={{delay: 300}}
+            icon={<IconCheckmark size="xs" />}
+            onClick={() => onUpdate({status: ResolutionStatus.RESOLVED})}
           >
-            <ActionLink
-              {...actionLinkProps}
-              type="button"
-              title={t('Resolve')}
-              icon={<IconCheckmark size="xs" />}
-              onAction={() => onUpdate({status: ResolutionStatus.RESOLVED})}
-              hasDropdown
-            >
-              {t('Resolve')}
-            </ActionLink>
-          </Tooltip>
+            {t('Resolve')}
+          </ResolveButton>
           {this.renderDropdownMenu()}
         </ButtonBar>
       </Tooltip>
@@ -259,6 +252,13 @@ class ResolveActions extends React.Component<Props> {
 
 export default withOrganization(ResolveActions);
 
-const StyledActionButton = styled(ActionButton)`
+const ResolveButton = styled(Button)`
   box-shadow: none;
+  border-radius: ${p => p.theme.borderRadiusLeft};
+`;
+
+const DropdownTrigger = styled(Button)`
+  box-shadow: none;
+  border-radius: ${p => p.theme.borderRadiusRight};
+  border-left: none;
 `;

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -218,25 +218,26 @@ class ResolveActions extends React.Component<Props> {
       return this.renderResolved();
     }
 
-    const actionLinkProps = {
-      shouldConfirm,
-      message: confirmMessage,
-      confirmLabel,
-      disabled,
-    };
+    const onResolve = () =>
+      openConfirmModal({
+        bypass: !shouldConfirm,
+        onConfirm: () => onUpdate({status: ResolutionStatus.RESOLVED}),
+        message: confirmMessage,
+        confirmText: confirmLabel,
+      });
 
     return (
       <Tooltip disabled={!projectFetchError} title={t('Error fetching project')}>
         <ButtonBar merged>
           <ResolveButton
-            {...actionLinkProps}
             size="xsmall"
             title={t(
               'Resolves the issue. The issue will get unresolved if it happens again.'
             )}
             tooltipProps={{delay: 300}}
             icon={<IconCheckmark size="xs" />}
-            onClick={() => onUpdate({status: ResolutionStatus.RESOLVED})}
+            onClick={onResolve}
+            disabled={disabled}
           >
             {t('Resolve')}
           </ResolveButton>

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -172,9 +172,6 @@ class ResolveActions extends React.Component<Props> {
           <DropdownTrigger
             ref={triggerRef}
             {...triggerProps}
-            // to prevent prop type warning due to
-            // ConditionalAriaLabel in button.tsx
-            children={null}
             aria-label={t('More resolve options')}
             size="xsmall"
             icon={<IconChevron direction="down" size="xs" />}

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -172,8 +172,11 @@ class ResolveActions extends React.Component<Props> {
           <DropdownTrigger
             ref={triggerRef}
             {...triggerProps}
-            size="xsmall"
+            // to prevent prop type warning due to
+            // ConditionalAriaLabel in button.tsx
+            children={null}
             aria-label={t('More resolve options')}
+            size="xsmall"
             icon={<IconChevron direction="down" size="xs" />}
             disabled={!projectSlug ? disabled : disableDropdown}
           />

--- a/static/app/components/dropdownMenuControlV2.tsx
+++ b/static/app/components/dropdownMenuControlV2.tsx
@@ -12,7 +12,7 @@ import {MenuItemProps} from 'sentry/components/dropdownMenuItemV2';
 import Menu from 'sentry/components/dropdownMenuV2';
 
 type TriggerProps = {
-  props: React.HTMLAttributes<Element> & {
+  props: Omit<React.HTMLAttributes<Element>, 'children'> & {
     onClick?: (e: MouseEvent) => void;
   };
   ref: React.RefObject<HTMLButtonElement>;

--- a/static/app/components/dropdownMenuControlV2.tsx
+++ b/static/app/components/dropdownMenuControlV2.tsx
@@ -121,7 +121,7 @@ function MenuControl({
 
   const renderTrigger = isOpen => {
     if (trigger) {
-      return trigger({props: {...buttonProps, isOpen: state.isOpen}, ref});
+      return trigger({props: {...buttonProps, isOpen}, ref});
     }
     return (
       <DropdownButton

--- a/static/app/components/dropdownMenuControlV2.tsx
+++ b/static/app/components/dropdownMenuControlV2.tsx
@@ -119,14 +119,21 @@ function MenuControl({
     ref
   );
 
-  const renderTrigger = isOpen => {
+  function renderTrigger() {
     if (trigger) {
-      return trigger({props: {...buttonProps, isOpen}, ref});
+      return trigger({
+        props: {
+          ...triggerProps,
+          ...buttonProps,
+          isOpen: state.isOpen,
+        },
+        ref,
+      });
     }
     return (
       <DropdownButton
         ref={ref}
-        isOpen={isOpen}
+        isOpen={state.isOpen}
         disabled={isDisabled}
         {...triggerProps}
         {...buttonProps}
@@ -134,10 +141,10 @@ function MenuControl({
         {triggerLabel}
       </DropdownButton>
     );
-  };
+  }
 
-  const renderMenu = isOpen => {
-    if (!isOpen) {
+  function renderMenu() {
+    if (!state.isOpen) {
       return null;
     }
 
@@ -165,18 +172,18 @@ function MenuControl({
         }}
       </Menu>
     );
-  };
+  }
 
   return (
-    <Wrap className={className} as={renderWrapAs} role="presentation">
-      {renderTrigger(state.isOpen)}
-      {renderMenu(state.isOpen)}
-    </Wrap>
+    <MenuControlWrap className={className} as={renderWrapAs} role="presentation">
+      {renderTrigger()}
+      {renderMenu()}
+    </MenuControlWrap>
   );
 }
 
 export default MenuControl;
 
-const Wrap = styled('div')`
+const MenuControlWrap = styled('div')`
   list-style-type: none;
 `;

--- a/static/app/components/dropdownMenuControlV2.tsx
+++ b/static/app/components/dropdownMenuControlV2.tsx
@@ -12,7 +12,7 @@ import {MenuItemProps} from 'sentry/components/dropdownMenuItemV2';
 import Menu from 'sentry/components/dropdownMenuV2';
 
 type TriggerProps = {
-  props: React.HTMLAttributes<HTMLButtonElement> & {
+  props: React.HTMLAttributes<Element> & {
     onClick?: (e: MouseEvent) => void;
   };
   ref: React.RefObject<HTMLButtonElement>;

--- a/static/app/components/dropdownMenuItemV2.tsx
+++ b/static/app/components/dropdownMenuItemV2.tsx
@@ -193,7 +193,7 @@ const MenuItem = forwardRef<React.RefObject<HTMLLIElement>, Props>(
     const showDividers = item.showDividers && !isLastNode;
 
     return (
-      <Wrap
+      <MenuItemWrap
         ref={ref}
         as={renderAs}
         isDisabled={isDisabled}
@@ -233,14 +233,14 @@ const MenuItem = forwardRef<React.RefObject<HTMLLIElement>, Props>(
             )}
           </ContentWrap>
         </InnerWrap>
-      </Wrap>
+      </MenuItemWrap>
     );
   }
 );
 
 export default MenuItem;
 
-const Wrap = styled('li')<{isDisabled?: boolean}>`
+const MenuItemWrap = styled('li')<{isDisabled?: boolean}>`
   position: static;
   list-style-type: none;
   margin: 0;

--- a/static/app/components/dropdownMenuItemV2.tsx
+++ b/static/app/components/dropdownMenuItemV2.tsx
@@ -1,4 +1,4 @@
-import {forwardRef, Fragment, useEffect, useRef, useState} from 'react';
+import {forwardRef, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useHover, useKeyboard} from '@react-aria/interactions';
 import {useMenuItem} from '@react-aria/menu';
@@ -44,9 +44,9 @@ export type MenuItemProps = {
    */
   leadingItems?: React.ReactNode;
   /*
-   * Whether leading items should be centered wrt/ the entire height of the
-   * menu item. If false (default), they will be centered wrt/ the first line of the
-   * label element.
+   * Whether leading items should be centered with respect to the entire
+   * height of the menu item. If false (default), they will be centered with
+   * respect to the first line of the label element.
    */
   leadingItemsSpanFullHeight?: boolean;
   /*
@@ -133,9 +133,9 @@ const MenuItem = forwardRef<React.RefObject<HTMLLIElement>, Props>(
     const actionHandler = () => {
       if (isSubmenuTrigger) {
         state.selectionManager.select(node.key);
-      } else {
-        item.onAction?.(item.key);
+        return;
       }
+      item.onAction?.(item.key);
     };
 
     // Open submenu on hover
@@ -193,49 +193,47 @@ const MenuItem = forwardRef<React.RefObject<HTMLLIElement>, Props>(
     const showDividers = item.showDividers && !isLastNode;
 
     return (
-      <Fragment>
-        <Wrap
-          ref={ref}
-          as={renderAs}
-          isDisabled={isDisabled}
-          {...props}
-          {...(isSubmenuTrigger && {role: 'menuitemradio'})}
-        >
-          <InnerWrap isFocused={isFocused} role="presentation">
-            {leadingItems && (
-              <LeadingItems
-                isDisabled={isDisabled}
-                spanFullHeight={leadingItemsSpanFullHeight}
-              >
-                {leadingItems}
-              </LeadingItems>
-            )}
-            <ContentWrap
-              isFocused={isFocused}
-              showDividers={showDividers}
-              role="presentation"
+      <Wrap
+        ref={ref}
+        as={renderAs}
+        isDisabled={isDisabled}
+        {...props}
+        {...(isSubmenuTrigger && {role: 'menuitemradio'})}
+      >
+        <InnerWrap isFocused={isFocused} role="presentation">
+          {leadingItems && (
+            <LeadingItems
+              isDisabled={isDisabled}
+              spanFullHeight={leadingItemsSpanFullHeight}
             >
-              <LabelWrap role="presentation">
-                <Label isDisabled={isDisabled} {...labelProps} aria-hidden="true">
-                  {label}
-                </Label>
-                {details && <Details {...descriptionProps}>{details}</Details>}
-              </LabelWrap>
-              {(trailingItems || isSubmenuTrigger) && (
-                <TrailingItems
-                  isDisabled={isDisabled}
-                  spanFullHeight={trailingItemsSpanFullHeight}
-                >
-                  {trailingItems}
-                  {isSubmenuTrigger && (
-                    <IconChevron size="xs" direction="right" aria-hidden="true" />
-                  )}
-                </TrailingItems>
-              )}
-            </ContentWrap>
-          </InnerWrap>
-        </Wrap>
-      </Fragment>
+              {leadingItems}
+            </LeadingItems>
+          )}
+          <ContentWrap
+            isFocused={isFocused}
+            showDividers={showDividers}
+            role="presentation"
+          >
+            <LabelWrap role="presentation">
+              <Label isDisabled={isDisabled} {...labelProps} aria-hidden="true">
+                {label}
+              </Label>
+              {details && <Details {...descriptionProps}>{details}</Details>}
+            </LabelWrap>
+            {(trailingItems || isSubmenuTrigger) && (
+              <TrailingItems
+                isDisabled={isDisabled}
+                spanFullHeight={trailingItemsSpanFullHeight}
+              >
+                {trailingItems}
+                {isSubmenuTrigger && (
+                  <IconChevron size="xs" direction="right" aria-hidden="true" />
+                )}
+              </TrailingItems>
+            )}
+          </ContentWrap>
+        </InnerWrap>
+      </Wrap>
     );
   }
 );

--- a/static/app/components/dropdownMenuSectionV2.tsx
+++ b/static/app/components/dropdownMenuSectionV2.tsx
@@ -21,16 +21,16 @@ function MenuSection({node, children}: Props) {
   });
 
   return (
-    <Section {...itemProps}>
+    <MenuSectionWrap {...itemProps}>
       {node.rendered && <Heading {...headingProps}>{node.rendered}</Heading>}
       <Group {...groupProps}>{children}</Group>
-    </Section>
+    </MenuSectionWrap>
   );
 }
 
 export default MenuSection;
 
-const Section = styled('li')`
+const MenuSectionWrap = styled('li')`
   list-style-type: none;
 `;
 
@@ -44,7 +44,7 @@ const Heading = styled('span')`
   margin: ${space(1)} ${space(1.5)} ${space(0.5)};
   padding-right: ${space(1)};
 
-  ${/* sc-selector */ Section}:first-of-type & {
+  ${/* sc-selector */ MenuSectionWrap}:first-of-type & {
     margin-top: ${space(0.5)};
   }
 `;

--- a/static/app/components/dropdownMenuV2.tsx
+++ b/static/app/components/dropdownMenuV2.tsx
@@ -242,6 +242,11 @@ const Overlay = styled('div')<{placementProp: PositionAria['placement']}>`
   background: ${p => p.theme.backgroundElevated};
   box-shadow: 0 0 0 1px ${p => p.theme.translucentBorder}, ${p => p.theme.dropShadowHeavy};
   font-size: ${p => p.theme.fontSizeMedium};
+  overflow: hidden;
+
+  margin: ${space(1)} 0;
+  ${p => p.placementProp === 'top' && `margin-bottom: 0;`}
+  ${p => p.placementProp === 'bottom' && `margin-top: 0;`}
 
   margin: ${space(1)} 0;
   ${p => p.placementProp === 'top' && `margin-bottom: 0;`}

--- a/static/app/components/dropdownMenuV2.tsx
+++ b/static/app/components/dropdownMenuV2.tsx
@@ -242,7 +242,6 @@ const Overlay = styled('div')<{placementProp: PositionAria['placement']}>`
   background: ${p => p.theme.backgroundElevated};
   box-shadow: 0 0 0 1px ${p => p.theme.translucentBorder}, ${p => p.theme.dropShadowHeavy};
   font-size: ${p => p.theme.fontSizeMedium};
-  overflow: hidden;
 
   margin: ${space(1)} 0;
   ${p => p.placementProp === 'top' && `margin-bottom: 0;`}

--- a/static/app/components/dropdownMenuV2.tsx
+++ b/static/app/components/dropdownMenuV2.tsx
@@ -247,10 +247,6 @@ const Overlay = styled('div')<{placementProp: PositionAria['placement']}>`
   ${p => p.placementProp === 'top' && `margin-bottom: 0;`}
   ${p => p.placementProp === 'bottom' && `margin-top: 0;`}
 
-  margin: ${space(1)} 0;
-  ${p => p.placementProp === 'top' && `margin-bottom: 0;`}
-  ${p => p.placementProp === 'bottom' && `margin-top: 0;`}
-
   /* Override z-index from useOverlayPosition */
   z-index: ${p => p.theme.zIndex.dropdown} !important;
 `;

--- a/static/app/views/organizationGroupDetails/actions/deleteAction.tsx
+++ b/static/app/views/organizationGroupDetails/actions/deleteAction.tsx
@@ -5,12 +5,10 @@ import {ModalRenderProps, openModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import ActionButton from 'sentry/components/actions/button';
-import MenuHeader from 'sentry/components/actions/menuHeader';
-import MenuItemActionLink from 'sentry/components/actions/menuItemActionLink';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import Confirm from 'sentry/components/confirm';
-import DropdownLink from 'sentry/components/dropdownLink';
+import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
 import {IconChevron, IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -95,22 +93,26 @@ function DeleteAction({disabled, project, organization, onDiscard, onDelete}: Pr
           icon={<IconDelete size="xs" />}
         />
       </Confirm>
-      <DropdownLink
-        caret={false}
-        disabled={disabled}
-        customTitle={
-          <ActionButton
-            disabled={disabled}
+      <DropdownMenuControlV2
+        trigger={({props: triggerProps, ref: triggerRef}) => (
+          <DropdownTrigger
+            ref={triggerRef}
+            {...triggerProps}
+            size="xsmall"
             aria-label={t('More delete options')}
             icon={<IconChevron direction="down" size="xs" />}
+            disabled={disabled}
           />
-        }
-      >
-        <MenuHeader>{t('Delete & Discard')}</MenuHeader>
-        <MenuItemActionLink title="" onAction={openDiscardModal}>
-          {t('Delete and discard future events')}
-        </MenuItemActionLink>
-      </DropdownLink>
+        )}
+        menuTitle={t('Delete & Discard')}
+        items={[
+          {
+            key: 'delete',
+            label: t('Delete and discard future events'),
+            onAction: () => openDiscardModal(),
+          },
+        ]}
+      />
     </ButtonBar>
   );
 }
@@ -119,12 +121,18 @@ const DeleteButton = styled(ActionButton)`
   ${p =>
     !p.disabled &&
     `
-  &:hover {
-    background-color: ${p.theme.button.danger.background};
-    color: ${p.theme.button.danger.color};
-    border-color: ${p.theme.button.danger.border};
-  }
+    &:hover {
+      background-color: ${p.theme.button.danger.background};
+      color: ${p.theme.button.danger.color};
+      border-color: ${p.theme.button.danger.border};
+    }
   `}
+`;
+
+const DropdownTrigger = styled(Button)`
+  box-shadow: none;
+  border-radius: ${p => p.theme.borderRadiusRight};
+  border-left: none;
 `;
 
 export default DeleteAction;

--- a/static/app/views/organizationGroupDetails/actions/deleteAction.tsx
+++ b/static/app/views/organizationGroupDetails/actions/deleteAction.tsx
@@ -98,9 +98,6 @@ function DeleteAction({disabled, project, organization, onDiscard, onDelete}: Pr
           <DropdownTrigger
             ref={triggerRef}
             {...triggerProps}
-            // to prevent prop type warning due to
-            // ConditionalAriaLabel in button.tsx
-            children={null}
             aria-label={t('More delete options')}
             size="xsmall"
             icon={<IconChevron direction="down" size="xs" />}

--- a/static/app/views/organizationGroupDetails/actions/deleteAction.tsx
+++ b/static/app/views/organizationGroupDetails/actions/deleteAction.tsx
@@ -98,8 +98,11 @@ function DeleteAction({disabled, project, organization, onDiscard, onDelete}: Pr
           <DropdownTrigger
             ref={triggerRef}
             {...triggerProps}
-            size="xsmall"
+            // to prevent prop type warning due to
+            // ConditionalAriaLabel in button.tsx
+            children={null}
             aria-label={t('More delete options')}
+            size="xsmall"
             icon={<IconChevron direction="down" size="xs" />}
             disabled={disabled}
           />

--- a/tests/js/spec/components/actions/ignore.spec.jsx
+++ b/tests/js/spec/components/actions/ignore.spec.jsx
@@ -15,11 +15,11 @@ describe('IgnoreActions', function () {
         <IgnoreActions onUpdate={spy} disabled />,
         routerContext
       );
-      button = component.find('button[aria-label="Ignore"]').first();
+      button = component.find('IgnoreButton');
     });
 
     it('has disabled prop', function () {
-      expect(button.props()['aria-disabled']).toBe(true);
+      expect(button.props().disabled).toBe(true);
     });
 
     it('does not call onUpdate when clicked', function () {
@@ -60,7 +60,7 @@ describe('IgnoreActions', function () {
     });
 
     it('calls spy with ignore details when clicked', function () {
-      const button = component.find('button[aria-label="Ignore"]').first();
+      const button = component.find('IgnoreButton').first();
       button.simulate('click');
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith({status: 'ignored'});
@@ -76,7 +76,7 @@ describe('IgnoreActions', function () {
         <IgnoreActions onUpdate={spy} shouldConfirm confirmMessage="confirm me" />,
         routerContext
       );
-      button = component.find('button[aria-label="Ignore"]');
+      button = component.find('IgnoreButton');
     });
 
     it('displays confirmation modal with message provided', async function () {


### PR DESCRIPTION
(To be merged into master after https://github.com/getsentry/sentry/pull/31084)

Use DropdownMenuControlV2, which has an updated design, better keyboard accessibility and aria labeling.

**Before:**
<img width="1253" alt="Screen Shot 2022-01-26 at 2 31 43 PM" src="https://user-images.githubusercontent.com/44172267/151604134-64166a3f-c151-4c01-a641-fa94c611e6f5.png">
<img width="1253" alt="Screen Shot 2022-01-26 at 2 31 50 PM" src="https://user-images.githubusercontent.com/44172267/151604141-1740e382-ac8d-42b7-8377-c9e078140ea5.png">
<img width="1253" alt="Screen Shot 2022-01-26 at 2 31 56 PM" src="https://user-images.githubusercontent.com/44172267/151604144-ce4efdf5-8e6b-47f4-94e5-8ad29a92ec4a.png">

**After:**
<img width="1253" alt="Screen Shot 2022-01-26 at 2 32 08 PM" src="https://user-images.githubusercontent.com/44172267/151604156-8cbca510-6de5-4ccc-8e94-bb414dcd221d.png">
<img width="1253" alt="Screen Shot 2022-01-26 at 2 32 19 PM" src="https://user-images.githubusercontent.com/44172267/151604158-807ac04a-194f-429d-9078-89def3d8c84f.png">
<img width="1253" alt="Screen Shot 2022-01-26 at 2 32 24 PM" src="https://user-images.githubusercontent.com/44172267/151604163-6e9554fb-810a-4a7b-88aa-9d83ff407a12.png">

