### PR TITLE
fix(transitional-serializer): rollback as social_auth.backend isnt json serializable

### DIFF
--- a/src/sentry/utils/transitional_serializer.py
+++ b/src/sentry/utils/transitional_serializer.py
@@ -13,8 +13,12 @@ class TransitionalSerializer:
         self.json_serializer = JSONSerializer()
 
     def dumps(self, obj: Dict[str, Any]) -> bytes:
-        metrics.incr("transitional_serializer.json_write")
-        return self.json_serializer.dumps(obj)
+        # need to rollback json write
+        # metrics.incr("transitional_serializer.json_write")
+        # return self.json_serializer.dumps(obj)
+
+        metrics.incr("transitional_serializer.pickle_write")
+        return self.pickle_serializer.dumps(obj)
 
     def loads(self, data: bytes) -> Dict[str, Any]:
         try:

--- a/tests/sentry/utils/test_transitional_serializer.py
+++ b/tests/sentry/utils/test_transitional_serializer.py
@@ -20,5 +20,6 @@ class TransitionalSerializerTest(TestCase):
     def test_read_pickle(self):
         assert self.transitional_serializer.loads(self.pickle_obj) == self.obj
 
-    def test_write(self):
-        assert self.transitional_serializer.dumps(self.obj) == self.json_obj
+    # need to rollback json write
+    # def test_write(self):
+    #     assert self.transitional_serializer.dumps(self.obj) == self.json_obj


### PR DESCRIPTION
rollback https://github.com/getsentry/sentry/pull/31362 as social_auth.backend isnt jsonserializable