### PR TITLE
feat(notifications): Combine notification tables into one table

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -143,6 +143,12 @@ class NotificationSettings extends AsyncComponent<Props, State> {
 
       fields.push(field);
     }
+
+    const legacyField = SELF_NOTIFICATION_SETTINGS_TYPES.map(
+      type => NOTIFICATION_SETTING_FIELDS[type] as FieldObject
+    );
+    fields.push(...legacyField);
+
     return fields;
   }
 
@@ -160,20 +166,14 @@ class NotificationSettings extends AsyncComponent<Props, State> {
           apiEndpoint="/users/me/notification-settings/"
           initialData={this.getInitialData()}
         >
-          <JsonForm title={t('Notifications')} fields={this.getFields()} />
-        </Form>
-        <Form
-          initialData={legacyData}
-          saveOnBlur
-          apiMethod="PUT"
-          apiEndpoint="/users/me/notifications/"
-        >
-          <JsonForm
-            title={t('My Activity')}
-            fields={SELF_NOTIFICATION_SETTINGS_TYPES.map(
-              type => NOTIFICATION_SETTING_FIELDS[type] as FieldObject
-            )}
-          />
+          <Form
+            initialData={legacyData}
+            saveOnBlur
+            apiMethod="PUT"
+            apiEndpoint="/users/me/notifications/"
+          >
+            <JsonForm title={t('Notifications')} fields={this.getFields()} />
+          </Form>
         </Form>
         <AlertLink to="/settings/account/emails" icon={<IconMail />}>
           {t('Looking to add or remove an email address? Use the emails panel.')}

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -1,8 +1,10 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
 import AlertLink from 'sentry/components/alertLink';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import Link from 'sentry/components/links/link';
+import Panel from 'sentry/components/panels/panel';
 import {IconMail} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
@@ -144,11 +146,6 @@ class NotificationSettings extends AsyncComponent<Props, State> {
       fields.push(field);
     }
 
-    const legacyField = SELF_NOTIFICATION_SETTINGS_TYPES.map(
-      type => NOTIFICATION_SETTING_FIELDS[type] as FieldObject
-    );
-    fields.push(...legacyField);
-
     return fields;
   }
 
@@ -160,21 +157,26 @@ class NotificationSettings extends AsyncComponent<Props, State> {
         <SettingsPageHeader title="Notifications" />
         <TextBlock>Personal notifications sent via email or an integration.</TextBlock>
         <FeedbackAlert />
-        <Form
+        <StyledForm
           saveOnBlur
           apiMethod="PUT"
           apiEndpoint="/users/me/notification-settings/"
           initialData={this.getInitialData()}
         >
-          <Form
-            initialData={legacyData}
-            saveOnBlur
-            apiMethod="PUT"
-            apiEndpoint="/users/me/notifications/"
-          >
-            <JsonForm title={t('Notifications')} fields={this.getFields()} />
-          </Form>
-        </Form>
+          <JsonForm title={t('Notifications')} fields={this.getFields()} />
+        </StyledForm>
+        <StyledLegacyForm
+          initialData={legacyData}
+          saveOnBlur
+          apiMethod="PUT"
+          apiEndpoint="/users/me/notifications/"
+        >
+          <JsonForm
+            fields={SELF_NOTIFICATION_SETTINGS_TYPES.map(
+              type => NOTIFICATION_SETTING_FIELDS[type] as FieldObject
+            )}
+          />
+        </StyledLegacyForm>
         <AlertLink to="/settings/account/emails" icon={<IconMail />}>
           {t('Looking to add or remove an email address? Use the emails panel.')}
         </AlertLink>
@@ -184,3 +186,20 @@ class NotificationSettings extends AsyncComponent<Props, State> {
 }
 
 export default withOrganizations(NotificationSettings);
+
+const StyledForm = styled(Form)<Form['props']>`
+  ${Panel} {
+    margin-bottom: 0;
+    border-bottom: 1px solid ${p => p.theme.innerBorder};
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+`;
+
+const StyledLegacyForm = styled(Form)<Form['props']>`
+  ${Panel} {
+    border-top: 0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+`;

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -145,7 +145,6 @@ class NotificationSettings extends AsyncComponent<Props, State> {
 
       fields.push(field);
     }
-
     return fields;
   }
 


### PR DESCRIPTION
There are currently multiple tables on the Notifications settings page. This will combine all tables into one table.

[FIXES WOR-1572](https://getsentry.atlassian.net/browse/WOR-1572)

# Before
<img width="962" alt="Screen Shot 2022-01-28 at 3 04 54 PM" src="https://user-images.githubusercontent.com/20312973/151633897-43b0f9d6-904f-4db7-9d8f-fc69c8c6672e.png">

# After
<img width="965" alt="Screen Shot 2022-01-28 at 3 04 04 PM" src="https://user-images.githubusercontent.com/20312973/151634060-a32ccd77-7012-4ddb-b15e-fc67f601f143.png">
