### PR TITLE
chore(performance): removed backend flag for performance-events-tab

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1069,8 +1069,6 @@ SENTRY_FEATURES = {
     "organizations:performance-ops-breakdown": False,
     # Enable landing improvements for performance
     "organizations:performance-landing-widgets": False,
-    # Enable views for transaction events page in performance
-    "organizations:performance-events-page": False,
     # Enable interpolation of null data points in charts instead of zerofilling in performance
     "organizations:performance-chart-interpolation": False,
     # Enable mobile vitals

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -126,7 +126,6 @@ default_manager.add(
     "organizations:pagerduty-metric-alert-resolve-logging", OrganizationFeature, True
 )
 default_manager.add("organizations:performance-chart-interpolation", OrganizationFeature, True)
-default_manager.add("organizations:performance-events-page", OrganizationFeature, True)
 default_manager.add("organizations:performance-landing-widgets", OrganizationFeature, True)
 default_manager.add("organizations:performance-mobile-vitals", OrganizationFeature, True)
 default_manager.add("organizations:performance-ops-breakdown", OrganizationFeature)


### PR DESCRIPTION
Removes the performance-events-tab flag setup from the backend

For the frontend pr: https://github.com/getsentry/sentry/pull/31587