### PR TITLE
fix(dashboard-layout): Change cursor hover on resize handle to nwse

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -677,4 +677,5 @@ const ResizeHandle = styled('div')`
   position: absolute;
   bottom: 2px;
   right: 4px;
+  cursor: nwse-resize;
 `;


### PR DESCRIPTION
Signals to the user that the icon is clickable and gives them an idea of what it does.

Makes the cursor look like this on hover (minus the colouring):
![Screen Shot 2022-01-31 at 9 59 29 AM](https://user-images.githubusercontent.com/22846452/151820752-5bc9cc96-8b46-4313-b0ac-1c5df9068c65.png)

