### PR TITLE
test(acceptance): Move data-test-id up to wrapper

### DIFF
--- a/static/app/views/dashboardsV2/addWidget.tsx
+++ b/static/app/views/dashboardsV2/addWidget.tsx
@@ -58,9 +58,8 @@ function AddWidget({onAddWidget, onOpenWidgetBuilder, orgFeatures}: Props) {
         duration: 0.25,
       }}
     >
-      <InnerWrapper onClick={onClick}>
+      <InnerWrapper onClick={onClick} data-test-id="widget-add">
         <AddButton
-          data-test-id="widget-add"
           icon={<IconAdd size="lg" isCircled color="inactive" />}
           aria-label={t('Add widget')}
         />

--- a/tests/js/spec/views/dashboardsV2/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/detail.spec.jsx
@@ -495,7 +495,7 @@ describe('Dashboards > Detail', function () {
       // Enter edit mode.
       wrapper.find('Controls Button[data-test-id="dashboard-edit"]').simulate('click');
       wrapper.update();
-      wrapper.find('AddButton[data-test-id="widget-add"]').simulate('click');
+      wrapper.find('InnerWrapper[data-test-id="widget-add"]').simulate('click');
       expect(openEditModal).toHaveBeenCalledTimes(1);
     });
 
@@ -528,7 +528,7 @@ describe('Dashboards > Detail', function () {
       // Enter edit mode.
       wrapper.find('Controls Button[data-test-id="dashboard-edit"]').simulate('click');
       wrapper.update();
-      wrapper.find('AddButton[data-test-id="widget-add"]').simulate('click');
+      wrapper.find('InnerWrapper[data-test-id="widget-add"]').simulate('click');
       expect(openEditModal).toHaveBeenCalledTimes(1);
       expect(openEditModal).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
@@ -376,7 +376,7 @@ describe('Dashboards > Detail', function () {
       // Enter edit mode.
       wrapper.find('Controls Button[data-test-id="dashboard-edit"]').simulate('click');
       wrapper.update();
-      wrapper.find('AddButton[data-test-id="widget-add"]').simulate('click');
+      wrapper.find('InnerWrapper[data-test-id="widget-add"]').simulate('click');
       expect(openEditModal).toHaveBeenCalledTimes(1);
     });
 
@@ -409,7 +409,7 @@ describe('Dashboards > Detail', function () {
       // Enter edit mode.
       wrapper.find('Controls Button[data-test-id="dashboard-edit"]').simulate('click');
       wrapper.update();
-      wrapper.find('AddButton[data-test-id="widget-add"]').simulate('click');
+      wrapper.find('InnerWrapper[data-test-id="widget-add"]').simulate('click');
       expect(openEditModal).toHaveBeenCalledTimes(1);
       expect(openEditModal).toHaveBeenCalledWith(
         expect.objectContaining({


### PR DESCRIPTION
Selenium complained that the wrapper was going to receive the click.
Since the onClick handler was on the wrapper I found it appropriate to
move the data-test-id up to more closely match what the user's
interaction would be (i.e. clicking the full button and not just the
icon)