### PR TITLE
fix(alerts): Set default threshold type to below or apdex

### DIFF
--- a/static/app/views/alerts/incidentRules/constants.tsx
+++ b/static/app/views/alerts/incidentRules/constants.tsx
@@ -179,6 +179,10 @@ export function createRuleFromWizardTemplate(
     defaultRuleOptions.timeWindow = TimeWindow.ONE_HOUR;
   }
 
+  if (aggregate.includes('apdex')) {
+    defaultRuleOptions.thresholdType = AlertRuleThresholdType.BELOW;
+  }
+
   return {
     ...createDefaultRule(defaultRuleOptions),
     eventTypes: [eventTypes],

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -320,7 +320,7 @@ export function getFunctionHelpText(alertType: AlertType): {
   const timeWindowText = t('over');
   if (alertType === 'apdex') {
     return {
-      labelText: t('Select apdex value and time interval'),
+      labelText: t('Select apdex threshold and time interval'),
       timeWindowText,
     };
   }


### PR DESCRIPTION
This updates the alert wizard threshold control for apdex, the default direction for it should be below.

Jira: [WOR-979](https://getsentry.atlassian.net/browse/WOR-979)