### PR TITLE
chore(build): pin git commit gh action in openapi workflow

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -65,7 +65,7 @@ jobs:
           cp tests/apidocs/openapi-derefed.json sentry-api-schema
 
       - name: Git Commit & Push
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@5804e42f86b1891093b151b6c4e78e759c746c4d
         if: steps.changes.outputs.api_docs == 'true'
         with:
           repository: sentry-api-schema


### PR DESCRIPTION
following up from https://github.com/getsentry/sentry/pull/31526