### PR TITLE
feat: remove ViewSampleSandboxExperiment

### DIFF
--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -43,12 +43,6 @@ export const experimentList = [
     parameter: 'exposed',
     assignments: [0, 1],
   },
-  {
-    key: 'ViewSampleSandboxExperiment',
-    type: ExperimentType.Organization,
-    parameter: 'exposed',
-    assignments: [0, 1],
-  },
 ] as const;
 
 export const experimentConfig = experimentList.reduce(


### PR DESCRIPTION
We had an experiment to send folks to the Sandbox instead of creating a sample event from the empty project state. The experiment was a failure and the sandbox version is doing worse so we're removing it.