### PR TITLE
test(acceptance): Attempt to fix events v2 flake

### DIFF
--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -205,15 +205,14 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
             # This test is flakey in that we sometimes load this page before the event is processed
             # depend on pytest-retry to reload the page
-            self.browser.wait_until_not(
-                '[data-test-id="grid-editable"] [data-test-id="empty-state"]', timeout=2
-            )
+            self.browser.wait_until('[data-test-id="grid-editable"] > tbody > tr:nth-child(2)')
             self.browser.snapshot("events-v2 - all events query - list")
 
         with self.feature(FEATURE_NAMES):
             # expect table to expand to the right when no tags are provided
             self.browser.get(self.result_path + "?" + all_events_query(tag=[]))
             self.wait_until_loaded()
+            self.browser.wait_until('[data-test-id="grid-editable"] > tbody > tr:nth-child(2)')
             self.browser.snapshot("events-v2 - all events query - list - no tags")
 
     def test_errors_query_empty_state(self):


### PR DESCRIPTION
This will cause pytest to fail and hopefully retry the test until we get 2 events.

Fixes this flake: 
![image](https://user-images.githubusercontent.com/79684/152439955-ebe88b6e-7257-4261-ad89-6743202c0bd4.png)

https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/72fcff6d991ac37e818b8f7e0cd12a6db27e4ba2/index.html