### PR TITLE
feat(charts): Add support for scatter plots

### DIFF
--- a/docs-ui/stories/components/scatterChart.stories.js
+++ b/docs-ui/stories/components/scatterChart.stories.js
@@ -1,0 +1,45 @@
+import ScatterChart from 'sentry/components/charts/scatterChart';
+
+export default {
+  title: 'Components/Data Visualization/Charts/Scatter Chart',
+  component: ScatterChart,
+};
+
+export const _ScatterChart = () => {
+  return (
+    <ScatterChart
+      style={{height: 400}}
+      series={[
+        {
+          seriesName: 'Chrome',
+          data: [
+            {
+              value: 632,
+              name: 'Jan 1',
+            },
+            {
+              value: 326,
+              name: 'Jan 1',
+            },
+            {
+              value: 236,
+              name: 'Jan 1',
+            },
+            {
+              value: 107,
+              name: 'Jan 2',
+            },
+            {
+              value: 302,
+              name: 'Jan 3',
+            },
+            {
+              value: 3,
+              name: 'Jan 4',
+            },
+          ],
+        },
+      ]}
+    />
+  );
+};

--- a/static/app/components/charts/scatterChart.tsx
+++ b/static/app/components/charts/scatterChart.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+
+import {Series} from 'sentry/types/echarts';
+
+import ScatterSeries from './series/scatterSeries';
+import BaseChart from './baseChart';
+
+type ChartProps = Omit<React.ComponentProps<typeof BaseChart>, 'css'>;
+
+export type ScatterChartSeries = Series;
+
+type Props = Omit<ChartProps, 'series'> & {
+  series: ScatterChartSeries[];
+};
+
+function ScatterChart({series, ...props}: Props) {
+  return (
+    <BaseChart
+      {...props}
+      xAxis={{
+        // do not want the axis pointer when working with scatter charts
+        axisPointer: {
+          show: false,
+          ...props.xAxis?.axisPointer,
+        },
+        ...props.xAxis,
+      }}
+      series={series.map(({seriesName, data, ...options}) =>
+        ScatterSeries({
+          name: seriesName,
+          data: data.map(({name, value}) => [name, value, 'stuff']),
+          ...options,
+          animation: false,
+          animationThreshold: 1,
+          animationDuration: 0,
+        })
+      )}
+    />
+  );
+}
+
+export default ScatterChart;

--- a/static/app/components/charts/scatterChart.tsx
+++ b/static/app/components/charts/scatterChart.tsx
@@ -31,8 +31,6 @@ function ScatterChart({series, ...props}: Props) {
           data: data.map(({name, value}) => [name, value, 'stuff']),
           ...options,
           animation: false,
-          animationThreshold: 1,
-          animationDuration: 0,
         })
       )}
     />

--- a/static/app/components/charts/series/scatterSeries.tsx
+++ b/static/app/components/charts/series/scatterSeries.tsx
@@ -1,0 +1,28 @@
+import 'echarts/lib/chart/scatter';
+
+import type {ScatterSeriesOption} from 'echarts';
+
+import theme from 'sentry/utils/theme';
+
+export default function ScatterSeries(props: ScatterSeriesOption): ScatterSeriesOption {
+  return {
+    // showSymbol: false,
+    symbolSize: theme.charts.symbolSize,
+    ...props,
+    type: 'scatter',
+    emphasis: {
+      ...props.emphasis,
+      scale: true,
+      // lineStyle: {
+      //   // disable color highlight on hover
+      //   color: props.color as string,
+      //   width: undefined,
+      // },
+      // areaStyle: {
+      //   // Disable AreaSeries highlight on hover
+      //   color: props.areaStyle?.color ?? (props.color as string),
+      //   opacity: props.areaStyle?.opacity,
+      // },
+    },
+  };
+}

--- a/static/app/components/charts/series/scatterSeries.tsx
+++ b/static/app/components/charts/series/scatterSeries.tsx
@@ -6,23 +6,12 @@ import theme from 'sentry/utils/theme';
 
 export default function ScatterSeries(props: ScatterSeriesOption): ScatterSeriesOption {
   return {
-    // showSymbol: false,
     symbolSize: theme.charts.symbolSize,
     ...props,
     type: 'scatter',
     emphasis: {
       ...props.emphasis,
       scale: true,
-      // lineStyle: {
-      //   // disable color highlight on hover
-      //   color: props.color as string,
-      //   width: undefined,
-      // },
-      // areaStyle: {
-      //   // Disable AreaSeries highlight on hover
-      //   color: props.areaStyle?.color ?? (props.color as string),
-      //   opacity: props.areaStyle?.opacity,
-      // },
     },
   };
 }


### PR DESCRIPTION
In preparation for the scatter plot in the profiling ui, this adds support for
scatter plots.