### PR TITLE
fix(auth): fix invite flow for sso not required

### DIFF
--- a/static/app/views/acceptOrganizationInvite.tsx
+++ b/static/app/views/acceptOrganizationInvite.tsx
@@ -210,16 +210,43 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
     const {inviteDetails, accepting} = this.state;
 
     return (
-      <Actions>
-        <Button
-          aria-label="join-organization"
-          priority="primary"
-          disabled={accepting}
-          onClick={this.handleAcceptInvite}
-        >
-          {t('Join the %s organization', inviteDetails.orgSlug)}
-        </Button>
-      </Actions>
+      <Fragment>
+        {inviteDetails.needsSso && !inviteDetails.requireSso && (
+          <p data-test-id="action-info-sso">
+            {tct(
+              `Note that [orgSlug] has enabled Single Sign-On (SSO) using
+               [authProvider]. You may join the organization by authenticating with
+               the organization's SSO provider or via your standard account authentication.`,
+              {
+                orgSlug: <strong>{inviteDetails.orgSlug}</strong>,
+                authProvider: inviteDetails.ssoProvider,
+              }
+            )}
+          </p>
+        )}
+        <Actions>
+          <ActionsLeft>
+            {inviteDetails.needsSso && !inviteDetails.requireSso && (
+              <Button
+                aria-label="sso-login"
+                priority="primary"
+                href={this.makeNextUrl(`/auth/login/${inviteDetails.orgSlug}/`)}
+              >
+                {t('Join with %s', inviteDetails.ssoProvider)}
+              </Button>
+            )}
+
+            <Button
+              aria-label="join-organization"
+              priority="primary"
+              disabled={accepting}
+              onClick={this.handleAcceptInvite}
+            >
+              {t('Join the %s organization', inviteDetails.orgSlug)}
+            </Button>
+          </ActionsLeft>
+        </Actions>
+      </Fragment>
     );
   }
 
@@ -257,7 +284,7 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
           ? this.warning2fa
           : inviteDetails.needsEmailVerification
           ? this.warningEmailVerification
-          : inviteDetails.needsSso
+          : inviteDetails.requireSso
           ? this.authenticationActions
           : this.acceptActions}
       </NarrowLayout>

--- a/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
+++ b/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
@@ -186,6 +186,28 @@ describe('AcceptOrganizationInvite', function () {
     window.location.replace = replace;
   });
 
+  it('shows right options for logged in user and optional SSO', async function () {
+    addMock({
+      orgSlug: 'test-org',
+      needsAuthentication: false,
+      needs2fa: false,
+      needsSso: true,
+      requireSso: false,
+      existingMember: false,
+    });
+
+    const wrapper = mountWithTheme(
+      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />,
+      TestStubs.routerContext()
+    );
+
+    const ssoLink = wrapper.find('[data-test-id="action-info-sso"]');
+    expect(ssoLink.exists()).toBe(true);
+
+    const joinButton = wrapper.find('Button[aria-label="join-organization"]');
+    expect(joinButton.exists()).toBe(true);
+  });
+
   it('shows a logout button for existing members', async function () {
     addMock({
       orgSlug: 'test-org',


### PR DESCRIPTION
- Fixes flow for when user is accepting an invite, logged in, and the organization has sso, but it is not required.
- We give the user the option to either join with the auth provider or without. Still thinking about wording for this but since the flow for "join without XXX" flow currently does not work at all, this is an improvement.

![Screen Shot 2022-01-31 at 2 20 42 PM](https://user-images.githubusercontent.com/1976777/151885205-daf96626-8980-4ba6-9020-58f780e47985.png)
.