### PR TITLE
fix(bitbucket): Fix domain name

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -171,13 +171,15 @@ class BitbucketIntegrationProvider(IntegrationProvider):
     def build_integration(self, state):
         if state.get("publicKey"):
             principal_data = state["principal"]
-
-            domain = principal_data["links"]["html"]["href"].replace("https://", "").rstrip("/")
+            base_url = state["baseUrl"].replace("https://", "")
+            username = principal_data.get("display_name")
+            account_type = principal_data["type"]
+            domain = f"{base_url}/{username}" if account_type == "team" else username
 
             return {
                 "provider": self.key,
                 "external_id": state["clientKey"],
-                "name": principal_data.get("username", principal_data["uuid"]),
+                "name": principal_data.get("username", principal_data["display_name"]),
                 "metadata": {
                     "public_key": state["publicKey"],
                     "shared_secret": state["sharedSecret"],
@@ -186,7 +188,7 @@ class BitbucketIntegrationProvider(IntegrationProvider):
                     "icon": principal_data["links"]["avatar"]["href"],
                     "scopes": self.scopes,
                     "uuid": principal_data["uuid"],
-                    "type": principal_data["type"],  # team or user account
+                    "type": account_type,  # team or user account
                 },
             }
         else:

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -172,14 +172,15 @@ class BitbucketIntegrationProvider(IntegrationProvider):
         if state.get("publicKey"):
             principal_data = state["principal"]
             base_url = state["baseUrl"].replace("https://", "")
-            username = principal_data.get("display_name")
+            # fall back to display name, user installations will use this primarily
+            username = principal_data.get("username", principal_data["display_name"])
             account_type = principal_data["type"]
             domain = f"{base_url}/{username}" if account_type == "team" else username
 
             return {
                 "provider": self.key,
                 "external_id": state["clientKey"],
-                "name": principal_data.get("username", principal_data["display_name"]),
+                "name": username,
                 "metadata": {
                     "public_key": state["publicKey"],
                     "shared_secret": state["sharedSecret"],

--- a/tests/sentry/integrations/bitbucket/test_installed.py
+++ b/tests/sentry/integrations/bitbucket/test_installed.py
@@ -40,6 +40,7 @@ class BitbucketInstalledEndpointTest(APITestCase):
         }
         self.user_data = self.team_data.copy()
         self.user_data["type"] = "user"
+
         self.user_data["display_name"] = self.user_display_name
 
         self.metadata = {
@@ -96,8 +97,9 @@ class BitbucketInstalledEndpointTest(APITestCase):
         integration, created = Integration.objects.get_or_create(
             provider=self.provider,
             external_id=self.client_key,
-            defaults={"name": self.username, "metadata": self.user_metadata},
+            defaults={"name": self.user_display_name, "metadata": self.user_metadata},
         )
+        del self.user_data_from_bitbucket["principal"]["username"]
         response = self.client.post(self.path, data=self.user_data_from_bitbucket)
         assert response.status_code == 200
 


### PR DESCRIPTION
This PR fixes a display issue on the front end where we show the "domain" name in the Bitbucket configuration and repository pages. When the integration was first built, the data that we stored was sane, but at some point (I think sometime in 2018 from looking at Redash) they changed the data that was sent to be this non-human readable identifier. We won't be able to backfill the `domain_name` metadata for existing Bitbucket installations, but this will display something nicer (e.g. bitbucket.org/yourworkspace) for all new installations. 

Where this gets tricky is that you can install this on a "team" level (installing a workspace) or on a "user" level (using your Atlassian account, I am honestly not super sure how this works since I don't use Bitbucket, but I did manually test both). If it is a "team" installation, we have a `username` attribute (this is the name of the workspace) sent to us from Bitbucket that we can piece together with the base URL. When it's a "user" installation, there isn't a username but rather a "display name" that is [always visible, despite your settings](https://support.atlassian.com/atlassian-account/docs/update-your-profile-and-visibility-settings/), so we can rely on that being present. 

I updated tests a bit to make it more clear where the data differs in a user and team installation.

**Before**
<img width="974" alt="Screen Shot 2022-02-01 at 12 08 59 PM" src="https://user-images.githubusercontent.com/29959063/152073512-4a02caf8-917e-4846-848f-5c37b90c92ca.png">
<img width="978" alt="Screen Shot 2022-02-01 at 12 09 06 PM" src="https://user-images.githubusercontent.com/29959063/152073515-fb11bee6-ba83-4c56-8868-2c524646e429.png">
**After**
<img width="983" alt="Screen Shot 2022-02-01 at 12 08 23 PM" src="https://user-images.githubusercontent.com/29959063/152073501-3035cf7e-aaa2-4f90-9343-7e3c0a2dfc8d.png">
<img width="982" alt="Screen Shot 2022-02-01 at 12 06 35 PM" src="https://user-images.githubusercontent.com/29959063/152073481-3c44a3f3-3ef1-4604-b384-127b61545af5.png">
For a user installation:
<img width="978" alt="Screen Shot 2022-02-01 at 4 54 01 PM" src="https://user-images.githubusercontent.com/29959063/152076140-2deef1e2-7502-400a-aef0-8fb7ca383713.png">


