### PR TITLE
fix(page-filters): Fix quick select for environment selectors

### DIFF
--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -32,12 +32,11 @@ function EnvironmentPageFilter({router, resetParamsOnChange = []}: Props) {
     setSelectedEnvironments(environments);
   };
 
-  const handleUpdateEnvironments = () => {
-    updateEnvironments(selectedEnvironments, router, {
+  const handleUpdateEnvironments = (quickSelectedEnvs?: string[]) => {
+    updateEnvironments(quickSelectedEnvs || selectedEnvironments, router, {
       save: true,
       resetParams: resetParamsOnChange,
     });
-    setSelectedEnvironments(null);
   };
 
   const customDropdownButton = ({isOpen, getActorProps, summary}) => {

--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -33,7 +33,7 @@ function EnvironmentPageFilter({router, resetParamsOnChange = []}: Props) {
   };
 
   const handleUpdateEnvironments = (quickSelectedEnvs?: string[]) => {
-    updateEnvironments(quickSelectedEnvs || selectedEnvironments, router, {
+    updateEnvironments(quickSelectedEnvs ?? selectedEnvironments, router, {
       save: true,
       resetParams: resetParamsOnChange,
     });

--- a/static/app/components/organizations/multipleEnvironmentSelector.tsx
+++ b/static/app/components/organizations/multipleEnvironmentSelector.tsx
@@ -46,7 +46,7 @@ type Props = WithRouterProps & {
   /**
    * When menu is closed
    */
-  onUpdate: () => void;
+  onUpdate: (selectedEnvs?: string[]) => void;
   customDropdownButton?: (config: {
     getActorProps: GetActorPropsFn;
     isOpen: boolean;
@@ -95,9 +95,11 @@ class MultipleEnvironmentSelector extends React.PureComponent<Props, State> {
 
   /**
    * Checks if "onUpdate" is callable. Only calls if there are changes
+   * @param selectedEnvs optional parameter passed to onUpdate representing
+   * an array containing a directly selected environment (not multi-selected)
    */
-  doUpdate = () => {
-    this.setState({hasChanges: false}, this.props.onUpdate);
+  doUpdate = (selectedEnvs?: string[]) => {
+    this.setState({hasChanges: false}, () => this.props.onUpdate(selectedEnvs));
   };
 
   /**
@@ -182,13 +184,18 @@ class MultipleEnvironmentSelector extends React.PureComponent<Props, State> {
       org_id: parseInt(this.props.organization.id, 10),
     });
 
-    this.setState(() => {
-      this.doChange([environment]);
+    const envSelection = [environment];
 
-      return {
-        selectedEnvs: new Set([environment]),
-      };
-    }, this.doUpdate);
+    this.setState(
+      () => {
+        this.doChange(envSelection);
+
+        return {
+          selectedEnvs: new Set(envSelection),
+        };
+      },
+      () => this.doUpdate(envSelection)
+    );
   };
 
   /**

--- a/tests/js/spec/components/environmentPageFilter.spec.tsx
+++ b/tests/js/spec/components/environmentPageFilter.spec.tsx
@@ -112,8 +112,7 @@ describe('EnvironmentPageFilter', function () {
     userEvent.click(screen.getByText('All Environments'));
 
     // Click the first environment directly
-    const prodEnvOption = screen.getByText('prod');
-    userEvent.click(prodEnvOption);
+    userEvent.click(screen.getByText('prod'));
 
     // Verify we were redirected
     expect(router.push).toHaveBeenCalledWith(

--- a/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
@@ -69,7 +69,7 @@ describe('MultipleEnvironmentSelector', function () {
     wrapper
       .find('MultipleSelectorSubmitRow button[aria-label="Apply"]')
       .simulate('click');
-    expect(onUpdate).toHaveBeenCalledWith();
+    expect(onUpdate).toHaveBeenCalledWith(undefined);
   });
 
   it('selects multiple environments and uses chevron to update', async function () {
@@ -89,7 +89,7 @@ describe('MultipleEnvironmentSelector', function () {
     expect(onChange).toHaveBeenLastCalledWith(['production', 'staging']);
 
     wrapper.find('MultipleEnvironmentSelector StyledChevron').simulate('click');
-    expect(onUpdate).toHaveBeenCalledWith();
+    expect(onUpdate).toHaveBeenCalledWith(undefined);
   });
 
   it('does not update when there are no changes', async function () {


### PR DESCRIPTION
Similar to the fix employed here https://github.com/getsentry/sentry/pull/31502, there was a bug with the environment selector that caused the updated env value to be stale when clicking on an environment label directly.

Solution is to pass the directly selected environment to the `onUpdate` function rather than relying on the stale state value.

Example:
![Kapture 2022-01-31 at 17 28 48](https://user-images.githubusercontent.com/9372512/151899898-d5d645d0-a4da-41a2-95b3-ad745c844043.gif)
