### PR TITLE
feat(codeowners):  Display CTA

### DIFF
--- a/static/app/components/group/suggestedOwners/ownershipRules.tsx
+++ b/static/app/components/group/suggestedOwners/ownershipRules.tsx
@@ -38,10 +38,7 @@ const OwnershipRules = ({
   const handleOpenCreateOwnershipRule = () => {
     openCreateOwnershipRule({project, organization, issueId});
   };
-  const showCTA =
-    organization.features.includes('integrations-codeowners') &&
-    !codeowners.length &&
-    !isDismissed;
+  const showCTA = !codeowners.length && !isDismissed;
 
   const createRuleButton = (
     <Access access={['project:write']}>


### PR DESCRIPTION
Code owners CTA on issue details page displays to all organizations, as long as the displayed issue's project has set up stack trace linking (has a code path mapping.)