### PR TITLE
fix(ui): Support translated suffix in relative dates

### DIFF
--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -169,14 +169,12 @@ export function getRelativeDate(
   if ((shorten || extraShort) && !suffix) {
     return getDuration(moment().diff(moment(date), 'seconds'), 0, shorten, extraShort);
   }
-  if (!suffix) {
-    return moment(date).fromNow(true);
-  }
   if (suffix === 'ago') {
     return moment(date).fromNow();
   }
-  if (suffix === 'old') {
-    return t('%(time)s old', {time: moment(date).fromNow(true)});
+  if (suffix?.length) {
+    return t('%(time)s %(suffix)s', {time: moment(date).fromNow(true), suffix});
   }
-  throw new Error('Unsupported time format suffix');
+
+  return moment(date).fromNow(true);
 }

--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -169,12 +169,12 @@ export function getRelativeDate(
   if ((shorten || extraShort) && !suffix) {
     return getDuration(moment().diff(moment(date), 'seconds'), 0, shorten, extraShort);
   }
+  if (!suffix) {
+    return moment(date).fromNow(true);
+  }
   if (suffix === 'ago') {
     return moment(date).fromNow();
   }
-  if (suffix?.length) {
-    return t('%(time)s %(suffix)s', {time: moment(date).fromNow(true), suffix});
-  }
 
-  return moment(date).fromNow(true);
+  return t('%(time)s %(suffix)s', {time: moment(date).fromNow(true), suffix});
 }

--- a/tests/js/spec/components/timeSince.spec.tsx
+++ b/tests/js/spec/components/timeSince.spec.tsx
@@ -5,8 +5,10 @@ import TimeSince from 'sentry/components/timeSince';
 describe('TimeSince', function () {
   const tenMinAgo = new Date(new Date().getTime() - 60000 * 10);
   it('renders a relative date', () => {
-    mountWithTheme(<TimeSince date={new Date()} />);
+    const {rerender} = mountWithTheme(<TimeSince date={new Date()} />);
     expect(screen.getByText('a few seconds ago')).toBeInTheDocument();
+    rerender(<TimeSince date={tenMinAgo} />);
+    expect(screen.getByText('10 minutes ago')).toBeInTheDocument();
   });
 
   it('renders a relative date without suffix', () => {

--- a/tests/js/spec/components/timeSince.spec.tsx
+++ b/tests/js/spec/components/timeSince.spec.tsx
@@ -1,0 +1,36 @@
+import {mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
+
+import TimeSince from 'sentry/components/timeSince';
+
+describe('TimeSince', function () {
+  const tenMinAgo = new Date(new Date().getTime() - 60000 * 10);
+  it('renders a relative date', () => {
+    mountWithTheme(<TimeSince date={new Date()} />);
+    expect(screen.getByText('a few seconds ago')).toBeInTheDocument();
+  });
+
+  it('renders a relative date without suffix', () => {
+    mountWithTheme(<TimeSince date={tenMinAgo} suffix="" />);
+    expect(screen.getByText('10 minutes')).toBeInTheDocument();
+  });
+
+  it('renders a shortened date', () => {
+    mountWithTheme(<TimeSince shorten date={tenMinAgo} />);
+    expect(screen.getByText('10min ago')).toBeInTheDocument();
+  });
+
+  it('renders a extrashort date', () => {
+    mountWithTheme(<TimeSince shorten extraShort date={tenMinAgo} />);
+    expect(screen.getByText('10m ago')).toBeInTheDocument();
+  });
+
+  it('renders a spanish suffix', () => {
+    mountWithTheme(<TimeSince date={tenMinAgo} suffix="atrás" />);
+    expect(screen.getByText('10 minutes atrás')).toBeInTheDocument();
+  });
+
+  it('renders a spanish suffix with shortened', () => {
+    mountWithTheme(<TimeSince shorten extraShort date={tenMinAgo} suffix="atrás" />);
+    expect(screen.getByText('10m atrás')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
fixes #31542
fixes JAVASCRIPT-26DC

checking for 'ago' when the strings are translated errors. This uses any suffix provided and falls back to just the date instead of an error.