### PR TITLE
ref(invites): change needsSso fieldname to hasAuthProvider on invite page

### DIFF
--- a/static/app/views/acceptOrganizationInvite.tsx
+++ b/static/app/views/acceptOrganizationInvite.tsx
@@ -20,7 +20,7 @@ type InviteDetails = {
   needsAuthentication: boolean;
   needs2fa: boolean;
   needsEmailVerification: boolean;
-  needsSso: boolean;
+  hasAuthProvider: boolean;
   requireSso: boolean;
   existingMember: boolean;
   ssoProvider?: string;
@@ -107,7 +107,7 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
           </p>
         )}
 
-        {inviteDetails.needsSso && (
+        {inviteDetails.hasAuthProvider && (
           <p data-test-id="action-info-sso">
             {inviteDetails.requireSso
               ? tct(
@@ -133,7 +133,7 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
 
         <Actions>
           <ActionsLeft>
-            {inviteDetails.needsSso && (
+            {inviteDetails.hasAuthProvider && (
               <Button
                 aria-label="sso-login"
                 priority="primary"
@@ -211,7 +211,7 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
 
     return (
       <Fragment>
-        {inviteDetails.needsSso && !inviteDetails.requireSso && (
+        {inviteDetails.hasAuthProvider && !inviteDetails.requireSso && (
           <p data-test-id="action-info-sso">
             {tct(
               `Note that [orgSlug] has enabled Single Sign-On (SSO) using
@@ -226,7 +226,7 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
         )}
         <Actions>
           <ActionsLeft>
-            {inviteDetails.needsSso && !inviteDetails.requireSso && (
+            {inviteDetails.hasAuthProvider && !inviteDetails.requireSso && (
               <Button
                 aria-label="sso-login"
                 priority="primary"

--- a/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
+++ b/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
@@ -20,7 +20,7 @@ describe('AcceptOrganizationInvite', function () {
       orgSlug: 'test-org',
       needsAuthentication: false,
       needs2fa: false,
-      needsSso: false,
+      hasAuthProvider: false,
       requireSso: false,
       existingMember: false,
     });
@@ -55,7 +55,7 @@ describe('AcceptOrganizationInvite', function () {
       orgSlug: 'test-org',
       needsAuthentication: true,
       needs2fa: false,
-      needsSso: false,
+      hasAuthProvider: false,
       requireSso: false,
       existingMember: false,
     });
@@ -81,7 +81,7 @@ describe('AcceptOrganizationInvite', function () {
       orgSlug: 'test-org',
       needsAuthentication: true,
       needs2fa: false,
-      needsSso: true,
+      hasAuthProvider: true,
       requireSso: false,
       existingMember: false,
     });
@@ -107,7 +107,7 @@ describe('AcceptOrganizationInvite', function () {
       orgSlug: 'test-org',
       needsAuthentication: true,
       needs2fa: false,
-      needsSso: true,
+      hasAuthProvider: true,
       requireSso: true,
       existingMember: false,
     });
@@ -133,7 +133,7 @@ describe('AcceptOrganizationInvite', function () {
       orgSlug: 'test-org',
       needsAuthentication: false,
       needs2fa: false,
-      needsSso: true,
+      hasAuthProvider: true,
       requireSso: true,
       existingMember: false,
     });
@@ -159,7 +159,7 @@ describe('AcceptOrganizationInvite', function () {
       orgSlug: 'test-org',
       needsAuthentication: false,
       needs2fa: false,
-      needsSso: true,
+      hasAuthProvider: true,
       requireSso: true,
       existingMember: true,
     });
@@ -191,7 +191,7 @@ describe('AcceptOrganizationInvite', function () {
       orgSlug: 'test-org',
       needsAuthentication: false,
       needs2fa: false,
-      needsSso: true,
+      hasAuthProvider: true,
       requireSso: false,
       existingMember: false,
     });
@@ -213,7 +213,7 @@ describe('AcceptOrganizationInvite', function () {
       orgSlug: 'test-org',
       needsAuthentication: false,
       needs2fa: false,
-      needsSso: false,
+      hasAuthProvider: false,
       requireSso: false,
       existingMember: true,
     });
@@ -245,7 +245,7 @@ describe('AcceptOrganizationInvite', function () {
       orgSlug: 'test-org',
       needsAuthentication: false,
       needs2fa: true,
-      needsSso: false,
+      hasAuthProvider: false,
       requireSso: false,
       existingMember: false,
     });


### PR DESCRIPTION
in #31519 We added a fieldName `hasAuthProvider` to replace `needsSso` on the invite API endpoint. This changes the frontend to use this field instead.