### PR TITLE
feat(page-filters): Page filters can now live alongside global selection header

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -16,7 +16,10 @@ import {
   setPageFiltersStorage,
 } from 'sentry/components/organizations/pageFilters/persistence';
 import {PageFiltersStringified} from 'sentry/components/organizations/pageFilters/types';
-import {getDefaultSelection} from 'sentry/components/organizations/pageFilters/utils';
+import {
+  getDefaultSelection,
+  getPathsWithNewFilters,
+} from 'sentry/components/organizations/pageFilters/utils';
 import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/constants/pageFilters';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import {
@@ -117,6 +120,7 @@ type InitializeUrlStateParams = {
   memberProjects: Project[];
   organization: Organization;
   queryParams: Location['query'];
+  pathname: Location['pathname'];
   router: InjectedRouter;
   shouldEnforceSingleProject: boolean;
   defaultSelection?: Partial<PageFilters>;
@@ -132,6 +136,7 @@ type InitializeUrlStateParams = {
 export function initializeUrlState({
   organization,
   queryParams,
+  pathname,
   router,
   memberProjects,
   skipLoadLastUsed,
@@ -182,9 +187,9 @@ export function initializeUrlState({
   if (storedPageFilters) {
     const {state: storedState, pinnedFilters} = storedPageFilters;
 
-    const hasPinning = organization.features.includes('selection-filters-v2');
+    const pageHasPinning = getPathsWithNewFilters(organization).includes(pathname);
 
-    const filtersToRestore = hasPinning
+    const filtersToRestore = pageHasPinning
       ? pinnedFilters
       : new Set<PinnedPageFilter>(['projects', 'environments']);
 

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -119,8 +119,8 @@ function mergeDatetime(
 type InitializeUrlStateParams = {
   memberProjects: Project[];
   organization: Organization;
-  queryParams: Location['query'];
   pathname: Location['pathname'];
+  queryParams: Location['query'];
   router: InjectedRouter;
   shouldEnforceSingleProject: boolean;
   defaultSelection?: Partial<PageFilters>;

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -32,6 +32,11 @@ type GlobalSelectionHeaderProps = Omit<
 type Props = WithRouterProps &
   GlobalSelectionHeaderProps & {
     /**
+     * Hide the global header
+     * Mainly used for pages which are using the new style page filters
+     */
+    hideGlobalHeader?: boolean;
+    /**
      * Skip loading from local storage
      * An example is Issue Details, in the case where it is accessed directly (e.g. from email).
      * We do not want to load the user's last used env/project in this case, otherwise will
@@ -54,6 +59,7 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
     showAbsolute,
     shouldForceProject,
     specificProjectSlugs,
+    hideGlobalHeader,
   } = props;
 
   const {isReady} = useLegacyStore(PageFiltersStore);
@@ -99,6 +105,7 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
     initializeUrlState({
       organization,
       queryParams: location.query,
+      pathname: location.pathname,
       router,
       skipLoadLastUsed,
       memberProjects,
@@ -160,12 +167,9 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
     return <PageContent />;
   }
 
-  // New-style selection filters no longer have a 'global'header
-  const hasGlobalHeader = !organization.features.includes('selection-filters-v2');
-
   return (
     <Fragment>
-      {hasGlobalHeader && <GlobalSelectionHeader {...props} {...additionalProps} />}
+      {!hideGlobalHeader && <GlobalSelectionHeader {...props} {...additionalProps} />}
       {children}
     </Fragment>
   );

--- a/static/app/components/organizations/pageFilters/utils.tsx
+++ b/static/app/components/organizations/pageFilters/utils.tsx
@@ -6,7 +6,7 @@ import pickBy from 'lodash/pickBy';
 
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/constants/pageFilters';
-import {PageFilters} from 'sentry/types';
+import {Organization, PageFilters} from 'sentry/types';
 
 /**
  * Make a default page filters object
@@ -68,4 +68,18 @@ export function isSelectionEqual(selection: PageFilters, other: PageFilters): bo
   }
 
   return true;
+}
+
+/**
+ * TODO(davidenwang): Temporarily used for when pages with the GSH live alongside new page filters
+ * @param organization
+ * @returns list of paths that have the new page filters, these pages
+ * should only load the pinned filters, not the whole global selection
+ */
+export function getPathsWithNewFilters(organization: Organization): string[] {
+  return (
+    organization.features.includes('selection-filters-v2')
+      ? ['issues', 'user-feedback']
+      : []
+  ).map(route => `/organizations/${organization.slug}/${route}/`);
 }

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -10,7 +10,10 @@ import SidebarPanelActions from 'sentry/actions/sidebarPanelActions';
 import Feature from 'sentry/components/acl/feature';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import HookOrDefault from 'sentry/components/hookOrDefault';
-import {extractSelectionParameters} from 'sentry/components/organizations/pageFilters/utils';
+import {
+  extractSelectionParameters,
+  getPathsWithNewFilters,
+} from 'sentry/components/organizations/pageFilters/utils';
 import {
   IconActivity,
   IconChevron,
@@ -108,11 +111,13 @@ function Sidebar({location, organization}: Props) {
     pathname: string,
     evt: React.MouseEvent<HTMLAnchorElement>
   ) => {
-    // XXX(epurkhiser): No need to navigation w/ the page filters in the world
+    // XXX(epurkhiser): No need to navigate w/ the page filters in the world
     // of new page filter selection. You must pin your filters in which case
     // they will persist anyway.
-    if (organization?.features.includes('selection-filters-v2')) {
-      return;
+    if (organization) {
+      if (getPathsWithNewFilters(organization).includes(pathname)) {
+        return;
+      }
     }
 
     const globalSelectionRoutes = [

--- a/static/app/views/issueList/container.tsx
+++ b/static/app/views/issueList/container.tsx
@@ -31,7 +31,9 @@ function IssueListContainer({organization, children}: Props) {
     <SentryDocumentTitle title={t('Issues')} orgSlug={organization.slug}>
       <Fragment>
         {showSampleEventBanner && <SampleEventAlert />}
-        <PageFiltersContainer>
+        <PageFiltersContainer
+          hideGlobalHeader={organization.features.includes('selection-filters-v2')}
+        >
           <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
         </PageFiltersContainer>
       </Fragment>

--- a/static/app/views/userFeedback/index.tsx
+++ b/static/app/views/userFeedback/index.tsx
@@ -120,8 +120,10 @@ class OrganizationUserFeedback extends AsyncView<Props, State> {
     const unresolvedQuery = omit(query, 'status');
     const allIssuesQuery = {...query, status: ''};
 
+    const hasNewPageFilters = organization.features.includes('selection-filters-v2');
+
     return (
-      <PageFiltersContainer>
+      <PageFiltersContainer hideGlobalHeader={hasNewPageFilters}>
         <PageContent>
           <NoProjectMessage organization={organization}>
             <div data-test-id="user-feedback">

--- a/tests/js/spec/actionCreators/pageFilters.spec.jsx
+++ b/tests/js/spec/actionCreators/pageFilters.spec.jsx
@@ -5,12 +5,16 @@ import {
   updateProjects,
 } from 'sentry/actionCreators/pageFilters';
 import PageFiltersActions from 'sentry/actions/pageFiltersActions';
+import * as PageFilterPersistence from 'sentry/components/organizations/pageFilters/persistence';
 import localStorage from 'sentry/utils/localStorage';
 
 jest.mock('sentry/utils/localStorage');
 
 describe('PageFilters ActionCreators', function () {
   const organization = TestStubs.Organization();
+  const pageFiltersOrganization = TestStubs.Organization({
+    features: ['selection-filters-v2'],
+  });
   beforeEach(function () {
     localStorage.getItem.mockClear();
     jest.spyOn(PageFiltersActions, 'updateProjects');
@@ -29,6 +33,7 @@ describe('PageFilters ActionCreators', function () {
       initializeUrlState({
         organization,
         queryParams: {},
+        pathname: '/mock-pathname/',
         router,
       });
 
@@ -56,6 +61,7 @@ describe('PageFilters ActionCreators', function () {
       initializeUrlState({
         organization,
         queryParams: {},
+        pathname: '/mock-pathname/',
         skipLoadLastUsed: true,
         router,
       });
@@ -69,6 +75,7 @@ describe('PageFilters ActionCreators', function () {
         queryParams: {
           project: '1',
         },
+        pathname: '/mock-pathname/',
         router,
       });
       expect(PageFiltersActions.initializeUrlState).toHaveBeenCalledWith(
@@ -90,6 +97,7 @@ describe('PageFilters ActionCreators', function () {
         queryParams: {
           project: '1',
         },
+        pathname: '/mock-pathname/',
         defaultSelection: {
           datetime: {
             period: '3h',
@@ -117,6 +125,7 @@ describe('PageFilters ActionCreators', function () {
           statsPeriod: '1h',
           project: '1',
         },
+        pathname: '/mock-pathname/',
         defaultSelection: {
           datetime: {
             period: '24h',
@@ -144,6 +153,7 @@ describe('PageFilters ActionCreators', function () {
           end: '2020-04-21T00:53:38',
           project: '1',
         },
+        pathname: '/mock-pathname/',
         defaultSelection: {
           datetime: {
             period: '24h',
@@ -170,6 +180,7 @@ describe('PageFilters ActionCreators', function () {
         queryParams: {
           project: '1',
         },
+        pathname: 'mock-pathname',
         router,
       });
 
@@ -194,6 +205,73 @@ describe('PageFilters ActionCreators', function () {
           },
         })
       );
+    });
+
+    it('does not add non-pinned filters to query for pages with new page filters', function () {
+      // Mock storage to have a saved value
+      const pageFilterStorageMock = jest
+        .spyOn(PageFilterPersistence, 'getPageFilterStorage')
+        .mockReturnValueOnce({
+          state: {
+            project: ['1'],
+            environment: [],
+            start: null,
+            end: null,
+            period: '14d',
+            utc: null,
+          },
+          pinnedFilters: new Set(),
+        });
+
+      // Initialize state with a page that shouldn't restore from local storage
+      initializeUrlState({
+        organization: pageFiltersOrganization,
+        queryParams: {},
+        pathname: '/organizations/org-slug/issues/',
+        router,
+      });
+
+      // Confirm that query params are not restored from local storage
+      expect(router.replace).not.toHaveBeenCalled();
+
+      pageFilterStorageMock.mockRestore();
+    });
+
+    it('uses pinned filters for pages with new page filters', function () {
+      // Mock storage to have a saved/pinned value
+      const pageFilterStorageMock = jest
+        .spyOn(PageFilterPersistence, 'getPageFilterStorage')
+        .mockReturnValueOnce({
+          state: {
+            project: ['1'],
+            environment: ['prod'],
+            start: null,
+            end: null,
+            period: '14d',
+            utc: null,
+          },
+          pinnedFilters: new Set(['environments']),
+        });
+
+      // Initialize state with a page that uses pinned filters
+      initializeUrlState({
+        organization: pageFiltersOrganization,
+        queryParams: {},
+        pathname: '/organizations/org-slug/issues/',
+        router,
+      });
+
+      // Confirm that only environment is restored from local storage
+      expect(router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            environment: ['prod'],
+            project: [],
+          },
+        })
+      );
+
+      pageFilterStorageMock.mockRestore();
     });
   });
 


### PR DESCRIPTION
Changes how the `selection-filters-v2` feature flag affects the sentry frontend. 

Instead of removing the global selection header from **all** pages we record which pages have the new page filters and conditionally disable the GSH on those pages **only**.

Example page filters issue page:
![image](https://user-images.githubusercontent.com/9372512/152926669-340411b3-e127-4fbd-bf4f-925da4b85bfe.png)

Alongside normal performance page:
![image](https://user-images.githubusercontent.com/9372512/152926681-efa4b9c9-ecc0-4875-ad92-d670af2a31b2.png)
