### PR TITLE
fix(ui) Catch network errors when fetching status page

### DIFF
--- a/static/app/actionCreators/serviceIncidents.tsx
+++ b/static/app/actionCreators/serviceIncidents.tsx
@@ -55,10 +55,12 @@ export async function loadIncidents(): Promise<SentryServiceStatus | null> {
       `https://${cfg.id}.${cfg.api_host}/api/v2/incidents/unresolved.json`
     );
   } catch (err) {
+    // No point in capturing this as we can't make statuspage come back.
     return null;
   }
 
   if (!response.ok) {
+    // Sometimes statuspage responds with a 500
     return null;
   }
 

--- a/static/app/actionCreators/serviceIncidents.tsx
+++ b/static/app/actionCreators/serviceIncidents.tsx
@@ -46,12 +46,17 @@ function getIncidentsFromIncidentResponse(statuspageIncidents: StatuspageInciden
 
 export async function loadIncidents(): Promise<SentryServiceStatus | null> {
   const cfg = ConfigStore.get('statuspage');
+  let response: Response | undefined = undefined;
   if (!cfg || !cfg.id) {
     return null;
   }
-  const response = await fetch(
-    `https://${cfg.id}.${cfg.api_host}/api/v2/incidents/unresolved.json`
-  );
+  try {
+    response = await fetch(
+      `https://${cfg.id}.${cfg.api_host}/api/v2/incidents/unresolved.json`
+    );
+  } catch (err) {
+    return null;
+  }
 
   if (!response.ok) {
     return null;


### PR DESCRIPTION
When requests to statuspage.io fail we don't need to be alerted as there isn't anything we can do.

Refs JAVASCRIPT-231K