### PR TITLE
fix(perf): Fix slicing of dates in anomalies

### DIFF
--- a/static/app/utils/performance/anomalies/anomaliesQuery.tsx
+++ b/static/app/utils/performance/anomalies/anomaliesQuery.tsx
@@ -46,7 +46,6 @@ export type AnomalyPayload = {
 
 function transformStatsTimes(stats: AnomalyStatsData) {
   stats.data.forEach(d => (d[0] = d[0] * 1000));
-  stats.data = stats.data.slice((stats.data.length * 4) / 6, stats.data.length);
   return stats;
 }
 function transformAnomaliesTimes(anoms: AnomalyInfo[]) {


### PR DESCRIPTION
### Summary
Had some code that reduced the number of buckets to only show the most recent fraction of the response. This should now show the entire responses worth of data.