### PR TITLE
ref(perf): Add missed data check for perf component

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -57,7 +57,7 @@ export const VisuallyCompleteWithData = ({
         });
         isVisuallyCompleteSet.current = true;
       }
-      if (!isDataCompleteSet.current) {
+      if (!isDataCompleteSet.current && hasData) {
         transaction.registerBeforeFinishCallback((t, _) => {
           // Should be called after performance entries finish callback.
           t.setMeasurements({


### PR DESCRIPTION
### Summary
After checking results in discover, noticed that the data was the same for load and when data was set. 'hasData' check was missing in the second if condition.