### PR TITLE
feat(profiling): add support for chrometrace format

### DIFF
--- a/docs-ui/stories/components/profiling/flamegraphZoomView.stories.js
+++ b/docs-ui/stories/components/profiling/flamegraphZoomView.stories.js
@@ -35,3 +35,19 @@ export const JSSelfProfiling = () => {
     </FlamegraphStateProvider>
   );
 };
+
+const typescriptProfile = importProfile(
+  require('./../../../../tests/js/spec/utils/profiling/profile/samples/chrometrace/typescript/trace.json')
+);
+
+export const TypescriptProfile = () => {
+  return (
+    <FlamegraphPreferencesProvider>
+      <FlamegraphThemeProvider>
+        <FullScreenFlamegraphContainer>
+          {typescriptProfile ? <Flamegraph profiles={typescriptProfile} /> : null}
+        </FullScreenFlamegraphContainer>
+      </FlamegraphThemeProvider>
+    </FlamegraphPreferencesProvider>
+  );
+};

--- a/docs-ui/stories/components/profiling/flamegraphZoomView.stories.js
+++ b/docs-ui/stories/components/profiling/flamegraphZoomView.stories.js
@@ -42,12 +42,12 @@ const typescriptProfile = importProfile(
 
 export const TypescriptProfile = () => {
   return (
-    <FlamegraphPreferencesProvider>
+    <FlamegraphStateProvider>
       <FlamegraphThemeProvider>
         <FullScreenFlamegraphContainer>
           {typescriptProfile ? <Flamegraph profiles={typescriptProfile} /> : null}
         </FullScreenFlamegraphContainer>
       </FlamegraphThemeProvider>
-    </FlamegraphPreferencesProvider>
+    </FlamegraphStateProvider>
   );
 };

--- a/static/app/types/chromeTrace.d.ts
+++ b/static/app/types/chromeTrace.d.ts
@@ -74,5 +74,25 @@ namespace ChromeTrace {
     args: Record<string, any | Record<string, any>>;
   }
 
+  // https://github.com/v8/v8/blob/b8626ca445554b8376b5a01f651b70cb8c01b7dd/src/inspector/js_protocol.json#L1399
+  interface ProfileNode {
+    id: number;
+    callFrame: CPUProfileCallFrame;
+    hitCount: number;
+    children?: number[];
+    parent?: CPUProfileNode;
+    deoptReason?: string;
+    positionTicks?: PositionTickInfo[];
+  }
+
+  // https://github.com/v8/v8/blob/b8626ca445554b8376b5a01f651b70cb8c01b7dd/src/inspector/js_protocol.json#L1453
+  interface Profile {
+    nodes: ProfileNode[];
+    startTime: number;
+    endTime: number;
+    samples?: number[];
+    timeDeltas?: number[];
+  }
+
   type ProfileType = ArrayFormat | ObjectFormat;
 }

--- a/static/app/types/chromeTrace.d.ts
+++ b/static/app/types/chromeTrace.d.ts
@@ -68,6 +68,8 @@ namespace ChromeTrace {
     ts: number;
     // Thread clock timestamp
     tts?: number;
+    dur?: number;
+    tdur?: number;
     pid: number;
     tid: number;
     cname?: string;

--- a/static/app/types/chromeTrace.d.ts
+++ b/static/app/types/chromeTrace.d.ts
@@ -1,0 +1,78 @@
+// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+
+namespace ChromeTrace {
+  interface ObjectFormat {
+    traceEvents: ReadonlyArray<Event>;
+    displayTimeUnit: 'ms' | 'ns';
+    /**
+     *  Linux ftrace data or Windows ETW trace data.
+     *  This data must start with # tracer: and adhere to the
+     *   Linux ftrace format or adhere to Windows ETW format.
+     */
+    systemTraceEvents: string;
+    otherData: Record<string, string>;
+    powerTraceAsString: string;
+    /**
+     * string that specifies which trace data comes from tracing controller.
+     * Its value should be the key for that specific trace data. For example,
+     * {..., "controllerTraceDataKey": "traceEvents"} means the data for traceEvents
+     * comes from the tracing controller. This is mainly for the purpose of clock synchronization.
+     */
+    controllerTraceDataKey?: string;
+    stackFrames: ReadonlyArray<any>;
+    samples: ReadonlyArray<any>;
+  }
+
+  type ArrayFormat = ReadonlyArray<Event>;
+  type DurationEvent = 'B' | 'E';
+  type CompleteEvent = 'X';
+  type InstantEvent = 'i';
+  type DeprecatedInstantEvent = 'I';
+
+  type CounterEvent = 'C';
+  // b = nestable start, n = nestable instant, e = nestable end
+  type AsyncEvent = 'b' | 'n' | 'e';
+  // S = start, T = step into, p = step past, F = end
+  type DeprecatedAsyncEvent = 'S' | 'T' | 'p' | 'F';
+  // s = start, t = step, f = end
+  type FlowEvent = 's' | 't' | 'f';
+  type SampleEvent = 'P';
+  // N = created, O = snapshot, D = destroyed
+  type ObjectEvent = 'N' | 'O' | 'D';
+  type MetadataEvent = 'M';
+  // V = global, v = process
+  type MemoryDumpEvent = 'V' | 'v';
+  type MarkEvent = 'R';
+  type ClockSyncEvent = 'c';
+  type ContextEvents = '(,)';
+
+  interface Event {
+    name: string;
+    cat: string;
+    ph:
+      | DurationEvent
+      | CompleteEvent
+      | InstantEvent
+      | DeprecatedInstantEvent
+      | CounterEvent
+      | AsyncEvent
+      | DeprecatedAsyncEvent
+      | FlowEvent
+      | SampleEvent
+      | ObjectEvent
+      | MetadataEvent
+      | MemoryDumpEvent
+      | MarkEvent
+      | ClockSyncEvent
+      | ContextEvents;
+    ts: number;
+    // Thread clock timestamp
+    tts?: number;
+    pid: number;
+    tid: number;
+    cname?: string;
+    args: Record<string, any | Record<string, any>>;
+  }
+
+  type ProfileType = ArrayFormat | ObjectFormat;
+}

--- a/static/app/types/chromeTrace.d.ts
+++ b/static/app/types/chromeTrace.d.ts
@@ -25,6 +25,7 @@ namespace ChromeTrace {
 
   type ArrayFormat = ReadonlyArray<Event>;
   type DurationEvent = 'B' | 'E';
+  // Instant event
   type CompleteEvent = 'X';
   type InstantEvent = 'i';
   type DeprecatedInstantEvent = 'I';

--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -1,3 +1,23 @@
+/**
+ * The import code is very similar to speedscope's import code. The queue approach works well and allows us
+ * to easily split the X events and handle them. There are some small differences when it comes to building
+ * profiles where we opted to throw instead of closing a frame that was never opened.
+ *
+ * Overall, it seems that mostly typescript compiler uses this output, so we could possibly do a bit more
+ * in order to detect if this is a tsc trace and mark the different compiler phases and give users the preference
+ * to color encode by the program/bind/check/emit phases.
+ */
+
+import {Frame} from 'sentry/utils/profiling/frame';
+import {Profile} from 'sentry/utils/profiling/profile/profile';
+
+import {EventedProfile} from './eventedProfile';
+import {ProfileGroup} from './importProfile';
+
+export function isChromeTraceFormat(input: any): input is ChromeTrace.ProfileType {
+  return isChromeTraceArrayFormat(input) || isChromeTraceObjectFormat(input);
+}
+
 function isChromeTraceObjectFormat(input: any): input is ChromeTrace.ObjectFormat {
   return typeof input === 'object' && 'traceEvents' in input;
 }
@@ -6,15 +26,265 @@ function isChromeTraceArrayFormat(input: any): input is ChromeTrace.ArrayFormat 
   return Array.isArray(input);
 }
 
-export function parseChromeTrace(
-  input: string | ChromeTrace.ProfileType
-): ChromeTrace.ProfileType {
+export function importChromeTrace(input: string | ChromeTrace.ProfileType): ProfileGroup {
   if (isChromeTraceObjectFormat(input)) {
-    return input;
+    throw new Error('Chrometrace object format is not yet supported');
   }
   if (isChromeTraceArrayFormat(input)) {
-    return input;
+    return parseChromeTraceArrayFormat(input);
   }
 
   throw new Error('Failed to parse trace input format');
+}
+
+type ProcessId = number;
+type ThreadId = number;
+
+export function splitEventsByProcessAndTraceId(
+  trace: ChromeTrace.ArrayFormat
+): Record<ProcessId, Record<ThreadId, ChromeTrace.Event[]>> {
+  const collections: Record<ProcessId, Record<ThreadId, ChromeTrace.Event[]>> = {};
+
+  for (let i = 0; i < trace.length; i++) {
+    if (typeof trace[i].pid !== 'number') {
+      continue;
+    }
+    if (typeof trace[i].tid !== 'number') {
+      continue;
+    }
+
+    const event = trace[i];
+
+    if (!collections[event.pid]) {
+      collections[event.pid] = {};
+    }
+    if (!collections[event.pid][event.tid]) {
+      collections[event.pid][event.tid] = [];
+    }
+
+    collections[event.pid][event.tid].push(event);
+  }
+
+  return collections;
+}
+
+function chronologicalSort(a: ChromeTrace.Event, b: ChromeTrace.Event): number {
+  if (a.ts < b.ts) {
+    return -1;
+  }
+  if (a.ts > b.ts) {
+    return 1;
+  }
+  return 0;
+}
+
+function getNextQueue(
+  beginQueue: ChromeTrace.Event[],
+  endQueue: ChromeTrace.Event[]
+): 'B' | 'E' {
+  if (!beginQueue.length && !endQueue.length) {
+    throw new Error('Profile contains no events');
+  }
+
+  const nextBegin = beginQueue[0];
+  const nextEnd = endQueue[0];
+
+  if (!nextEnd) {
+    return 'B';
+  }
+  if (!nextBegin) {
+    return 'E';
+  }
+  if (nextBegin.ts < nextEnd.ts) {
+    return 'B';
+  }
+  if (nextEnd.ts < nextBegin.ts) {
+    return 'E';
+  }
+  return 'B';
+}
+
+function buildProfile(
+  processId: string,
+  threadId: string,
+  events: ChromeTrace.Event[]
+): EventedProfile {
+  let processName: string = `pid (${processId})`;
+  let threadName: string = `tid (${threadId})`;
+
+  // We dont care about other events besides begin, end, instant events and metadata events
+  const timelineEvents = events.filter(
+    e => e.ph === 'B' || e.ph === 'E' || e.ph === 'X' || e.ph === 'M'
+  );
+
+  // @TODO use a heap so we dont need to sort this again afterwards
+  const beginQueue: Array<ChromeTrace.Event> = [];
+  const endQueue: Array<ChromeTrace.Event> = [];
+
+  for (let i = 0; i < timelineEvents.length; i++) {
+    const event = timelineEvents[i];
+
+    // M events are not pushed to the queue, we just store their information
+    if (event.ph === 'M') {
+      if (event.name === 'thread_name' && typeof event.args.name === 'string') {
+        threadName = `${event.args.name} (${threadId})`;
+        continue;
+      }
+
+      if (event.name === 'process_name' && typeof event.args.name === 'string') {
+        processName = `${event.args.name} (${processId})`;
+        continue;
+      }
+    }
+
+    // B, E and X events are pushed to the timeline. We transform all X events into
+    // B and E event, so that they can be pushed onto the queue and handled
+    if (event.ph === 'B') {
+      beginQueue.push(event);
+      continue;
+    }
+
+    if (event.ph === 'E') {
+      endQueue.push(event);
+      continue;
+    }
+
+    if (event.ph === 'X') {
+      if (typeof event.dur === 'number' || typeof event.tdur === 'number') {
+        beginQueue.push({...event, ph: 'B'});
+        endQueue.push({...event, ph: 'E', ts: event.ts + (event.dur ?? event.tdur ?? 0)});
+        continue;
+      }
+    }
+  }
+
+  beginQueue.sort(chronologicalSort);
+  endQueue.sort(chronologicalSort);
+
+  if (!beginQueue.length) {
+    throw new Error('Profile does not contain any frame events');
+  }
+
+  const firstTimestamp = beginQueue[0].ts;
+
+  if (typeof firstTimestamp !== 'number') {
+    throw new Error('First begin event contains no timestamp');
+  }
+
+  const profile = new EventedProfile(
+    0,
+    0,
+    0,
+    `${processName}: ${threadName}`,
+    'milliseconds'
+  );
+
+  const stack: ChromeTrace.Event[] = [];
+  const frameCache = new Map<string, Frame>();
+
+  while (beginQueue.length > 0 || endQueue.length > 0) {
+    const next = getNextQueue(beginQueue, endQueue);
+
+    if (next === 'B') {
+      const item = beginQueue.shift();
+      if (!item) {
+        throw new Error('Nothing to take from begin queue');
+      }
+
+      const frameInfo = createFrameInfoFromEvent(item);
+
+      if (!frameCache.has(frameInfo.key)) {
+        frameCache.set(frameInfo.key, new Frame(frameInfo));
+      }
+
+      const frame = frameCache.get(frameInfo.key)!;
+      profile.enterFrame(frame, item.ts - firstTimestamp);
+      stack.push(item);
+      continue;
+    }
+
+    if (next === 'E') {
+      const item = endQueue.shift()!;
+      let frameInfo = createFrameInfoFromEvent(item);
+      const topFrameInfro = createFrameInfoFromEvent(stack[stack.length - 1]);
+
+      for (let i = 1; i < endQueue.length; i++) {
+        if (endQueue[i].ts > endQueue[0].ts) {
+          break;
+        }
+
+        const nextEndInfo = createFrameInfoFromEvent(endQueue[i]);
+        if (topFrameInfro.key === nextEndInfo.key) {
+          const tmp = endQueue[0];
+          endQueue[0] = endQueue[i];
+          endQueue[i] = tmp;
+
+          frameInfo = nextEndInfo;
+          break;
+        }
+      }
+
+      if (!frameCache.has(frameInfo.key)) {
+        throw new Error(
+          `Cannot leave frame that was never entered, leaving ${frameInfo.key}`
+        );
+      }
+
+      const frame = frameCache.get(frameInfo.key)!;
+      profile.leaveFrame(frame, item.ts - firstTimestamp);
+      stack.pop();
+      continue;
+    }
+  }
+
+  // Close the leftover frames in stack
+  while (stack.length) {
+    const item = stack.pop()!;
+    const frameInfo = createFrameInfoFromEvent(item);
+
+    const frame = frameCache.get(frameInfo.key);
+    if (!frame) {
+      throw new Error(
+        `Cannot leave frame that was never entered, leaving ${frameInfo.key}`
+      );
+    }
+    profile.leaveFrame(frame, frame.totalWeight);
+  }
+
+  return profile.build();
+}
+
+function createFrameInfoFromEvent(event: ChromeTrace.Event) {
+  const key = JSON.stringify(event.args);
+
+  return {
+    key,
+    name: `${event?.name || 'Unknown'} ${key}`.trim(),
+  };
+}
+
+export function parseChromeTraceArrayFormat(
+  input: ChromeTrace.ArrayFormat
+): ProfileGroup {
+  const profiles: Profile[] = [];
+  const eventsByProcessAndThreadID = splitEventsByProcessAndTraceId(input);
+
+  for (const processId in eventsByProcessAndThreadID) {
+    for (const threadId in eventsByProcessAndThreadID[processId]) {
+      profiles.push(
+        buildProfile(
+          processId,
+          threadId,
+          eventsByProcessAndThreadID[processId][threadId] ?? []
+        )
+      );
+    }
+  }
+
+  return {
+    name: 'chrometrace',
+    traceID: '',
+    activeProfileIndex: 0,
+    profiles,
+  };
 }

--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -13,6 +13,8 @@ import {Profile} from 'sentry/utils/profiling/profile/profile';
 import {EventedProfile} from './eventedProfile';
 import {ProfileGroup} from './importProfile';
 
+export class ChromeTraceProfile extends EventedProfile {}
+
 export function isChromeTraceFormat(input: any): input is ChromeTrace.ProfileType {
   return isChromeTraceArrayFormat(input) || isChromeTraceObjectFormat(input);
 }
@@ -102,7 +104,7 @@ function buildProfile(
   processId: string,
   threadId: string,
   events: ChromeTrace.Event[]
-): EventedProfile {
+): ChromeTraceProfile {
   let processName: string = `pid (${processId})`;
   let threadName: string = `tid (${threadId})`;
 
@@ -165,7 +167,7 @@ function buildProfile(
     throw new Error('First begin event contains no timestamp');
   }
 
-  const profile = new EventedProfile(
+  const profile = new ChromeTraceProfile(
     0,
     0,
     0,

--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -36,3 +36,8 @@ export function parseChromeTrace(
 
   throw new Error('Failed to parse trace input format');
 }
+
+function importChromeTrace(profile: ChromeTrace.ProfileType) {
+  if (Array.isArray(profile)) {
+  }
+}

--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -1,0 +1,38 @@
+function tryParseInputString(input: string): any {
+  try {
+    return JSON.parse(input);
+  } catch (e) {
+    return null;
+  }
+}
+
+function isChromeTraceObjectFormat(input: any): input is ChromeTrace.ObjectFormat {
+  return typeof input === 'object' && 'traceEvents' in input;
+}
+
+function isChromeTraceArrayFormat(input: any): input is ChromeTrace.ArrayFormat {
+  return Array.isArray(input);
+}
+
+export function parseChromeTrace(
+  input: string | ChromeTrace.ProfileType
+): ChromeTrace.ProfileType {
+  if (typeof input === 'string') {
+    const parsed = tryParseInputString(input) || tryParseInputString(input + ']');
+
+    if (parsed) {
+      return parsed;
+    }
+
+    throw new Error('Failed to parse trace input format');
+  }
+
+  if (isChromeTraceObjectFormat(input)) {
+    return input;
+  }
+  if (isChromeTraceArrayFormat(input)) {
+    return input;
+  }
+
+  throw new Error('Failed to parse trace input format');
+}

--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -1,11 +1,3 @@
-function tryParseInputString(input: string): any {
-  try {
-    return JSON.parse(input);
-  } catch (e) {
-    return null;
-  }
-}
-
 function isChromeTraceObjectFormat(input: any): input is ChromeTrace.ObjectFormat {
   return typeof input === 'object' && 'traceEvents' in input;
 }
@@ -17,16 +9,6 @@ function isChromeTraceArrayFormat(input: any): input is ChromeTrace.ArrayFormat 
 export function parseChromeTrace(
   input: string | ChromeTrace.ProfileType
 ): ChromeTrace.ProfileType {
-  if (typeof input === 'string') {
-    const parsed = tryParseInputString(input) || tryParseInputString(input + ']');
-
-    if (parsed) {
-      return parsed;
-    }
-
-    throw new Error('Failed to parse trace input format');
-  }
-
   if (isChromeTraceObjectFormat(input)) {
     return input;
   }
@@ -35,9 +17,4 @@ export function parseChromeTrace(
   }
 
   throw new Error('Failed to parse trace input format');
-}
-
-function importChromeTrace(profile: ChromeTrace.ProfileType) {
-  if (Array.isArray(profile)) {
-  }
 }

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -5,6 +5,7 @@ import {
   isSchema,
 } from '../guards/profile';
 
+import {importChromeTrace, isChromeTraceFormat} from './chromeTraceProfile';
 import {EventedProfile} from './eventedProfile';
 import {JSSelfProfile} from './jsSelfProfile';
 import {Profile} from './profile';
@@ -134,6 +135,10 @@ export async function importDroppedProfile(
 
         if (isJSProfile(json)) {
           return importJSSelfProfile(json, file.name);
+        }
+
+        if (isChromeTraceFormat(json)) {
+          return importChromeTrace(json);
         }
 
         throw new Error('Unsupported JSON format');

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -72,6 +72,10 @@ export function importProfile(
     return importJSSelfProfile(input, traceID);
   }
 
+  if (isChromeTraceFormat(input)) {
+    return importChromeTrace(input);
+  }
+
   if (isSchema(input)) {
     const frameIndex = createFrameIndex(input.shared.frames);
 

--- a/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
@@ -1,4 +1,5 @@
 import {
+  importChromeTrace,
   parseChromeTraceArrayFormat,
   splitEventsByProcessAndTraceId,
 } from 'sentry/utils/profiling/profile/chromeTraceProfile';
@@ -280,5 +281,26 @@ describe('parseChromeTraceArrayFormat', () => {
     ]);
 
     expect(trace.profiles[0].duration).toBe(100);
+  });
+});
+
+import trace from './samples/chrometrace/typescript/trace.json';
+
+// Keeping the benchmark around
+// eslint-disable-next-line
+describe.skip('Benchmark', () => {
+  it('imports profile', () => {
+    const measures: number[] = [];
+    const _avg = (arr: number[]) => arr.reduce((a, b) => a + b) / arr.length;
+
+    for (let i = 0; i < 10; i++) {
+      const start = performance.now();
+
+      importChromeTrace(trace as ChromeTrace.ProfileType);
+      measures.push(performance.now() - start);
+    }
+
+    // console.log(avg(measures));
+    expect(true).toBe(true);
   });
 });

--- a/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
@@ -1,26 +1,284 @@
-import {parseChromeTrace} from 'sentry/utils/profiling/profile/chromeTraceProfile';
+import {
+  parseChromeTraceArrayFormat,
+  splitEventsByProcessAndTraceId,
+} from 'sentry/utils/profiling/profile/chromeTraceProfile';
 
-describe('ChromeTraceProfile', () => {
-  it('parses incomplete trace', () => {
+describe('splitEventsByProcessAndTraceId', () => {
+  it('splits by thread id', () => {
     const trace: ChromeTrace.ArrayFormat = [
-      {ts: 0, ph: 'B', cat: 'a', name: 'b', pid: 1, tid: 2, args: {}},
+      {
+        ph: 'B',
+        tid: 0,
+        pid: 0,
+        cat: '',
+        name: '',
+        ts: 0,
+        args: [],
+      },
+      {
+        ph: 'B',
+        tid: 1,
+        pid: 0,
+        cat: '',
+        name: '',
+        ts: 0,
+        args: [],
+      },
     ];
 
-    const stringifiedTrace = JSON.stringify(trace);
+    expect(splitEventsByProcessAndTraceId(trace)[0][0]).toEqual([trace[0]]);
+    expect(splitEventsByProcessAndTraceId(trace)[0][1]).toEqual([trace[1]]);
+  });
+});
 
-    // Drop last character, parsing should attempt to inject it
-    const partialTrace = trace.slice(0, stringifiedTrace.length - 1);
+describe('parseChromeTraceArrayFormat', () => {
+  it('marks process name', () => {
+    expect(
+      parseChromeTraceArrayFormat([
+        {
+          ph: 'M',
+          ts: 0,
+          cat: '',
+          pid: 0,
+          tid: 0,
+          name: 'process_name',
+          args: {name: 'Process Name'},
+        },
+        {
+          ph: 'B',
+          ts: 0,
+          cat: 'program',
+          pid: 0,
+          tid: 0,
+          name: 'createProgram',
+          args: {configFilePath: '/Users/jonasbadalic/Work/sentry/tsconfig.json'},
+        },
+      ]).profiles[0].name
+    ).toBe('Process Name (0): tid (0)');
+  });
 
-    expect(parseChromeTrace(partialTrace)).toEqual([
+  it('marks thread name', () => {
+    expect(
+      parseChromeTraceArrayFormat([
+        {
+          ph: 'M',
+          ts: 0,
+          cat: '',
+          pid: 0,
+          tid: 0,
+          name: 'thread_name',
+          args: {name: 'Thread Name'},
+        },
+        {
+          ph: 'B',
+          ts: 0,
+          cat: 'program',
+          pid: 0,
+          tid: 0,
+          name: 'createProgram',
+          args: {configFilePath: '/Users/jonasbadalic/Work/sentry/tsconfig.json'},
+        },
+      ]).profiles[0].name
+    ).toBe('pid (0): Thread Name (0)');
+  });
+  it('imports a simple trace', () => {
+    const trace = parseChromeTraceArrayFormat([
       {
-        ts: 0,
         ph: 'B',
-        cat: 'a',
-        name: 'b',
-        pid: 1,
-        tid: 2,
-        args: {},
+        ts: 0,
+        cat: 'program',
+        pid: 0,
+        tid: 0,
+        name: 'createProgram',
+        args: {configFilePath: '/Users/jonasbadalic/Work/sentry/tsconfig.json'},
+      },
+      {
+        ph: 'E',
+        ts: 1000,
+        cat: 'program',
+        pid: 0,
+        tid: 0,
+        name: 'createProgram',
+        args: {configFilePath: '/Users/jonasbadalic/Work/sentry/tsconfig.json'},
       },
     ]);
+
+    expect(trace.profiles[0].duration).toBe(1000);
+    expect(trace.profiles[0].appendOrderTree.children[0].totalWeight).toBe(1000);
+  });
+
+  it('closes unclosed events', () => {
+    const trace = parseChromeTraceArrayFormat([
+      {
+        ph: 'B',
+        ts: 0,
+        cat: 'program',
+        pid: 0,
+        tid: 0,
+        name: 'createProgram',
+        args: {frame: '0'},
+      },
+      {
+        ph: 'B',
+        ts: 1000,
+        cat: 'program',
+        pid: 0,
+        tid: 0,
+        name: 'createProgram',
+        args: {frame: '1'},
+      },
+      {
+        ph: 'E',
+        ts: 2000,
+        cat: 'program',
+        pid: 0,
+        tid: 0,
+        name: 'createProgram',
+        args: {frame: '1'},
+      },
+    ]);
+
+    expect(trace.profiles[0].duration).toBe(2000);
+    expect(trace.profiles[0].appendOrderTree.children[0].selfWeight).toBe(1000);
+    expect(trace.profiles[0].appendOrderTree.children[0].totalWeight).toBe(2000);
+    expect(trace.profiles[0].appendOrderTree.children[0].children[0].selfWeight).toBe(
+      1000
+    );
+  });
+  it('handles out of order E events', () => {
+    const trace = parseChromeTraceArrayFormat([
+      {
+        ph: 'B',
+        ts: 0,
+        cat: '',
+        pid: 0,
+        tid: 0,
+        name: '',
+        args: {frame: '0'},
+      },
+      {
+        ph: 'B',
+        ts: 1,
+        cat: '',
+        pid: 0,
+        tid: 0,
+        name: '',
+        args: {frame: '1'},
+      },
+      {
+        ph: 'E',
+        ts: 2,
+        cat: '',
+        pid: 0,
+        tid: 0,
+        name: '',
+        args: {frame: '0'},
+      },
+      {
+        ph: 'E',
+        ts: 2,
+        cat: '',
+        pid: 0,
+        tid: 0,
+        name: '',
+        args: {frame: '1'},
+      },
+    ]);
+
+    expect(trace.profiles[0].duration).toBe(2);
+    expect(trace.profiles[0].appendOrderTree.children[0].selfWeight).toBe(1);
+    expect(trace.profiles[0].appendOrderTree.children[0].totalWeight).toBe(2);
+    expect(trace.profiles[0].appendOrderTree.children[0].frame.name).toBe(
+      'Unknown {"frame":"0"}'
+    );
+    expect(trace.profiles[0].appendOrderTree.children[0].children[0].frame.name).toBe(
+      'Unknown {"frame":"1"}'
+    );
+    expect(trace.profiles[0].appendOrderTree.children[0].children[0].selfWeight).toBe(1);
+    expect(trace.profiles[0].appendOrderTree.children[0].children[0].totalWeight).toBe(1);
+  });
+  it('handles out of order B events', () => {
+    const trace = parseChromeTraceArrayFormat([
+      {
+        ph: 'B',
+        ts: 0,
+        cat: '',
+        pid: 0,
+        tid: 0,
+        name: '',
+        args: {frame: '0'},
+      },
+      {
+        ph: 'B',
+        ts: 1,
+        cat: '',
+        pid: 0,
+        tid: 0,
+        name: '',
+        args: {frame: '1'},
+      },
+      {
+        ph: 'E',
+        ts: 2,
+        cat: '',
+        pid: 0,
+        tid: 0,
+        name: '',
+        args: {frame: '0'},
+      },
+      {
+        ph: 'E',
+        ts: 2,
+        cat: '',
+        pid: 0,
+        tid: 0,
+        name: '',
+        args: {frame: '1'},
+      },
+    ]);
+
+    expect(trace.profiles[0].duration).toBe(2);
+    expect(trace.profiles[0].appendOrderTree.children[0].selfWeight).toBe(1);
+    expect(trace.profiles[0].appendOrderTree.children[0].totalWeight).toBe(2);
+    expect(trace.profiles[0].appendOrderTree.children[0].frame.name).toBe(
+      'Unknown {"frame":"0"}'
+    );
+    expect(trace.profiles[0].appendOrderTree.children[0].children[0].frame.name).toBe(
+      'Unknown {"frame":"1"}'
+    );
+    expect(trace.profiles[0].appendOrderTree.children[0].children[0].selfWeight).toBe(1);
+    expect(trace.profiles[0].appendOrderTree.children[0].children[0].totalWeight).toBe(1);
+  });
+  it('handles X trace with tdur', () => {
+    const trace = parseChromeTraceArrayFormat([
+      {
+        ph: 'X',
+        ts: 0,
+        cat: '',
+        pid: 0,
+        tid: 0,
+        tdur: 100,
+        name: '',
+        args: {frame: '0'},
+      },
+    ]);
+
+    expect(trace.profiles[0].duration).toBe(100);
+  });
+  it('handles X trace with dur', () => {
+    const trace = parseChromeTraceArrayFormat([
+      {
+        ph: 'X',
+        ts: 0,
+        cat: '',
+        pid: 0,
+        tid: 0,
+        dur: 100,
+        name: '',
+        args: {frame: '0'},
+      },
+    ]);
+
+    expect(trace.profiles[0].duration).toBe(100);
   });
 });

--- a/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
@@ -1,0 +1,26 @@
+import {parseChromeTrace} from 'sentry/utils/profiling/profile/chromeTraceProfile';
+
+describe('ChromeTraceProfile', () => {
+  it('parses incomplete trace', () => {
+    const trace: ChromeTrace.ArrayFormat = [
+      {ts: 0, ph: 'B', cat: 'a', name: 'b', pid: 1, tid: 2, args: {}},
+    ];
+
+    const stringifiedTrace = JSON.stringify(trace);
+
+    // Drop last character, parsing should attempt to inject it
+    const partialTrace = trace.slice(0, stringifiedTrace.length - 1);
+
+    expect(parseChromeTrace(partialTrace)).toEqual([
+      {
+        ts: 0,
+        ph: 'B',
+        cat: 'a',
+        name: 'b',
+        pid: 1,
+        tid: 2,
+        args: {},
+      },
+    ]);
+  });
+});

--- a/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
@@ -1,4 +1,5 @@
 import {
+  ChromeTraceProfile,
   importChromeTrace,
   parseChromeTraceArrayFormat,
   splitEventsByProcessAndTraceId,
@@ -33,6 +34,30 @@ describe('splitEventsByProcessAndTraceId', () => {
 });
 
 describe('parseChromeTraceArrayFormat', () => {
+  it('returns chrometrace profile', () => {
+    expect(
+      parseChromeTraceArrayFormat([
+        {
+          ph: 'M',
+          ts: 0,
+          cat: '',
+          pid: 0,
+          tid: 0,
+          name: 'process_name',
+          args: {name: 'Process Name'},
+        },
+        {
+          ph: 'B',
+          ts: 0,
+          cat: 'program',
+          pid: 0,
+          tid: 0,
+          name: 'createProgram',
+          args: {configFilePath: '/Users/jonasbadalic/Work/sentry/tsconfig.json'},
+        },
+      ]).profiles[0]
+    ).toBeInstanceOf(ChromeTraceProfile);
+  });
   it('marks process name', () => {
     expect(
       parseChromeTraceArrayFormat([
@@ -291,7 +316,8 @@ import trace from './samples/chrometrace/typescript/trace.json';
 describe.skip('Benchmark', () => {
   it('imports profile', () => {
     const measures: number[] = [];
-    const _avg = (arr: number[]) => arr.reduce((a, b) => a + b) / arr.length;
+    // eslint-disable-next-line
+    const avg = (arr: number[]) => arr.reduce((a, b) => a + b) / arr.length;
 
     for (let i = 0; i < 10; i++) {
       const start = performance.now();
@@ -300,7 +326,7 @@ describe.skip('Benchmark', () => {
       measures.push(performance.now() - start);
     }
 
-    // console.log(avg(measures));
+    avg(measures);
     expect(true).toBe(true);
   });
 });

--- a/tests/js/spec/utils/profiling/profile/importProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/importProfile.spec.tsx
@@ -172,7 +172,7 @@ describe('importDroppedProfile', () => {
 
   it('throws if contents are not valid JSON', async () => {
     const file = new File(['{"json": true'], 'test.tsx');
-    await expect(importDroppedProfile(file)).rejects.toBeInstanceOf(SyntaxError);
+    await expect(importDroppedProfile(file)).rejects.toBeInstanceOf(Error);
   });
 
   it('imports schema file', async () => {


### PR DESCRIPTION
support https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview. This is the format that typescript uses and is a subset of the chrometrace format. The electron app uses https://github.com/v8/v8/blob/b8626ca445554b8376b5a01f651b70cb8c01b7dd/src/inspector/js_protocol.json