### PR TITLE
fix(discover): fix Go to Summary sometimes redirecting to performance landing

### DIFF
--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -374,7 +374,9 @@ class TableView extends React.Component<TableViewProps> {
       switch (action) {
         case Actions.TRANSACTION: {
           const maybeProject = projects.find(
-            project => project.slug === dataRow['project.name']
+            project =>
+              project.slug &&
+              [dataRow['project.name'], dataRow.project].includes(project.slug)
           );
           const projectID = maybeProject ? [maybeProject.id] : undefined;
 

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -373,8 +373,9 @@ class TableView extends React.Component<TableViewProps> {
 
       switch (action) {
         case Actions.TRANSACTION: {
-          const maybeProject = projects.find(project => project.slug === dataRow.project);
-
+          const maybeProject = projects.find(
+            project => project.slug === dataRow['project.name']
+          );
           const projectID = maybeProject ? [maybeProject.id] : undefined;
 
           const next = transactionSummaryRouteWithQuery({


### PR DESCRIPTION
The "Go to Summary" cell action on the transaction column only works if `project` is a selected column. Otherwise, it gets redirected to the performance landing page.

Fixes this issue by using `project.name` which is provided by eventsV2 instead of expecting the user to have selected the `project` column