### PR TITLE
ref(sentry-metrics): configure arroyo metrics

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import cpu_count
 
 import click
+from arroyo import configure_metrics
 
 from sentry.bgtasks.api import managed_bgtasks
 from sentry.ingest.types import ConsumerType
@@ -553,7 +554,12 @@ def metrics_consumer(**options):
 @click.option("--input-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 def metrics_streaming_consumer(**options):
+    from sentry.sentry_metrics.metrics_wrapper import MetricsWrapper
     from sentry.sentry_metrics.multiprocess import get_streaming_metrics_consumer
+    from sentry.utils.metrics import backend
+
+    metrics = MetricsWrapper(backend, "sentry_metrics.indexer")
+    configure_metrics(metrics)
 
     streamer = get_streaming_metrics_consumer(**options)
     streamer.run()

--- a/src/sentry/sentry_metrics/metrics_wrapper.py
+++ b/src/sentry/sentry_metrics/metrics_wrapper.py
@@ -6,7 +6,7 @@ from sentry.metrics.base import MetricsBackend
 Tags = Mapping[str, str]
 
 
-class MetricsWrapper(MetricsBackend):
+class MetricsWrapper(MetricsBackend):  # type: ignore
     def __init__(
         self,
         backend: MetricsBackend,

--- a/src/sentry/sentry_metrics/metrics_wrapper.py
+++ b/src/sentry/sentry_metrics/metrics_wrapper.py
@@ -1,0 +1,44 @@
+from collections import ChainMap
+from typing import Mapping, Optional, Union
+
+from sentry.metrics.base import MetricsBackend
+
+Tags = Mapping[str, str]
+
+
+class MetricsWrapper(MetricsBackend):
+    def __init__(
+        self,
+        backend: MetricsBackend,
+        name: Optional[str] = None,
+        tags: Optional[Tags] = None,
+    ) -> None:
+        self.__backend = backend
+        self.__name = name
+        self.__tags = tags
+
+    def __merge_name(self, name: str) -> str:
+        if self.__name is None:
+            return name
+        else:
+            return f"{self.__name}.{name}"
+
+    def __merge_tags(self, tags: Optional[Tags]) -> Optional[Tags]:
+        if self.__tags is None:
+            return tags
+        elif tags is None:
+            return self.__tags
+        else:
+            return ChainMap(tags, self.__tags)
+
+    def increment(
+        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+    ) -> None:
+        # sentry metrics backend uses `incr` instead of `increment`
+        self.__backend.incr(self.__merge_name(name), value, self.__merge_tags(tags))
+
+    def gauge(self, name: str, value: Union[int, float], tags: Optional[Tags] = None) -> None:
+        self.__backend.gauge(self.__merge_name(name), value, self.__merge_tags(tags))
+
+    def timing(self, name: str, value: Union[int, float], tags: Optional[Tags] = None) -> None:
+        self.__backend.timing(self.__merge_name(name), value, self.__merge_tags(tags))


### PR DESCRIPTION
In order for us to get useful metrics from arroyo we need to use `configure_metrics`. 

In the case of the ingest metrics indexer, we want metrics for the `ParallelTransformStep`, with this PR we should start seeing metrics [like these](https://github.com/getsentry/arroyo/blob/c1765a28364f020426b4afde8c3cf3eae197b912/arroyo/processing/strategies/streaming/transform.py#L344-L345) in datadog. The should be prefixed with `sentry_metrics.indexer` so some example metrics would be

```python
sentry_metrics.indexer.batch.size.msg
sentry_metrics.indexer.batch.size.bytes