### PR TITLE
fix(ingest-metrics-consumer): Handle back pressure correctly

### DIFF
--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -3,6 +3,7 @@ import logging
 import time
 from collections import deque
 from concurrent.futures import Future
+from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -375,7 +376,7 @@ def process_messages(
 
     for message in outer_message.payload:
         parsed_payload_value = parsed_payloads_by_offset[message.offset]
-        new_payload_value = parsed_payload_value.copy()
+        new_payload_value = deepcopy(parsed_payload_value)
 
         metric_name = parsed_payload_value["name"]
         tags = parsed_payload_value.get("tags", {})

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -3,15 +3,18 @@ from datetime import datetime, timezone
 from typing import Dict, List, Mapping, MutableMapping, Union
 from unittest.mock import Mock, call, patch
 
+import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker as Broker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
+from arroyo.processing.strategies import MessageRejected
 from arroyo.types import Message, Partition, Position, Topic
 from arroyo.utils.clock import TestingClock as Clock
 
 from sentry.sentry_metrics.indexer.mock import MockIndexer
 from sentry.sentry_metrics.multiprocess import (
     BatchMessages,
+    DuplicateMessage,
     MetricsBatchBuilder,
     ProduceStep,
     process_messages,
@@ -51,20 +54,48 @@ def test_batch_messages() -> None:
     assert not next_step.submit.called
 
     # submit the second message, message should be added to the batch
+    # which will now saturate the batch_size (2). This will trigger
+    # __flush which in turn calls next.submit and reset the batch to None
     batch_messages_step.submit(message=message2)
-
-    assert len(batch_messages_step._BatchMessages__batch) == 2
-
-    # now the batch_size (2) has been reached, poll should call
-    # self.flush which will call the next step's submit and then
-    # reset the batch to None
-    batch_messages_step.poll()
 
     assert next_step.submit.call_args == call(
         Message(message2.partition, message2.offset, [message1, message2], message2.timestamp),
     )
 
     assert batch_messages_step._BatchMessages__batch is None
+
+
+def test_batch_messages_rejected_message():
+    next_step = Mock()
+    next_step.submit.side_effect = MessageRejected()
+
+    max_batch_time = 100.0  # seconds
+    max_batch_size = 2
+
+    batch_messages_step = BatchMessages(
+        next_step=next_step, max_batch_time=max_batch_time, max_batch_size=max_batch_size
+    )
+
+    message1 = Message(
+        Partition(Topic("topic"), 0), 1, KafkaPayload(None, b"some value", []), datetime.now()
+    )
+    message2 = Message(
+        Partition(Topic("topic"), 0), 2, KafkaPayload(None, b"another value", []), datetime.now()
+    )
+    batch_messages_step.poll()
+    batch_messages_step.submit(message=message1)
+
+    # if we try to submit a batch when the next step is
+    # not ready to accept more messages we'll get a
+    # MessageRejected error which will bubble up to the
+    # StreamProcessor.
+    with pytest.raises(MessageRejected):
+        batch_messages_step.submit(message=message2)
+
+    # when poll is called, we still try to flush the batch
+    # caust its full but we handled the MessageRejected error
+    batch_messages_step.poll()
+    assert next_step.submit.called
 
 
 def test_metrics_batch_builder():
@@ -105,6 +136,17 @@ def test_metrics_batch_builder():
 
     time.sleep(3)
     assert batch_builder_time.ready()
+
+    # 3. Adding the same message twice to the same batch
+    batch_builder_time = MetricsBatchBuilder(
+        max_batch_size=max_batch_size, max_batch_time=max_batch_time
+    )
+    message1 = Message(
+        Partition(Topic("topic"), 0), 1, KafkaPayload(None, b"some value", []), datetime.now()
+    )
+    batch_builder_time.append(message1)
+    with pytest.raises(DuplicateMessage):
+        batch_builder_time.append(message1)
 
 
 ts = int(datetime.now(tz=timezone.utc).timestamp())


### PR DESCRIPTION
**context**
The second version of the ingest-metrics-consumer was added in https://github.com/getsentry/sentry/pull/30462. In attempts to run this new consumer we first stopped the old consumers and set their replicas to `0` and then started up the new consumers. However, we ran into the following error: `MessageRejected("no available input blocks")` which is thrown [here](https://github.com/getsentry/arroyo/blob/1dbc30cbe842d4ca6aa8e46893805c50a6946f2d/arroyo/processing/strategies/streaming/transform.py#L429) in arroyo. 

**problem**
We run into this error when all the shared memory is use in `ParallelTransformStep` and we apply back pressure. This is expected. What is _not_ expected is for the consumer to crash because of this. 

Per the comment [here](https://github.com/getsentry/arroyo/blob/1dbc30cbe842d4ca6aa8e46893805c50a6946f2d/arroyo/processing/processor.py#L147-L150):
```python 
# If the processing strategy rejected our message, we need
# to pause the consumer and hold the message until it is
# accepted, at which point we can resume consuming.
```
what is supposed to happen is that we catch the `MessageRejected` error, we pause, we keep trying to submit the "carried over" message until it's successful and then we resume consuming. 

The problem with the current implementation is that we are not bubbling up the error correctly through `submit`. It's getting raised from calling `poll`. 

**solution & changes**

* We need to be trying to flush within `submit` as well as `poll` so that the `MessageRejected` error will get bubbled up and in turn pause the consumer. 
* We also need to handle the error within `poll` now that `submit` is bubbling up the error. If we don't do this we will continue to crash the consumer the next time we called `poll`.
* Since we will be retrying the same message over and over until it succeeds, we want to make sure it doesn't get added to the batch again.

I tried to outline the overall `StreamProcessor`'s `_run_once` method in https://github.com/getsentry/sentry/pull/31562#issuecomment-1028523806 to help explain the what's going on.