### PR TITLE
fix(ui): Handle truncation for different screen sizes

### DIFF
--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -340,6 +340,7 @@ class MetricChart extends React.PureComponent<Props, State> {
       organization,
       timePeriod: {start, end},
     } = this.props;
+    const {width} = this.state;
     const {dateModified, timeWindow, aggregate} = rule;
 
     if (loading || !timeseriesData) {
@@ -537,6 +538,18 @@ class MetricChart extends React.PureComponent<Props, State> {
 
     const queryFilter = filter?.join(' ');
 
+    const percentOfWidth =
+      width >= 1151
+        ? 15
+        : width < 1151 && width >= 700
+        ? 14
+        : width < 700 && width >= 515
+        ? 13
+        : width < 515 && width >= 300
+        ? 12
+        : 8;
+    const truncateWidth = (percentOfWidth / 100) * width;
+
     return (
       <ChartPanel>
         <StyledPanelBody withPadding>
@@ -548,7 +561,7 @@ class MetricChart extends React.PureComponent<Props, State> {
           <ChartFilters>
             <StyledCircleIndicator size={8} />
             <Filters>{rule.aggregate}</Filters>
-            <Truncate value={queryFilter ?? ''} maxLength={75} />
+            <Truncate value={queryFilter ?? ''} maxLength={truncateWidth} />
           </ChartFilters>
           {getDynamicText({
             value: (
@@ -822,14 +835,9 @@ const ChartFilters = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   font-family: ${p => p.theme.text.family};
   color: ${p => p.theme.textColor};
-  white-space: nowrap;
-  text-overflow: ellipsis;
-
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
+  display: inline-grid;
+  grid-template-columns: repeat(3, max-content);
+  align-items: center;
 `;
 
 const Filters = styled('span')`


### PR DESCRIPTION
Handle alert filter truncation for different screen sizes and extend to width of chart container (metric details page).

[FIXES WOR-1580](https://getsentry.atlassian.net/browse/WOR-1580)

# Before
<img width="832" alt="Screen Shot 2022-02-03 at 2 17 32 AM" src="https://user-images.githubusercontent.com/20312973/152324168-db34367c-61d1-418b-a053-bdca4fd2a5c6.png">

# After
<img width="830" alt="Screen Shot 2022-02-03 at 2 15 03 AM" src="https://user-images.githubusercontent.com/20312973/152324189-08defafd-0129-4324-b0c6-4529697fb9c0.png">

