### PR TITLE
ref(sdk): Add temporary perf component

### DIFF
--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -20,6 +20,7 @@ import {
   fieldAlignment,
   getAggregateAlias,
 } from 'sentry/utils/discover/fields';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import CellAction, {Actions} from 'sentry/views/eventsV2/table/cellAction';
 import {TableColumn} from 'sentry/views/eventsV2/table/types';
 import {GridCell, GridCellNumber} from 'sentry/views/performance/styles';
@@ -201,17 +202,19 @@ class TransactionsTable extends React.PureComponent<Props> {
     const loader = <LoadingIndicator style={{margin: '70px auto'}} />;
 
     return (
-      <PanelTable
-        data-test-id="transactions-table"
-        isEmpty={!hasResults}
-        emptyMessage={t('No transactions found')}
-        headers={this.renderHeader()}
-        isLoading={isLoading}
-        disablePadding
-        loader={loader}
-      >
-        {this.renderResults()}
-      </PanelTable>
+      <VisuallyCompleteWithData id="TransactionsTable" hasData={hasResults}>
+        <PanelTable
+          data-test-id="transactions-table"
+          isEmpty={!hasResults}
+          emptyMessage={t('No transactions found')}
+          headers={this.renderHeader()}
+          isLoading={isLoading}
+          disablePadding
+          loader={loader}
+        >
+          {this.renderResults()}
+        </PanelTable>
+      </VisuallyCompleteWithData>
     );
   }
 }

--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -34,9 +34,9 @@ export const VisuallyCompleteWithData = ({
   hasData,
   children,
 }: {
-  id: string;
-  hasData: boolean;
   children: ReactNode;
+  hasData: boolean;
+  id: string;
 }) => {
   const isVisuallyCompleteSet = useRef(false);
   const isDataCompleteSet = useRef(false);

--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -1,3 +1,4 @@
+import {Fragment, Profiler, ReactNode, useEffect, useRef} from 'react';
 import {timestampWithMs} from '@sentry/utils';
 
 import getCurrentSentryReactTransaction from './getCurrentSentryReactTransaction';
@@ -27,3 +28,44 @@ export function onRenderCallback(
     // Add defensive catch since this wraps all of App
   }
 }
+
+export const VisuallyCompleteWithData = ({
+  id,
+  hasData,
+  children,
+}: {
+  id: string;
+  hasData: boolean;
+  children: ReactNode;
+}) => {
+  const isVisuallyCompleteSet = useRef(false);
+  const isDataCompleteSet = useRef(false);
+  useEffect(() => {
+    try {
+      const transaction: any = getCurrentSentryReactTransaction(); // Using any to override types for private api.
+      const now = performance.now();
+      if (!isVisuallyCompleteSet.current) {
+        transaction.setMeasurements({
+          ...transaction._measurements,
+          visuallyComplete: {value: now},
+        });
+        isVisuallyCompleteSet.current = true;
+      }
+      if (!isDataCompleteSet.current) {
+        transaction.setMeasurements({
+          ...transaction._measurements,
+          visuallyCompleteData: {value: now},
+        });
+        isDataCompleteSet.current = true;
+      }
+    } catch (_) {
+      // Defensive catch since this code is auxiliary.
+    }
+  }, [hasData]);
+
+  return (
+    <Profiler id={id} onRender={onRenderCallback}>
+      <Fragment>{children}</Fragment>
+    </Profiler>
+  );
+};


### PR DESCRIPTION
### Summary
This will help measure component completeness (as the primary visualization on transaction summary) vs. reported vitals.

Other:
- Adds a profiler so we can see if there are additional transaction table renders afterwards that are more likely to be 'visually complete'. 