### PR TITLE
fix(page-filters): Fix quick select for project selectors

### DIFF
--- a/static/app/components/organizations/multipleProjectSelector.tsx
+++ b/static/app/components/organizations/multipleProjectSelector.tsx
@@ -26,8 +26,8 @@ type Props = WithRouterProps & {
   value: number[];
   projects: Project[];
   nonMemberProjects: Project[];
-  onChange: (selected: number[]) => unknown;
-  onUpdate: () => unknown;
+  onChange: (selected: number[]) => void;
+  onUpdate: (newProjects?: number[]) => void;
   isGlobalSelectionReady?: boolean;
   disableMultipleProjectSelection?: boolean;
   shouldForceProject?: boolean;
@@ -65,9 +65,12 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
     );
   }
 
-  // Reset "hasChanges" state and call `onUpdate` callback
-  doUpdate = () => {
-    this.setState({hasChanges: false}, this.props.onUpdate);
+  /**
+   * Reset "hasChanges" state and call `onUpdate` callback
+   * @param value optional parameter that will be passed to onUpdate callback
+   */
+  doUpdate = (value?: number[]) => {
+    this.setState({hasChanges: false}, () => this.props.onUpdate(value));
   };
 
   /**
@@ -93,7 +96,7 @@ class MultipleProjectSelector extends React.PureComponent<Props, State> {
     });
     const value = selected.id === null ? [] : [parseInt(selected.id, 10)];
     this.props.onChange(value);
-    this.doUpdate();
+    this.doUpdate(value);
   };
 
   /**

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -74,12 +74,12 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
     setCurrentSelectedProjects(newProjects);
   };
 
-  const handleUpdateProjects = () => {
-    // Clear environments when switching projects
-    updateProjects(currentSelectedProjects || [], router, {
+  const handleUpdateProjects = (newProjects?: number[]) => {
+    // Use newProjects if provided otherwise fallback to current selection
+    updateProjects(newProjects || currentSelectedProjects || [], router, {
       save: true,
       resetParams: [],
-      environments: [],
+      environments: [], // Clear environments when switching projects
     });
   };
 

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -76,7 +76,7 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
 
   const handleUpdateProjects = (newProjects?: number[]) => {
     // Use newProjects if provided otherwise fallback to current selection
-    updateProjects(newProjects || currentSelectedProjects || [], router, {
+    updateProjects(newProjects ?? (currentSelectedProjects || []), router, {
       save: true,
       resetParams: [],
       environments: [], // Clear environments when switching projects

--- a/tests/js/spec/components/projectPageFilter.spec.tsx
+++ b/tests/js/spec/components/projectPageFilter.spec.tsx
@@ -108,8 +108,7 @@ describe('ProjectPageFilter', function () {
     userEvent.click(screen.getByText('My Projects'));
 
     // Click the first project's checkbox
-    const projectLabel = screen.getByText('project-2');
-    userEvent.click(projectLabel);
+    userEvent.click(screen.getByText('project-2'));
 
     // Verify we were redirected
     expect(router.push).toHaveBeenCalledWith(


### PR DESCRIPTION
I tried to fix this in https://github.com/getsentry/sentry/pull/31476, but I misunderstood the underlying race condition/async issue with the useState hook in the project selector. 

Final solution involves passing the value of the quick selection made by the user to the `onUpdate` function which will allow the component to not rely on a stale state value.

Example:
![Kapture 2022-01-31 at 16 56 03](https://user-images.githubusercontent.com/9372512/151897266-6fa9965e-69e9-4d7d-8fb9-3714086c6ca7.gif)
