### PR TITLE
ref(sentryapps): New UI for schema field on Sentry App Details

### DIFF
--- a/static/app/data/forms/sentryApplication.tsx
+++ b/static/app/data/forms/sentryApplication.tsx
@@ -68,7 +68,8 @@ const getPublicFormFields = (): Field[] => [
     type: 'textarea',
     label: 'Schema',
     autosize: true,
-    rows: 1,
+    inline: false,
+    maxRows: 15,
     help: tct(
       'Schema for your UI components. Click [schema_docs:here] for documentation.',
       {
@@ -105,11 +106,15 @@ const getPublicFormFields = (): Field[] => [
     autosize: true,
     rows: 1,
     help: 'Description of your Integration and its functionality.',
+    // Prevents this field from displaying in a monospace font
+    style: {fontFamily: 'inherit'},
   },
   {
     name: 'allowedOrigins',
     type: 'string',
     multiline: true,
+    autosize: true,
+    rows: 1,
     placeholder: 'e.g. example.com',
     label: 'Authorized JavaScript Origins',
     help: 'Separate multiple entries with a newline.',

--- a/static/app/views/settings/components/forms/type.tsx
+++ b/static/app/views/settings/components/forms/type.tsx
@@ -96,6 +96,7 @@ type BaseField = {
   stacked?: boolean;
   hideLabel?: boolean;
   flexibleControlStateSize?: boolean;
+  style?: React.CSSProperties;
 };
 
 // TODO(ts): These are field specific props. May not be needed as we convert

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -420,7 +420,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
               const webhookDisabled =
                 this.isInternal && !this.form.getValue('webhookUrl');
               return (
-                <React.Fragment>
+                <StyledFormWrapper>
                   <JsonForm additionalFieldProps={{webhookDisabled}} forms={forms} />
                   {this.getAvatarChooser(true)}
                   {this.getAvatarChooser(false)}
@@ -430,7 +430,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
                     scopes={scopes}
                     events={events}
                   />
-                </React.Fragment>
+                </StyledFormWrapper>
               );
             }}
           </Observer>
@@ -538,4 +538,11 @@ const AvatarPreviewText = styled('span')`
   display: block;
   grid-area: 2 / 2 / 3 / 3;
   padding-left: ${space(2)};
+`;
+
+const StyledFormWrapper = styled('div')`
+  /* Applies to Schema and Authorized JS Origins */
+  textarea {
+    font-family: ${p => p.theme.text.familyMono};
+  }
 `;


### PR DESCRIPTION
Okay so there was no design reference for this, but the schema field always bothered me so much and I frequent this page so I had to fix it.

The Old UI would just let the schema dominate the page, illegible and difficult to read/change

https://user-images.githubusercontent.com/35509934/152619043-df3a9cb7-3ec9-45e9-bd2e-dc4e2929dbbb.mov

Even if mine doesn't have design input, it's at least more servicable than the previous.
Incremental improvment I guess

https://user-images.githubusercontent.com/35509934/152619047-5e653ade-fb13-4f85-a8c9-1eb1058d85ef.mov

Here's what it looks like empty:


<img width="1694" alt="image" src="https://user-images.githubusercontent.com/35509934/152619323-439489a2-ca91-4bc8-b538-fa5743085500.png">

I will concede that the one field being stacked vs the rest being inline is a bit jarring, but once they provide a schema it is actually managable, searchable and editable now.
 