### PR TITLE
feat(page-filters): Produce state for when URL filters differ from pinned filters

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -171,17 +171,8 @@ export function initializeUrlState({
   }
 
   const hasDatetimeInUrl = Object.keys(pick(queryParams, DATE_TIME_KEYS)).length > 0;
-
-  const projectFromUrl = queryParams[URL_PARAM.PROJECT];
-  const urlProjectArr =
-    typeof projectFromUrl === 'string'
-      ? [Number(projectFromUrl)]
-      : (projectFromUrl ?? []).map(Number);
-
-  const envFromUrl = queryParams[URL_PARAM.ENVIRONMENT];
-  const urlEnvArr = typeof envFromUrl === 'string' ? [envFromUrl] : envFromUrl ?? [];
-
-  const hasProjectOrEnvironmentInUrl = defined(projectFromUrl) || defined(envFromUrl);
+  const hasProjectOrEnvironmentInUrl =
+    Object.keys(pick(queryParams, [URL_PARAM.PROJECT, URL_PARAM.ENVIRONMENT])).length > 0;
 
   if (hasProjectOrEnvironmentInUrl) {
     pageFilters.projects = parsed.project || [];
@@ -218,12 +209,26 @@ export function initializeUrlState({
     }
 
     // Check if stored and pinned filters differ from url query params
-    if (defined(projectFromUrl) && !valueIsEqual(storedState.project, urlProjectArr)) {
+    if (defined(parsed.project) && !valueIsEqual(storedState.project, parsed.project)) {
       filtersInUrlDifferingFromPinned.add('projects');
     }
 
-    if (defined(envFromUrl) && !valueIsEqual(storedState.environment, urlEnvArr)) {
+    if (
+      defined(parsed.environment) &&
+      !valueIsEqual(storedState.environment, parsed.environment)
+    ) {
       filtersInUrlDifferingFromPinned.add('environments');
+    }
+
+    const filteredDateKeys = DATE_TIME_KEYS.filter(key => key !== 'statsPeriod');
+    const parsedDatetime = pick(parsed, filteredDateKeys);
+    const storedDatetime = pick(storedState, filteredDateKeys);
+
+    if (
+      Object.values(parsedDatetime).some(defined) &&
+      !valueIsEqual(parsedDatetime, storedDatetime)
+    ) {
+      filtersInUrlDifferingFromPinned.add('datetime');
     }
   }
 

--- a/tests/js/spec/actionCreators/pageFilters.spec.jsx
+++ b/tests/js/spec/actionCreators/pageFilters.spec.jsx
@@ -45,6 +45,7 @@ describe('PageFilters ActionCreators', function () {
           environments: [],
           projects: [1],
         }),
+        new Set(),
         new Set()
       );
       expect(router.replace).toHaveBeenCalledWith(
@@ -87,6 +88,7 @@ describe('PageFilters ActionCreators', function () {
             utc: null,
           },
         }),
+        new Set(),
         new Set()
       );
     });
@@ -114,6 +116,7 @@ describe('PageFilters ActionCreators', function () {
             utc: null,
           },
         }),
+        new Set(),
         new Set()
       );
     });
@@ -195,6 +198,7 @@ describe('PageFilters ActionCreators', function () {
           projects: [1],
           environments: [],
         },
+        new Set(),
         new Set()
       );
       expect(router.replace).toHaveBeenCalledWith(
@@ -213,7 +217,7 @@ describe('PageFilters ActionCreators', function () {
         .spyOn(PageFilterPersistence, 'getPageFilterStorage')
         .mockReturnValueOnce({
           state: {
-            project: ['1'],
+            project: [1],
             environment: [],
             start: null,
             end: null,
@@ -243,7 +247,7 @@ describe('PageFilters ActionCreators', function () {
         .spyOn(PageFilterPersistence, 'getPageFilterStorage')
         .mockReturnValueOnce({
           state: {
-            project: ['1'],
+            project: [1],
             environment: ['prod'],
             start: null,
             end: null,
@@ -269,6 +273,53 @@ describe('PageFilters ActionCreators', function () {
             project: [],
           },
         })
+      );
+
+      pageFilterStorageMock.mockRestore();
+    });
+
+    it('records when query params differ from stored pinned filters', function () {
+      const pinnedFilters = new Set(['projects', 'datetime', 'environments']);
+      // Mock storage to have a saved/pinned value
+      const pageFilterStorageMock = jest
+        .spyOn(PageFilterPersistence, 'getPageFilterStorage')
+        .mockReturnValueOnce({
+          state: {
+            project: [1],
+            environment: ['prod'],
+            start: null,
+            end: null,
+            period: '14d',
+            utc: null,
+          },
+          pinnedFilters,
+        });
+
+      initializeUrlState({
+        organization: pageFiltersOrganization,
+        queryParams: {
+          project: '2',
+          environment: 'not-prod',
+          statsPeriod: '24h',
+        },
+        pathname: '/organizations/org-slug/issues/',
+        router,
+      });
+
+      expect(PageFiltersActions.initializeUrlState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environments: ['not-prod'],
+          projects: [2],
+          datetime: {
+            end: null,
+            period: '24h',
+            start: null,
+            utc: null,
+          },
+        }),
+        pinnedFilters,
+        // All pinned page filters should differ from query params
+        new Set(['projects', 'environments', 'datetime'])
       );
 
       pageFilterStorageMock.mockRestore();

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -50,6 +50,7 @@ describe('DatePageFilter', function () {
     );
     expect(PageFiltersStore.getState()).toEqual({
       isReady: true,
+      filtersInUrlDifferingFromPinned: new Set(),
       pinnedFilters: new Set(),
       selection: {
         datetime: {

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -28,6 +28,7 @@ describe('DatePageFilter', function () {
         utc: null,
       },
     },
+    new Set(),
     new Set()
   );
 

--- a/tests/js/spec/components/environmentPageFilter.spec.tsx
+++ b/tests/js/spec/components/environmentPageFilter.spec.tsx
@@ -35,6 +35,7 @@ describe('EnvironmentPageFilter', function () {
           environments: [],
           datetime: {start: null, end: null, period: '14d', utc: null},
         },
+        new Set(),
         new Set()
       );
     });

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -309,6 +309,7 @@ describe('GlobalSelectionHeader', function () {
     await tick();
 
     expect(PageFiltersStore.getState()).toEqual({
+      filtersInUrlDifferingFromPinned: new Set(),
       isReady: true,
       pinnedFilters: new Set(),
       selection: {
@@ -337,6 +338,7 @@ describe('GlobalSelectionHeader', function () {
     await tick();
 
     expect(PageFiltersStore.getState()).toEqual({
+      filtersInUrlDifferingFromPinned: new Set(),
       isReady: true,
       pinnedFilters: new Set(),
       selection: {
@@ -364,6 +366,7 @@ describe('GlobalSelectionHeader', function () {
     await tick();
 
     expect(PageFiltersStore.getState()).toEqual({
+      filtersInUrlDifferingFromPinned: new Set(),
       isReady: true,
       pinnedFilters: new Set(),
       selection: {
@@ -410,6 +413,7 @@ describe('GlobalSelectionHeader', function () {
     expect(globalActions.updateEnvironments).not.toHaveBeenCalled();
 
     expect(PageFiltersStore.getState()).toEqual({
+      filtersInUrlDifferingFromPinned: new Set(),
       isReady: true,
       pinnedFilters: new Set(),
       selection: {

--- a/tests/js/spec/components/projectPageFilter.spec.tsx
+++ b/tests/js/spec/components/projectPageFilter.spec.tsx
@@ -34,6 +34,7 @@ describe('ProjectPageFilter', function () {
           environments: [],
           datetime: {start: null, end: null, period: '14d', utc: null},
         },
+        new Set(),
         new Set()
       );
     });

--- a/tests/js/spec/stores/pageFiltersStore.spec.jsx
+++ b/tests/js/spec/stores/pageFiltersStore.spec.jsx
@@ -18,6 +18,7 @@ describe('PageFiltersStore', function () {
 
   it('getState()', function () {
     expect(PageFiltersStore.getState()).toEqual({
+      filtersInUrlDifferingFromPinned: new Set(),
       isReady: false,
       pinnedFilters: new Set(),
       selection: {
@@ -101,5 +102,35 @@ describe('PageFiltersStore', function () {
     pinFilter('projects', false);
     await tick();
     expect(PageFiltersStore.getState().pinnedFilters).toEqual(new Set(['environments']));
+  });
+
+  it('updates stored values which differ from query params', async function () {
+    expect(PageFiltersStore.getState().filtersInUrlDifferingFromPinned).toEqual(
+      new Set()
+    );
+    PageFiltersStore.onInitializeUrlState(
+      {},
+      new Set(['projects', 'environments', 'datetime']),
+      new Set(['projects', 'environments', 'datetime'])
+    );
+
+    // Updating environment should remove the difference between stored value and query param
+    updateEnvironments(['test']);
+    await tick();
+    expect(PageFiltersStore.getState().filtersInUrlDifferingFromPinned).toEqual(
+      new Set(['projects', 'datetime'])
+    );
+
+    updateProjects([1]);
+    await tick();
+    expect(PageFiltersStore.getState().filtersInUrlDifferingFromPinned).toEqual(
+      new Set(['datetime'])
+    );
+
+    updateDateTime({period: '14d'});
+    await tick();
+    expect(PageFiltersStore.getState().filtersInUrlDifferingFromPinned).toEqual(
+      new Set()
+    );
   });
 });


### PR DESCRIPTION
When navigating to a shared link and the query params we expose a set `filtersInUrlDifferingFromPinned` which contains the query params which do not match the local storage filters which are pinned. 

This will allow us to highlight changed page filters to alert the user as to why they were overridden by query params.