### PR TITLE
test(acceptance): Comment out wait_until_clickable in dashboard test

### DIFF
--- a/tests/acceptance/page_objects/dashboard_detail.py
+++ b/tests/acceptance/page_objects/dashboard_detail.py
@@ -39,7 +39,9 @@ class DashboardDetailPage(BasePage):
         self.wait_until_loaded()
 
     def click_dashboard_add_widget_button(self):
-        self.browser.wait_until_clickable('[data-test-id="widget-add"]')
+        # TODO(nar): This clickable check is causing flake when CSS Transforms are
+        # disabled for the grid library
+        # self.browser.wait_until_clickable('[data-test-id="widget-add"]')
         button = self.browser.element('[data-test-id="widget-add"]')
         button.click()
         self.wait_until_loaded()


### PR DESCRIPTION
With CSS transforms off, the check for clickability of the add widget
tile is always erroring out with a message about another element
receiving the click

This change consistently passes in my local env.