### PR TITLE
fix(page-filters): Fix project page filter quick select

### DIFF
--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -70,7 +70,7 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
   const organization = useOrganization();
   const {selection, pinnedFilters, isReady} = useLegacyStore(PageFiltersStore);
 
-  const handleChangeProjects = (newProjects: number[] | null) => {
+  const handleChangeProjects = (newProjects: number[]) => {
     setCurrentSelectedProjects(newProjects);
   };
 
@@ -81,7 +81,6 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
       resetParams: [],
       environments: [],
     });
-    setCurrentSelectedProjects(null);
   };
 
   const specifiedProjects = specificProjectSlugs


### PR DESCRIPTION
Quick select (directly clicking a project's name instead of the checkbox) wasn't working before seemingly due to some race conditions with the useState hook causing the quick select to always result in a null project selection. Got rid of an unnecessary setState call which seems to fix it.

Before:
![Kapture 2022-01-28 at 15 23 55](https://user-images.githubusercontent.com/9372512/151635024-4f8daaa8-1e1c-494e-a903-4ad1da186cd6.gif)

After:
![Kapture 2022-01-28 at 15 25 23](https://user-images.githubusercontent.com/9372512/151635081-fa8aa5ae-c336-43f8-8805-fc3d697f6a4a.gif)

