### PR TITLE
fix(codeowners): Correctly search for Gitlab CODEOWNERS file

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -221,11 +221,10 @@ class GitHubClientMixin(ApiClient):  # type: ignore
         results: Mapping[str, Any] = self.get(path="/search/code", params={"q": query})
         return results
 
-    def get_file(self, repo: str, path: str) -> bytes:
+    def get_file(self, repo: Repository, path: str, ref: str) -> bytes:
         from base64 import b64decode
 
-        # default ref will be the default_branch
-        contents = self.get(path=f"/repos/{repo}/contents/{path}")
+        contents = self.get(path=f"/repos/{repo.name}/contents/{path}", params={"ref": ref})
         encoded_content = contents["content"]
         return b64decode(encoded_content)
 

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -294,7 +294,7 @@ class GitLabApiClient(ApiClient):
                 raise
             return None
 
-    def get_file(self, repo, path, ref):
+    def get_file(self, repo: Repository, path: str, ref: str) -> bytes:
         """Get the contents of a file
 
         See https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -131,7 +131,7 @@ class RepositoryMixin:
             html_url = self.check_file(repo, filepath, ref)
             if html_url:
                 try:
-                    contents = self.get_client().get_file(repo.name, filepath)
+                    contents = self.get_client().get_file(repo, filepath, ref)
                 except ApiError:
                     continue
                 return {"filepath": filepath, "html_url": html_url, "raw": contents}


### PR DESCRIPTION
See: [API-2462](https://getsentry.atlassian.net/browse/API-2426)
Previous: https://github.com/getsentry/sentry/pull/31448

In my previous PR, there was a slight difference in the arguments for Github's `get_file` function, and Gitlab's `check_file` function, that means using one call for both didn't work for a while, since GItlab needed the 'branch' but Github didn't. Now both methods should work the same, and to test, I setup Gitlab and Github and both worked just fine.


https://user-images.githubusercontent.com/35509934/152235072-22f6e2d8-ab9a-413c-8f43-09026f28dbb0.mov

 