### PR TITLE
ref(ui): Update button focus states

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -244,6 +244,7 @@ const getColors = ({
 
     &.focus-visible {
       ${getFocusState()}
+      z-index: 1;
     }
   `;
 };

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -200,6 +200,26 @@ const getColors = ({
     focusShadow,
   } = theme.button[themeName];
 
+  const getFocusState = () => {
+    switch (priority) {
+      case 'primary':
+      case 'success':
+      case 'danger':
+        return `
+          border-color: ${focusBorder};
+          box-shadow: ${focusBorder} 0 0 0 1px, ${focusShadow} 0 0 0 4px;`;
+      default:
+        if (translucentBorder) {
+          return `
+            border-color: ${focusBorder};
+            box-shadow: ${focusBorder} 0 0 0 2px;`;
+        }
+        return `
+          border-color: ${focusBorder};
+          box-shadow: ${focusBorder} 0 0 0 1px;`;
+    }
+  };
+
   return css`
     color: ${color};
     background-color: ${background};
@@ -223,8 +243,7 @@ const getColors = ({
     }`}
 
     &.focus-visible {
-      border: 1px solid ${focusBorder};
-      box-shadow: ${focusBorder} 0 0 0 1px, ${focusShadow} 0 0 0 4px;
+      ${getFocusState()}
     }
   `;
 };


### PR DESCRIPTION
Use a single focus ring instead of a 2-ring design for default buttons. The second, translucent ring is only really necessary for buttons with solid fill colors (i.e. those with priority `primary`, `success`, and `danger`).

**Before:**
<img width="781" alt="Screen Shot 2022-02-04 at 4 13 08 PM" src="https://user-images.githubusercontent.com/44172267/152619656-82c23ef3-3767-452f-8c9d-854e130cd8ca.png">

**After:**
<img width="781" alt="Screen Shot 2022-02-04 at 4 12 46 PM" src="https://user-images.githubusercontent.com/44172267/152619665-3e0b125a-0c8e-49c3-b8bd-fc117f0576a9.png">

