### PR TITLE
ref(ui): Update <SearchBar /> focus state

### DIFF
--- a/static/app/components/searchBar.tsx
+++ b/static/app/components/searchBar.tsx
@@ -132,9 +132,10 @@ class SearchBar extends React.PureComponent<Props, State> {
 
 const StyledInput = styled(Input)`
   width: ${p => (p.width ? p.width : undefined)};
+
   &.focus-visible {
-    box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.04), 0 0 6px rgba(177, 171, 225, 0.3);
-    border-color: #a598b2;
+    box-shadow: 0 0 0 1px ${p => p.theme.focusBorder};
+    border-color: ${p => p.theme.focusBorder};
     outline: none;
   }
 `;


### PR DESCRIPTION
With the new purple focus ring.

Before:
<img width="1079" alt="Screen Shot 2022-02-01 at 1 03 13 PM" src="https://user-images.githubusercontent.com/44172267/152051019-1bd417de-6503-4099-aa99-2ec155d59a68.png">

After:
<img width="1079" alt="Screen Shot 2022-02-01 at 1 03 25 PM" src="https://user-images.githubusercontent.com/44172267/152051041-0bbf3010-e97b-4b9d-98b7-0007e40ceda4.png">

