### PR TITLE
ref(ui): Alert Details Sidebar

### DIFF
--- a/static/app/views/alerts/alertBadge.tsx
+++ b/static/app/views/alerts/alertBadge.tsx
@@ -73,7 +73,6 @@ const AlertIconWrapper = styled('div')<{color: Color; icon: React.ReactNode}>`
   }
 `;
 
-const IncidentStatusValue = styled('div')<{color: Color}>`
-  margin-left: ${space(1)};
-  color: ${p => p.theme[p.color]};
+const IncidentStatusValue = styled('div')`
+  margin-left: ${space(1.5)};
 `;

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -275,11 +275,15 @@ export default class DetailsBody extends React.Component<Props> {
     return (
       <StatusContainer>
         <HeaderItem>
-          <Heading noMargin>{t('Current Status')}</Heading>
+          <Heading noMargin>{t('Alert Status')}</Heading>
           <Status>
-            <AlertBadge status={status} hideText />
-            {activeIncident ? t('Triggered') : t('Resolved')}
-            {activityDate ? <TimeSince date={activityDate} /> : ''}
+            <AlertBadge status={status} />
+          </Status>
+        </HeaderItem>
+        <HeaderItem>
+          <Heading noMargin>{t('Last Triggered')}</Heading>
+          <Status>
+            {activityDate ? <TimeSince date={activityDate} /> : 'No alerts triggered'}
           </Status>
         </HeaderItem>
       </StatusContainer>

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -283,7 +283,7 @@ export default class DetailsBody extends React.Component<Props> {
         <HeaderItem>
           <Heading noMargin>{t('Last Triggered')}</Heading>
           <Status>
-            {activityDate ? <TimeSince date={activityDate} /> : 'No alerts triggered'}
+            {activityDate ? <TimeSince date={activityDate} /> : t('No alerts triggered')}
           </Status>
         </HeaderItem>
       </StatusContainer>


### PR DESCRIPTION
The Alert Details sidebar is confusing, so I’ve broken up `Alert Status` from `Last Triggered`

## Before 
![CleanShot 2022-02-08 at 13 36 1](https://user-images.githubusercontent.com/1900676/153093071-c14f8bae-2ed5-498c-8c29-293b3905f1a6.png)

## After
![CleanShot 2022-02-08 at 13 42 1](https://user-images.githubusercontent.com/1900676/153093081-389cff1e-a972-4dd9-aa09-6919c7c21ba8.png)