### PR TITLE
chore(widget-lib): Update CTA to "Add"

### DIFF
--- a/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
+++ b/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import {useState} from 'react';
 import {css} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
 import Tooltip from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
+import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {assignTempId} from 'sentry/views/dashboardsV2/layoutUtils';
@@ -90,7 +92,7 @@ function DashboardWidgetLibraryModal({
             )}
             disabled={!!!overLimit}
           >
-            <Button
+            <StyledButton
               data-test-id="confirm-widgets"
               priority="primary"
               disabled={overLimit}
@@ -117,7 +119,7 @@ function DashboardWidgetLibraryModal({
               }}
             >
               {t('Add')}
-            </Button>
+            </StyledButton>
           </Tooltip>
         </ButtonBar>
       </Footer>
@@ -129,6 +131,10 @@ export const modalCss = css`
   width: 100%;
   max-width: 700px;
   margin: 70px auto;
+`;
+
+const StyledButton = styled(Button)`
+  padding: 0 ${space(3)};
 `;
 
 export default DashboardWidgetLibraryModal;

--- a/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
+++ b/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
@@ -75,7 +75,7 @@ function DashboardWidgetLibraryModal({
         <ButtonBar gap={1}>
           <Button
             external
-            href="https://docs.sentry.io/product/dashboards/custom-dashboards/#widget-builder"
+            href="https://docs.sentry.io/product/dashboards/widget-library/"
           >
             {t('Read the docs')}
           </Button>

--- a/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
+++ b/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
@@ -116,7 +116,7 @@ function DashboardWidgetLibraryModal({
                 handleSubmit();
               }}
             >
-              {t('Save')}
+              {t('Add')}
             </Button>
           </Tooltip>
         </ButtonBar>

--- a/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
+++ b/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
@@ -134,7 +134,8 @@ export const modalCss = css`
 `;
 
 const StyledButton = styled(Button)`
-  padding: 0 ${space(3)};
+  padding-left: ${space(3)};
+  padding-right: ${space(3)};
 `;
 
 export default DashboardWidgetLibraryModal;


### PR DESCRIPTION
Widget Library tab should be “Add” rather than
“Save” since it’s a more appropriate action for
adding pre-constructed queries/widgets regardless of mode.
Also update docs url to widget library.