### PR TITLE
ref(perf): Tweak visuallyComplete component

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -43,18 +43,28 @@ export const VisuallyCompleteWithData = ({
   useEffect(() => {
     try {
       const transaction: any = getCurrentSentryReactTransaction(); // Using any to override types for private api.
-      const now = performance.now();
+      const now = timestampWithMs();
+      const transactionStart = transaction.startTimestamp;
+      const normalizedValue = Math.abs((now - transactionStart) * 1000);
+
       if (!isVisuallyCompleteSet.current) {
-        transaction.setMeasurements({
-          ...transaction._measurements,
-          visuallyComplete: {value: now},
+        transaction.registerBeforeFinishCallback(function (t, _) {
+          // Should be called after performance entries finish callback.
+          t.setMeasurements({
+            ...t._measurements,
+            visuallyComplete: {value: normalizedValue},
+          });
         });
         isVisuallyCompleteSet.current = true;
       }
       if (!isDataCompleteSet.current) {
-        transaction.setMeasurements({
-          ...transaction._measurements,
-          visuallyCompleteData: {value: now},
+        transaction.registerBeforeFinishCallback(function (t, _) {
+          // Should be called after performance entries finish callback.
+          t.setMeasurements({
+            ...t._measurements,
+            visuallyCompleteData: {value: normalizedValue},
+          });
+          console.log(t);
         });
         isDataCompleteSet.current = true;
       }

--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -48,7 +48,7 @@ export const VisuallyCompleteWithData = ({
       const normalizedValue = Math.abs((now - transactionStart) * 1000);
 
       if (!isVisuallyCompleteSet.current) {
-        transaction.registerBeforeFinishCallback(function (t, _) {
+        transaction.registerBeforeFinishCallback((t, _) => {
           // Should be called after performance entries finish callback.
           t.setMeasurements({
             ...t._measurements,
@@ -58,7 +58,7 @@ export const VisuallyCompleteWithData = ({
         isVisuallyCompleteSet.current = true;
       }
       if (!isDataCompleteSet.current) {
-        transaction.registerBeforeFinishCallback(function (t, _) {
+        transaction.registerBeforeFinishCallback((t, _) => {
           // Should be called after performance entries finish callback.
           t.setMeasurements({
             ...t._measurements,

--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -64,7 +64,6 @@ export const VisuallyCompleteWithData = ({
             ...t._measurements,
             visuallyCompleteData: {value: normalizedValue},
           });
-          console.log(t);
         });
         isDataCompleteSet.current = true;
       }


### PR DESCRIPTION
### Summary
Measurements were being replaced by transaction metrics since they are added with 'setMeasurements' (destructive) inside a registerBeforeTransactionFinish callback. Since the callbacks inside the component are registered after, they should be called after, when the transaction metrics has already run. This isn't ideal since it relies on call order, but once/if custom measurements lands we would switch to that.