### PR TITLE
fix(pagefilters): Fix page filters overflowing on issues page

### DIFF
--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -306,6 +306,7 @@ const DateSelectorContainer = styled('div')`
 const PinButton = styled(Button)`
   display: block;
   color: ${p => p.theme.gray300};
+  background: transparent;
 `;
 
 const RelativePeriodButton = styled(Button)<{selected?: boolean}>`

--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -93,6 +93,7 @@ const DropdownTitle = styled('div')`
   display: flex;
   overflow: hidden;
   align-items: center;
+  flex: 1;
 `;
 
 export default withRouter(EnvironmentPageFilter);

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -163,6 +163,7 @@ const DropdownTitle = styled('div')`
   display: flex;
   overflow: hidden;
   align-items: center;
+  flex: 1;
 `;
 
 export default withRouter(ProjectPageFilter);

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -168,7 +168,7 @@ const SearchContainer = styled('div')<{
 const ProjectEnvironmentFilters = styled('div')`
   display: grid;
   gap: ${space(1)};
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 `;
 
 const DropdownsWrapper = styled('div')<{hasIssuePercentDisplay?: boolean}>`


### PR DESCRIPTION
Fixes this overflow issue for users with `selection-filters-v2` enabled

Also made the pin button on the datetime filter transparent since it is sneakily white which won't work on other pages.

Before:
![image](https://user-images.githubusercontent.com/9372512/152065255-d15a509c-c63b-439a-882b-f64a298a3d21.png)

After:
![image](https://user-images.githubusercontent.com/9372512/152065308-41d35877-f1bd-41d3-a667-5beec713f25f.png)
