### PR TITLE
fix(discover): Styling fixes for Discover query cards and yaxis dropdown

### DIFF
--- a/static/app/components/charts/optionCheckboxSelector.tsx
+++ b/static/app/components/charts/optionCheckboxSelector.tsx
@@ -196,7 +196,6 @@ const MenuContainer = styled('div')`
 
 const StyledDropdownButton = styled(DropdownButton)`
   padding: ${space(1)} ${space(2)};
-  font-weight: normal;
   z-index: ${p => (p.isOpen ? p.theme.zIndex.dropdownAutocomplete.actor : 'auto')};
 `;
 

--- a/static/app/views/eventsV2/querycard.tsx
+++ b/static/app/views/eventsV2/querycard.tsx
@@ -106,6 +106,7 @@ const QueryTitle = styled('div')`
   ${p => p.theme.text.cardTitle};
   color: ${p => p.theme.headingColor};
   ${overflowEllipsis};
+  font-weight: initial;
 `;
 
 const QueryDetail = styled('div')`


### PR DESCRIPTION
unbolds query card titles and bolds yaxis dropdown to match other dropdowns

![image](https://user-images.githubusercontent.com/83961295/152824006-f35d505e-1b9c-4a97-ac4a-ba47e540d42a.png)

![image](https://user-images.githubusercontent.com/83961295/152823964-394dc0af-c0bb-4d64-add1-eba424834250.png)
