### PR TITLE
fix(suspect-spans): Bad example txns without the span

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsTable.tsx
@@ -67,20 +67,25 @@ export default function SpanTable(props: Props) {
     return null;
   }
 
-  const data = examples.map(example => ({
-    id: example.id,
-    project: project?.slug,
-    // timestamps are in seconds but want them in milliseconds
-    timestamp: example.finishTimestamp * 1000,
-    transactionDuration: (example.finishTimestamp - example.startTimestamp) * 1000,
-    spanDuration: example.nonOverlappingExclusiveTime,
-    occurrences: example.spans.length,
-    cumulativeDuration: example.spans.reduce(
-      (duration, span) => duration + span.exclusiveTime,
-      0
-    ),
-    spans: example.spans,
-  }));
+  const data = examples
+    // we assume that the span appears in each example at least once,
+    // if this assumption is broken, nothing onwards will work so
+    // filter out such examples
+    .filter(example => example.spans.length > 0)
+    .map(example => ({
+      id: example.id,
+      project: project?.slug,
+      // timestamps are in seconds but want them in milliseconds
+      timestamp: example.finishTimestamp * 1000,
+      transactionDuration: (example.finishTimestamp - example.startTimestamp) * 1000,
+      spanDuration: example.nonOverlappingExclusiveTime,
+      occurrences: example.spans.length,
+      cumulativeDuration: example.spans.reduce(
+        (duration, span) => duration + span.exclusiveTime,
+        0
+      ),
+      spans: example.spans,
+    }));
 
   return (
     <Fragment>


### PR DESCRIPTION
There are some cases where we get a bad response where an example doesn't
actually contain the specified span. This is a hot fix to make sure the page
doesn't error, and an actual fix to follow.