### PR TITLE
fix(dashboard-layout): Positioning during add in edit/create state

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -316,9 +316,11 @@ class DashboardDetail extends Component<Props, State> {
   handleUpdateWidgetList = (widgets: Widget[]) => {
     const {organization, dashboard, api, onDashboardUpdate, location} = this.props;
     const {modifiedDashboard} = this.state;
-    const layoutColumnDepths = calculateColumnDepths(
-      getDashboardLayout(dashboard.widgets)
-    );
+
+    // Use the new widgets for calculating layout because widgets has
+    // the most up to date information in edit state
+    const currentLayout = getDashboardLayout(widgets);
+    const layoutColumnDepths = calculateColumnDepths(currentLayout);
     const newModifiedDashboard = {
       ...cloneDashboard(modifiedDashboard || dashboard),
       widgets: assignDefaultLayout(widgets, layoutColumnDepths),

--- a/tests/acceptance/page_objects/dashboard_detail.py
+++ b/tests/acceptance/page_objects/dashboard_detail.py
@@ -30,18 +30,22 @@ class DashboardDetailPage(BasePage):
         self.wait_until_loaded()
 
     def enter_edit_state(self):
+        self.browser.wait_until_clickable('[data-test-id="dashboard-edit"]')
         button = self.browser.element('[data-test-id="dashboard-edit"]')
         button.click()
 
     def click_dashboard_add_widget_button(self):
+        self.browser.wait_until_clickable('[data-test-id="widget-add"]')
         button = self.browser.element('[data-test-id="widget-add"]')
         button.click()
 
     def click_dashboard_header_add_widget_button(self):
+        self.browser.wait_until_clickable('[data-test-id="add-widget-library"]')
         button = self.browser.element('[data-test-id="add-widget-library"]')
         button.click()
 
     def click_cancel_button(self):
+        self.browser.wait_until_clickable('[data-test-id="dashboard-cancel"]')
         button = self.browser.element('[data-test-id="dashboard-cancel"]')
         button.click()
 
@@ -53,5 +57,6 @@ class DashboardDetailPage(BasePage):
         button.click()
 
     def save_dashboard(self):
+        self.browser.wait_until_clickable('[data-test-id="dashboard-commit"]')
         button = self.browser.element('[data-test-id="dashboard-commit"]')
         button.click()

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -124,7 +124,6 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
         self.browser.snapshot(screenshot_name)
         self.browser.refresh()
         self.page.wait_until_loaded()
-
         self.browser.snapshot(f"{screenshot_name} (refresh)")
 
     def test_add_and_move_new_widget_on_existing_dashboard(self):
@@ -466,6 +465,64 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
             self.page.click_cancel_button()
             wait = WebDriverWait(self.browser.driver, 5)
             wait.until_not(EC.alert_is_present())
+
+    def test_position_when_adding_multiple_widgets_through_add_widget_tile_in_edit(
+        self,
+    ):
+        with self.feature(
+            FEATURE_NAMES + EDIT_FEATURE + GRID_LAYOUT_FEATURE + WIDGET_LIBRARY_FEATURE
+        ):
+            self.page.visit_dashboard_detail()
+            self.page.enter_edit_state()
+
+            # Widgets should take up the whole first row and the first spot in second row
+            self.page.add_widget_through_dashboard("A")
+            self.page.add_widget_through_dashboard("B")
+            self.page.add_widget_through_dashboard("C")
+            self.page.add_widget_through_dashboard("D")
+            self.page.wait_until_loaded()
+
+            self.browser.snapshot(
+                "dashboards - pre save position when adding multiple widgets through Add Widget tile in edit"
+            )
+
+            self.page.save_dashboard()
+            self.capture_screenshots(
+                "dashboards - position when adding multiple widgets through Add Widget tile in edit"
+            )
+
+    def test_position_when_adding_multiple_widgets_through_add_widget_tile_in_create(
+        self,
+    ):
+        with self.feature(
+            FEATURE_NAMES + EDIT_FEATURE + GRID_LAYOUT_FEATURE + WIDGET_LIBRARY_FEATURE
+        ):
+            self.page.visit_create_dashboard()
+
+            # Widgets should take up the whole first row and the first spot in second row
+            self.page.add_widget_through_dashboard("A")
+            self.page.add_widget_through_dashboard("B")
+            self.page.add_widget_through_dashboard("C")
+            self.page.add_widget_through_dashboard("D")
+            self.page.wait_until_loaded()
+
+            self.browser.snapshot(
+                "dashboards - pre save position when adding multiple widgets through Add Widget tile in create"
+            )
+
+            self.page.save_dashboard()
+
+            # Wait for page redirect, or else loading check passes too early
+            wait = WebDriverWait(self.browser.driver, 10)
+            wait.until(
+                lambda driver: (
+                    f"/organizations/{self.organization.slug}/dashboards/new/"
+                    not in driver.current_url
+                )
+            )
+            self.capture_screenshots(
+                "dashboards - position when adding multiple widgets through Add Widget tile in create"
+            )
 
 
 class OrganizationDashboardsManageAcceptanceTest(AcceptanceTestCase):


### PR DESCRIPTION
In Edit state, using `dashboard.widgets` to get the column depths results in a stale result, leading to added widgets receiving positions from the wrong starting point (and causing widgets to stack).

Instead, we should use `widgets` because the layouts assigned to new widgets are preserved over multiple add actions.