### PR TITLE
feat(transitional-serializer): write to sessions as JSON obj

### DIFF
--- a/src/sentry/utils/transitional_serializer.py
+++ b/src/sentry/utils/transitional_serializer.py
@@ -13,12 +13,8 @@ class TransitionalSerializer:
         self.json_serializer = JSONSerializer()
 
     def dumps(self, obj: Dict[str, Any]) -> bytes:
-        # need to rollback json write
-        # metrics.incr("transitional_serializer.json_write")
-        # return self.json_serializer.dumps(obj)
-
-        metrics.incr("transitional_serializer.pickle_write")
-        return self.pickle_serializer.dumps(obj)
+        metrics.incr("transitional_serializer.json_write")
+        return self.json_serializer.dumps(obj)
 
     def loads(self, data: bytes) -> Dict[str, Any]:
         try:

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode
 from urllib.request import Request
 
 import requests
+from django.conf import settings
 from django.contrib.auth import authenticate, load_backend
 from django.utils.crypto import constant_time_compare, get_random_string
 from requests_oauthlib import OAuth1
@@ -291,7 +292,8 @@ class BaseAuth:
 
         if saved_kwargs["backend"] and type(saved_kwargs["backend"]) == str:
             backend_path = saved_kwargs["backend"]
-            saved_kwargs["backend"] = load_backend(backend_path)
+            if backend_path in settings.AUTHENTICATION_BACKENDS:
+                saved_kwargs["backend"] = load_backend(backend_path)
 
         return (session_data["next"], args, saved_kwargs)
 

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -290,7 +290,7 @@ class BaseAuth:
         saved_kwargs = {key: ctype_to_model(val) for key, val in session_data["kwargs"].items()}
         saved_kwargs.update((key, val) for key, val in kwargs.items())
 
-        if saved_kwargs["backend"] and type(saved_kwargs["backend"]) == str:
+        if isinstance(saved_kwargs.get("backend"), str):
             backend_path = saved_kwargs["backend"]
             if backend_path in settings.AUTHENTICATION_BACKENDS:
                 saved_kwargs["backend"] = load_backend(backend_path)

--- a/tests/sentry/utils/test_transitional_serializer.py
+++ b/tests/sentry/utils/test_transitional_serializer.py
@@ -20,6 +20,5 @@ class TransitionalSerializerTest(TestCase):
     def test_read_pickle(self):
         assert self.transitional_serializer.loads(self.pickle_obj) == self.obj
 
-    # need to rollback json write
-    # def test_write(self):
-    #     assert self.transitional_serializer.dumps(self.obj) == self.json_obj
+    def test_write(self):
+        assert self.transitional_serializer.dumps(self.obj) == self.json_obj


### PR DESCRIPTION
Transitional serializer now writes a json object to sessions. In addition, made social_auth object serializable.
 
Fixed the problem in https://github.com/getsentry/sentry/pull/31362 which was reverted by https://github.com/getsentry/sentry/pull/31471