### PR TITLE
fix(ui): replaced unhandled icon

### DIFF
--- a/static/app/components/events/contextSummary/contextSummaryGeneric.tsx
+++ b/static/app/components/events/contextSummary/contextSummaryGeneric.tsx
@@ -37,6 +37,7 @@ const ContextSummaryGeneric = ({data, unknownTitle}: Props) => {
       <h3>{renderValue('name')}</h3>
       <TextOverflow isParagraph>
         <Subject>{t('Version:')}</Subject>
+        LOL
         {!data.version ? t('Unknown') : renderValue('version')}
       </TextOverflow>
     </Item>

--- a/static/app/components/events/contextSummary/contextSummaryGeneric.tsx
+++ b/static/app/components/events/contextSummary/contextSummaryGeneric.tsx
@@ -37,7 +37,6 @@ const ContextSummaryGeneric = ({data, unknownTitle}: Props) => {
       <h3>{renderValue('name')}</h3>
       <TextOverflow isParagraph>
         <Subject>{t('Version:')}</Subject>
-        LOL
         {!data.version ? t('Unknown') : renderValue('version')}
       </TextOverflow>
     </Item>

--- a/static/app/components/group/inboxBadges/unhandledTag.tsx
+++ b/static/app/components/group/inboxBadges/unhandledTag.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 
 import Tooltip from 'sentry/components/tooltip';
-import {IconFire} from 'sentry/icons';
+import {IconFatal} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 const UnhandledTag = () => (
   <Tooltip title={t('An unhandled error was detected in this Issue.')}>
     <UnhandledTagWrapper>
-      <StyledIconFire size="xs" color="red300" />
+      <StyledIconFatal size="xs" color="red300" />
       {t('Unhandled')}
     </UnhandledTagWrapper>
   </Tooltip>
@@ -22,6 +22,6 @@ const UnhandledTagWrapper = styled('div')`
   color: ${p => p.theme.red300};
 `;
 
-const StyledIconFire = styled(IconFire)`
+const StyledIconFatal = styled(IconFatal)`
   margin-right: 3px;
 `;


### PR DESCRIPTION
Replacing the unhandled fire icon with a lil skull guy because we don’t want to confuse unhandled errors with regular ol’ errors.

## Before
![CleanShot 2022-02-01 at 10 47 06](https://user-images.githubusercontent.com/1900676/152031419-54865632-756e-4423-a6d9-ef8da5984a54.png)

## After
![CleanShot 2022-02-01 at 10 46 44](https://user-images.githubusercontent.com/1900676/152031431-c5ad14c1-1bee-42e9-8279-2fcff1768065.png)

