### PR TITLE
fix(discover): toggleable legends for discover events chart

### DIFF
--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -8,6 +8,7 @@ import {Client} from 'sentry/api';
 import LoadingPanel from 'sentry/components/charts/loadingPanel';
 import {
   canIncludePreviousPeriod,
+  getPreviousSeriesName,
   isMultiSeriesStats,
 } from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
@@ -444,7 +445,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
       ? this.transformPreviousPeriodData(
           current,
           previous,
-          (seriesName ? `previous ${seriesName}` : undefined) ??
+          (seriesName ? getPreviousSeriesName(seriesName) : undefined) ??
             previousSeriesNames?.[seriesIndex]
         )
       : null;

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -260,3 +260,7 @@ export const processTableResults = (tableResults?: TableDataWithTitle[]) => {
     }),
   };
 };
+
+export const getPreviousSeriesName = (seriesName: string) => {
+  return `previous ${seriesName}`;
+};

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -8,7 +8,7 @@ import {Client} from 'sentry/api';
 import AreaChart from 'sentry/components/charts/areaChart';
 import BarChart from 'sentry/components/charts/barChart';
 import EventsChart from 'sentry/components/charts/eventsChart';
-import {getInterval} from 'sentry/components/charts/utils';
+import {getInterval, getPreviousSeriesName} from 'sentry/components/charts/utils';
 import WorldMapChart from 'sentry/components/charts/worldMapChart';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Panel} from 'sentry/components/panels';
@@ -102,7 +102,7 @@ class ResultsChart extends Component<ResultsChartProps> {
     const seriesLabels = yAxisValue.map(stripEquationPrefix);
     const disableableSeries = [
       ...seriesLabels,
-      ...seriesLabels.map(label => `previous ${label}`),
+      ...seriesLabels.map(getPreviousSeriesName),
     ];
     return (
       <Fragment>

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -17,7 +17,7 @@ import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
-import {isEquation} from 'sentry/utils/discover/fields';
+import {isEquation, stripEquationPrefix} from 'sentry/utils/discover/fields';
 import {
   DisplayModes,
   MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES,
@@ -99,6 +99,11 @@ class ResultsChart extends Component<ResultsChartProps> {
           )
         : eventView.interval;
 
+    const seriesLabels = yAxisValue.map(stripEquationPrefix);
+    const disableableSeries = [
+      ...seriesLabels,
+      ...seriesLabels.map(label => `previous ${label}`),
+    ];
     return (
       <Fragment>
         {getDynamicText({
@@ -128,6 +133,7 @@ class ResultsChart extends Component<ResultsChartProps> {
               chartComponent={chartComponent}
               referrer={referrer}
               fromDiscover
+              disableableSeries={disableableSeries}
             />
           ),
           fixed: <Placeholder height="200px" testId="skeleton-ui" />,

--- a/static/app/views/performance/landing/widgets/transforms/transformMetricsToArea.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformMetricsToArea.tsx
@@ -1,6 +1,7 @@
 import mean from 'lodash/mean';
 import moment from 'moment';
 
+import {getPreviousSeriesName} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Series, SeriesDataUnit} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
@@ -195,7 +196,7 @@ export function transformMetricsToArea<T extends WidgetDataConstraint>(
     }));
 
     return {
-      seriesName: `previous ${metricsField}`,
+      seriesName: getPreviousSeriesName(metricsField),
       stack: 'previous',
       data: series.some(serie => defined(serie.value)) ? series : [],
     };

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
-import {getInterval} from 'sentry/components/charts/utils';
+import {getInterval, getPreviousSeriesName} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
 import {QueryBatchNode} from 'sentry/utils/performance/contexts/genericQueryBatcher';
 import withApi from 'sentry/utils/withApi';
@@ -42,7 +42,7 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
               includeTransformedData
               partial
               currentSeriesNames={[field]}
-              previousSeriesNames={[`previous ${field}`]}
+              previousSeriesNames={[getPreviousSeriesName(field)]}
               query={provided.eventView.getQueryWithAdditionalConditions()}
               interval={getInterval(
                 {


### PR DESCRIPTION
Allows toggling series through legends in discover charts
![image](https://user-images.githubusercontent.com/83961295/153083295-b1f39e09-c267-4bae-8d44-d78ac94d5d13.png)
