### PR TITLE
chore(dashboard): Hide widget context menu in edit state

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -113,7 +113,12 @@ class WidgetCard extends React.Component<Props> {
       onEdit,
       onDuplicate,
       onDelete,
+      isEditing,
     } = this.props;
+
+    if (isEditing) {
+      return null;
+    }
 
     return (
       <WidgetCardContextMenu


### PR DESCRIPTION
We want to hide the context menu icon when in edit
state so the edit state icons don’t overlap.