### PR TITLE
feat(profiling): Add empty profiling tab

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -22,6 +22,7 @@ import {
   IconReleases,
   IconSettings,
   IconSiren,
+  IconSpan,
   IconStats,
   IconSupport,
   IconTelescope,
@@ -298,6 +299,27 @@ function Sidebar({location, organization}: Props) {
     </Feature>
   );
 
+  const profiling = hasOrganization && (
+    <Feature
+      hookName="feature-disabled:profiling-sidebar-item"
+      features={['profiling']}
+      organization={organization}
+      requireAll={false}
+    >
+      <SidebarItem
+        {...sidebarItemProps}
+        index
+        onClick={(_id, evt) =>
+          navigateWithPageFilters(`/organizations/${organization.slug}/profiling/`, evt)
+        }
+        icon={<IconSpan size="md" />}
+        label={t('Profiling')}
+        to={`/organizations/${organization.slug}/profiling/`}
+        id="profiling"
+      />
+    </Feature>
+  );
+
   const activity = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
@@ -353,6 +375,7 @@ function Sidebar({location, organization}: Props) {
                 {alerts}
                 {discover2}
                 {dashboards}
+                {profiling}
               </SidebarSection>
 
               <SidebarSection>{monitors}</SidebarSection>

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1815,6 +1815,19 @@ function buildRoutes() {
     </Route>
   );
 
+  const profilingRoutes = (
+    <Route
+      path="/organizations/:orgId/profiling/"
+      componentPromise={() => import('sentry/views/profiling')}
+      component={SafeLazyLoad}
+    >
+      <IndexRoute
+        componentPromise={() => import('sentry/views/profiling/content')}
+        component={SafeLazyLoad}
+      />
+    </Route>
+  );
+
   const organizationRoutes = (
     <Route component={errorHandler(OrganizationDetails)}>
       {settingsRoutes}
@@ -1830,6 +1843,7 @@ function buildRoutes() {
       {statsRoutes}
       {discoverRoutes}
       {performanceRoutes}
+      {profilingRoutes}
       {adminManageRoutes}
       {legacyOrganizationRootRoutes}
       {legacyGettingStartedRoutes}

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -162,6 +162,8 @@ export type FeatureDisabledHooks = {
   'feature-disabled:performance-page': FeatureDisabledHook;
   'feature-disabled:performance-quick-trace': FeatureDisabledHook;
   'feature-disabled:performance-sidebar-item': FeatureDisabledHook;
+  'feature-disabled:profiling-page': FeatureDisabledHook;
+  'feature-disabled:profiling-sidebar-item': FeatureDisabledHook;
   'feature-disabled:project-performance-score-card': FeatureDisabledHook;
   'feature-disabled:project-selector-all-projects': FeatureDisabledHook;
   'feature-disabled:project-selector-checkbox': FeatureDisabledHook;

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -1,0 +1,7 @@
+type Props = {};
+
+function ProfilingContent(_props: Props) {
+  return <h1>Profiling</h1>;
+}
+
+export default ProfilingContent;

--- a/static/app/views/profiling/index.tsx
+++ b/static/app/views/profiling/index.tsx
@@ -1,0 +1,34 @@
+import Feature from 'sentry/components/acl/feature';
+import Alert from 'sentry/components/alert';
+import {t} from 'sentry/locale';
+import {PageContent} from 'sentry/styles/organization';
+import {Organization} from 'sentry/types';
+import withOrganization from 'sentry/utils/withOrganization';
+
+type Props = {
+  children: React.ReactChildren;
+  organization: Organization;
+};
+
+function ProfilingContainer({organization, children}: Props) {
+  function renderNoAccess() {
+    return (
+      <PageContent>
+        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+      </PageContent>
+    );
+  }
+
+  return (
+    <Feature
+      hookName="feature-disabled:profiling-page"
+      features={['profiling']}
+      organization={organization}
+      renderDisabled={renderNoAccess}
+    >
+      {children}
+    </Feature>
+  );
+}
+
+export default withOrganization(ProfilingContainer);


### PR DESCRIPTION
This adds a new profiling tab to sentry behind the profiling feature flag.