### PR TITLE
feat(apidocs): document SCIM members delete with new tooling

### DIFF
--- a/src/sentry/apidocs/constants.py
+++ b/src/sentry/apidocs/constants.py
@@ -5,3 +5,5 @@ RESPONSE_UNAUTHORIZED = OpenApiResponse(description="Unauthorized")
 RESPONSE_FORBIDDEN = OpenApiResponse(description="Forbidden")
 
 RESPONSE_NOTFOUND = OpenApiResponse(description="Not Found")
+
+RESPONSE_SUCCESS = OpenApiResponse(description="Success")


### PR DESCRIPTION
- In code Documentation for SCIM Members DELETE method

Note that until the routes are removed in `api-docs/openapi.json`, the old docs will override this. (Will remove from the json once all the endpoints on the endpoint are in-code documented).