### PR TITLE
fix(teambadge): Update team badge when props change

### DIFF
--- a/static/app/components/idBadge/teamBadge/index.tsx
+++ b/static/app/components/idBadge/teamBadge/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import isEqual from 'lodash/isEqual';
 
 import TeamStore from 'sentry/stores/teamStore';
 import {Team} from 'sentry/types';
@@ -7,6 +8,18 @@ import Badge, {BadgeProps} from './badge';
 
 function TeamBadge(props: BadgeProps) {
   const [team, setTeam] = React.useState<Team>(props.team);
+
+  React.useEffect(() => {
+    if (team === props.team) {
+      return;
+    }
+
+    if (isEqual(team, props.team)) {
+      return;
+    }
+
+    setTeam(props.team);
+  }, [props.team]);
 
   const onTeamStoreUpdate = React.useCallback(
     (updatedTeam: Set<string>) => {

--- a/static/app/components/idBadge/teamBadge/index.tsx
+++ b/static/app/components/idBadge/teamBadge/index.tsx
@@ -10,10 +10,6 @@ function TeamBadge(props: BadgeProps) {
   const [team, setTeam] = React.useState<Team>(props.team);
 
   React.useEffect(() => {
-    if (team === props.team) {
-      return;
-    }
-
     if (isEqual(team, props.team)) {
       return;
     }

--- a/static/app/components/idBadge/teamBadge/index.tsx
+++ b/static/app/components/idBadge/teamBadge/index.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import isEqual from 'lodash/isEqual';
 
 import TeamStore from 'sentry/stores/teamStore';
 import {Team} from 'sentry/types';
@@ -10,10 +9,6 @@ function TeamBadge(props: BadgeProps) {
   const [team, setTeam] = React.useState<Team>(props.team);
 
   React.useEffect(() => {
-    if (isEqual(team, props.team)) {
-      return;
-    }
-
     setTeam(props.team);
   }, [props.team]);
 
@@ -31,7 +26,7 @@ function TeamBadge(props: BadgeProps) {
 
       setTeam(newTeam);
     },
-    [team, TeamStore]
+    [props.team]
   );
 
   React.useEffect(() => {

--- a/tests/js/spec/components/idBadge/teamBadge.spec.tsx
+++ b/tests/js/spec/components/idBadge/teamBadge.spec.tsx
@@ -9,18 +9,14 @@ describe('TeamBadge', function () {
   });
 
   it('renders with Avatar and team name', function () {
-    mountWithTheme(<TeamBadge team={TestStubs.Team()} />, {
-      context: TestStubs.routerContext(),
-    });
+    mountWithTheme(<TeamBadge team={TestStubs.Team()} />);
     expect(screen.getByTestId('badge-styled-avatar')).toBeInTheDocument();
     expect(screen.getByText(/#team-slug/)).toBeInTheDocument();
   });
 
   it('listens for avatar changes from TeamStore', async function () {
     const team = TestStubs.Team();
-    mountWithTheme(<TeamBadge team={team} />, {
-      context: TestStubs.routerContext(),
-    });
+    mountWithTheme(<TeamBadge team={team} />);
 
     act(() => {
       TeamStore.onUpdateSuccess(team.id, {
@@ -34,9 +30,7 @@ describe('TeamBadge', function () {
 
   it('updates state from props', async function () {
     const team = TestStubs.Team();
-    const {rerender} = mountWithTheme(<TeamBadge team={team} />, {
-      context: TestStubs.routerContext(),
-    });
+    const {rerender} = mountWithTheme(<TeamBadge team={team} />);
 
     rerender(<TeamBadge team={TestStubs.Team({slug: 'new-team-slug'})} />);
 


### PR DESCRIPTION
There was good test coverage , but RTL `rerender()` was destroying the component and the test was not testing via props being updated. RTL bug fixed in #31716

I have no idea if i'm using hooks correctly