### PR TITLE
ref(celery): Test celerybeat schedules so they match celery's flavour of cron

### DIFF
--- a/tests/sentry/celery/test_app.py
+++ b/tests/sentry/celery/test_app.py
@@ -15,3 +15,5 @@ def test_validate_celerybeat_schedule(name, entry):
     assert entry.task in app.tasks
     mod_name = app.tasks[entry.task].__module__
     assert mod_name in settings.CELERY_IMPORTS, f"{mod_name} is missing from CELERY_IMPORTS"
+    # Test that the schedules are valid. Throws a RuntimeError if one is invalid.
+    entry.is_due()


### PR DESCRIPTION
Extends a test to prevent situations like https://github.com/getsentry/sentry/pull/30210 from happening, which tried to do something clever with cron schedules that celery did not appreciate.

NATIVE-411