### PR TITLE
fix(ui): Error count on issue stream bar chart cut off

### DIFF
--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -207,7 +207,7 @@ function MiniBarChart({
     grid: {
       // Offset to ensure there is room for the marker symbols at the
       // default size.
-      top: labelYAxisExtents ? 6 : 0,
+      top: labelYAxisExtents || showMarkLineLabel ? 6 : 0,
       bottom: markers || labelYAxisExtents || showMarkLineLabel ? 4 : 0,
       left: markers ? 8 : showMarkLineLabel ? 35 : 4,
       right: markers ? 4 : 0,

--- a/static/app/components/stream/groupChart.tsx
+++ b/static/app/components/stream/groupChart.tsx
@@ -64,7 +64,7 @@ function GroupChart({
         showMarkLine && Math.max(...markLinePoint) > 0
           ? MarkLine({
               silent: true,
-              lineStyle: {color: theme.gray200, type: 'solid', width: 1},
+              lineStyle: {color: theme.gray200, type: 'dotted', width: 1},
               data: [
                 {
                   type: 'max',
@@ -86,7 +86,7 @@ function GroupChart({
   return (
     <LazyLoad debounce={50} height={showMarkLine ? 30 : height}>
       <MiniBarChart
-        height={showMarkLine ? 30 : height}
+        height={showMarkLine ? 36 : height}
         isGroupedByDate
         showTimeInTooltip
         series={series}


### PR DESCRIPTION
Fix the error count from being cut off when the number is at the top of the bar chart on the issue stream. Also, change the line from "solid" to "dotted".

[FIXES WOR-1585](https://getsentry.atlassian.net/browse/WOR-1585)

# Before
<img width="205" alt="Screen Shot 2022-02-01 at 12 44 05 AM" src="https://user-images.githubusercontent.com/20312973/151938147-e6d7b14c-9fe3-4b89-8707-66e63b02ed7f.png">

# After
<img width="201" alt="Screen Shot 2022-02-01 at 12 45 17 AM" src="https://user-images.githubusercontent.com/20312973/151938173-11fcf37c-ab69-4d1d-8acc-faab41e730fd.png">

