### PR TITLE
tests(codeowners): Add tests for integration user/team mappings

### DIFF
--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -46,7 +46,7 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
 
   getDefaultOptions(mapping?: ExternalActorMappingOrSuggestion) {
     const {defaultOptions, type} = this.props;
-    if (typeof defaultOptions === 'boolean' || !defaultOptions) {
+    if (typeof defaultOptions !== 'object') {
       return defaultOptions;
     }
     const options = [...(defaultOptions ?? [])];

--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -46,7 +46,7 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
 
   getDefaultOptions(mapping?: ExternalActorMappingOrSuggestion) {
     const {defaultOptions, type} = this.props;
-    if (typeof defaultOptions === 'boolean') {
+    if (typeof defaultOptions === 'boolean' || !defaultOptions) {
       return defaultOptions;
     }
     const options = [...(defaultOptions ?? [])];

--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -49,7 +49,7 @@ type Props = AsyncComponent['props'] &
   > & {
     organization: Organization;
     integration: Integration;
-    mappings: ExternalActorMappingOrSuggestion[];
+    mappings: ExternalActorMapping[];
     type: 'team' | 'user';
     onCreate: (mapping?: ExternalActorMappingOrSuggestion) => void;
     onDelete: (mapping: ExternalActorMapping) => void;
@@ -173,6 +173,7 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
               icon={<IconEllipsisVertical size="sm" />}
               disabled={!hasAccess}
               aria-label={t('Actions')}
+              data-test-id="mapping-option"
             />
           }
         >
@@ -182,6 +183,7 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
             disabled={!hasAccess}
             onAction={() => onDelete(mapping)}
             title={t(`Delete External ${capitalize(type)}`)}
+            data-test-id="delete-mapping-button"
           >
             <RedText>{t('Delete')}</RedText>
           </MenuItemActionLink>
@@ -199,6 +201,7 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
           aria-label={t(
             `This ${type} mapping suggestion was generated from a CODEOWNERS file`
           )}
+          data-test-id="suggestion-option"
         />
       </Tooltip>
     );
@@ -243,9 +246,12 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
               </Access>
             </HeaderLayout>
           </PanelHeader>
-          <PanelBody>
+          <PanelBody data-test-id="mapping-table">
             {!this.allMappings.length && (
-              <EmptyMessage icon={getIntegrationIcon(integration.provider.key, 'lg')}>
+              <EmptyMessage
+                icon={getIntegrationIcon(integration.provider.key, 'lg')}
+                data-test-id="empty-message"
+              >
                 {tct('Set up External [type] Mappings.', {type: capitalize(type)})}
               </EmptyMessage>
             )}

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -52,6 +52,8 @@ class SelectAsyncField extends React.Component<
   findValue(propsValue: string): GeneralSelectValue {
     const {defaultOptions} = this.props;
     const {results, latestSelection} = this.state;
+    const options =
+      typeof defaultOptions !== 'boolean' && defaultOptions ? defaultOptions : [];
     /**
      * The propsValue is the `id` of the object (user, team, etc), and
      * react-select expects a full value object: {value: "id", label: "name"}
@@ -60,7 +62,7 @@ class SelectAsyncField extends React.Component<
       // When rendering the selected value, first look at the API results...
       results.find(({value}) => value === propsValue) ??
       // Then at the defaultOptions passed in props...
-      defaultOptions?.find(({value}) => value === propsValue) ??
+      options?.find(({value}) => value === propsValue) ??
       // Then at the latest value selected in the form
       latestSelection
     );

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -52,8 +52,8 @@ class SelectAsyncField extends React.Component<
   findValue(propsValue: string): GeneralSelectValue {
     const {defaultOptions} = this.props;
     const {results, latestSelection} = this.state;
-    const options =
-      typeof defaultOptions !== 'boolean' && defaultOptions ? defaultOptions : [];
+    // We don't use defaultOptions if it is undefined or a boolean
+    const options = typeof defaultOptions === 'object' ? defaultOptions : [];
     /**
      * The propsValue is the `id` of the object (user, team, etc), and
      * react-select expects a full value object: {value: "id", label: "name"}

--- a/tests/js/spec/components/integrationExternalMappingForm.spec.jsx
+++ b/tests/js/spec/components/integrationExternalMappingForm.spec.jsx
@@ -1,0 +1,202 @@
+import {act, mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import IntegrationExternalMappingForm from 'sentry/components/integrationExternalMappingForm';
+
+describe('IntegrationExternalMappingForm', function () {
+  const dataEndpoint = '/test/dataEndpoint/';
+  const baseProps = {
+    integration: TestStubs.GitHubIntegration(),
+    dataEndpoint,
+    getBaseFormEndpoint: jest.fn(_mapping => dataEndpoint),
+    sentryNamesMapper: mappings => mappings,
+  };
+  const MOCK_USER_MAPPING = {
+    id: '1',
+    userId: '1',
+    externalName: '@gwen',
+    sentryName: 'gwen@mcu.org',
+  };
+  const MOCK_TEAM_MAPPING = {
+    id: '1',
+    teamId: '1',
+    externalName: '@getsentry/animals',
+    sentryName: '#zoo',
+  };
+  const DEFAULT_OPTIONS = [
+    {id: '1', name: 'option1'},
+    {id: '2', name: 'option2'},
+    {id: '3', name: 'option3'},
+  ];
+
+  let getResponse, postResponse, putResponse;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockApiClient.clearMockResponses();
+    getResponse = MockApiClient.addMockResponse({
+      url: dataEndpoint,
+      method: 'GET',
+      body: DEFAULT_OPTIONS,
+    });
+    postResponse = MockApiClient.addMockResponse({
+      url: dataEndpoint,
+      method: 'POST',
+      body: {},
+    });
+    putResponse = MockApiClient.addMockResponse({
+      url: `${dataEndpoint}1/`,
+      method: 'PUT',
+      body: {},
+    });
+  });
+
+  // No mapping provided (e.g. Create a new mapping)
+  it('renders with no mapping provided as a form', async function () {
+    mountWithTheme(<IntegrationExternalMappingForm type="user" {...baseProps} />);
+    expect(screen.getByPlaceholderText('@username')).toBeInTheDocument();
+    expect(screen.getByText('Select Sentry User')).toBeInTheDocument();
+    expect(screen.getByTestId('form-submit')).toBeInTheDocument();
+  });
+  it('renders with no mapping as an inline field', async function () {
+    mountWithTheme(
+      <IntegrationExternalMappingForm isInline type="user" {...baseProps} />
+    );
+    await act(tick);
+    expect(screen.queryByPlaceholderText('@username')).not.toBeInTheDocument();
+    expect(screen.getByText('Select Sentry User')).toBeInTheDocument();
+    expect(screen.queryByTestId('form-submit')).not.toBeInTheDocument();
+  });
+
+  // Full mapping provided (e.g. Update an existing mapping)
+  it('renders with a full mapping provided as a form', async function () {
+    mountWithTheme(
+      <IntegrationExternalMappingForm
+        type="user"
+        mapping={MOCK_USER_MAPPING}
+        {...baseProps}
+      />
+    );
+    await act(tick);
+    expect(screen.getByDisplayValue(MOCK_USER_MAPPING.externalName)).toBeInTheDocument();
+    expect(screen.getByText(`option${MOCK_USER_MAPPING.userId}`)).toBeInTheDocument();
+    expect(screen.getByTestId('form-submit')).toBeInTheDocument();
+  });
+  it('renders with a full mapping provided as an inline field', async function () {
+    mountWithTheme(
+      <IntegrationExternalMappingForm
+        isInline
+        type="user"
+        mapping={MOCK_USER_MAPPING}
+        {...baseProps}
+      />
+    );
+    await act(tick);
+    expect(
+      screen.queryByDisplayValue(MOCK_USER_MAPPING.externalName)
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(`option${MOCK_USER_MAPPING.userId}`)).toBeInTheDocument();
+    expect(screen.queryByTestId('form-submit')).not.toBeInTheDocument();
+  });
+
+  // Suggested mapping provided (e.g. Create new mapping from suggested external name)
+  it('renders with a suggested mapping provided as a form', async function () {
+    mountWithTheme(
+      <IntegrationExternalMappingForm
+        type="team"
+        mapping={{externalName: MOCK_TEAM_MAPPING.externalName}}
+        {...baseProps}
+      />
+    );
+    expect(screen.getByDisplayValue(MOCK_TEAM_MAPPING.externalName)).toBeInTheDocument();
+    expect(screen.getByText('Select Sentry Team')).toBeInTheDocument();
+    expect(screen.getByTestId('form-submit')).toBeInTheDocument();
+  });
+  it('renders with a suggested mapping provided as an inline field', async function () {
+    mountWithTheme(
+      <IntegrationExternalMappingForm
+        isInline
+        type="team"
+        mapping={{externalName: MOCK_TEAM_MAPPING.externalName}}
+        {...baseProps}
+      />
+    );
+    expect(
+      screen.queryByDisplayValue(MOCK_TEAM_MAPPING.externalName)
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Select Sentry Team')).toBeInTheDocument();
+    expect(screen.queryByTestId('form-submit')).not.toBeInTheDocument();
+  });
+
+  it('updates the model when submitting', async function () {
+    mountWithTheme(
+      <IntegrationExternalMappingForm
+        type="user"
+        mapping={{externalName: MOCK_USER_MAPPING.externalName}}
+        {...baseProps}
+      />
+    );
+    expect(baseProps.getBaseFormEndpoint).not.toHaveBeenCalled();
+    expect(postResponse).not.toHaveBeenCalled();
+    userEvent.type(screen.getByText('Select Sentry User'), 'option2');
+    await act(tick);
+    userEvent.click(screen.getAllByText('option2')[1]);
+    userEvent.click(screen.getByTestId('form-submit'));
+    expect(baseProps.getBaseFormEndpoint).toHaveBeenCalledWith({
+      externalName: MOCK_USER_MAPPING.externalName,
+      integrationId: baseProps.integration.id,
+      provider: baseProps.integration.provider.name.toLowerCase(),
+      // From option2 selection
+      userId: '2',
+    });
+    expect(postResponse).toHaveBeenCalled();
+    expect(putResponse).not.toHaveBeenCalled();
+  });
+
+  it('submits on blur when used as an inline field', async function () {
+    mountWithTheme(
+      <IntegrationExternalMappingForm
+        isInline
+        type="team"
+        mapping={MOCK_TEAM_MAPPING}
+        {...baseProps}
+      />
+    );
+    await act(tick);
+    expect(baseProps.getBaseFormEndpoint).not.toHaveBeenCalled();
+    expect(putResponse).not.toHaveBeenCalled();
+    userEvent.type(screen.getByRole('textbox'), 'option3');
+    await act(tick);
+    userEvent.click(screen.getAllByText('option3')[1]);
+    expect(baseProps.getBaseFormEndpoint).toHaveBeenCalledWith({
+      ...MOCK_TEAM_MAPPING,
+      integrationId: baseProps.integration.id,
+      provider: baseProps.integration.provider.name.toLowerCase(),
+      // From option3 selection
+      teamId: '3',
+    });
+    await act(tick);
+    expect(putResponse).toHaveBeenCalled();
+    expect(postResponse).not.toHaveBeenCalled();
+  });
+
+  it('allows defaultOptions to be provided', async function () {
+    mountWithTheme(
+      <IntegrationExternalMappingForm
+        type="user"
+        mapping={MOCK_USER_MAPPING}
+        defaultOptions={DEFAULT_OPTIONS.map(({id, name}) => ({value: id, label: name}))}
+        {...baseProps}
+      />
+    );
+    const sentryNameField = screen.getByText(`option${MOCK_USER_MAPPING.userId}`);
+    // Don't query for results on load
+    expect(sentryNameField).toBeInTheDocument();
+    await act(tick);
+    expect(getResponse).not.toHaveBeenCalled();
+    // Now that the user types, query for results
+    userEvent.type(sentryNameField, 'option2');
+    await act(tick);
+    userEvent.click(screen.getAllByText('option2')[1]);
+    expect(getResponse).toHaveBeenCalled();
+  });
+});

--- a/tests/js/spec/components/integrationExternalMappings.spec.jsx
+++ b/tests/js/spec/components/integrationExternalMappings.spec.jsx
@@ -1,0 +1,166 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountGlobalModal} from 'sentry-test/modal';
+import {act, mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import IntegrationExternalMappings from 'sentry/components/integrationExternalMappings';
+
+describe('IntegrationExternalMappings', function () {
+  const {organization, routerContext} = initializeOrg();
+
+  const onCreateMock = jest.fn();
+  const onDeleteMock = jest.fn();
+
+  const MOCK_USER_SUGGESTIONS = ['@peter', '@ned', '@mj'];
+  const MOCK_TEAM_SUGGESTIONS = [
+    '@getsentry/snacks',
+    '@getsentry/sports',
+    '@getsentry/hype',
+  ];
+  const MOCK_USER_MAPPINGS = [
+    {
+      id: '1',
+      userId: '1',
+      externalName: '@gwen',
+      sentryName: 'gwen@mcu.org',
+    },
+    {
+      id: '2',
+      userId: '2',
+      externalName: '@eddie',
+      sentryName: 'eddie@mcu.org',
+    },
+  ];
+  const MOCK_TEAM_MAPPINGS = [
+    {
+      id: '1',
+      teamId: '1',
+      externalName: '@getsentry/animals',
+      sentryName: '#zoo',
+    },
+    {
+      id: '2',
+      teamId: '2',
+      externalName: '@getsentry/ghosts',
+      sentryName: '#boo',
+    },
+  ];
+
+  const createMockSuggestions = () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/codeowners-associations/`,
+      method: 'GET',
+      body: {
+        'project-1': {
+          errors: {
+            missing_external_users: MOCK_USER_SUGGESTIONS,
+            missing_external_teams: MOCK_TEAM_SUGGESTIONS,
+          },
+        },
+      },
+    });
+  };
+
+  it('renders empty if not mappings are provided or found', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/codeowners-associations/`,
+      method: 'GET',
+      body: {},
+    });
+    mountWithTheme(
+      <IntegrationExternalMappings
+        organization={organization}
+        integration={TestStubs.GitHubIntegration()}
+        mappings={[]}
+        type="user"
+        onCreate={onCreateMock}
+        onDelete={onDeleteMock}
+      />,
+      {
+        context: routerContext,
+      }
+    );
+    await act(tick);
+    expect(screen.getByTestId('empty-message')).toBeInTheDocument();
+  });
+
+  it('still renders suggestions if no mappings are provided', async function () {
+    createMockSuggestions();
+    mountWithTheme(
+      <IntegrationExternalMappings
+        organization={organization}
+        integration={TestStubs.GitHubIntegration()}
+        mappings={[]}
+        type="user"
+        onCreate={onCreateMock}
+        onDelete={onDeleteMock}
+      />,
+      {
+        context: routerContext,
+      }
+    );
+    await act(tick);
+
+    expect(await screen.findByTestId('mapping-table')).toBeInTheDocument();
+    for (const user of MOCK_USER_SUGGESTIONS) {
+      expect(await screen.findByText(user)).toBeInTheDocument();
+    }
+    expect(await screen.findAllByTestId('suggestion-option')).toHaveLength(3);
+  });
+
+  it('renders suggestions along with the provided mappings', async function () {
+    createMockSuggestions();
+    mountWithTheme(
+      <IntegrationExternalMappings
+        organization={organization}
+        integration={TestStubs.GitHubIntegration()}
+        mappings={MOCK_TEAM_MAPPINGS}
+        type="team"
+        onCreate={onCreateMock}
+        onDelete={onDeleteMock}
+      />,
+      {
+        context: routerContext,
+      }
+    );
+    await act(tick);
+
+    expect(await screen.findByTestId('mapping-table')).toBeInTheDocument();
+    for (const team of MOCK_TEAM_SUGGESTIONS) {
+      expect(await screen.findByText(team)).toBeInTheDocument();
+    }
+    expect(await screen.findAllByTestId('mapping-option')).toHaveLength(2);
+
+    for (const team of MOCK_TEAM_MAPPINGS) {
+      expect(await screen.findByText(team.externalName)).toBeInTheDocument();
+      expect(await screen.findByText(team.sentryName)).toBeInTheDocument();
+    }
+    expect(await screen.findAllByTestId('suggestion-option')).toHaveLength(3);
+  });
+
+  it('uses the methods passed down from props appropriately', async function () {
+    mountWithTheme(
+      <IntegrationExternalMappings
+        organization={organization}
+        integration={TestStubs.GitHubIntegration()}
+        mappings={MOCK_USER_MAPPINGS}
+        type="user"
+        onCreate={onCreateMock}
+        onDelete={onDeleteMock}
+      />,
+      {
+        context: routerContext,
+      }
+    );
+    await act(tick);
+
+    expect(await screen.findByTestId('mapping-table')).toBeInTheDocument();
+    userEvent.click(screen.getByTestId('add-mapping-button'));
+    expect(onCreateMock).toHaveBeenCalled();
+
+    userEvent.click(screen.getAllByTestId('delete-mapping-button')[0]);
+    await act(tick);
+    mountGlobalModal();
+    userEvent.click(screen.getByTestId('confirm-button'));
+    expect(onDeleteMock).toHaveBeenCalled();
+  });
+});

--- a/tests/js/spec/components/integrationExternalMappings.spec.jsx
+++ b/tests/js/spec/components/integrationExternalMappings.spec.jsx
@@ -74,6 +74,7 @@ describe('IntegrationExternalMappings', function () {
         type="user"
         onCreate={onCreateMock}
         onDelete={onDeleteMock}
+        defaultOptions={[]}
       />,
       {
         context: routerContext,
@@ -93,6 +94,7 @@ describe('IntegrationExternalMappings', function () {
         type="user"
         onCreate={onCreateMock}
         onDelete={onDeleteMock}
+        defaultOptions={[]}
       />,
       {
         context: routerContext,
@@ -117,6 +119,7 @@ describe('IntegrationExternalMappings', function () {
         type="team"
         onCreate={onCreateMock}
         onDelete={onDeleteMock}
+        defaultOptions={[]}
       />,
       {
         context: routerContext,
@@ -146,6 +149,7 @@ describe('IntegrationExternalMappings', function () {
         type="user"
         onCreate={onCreateMock}
         onDelete={onDeleteMock}
+        defaultOptions={[]}
       />,
       {
         context: routerContext,


### PR DESCRIPTION
See [API-2404](https://getsentry.atlassian.net/browse/API-2404)

This PR adds tests for the `IntegrationExternalMappings` (The table component) and `IntegrationExternalMappingForm` (the inline form and modal form) components. Both of these components are the root for IntegreationExternalUserMappings and IntegrationExternalTeamMappings, so I figured adding tests there would be a bit redundant. If you have suggestions for more tests or rewrites, please let me know!

