### PR TITLE
fix(discover): Equations not rendering in discover

### DIFF
--- a/static/app/components/charts/simpleTableChart.tsx
+++ b/static/app/components/charts/simpleTableChart.tsx
@@ -37,8 +37,8 @@ class SimpleTableChart extends Component<Props> {
 
     return columns.map(column => {
       const fieldRenderer =
-        getCustomFieldRenderer?.(column.name, tableMeta) ??
-        getFieldRenderer(column.name, tableMeta);
+        getCustomFieldRenderer?.(column.key, tableMeta) ??
+        getFieldRenderer(column.key, tableMeta);
       const rendered = fieldRenderer(row, {organization, location});
       return <TableCell key={`${index}:${column.name}`}>{rendered}</TableCell>;
     });
@@ -57,7 +57,7 @@ class SimpleTableChart extends Component<Props> {
           isLoading={loading}
           headers={columns.map((column, index) => {
             const align = fieldAlignment(column.name, column.type, meta);
-            const header = fieldHeaderMap?.[column.name] ?? column.key;
+            const header = fieldHeaderMap?.[column.key] ?? column.name;
             return (
               <HeadCell key={index} align={align}>
                 <Tooltip title={header}>

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -63,8 +63,8 @@ export function decodeColumnOrder(fields: Readonly<Field[]>): TableColumn<string
     const col = explodeFieldString(f.field);
     const columnName = f.field;
     if (isEquation(f.field)) {
-      column.name = `equation[${equations}]`;
-      column.key = getEquation(columnName);
+      column.key = `equation[${equations}]`;
+      column.name = getEquation(columnName);
       equations += 1;
     } else {
       column.key = columnName;


### PR DESCRIPTION
- Because the column key & name was revered, discover was no longer showing equations
- This flips them back and aligns the dashboard rendering to how discover does it