### PR TITLE
feat(codeowners): add api owners group to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,9 @@
 # Migrations
 /src/sentry/migrations/  @getsentry/owners-migrations
 
-# API Owners for unowned endpoints
+# API Owners for unowned endpoints / serializers
 endpoints/                      @getsentry/owners-api
-
+/src/sentry/api/                @getsentry/owners-api
 
 # Snuba
 /src/sentry/eventstream/        @getsentry/owners-snuba

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,10 @@
 # Migrations
 /src/sentry/migrations/  @getsentry/owners-migrations
 
+# API Owners for unowned endpoints
+endpoints/                      @getsentry/owners-api
+
+
 # Snuba
 /src/sentry/eventstream/        @getsentry/owners-snuba
 /src/sentry/utils/snuba.py      @getsentry/owners-snuba @getsentry/visibility
@@ -300,3 +304,13 @@ tests/js/spec/utils/profiling                                   @getsentry/profi
 /src/sentry/reprocessing2.py       @getsentry/owners-ingest @getsentry/owners-native
 
 ## End of Native ##
+
+
+### APIs Group ##
+
+/src/sentry/apidocs/                @getsentry/owners-api
+/src/sentry/api/urls.py             @getsentry/owners-api
+/api-docs/                          @getsentry/owners-api
+/tests/apidocs/                     @getsentry/owners-api
+/.github/workflows/openapi.yml      @getsentry/owners-api
+/.github/workflows/openapi-diff.yml @getsentry/owners-api


### PR DESCRIPTION
The intention with these CODEOWNERS rules is as follows:

- the owners-api should be requested on any new API added. for now, this will happen via the ownership rule on the `/src/sentry/api/urls.py`, and on the `/src/sentry/apidocs/` folder when the registry is merged in. https://github.com/getsentry/sentry/pull/31711
    - We may want to consider simply committing our built OpenAPI JSON with each commit, and adding an ownership rule for that, which would be more fullproof combined with the registry.
- For now, owners-api group should own the tooling for generating the OpenAPI schema and associated tests
- The owners-api group will be tagged as a reviewer on any unowned endpoint. (the `endpoints/` rule). The intention with this is going forward, an owner should be added for endpoints as they are modified, if possible.

