### PR TITLE
feat(dashboards): Updated clicking edit on a dashboard title to automatically select the entire title

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -14,6 +14,7 @@ import Input from 'sentry/views/settings/components/forms/controls/input';
 type Props = {
   onChange: (value: string) => void;
   value: string;
+  autoSelect?: boolean;
   errorMessage?: React.ReactNode;
   isDisabled?: boolean;
   name?: string;
@@ -27,6 +28,7 @@ function EditableText({
   errorMessage,
   successMessage,
   isDisabled = false,
+  autoSelect = false,
 }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(value);
@@ -148,6 +150,7 @@ function EditableText({
             ref={inputRef}
             value={inputValue}
             onChange={handleInputChange}
+            onFocus={event => autoSelect && event.target.select()}
           />
           <InputLabel>{inputValue}</InputLabel>
         </InputWrapper>

--- a/static/app/views/dashboardsV2/title.tsx
+++ b/static/app/views/dashboardsV2/title.tsx
@@ -28,6 +28,7 @@ function DashboardTitle({dashboard, isEditing, organization, onUpdate}: Props) {
           }
           onChange={newTitle => onUpdate({...dashboard, title: newTitle})}
           errorMessage={t('Please set a title for this dashboard')}
+          autoSelect
         />
       )}
     </div>


### PR DESCRIPTION
Updated clicking edit on a dashboard title to automatically select the entire title
![image](https://user-images.githubusercontent.com/83961295/153083697-6f396782-2774-40c4-9a96-5d6dd64bf41e.png)
![image](https://user-images.githubusercontent.com/83961295/153083711-d392c029-7465-4314-bc0b-6ebc31f51bac.png)
