### PR TITLE
ref(pagerduty): Add more parameters to logs

### DIFF
--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -74,8 +74,8 @@ class PagerDutyClient(ApiClient):
                 extra={
                     "organization_id": organization.id,
                     "status_code": response.status_code,
-                    "dedup_key": response.dedup_key,
-                    "message": response.message,
+                    "dedup_key": response.get("dedup_key"),
+                    "message": response.get("message"),
                 },
             )
         return response

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -63,7 +63,10 @@ class PagerDutyClient(ApiClient):
             # the payload is for a metric alert
             payload = data
 
-        response = self.post("/", data=payload)
+        try:
+            response = self.post("/", data=payload)
+        except Exception as exc:
+            raise exc
         if (
             organization
             and features.has("organizations:pagerduty-metric-alert-resolve-logging", organization)

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -63,10 +63,7 @@ class PagerDutyClient(ApiClient):
             # the payload is for a metric alert
             payload = data
 
-        try:
-            response = self.post("/", data=payload)
-        except Exception as exc:
-            raise exc
+        response = self.post("/", data=payload)
         if (
             organization
             and features.has("organizations:pagerduty-metric-alert-resolve-logging", organization)

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -71,7 +71,12 @@ class PagerDutyClient(ApiClient):
         ):
             logger.info(
                 "resolve.received.pagerduty_metric_alert",
-                extra={"organization_id": organization.id, "status_code": response.status_code},
+                extra={
+                    "organization_id": organization.id,
+                    "status_code": response.status_code,
+                    "dedup_key": response.dedup_key,
+                    "message": response.message,
+                },
             )
         return response
 


### PR DESCRIPTION
Add a `dedup_key` and `message` to the PagerDuty response logs for metric alert resolves, and add a try/except around posting the payload to help diagnose a customer issue.

See https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI2Nw-send-an-event-to-pager-duty#Responses