### PR TITLE
ref(slack): Avoid channel_not_found errors

### DIFF
--- a/src/sentry/integrations/slack/endpoints/event.py
+++ b/src/sentry/integrations/slack/endpoints/event.py
@@ -71,6 +71,8 @@ class SlackEventEndpoint(SlackDMEndpoint):
             channel_id=slack_request.channel_id,
             response_url=slack_request.response_url,
         )
+        if not slack_request.channel_name:
+            return
 
         payload = {
             "token": self._get_access_token(slack_request.integration),
@@ -199,7 +201,6 @@ class SlackEventEndpoint(SlackDMEndpoint):
 
         if slack_request.is_challenge():
             return self.on_url_verification(request, slack_request.data)
-
         if slack_request.type == "link_shared":
             if self.on_link_shared(request, slack_request):
                 return self.respond()


### PR DESCRIPTION
If a user shares a discover link and they don't have a linked identity, we will prompt them to link it. Sometimes, the payload doesn't have the channel name in it though, so we aren't able to send a message and this causes an error. This PR checks for the existence of the channel name before attempting to send the message.

Fixes (parts of) [SENTRY-S9K](https://sentry.io/organizations/sentry/issues/2676816643/events/5a669fccc2ce499eabb008831cf42a8a/?project=1) -I say parts of because there are a lot of unfurl errors in there, this only addresses the channel not found errors.