### PR TITLE
Move access logs into middleware

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -282,7 +282,7 @@ MIDDLEWARE = (
     "sentry.middleware.env.SentryEnvMiddleware",
     "sentry.middleware.proxy.SetRemoteAddrFromForwardedFor",
     "sentry.middleware.stats.RequestTimingMiddleware",
-    "sentry.middleware.access_log.AccessLogMiddleware",
+    "sentry.middleware.access_log.access_log_middleware",
     "sentry.middleware.stats.ResponseCodeMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -282,7 +282,7 @@ MIDDLEWARE = (
     "sentry.middleware.env.SentryEnvMiddleware",
     "sentry.middleware.proxy.SetRemoteAddrFromForwardedFor",
     "sentry.middleware.stats.RequestTimingMiddleware",
-    "sentry.middleware.access_log.AccessLogMiddlewware",
+    "sentry.middleware.access_log.AccessLogMiddleware",
     "sentry.middleware.stats.ResponseCodeMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -281,7 +281,6 @@ MIDDLEWARE = (
     "sentry.middleware.security.SecurityHeadersMiddleware",
     "sentry.middleware.env.SentryEnvMiddleware",
     "sentry.middleware.proxy.SetRemoteAddrFromForwardedFor",
-    "sentry.middleware.access_log.AccessLogMiddlewware",
     "sentry.middleware.stats.RequestTimingMiddleware",
     "sentry.middleware.stats.ResponseCodeMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -292,6 +291,7 @@ MIDDLEWARE = (
     "sentry.middleware.sudo.SudoMiddleware",
     "sentry.middleware.superuser.SuperuserMiddleware",
     "sentry.middleware.locale.SentryLocaleMiddleware",
+    "sentry.middleware.access_log.AccessLogMiddlewware",
     "sentry.middleware.ratelimit.RatelimitMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
 )

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -282,6 +282,7 @@ MIDDLEWARE = (
     "sentry.middleware.env.SentryEnvMiddleware",
     "sentry.middleware.proxy.SetRemoteAddrFromForwardedFor",
     "sentry.middleware.stats.RequestTimingMiddleware",
+    "sentry.middleware.access_log.AccessLogMiddlewware",
     "sentry.middleware.stats.ResponseCodeMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -291,7 +292,6 @@ MIDDLEWARE = (
     "sentry.middleware.sudo.SudoMiddleware",
     "sentry.middleware.superuser.SuperuserMiddleware",
     "sentry.middleware.locale.SentryLocaleMiddleware",
-    "sentry.middleware.access_log.AccessLogMiddlewware",
     "sentry.middleware.ratelimit.RatelimitMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
 )

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -281,6 +281,7 @@ MIDDLEWARE = (
     "sentry.middleware.security.SecurityHeadersMiddleware",
     "sentry.middleware.env.SentryEnvMiddleware",
     "sentry.middleware.proxy.SetRemoteAddrFromForwardedFor",
+    "sentry.middleware.access_log.AccessLogMiddlewware",
     "sentry.middleware.stats.RequestTimingMiddleware",
     "sentry.middleware.stats.ResponseCodeMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -67,7 +67,7 @@ def _create_api_access_log(
         )
         api_access_logger.info("api.access", extra=log_metrics)
     except Exception:
-        api_access_logger.exception("api.access")
+        api_access_logger.exception("api.access", "Error capturing API access logs")
 
 
 def access_log_middleware(

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -73,9 +73,6 @@ class AccessLogMiddleware(MiddlewareMixin):
         except Exception:
             api_access_logger.exception("api.access")
 
-    #    def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response | None:
-    #        request.access_log_metadata = _AccessLogMetaData(request_start_time=time.time())
-    #
     def process_request(self, request: Request):
         request.access_log_metadata = _AccessLogMetaData(request_start_time=time.time())
 

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -22,7 +22,7 @@ class _AccessLogMetaData:
 _empty_request_metadata = _AccessLogMetaData(request_start_time=None)
 
 
-class AccessLogMiddlewware(MiddlewareMixin):
+class AccessLogMiddleware(MiddlewareMixin):
     def _get_token_name(self, request: Request):
         auth = getattr(request, "auth", None)
         if not auth:
@@ -37,8 +37,10 @@ class AccessLogMiddlewware(MiddlewareMixin):
         Create a log entry to be used for api metrics gathering
         """
         try:
-
-            view = request.resolver_match._func_path
+            try:
+                view = request.resolver_match._func_path
+            except AttributeError:
+                view = "Unknown"
 
             request_user = getattr(request, "user", None)
             user_id = getattr(request_user, "id", None)
@@ -71,7 +73,10 @@ class AccessLogMiddlewware(MiddlewareMixin):
         except Exception:
             api_access_logger.exception("api.access")
 
-    def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response | None:
+    #    def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response | None:
+    #        request.access_log_metadata = _AccessLogMetaData(request_start_time=time.time())
+    #
+    def process_request(self, request: Request):
         request.access_log_metadata = _AccessLogMetaData(request_start_time=time.time())
 
     def process_response(self, request: Request, response: Response) -> Response:

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -67,7 +67,7 @@ def _create_api_access_log(
         )
         api_access_logger.info("api.access", extra=log_metrics)
     except Exception:
-        api_access_logger.exception("api.access", "Error capturing API access logs")
+        api_access_logger.exception("api.access: Error capturing API access logs")
 
 
 def access_log_middleware(

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+from django.utils.deprecation import MiddlewareMixin
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+api_access_logger = logging.getLogger("sentry.access.api")
+
+
+@dataclass
+class _AccessLogMetaData:
+    request_start_time: float | None
+
+    def get_request_duration(self) -> float | None:
+        return time.time() - self.request_start_time if self.request_start_time else None
+
+
+_empty_request_metadata = _AccessLogMetaData(request_start_time=None)
+
+
+class AccessLogMiddlewware(MiddlewareMixin):
+    def _get_token_name(self, request: Request):
+        auth = getattr(request, "auth", None)
+        if not auth:
+            return None
+        token_class = getattr(auth, "__class__", None)
+        return token_class.__name__ if token_class else None
+
+    def _create_api_access_log(
+        self, request: Request, response: Response | None, exception: Exception | None
+    ):
+        """
+        Create a log entry to be used for api metrics gathering
+        """
+        try:
+
+            view = request.resolver_match._func_path
+
+            request_user = getattr(request, "user", None)
+            user_id = getattr(request_user, "id", None)
+            is_app = getattr(request_user, "is_sentry_app", None)
+
+            request_access = getattr(request, "access", None)
+            org_id = getattr(request_access, "organization_id", None)
+
+            request_auth = getattr(request, "auth", None)
+            auth_id = getattr(request_auth, "id", None)
+            access_log_metadata = getattr(request, "access_log_metadata", _empty_request_metadata)
+            status_code = response.status_code if response else 500
+            log_metrics = dict(
+                method=str(request.method),
+                view=view,
+                response=status_code,
+                user_id=str(user_id),
+                is_app=str(is_app),
+                token_type=str(self._get_token_name(request)),
+                organization_id=str(org_id),
+                auth_id=str(auth_id),
+                path=str(request.path),
+                caller_ip=str(request.META.get("REMOTE_ADDR")),
+                user_agent=str(request.META.get("HTTP_USER_AGENT")),
+                rate_limited=str(getattr(request, "will_be_rate_limited", False)),
+                rate_limit_category=str(getattr(request, "rate_limit_category", None)),
+                request_duration_seconds=access_log_metadata.get_request_duration(),
+            )
+            api_access_logger.info("api.access", extra=log_metrics)
+        except Exception:
+            api_access_logger.exception("api.access")
+
+    def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response | None:
+        request.access_log_metadata = _AccessLogMetaData(request_start_time=time.time())
+
+    def process_response(self, request: Request, response: Response) -> Response:
+        self._create_api_access_log(request, response, exception=None)
+        return response
+
+    def process_exception(self, request: Request, exception: Exception) -> Response:
+        # NOTE: This function will likely never be hit because the sentry API endpoint
+        # handles exceptions and wraps them in responses but this is here for completeness
+        self._create_api_access_log(request, response=None, exception=exception)
+        raise exception

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -7,6 +7,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
+from sentry.models import ApiToken
 from sentry.testutils import APITestCase
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -82,23 +83,26 @@ class TestAccessLogRateLimited(LogCaptureAPITestCase):
 
     endpoint = "ratelimit-endpoint"
 
-    def test_access_log_success(self):
+    def test_access_log_rate_limited(self):
         self._caplog.set_level(logging.INFO, logger="api.access")
         self.get_error_response(status_code=429)
         self.assert_access_log_recorded()
+        # no token because the endpoint was not hit
+        assert self._caplog.records[0].token_type == "None"
 
 
-@override_settings(ROOT_URLCONF="tests.sentry.middleware.test_access_log_middleware")
 class TestAccessLogSuccess(LogCaptureAPITestCase):
 
     endpoint = "dummy-endpoint"
 
     def test_access_log_success(self):
-        self.get_success_response()
+        token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
+        self.login_as(user=self.create_user())
+        self.get_success_response(extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token.token}"})
         self.assert_access_log_recorded()
+        assert self._caplog.records[0].token_type == "ApiToken"
 
 
-@override_settings(ROOT_URLCONF="tests.sentry.middleware.test_access_log_middleware")
 class TestAccessLogFail(LogCaptureAPITestCase):
     endpoint = "dummy-fail-endpoint"
 

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -1,0 +1,107 @@
+import logging
+
+import pytest
+from django.conf.urls import url
+from django.test import override_settings
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+from sentry.testutils import APITestCase
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+
+class DummyEndpoint(Endpoint):
+    permission_classes = (AllowAny,)
+
+    def get(self, request):
+        return Response({"ok": True})
+
+
+class DummyFailEndpoint(Endpoint):
+    permission_classes = (AllowAny,)
+
+    def get(self, request):
+        raise Exception("this is bad yo")
+
+
+class RateLimitedEndpoint(Endpoint):
+    permission_classes = (AllowAny,)
+    enforce_rate_limit = True
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(0, 1),
+            RateLimitCategory.USER: RateLimit(0, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(0, 1),
+        },
+    }
+
+    def get(self, request):
+        return Response({"ok": True})
+
+
+access_log_fields = (
+    "method",
+    "view",
+    "response",
+    "user_id",
+    "is_app",
+    "token_type",
+    "organization_id",
+    "auth_id",
+    "path",
+    "caller_ip",
+    "user_agent",
+    "rate_limited",
+    "rate_limit_category",
+    "request_duration_seconds",
+)
+
+
+urlpatterns = [
+    url(r"^/dummy$", DummyEndpoint.as_view(), name="dummy-endpoint"),
+    url(r"^/dummyfail$", DummyFailEndpoint.as_view(), name="dummy-fail-endpoint"),
+    url(r"^/dummyratelimit$", RateLimitedEndpoint.as_view(), name="ratelimit-endpoint"),
+]
+
+
+@override_settings(ROOT_URLCONF="tests.sentry.middleware.test_access_log_middleware")
+class LogCaptureAPITestCase(APITestCase):
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    def assert_access_log_recorded(self):
+        sentinel = object()
+        for record in self._caplog.records:
+            for field in access_log_fields:
+                assert getattr(record, field, sentinel) != sentinel
+
+
+class TestAccessLogRateLimited(LogCaptureAPITestCase):
+
+    endpoint = "ratelimit-endpoint"
+
+    def test_access_log_success(self):
+        self._caplog.set_level(logging.INFO, logger="api.access")
+        self.get_error_response(status_code=429)
+        self.assert_access_log_recorded()
+
+
+@override_settings(ROOT_URLCONF="tests.sentry.middleware.test_access_log_middleware")
+class TestAccessLogSuccess(LogCaptureAPITestCase):
+
+    endpoint = "dummy-endpoint"
+
+    def test_access_log_success(self):
+        self.get_success_response()
+        self.assert_access_log_recorded()
+
+
+@override_settings(ROOT_URLCONF="tests.sentry.middleware.test_access_log_middleware")
+class TestAccessLogFail(LogCaptureAPITestCase):
+    endpoint = "dummy-fail-endpoint"
+
+    def test_access_log_fail(self):
+        self.get_error_response(status_code=500)
+        self.assert_access_log_recorded()


### PR DESCRIPTION
### Problem

The API access log used to live in the base endpoint however if any middleware intercepts the request (for example the rate limit middleware), the endpoint code will never be hit. We still want those logs to be created so we move the logger into middleware

### Solution
Move the access logs into middleware as well. Put it early enough in the middleware onion that it will log any API request that we care about