### PR TITLE
fix(dashboards): Unbolds widget and dashboard card titles

### DIFF
--- a/static/app/views/dashboardsV2/manage/dashboardCard.tsx
+++ b/static/app/views/dashboardsV2/manage/dashboardCard.tsx
@@ -98,6 +98,7 @@ const Title = styled('div')`
   ${p => p.theme.text.cardTitle};
   color: ${p => p.theme.headingColor};
   ${overflowEllipsis};
+  font-weight: normal;
 `;
 
 const Detail = styled('div')`

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -341,6 +341,7 @@ const StyledIconGrabbable = styled(IconGrabbable)`
 
 const WidgetTitle = styled(HeaderTitle)`
   ${overflowEllipsis};
+  font-weight: normal;
 `;
 
 const WidgetHeader = styled('div')`


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/83961295/151873816-30caa256-7adb-40db-8d17-0e654989e55d.png)
![image](https://user-images.githubusercontent.com/83961295/151873848-3914f8d8-be69-4b1e-b5a3-0548c13ed18f.png)

After
![image](https://user-images.githubusercontent.com/83961295/151873705-d4717580-d06d-4270-97fc-10cf6f280666.png)
![image](https://user-images.githubusercontent.com/83961295/151873782-e90efe0c-e2c5-46d9-868f-db73bec82cfb.png)

@jas-kas