### PR TITLE
fix(notifications: remove duplicate analytics event

### DIFF
--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -72,7 +72,6 @@ def get_unsubscribe_link(
 def log_message(notification: BaseNotification, recipient: Team | User) -> None:
     extra = notification.get_log_params(recipient)
     logger.info("mail.adapter.notify.mail_user", extra={**extra})
-    notification.record_notification_sent(recipient, ExternalProviders.EMAIL)
 
 
 def get_context(


### PR DESCRIPTION
We are sending duplicate analytics events because we call `notification.record_notification_sent` twice, see: https://github.com/getsentry/sentry/blob/ff2dc016b7ec84c8083444e5525509fbc81e1fef/src/sentry/mail/notifications.py#L132