### PR TITLE
ref(jira): Handle ApiHostErrors

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -25,6 +25,7 @@ from sentry.models import (
 )
 from sentry.shared_integrations.exceptions import (
     ApiError,
+    ApiHostError,
     ApiUnauthorized,
     IntegrationError,
     IntegrationFormError,
@@ -913,8 +914,10 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         # don't bother updating if it's already the status we'd change it to
         if jira_issue["fields"]["status"]["id"] == jira_status:
             return
-
-        transitions = client.get_transitions(external_issue.key)
+        try:
+            transitions = client.get_transitions(external_issue.key)
+        except ApiHostError:
+            raise IntegrationError("Could not reach host to get transitions.")
 
         try:
             transition = [t for t in transitions if t.get("to", {}).get("id") == jira_status][0]

--- a/src/sentry/integrations/jira/issue_hook.py
+++ b/src/sentry/integrations/jira/issue_hook.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from sentry.api.serializers import StreamGroupSerializer, serialize
 from sentry.integrations.utils import AtlassianConnectValidationError, get_integration_from_request
 from sentry.models import ExternalIssue, Group, GroupLink
+from sentry.shared_integrations.exceptions import ApiHostError, IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.utils.sdk import configure_scope
 
@@ -31,7 +32,10 @@ class JiraIssueHookView(JiraBaseHook):
             JiraCloud(integration.metadata["shared_secret"]),
             verify_ssl=True,
         )
-        return client.set_issue_property(issue_key, group_link_num)
+        try:
+            return client.set_issue_property(issue_key, group_link_num)
+        except ApiHostError:
+            raise IntegrationError("Cannot reach host to set badge.")
 
     def get(self, request: Request, issue_key, *args, **kwargs) -> Response:
         with configure_scope() as scope:

--- a/src/sentry/integrations/jira/webhooks.py
+++ b/src/sentry/integrations/jira/webhooks.py
@@ -14,6 +14,7 @@ from sentry.integrations.utils import (
     get_integration_from_jwt,
     sync_group_assignee_inbound,
 )
+from sentry.shared_integrations.exceptions import ApiHostError, IntegrationError
 
 from .client import JiraApiClient, JiraCloud
 
@@ -37,7 +38,10 @@ def get_assignee_email(
             JiraCloud(integration.metadata["shared_secret"]),
             verify_ssl=True,
         )
-        email = client.get_email(account_id)
+        try:
+            email = client.get_email(account_id)
+        except ApiHostError:
+            raise IntegrationError("Cannot reach host to get email.")
     return email
 
 


### PR DESCRIPTION
We have several Sentry issues about unhandled ApiHostErrors for Jira Server integrations - this PR handles them gracefully.

Fixes (a lot of duplicates):
[SENTRY-T3R](https://sentry.io/organizations/sentry/issues/2934493595/?project=1&query=is%3Aunresolved+assigned_or_suggested%3A%23ecosystem+ApiHostError&sort=user&statsPeriod=14d)
[SENTRY-T73](https://sentry.io/organizations/sentry/issues/2984322297/?project=1&query=is%3Aunresolved+assigned_or_suggested%3A%23ecosystem+ApiHostError&sort=user&statsPeriod=14d)
[SENTRY-T6W](https://sentry.io/organizations/sentry/issues/2980938429/?project=1&query=is%3Aunresolved+assigned_or_suggested%3A%23ecosystem+ApiHostError&sort=user&statsPeriod=14d)
[SENTRY-T43](https://sentry.io/organizations/sentry/issues/2938309213/?project=1&query=is%3Aunresolved+assigned_or_suggested%3A%23ecosystem+ApiHostError&sort=user&statsPeriod=14d)
[SENTRY-T3K](https://sentry.io/organizations/sentry/issues/2930861741/?project=1&query=is%3Aunresolved+assigned_or_suggested%3A%23ecosystem+ApiHostError&sort=user&statsPeriod=14d)
[SENTRY-T3D](https://sentry.io/organizations/sentry/issues/2929579545/?project=1&query=is%3Aunresolved+assigned_or_suggested%3A%23ecosystem+ApiHostError&sort=user&statsPeriod=14d)
[SENTRY-Y3M](https://sentry.io/organizations/sentry/issues/2930919843/?project=1&query=is%3Aunresolved+assigned_or_suggested%3A%23ecosystem+ApiHostError&sort=user&statsPeriod=14d)
[SENTRY-T26](https://sentry.io/organizations/sentry/issues/2928687018/?project=1&query=is%3Aunresolved+assigned_or_suggested%3A%23ecosystem+ApiHostError&sort=user&statsPeriod=14d)
[SENTRY-T25](https://sentry.io/organizations/sentry/issues/2928683785/?project=1&referrer=jira_integration)