### PR TITLE
ref(ui): Use DropdownMenuV2 for dashboard widget dropdown

### DIFF
--- a/static/app/components/dropdownMenuItemV2.tsx
+++ b/static/app/components/dropdownMenuItemV2.tsx
@@ -209,7 +209,6 @@ const MenuItem = withRouter(
         as={renderAs}
         isDisabled={isDisabled}
         data-test-id={item.key}
-        {...(item.to && {'data-test-href': item.to})}
         {...props}
         {...(isSubmenuTrigger && {role: 'menuitemradio'})}
       >

--- a/static/app/components/dropdownMenuItemV2.tsx
+++ b/static/app/components/dropdownMenuItemV2.tsx
@@ -209,6 +209,7 @@ const MenuItem = withRouter(
         as={renderAs}
         isDisabled={isDisabled}
         data-test-id={item.key}
+        {...(item.to && {'data-test-href': item.to})}
         {...props}
         {...(isSubmenuTrigger && {role: 'menuitemradio'})}
       >

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -1,12 +1,19 @@
-import * as React from 'react';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
 import {openDashboardWidgetQuerySelectorModal} from 'sentry/actionCreators/modal';
 import {parseArithmetic} from 'sentry/components/arithmeticInput/parser';
-import Confirm from 'sentry/components/confirm';
-import Link from 'sentry/components/links/link';
-import MenuItem from 'sentry/components/menuItem';
+import {openConfirmModal} from 'sentry/components/confirm';
+import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
+import {MenuItemProps} from 'sentry/components/dropdownMenuItemV2';
+import {
+  IconCopy,
+  IconDelete,
+  IconEdit,
+  IconEllipsis,
+  IconIssues,
+  IconTelescope,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
@@ -17,7 +24,6 @@ import {DisplayModes} from 'sentry/utils/discover/types';
 import {eventViewFromWidget} from 'sentry/views/dashboardsV2/utils';
 import {DisplayType} from 'sentry/views/dashboardsV2/widget/utils';
 
-import ContextMenu from '../contextMenu';
 import {Widget, WidgetType} from '../types';
 
 type Props = {
@@ -47,16 +53,29 @@ function WidgetCardContextMenu({
     return null;
   }
 
-  const menuOptions: React.ReactNode[] = [];
+  const menuOptions: MenuItemProps[] = [];
+  const disabledKeys: string[] = [];
 
   if (isPreview) {
     return (
       <ContextWrapper>
-        <ContextMenu>
-          <PreviewMessage>
-            {t('This is a preview only. To edit, you must add this dashboard.')}
-          </PreviewMessage>
-        </ContextMenu>
+        <DropdownMenuControlV2
+          items={[
+            {
+              key: 'preview',
+              label: t('This is a preview only. To edit, you must add this dashboard.'),
+            },
+          ]}
+          triggerProps={{
+            'aria-label': t('Widget actions'),
+            size: 'xsmall',
+            borderless: true,
+            showChevron: false,
+            icon: <IconEllipsis direction="down" size="sm" />,
+          }}
+          placement="bottom right"
+          disabledKeys={['preview']}
+        />
       </ContextWrapper>
     );
   }
@@ -119,36 +138,31 @@ function WidgetCardContextMenu({
         ...discoverLocation.query,
       })}`;
       if (widget.queries.length === 1) {
-        menuOptions.push(
-          <Link
-            key="open-discover-link"
-            to={discoverPath}
-            onClick={() => {
-              trackAdvancedAnalyticsEvent('dashboards_views.open_in_discover.opened', {
-                organization,
-                widget_type: widget.displayType,
-              });
-            }}
-          >
-            <StyledMenuItem key="open-discover">{t('Open in Discover')}</StyledMenuItem>
-          </Link>
-        );
+        menuOptions.push({
+          key: 'open-in-discover',
+          label: t('Open in Discover'),
+          leadingItems: <IconTelescope />,
+          to: discoverPath,
+          onAction: () => {
+            trackAdvancedAnalyticsEvent('dashboards_views.open_in_discover.opened', {
+              organization,
+              widget_type: widget.displayType,
+            });
+          },
+        });
       } else {
-        menuOptions.push(
-          <StyledMenuItem
-            key="open-discover"
-            onClick={event => {
-              event.preventDefault();
-              trackAdvancedAnalyticsEvent('dashboards_views.query_selector.opened', {
-                organization,
-                widget_type: widget.displayType,
-              });
-              openDashboardWidgetQuerySelectorModal({organization, widget});
-            }}
-          >
-            {t('Open in Discover')}
-          </StyledMenuItem>
-        );
+        menuOptions.push({
+          key: 'open-discover',
+          label: t('Open in Discover'),
+          leadingItems: <IconTelescope />,
+          onAction: () => {
+            trackAdvancedAnalyticsEvent('dashboards_views.query_selector.opened', {
+              organization,
+              widget_type: widget.displayType,
+            });
+            openDashboardWidgetQuerySelectorModal({organization, widget});
+          },
+        });
       }
     }
   }
@@ -165,43 +179,42 @@ function WidgetCardContextMenu({
       ...datetime,
     })}`;
 
-    menuOptions.push(
-      <Link to={issuesLocation} key="open-issues-link">
-        <StyledMenuItem key="open-issues">{t('Open in Issues')}</StyledMenuItem>
-      </Link>
-    );
+    menuOptions.push({
+      key: 'open-in-issues',
+      label: t('Open in Issues'),
+      leadingItems: <IconIssues />,
+      to: issuesLocation,
+    });
   }
 
   if (organization.features.includes('dashboards-edit')) {
-    menuOptions.push(
-      <StyledMenuItem
-        key="duplicate-widget"
-        data-test-id="duplicate-widget"
-        onSelect={onDuplicate}
-        disabled={widgetLimitReached}
-      >
-        {t('Duplicate Widget')}
-      </StyledMenuItem>
-    );
+    menuOptions.push({
+      key: 'duplicate-widget',
+      label: t('Duplicate Widget'),
+      leadingItems: <IconCopy />,
+      onAction: () => onDuplicate(),
+    });
+    widgetLimitReached && disabledKeys.push('duplicate-widget');
 
-    menuOptions.push(
-      <StyledMenuItem key="edit-widget" data-test-id="edit-widget" onSelect={onEdit}>
-        {t('Edit Widget')}
-      </StyledMenuItem>
-    );
+    menuOptions.push({
+      key: 'edit-widget',
+      label: t('Edit Widget'),
+      leadingItems: <IconEdit />,
+      onAction: () => onEdit(),
+    });
 
-    menuOptions.push(
-      <Confirm
-        key="delete-widget"
-        priority="danger"
-        message={t('Are you sure you want to delete this widget?')}
-        onConfirm={onDelete}
-      >
-        <StyledMenuItem data-test-id="delete-widget" danger>
-          {t('Delete Widget')}
-        </StyledMenuItem>
-      </Confirm>
-    );
+    menuOptions.push({
+      key: 'delete-widget',
+      label: t('Delete Widget'),
+      leadingItems: <IconDelete />,
+      onAction: () => {
+        openConfirmModal({
+          message: t('Are you sure you want to delete this widget?'),
+          priority: 'danger',
+          onConfirm: () => onDelete(),
+        });
+      },
+    });
   }
 
   if (!menuOptions.length) {
@@ -210,7 +223,18 @@ function WidgetCardContextMenu({
 
   return (
     <ContextWrapper>
-      <ContextMenu>{menuOptions}</ContextMenu>
+      <DropdownMenuControlV2
+        items={menuOptions}
+        triggerProps={{
+          'aria-label': t('Widget actions'),
+          size: 'xsmall',
+          borderless: true,
+          showChevron: false,
+          icon: <IconEllipsis direction="down" size="sm" />,
+        }}
+        placement="bottom right"
+        disabledKeys={disabledKeys}
+      />
     </ContextWrapper>
   );
 }
@@ -219,17 +243,4 @@ export default WidgetCardContextMenu;
 
 const ContextWrapper = styled('div')`
   margin-left: ${space(1)};
-`;
-
-const StyledMenuItem = styled(MenuItem)<{danger?: boolean}>`
-  white-space: nowrap;
-  color: ${p => (p.danger ? p.theme.red300 : p.theme.textColor)};
-  :hover {
-    color: ${p => (p.danger ? p.theme.red300 : p.theme.textColor)};
-  }
-`;
-
-const PreviewMessage = styled('span')`
-  padding: ${space(1)};
-  display: block;
 `;

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -137,33 +137,28 @@ function WidgetCardContextMenu({
       const discoverPath = `${discoverLocation.pathname}?${qs.stringify({
         ...discoverLocation.query,
       })}`;
-      if (widget.queries.length === 1) {
-        menuOptions.push({
-          key: 'open-in-discover',
-          label: t('Open in Discover'),
-          leadingItems: <IconTelescope />,
-          to: discoverPath,
-          onAction: () => {
+
+      menuOptions.push({
+        key: 'open-in-discover',
+        label: t('Open in Discover'),
+        leadingItems: <IconTelescope />,
+        to: widget.queries.length === 1 ? discoverPath : undefined,
+        onAction: () => {
+          if (widget.queries.length === 1) {
             trackAdvancedAnalyticsEvent('dashboards_views.open_in_discover.opened', {
               organization,
               widget_type: widget.displayType,
             });
-          },
-        });
-      } else {
-        menuOptions.push({
-          key: 'open-discover',
-          label: t('Open in Discover'),
-          leadingItems: <IconTelescope />,
-          onAction: () => {
-            trackAdvancedAnalyticsEvent('dashboards_views.query_selector.opened', {
-              organization,
-              widget_type: widget.displayType,
-            });
-            openDashboardWidgetQuerySelectorModal({organization, widget});
-          },
-        });
-      }
+            return;
+          }
+
+          trackAdvancedAnalyticsEvent('dashboards_views.query_selector.opened', {
+            organization,
+            widget_type: widget.displayType,
+          });
+          openDashboardWidgetQuerySelectorModal({organization, widget});
+        },
+      });
     }
   }
 

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -242,5 +242,8 @@ function WidgetCardContextMenu({
 export default WidgetCardContextMenu;
 
 const ContextWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  height: ${space(3)};
   margin-left: ${space(1)};
 `;

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -118,11 +118,11 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
         with self.feature(FEATURE_NAMES + EDIT_FEATURE):
             self.page.visit_dashboard_detail()
 
-            self.browser.element('[data-test-id="context-menu"]').click()
+            self.browser.element('[aria-haspopup="true"]').click()
             self.browser.element('[data-test-id="duplicate-widget"]').click()
             self.page.wait_until_loaded()
 
-            self.browser.elements('[data-test-id="context-menu"]')[0].click()
+            self.browser.element('[aria-haspopup="true"]').click()
             self.browser.element('[data-test-id="duplicate-widget"]').click()
             self.page.wait_until_loaded()
 
@@ -132,7 +132,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
         with self.feature(FEATURE_NAMES + EDIT_FEATURE):
             self.page.visit_dashboard_detail()
 
-            self.browser.element('[data-test-id="context-menu"]').click()
+            self.browser.element('[aria-haspopup="true"]').click()
             self.browser.element('[data-test-id="delete-widget"]').click()
             self.browser.element('[data-test-id="confirm-button"]').click()
 
@@ -476,11 +476,11 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
         with self.feature(FEATURE_NAMES + EDIT_FEATURE):
             self.page.visit_dashboard_detail()
 
-            self.browser.element('[data-test-id="context-menu"]').click()
+            self.browser.element('[aria-haspopup="true"]').click()
             self.browser.element('[data-test-id="duplicate-widget"]').click()
             self.page.wait_until_loaded()
 
-            self.browser.elements('[data-test-id="context-menu"]')[0].click()
+            self.browser.element('[aria-haspopup="true"]').click()
             self.browser.element('[data-test-id="duplicate-widget"]').click()
             self.page.wait_until_loaded()
 
@@ -507,7 +507,7 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
         with self.feature(FEATURE_NAMES + EDIT_FEATURE):
             self.page.visit_dashboard_detail()
 
-            self.browser.element('[data-test-id="context-menu"]').click()
+            self.browser.element('[aria-haspopup="true"]').click()
             self.browser.element('[data-test-id="delete-widget"]').click()
             self.browser.element('[data-test-id="confirm-button"]').click()
 
@@ -643,8 +643,8 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
         ):
             self.page.visit_dashboard_detail()
 
-            context_menu_icon = self.browser.element('[data-test-id="context-menu"]')
-            context_menu_icon.click()
+            dropdown_trigger = self.browser.element('[aria-haspopup="true"]')
+            dropdown_trigger.click()
 
             delete_widget_menu_item = self.browser.element('[data-test-id="delete-widget"]')
             delete_widget_menu_item.click()
@@ -695,8 +695,8 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
             self.page.visit_dashboard_detail()
 
             # Open edit modal for first widget
-            context_menu_icon = self.browser.element('[data-test-id="context-menu"]')
-            context_menu_icon.click()
+            dropdown_trigger = self.browser.element('[aria-haspopup="true"]')
+            dropdown_trigger.click()
             edit_widget_menu_item = self.browser.element('[data-test-id="edit-widget"]')
             edit_widget_menu_item.click()
 
@@ -743,8 +743,8 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
             self.page.visit_dashboard_detail()
 
             # Open edit modal for first widget
-            context_menu_icon = self.browser.element('[data-test-id="context-menu"]')
-            context_menu_icon.click()
+            dropdown_trigger = self.browser.element('[aria-haspopup="true"]')
+            dropdown_trigger.click()
             edit_widget_menu_item = self.browser.element('[data-test-id="edit-widget"]')
             edit_widget_menu_item.click()
 
@@ -791,8 +791,8 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
             self.page.visit_dashboard_detail()
 
             # Open edit modal for first widget
-            context_menu_icon = self.browser.element('[data-test-id="context-menu"]')
-            context_menu_icon.click()
+            dropdown_trigger = self.browser.element('[aria-haspopup="true"]')
+            dropdown_trigger.click()
             edit_widget_menu_item = self.browser.element('[data-test-id="edit-widget"]')
             edit_widget_menu_item.click()
 

--- a/tests/js/sentry-test/dropdownMenu.tsx
+++ b/tests/js/sentry-test/dropdownMenu.tsx
@@ -46,7 +46,7 @@ export async function selectDropdownMenuItem({
   wrapper,
   itemKey,
   specifiers,
-  triggerSelector = 'DropdownTrigger',
+  triggerSelector = 'Button',
 }: SelectDropdownItemProps) {
   /**
    * Returns a ReactWrapper which we'll use to find the

--- a/tests/js/spec/components/actions/resolve.spec.jsx
+++ b/tests/js/spec/components/actions/resolve.spec.jsx
@@ -210,6 +210,7 @@ describe('ResolveActions', function () {
     await selectDropdownMenuItem({
       wrapper,
       itemKey: 'another-release',
+      triggerSelector: 'DropdownTrigger',
     });
 
     expect(wrapper.find('CustomResolutionModal Select').prop('options')).toEqual([

--- a/tests/js/spec/views/dashboardsV2/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/detail.spec.jsx
@@ -1,10 +1,12 @@
 import {browserHistory} from 'react-router';
 
 import {createListeners} from 'sentry-test/createListeners';
+import {selectDropdownMenuItem} from 'sentry-test/dropdownMenu';
 import {enforceActOnUseLegacyStoreHook, mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountGlobalModal} from 'sentry-test/modal';
 import {act} from 'sentry-test/reactTestingLibrary';
+import {triggerPress} from 'sentry-test/utils';
 
 import * as modals from 'sentry/actionCreators/modal';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -722,16 +724,15 @@ describe('Dashboards > Detail', function () {
       ).toEqual(true);
       expect(wrapper.find('Controls Tooltip').prop('disabled')).toBe(false);
 
-      const card2 = wrapper.find('WidgetCard').first();
-      card2.find('DropdownMenu MoreOptions svg').simulate('click');
+      await act(async () => {
+        triggerPress(wrapper.first().find('MenuControlWrap Button').first());
 
-      card2.update();
-      wrapper.update();
+        await tick();
+        wrapper.update();
+      });
 
       expect(
-        wrapper
-          .find(`DropdownMenu MenuItem[data-test-id="duplicate-widget"] MenuTarget`)
-          .props().disabled
+        wrapper.find(`MenuItemWrap[data-test-id="duplicate-widget"]`).props().isDisabled
       ).toEqual(true);
     });
 
@@ -750,15 +751,11 @@ describe('Dashboards > Detail', function () {
 
       expect(wrapper.find('WidgetCard')).toHaveLength(3);
 
-      const card = wrapper.find('WidgetCard').first();
-      card.find('DropdownMenu MoreOptions svg').simulate('click');
-
-      card.update();
-      wrapper.update();
-
-      wrapper
-        .find(`DropdownMenu MenuItem[data-test-id="edit-widget"] MenuTarget`)
-        .simulate('click');
+      await selectDropdownMenuItem({
+        wrapper,
+        specifiers: {prefix: 'WidgetCard', first: true},
+        itemKey: 'edit-widget',
+      });
 
       expect(openEditModal).toHaveBeenCalledTimes(1);
       expect(openEditModal).toHaveBeenCalledWith(

--- a/tests/js/spec/views/dashboardsV2/issueWidgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/issueWidgetCard.spec.tsx
@@ -131,8 +131,9 @@ describe('Dashboards > IssueWidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
-    expect(screen.getByText('Open in Issues').closest('a')?.href).toContain(
+    userEvent.click(screen.getByLabelText('Widget actions'));
+    expect(screen.getByRole('menuitemradio', {name: 'Open in Issues'})).toHaveAttribute(
+      'data-test-href',
       '/organizations/org-slug/issues/?query=event.type%3Adefault&sort=freq&statsPeriod=14d'
     );
     expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
@@ -160,7 +161,7 @@ describe('Dashboards > IssueWidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Duplicate Widget'));
     expect(mock).toHaveBeenCalledTimes(1);
@@ -188,7 +189,7 @@ describe('Dashboards > IssueWidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Duplicate Widget'));
     expect(mock).toHaveBeenCalledTimes(0);

--- a/tests/js/spec/views/dashboardsV2/issueWidgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/issueWidgetCard.spec.tsx
@@ -8,7 +8,7 @@ import WidgetCard from 'sentry/views/dashboardsV2/widgetCard';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 describe('Dashboards > IssueWidgetCard', function () {
-  const initialData = initializeOrg({
+  const {router, organization, routerContext} = initializeOrg({
     organization: TestStubs.Organization({
       features: ['dashboards-edit'],
     }),
@@ -79,7 +79,7 @@ describe('Dashboards > IssueWidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={widget}
         selection={selection}
         isEditing={false}
@@ -112,7 +112,7 @@ describe('Dashboards > IssueWidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={widget}
         selection={selection}
         isEditing={false}
@@ -124,15 +124,18 @@ describe('Dashboards > IssueWidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      />
+      />,
+      {context: routerContext}
     );
 
     userEvent.click(await screen.findByLabelText('Widget actions'));
-    expect(screen.getByRole('menuitemradio', {name: 'Open in Issues'})).toHaveAttribute(
-      'data-test-href',
+    expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
+
+    expect(screen.getByText('Open in Issues')).toBeInTheDocument();
+    userEvent.click(screen.getByRole('menuitemradio', {name: 'Open in Issues'}));
+    expect(router.push).toHaveBeenCalledWith(
       '/organizations/org-slug/issues/?query=event.type%3Adefault&sort=freq&statsPeriod=14d'
     );
-    expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
   });
 
   it('calls onDuplicate when Duplicate Widget is clicked', async function () {
@@ -140,7 +143,7 @@ describe('Dashboards > IssueWidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={widget}
         selection={selection}
         isEditing={false}
@@ -166,7 +169,7 @@ describe('Dashboards > IssueWidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={widget}
         selection={selection}
         isEditing={false}
@@ -192,7 +195,7 @@ describe('Dashboards > IssueWidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{
           ...widget,
           queries: [

--- a/tests/js/spec/views/dashboardsV2/issueWidgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/issueWidgetCard.spec.tsx
@@ -94,9 +94,7 @@ describe('Dashboards > IssueWidgetCard', function () {
       />
     );
 
-    await tick();
-
-    expect(screen.getByText('Issues')).toBeInTheDocument();
+    expect(await screen.findByText('Issues')).toBeInTheDocument();
     expect(screen.getByText('assignee')).toBeInTheDocument();
     expect(screen.getByText('title')).toBeInTheDocument();
     expect(screen.getByText('issue')).toBeInTheDocument();
@@ -129,9 +127,7 @@ describe('Dashboards > IssueWidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByRole('menuitemradio', {name: 'Open in Issues'})).toHaveAttribute(
       'data-test-href',
       '/organizations/org-slug/issues/?query=event.type%3Adefault&sort=freq&statsPeriod=14d'
@@ -159,9 +155,7 @@ describe('Dashboards > IssueWidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Duplicate Widget'));
     expect(mock).toHaveBeenCalledTimes(1);
@@ -187,9 +181,7 @@ describe('Dashboards > IssueWidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Duplicate Widget'));
     expect(mock).toHaveBeenCalledTimes(0);
@@ -223,9 +215,7 @@ describe('Dashboards > IssueWidgetCard', function () {
       />
     );
 
-    await tick();
-
-    expect(screen.getByText('Lifetime Events')).toBeInTheDocument();
+    expect(await screen.findByText('Lifetime Events')).toBeInTheDocument();
     expect(screen.getByText('Lifetime Users')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -13,7 +13,7 @@ jest.mock('sentry/components/charts/simpleTableChart');
 jest.mock('sentry/views/dashboardsV2/widgetCard/metricsWidgetQueries');
 
 describe('Dashboards > WidgetCard', function () {
-  const initialData = initializeOrg({
+  const {router, organization, routerContext} = initializeOrg({
     organization: TestStubs.Organization({
       features: ['dashboards-edit', 'discover-basic'],
       projects: [TestStubs.Project()],
@@ -82,7 +82,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={multipleQueryWidget}
         selection={selection}
         isEditing={false}
@@ -101,7 +101,7 @@ describe('Dashboards > WidgetCard', function () {
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     userEvent.click(screen.getByText('Open in Discover'));
     expect(spy).toHaveBeenCalledWith({
-      organization: initialData.organization,
+      organization,
       widget: multipleQueryWidget,
     });
   });
@@ -110,7 +110,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{...multipleQueryWidget, queries: [multipleQueryWidget.queries[0]]}}
         selection={selection}
         isEditing={false}
@@ -122,13 +122,14 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      />
+      />,
+      {context: routerContext}
     );
 
     userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
-    expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
-      'data-test-href',
+    userEvent.click(screen.getByRole('menuitemradio', {name: 'Open in Discover'}));
+    expect(router.push).toHaveBeenCalledWith(
       '/organizations/org-slug/discover/results/?environment=prod&field=count%28%29&field=failure_count%28%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29&yAxis=failure_count%28%29'
     );
   });
@@ -137,7 +138,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.WORLD_MAP,
@@ -153,13 +154,14 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      />
+      />,
+      {context: routerContext}
     );
 
     userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
-    expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
-      'data-test-href',
+    userEvent.click(screen.getByRole('menuitemradio', {name: 'Open in Discover'}));
+    expect(router.push).toHaveBeenCalledWith(
       '/organizations/org-slug/discover/results/?display=worldmap&environment=prod&field=geo.country_code&field=count%28%29&name=Errors&project=1&query=event.type%3Aerror%20has%3Ageo.country_code&statsPeriod=14d&yAxis=count%28%29'
     );
   });
@@ -168,7 +170,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{
           ...multipleQueryWidget,
           queries: [
@@ -190,13 +192,14 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      />
+      />,
+      {context: routerContext}
     );
 
     userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
-    expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
-      'data-test-href',
+    userEvent.click(screen.getByRole('menuitemradio', {name: 'Open in Discover'}));
+    expect(router.push).toHaveBeenCalledWith(
       '/organizations/org-slug/discover/results/?environment=prod&field=count_if%28transaction.duration%2Cequals%2C300%29&field=failure_count%28%29&field=count%28%29&field=equation%7C%28count%28%29%20%2B%20failure_count%28%29%29%20%2F%20count_if%28transaction.duration%2Cequals%2C300%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=equation%7C%28count%28%29%20%2B%20failure_count%28%29%29%20%2F%20count_if%28transaction.duration%2Cequals%2C300%29'
     );
   });
@@ -205,7 +208,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.TOP_N,
@@ -223,13 +226,14 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      />
+      />,
+      {context: routerContext}
     );
 
     userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
-    expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
-      'data-test-href',
+    userEvent.click(screen.getByRole('menuitemradio', {name: 'Open in Discover'}));
+    expect(router.push).toHaveBeenCalledWith(
       '/organizations/org-slug/discover/results/?display=top5&environment=prod&field=transaction&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29'
     );
   });
@@ -239,7 +243,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.WORLD_MAP,
@@ -269,7 +273,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.WORLD_MAP,
@@ -299,7 +303,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.WORLD_MAP,
@@ -329,7 +333,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.WORLD_MAP,
@@ -365,7 +369,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.TABLE,
@@ -400,7 +404,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.TABLE,
@@ -447,7 +451,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={tableWidget}
         selection={selection}
         isEditing={false}
@@ -480,7 +484,7 @@ describe('Dashboards > WidgetCard', function () {
     mountWithTheme(
       <WidgetCard
         api={api}
-        organization={initialData.organization}
+        organization={organization}
         widget={widget}
         selection={selection}
         isEditing={false}

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -99,7 +99,7 @@ describe('Dashboards > WidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     userEvent.click(screen.getByText('Open in Discover'));
     expect(spy).toHaveBeenCalledWith({
@@ -129,10 +129,10 @@ describe('Dashboards > WidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
-    expect(screen.getByText('Open in Discover').closest('a')).toHaveAttribute(
-      'href',
+    expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
+      'data-test-href',
       '/organizations/org-slug/discover/results/?environment=prod&field=count%28%29&field=failure_count%28%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29&yAxis=failure_count%28%29'
     );
   });
@@ -162,10 +162,10 @@ describe('Dashboards > WidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
-    expect(screen.getByText('Open in Discover').closest('a')).toHaveAttribute(
-      'href',
+    expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
+      'data-test-href',
       '/organizations/org-slug/discover/results/?display=worldmap&environment=prod&field=geo.country_code&field=count%28%29&name=Errors&project=1&query=event.type%3Aerror%20has%3Ageo.country_code&statsPeriod=14d&yAxis=count%28%29'
     );
   });
@@ -201,10 +201,10 @@ describe('Dashboards > WidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
-    expect(screen.getByText('Open in Discover').closest('a')).toHaveAttribute(
-      'href',
+    expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
+      'data-test-href',
       '/organizations/org-slug/discover/results/?environment=prod&field=count_if%28transaction.duration%2Cequals%2C300%29&field=failure_count%28%29&field=count%28%29&field=equation%7C%28count%28%29%20%2B%20failure_count%28%29%29%20%2F%20count_if%28transaction.duration%2Cequals%2C300%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=equation%7C%28count%28%29%20%2B%20failure_count%28%29%29%20%2F%20count_if%28transaction.duration%2Cequals%2C300%29'
     );
   });
@@ -236,10 +236,10 @@ describe('Dashboards > WidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
-    expect(screen.getByText('Open in Discover').closest('a')).toHaveAttribute(
-      'href',
+    expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
+      'data-test-href',
       '/organizations/org-slug/discover/results/?display=top5&environment=prod&field=transaction&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29'
     );
   });
@@ -270,7 +270,7 @@ describe('Dashboards > WidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Duplicate Widget'));
     expect(mock).toHaveBeenCalledTimes(1);
@@ -302,7 +302,7 @@ describe('Dashboards > WidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Duplicate Widget'));
     expect(mock).toHaveBeenCalledTimes(0);
@@ -334,7 +334,7 @@ describe('Dashboards > WidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Edit Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Edit Widget'));
     expect(mock).toHaveBeenCalledTimes(1);
@@ -366,7 +366,7 @@ describe('Dashboards > WidgetCard', function () {
 
     await tick();
 
-    userEvent.click(screen.getByTestId('context-menu'));
+    userEvent.click(screen.getByLabelText('Widget actions'));
     expect(screen.getByText('Delete Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Delete Widget'));
     // Confirm Modal

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -97,9 +97,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     userEvent.click(screen.getByText('Open in Discover'));
     expect(spy).toHaveBeenCalledWith({
@@ -127,9 +125,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
       'data-test-href',
@@ -160,9 +156,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
       'data-test-href',
@@ -199,9 +193,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
       'data-test-href',
@@ -234,9 +226,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
       'data-test-href',
@@ -268,9 +258,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Duplicate Widget'));
     expect(mock).toHaveBeenCalledTimes(1);
@@ -300,9 +288,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Duplicate Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Duplicate Widget'));
     expect(mock).toHaveBeenCalledTimes(0);
@@ -332,9 +318,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Edit Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Edit Widget'));
     expect(mock).toHaveBeenCalledTimes(1);
@@ -364,9 +348,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
-    await tick();
-
-    userEvent.click(screen.getByLabelText('Widget actions'));
+    userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Delete Widget')).toBeInTheDocument();
     userEvent.click(screen.getByText('Delete Widget'));
     // Confirm Modal

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -229,6 +229,7 @@ describe('IssueListActions', function () {
         await selectDropdownMenuItem({
           wrapper,
           specifiers: {prefix: 'IgnoreActions'},
+          triggerSelector: 'DropdownTrigger',
           itemKey: ['until-affect', 'until-affect-custom'],
         });
 


### PR DESCRIPTION
**Before:**
<img width="341" alt="Screen Shot 2022-02-08 at 2 52 17 PM" src="https://user-images.githubusercontent.com/44172267/153089133-77de5733-6242-4b98-a67f-32d02bab6577.png">

**After:**
<img width="341" alt="Screen Shot 2022-02-08 at 2 53 12 PM" src="https://user-images.githubusercontent.com/44172267/153089214-0f8bba79-bad2-4bc6-a424-496b18aa42f3.png">

(the "Delete Widget" item have red text & icons with a new `priority` prop, https://github.com/getsentry/sentry/pull/31690)