### PR TITLE
fix(post_process): Fetch buffered `times_seen` values and add them to `Group.times_seen`

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -28,7 +28,13 @@ class Buffer(Service, metaclass=BufferMount):
     keep up with the updates.
     """
 
-    __all__ = ("incr", "process", "process_pending", "validate")
+    __all__ = ("get", "incr", "process", "process_pending", "validate")
+
+    def get(self, model, columns, filters):
+        """
+        We can't fetch values from Celery, so just assume buffer values are all 0 here.
+        """
+        return {col: 0 for col in columns}
 
     def incr(self, model, columns, filters, extra=None, signal_only=None):
         """

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -641,3 +641,26 @@ class Group(Model):
             return assigned_actor.resolve()
         except assigned_actor.type.DoesNotExist:
             return None
+
+    @property
+    def times_seen_with_pending(self) -> int:
+        """
+        Returns `times_seen` with any additional pending updates from `buffers` added on. This value
+        must be set first.
+        """
+        return self.times_seen + self.times_seen_pending
+
+    @property
+    def times_seen_pending(self) -> int:
+        pending = 0
+        assert hasattr(self, "_times_seen_pending")
+        if not hasattr(self, "_times_seen_pending"):
+            logger.error("Attempted to fetch pending `times_seen` value without first setting it")
+        else:
+            pending = self._times_seen_pending
+
+        return pending
+
+    @times_seen_pending.setter
+    def times_seen_pending(self, times_seen: int):
+        self._times_seen_pending = times_seen

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -652,14 +652,11 @@ class Group(Model):
 
     @property
     def times_seen_pending(self) -> int:
-        pending = 0
         assert hasattr(self, "_times_seen_pending")
         if not hasattr(self, "_times_seen_pending"):
             logger.error("Attempted to fetch pending `times_seen` value without first setting it")
-        else:
-            pending = self._times_seen_pending
 
-        return pending
+        return getattr(self, "_times_seen_pending", 0)
 
     @times_seen_pending.setter
     def times_seen_pending(self, times_seen: int):

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -54,7 +54,7 @@ class GroupSnooze(Model):
     def get_cache_key(cls, group_id):
         return "groupsnooze_group_id:1:%s" % (group_id)
 
-    def is_valid(self, group=None, test_rates=False):
+    def is_valid(self, group=None, test_rates=False, use_pending_data=False):
         if group is None:
             group = self.group
         elif group.id != self.group_id:
@@ -69,8 +69,10 @@ class GroupSnooze(Model):
                 if test_rates:
                     if not self.test_frequency_rates():
                         return False
-            elif self.count <= group.times_seen_with_pending - self.state["times_seen"]:
-                return False
+            else:
+                times_seen = group.times_seen_with_pending if use_pending_data else group.times_seen
+                if self.count <= times_seen - self.state["times_seen"]:
+                    return False
 
         if self.user_count and test_rates:
             if self.user_window:

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -69,7 +69,7 @@ class GroupSnooze(Model):
                 if test_rates:
                     if not self.test_frequency_rates():
                         return False
-            elif self.count <= group.times_seen - self.state["times_seen"]:
+            elif self.count <= group.times_seen_with_pending - self.state["times_seen"]:
                 return False
 
         if self.user_count and test_rates:

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -22,7 +22,7 @@ class IssueOccurrencesFilter(EventFilter):
         except (TypeError, ValueError):
             return False
 
-        # This value is slightly delayed due to us batching writes to times_seen
-        # which can cause the filter to be delayed or occasionally not work as expected.
-        issue_occurrences = event.group.times_seen
+        # This value is slightly delayed due to us batching writes to times_seen. We attempt to work
+        # around this by including pending updates from buffers to improve accuracy.
+        issue_occurrences = event.group.times_seen_with_pending
         return issue_occurrences >= value

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -475,7 +475,7 @@ def process_snoozes(group):
     if not snooze:
         return False
 
-    if not snooze.is_valid(group, test_rates=True):
+    if not snooze.is_valid(group, test_rates=True, use_pending_data=True):
         snooze_details = {
             "until": snooze.until,
             "count": snooze.count,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -222,7 +222,7 @@ def fetch_buffered_group_stats(group):
     from sentry.models import Group
 
     result = buffer.get(Group, ["times_seen"], {"pk": group.id})
-    group.times_seen += result["times_seen"]
+    group.times_seen_pending = result["times_seen"]
 
 
 @instrumented_task(

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -86,8 +86,18 @@ class RedisBufferTest(TestCase):
         self.buf.process("foo")
         process.assert_called_once_with(Group, columns, filters, extra, signal_only)
 
-    @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
-    @mock.patch("sentry.buffer.redis.process_incr", mock.Mock())
+    def test_get(self):
+        model = mock.Mock()
+        model.__name__ = "Mock"
+        columns = ["times_seen"]
+        filters = {"pk": 1}
+        # If the value doesn't exist we just assume 0
+        assert self.buf.get(model, columns, filters=filters) == {"times_seen": 0}
+        self.buf.incr(model, {"times_seen": 1}, filters)
+        assert self.buf.get(model, columns, filters=filters) == {"times_seen": 1}
+        self.buf.incr(model, {"times_seen": 5}, filters)
+        assert self.buf.get(model, columns, filters=filters) == {"times_seen": 6}
+
     def test_incr_saves_to_redis(self):
         now = datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc)
         client = self.buf.cluster.get_routing_client()
@@ -95,8 +105,9 @@ class RedisBufferTest(TestCase):
         model.__name__ = "Mock"
         columns = {"times_seen": 1}
         filters = {"pk": 1, "datetime": now}
+        key = self.buf._make_key(model, filters=filters)
         self.buf.incr(model, columns, filters, extra={"foo": "bar", "datetime": now})
-        result = client.hgetall("foo")
+        result = client.hgetall(key)
         # Force keys to strings
         result = {force_text(k): v for k, v in result.items()}
 
@@ -107,9 +118,9 @@ class RedisBufferTest(TestCase):
         assert result == {"i+times_seen": b"1", "m": b"unittest.mock.Mock"}
 
         pending = client.zrange("b:p", 0, -1)
-        assert pending == [b"foo"]
+        assert pending == [key.encode("utf-8")]
         self.buf.incr(model, columns, filters, extra={"foo": "baz", "datetime": now})
-        result = client.hgetall("foo")
+        result = client.hgetall(key)
         # Force keys to strings
         result = {force_text(k): v for k, v in result.items()}
         f = result.pop("f")
@@ -119,7 +130,7 @@ class RedisBufferTest(TestCase):
         assert result == {"i+times_seen": b"2", "m": b"unittest.mock.Mock"}
 
         pending = client.zrange("b:p", 0, -1)
-        assert pending == [b"foo"]
+        assert pending == [key.encode("utf-8")]
 
     @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
     @mock.patch("sentry.buffer.redis.process_incr")

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -47,10 +47,10 @@ class GroupSnoozeTest(TestCase, SnubaTestCase):
     def test_delta_reached_pending(self):
         snooze = GroupSnooze.objects.create(group=self.group, count=100, state={"times_seen": 0})
         self.group.update(times_seen=90)
-        assert snooze.is_valid()
+        assert snooze.is_valid(use_pending_data=True)
 
         self.group.times_seen_pending = 10
-        assert not snooze.is_valid()
+        assert not snooze.is_valid(use_pending_data=True)
 
     def test_user_delta_not_reached(self):
         snooze = GroupSnooze.objects.create(

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -14,6 +14,10 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 class GroupSnoozeTest(TestCase, SnubaTestCase):
     sequence = itertools.count()  # generates unique values, class scope doesn't matter
 
+    def setUp(self):
+        super().setUp()
+        self.group.times_seen_pending = 0
+
     def test_until_not_reached(self):
         snooze = GroupSnooze.objects.create(
             group=self.group, until=timezone.now() + timedelta(days=1)
@@ -38,6 +42,14 @@ class GroupSnoozeTest(TestCase, SnubaTestCase):
     def test_delta_reached(self):
         snooze = GroupSnooze.objects.create(group=self.group, count=100, state={"times_seen": 0})
         self.group.update(times_seen=100)
+        assert not snooze.is_valid()
+
+    def test_delta_reached_pending(self):
+        snooze = GroupSnooze.objects.create(group=self.group, count=100, state={"times_seen": 0})
+        self.group.update(times_seen=90)
+        assert snooze.is_valid()
+
+        self.group.times_seen_pending = 10
         assert not snooze.is_valid()
 
     def test_user_delta_not_reached(self):

--- a/tests/sentry/rules/filters/test_issue_occurrences.py
+++ b/tests/sentry/rules/filters/test_issue_occurrences.py
@@ -5,6 +5,10 @@ from sentry.testutils.cases import RuleTestCase
 class IssueOccurrencesTest(RuleTestCase):
     rule_cls = IssueOccurrencesFilter
 
+    def setUp(self):
+        super().setUp()
+        self.event.group.times_seen_pending = 0
+
     def test_compares_correctly(self):
         event = self.get_event()
         value = 10
@@ -20,6 +24,19 @@ class IssueOccurrencesTest(RuleTestCase):
 
         event.group.times_seen = 8
         self.assertDoesNotPass(rule, event)
+
+    def test_uses_pending(self):
+        event = self.get_event()
+        value = 10
+        data = {"value": str(value)}
+
+        rule = self.get_rule(data=data)
+
+        event.group.times_seen = 8
+        self.assertDoesNotPass(rule, event)
+
+        event.group.times_seen_pending = 3
+        self.assertPasses(rule, event)
 
     def test_fails_on_bad_data(self):
         event = self.get_event()

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -1,8 +1,12 @@
 from datetime import timedelta
+from unittest import mock
 from unittest.mock import ANY, Mock, patch
 
+from django.test import override_settings
 from django.utils import timezone
 
+from sentry import buffer
+from sentry.buffer.redis import RedisBuffer
 from sentry.eventstore.processing import event_processing_store
 from sentry.models import (
     Activity,
@@ -18,6 +22,7 @@ from sentry.models import (
     ProjectTeam,
 )
 from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
+from sentry.rules import init_registry
 from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import post_process_group
 from sentry.testutils import TestCase
@@ -169,6 +174,71 @@ class PostProcessGroupTest(TestCase):
         mock_processor.return_value.apply.assert_called_once_with()
 
         mock_callback.assert_called_once_with(EventMatcher(event), mock_futures)
+
+    @override_settings(SENTRY_BUFFER="sentry.buffer.redis.RedisBuffer")
+    def test_rule_processor_buffer_values(self):
+        # Test that pending buffer values for `times_seen` are applied to the group and that alerts
+        # fire as expected
+        from sentry.models import Rule
+
+        MOCK_RULES = ("sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",)
+
+        redis_buffer = RedisBuffer()
+        with mock.patch("sentry.buffer.get", redis_buffer.get), mock.patch(
+            "sentry.buffer.incr", redis_buffer.incr
+        ), patch("sentry.constants._SENTRY_RULES", MOCK_RULES), patch(
+            "sentry.rules.processor.rules", init_registry()
+        ) as rules:
+            MockAction = mock.Mock()
+            MockAction.rule_type = "action/event"
+            MockAction.id = "tests.sentry.tasks.post_process.tests.MockAction"
+            MockAction.return_value.after.return_value = []
+            rules.add(MockAction)
+
+            conditions = [
+                {
+                    "id": "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
+                    "value": 10,
+                },
+            ]
+            actions = [{"id": "tests.sentry.tasks.post_process.tests.MockAction"}]
+            Rule.objects.filter(project=self.project).delete()
+            Rule.objects.create(
+                project=self.project, data={"conditions": conditions, "actions": actions}
+            )
+
+            event = self.store_event(
+                data={"message": "testing", "fingerprint": ["group-1"]}, project_id=self.project.id
+            )
+            event_2 = self.store_event(
+                data={"message": "testing", "fingerprint": ["group-1"]}, project_id=self.project.id
+            )
+            cache_key = write_event_to_cache(event)
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                cache_key=cache_key,
+                group_id=event.group_id,
+            )
+            event.group.update(times_seen=2)
+            assert MockAction.return_value.after.call_count == 0
+
+            cache_key = write_event_to_cache(event_2)
+            buffer.incr(Group, {"times_seen": 15}, filters={"pk": event.group.id})
+            post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                cache_key=cache_key,
+                group_id=event_2.group_id,
+            )
+            assert MockAction.return_value.after.call_count == 1
+
+            event.group.refresh_from_db()
+            # Make sure that we haven't inadvertently saved the updated `times_seen` value to the
+            # database.
+            assert event.group.times_seen == 2
 
     @patch("sentry.rules.processor.RuleProcessor")
     def test_group_refresh(self, mock_processor):


### PR DESCRIPTION
In `post_process_group` we process issue alert rules and also ignored groups. Both of these can have
conditions that read from the `times_seen` value on the `Group`.

The problem here is that updates to `times_seen` are buffered and only written every 45s or so. This
means that most of the time when a `Group` goes through `post_process_group` it has an out of date
`times_seen` value. For infrequently updated groups, this can just mean that the count is -1. But
for high volume groups this could mean that we're considerably below the count.

To improve this, we read the current value from buffers and store it as pending updates on the group.
We then use this pending value when checking rules and snoozes in post process. There's a potential 
race condition here where we fetch the `Group`, and before we fetch the value from buffers it is 
cleared, and so we miss out on the update. This should be infrequent enough that  it's not a problem, 
and either way we will be considerably more accurate most of the time.
