### PR TITLE
fix(page-filters): Fix absolute date time persistence

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -403,6 +403,7 @@ function getNewQueryParams(
   // Normalize existing query parameters
   const currentQueryState = getStateFromQuery(cleanCurrentQuery, {
     allowEmptyPeriod: true,
+    allowAbsoluteDatetime: true,
   });
 
   // Extract non page filter parameters.

--- a/tests/js/spec/actionCreators/pageFilters.spec.jsx
+++ b/tests/js/spec/actionCreators/pageFilters.spec.jsx
@@ -265,6 +265,21 @@ describe('PageFilters ActionCreators', function () {
 
       expect(router.replace).not.toHaveBeenCalled();
     });
+
+    it('does not override an absolute date selection', function () {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {project: '1', start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'},
+        },
+      });
+      updateProjects([2], router, {replace: true});
+
+      expect(router.replace).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {project: ['2'], start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'},
+      });
+    });
   });
 
   describe('updateEnvironments()', function () {
@@ -309,6 +324,29 @@ describe('PageFilters ActionCreators', function () {
       expect(router.push).toHaveBeenCalledWith({
         pathname: '/test/',
         query: {},
+      });
+    });
+
+    it('does not override an absolute date selection', function () {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {
+            environment: 'test',
+            start: '2020-03-22T00:53:38',
+            end: '2020-04-21T00:53:38',
+          },
+        },
+      });
+      updateEnvironments(['new-env'], router, {replace: true});
+
+      expect(router.replace).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {
+          environment: ['new-env'],
+          start: '2020-03-22T00:53:38',
+          end: '2020-04-21T00:53:38',
+        },
       });
     });
   });


### PR DESCRIPTION
Fixes a bug where changing an environment or project would remove an absolute date range selection due to this new code path not accounting for absolute date time

Previously this broken behavior could be seen by
1. selecting an absolute date time
2. selecting an environment or project
3. observing that the absolute date time is now the default period