### PR TITLE
feat(sessions): Track number of points in time requested [ISSUE-1372]

### DIFF
--- a/src/sentry/grouping/fingerprinting.py
+++ b/src/sentry/grouping/fingerprinting.py
@@ -279,6 +279,7 @@ class Match:
         return "frames"
 
     def matches(self, values):
+
         rv = self._positive_match(values)
         if self.negated:
             rv = not rv

--- a/src/sentry/grouping/fingerprinting.py
+++ b/src/sentry/grouping/fingerprinting.py
@@ -279,7 +279,6 @@ class Match:
         return "frames"
 
     def matches(self, values):
-
         rv = self._positive_match(values)
         if self.negated:
             rv = not rv


### PR DESCRIPTION
Add sentry tag for the number of intervals requested in the sessions API, so we can decide if we can reduce the maximum from 1000 to 365.