### PR TITLE
feat(ui): Change Alert chart from Line Chart to Area Chart [WIP]

### DIFF
--- a/static/app/components/charts/series/areaSeries.tsx
+++ b/static/app/components/charts/series/areaSeries.tsx
@@ -5,5 +5,19 @@ import LineSeries from 'sentry/components/charts/series/lineSeries';
 export default function AreaSeries(props: LineSeriesOption = {}): LineSeriesOption {
   return LineSeries({
     ...props,
+    emphasis: {
+      ...props.emphasis,
+      scale: false,
+      lineStyle: {
+        // disable color highlight on hover
+        color: props.color as string,
+        width: undefined,
+      },
+      areaStyle: {
+        // Disable AreaSeries highlight on hover
+        color: props.areaStyle?.color ?? (props.color as string),
+        opacity: props.areaStyle?.opacity,
+      },
+    },
   });
 }

--- a/static/app/components/charts/series/areaSeries.tsx
+++ b/static/app/components/charts/series/areaSeries.tsx
@@ -5,19 +5,5 @@ import LineSeries from 'sentry/components/charts/series/lineSeries';
 export default function AreaSeries(props: LineSeriesOption = {}): LineSeriesOption {
   return LineSeries({
     ...props,
-    emphasis: {
-      ...props.emphasis,
-      scale: false,
-      lineStyle: {
-        // disable color highlight on hover
-        color: props.color as string,
-        width: undefined,
-      },
-      areaStyle: {
-        // Disable AreaSeries highlight on hover
-        color: props.areaStyle?.color ?? (props.color as string),
-        opacity: props.areaStyle?.opacity,
-      },
-    },
   });
 }

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -26,6 +26,7 @@ import {
 import {Panel, PanelBody, PanelFooter} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import Truncate from 'sentry/components/truncate';
+import CHART_PALETTE from 'sentry/constants/chartPalette';
 import {IconCheckmark, IconFire, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -353,6 +354,8 @@ class MetricChart extends React.PureComponent<Props, State> {
     const areaSeries: any[] = [];
     // Ensure series data appears below incident/mark lines
     series[0].z = 1;
+    series[0].color = CHART_PALETTE[0][0];
+
     const dataArr = timeseriesData[0].data;
     const maxSeriesValue = dataArr.reduce(
       (currMax, coord) => Math.max(currMax, coord.value),

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -10,11 +10,11 @@ import momentTimezone from 'moment-timezone';
 import {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
 import Button from 'sentry/components/button';
+import AreaChart, {AreaChartSeries} from 'sentry/components/charts/areaChart';
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import MarkArea from 'sentry/components/charts/components/markArea';
 import MarkLine from 'sentry/components/charts/components/markLine';
 import EventsRequest from 'sentry/components/charts/eventsRequest';
-import LineChart, {LineChartSeries} from 'sentry/components/charts/lineChart';
 import LineSeries from 'sentry/components/charts/series/lineSeries';
 import SessionsRequest from 'sentry/components/charts/sessionsRequest';
 import {HeaderTitleLegend, SectionHeading} from 'sentry/components/charts/styles';
@@ -86,7 +86,7 @@ function formatTooltipDate(date: moment.MomentInput, format: string): string {
   return momentTimezone.tz(date, timezone).format(format);
 }
 
-function createThresholdSeries(lineColor: string, threshold: number): LineChartSeries {
+function createThresholdSeries(lineColor: string, threshold: number): AreaChartSeries {
   return {
     seriesName: 'Threshold Line',
     type: 'line',
@@ -107,7 +107,7 @@ function createStatusAreaSeries(
   startTime: number,
   endTime: number,
   yPosition: number
-): LineChartSeries {
+): AreaChartSeries {
   return {
     seriesName: '',
     type: 'line',
@@ -126,10 +126,10 @@ function createIncidentSeries(
   lineColor: string,
   incidentTimestamp: number,
   incident: Incident,
-  dataPoint?: LineChartSeries['data'][0],
+  dataPoint?: AreaChartSeries['data'][0],
   seriesName?: string,
   aggregate?: string
-): LineChartSeries {
+): AreaChartSeries {
   const formatter = ({value, marker}: any) => {
     const time = formatTooltipDate(moment(value), 'MMM D, YYYY LT');
     return [
@@ -231,7 +231,7 @@ class MetricChart extends React.PureComponent<Props, State> {
     }
   };
 
-  getRuleChangeSeries = (data: LineChartSeries[]): LineSeriesOption[] => {
+  getRuleChangeSeries = (data: AreaChartSeries[]): LineSeriesOption[] => {
     const {dateModified} = this.props.rule || {};
 
     if (!data.length || !data[0].data.length || !dateModified) {
@@ -349,10 +349,10 @@ class MetricChart extends React.PureComponent<Props, State> {
     const criticalTrigger = rule.triggers.find(({label}) => label === 'critical');
     const warningTrigger = rule.triggers.find(({label}) => label === 'warning');
 
-    const series: LineChartSeries[] = [...timeseriesData];
+    const series: AreaChartSeries[] = [...timeseriesData];
     const areaSeries: any[] = [];
-    // Ensure series data appears above incident lines
-    series[0].z = 100;
+    // Ensure series data appears below incident/mark lines
+    series[0].z = 1;
     const dataArr = timeseriesData[0].data;
     const maxSeriesValue = dataArr.reduce(
       (currMax, coord) => Math.max(currMax, coord.value),
@@ -559,7 +559,7 @@ class MetricChart extends React.PureComponent<Props, State> {
                 onZoom={zoomArgs => handleZoom(zoomArgs.start, zoomArgs.end)}
               >
                 {zoomRenderProps => (
-                  <LineChart
+                  <AreaChart
                     {...zoomRenderProps}
                     isGroupedByDate
                     showTimeInTooltip


### PR DESCRIPTION
Change the Alert Chart on the Alert Details page from a Line Chart to an Area Chart. Also move the marklines to the top layer.

[FIXES WOR-1560
](https://getsentry.atlassian.net/browse/WOR-1560)[FIXES WOR-1582](https://getsentry.atlassian.net/browse/WOR-1582)

# Before
<img width="792" alt="Screen Shot 2022-02-02 at 11 05 05 AM" src="https://user-images.githubusercontent.com/20312973/152222156-23cc8067-7105-44fd-9d35-f816725e1d83.png">

# After
<img width="796" alt="Screen Shot 2022-02-02 at 11 01 22 AM" src="https://user-images.githubusercontent.com/20312973/152222183-793e0ba3-2eca-4a8c-88c7-2681546a2a8c.png">