### PR TITLE
ref(images-loaded-filter): Remove underline blue indicator when hovering filter option

### DIFF
--- a/static/app/components/events/interfaces/searchBarAction/searchBarActionFilter.tsx
+++ b/static/app/components/events/interfaces/searchBarAction/searchBarActionFilter.tsx
@@ -149,10 +149,6 @@ const StyledListItem = styled(ListItem)<{isChecked: boolean; hasDescription: boo
     ${CheckboxFancy} {
       opacity: 1;
     }
-    span {
-      color: ${p => p.theme.blue300};
-      text-decoration: underline;
-    }
   }
 `;
 


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/29228205/152525084-c21702ce-8e20-4eb1-84b1-ea4d683bc76c.png)
![image](https://user-images.githubusercontent.com/29228205/152525502-e8d8afb9-d13f-4902-a28a-f83c763982bc.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/152525011-59b9dfbb-bd51-4ef1-b681-b4b0c992c2e0.png)
![image](https://user-images.githubusercontent.com/29228205/152525451-54b5a21e-66a3-472d-9542-f73285da7b03.png)
