### PR TITLE
fix(dashboards): Fix World Map Widget Open in Discover

### DIFF
--- a/static/app/views/dashboardsV2/utils.tsx
+++ b/static/app/views/dashboardsV2/utils.tsx
@@ -35,12 +35,14 @@ export function eventViewFromWidget(
 
   // World Map requires an additional column (geo.country_code) to display in discover when navigating from the widget
   const fields =
-    widgetDisplayType === DisplayType.WORLD_MAP
+    widgetDisplayType === DisplayType.WORLD_MAP &&
+    !query.fields.includes('geo.country_code')
       ? ['geo.country_code', ...query.fields]
       : query.fields;
   const conditions =
-    widgetDisplayType === DisplayType.WORLD_MAP
-      ? `${query.conditions} has:geo.country_code`
+    widgetDisplayType === DisplayType.WORLD_MAP &&
+    !query.conditions.includes('has:geo.country_code')
+      ? `${query.conditions} has:geo.country_code`.trim()
       : query.conditions;
 
   return EventView.fromSavedQuery({


### PR DESCRIPTION
When opening a world map widget in discover, only add `geo.country_code` condition and field if the widget does not already have them'