### PR TITLE
feat(pageFilters): Restore filters using pinnedFilters state

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -157,7 +157,7 @@ export function initializeUrlState({
     datetime: mergeDatetime(parsed, customDatetime),
   };
 
-  // Use period from default of we don't have a period set
+  // Use period from default if we don't have a period set
   pageFilters.datetime.period ??= defaultDatetime.period;
 
   // Do not set a period if we have absolute start and end
@@ -182,9 +182,7 @@ export function initializeUrlState({
   if (storedPageFilters) {
     const {state: storedState, pinnedFilters} = storedPageFilters;
 
-    const hasPinning = organization.features.includes(
-      'organizations:selection-filters-v2'
-    );
+    const hasPinning = organization.features.includes('selection-filters-v2');
 
     const filtersToRestore = hasPinning
       ? pinnedFilters

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -101,7 +101,7 @@ function getProjectIdFromProject(project: MinimalProject) {
  */
 function mergeDatetime(
   base: PageFilters['datetime'],
-  fallback: Partial<PageFilters['datetime']> | undefined
+  fallback?: Partial<PageFilters['datetime']>
 ) {
   const datetime: PageFilters['datetime'] = {
     start: base.start ?? fallback?.start ?? null,

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -9,7 +9,6 @@ import {
   updateEnvironments,
   updateProjects,
 } from 'sentry/actionCreators/pageFilters';
-import {DATE_TIME_KEYS} from 'sentry/constants/pageFilters';
 import ConfigStore from 'sentry/stores/configStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
@@ -18,15 +17,7 @@ import useProjects from 'sentry/utils/useProjects';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import GlobalSelectionHeader from './globalSelectionHeader';
-import {getStateFromQuery} from './parse';
-import {PageFiltersState} from './types';
-
-type DatetimeState = Pick<PageFiltersState, 'start' | 'end' | 'period' | 'utc'>;
-
-const getDatetimeFromState = (state: PageFiltersState) =>
-  Object.fromEntries(
-    Object.entries(state).filter(([key]) => DATE_TIME_KEYS.includes(key))
-  ) as DatetimeState;
+import {getDatetimeFromState, getStateFromQuery} from './parse';
 
 type GlobalSelectionHeaderProps = Omit<
   React.ComponentPropsWithoutRef<typeof GlobalSelectionHeader>,

--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -2,8 +2,8 @@ import {Location} from 'history';
 import moment from 'moment';
 
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
-import {URL_PARAM} from 'sentry/constants/pageFilters';
-import {IntervalPeriod} from 'sentry/types';
+import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/constants/pageFilters';
+import {IntervalPeriod, PageFilters} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 
@@ -314,4 +314,13 @@ export function getStateFromQuery(
   };
 
   return state;
+}
+
+/**
+ * Extract the datetime component from the page filter state object
+ */
+export function getDatetimeFromState(state: PageFiltersState) {
+  return Object.fromEntries(
+    Object.entries(state).filter(([key]) => DATE_TIME_KEYS.includes(key))
+  ) as PageFilters['datetime'];
 }

--- a/static/app/components/organizations/pageFilters/persistence.tsx
+++ b/static/app/components/organizations/pageFilters/persistence.tsx
@@ -99,7 +99,7 @@ export function getPageFilterStorage(orgSlug: string) {
     {allowAbsoluteDatetime: true}
   );
 
-  return {selection: state, pinnedFilters: new Set(pinnedFilters)};
+  return {state, pinnedFilters: new Set(pinnedFilters)};
 }
 
 /**

--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -23,7 +23,7 @@ type Internals = {
 type PageFiltersStoreInterface = CommonStoreInterface<State> & {
   reset(selection?: PageFilters): void;
   onReset(): void;
-  onInitializeUrlState(newSelection: PageFilters): void;
+  onInitializeUrlState(newSelection: PageFilters, pinned: Set<PinnedPageFilter>): void;
   updateProjects(projects: PageFilters['projects'], environments: null | string[]): void;
   updateDateTime(datetime: PageFilters['datetime']): void;
   updateEnvironments(environments: string[]): void;
@@ -48,14 +48,17 @@ const storeConfig: Reflux.StoreDefinition & Internals & PageFiltersStoreInterfac
   reset(selection) {
     this._hasInitialState = false;
     this.selection = selection || getDefaultSelection();
+    this.pinnedFilters = new Set();
   },
 
   /**
    * Initializes the page filters store data
    */
-  onInitializeUrlState(newSelection) {
+  onInitializeUrlState(newSelection, pinned) {
     this._hasInitialState = true;
+
     this.selection = newSelection;
+    this.pinnedFilters = pinned;
     this.trigger(this.getState());
   },
 

--- a/tests/js/spec/actionCreators/pageFilters.spec.jsx
+++ b/tests/js/spec/actionCreators/pageFilters.spec.jsx
@@ -39,7 +39,8 @@ describe('PageFilters ActionCreators', function () {
         expect.objectContaining({
           environments: [],
           projects: [1],
-        })
+        }),
+        new Set()
       );
       expect(router.replace).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -78,7 +79,8 @@ describe('PageFilters ActionCreators', function () {
             period: '14d',
             utc: null,
           },
-        })
+        }),
+        new Set()
       );
     });
 
@@ -103,7 +105,8 @@ describe('PageFilters ActionCreators', function () {
             period: '3h',
             utc: null,
           },
-        })
+        }),
+        new Set()
       );
     });
 
@@ -170,17 +173,19 @@ describe('PageFilters ActionCreators', function () {
         router,
       });
 
-      expect(localStorage.getItem).not.toHaveBeenCalled();
-      expect(PageFiltersActions.initializeUrlState).toHaveBeenCalledWith({
-        datetime: {
-          start: null,
-          end: null,
-          period: '14d',
-          utc: null,
+      expect(PageFiltersActions.initializeUrlState).toHaveBeenCalledWith(
+        {
+          datetime: {
+            start: null,
+            end: null,
+            period: '14d',
+            utc: null,
+          },
+          projects: [1],
+          environments: [],
         },
-        projects: [1],
-        environments: [],
-      });
+        new Set()
+      );
       expect(router.replace).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -17,16 +17,19 @@ describe('DatePageFilter', function () {
     },
   });
   OrganizationStore.onUpdate(organization, {replace: true});
-  PageFiltersStore.onInitializeUrlState({
-    projects: [],
-    environments: [],
-    datetime: {
-      period: '7d',
-      start: null,
-      end: null,
-      utc: null,
+  PageFiltersStore.onInitializeUrlState(
+    {
+      projects: [],
+      environments: [],
+      datetime: {
+        period: '7d',
+        start: null,
+        end: null,
+        utc: null,
+      },
     },
-  });
+    new Set()
+  );
 
   it('can change period', function () {
     mountWithTheme(

--- a/tests/js/spec/components/environmentPageFilter.spec.tsx
+++ b/tests/js/spec/components/environmentPageFilter.spec.tsx
@@ -29,11 +29,14 @@ describe('EnvironmentPageFilter', function () {
   beforeEach(() => {
     act(() => {
       PageFiltersStore.reset();
-      PageFiltersStore.onInitializeUrlState({
-        projects: [2],
-        environments: [],
-        datetime: {start: null, end: null, period: '14d', utc: null},
-      });
+      PageFiltersStore.onInitializeUrlState(
+        {
+          projects: [2],
+          environments: [],
+          datetime: {start: null, end: null, period: '14d', utc: null},
+        },
+        new Set()
+      );
     });
   });
 

--- a/tests/js/spec/components/projectPageFilter.spec.tsx
+++ b/tests/js/spec/components/projectPageFilter.spec.tsx
@@ -28,11 +28,14 @@ describe('ProjectPageFilter', function () {
   beforeEach(() => {
     act(() => {
       PageFiltersStore.reset();
-      PageFiltersStore.onInitializeUrlState({
-        projects: [],
-        environments: [],
-        datetime: {start: null, end: null, period: '14d', utc: null},
-      });
+      PageFiltersStore.onInitializeUrlState(
+        {
+          projects: [],
+          environments: [],
+          datetime: {start: null, end: null, period: '14d', utc: null},
+        },
+        new Set()
+      );
     });
   });
 


### PR DESCRIPTION
This change makes it so that those with the page filters feature flag will have to "pin" a filter (project, environment, and eventually datetime) in order to persist it across pages and pageloads.

**Example pinned project:**
![image](https://user-images.githubusercontent.com/9372512/152055462-9f30329b-100e-4b75-9c74-00c4e36618ce.png)

coauthored by davidenwang because evan is on vacation