### PR TITLE
feat(dashboard): Sticky headers on Dashboard Grid Layout Table

### DIFF
--- a/static/app/components/charts/simpleTableChart.tsx
+++ b/static/app/components/charts/simpleTableChart.tsx
@@ -24,6 +24,7 @@ type Props = {
   className?: string;
   getCustomFieldRenderer?: typeof getFieldRenderer;
   fieldHeaderMap?: Record<string, string>;
+  stickyHeaders?: boolean;
 };
 
 class SimpleTableChart extends Component<Props> {
@@ -45,8 +46,16 @@ class SimpleTableChart extends Component<Props> {
   }
 
   render() {
-    const {className, loading, fields, metadata, data, title, fieldHeaderMap} =
-      this.props;
+    const {
+      className,
+      loading,
+      fields,
+      metadata,
+      data,
+      title,
+      fieldHeaderMap,
+      stickyHeaders,
+    } = this.props;
     const meta = metadata ?? {};
     const columns = decodeColumnOrder(fields.map(field => ({field})));
     return (
@@ -67,6 +76,7 @@ class SimpleTableChart extends Component<Props> {
             );
           })}
           isEmpty={!data?.length}
+          stickyHeaders={stickyHeaders}
           disablePadding
         >
           {data?.map((row, index) => this.renderRow(index, row, meta, columns))}

--- a/static/app/components/panels/panelTable.tsx
+++ b/static/app/components/panels/panelTable.tsx
@@ -181,7 +181,7 @@ export const PanelTableHeader = styled('div')<{sticky: boolean}>`
     `
     position: sticky;
     top: 0;
-    zIndex: 1;
+    z-index: 1;
   `}
 `;
 

--- a/static/app/components/panels/panelTable.tsx
+++ b/static/app/components/panels/panelTable.tsx
@@ -51,6 +51,11 @@ type Props = {
    * A custom loading indicator.
    */
   loader?: React.ReactNode;
+
+  /**
+   * If true, scrolling headers out of view will pin to the top of container.
+   */
+  stickyHeaders?: boolean;
 };
 
 /**
@@ -77,6 +82,7 @@ const PanelTable = ({
   emptyMessage = t('There are no items to display'),
   emptyAction,
   loader,
+  stickyHeaders = false,
   ...props
 }: Props) => {
   const shouldShowLoading = isLoading === true;
@@ -92,7 +98,9 @@ const PanelTable = ({
       {...props}
     >
       {headers.map((header, i) => (
-        <PanelTableHeader key={i}>{header}</PanelTableHeader>
+        <PanelTableHeader key={i} sticky={stickyHeaders}>
+          {header}
+        </PanelTableHeader>
       ))}
 
       {shouldShowLoading && (
@@ -155,7 +163,7 @@ const Wrapper = styled(Panel, {
   overflow: auto;
 `;
 
-export const PanelTableHeader = styled('div')`
+export const PanelTableHeader = styled('div')<{sticky: boolean}>`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 600;
@@ -167,6 +175,14 @@ export const PanelTableHeader = styled('div')`
   flex-direction: column;
   justify-content: center;
   min-height: 45px;
+
+  ${p =>
+    p.sticky &&
+    `
+    position: sticky;
+    top: 0;
+    zIndex: 1;
+  `}
 `;
 
 export default PanelTable;

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -620,7 +620,7 @@ const WidgetContainer = styled('div')`
 
 const GridItem = styled('div')`
   .react-resizable-handle {
-    z-index: 1;
+    z-index: 2;
   }
 `;
 

--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -123,6 +123,7 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
           metadata={result.meta}
           data={result.data}
           organization={organization}
+          stickyHeaders
         />
       );
     });

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -315,7 +315,7 @@ const ToolbarPanel = styled('div')`
   position: absolute;
   top: 0;
   left: 0;
-  z-index: auto;
+  z-index: 2;
 
   width: 100%;
   height: 100%;

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -165,6 +165,7 @@ class WidgetCard extends React.Component<Props> {
         organization={organization}
         getCustomFieldRenderer={getIssueFieldRenderer}
         fieldHeaderMap={ISSUE_FIELD_TO_HEADER_MAP}
+        stickyHeaders
       />
     );
   }

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -432,4 +432,45 @@ describe('Dashboards > WidgetCard', function () {
       })
     );
   });
+
+  it('has sticky table headers', async function () {
+    const tableWidget: Widget = {
+      title: 'Table Widget',
+      interval: '5m',
+      displayType: DisplayType.TABLE,
+      widgetType: WidgetType.DISCOVER,
+      queries: [
+        {
+          conditions: '',
+          fields: ['transaction', 'count()'],
+          name: 'Table',
+          orderby: '',
+        },
+      ],
+    };
+    mountWithTheme(
+      <WidgetCard
+        api={api}
+        organization={initialData.organization}
+        widget={tableWidget}
+        selection={selection}
+        isEditing={false}
+        onDelete={() => undefined}
+        onEdit={() => undefined}
+        onDuplicate={() => undefined}
+        renderErrorMessage={() => undefined}
+        isSorting={false}
+        currentWidgetDragging={false}
+        showContextMenu
+        widgetLimitReached={false}
+        tableItemLimit={20}
+      />
+    );
+    await tick();
+    expect(screen.getByText('transaction').parentElement).toHaveStyle({
+      position: 'sticky',
+      top: 0,
+      'z-index': 1,
+    });
+  });
 });

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -3,8 +3,11 @@ import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary
 
 import * as modal from 'sentry/actionCreators/modal';
 import {Client} from 'sentry/api';
+import SimpleTableChart from 'sentry/components/charts/simpleTableChart';
 import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';
 import WidgetCard from 'sentry/views/dashboardsV2/widgetCard';
+
+jest.mock('sentry/components/charts/simpleTableChart');
 
 describe('Dashboards > WidgetCard', function () {
   const initialData = initializeOrg({
@@ -467,10 +470,9 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
     await tick();
-    expect(screen.getByText('transaction').parentElement).toHaveStyle({
-      position: 'sticky',
-      top: 0,
-      'z-index': 1,
-    });
+    expect(SimpleTableChart).toHaveBeenCalledWith(
+      expect.objectContaining({stickyHeaders: true}),
+      expect.anything()
+    );
   });
 });


### PR DESCRIPTION
Updates the Table widgets to always display the Table header even when scrolling down the list
![image](https://user-images.githubusercontent.com/83961295/151605609-c953fc31-2e34-4987-a688-0a25b1323fa9.png)
