### PR TITLE
chore(weekly_reports): Add task to verify that `prepare_reports` finished successfully.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -762,6 +762,13 @@ CELERYBEAT_SCHEDULE = {
         ),
         "options": {"expires": 60 * 60 * 3},
     },
+    "schedule-verify-weekly-organization-reports": {
+        "task": "sentry.tasks.reports.verify_prepare_reports",
+        "schedule": crontab(
+            minute=0, hour=12, day_of_week="tuesday"  # 05:00 PDT, 09:00 EDT, 12:00 UTC
+        ),
+        "options": {"expires": 60 * 60},
+    },
     "schedule-vsts-integration-subscription-check": {
         "task": "sentry.tasks.integrations.kickoff_vsts_subscription_check",
         "schedule": crontab_with_minute_jitter(hour="*/6"),

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -5,7 +5,7 @@ import operator
 import zlib
 from calendar import Calendar
 from collections import OrderedDict, namedtuple
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from functools import partial, reduce
 from itertools import zip_longest
 from typing import Iterable, Mapping, NamedTuple, Tuple
@@ -587,7 +587,33 @@ def prepare_reports(dry_run=False, *args, **kwargs):
                 extra={"organization_id": organization_id, "total_scheduled": i},
             )
 
+    client = redis.redis_clusters.get("default")
+    client.set(prepare_reports_verify_key(), 1, ex=int(timedelta(days=3).total_seconds()))
     logger.info("reports.finish_prepare_report")
+
+
+def prepare_reports_verify_key():
+    today = date.today()
+    week = today - timedelta(days=today.weekday())
+    return f"prepare_reports_completed:{week.isoformat()}"
+
+
+@instrumented_task(
+    name="sentry.tasks.reports.verify_prepare_reports",
+    queue="reports.prepare",
+    max_retries=5,
+    acks_late=True,
+)
+def verify_prepare_reports(*args, **kwargs):
+    logger.info("reports.begin_verify_prepare_reports")
+    client = redis.redis_clusters.get("default")
+    verify = client.get(prepare_reports_verify_key())
+    if verify is None:
+        logger.error(
+            "Failed to verify that sentry.tasks.reports.prepare_reports successfully completed. "
+            "Confirm whether this worked via logs"
+        )
+    logger.info("reports.end_verify_prepare_reports")
 
 
 @instrumented_task(

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -3,6 +3,7 @@ import functools
 from datetime import datetime, timedelta
 from unittest import mock
 
+import freezegun
 import pytest
 import pytz
 from django.core import mail
@@ -32,12 +33,15 @@ from sentry.tasks.reports import (
     merge_series,
     month_to_index,
     prepare_reports,
+    prepare_reports_verify_key,
     safe_add,
     user_subscribed_to_organization_reports,
+    verify_prepare_reports,
 )
 from sentry.testutils.cases import OutcomesSnubaTest, SnubaTestCase, TestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import iso_format
+from sentry.utils import redis
 from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
 from sentry.utils.outcomes import Outcome
 
@@ -242,6 +246,53 @@ class ReportTestCase(TestCase, SnubaTestCase):
 
             message = mail.outbox[0]
             assert self.organization.name in message.subject
+        client = redis.redis_clusters.get("default")
+        assert client.get(prepare_reports_verify_key()) == "1"
+
+    @mock.patch("sentry.tasks.reports.logger")
+    def test_verify(self, logger):
+        verify_prepare_reports()
+        logger.error.assert_called_once_with(
+            "Failed to verify that sentry.tasks.reports.prepare_reports successfully completed. "
+            "Confirm whether this worked via logs"
+        )
+        logger.reset_mock()
+        prepare_reports()
+        verify_prepare_reports()
+        assert logger.error.call_count == 0
+
+    @mock.patch("sentry.tasks.reports.logger")
+    def test_verify_with_error(self, logger):
+        logger.reset_mock()
+        with mock.patch("sentry.tasks.reports.prepare_organization_report") as prep_report:
+            prep_report.delay.side_effect = Exception
+            try:
+                prepare_reports()
+            except Exception:
+                pass
+        verify_prepare_reports()
+        logger.error.assert_called_once_with(
+            "Failed to verify that sentry.tasks.reports.prepare_reports successfully completed. "
+            "Confirm whether this worked via logs"
+        )
+
+    @mock.patch("sentry.tasks.reports.logger")
+    def test_verify_weeks_dont_clash(self, logger):
+        with freezegun.freeze_time(timedelta(days=-7)):
+            prepare_reports()
+            verify_prepare_reports()
+            assert logger.error.call_count == 0
+
+        logger.reset_mock()
+        verify_prepare_reports()
+        logger.error.assert_called_once_with(
+            "Failed to verify that sentry.tasks.reports.prepare_reports successfully completed. "
+            "Confirm whether this worked via logs"
+        )
+        logger.reset_mock()
+        prepare_reports()
+        verify_prepare_reports()
+        assert logger.error.call_count == 0
 
     def test_deliver_organization_user_report_respects_settings(self):
         user = self.user


### PR DESCRIPTION
This just adds a basic checker to weekly reports so that we can verify that the task ran as
expected. I considered monitors for this, but since it seems to rely on Django signals I'm not sure
it would catch cases like OOM kills.