### PR TITLE
ref(auth): add hasAuthProvider field to accept invite endpoint

### DIFF
--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -43,6 +43,7 @@ class AcceptOrganizationInvite(Endpoint):
             "orgSlug": organization.slug,
             "needsAuthentication": not helper.user_authenticated,
             "needsSso": auth_provider is not None,
+            "hasAuthProvider": auth_provider is not None,
             "requireSso": auth_provider is not None and not auth_provider.flags.allow_unlinked,
             # If they're already a member of the organization its likely
             # they're using a shared account and either previewing this invite

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -142,6 +142,7 @@ class AcceptInviteTest(TestCase):
         )
         assert resp.status_code == 200
         assert resp.data["needsSso"]
+        assert resp.data["hasAuthProvider"]
         assert resp.data["ssoProvider"] == "Google"
 
     def test_can_accept_while_authenticated(self):


### PR DESCRIPTION
Right now on on the invite accept endpoint, we have `requireSSO` and `needsSso` which is super confusing. Adding `hasAuthProvider` to replace `needsSso`. Will change FE then remove `needsSso`.
