### PR TITLE
ref(metrics-indexer): Test strategy sans multiprocessing

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -241,7 +241,7 @@ def devserver(
                     "`SENTRY_USE_METRICS_DEV` can only be used when "
                     "`SENTRY_EVENTSTREAM=sentry.eventstream.kafka.KafkaEventStream`."
                 )
-            # daemons += [_get_daemon("metrics")]
+            daemons += [_get_daemon("metrics")]
 
     if settings.SENTRY_USE_RELAY:
         daemons += [_get_daemon("ingest")]

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -241,7 +241,7 @@ def devserver(
                     "`SENTRY_USE_METRICS_DEV` can only be used when "
                     "`SENTRY_EVENTSTREAM=sentry.eventstream.kafka.KafkaEventStream`."
                 )
-            daemons += [_get_daemon("metrics")]
+            # daemons += [_get_daemon("metrics")]
 
     if settings.SENTRY_USE_RELAY:
         daemons += [_get_daemon("ingest")]

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -553,6 +553,7 @@ def metrics_consumer(**options):
 )
 @click.option("--input-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
+@click.option("--factory-name", default="default")
 def metrics_streaming_consumer(**options):
     from sentry.sentry_metrics.metrics_wrapper import MetricsWrapper
     from sentry.sentry_metrics.multiprocess import get_streaming_metrics_consumer

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -554,7 +554,7 @@ def metrics_consumer(**options):
 @click.option("--input-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--factory-name", default="default")
-@click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=10000)
+@click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=7500)
 @click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=4000)
 def metrics_streaming_consumer(**options):
     from sentry.sentry_metrics.metrics_wrapper import MetricsWrapper

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -554,6 +554,8 @@ def metrics_consumer(**options):
 @click.option("--input-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--factory-name", default="default")
+@click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=10000)
+@click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=4000)
 def metrics_streaming_consumer(**options):
     from sentry.sentry_metrics.metrics_wrapper import MetricsWrapper
     from sentry.sentry_metrics.multiprocess import get_streaming_metrics_consumer


### PR DESCRIPTION
**context**
Simplified version of the metrics indexer v2 that was added in https://github.com/getsentry/sentry/pull/30462. 

In an effort to be able to pinpoint where problems are actually occurring in the indexer, we've decided to slim it down and remove complexity. This new test (for now a test) strategy takes out the `ParallelTransformStep`, so it no longer does multiprocessing. However it does add in the `CollectStep` to batch up commits. 