### PR TITLE
fix(dashboards): force empty div on acceptance test for issue widget

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/issueWidgetQueries.tsx
@@ -10,6 +10,7 @@ import MemberListStore from 'sentry/stores/memberListStore';
 import {Group, OrganizationSummary, PageFilters} from 'sentry/types';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import getDynamicText from 'sentry/utils/getDynamicText';
 import {queryToObj} from 'sentry/utils/stream';
 import {
   DISCOVER_EXCLUSION_FIELDS,
@@ -248,10 +249,13 @@ class IssueWidgetQueries extends React.Component<Props, State> {
     const {children} = this.props;
     const {loading, errorMessage, memberListStoreLoaded} = this.state;
     const transformedResults = this.transformTableResults();
-    return children({
-      loading: loading || !memberListStoreLoaded,
-      transformedResults,
-      errorMessage,
+    return getDynamicText({
+      value: children({
+        loading: loading || !memberListStoreLoaded,
+        transformedResults,
+        errorMessage,
+      }),
+      fixed: <div />,
     });
   }
 }


### PR DESCRIPTION
Uses `getDynamicText` to force Issue Widget acceptance test to be an empty div. This fixes issues with flakes due to loading spinners.
![image](https://user-images.githubusercontent.com/83961295/151852617-8b2a366c-f7ee-4fa7-afc3-41768a0ae5d1.png)
