### PR TITLE
fix(ingest-metrics-consumer): handle back pressure in join

### DIFF
--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -199,17 +199,13 @@ class BatchMessages(ProcessingStep[KafkaPayload]):  # type: ignore
         self.__closed = True
 
     def join(self, timeout: Optional[float] = None) -> None:
-        start = time.time()
-        while self.__batch:
-            remaining = timeout - (time.time() - start) if timeout is not None else None
-            if remaining is not None and remaining <= 0:
-                logger.warning(f"Timed out with {len(self.__batch)} messages left in batch")
-                break
-            try:
-                self.__flush()
-            except MessageRejected:
-                pass
+        if self.__batch:
+            last = self.__batch.messages[-1]
+            logger.debug(
+                f"Abandoning batch of {len(self.__batch)} messages...latest offset: {last.offset}"
+            )
 
+        self.__next_step.close()
         self.__next_step.join(timeout)
 
 
@@ -290,8 +286,8 @@ class ProduceStep(ProcessingStep[MessageBatch]):  # type: ignore
     def _record_commit_duration(self, commit_duration: float) -> None:
         self.__commit_duration_sum += commit_duration
 
-        # record commit durations every 5 minutes
-        if (self.__commit_start + 300) < time.time():
+        # record commit durations every 5 seconds
+        if (self.__commit_start + 5) < time.time():
             self.__metrics.incr(
                 "produce_step.commit_duration", amount=int(self.__commit_duration_sum)
             )

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from datetime import datetime, timezone
 from typing import Dict, List, Mapping, MutableMapping, Union
@@ -22,13 +23,11 @@ from sentry.sentry_metrics.multiprocess import (
 from sentry.sentry_metrics.sessions import SessionMetricKey
 from sentry.utils import json
 
+LOGGER = logging.getLogger(__name__)
 
-def test_batch_messages() -> None:
-    next_step = Mock()
 
-    max_batch_time = 100.0  # seconds
-    max_batch_size = 2
-
+def _batch_message_set_up(next_step: Mock, max_batch_time: float = 100.0, max_batch_size: int = 2):
+    # batch time is in seconds
     batch_messages_step = BatchMessages(
         next_step=next_step, max_batch_time=max_batch_time, max_batch_size=max_batch_size
     )
@@ -39,6 +38,13 @@ def test_batch_messages() -> None:
     message2 = Message(
         Partition(Topic("topic"), 0), 2, KafkaPayload(None, b"another value", []), datetime.now()
     )
+    return (batch_messages_step, message1, message2)
+
+
+def test_batch_messages() -> None:
+    next_step = Mock()
+
+    batch_messages_step, message1, message2 = _batch_message_set_up(next_step)
 
     # submit the first message, batch builder should should be created
     # and the messaged added to the batch
@@ -69,19 +75,8 @@ def test_batch_messages_rejected_message():
     next_step = Mock()
     next_step.submit.side_effect = MessageRejected()
 
-    max_batch_time = 100.0  # seconds
-    max_batch_size = 2
+    batch_messages_step, message1, message2 = _batch_message_set_up(next_step)
 
-    batch_messages_step = BatchMessages(
-        next_step=next_step, max_batch_time=max_batch_time, max_batch_size=max_batch_size
-    )
-
-    message1 = Message(
-        Partition(Topic("topic"), 0), 1, KafkaPayload(None, b"some value", []), datetime.now()
-    )
-    message2 = Message(
-        Partition(Topic("topic"), 0), 2, KafkaPayload(None, b"another value", []), datetime.now()
-    )
     batch_messages_step.poll()
     batch_messages_step.submit(message=message1)
 
@@ -95,6 +90,44 @@ def test_batch_messages_rejected_message():
     # when poll is called, we still try to flush the batch
     # caust its full but we handled the MessageRejected error
     batch_messages_step.poll()
+    assert next_step.submit.called
+
+
+def test_batch_messages_join_timeout(caplog):
+    next_step = Mock()
+    next_step.submit.side_effect = MessageRejected()
+
+    batch_messages_step, message1, message2 = _batch_message_set_up(next_step)
+
+    batch_messages_step.submit(message=message1)
+
+    # if we try to submit a batch when the next step is
+    # not ready to accept more messages we'll get a
+    # MessageRejected error which will bubble up to the
+    # StreamProcessor.
+    with pytest.raises(MessageRejected):
+        batch_messages_step.submit(message=message2)
+
+    # A rebalance, restart, scale up or any other event
+    # that causes partitions to be revoked will call join
+    with caplog.at_level(logging.WARNING):
+        batch_messages_step.join(timeout=3)
+
+    assert "Timed out with 2 messages left in batch" in caplog.text
+
+
+def test_batch_messages_join():
+    next_step = Mock()
+
+    batch_messages_step, message1, _ = _batch_message_set_up(next_step)
+
+    batch_messages_step.poll()
+    batch_messages_step.submit(message=message1)
+    # A rebalance, restart, scale up or any other event
+    # that causes partitions to be revoked will call join
+    batch_messages_step.join(timeout=3)
+    # we flush the batch even if it's not full because
+    # we still need to finish the work we've done thus far
     assert next_step.submit.called
 
 


### PR DESCRIPTION
fixes the same problem that happened in https://github.com/getsentry/sentry/pull/31562, but within the `join` method. 


`join` gets called from [the processor](https://github.com/getsentry/arroyo/blob/main/arroyo/processing/processor.py#L79) when partitions are revoked. This could happen at any time. 

~While we still have an unflushed batch, we want to keep trying to submit to the `next_step` until we reach the timeout. Right now we crash right away because we don't handle the `MessageRejected` error.~ This actually won't work see https://github.com/getsentry/sentry/pull/31589#discussion_r799078289

Instead let's just throw away the batch so that we will start over when the consumer restarts. 

**testing locally**
```python
# start one consumer
sentry run ingest-metrics-consumer-2 --max-batch-size=2
# send some test events to fill up the batches 
stop the consumer 
# restart consumer, parallel step should be saturated since we catching up
sentry run ingest-metrics-consumer-2 --max-batch-size=2
# start another consumer, cause a rebalance
sentry run ingest-metrics-consumer-2 --max-batch-size=2
```
^ in the above scenario I was able to log the last offset of the batch we abandoned in the `join` and made sure to see that we did end up committing it after the rebalance