### PR TITLE
test(acceptance): Update conflicting snapshot filename

### DIFF
--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -484,7 +484,7 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
             self.browser.element('[data-test-id="duplicate-widget"]').click()
             self.page.wait_until_loaded()
 
-            self.browser.snapshot("dashboard widget - duplicate")
+            self.browser.snapshot("dashboard widget - duplicate with grid")
 
     def test_delete_widget_in_view_mode(self):
         existing_widget = DashboardWidget.objects.create(
@@ -507,7 +507,7 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
 
             self.page.wait_until_loaded()
 
-            self.browser.snapshot("dashboard widget - delete")
+            self.browser.snapshot("dashboard widget - delete with grid")
 
     def test_cancel_without_changes_does_not_trigger_confirm_with_widget_library_through_header(
         self,


### PR DESCRIPTION
There's possible flake if the filenames conflict and they override one another