### PR TITLE
fix(saml): gracefully handle empty attribute

### DIFF
--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -290,7 +290,8 @@ class SAML2Provider(Provider):
 
         # map configured provider attributes
         for key, provider_key in self.config["attribute_mapping"].items():
-            attributes[key] = raw_attributes.get(provider_key, [""])[0]
+            attribute_list = raw_attributes.get(provider_key, [""])
+            attributes[key] = attribute_list[0] if len(attribute_list) > 0 else ""
 
         # Email and identifier MUST be correctly mapped
         if not attributes[Attributes.IDENTIFIER] or not attributes[Attributes.USER_EMAIL]:

--- a/tests/sentry/auth/providers/test_saml2.py
+++ b/tests/sentry/auth/providers/test_saml2.py
@@ -68,3 +68,19 @@ class SAML2ProviderTest(TestCase):
         assert identity["id"] == "123"
         assert identity["email"] == "valid@example.com"
         assert identity["name"] == "Morty Smith"
+
+    def test_build_identity_empty_lastname(self):
+        self.provider.config = dummy_provider_config
+        attrs = {
+            "id": ["123"],
+            "email": ["valid@example.com"],
+            "first": ["Morty"],
+            "last": [],
+        }
+
+        state = {"auth_attributes": attrs}
+        identity = self.provider.build_identity(state)
+
+        assert identity["id"] == "123"
+        assert identity["email"] == "valid@example.com"
+        assert identity["name"] == "Morty"


### PR DESCRIPTION
Right now if a SAML assertion contains a field that is populated with an empty array, we will fail as we do not check the length of the list.

This PR makes it so the length is checked before accessing the 0 index. If this is a required field we'll still fail below but respond with a helpful error message for the user.

