### PR TITLE
ref(button): improve tsc compile time

### DIFF
--- a/static/app/components/actions/button.tsx
+++ b/static/app/components/actions/button.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import Button, {ButtonProps} from 'sentry/components/button';
 
-const ActionButton = (props: ButtonProps) => <Button size="xsmall" {...props} />;
+function ActionButton(props: ButtonProps): React.ReactElement {
+  return <Button size="xsmall" {...props} />;
+}
 
 export default ActionButton;

--- a/static/app/components/actions/button.tsx
+++ b/static/app/components/actions/button.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 
-const ActionButton = (props: React.ComponentProps<typeof Button>) => (
-  <Button size="xsmall" {...props} />
-);
+const ActionButton = (props: ButtonProps) => <Button size="xsmall" {...props} />;
 
 export default ActionButton;

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -3,7 +3,7 @@ import {Mention, MentionsInput, MentionsInputProps} from 'react-mentions';
 import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import NavTabs from 'sentry/components/navTabs';
 import {IconMarkdown} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -363,9 +363,9 @@ const Footer = styled('div')`
   padding-left: ${space(1.5)};
 `;
 
-type FooterButtonProps = {
+interface FooterButtonProps extends ButtonProps {
   error?: string | null;
-} & React.ComponentProps<typeof Button>;
+}
 
 const FooterButton = styled(Button)<FooterButtonProps>`
   font-size: 13px;

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -3,7 +3,7 @@ import {Mention, MentionsInput, MentionsInputProps} from 'react-mentions';
 import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import Button, {ButtonProps} from 'sentry/components/button';
+import Button, {ButtonPropsWithoutAriaLabel} from 'sentry/components/button';
 import NavTabs from 'sentry/components/navTabs';
 import {IconMarkdown} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -363,7 +363,7 @@ const Footer = styled('div')`
   padding-left: ${space(1.5)};
 `;
 
-interface FooterButtonProps extends ButtonProps {
+interface FooterButtonProps extends ButtonPropsWithoutAriaLabel {
   error?: string | null;
 }
 

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -17,7 +17,7 @@ import {Theme} from 'sentry/utils/theme';
  */
 type ButtonElement = HTMLButtonElement & HTMLAnchorElement & any;
 
-export interface ButtonProps
+interface BaseButtonProps
   extends Omit<
     React.ButtonHTMLAttributes<ButtonElement>,
     'ref' | 'label' | 'size' | 'title'
@@ -42,10 +42,15 @@ export interface ButtonProps
   translucentBorder?: boolean;
 }
 
-export interface ButtonPropsWithAriaLabel extends ButtonProps {
-  'aria-label': string;
-  children: never;
+export interface ButtonPropsWithoutAriaLabel extends BaseButtonProps {
+  children: NonNullable<React.ReactNode>;
 }
+export interface ButtonPropsWithAriaLabel extends BaseButtonProps {
+  'aria-label': string;
+  children?: never;
+}
+
+export type ButtonProps = ButtonPropsWithoutAriaLabel | ButtonPropsWithAriaLabel;
 
 type Url = ButtonProps['to'] | ButtonProps['href'];
 
@@ -66,7 +71,7 @@ function BaseButton({
   tooltipProps,
   onClick,
   ...buttonProps
-}: ButtonPropsWithAriaLabel | ButtonProps) {
+}: ButtonProps) {
   // Intercept onClick and propagate
   function handleClick(e: React.MouseEvent) {
     // Don't allow clicks when disabled or busy
@@ -142,7 +147,6 @@ const Button = reactForwardRef<ButtonElement, ButtonProps>((props, ref) => (
 ));
 
 Button.displayName = 'Button';
-
 export default Button;
 
 type StyledButtonProps = ButtonProps & {theme: Theme};

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -17,17 +17,7 @@ import {Theme} from 'sentry/utils/theme';
  */
 type ButtonElement = HTMLButtonElement & HTMLAnchorElement & any;
 
-type ConditionalAriaLabelProps =
-  | {
-      children: Omit<React.ReactNode, 'null' | 'undefined' | 'boolean'>;
-      'aria-label'?: string;
-    }
-  | {
-      'aria-label': string;
-      children?: null | boolean;
-    };
-
-interface Props
+export interface ButtonProps
   extends Omit<
     React.ButtonHTMLAttributes<ButtonElement>,
     'ref' | 'label' | 'size' | 'title'
@@ -52,7 +42,10 @@ interface Props
   translucentBorder?: boolean;
 }
 
-export type ButtonProps = Props & ConditionalAriaLabelProps;
+export interface ButtonPropsWithAriaLabel extends ButtonProps {
+  'aria-label': string;
+  children: never;
+}
 
 type Url = ButtonProps['to'] | ButtonProps['href'];
 
@@ -73,7 +66,7 @@ function BaseButton({
   tooltipProps,
   onClick,
   ...buttonProps
-}: ButtonProps) {
+}: ButtonPropsWithAriaLabel | ButtonProps) {
   // Intercept onClick and propagate
   function handleClick(e: React.MouseEvent) {
     // Don't allow clicks when disabled or busy
@@ -274,7 +267,7 @@ const getSizeStyles = ({size, translucentBorder, theme}: StyledButtonProps) => {
 const StyledButton = styled(
   reactForwardRef<any, ButtonProps>(
     (
-      {forwardRef, size: _size, external, to, href, disabled, ...otherProps}: Props,
+      {forwardRef, size: _size, external, to, href, disabled, ...otherProps}: ButtonProps,
       forwardRefAlt
     ) => {
       // XXX: There may be two forwarded refs here, one potentially passed from a
@@ -311,7 +304,7 @@ const StyledButton = styled(
       prop === 'external' ||
       (typeof prop === 'string' && isPropValid(prop)),
   }
-)<Props>`
+)<ButtonProps>`
   display: inline-block;
   border-radius: ${p => p.theme.button.borderRadius};
   text-transform: none;

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -46,7 +46,7 @@ interface BaseButtonProps
 }
 
 export interface ButtonPropsWithoutAriaLabel extends BaseButtonProps {
-  children: NonNullable<React.ReactNode>;
+  children: React.ReactNode;
 }
 export interface ButtonPropsWithAriaLabel extends BaseButtonProps {
   'aria-label': string;

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -28,6 +28,7 @@ interface BaseButtonProps
   borderless?: boolean;
   busy?: boolean;
   disabled?: boolean;
+  download?: HTMLAnchorElement['download'];
   external?: boolean;
   forwardRef?: React.Ref<ButtonElement>;
   href?: string;
@@ -35,7 +36,9 @@ interface BaseButtonProps
   name?: string;
   onClick?: (e: React.MouseEvent) => void;
   priority?: 'default' | 'primary' | 'danger' | 'link' | 'success' | 'form';
+  rel?: HTMLAnchorElement['rel'];
   size?: 'zero' | 'xsmall' | 'small';
+  target?: HTMLAnchorElement['target'];
   title?: React.ComponentProps<typeof Tooltip>['title'];
   to?: string | object;
   tooltipProps?: Omit<Tooltip['props'], 'children' | 'title' | 'skipWrapper'>;

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -1,4 +1,4 @@
-import {forwardRef as reactForwardRef} from 'react';
+import * as React from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -6,7 +6,6 @@ import styled from '@emotion/styled';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import Tooltip from 'sentry/components/tooltip';
-import space from 'sentry/styles/space';
 import mergeRefs from 'sentry/utils/mergeRefs';
 import {Theme} from 'sentry/utils/theme';
 
@@ -17,63 +16,44 @@ import {Theme} from 'sentry/utils/theme';
  */
 type ButtonElement = HTMLButtonElement & HTMLAnchorElement & any;
 
-type ConditionalAriaLabel =
-  | {
-      children: Omit<React.ReactNode, 'null' | 'undefined' | 'boolean'>;
-      'aria-label'?: string;
-    }
-  | {
-      'aria-label': string;
-      children?: null | boolean;
-    };
-
-type Props = {
-  align?: 'center' | 'left' | 'right';
-  // This is only used with `<ButtonBar>`
-  barId?: string;
-  borderless?: boolean;
-  busy?: boolean;
-  disabled?: boolean;
-  external?: boolean;
-  forwardRef?: React.Ref<ButtonElement>;
-  href?: string;
-  icon?: React.ReactNode;
-  name?: string;
-  onClick?: (e: React.MouseEvent) => void;
+interface Props {
   priority?: 'default' | 'primary' | 'danger' | 'link' | 'success' | 'form';
   size?: 'zero' | 'xsmall' | 'small';
-  title?: React.ComponentProps<typeof Tooltip>['title'];
+  align?: 'center' | 'left' | 'right';
+  disabled?: boolean;
+  busy?: boolean;
   to?: string | object;
+  href?: string;
+  icon?: React.ReactNode;
+  title?: React.ComponentProps<typeof Tooltip>['title'];
+  external?: boolean;
+  borderless?: boolean;
+  label?: string;
   tooltipProps?: Omit<Tooltip['props'], 'children' | 'title' | 'skipWrapper'>;
+  onClick?: (e: React.MouseEvent) => void;
+  forwardRef?: React.Ref<ButtonElement>;
+  name?: string;
 
-  translucentBorder?: boolean;
-} & ConditionalAriaLabel;
+  // This is only used with `<ButtonBar>`
+  barId?: string;
+}
 
-type ButtonProps = Omit<React.HTMLProps<ButtonElement>, keyof Props | 'ref' | 'label'> &
-  Props;
+export interface ButtonProps
+  extends Props,
+    Omit<React.HTMLProps<ButtonElement>, keyof Props | 'ref'> {}
 
 type Url = ButtonProps['to'] | ButtonProps['href'];
 
-function BaseButton({
-  size,
-  to,
-  busy,
-  href,
-  title,
-  icon,
-  children,
-  'aria-label': ariaLabel,
-  borderless,
-  translucentBorder,
-  align = 'center',
-  priority,
-  disabled = false,
-  tooltipProps,
-  onClick,
-  ...buttonProps
-}: Props) {
+class BaseButton extends React.Component<ButtonProps, {}> {
+  static defaultProps: ButtonProps = {
+    disabled: false,
+    align: 'center',
+  };
+
   // Intercept onClick and propagate
-  function handleClick(e: React.MouseEvent) {
+  handleClick = (e: React.MouseEvent) => {
+    const {disabled, busy, onClick} = this.props;
+
     // Don't allow clicks when disabled or busy
     if (disabled || busy) {
       e.preventDefault();
@@ -86,63 +66,82 @@ function BaseButton({
     }
 
     onClick(e);
-  }
+  };
 
-  function getUrl<T extends Url>(prop: T): T | undefined {
-    return disabled ? undefined : prop;
-  }
+  getUrl = <T extends Url>(prop: T): T | undefined =>
+    this.props.disabled ? undefined : prop;
 
-  // Fallbacking aria-label to string children is not necessary as screen readers natively understand that scenario.
-  // Leaving it here for a bunch of our tests that query by aria-label.
-  const screenReaderLabel =
-    ariaLabel || (typeof children === 'string' ? children : undefined);
+  render() {
+    const {
+      size,
+      to,
+      href,
+      title,
+      icon,
+      children,
+      label,
+      borderless,
+      align,
+      priority,
+      disabled,
+      tooltipProps,
 
-  const hasChildren = Array.isArray(children)
-    ? children.some(child => !!child)
-    : !!children;
+      // destructure from `buttonProps`
+      // not necessary, but just in case someone re-orders props
+      onClick: _onClick,
+      ...buttonProps
+    } = this.props;
+    // For `aria-label`
+    const screenReaderLabel =
+      label || (typeof children === 'string' ? children : undefined);
 
-  // Buttons come in 4 flavors: <Link>, <ExternalLink>, <a>, and <button>.
-  // Let's use props to determine which to serve up, so we don't have to think about it.
-  // *Note* you must still handle tabindex manually.
-  const button = (
-    <StyledButton
-      aria-label={screenReaderLabel}
-      aria-disabled={disabled}
-      disabled={disabled}
-      to={getUrl(to)}
-      href={getUrl(href)}
-      size={size}
-      priority={priority}
-      borderless={borderless}
-      translucentBorder={translucentBorder}
-      {...buttonProps}
-      onClick={handleClick}
-      role="button"
-    >
-      <ButtonLabel align={align} size={size} borderless={borderless}>
-        {icon && (
-          <Icon size={size} hasChildren={hasChildren}>
-            {icon}
-          </Icon>
-        )}
-        {children}
-      </ButtonLabel>
-    </StyledButton>
-  );
-
-  // Doing this instead of using `Tooltip`'s `disabled` prop so that we can minimize snapshot nesting
-  if (title) {
-    return (
-      <Tooltip skipWrapper {...tooltipProps} title={title}>
-        {button}
-      </Tooltip>
+    // Buttons come in 4 flavors: <Link>, <ExternalLink>, <a>, and <button>.
+    // Let's use props to determine which to serve up, so we don't have to think about it.
+    // *Note* you must still handle tabindex manually.
+    const button = (
+      <StyledButton
+        aria-label={screenReaderLabel}
+        aria-disabled={disabled}
+        disabled={disabled}
+        to={this.getUrl(to)}
+        href={this.getUrl(href)}
+        size={size}
+        priority={priority}
+        borderless={borderless}
+        {...buttonProps}
+        onClick={this.handleClick}
+        role="button"
+      >
+        <ButtonLabel
+          align={align}
+          size={size}
+          priority={priority}
+          borderless={borderless}
+        >
+          {icon && (
+            <Icon size={size} hasChildren={!!children}>
+              {icon}
+            </Icon>
+          )}
+          {children}
+        </ButtonLabel>
+      </StyledButton>
     );
-  }
 
-  return button;
+    // Doing this instead of using `Tooltip`'s `disabled` prop so that we can minimize snapshot nesting
+    if (title) {
+      return (
+        <Tooltip skipWrapper {...tooltipProps} title={title}>
+          {button}
+        </Tooltip>
+      );
+    }
+
+    return button;
+  }
 }
 
-const Button = reactForwardRef<ButtonElement, ButtonProps>((props, ref) => (
+const Button = React.forwardRef<ButtonElement, ButtonProps>((props, ref) => (
   <BaseButton forwardRef={ref} {...props} />
 ));
 
@@ -152,42 +151,34 @@ export default Button;
 
 type StyledButtonProps = ButtonProps & {theme: Theme};
 
+const getFontSize = ({size, priority, theme}: StyledButtonProps) => {
+  if (priority === 'link') {
+    return 'inherit';
+  }
+
+  switch (size) {
+    case 'xsmall':
+    case 'small':
+      return theme.fontSizeSmall;
+    default:
+      return theme.fontSizeMedium;
+  }
+};
+
 const getFontWeight = ({priority, borderless}: StyledButtonProps) =>
   `font-weight: ${priority === 'link' || borderless ? 'inherit' : 600};`;
 
-const getBoxShadow = ({
-  priority,
-  borderless,
-  translucentBorder,
-  disabled,
-  theme,
-}: StyledButtonProps) => {
-  const themeName = disabled ? 'disabled' : priority || 'default';
-  const {borderTranslucent} = theme.button[themeName];
-  const translucentBorderString = translucentBorder
-    ? `0 0 0 1px ${borderTranslucent},`
-    : '';
+const getBoxShadow =
+  (theme: Theme, active: boolean) =>
+  ({priority, borderless, disabled}: StyledButtonProps) => {
+    if (disabled || borderless || priority === 'link') {
+      return 'box-shadow: none';
+    }
 
-  if (disabled || borderless || priority === 'link') {
-    return 'box-shadow: none';
-  }
+    return `box-shadow: ${active ? 'inset' : ''} ${theme.dropShadowLight}`;
+  };
 
-  return `
-      box-shadow: ${translucentBorderString} ${theme.dropShadowLight};
-      &:active {
-        box-shadow: ${translucentBorderString} inset ${theme.dropShadowLight};
-      }
-    `;
-};
-
-const getColors = ({
-  size,
-  priority,
-  disabled,
-  borderless,
-  translucentBorder,
-  theme,
-}: StyledButtonProps) => {
+const getColors = ({priority, disabled, borderless, theme}: StyledButtonProps) => {
   const themeName = disabled ? 'disabled' : priority || 'default';
   const {
     color,
@@ -196,81 +187,37 @@ const getColors = ({
     backgroundActive,
     border,
     borderActive,
-    focusBorder,
     focusShadow,
   } = theme.button[themeName];
-
-  const getFocusState = () => {
-    switch (priority) {
-      case 'primary':
-      case 'success':
-      case 'danger':
-        return `
-          border-color: ${focusBorder};
-          box-shadow: ${focusBorder} 0 0 0 1px, ${focusShadow} 0 0 0 4px;`;
-      default:
-        if (translucentBorder) {
-          return `
-            border-color: ${focusBorder};
-            box-shadow: ${focusBorder} 0 0 0 2px;`;
-        }
-        return `
-          border-color: ${focusBorder};
-          box-shadow: ${focusBorder} 0 0 0 1px;`;
-    }
-  };
 
   return css`
     color: ${color};
     background-color: ${background};
-
-    border: 1px solid ${borderless ? 'transparent' : border};
-
-    ${translucentBorder && `border-width: 0;`}
+    border: 1px solid
+      ${priority !== 'link' && !borderless && !!border ? border : 'transparent'};
 
     &:hover {
       color: ${color};
     }
 
-    ${size !== 'zero' &&
-    `
     &:hover,
     &:focus,
     &:active {
       color: ${colorActive || color};
       background: ${backgroundActive};
-      border-color: ${borderless ? 'transparent' : borderActive};
-    }`}
+      border-color: ${priority !== 'link' && !borderless && (borderActive || border)
+        ? borderActive || border
+        : 'transparent'};
+    }
 
     &.focus-visible {
-      ${getFocusState()}
-      z-index: 1;
+      ${focusShadow && `box-shadow: ${focusShadow} 0 0 0 3px;`}
     }
   `;
 };
 
-const getSizeStyles = ({size, translucentBorder, theme}: StyledButtonProps) => {
-  const buttonSize = size === 'small' || size === 'xsmall' ? size : 'default';
-  const formStyles = theme.form[buttonSize];
-  const buttonPadding = theme.buttonPadding[buttonSize];
-
-  return {
-    ...formStyles,
-    ...buttonPadding,
-    // If using translucent borders, rewrite size styles to
-    // prevent layout shifts
-    ...(translucentBorder && {
-      height: formStyles.height - 2,
-      minHeight: formStyles.minHeight - 2,
-      paddingTop: buttonPadding.paddingTop - 1,
-      paddingBottom: buttonPadding.paddingBottom - 1,
-      margin: 1,
-    }),
-  };
-};
-
 const StyledButton = styled(
-  reactForwardRef<any, ButtonProps>(
+  React.forwardRef<any, ButtonProps>(
     (
       {forwardRef, size: _size, external, to, href, disabled, ...otherProps}: Props,
       forwardRefAlt
@@ -311,41 +258,67 @@ const StyledButton = styled(
   }
 )<Props>`
   display: inline-block;
+  line-height: 1;
   border-radius: ${p => p.theme.button.borderRadius};
+  padding: 0;
   text-transform: none;
   ${getFontWeight};
+  font-size: ${getFontSize};
   ${getColors};
-  ${getSizeStyles}
-  ${getBoxShadow};
+  ${p => getBoxShadow(p.theme, false)};
   cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
   opacity: ${p => (p.busy || p.disabled) && '0.65'};
-  transition: background 0.1s, border 0.1s, box-shadow 0.1s;
 
-  ${p => p.priority === 'link' && `font-size: inherit; padding: 0;`}
-  ${p => p.size === 'zero' && `height: auto; min-height: auto; padding: ${space(0.25)};`}
-
+  &:active {
+    ${p => getBoxShadow(p.theme, true)};
+  }
   &:focus {
     outline: none;
   }
+
+  ${p => (p.borderless || p.priority === 'link') && 'border-color: transparent'};
 `;
 
-const buttonLabelPropKeys = ['size', 'borderless', 'align'];
-type ButtonLabelProps = Pick<ButtonProps, 'size' | 'borderless' | 'align'>;
+/**
+ * Get label padding determined by size
+ */
+const getLabelPadding = ({
+  size,
+  priority,
+}: Pick<StyledButtonProps, 'size' | 'priority' | 'borderless'>) => {
+  if (priority === 'link') {
+    return '0';
+  }
+
+  switch (size) {
+    case 'zero':
+      return '0';
+    case 'xsmall':
+      return '5px 8px';
+    case 'small':
+      return '9px 12px';
+    default:
+      return '12px 16px';
+  }
+};
+
+const buttonLabelPropKeys = ['size', 'priority', 'borderless', 'align'];
+type ButtonLabelProps = Pick<ButtonProps, 'size' | 'priority' | 'borderless' | 'align'>;
 
 const ButtonLabel = styled('span', {
   shouldForwardProp: prop =>
     typeof prop === 'string' && isPropValid(prop) && !buttonLabelPropKeys.includes(prop),
 })<ButtonLabelProps>`
-  height: 100%;
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
   align-items: center;
   justify-content: ${p => p.align};
-  white-space: nowrap;
+  padding: ${getLabelPadding};
 `;
 
 type IconProps = {
-  hasChildren?: boolean;
   size?: ButtonProps['size'];
+  hasChildren?: boolean;
 };
 
 const getIconMargin = ({size, hasChildren}: IconProps) => {
@@ -354,13 +327,14 @@ const getIconMargin = ({size, hasChildren}: IconProps) => {
     return '0';
   }
 
-  return size === 'xsmall' ? '6px' : '8px';
+  return size && size.endsWith('small') ? '6px' : '8px';
 };
 
 const Icon = styled('span')<IconProps & Omit<StyledButtonProps, 'theme'>>`
   display: flex;
   align-items: center;
   margin-right: ${getIconMargin};
+  height: ${getFontSize};
 `;
 
 /**

--- a/static/app/components/buttonBar.tsx
+++ b/static/app/components/buttonBar.tsx
@@ -3,12 +3,12 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
-import Button, {StyledButton} from 'sentry/components/button';
+import {ButtonProps, StyledButton} from 'sentry/components/button';
 import space, {ValidSize} from 'sentry/styles/space';
 
 type ButtonBarProps = {
   children: React.ReactNode;
-  active?: React.ComponentProps<typeof Button>['barId'];
+  active?: ButtonProps['barId'];
   className?: string;
   gap?: ValidSize;
   merged?: boolean;

--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {ModalRenderProps, openModal} from 'sentry/actionCreators/modal';
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {t} from 'sentry/locale';
 
@@ -93,7 +93,7 @@ export type OpenConfirmOptions = {
   /**
    * Button priority
    */
-  priority?: React.ComponentProps<typeof Button>['priority'];
+  priority?: ButtonProps['priority'];
   /**
    * Custom function to render the cancel button
    */

--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -305,7 +305,7 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
                 onClick={this.handleClose}
                 aria-label={typeof cancelText === 'string' ? cancelText : t('Cancel')}
               >
-                {cancelText ??  t('Cancel')}
+                {cancelText ?? t('Cancel')}
               </Button>
             )}
             {renderConfirmButton ? (
@@ -322,7 +322,7 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
                 autoFocus
                 aria-label={typeof confirmText === 'string' ? confirmText : t('Confirm')}
               >
-                {confirmText ?? t('Confirm')}
+                {confirmText ? confirmText : t('Confirm')}
               </Button>
             )}
           </ButtonBar>

--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -305,7 +305,7 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
                 onClick={this.handleClose}
                 aria-label={typeof cancelText === 'string' ? cancelText : t('Cancel')}
               >
-                {cancelText}
+                {cancelText ? cancelText : t('Cancel')}
               </Button>
             )}
             {renderConfirmButton ? (
@@ -322,7 +322,7 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
                 autoFocus
                 aria-label={typeof confirmText === 'string' ? confirmText : t('Confirm')}
               >
-                {confirmText}
+                {confirmText ? confirmText : t('Confirm')}
               </Button>
             )}
           </ButtonBar>

--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -305,7 +305,7 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
                 onClick={this.handleClose}
                 aria-label={typeof cancelText === 'string' ? cancelText : t('Cancel')}
               >
-                {cancelText ? cancelText : t('Cancel')}
+                {cancelText ??  t('Cancel')}
               </Button>
             )}
             {renderConfirmButton ? (

--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -322,7 +322,7 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
                 autoFocus
                 aria-label={typeof confirmText === 'string' ? confirmText : t('Confirm')}
               >
-                {confirmText ? confirmText : t('Confirm')}
+                {confirmText ?? t('Confirm')}
               </Button>
             )}
           </ButtonBar>

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -36,10 +36,6 @@ import {getQueryDatasource} from 'sentry/views/alerts/utils';
  */
 type IncompatibleQueryProperties = {
   /**
-   * Must have exactly one project selected and not -1 (all projects)
-   */
-  hasProjectError: boolean;
-  /**
    * Must have zero or one environments
    */
   hasEnvironmentError: boolean;
@@ -47,17 +43,21 @@ type IncompatibleQueryProperties = {
    * event.type must be error or transaction
    */
   hasEventTypeError: boolean;
+  /**
+   * Must have exactly one project selected and not -1 (all projects)
+   */
+  hasProjectError: boolean;
   hasYAxisError: boolean;
 };
 
 type AlertProps = {
-  incompatibleQuery: IncompatibleQueryProperties;
   eventView: EventView;
-  orgId: string;
+  incompatibleQuery: IncompatibleQueryProperties;
   /**
    * Dismiss alert
    */
   onClose: () => void;
+  orgId: string;
 };
 
 /**
@@ -184,14 +184,10 @@ function IncompatibleQueryAlert({
 }
 
 type CreateAlertFromViewButtonProps = ButtonProps & {
-  className?: string;
-  projects: Project[];
   /**
    * Discover query used to create the alert
    */
   eventView: EventView;
-  organization: Organization;
-  referrer?: string;
   /**
    * Called when the current eventView does not meet the requirements of alert rules
    * @returns a function that takes an alert close function argument
@@ -204,6 +200,10 @@ type CreateAlertFromViewButtonProps = ButtonProps & {
    * Called when the user is redirected to the alert builder
    */
   onSuccess: () => void;
+  organization: Organization;
+  projects: Project[];
+  className?: string;
+  referrer?: string;
 };
 
 function incompatibleYAxis(eventView: EventView): boolean {
@@ -315,10 +315,10 @@ function CreateAlertFromViewButton({
 
 type Props = {
   organization: Organization;
-  projectSlug?: string;
-  iconProps?: SVGIconProps;
-  referrer?: string;
   hideIcon?: boolean;
+  iconProps?: SVGIconProps;
+  projectSlug?: string;
+  referrer?: string;
   showPermissionGuide?: boolean;
 } & WithRouterProps &
   ButtonProps;

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -173,7 +173,7 @@ function IncompatibleQueryAlert({
         </React.Fragment>
       )}
       <StyledCloseButton
-        icon={<IconClose color="yellow300" size="sm" isCircled />}
+        icon={<IconClose size="sm" />}
         aria-label={t('Close')}
         size="zero"
         onClick={onClose}
@@ -271,13 +271,21 @@ function CreateAlertFromViewButton({
     hasYAxisError,
   };
   const project = projects.find(p => p.id === `${eventView.project[0]}`);
+  const queryParams = eventView.generateQueryStringObject();
+  if (queryParams.query?.includes(`project:${project?.slug}`)) {
+    queryParams.query = (queryParams.query as string).replace(
+      `project:${project?.slug}`,
+      ''
+    );
+  }
+
   const hasErrors = Object.values(errors).some(x => x);
   const to = hasErrors
     ? undefined
     : {
         pathname: `/organizations/${organization.slug}/alerts/${project?.slug}/new/`,
         query: {
-          ...eventView.generateQueryStringObject(),
+          ...queryParams,
           createFromDiscover: true,
           referrer,
         },
@@ -439,6 +447,5 @@ const StyledCloseButton = styled(Button)`
   &:hover,
   &:focus {
     background-color: transparent;
-    opacity: 1;
   }
 `;

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -316,6 +316,7 @@ function CreateAlertFromViewButton({
       organization={organization}
       onClick={handleClick}
       to={to}
+      aria-label={t('Create Alert')}
       {...buttonProps}
     />
   );

--- a/static/app/components/demoSandboxButton.tsx
+++ b/static/app/components/demoSandboxButton.tsx
@@ -1,9 +1,9 @@
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import {Organization, SandboxData} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import useOrganization from 'sentry/utils/useOrganization';
 
-type Props = {
+interface DemoSandboxButtonProps extends ButtonProps {
   /**
    * The deep link scenario
    */
@@ -32,7 +32,7 @@ type Props = {
    * Which project we should link to in the sandbox
    */
   projectSlug?: 'react' | 'python' | 'ios' | 'android' | 'react-native';
-} & React.ComponentProps<typeof Button>;
+}
 
 /**
  * Renders a button that will kick off the sandbox around children
@@ -45,7 +45,7 @@ function DemoSandboxButton({
   errorType,
   clientData,
   ...buttonProps
-}: Props) {
+}: DemoSandboxButtonProps): React.ReactElement {
   const organization: Organization = useOrganization();
   const url = new URL('https://try.sentry-demo.com/demo/start/');
 

--- a/static/app/components/demoSandboxButton.tsx
+++ b/static/app/components/demoSandboxButton.tsx
@@ -1,9 +1,9 @@
-import Button, {ButtonProps} from 'sentry/components/button';
+import Button, {ButtonPropsWithoutAriaLabel} from 'sentry/components/button';
 import {Organization, SandboxData} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import useOrganization from 'sentry/utils/useOrganization';
 
-interface DemoSandboxButtonProps extends ButtonProps {
+interface DemoSandboxButtonProps extends ButtonPropsWithoutAriaLabel {
   /**
    * The deep link scenario
    */

--- a/static/app/components/discoverButton.tsx
+++ b/static/app/components/discoverButton.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import DiscoverFeature from 'sentry/components/discover/discoverFeature';
 import {t} from 'sentry/locale';
 
-type Props = Omit<React.ComponentProps<typeof Button>, 'aria-label'>;
+type DiscoverButtonProps = Omit<ButtonProps, 'aria-label'>;
 
 /**
  * Provide a button that turns itself off if the current organization
  * doesn't have access to discover results.
  */
-function DiscoverButton({children, ...buttonProps}: Props) {
+function DiscoverButton({children, ...buttonProps}: DiscoverButtonProps) {
   return (
     <DiscoverFeature>
       {({hasFeature}) => (

--- a/static/app/components/dropdownButton.tsx
+++ b/static/app/components/dropdownButton.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import {IconChevron} from 'sentry/icons';
 import space from 'sentry/styles/space';
 
-type Props = Omit<React.ComponentProps<typeof Button>, 'type' | 'priority'> & {
+interface DropdownButtonProps extends Omit<ButtonProps, 'prefix'> {
   /**
    * Forward a ref to the button's root
    */
@@ -30,7 +30,7 @@ type Props = Omit<React.ComponentProps<typeof Button>, 'type' | 'priority'> & {
    * Should a chevron icon be shown?
    */
   showChevron?: boolean;
-};
+}
 
 const DropdownButton = ({
   children,
@@ -42,7 +42,7 @@ const DropdownButton = ({
   disabled = false,
   priority = 'form',
   ...props
-}: Props) => {
+}: DropdownButtonProps) => {
   return (
     <StyledButton
       {...props}
@@ -69,7 +69,9 @@ const StyledChevron = styled(IconChevron)`
 `;
 
 const StyledButton = styled(Button)<
-  Required<Pick<Props, 'isOpen' | 'disabled' | 'hideBottomBorder' | 'priority'>>
+  Required<
+    Pick<DropdownButtonProps, 'isOpen' | 'disabled' | 'hideBottomBorder' | 'priority'>
+  >
 >`
   border-bottom-right-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
   border-bottom-left-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
@@ -95,6 +97,6 @@ const LabelText = styled('span')`
   }
 `;
 
-export default React.forwardRef<typeof Button, Props>((props, ref) => (
+export default React.forwardRef<typeof Button, DropdownButtonProps>((props, ref) => (
   <DropdownButton forwardedRef={ref} {...props} />
 ));

--- a/static/app/components/dropdownButtonV2.tsx
+++ b/static/app/components/dropdownButtonV2.tsx
@@ -1,11 +1,11 @@
 import {forwardRef} from 'react';
 import styled from '@emotion/styled';
 
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import {IconChevron} from 'sentry/icons';
 import space from 'sentry/styles/space';
 
-export type DropdownButtonProps = Omit<React.ComponentProps<typeof Button>, 'type'> & {
+export interface DropdownButtonProps extends Omit<ButtonProps, 'type' | 'prefix'> {
   children?: React.ReactNode;
   /**
    * Whether or not the button should render as open
@@ -19,7 +19,7 @@ export type DropdownButtonProps = Omit<React.ComponentProps<typeof Button>, 'typ
    * Should a chevron icon be shown?
    */
   showChevron?: boolean;
-};
+}
 
 const DropdownButton = forwardRef<
   React.RefObject<HTMLElement> | null,

--- a/static/app/components/dropdownButtonV2.tsx
+++ b/static/app/components/dropdownButtonV2.tsx
@@ -5,8 +5,7 @@ import Button, {ButtonProps} from 'sentry/components/button';
 import {IconChevron} from 'sentry/icons';
 import space from 'sentry/styles/space';
 
-export interface DropdownButtonProps extends Omit<ButtonProps, 'type' | 'prefix'> {
-  children?: React.ReactNode;
+export type DropdownButtonProps = {
   /**
    * Whether or not the button should render as open
    */
@@ -19,7 +18,7 @@ export interface DropdownButtonProps extends Omit<ButtonProps, 'type' | 'prefix'
    * Should a chevron icon be shown?
    */
   showChevron?: boolean;
-}
+} & Omit<ButtonProps, 'type' | 'prefix'>;
 
 const DropdownButton = forwardRef<
   React.RefObject<HTMLElement> | null,

--- a/static/app/components/dropdownControl.tsx
+++ b/static/app/components/dropdownControl.tsx
@@ -66,7 +66,7 @@ type Props = DefaultProps & {
   /**
    * String or element for the button contents.
    */
-  label?: React.ReactNode;
+  label?: NonNullable<React.ReactNode>;
 
   priority?: ButtonPriority;
 };

--- a/static/app/components/forms/choiceMapperField.tsx
+++ b/static/app/components/forms/choiceMapperField.tsx
@@ -18,7 +18,7 @@ type DefaultProps = {
   /**
    * Text used for the 'add row' button.
    */
-  addButtonText: React.ReactNode;
+  addButtonText: NonNullable<React.ReactNode>;
   /**
    * Automatically save even if fields are empty
    */

--- a/static/app/components/forms/form.tsx
+++ b/static/app/components/forms/form.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {Observer} from 'mobx-react';
 
 import {APIRequestMethod} from 'sentry/api';
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import FormContext, {FormContextData} from 'sentry/components/forms/formContext';
 import FormModel, {FormOptions} from 'sentry/components/forms/model';
 import {Data, OnSubmitCallback} from 'sentry/components/forms/type';
@@ -83,7 +83,7 @@ type Props = {
    */
   submitDisabled?: boolean;
   submitLabel?: string;
-  submitPriority?: React.ComponentProps<typeof Button>['priority'];
+  submitPriority?: ButtonProps['priority'];
 } & Pick<FormOptions, 'onSubmitSuccess' | 'onSubmitError' | 'onFieldChange'>;
 
 export default class Form extends React.Component<Props> {

--- a/static/app/components/globalModal/components.tsx
+++ b/static/app/components/globalModal/components.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 
-import Button, {ButtonProps} from 'sentry/components/button';
+import Button, {ButtonPropsWithAriaLabel} from 'sentry/components/button';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -25,13 +25,8 @@ const ModalHeader = styled('header')`
   }
 `;
 
-const CloseButton = styled((p: Omit<ButtonProps, 'aria-label'>) => (
-  <Button
-    size="zero"
-    icon={<IconClose size="10px" />}
-    aria-label={t('Close Modal')}
-    {...p}
-  />
+const CloseButton = styled((p: ButtonPropsWithAriaLabel) => (
+  <Button size="zero" icon={<IconClose size="10px" />} {...p} />
 ))`
   position: absolute;
   top: 0;
@@ -80,7 +75,9 @@ const makeClosableHeader = (closeModal: () => void) => {
     ({closeButton, children, ...props}) => (
       <ModalHeader {...props}>
         {children}
-        {closeButton && <CloseButton onClick={closeModal} />}
+        {closeButton ? (
+          <CloseButton aria-label={t('Close Modal')} onClick={closeModal} />
+        ) : null}
       </ModalHeader>
     );
 
@@ -95,6 +92,6 @@ const makeClosableHeader = (closeModal: () => void) => {
 const makeCloseButton =
   (closeModal: () => void): React.FC<React.ComponentProps<typeof CloseButton>> =>
   props =>
-    <CloseButton {...props} onClick={closeModal} />;
+    <CloseButton {...props} aria-label={t('Close Modal')} onClick={closeModal} />;
 
 export {makeClosableHeader, makeCloseButton, ModalBody, ModalFooter};

--- a/static/app/components/globalModal/components.tsx
+++ b/static/app/components/globalModal/components.tsx
@@ -90,7 +90,7 @@ const makeClosableHeader = (closeModal: () => void) => {
  * Creates a CloseButton component that is connected to the provided closeModal trigger
  */
 const makeCloseButton =
-  (closeModal: () => void): React.FC<React.ComponentProps<typeof CloseButton>> =>
+  (closeModal: () => void): React.FC<Omit<ButtonPropsWithAriaLabel, 'aria-label'>> =>
   props =>
     <CloseButton {...props} aria-label={t('Close Modal')} onClick={closeModal} />;
 

--- a/static/app/components/globalModal/components.tsx
+++ b/static/app/components/globalModal/components.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -25,16 +25,14 @@ const ModalHeader = styled('header')`
   }
 `;
 
-const CloseButton = styled(
-  (p: Omit<React.ComponentProps<typeof Button>, 'aria-label'>) => (
-    <Button
-      size="zero"
-      icon={<IconClose size="10px" />}
-      aria-label={t('Close Modal')}
-      {...p}
-    />
-  )
-)`
+const CloseButton = styled((p: Omit<ButtonProps, 'aria-label'>) => (
+  <Button
+    size="zero"
+    icon={<IconClose size="10px" />}
+    aria-label={t('Close Modal')}
+    {...p}
+  />
+))`
   position: absolute;
   top: 0;
   right: 0;

--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';
 import Alert from 'sentry/components/alert';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import {Hovercard} from 'sentry/components/hovercard';
 import Link from 'sentry/components/links/link';
 import {IconCommit, IconWarning} from 'sentry/icons';
@@ -198,13 +198,11 @@ const OwnershipTag = styled(({tagType, ...props}) => <div {...props}>{tagType}</
   text-align: center;
 `;
 
-const ViewMoreButton = styled(
-  (p: Omit<React.ComponentProps<typeof Button>, 'aria-label'>) => (
-    <Button {...p} priority="link" size="zero">
-      {t('View more')}
-    </Button>
-  )
-)`
+const ViewMoreButton = styled((p: Omit<ButtonProps, 'aria-label'>) => (
+  <Button {...p} priority="link" size="zero">
+    {t('View more')}
+  </Button>
+))`
   border: none;
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeExtraSmall};

--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';
 import Alert from 'sentry/components/alert';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
-import Button, {ButtonProps} from 'sentry/components/button';
+import Button from 'sentry/components/button';
 import {Hovercard} from 'sentry/components/hovercard';
 import Link from 'sentry/components/links/link';
 import {IconCommit, IconWarning} from 'sentry/icons';
@@ -105,8 +105,12 @@ class SuggestedOwnerHovercard extends React.Component<Props, State> {
                 </div>
                 {commits.length > 3 && !commitsExpanded ? (
                   <ViewMoreButton
+                    priority="link"
+                    size="zero"
                     onClick={() => this.setState({commitsExpanded: true})}
-                  />
+                  >
+                    {t('View more')}
+                  </ViewMoreButton>
                 ) : null}
               </React.Fragment>
             )}
@@ -126,7 +130,13 @@ class SuggestedOwnerHovercard extends React.Component<Props, State> {
                     ))}
                 </div>
                 {rules.length > 3 && !rulesExpanded ? (
-                  <ViewMoreButton onClick={() => this.setState({rulesExpanded: true})} />
+                  <ViewMoreButton
+                    priority="link"
+                    size="zero"
+                    onClick={() => this.setState({rulesExpanded: true})}
+                  >
+                    {t('View more')}
+                  </ViewMoreButton>
                 ) : null}
               </React.Fragment>
             )}
@@ -198,11 +208,7 @@ const OwnershipTag = styled(({tagType, ...props}) => <div {...props}>{tagType}</
   text-align: center;
 `;
 
-const ViewMoreButton = styled((p: Omit<ButtonProps, 'aria-label'>) => (
-  <Button {...p} priority="link" size="zero">
-    {t('View more')}
-  </Button>
-))`
+const ViewMoreButton = styled(Button)`
   border: none;
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeExtraSmall};

--- a/static/app/components/links/linkWithConfirmation.tsx
+++ b/static/app/components/links/linkWithConfirmation.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import Button from 'sentry/components/button';
+import {ButtonProps} from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
 
 type Props = {
@@ -10,7 +10,7 @@ type Props = {
   title: string;
   className?: string;
   disabled?: boolean;
-  priority?: React.ComponentProps<typeof Button>['priority'];
+  priority?: ButtonProps['priority'];
 };
 
 /**

--- a/static/app/components/navigationButtonGroup.tsx
+++ b/static/app/components/navigationButtonGroup.tsx
@@ -1,6 +1,6 @@
 import {LocationDescriptor} from 'history';
 
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {IconNext, IconPrevious} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -18,7 +18,7 @@ type Props = {
   onNewestClick?: () => void;
   onOlderClick?: () => void;
   onOldestClick?: () => void;
-  size?: React.ComponentProps<typeof Button>['size'];
+  size?: ButtonProps['size'];
 };
 
 const NavigationButtonGroup = ({

--- a/static/app/utils/discover/teamKeyTransactionField.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.tsx
@@ -7,14 +7,13 @@ import TeamKeyTransaction, {
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
 import Tooltip from 'sentry/components/tooltip';
 import {IconStar} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import withProjects from 'sentry/utils/withProjects';
 
 class TitleStar extends Component<TitleProps> {
   render() {
-    const {isOpen, keyedTeams, initialValue, children: _children, ...props} = this.props;
+    const {isOpen, keyedTeams, initialValue, children, ...props} = this.props;
     const keyedTeamsCount = keyedTeams?.length ?? initialValue ?? 0;
     const star = (
       <IconStar
@@ -24,13 +23,9 @@ class TitleStar extends Component<TitleProps> {
       />
     );
     const button = (
-      <Button
-        {...props}
-        icon={star}
-        borderless
-        size="zero"
-        aria-label={t('Toggle star for team')}
-      />
+      <Button {...props} icon={star} borderless size="zero">
+        {children}
+      </Button>
     );
 
     if (!isOpen && keyedTeams?.length) {

--- a/static/app/utils/discover/teamKeyTransactionField.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.tsx
@@ -7,13 +7,14 @@ import TeamKeyTransaction, {
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
 import Tooltip from 'sentry/components/tooltip';
 import {IconStar} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import withProjects from 'sentry/utils/withProjects';
 
 class TitleStar extends Component<TitleProps> {
   render() {
-    const {isOpen, keyedTeams, initialValue, children, ...props} = this.props;
+    const {isOpen, keyedTeams, initialValue, ...props} = this.props;
     const keyedTeamsCount = keyedTeams?.length ?? initialValue ?? 0;
     const star = (
       <IconStar
@@ -23,9 +24,13 @@ class TitleStar extends Component<TitleProps> {
       />
     );
     const button = (
-      <Button {...props} icon={star} borderless size="zero">
-        {children}
-      </Button>
+      <Button
+        {...props}
+        icon={star}
+        borderless
+        size="zero"
+        aria-label={t('Toggle star for team')}
+      />
     );
 
     if (!isOpen && keyedTeams?.length) {

--- a/static/app/utils/discover/teamKeyTransactionField.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.tsx
@@ -14,7 +14,7 @@ import withProjects from 'sentry/utils/withProjects';
 
 class TitleStar extends Component<TitleProps> {
   render() {
-    const {isOpen, keyedTeams, initialValue, ...props} = this.props;
+    const {isOpen, keyedTeams, initialValue, children: _children, ...props} = this.props;
     const keyedTeamsCount = keyedTeams?.length ?? initialValue ?? 0;
     const star = (
       <IconStar
@@ -32,6 +32,7 @@ class TitleStar extends Component<TitleProps> {
         aria-label={t('Toggle star for team')}
       />
     );
+
     if (!isOpen && keyedTeams?.length) {
       const teamSlugs = keyedTeams.map(({slug}) => slug).join(', ');
       return <Tooltip title={teamSlugs}>{button}</Tooltip>;

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/deleteActionButton.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/deleteActionButton.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
 
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
-type Props = Omit<React.ComponentProps<typeof Button>, 'onClick'> & {
+interface DeleteActionButtonProps extends Omit<ButtonProps, 'onClick'> {
   index: number;
   onClick: (triggerIndex: number, index: number, e: React.MouseEvent) => void;
   triggerIndex: number;
-};
+}
 
-export default function DeleteActionButton(props: Props) {
+export default function DeleteActionButton(
+  props: DeleteActionButtonProps
+): React.ReactElement {
   const handleClick = (e: React.MouseEvent) => {
     const {triggerIndex, index, onClick} = props;
     onClick(triggerIndex, index, e);

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -352,10 +352,12 @@ export default class DetailsBody extends React.Component<Props> {
                         <Heading noMargin>{t('Display')}</Heading>
                         <ChartControls>
                           <DropdownControl
-                            label={getDynamicText({
-                              fixed: 'Oct 14, 2:56 PM — Oct 14, 4:55 PM',
-                              value: timePeriod.display,
-                            })}
+                            label={
+                              getDynamicText({
+                                fixed: 'Oct 14, 2:56 PM — Oct 14, 4:55 PM',
+                                value: timePeriod.display,
+                              }) ?? '' // we should never get here because timePeriod.display is typed as always defined
+                            }
                           >
                             {TIME_OPTIONS.map(({label, value}) => (
                               <DropdownItem

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -375,7 +375,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
           onIncompatibleQuery={onIncompatibleAlertQuery}
           onSuccess={this.handleCreateAlertSuccess}
           referrer="discover"
-          aria-label={t('Create an alert')}
+          aria-label={t('Create Alert')}
           data-test-id="discover2-create-from-discover"
         />
       </GuideAnchor>

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -375,6 +375,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
           onIncompatibleQuery={onIncompatibleAlertQuery}
           onSuccess={this.handleCreateAlertSuccess}
           referrer="discover"
+          aria-label={t('Create an alert')}
           data-test-id="discover2-create-from-discover"
         />
       </GuideAnchor>

--- a/static/app/views/integrationPipeline/components/footerWithButtons.tsx
+++ b/static/app/views/integrationPipeline/components/footerWithButtons.tsx
@@ -2,20 +2,22 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/actions/button';
+import {ButtonProps} from 'sentry/components/button';
 import space from 'sentry/styles/space';
 
-type Props = {
+interface FooterWithButtonsProps
+  extends Partial<Pick<ButtonProps, 'disabled' | 'onClick' | 'href'>> {
   buttonText: string;
   formFields?: Array<{name: string; value: any}>;
   formProps?: Omit<React.HTMLProps<HTMLFormElement>, 'as'>;
-} & Partial<Pick<React.ComponentProps<typeof Button>, 'disabled' | 'onClick' | 'href'>>;
+}
 
 export default function FooterWithButtons({
   buttonText,
   formFields,
   formProps,
   ...rest
-}: Props) {
+}: FooterWithButtonsProps) {
   /**
    * We use a form post here to replicate what we do with standard HTML views for the integration pipeline.
    * Since this is a form post, we need to pass a hidden replica of the form inputs

--- a/static/app/views/onboarding/components/firstEventFooter.tsx
+++ b/static/app/views/onboarding/components/firstEventFooter.tsx
@@ -48,6 +48,7 @@ export default function FirstEventFooter({
           {
             sample: (
               <CreateSampleEventButton
+                aria-label="View a sample event"
                 project={project}
                 source="onboarding"
                 priority="link"

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -16,12 +16,12 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 
-interface CreateSampleEventButtonProps extends ButtonProps {
+type CreateSampleEventButtonProps = {
   api: Client;
   organization: Organization;
   source: string;
   project?: Project;
-}
+} & ButtonProps;
 
 type State = {
   creating: boolean;

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -8,7 +8,7 @@ import {
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import {trackAdhocEvent, trackAnalyticsEvent} from 'sentry/utils/analytics';
@@ -16,12 +16,12 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 
-type Props = React.ComponentProps<typeof Button> & {
+interface CreateSampleEventButtonProps extends ButtonProps {
   api: Client;
   organization: Organization;
   source: string;
   project?: Project;
-};
+}
 
 type State = {
   creating: boolean;
@@ -51,7 +51,10 @@ async function latestEventAvailable(
   }
 }
 
-class CreateSampleEventButton extends React.Component<Props, State> {
+class CreateSampleEventButton extends React.Component<
+  CreateSampleEventButtonProps,
+  State
+> {
   state: State = {
     creating: false,
   };

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -295,37 +295,31 @@ interface BackButtonProps extends Omit<ButtonProps, 'icon' | 'priority'> {
   className?: string;
 }
 
-const Back = styled(
-  ({className, animate, ...props}: BackButtonProps): React.ReactElement => (
-    <motion.div
-      className={className}
-      animate={animate}
-      transition={testableTransition()}
-      variants={{
-        initial: {opacity: 0, visibility: 'hidden'},
-        visible: {
-          opacity: 1,
-          visibility: 'visible',
-          transition: testableTransition({delay: 1}),
+const Back = styled(({className, animate, ...props}: BackButtonProps) => (
+  <motion.div
+    className={className}
+    animate={animate}
+    transition={testableTransition()}
+    variants={{
+      initial: {opacity: 0, visibility: 'hidden'},
+      visible: {
+        opacity: 1,
+        visibility: 'visible',
+        transition: testableTransition({delay: 1}),
+      },
+      hidden: {
+        opacity: 0,
+        transitionEnd: {
+          visibility: 'hidden',
         },
-        hidden: {
-          opacity: 0,
-          transitionEnd: {
-            visibility: 'hidden',
-          },
-        },
-      }}
-    >
-      <Button
-        {...props}
-        icon={<IconChevron direction="left" size="sm" />}
-        priority="link"
-      >
-        {t('Go back')}
-      </Button>
-    </motion.div>
-  )
-)`
+      },
+    }}
+  >
+    <Button {...props} icon={<IconChevron direction="left" size="sm" />} priority="link">
+      {t('Go back')}
+    </Button>
+  </motion.div>
+))`
   position: absolute;
   top: 40px;
   left: 20px;

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -3,7 +3,7 @@ import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion, MotionProps, useAnimation} from 'framer-motion';
 
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import Hook from 'sentry/components/hook';
 import LogoSentry from 'sentry/components/logoSentry';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -290,36 +290,42 @@ ProgressStatus.defaultProps = {
   transition: testableTransition(),
 };
 
-type BackProps = Omit<React.ComponentProps<typeof Button>, 'icon' | 'priority'> & {
+interface BackButtonProps extends Omit<ButtonProps, 'icon' | 'priority'> {
   animate: MotionProps['animate'];
   className?: string;
-};
+}
 
-const Back = styled(({className, animate, ...props}: BackProps) => (
-  <motion.div
-    className={className}
-    animate={animate}
-    transition={testableTransition()}
-    variants={{
-      initial: {opacity: 0, visibility: 'hidden'},
-      visible: {
-        opacity: 1,
-        visibility: 'visible',
-        transition: testableTransition({delay: 1}),
-      },
-      hidden: {
-        opacity: 0,
-        transitionEnd: {
-          visibility: 'hidden',
+const Back = styled(
+  ({className, animate, ...props}: BackButtonProps): React.ReactElement => (
+    <motion.div
+      className={className}
+      animate={animate}
+      transition={testableTransition()}
+      variants={{
+        initial: {opacity: 0, visibility: 'hidden'},
+        visible: {
+          opacity: 1,
+          visibility: 'visible',
+          transition: testableTransition({delay: 1}),
         },
-      },
-    }}
-  >
-    <Button {...props} icon={<IconChevron direction="left" size="sm" />} priority="link">
-      {t('Go back')}
-    </Button>
-  </motion.div>
-))`
+        hidden: {
+          opacity: 0,
+          transitionEnd: {
+            visibility: 'hidden',
+          },
+        },
+      }}
+    >
+      <Button
+        {...props}
+        icon={<IconChevron direction="left" size="sm" />}
+        priority="link"
+      >
+        {t('Go back')}
+      </Button>
+    </motion.div>
+  )
+)`
   position: absolute;
   top: 40px;
   left: 20px;

--- a/static/app/views/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/organizationIntegrations/addIntegrationButton.tsx
@@ -1,23 +1,24 @@
 import * as React from 'react';
 
-import Button from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import Tooltip from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {IntegrationWithConfig} from 'sentry/types';
 
 import AddIntegration from './addIntegration';
 
-type Props = {
+interface AddIntegrationButtonProps
+  extends Omit<ButtonProps, 'aria-label'>,
+    Pick<
+      React.ComponentProps<typeof AddIntegration>,
+      'provider' | 'organization' | 'analyticsParams' | 'modalParams'
+    > {
   onAddIntegration: (data: IntegrationWithConfig) => void;
   buttonText?: string;
   reinstall?: boolean;
-} & Omit<React.ComponentProps<typeof Button>, 'aria-label'> &
-  Pick<
-    React.ComponentProps<typeof AddIntegration>,
-    'provider' | 'organization' | 'analyticsParams' | 'modalParams'
-  >;
+}
 
-export default class AddIntegrationButton extends React.Component<Props> {
+export default class AddIntegrationButton extends React.Component<AddIntegrationButtonProps> {
   render() {
     const {
       provider,

--- a/static/app/views/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/organizationIntegrations/addIntegrationButton.tsx
@@ -8,7 +8,7 @@ import {IntegrationWithConfig} from 'sentry/types';
 import AddIntegration from './addIntegration';
 
 interface AddIntegrationButtonProps
-  extends ButtonPropsWithoutAriaLabel,
+  extends Omit<ButtonPropsWithoutAriaLabel, 'children'>,
     Pick<
       React.ComponentProps<typeof AddIntegration>,
       'provider' | 'organization' | 'analyticsParams' | 'modalParams'

--- a/static/app/views/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/organizationIntegrations/addIntegrationButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import Button, {ButtonProps} from 'sentry/components/button';
+import Button, {ButtonPropsWithoutAriaLabel} from 'sentry/components/button';
 import Tooltip from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {IntegrationWithConfig} from 'sentry/types';
@@ -8,7 +8,7 @@ import {IntegrationWithConfig} from 'sentry/types';
 import AddIntegration from './addIntegration';
 
 interface AddIntegrationButtonProps
-  extends Omit<ButtonProps, 'aria-label'>,
+  extends ButtonPropsWithoutAriaLabel,
     Pick<
       React.ComponentProps<typeof AddIntegration>,
       'provider' | 'organization' | 'analyticsParams' | 'modalParams'

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -123,7 +123,7 @@ class TransactionHeader extends React.Component<Props> {
         onIncompatibleQuery={this.handleIncompatibleQuery}
         onSuccess={this.handleCreateAlertSuccess}
         referrer="performance"
-        aria-label={t('Create alert')}
+        aria-label={t('Create Alert')}
       />
     );
   }

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -123,6 +123,7 @@ class TransactionHeader extends React.Component<Props> {
         onIncompatibleQuery={this.handleIncompatibleQuery}
         onSuccess={this.handleCreateAlertSuccess}
         referrer="performance"
+        aria-label={t('Create alert')}
       />
     );
   }

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -126,7 +126,7 @@ class VitalDetailContent extends Component<Props, State> {
         projects={projects}
         onIncompatibleQuery={this.handleIncompatibleQuery}
         onSuccess={() => {}}
-        aria-label={t('Create alert')}
+        aria-label={t('Create Alert')}
         referrer="performance"
       />
     );

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -126,6 +126,7 @@ class VitalDetailContent extends Component<Props, State> {
         projects={projects}
         onIncompatibleQuery={this.handleIncompatibleQuery}
         onSuccess={() => {}}
+        aria-label={t('Create alert')}
         referrer="performance"
       />
     );


### PR DESCRIPTION
In similar vein to what was done in https://github.com/getsentry/sentry/pull/31679

Before
<img width="911" alt="CleanShot 2022-02-09 at 10 00 14@2x" src="https://user-images.githubusercontent.com/9317857/153161225-2d3a2d8f-f1b6-4871-878d-bf308959cf8b.png">
After
<img width="925" alt="CleanShot 2022-02-09 at 10 29 13@2x" src="https://user-images.githubusercontent.com/9317857/153166281-133d4ed5-b704-4b49-aecb-e2cde6a72b25.png">

