### PR TITLE
fix(alert-rule-action): Initialize FormModel with existing values

### DIFF
--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -95,7 +95,14 @@ export class SentryAppExternalForm extends Component<Props, State> {
     });
     // For alert-rule-actions, the forms are entirely custom, extra fields are
     // passed in on submission, not as part of the form. See handleAlertRuleSubmit().
-    if (element !== 'alert-rule-action') {
+    if (element === 'alert-rule-action') {
+      const defaultResetValues = (this.props.resetValues || {}).settings || [];
+      const initialData = defaultResetValues.reduce((acc, curr) => {
+        acc[curr.name] = curr.value;
+        return acc;
+      }, {});
+      this.model.setInitialData({...initialData});
+    } else {
       this.model.setInitialData({
         ...extraFields,
         // we need to pass these fields in the API so just set them as values so we don't need hidden form fields


### PR DESCRIPTION
## Objective:
Fixes a bug where Selects with `depends_on` property are disabled even though the field they depend on actually has a value.