### PR TITLE
feat(notifications): use async_send_notification for join and integration requests

### DIFF
--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -9,6 +9,7 @@ from sentry.models import SentryApp
 from sentry.notifications.notifications.organization_request.integration_request import (
     IntegrationRequestNotification,
 )
+from sentry.notifications.utils.tasks import async_send_notification
 from sentry.plugins.base import plugins
 
 
@@ -63,8 +64,14 @@ class OrganizationIntegrationRequestEndpoint(OrganizationRequestChangeEndpoint):
         if not provider_name:
             return Response({"detail": f"Provider {provider_slug} not found"}, status=400)
 
-        IntegrationRequestNotification(
-            organization, requester, provider_type, provider_slug, provider_name, message_option
+        async_send_notification(
+            IntegrationRequestNotification,
+            organization,
+            requester,
+            provider_type,
+            provider_slug,
+            provider_name,
+            message_option,
         ).send()
 
         return Response(status=201)

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -72,6 +72,6 @@ class OrganizationIntegrationRequestEndpoint(OrganizationRequestChangeEndpoint):
             provider_slug,
             provider_name,
             message_option,
-        ).send()
+        )
 
         return Response(status=201)

--- a/src/sentry/api/endpoints/organization_join_request.py
+++ b/src/sentry/api/endpoints/organization_join_request.py
@@ -11,6 +11,7 @@ from sentry.api.validators import AllowedEmailField
 from sentry.app import ratelimiter
 from sentry.models import AuthProvider, InviteStatus, OrganizationMember
 from sentry.notifications.notifications.organization_request import JoinRequestNotification
+from sentry.notifications.utils.tasks import async_send_notification
 from sentry.signals import join_request_created
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -81,7 +82,7 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
         member = create_organization_join_request(organization, email, ip_address)
 
         if member:
-            JoinRequestNotification(member, request.user).send()
+            async_send_notification(JoinRequestNotification, member, request.user).send()
             # legacy analytics
             join_request_created.send_robust(sender=self, member=member)
 

--- a/src/sentry/api/endpoints/organization_join_request.py
+++ b/src/sentry/api/endpoints/organization_join_request.py
@@ -82,7 +82,7 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
         member = create_organization_join_request(organization, email, ip_address)
 
         if member:
-            async_send_notification(JoinRequestNotification, member, request.user).send()
+            async_send_notification(JoinRequestNotification, member, request.user)
             # legacy analytics
             join_request_created.send_robust(sender=self, member=member)
 

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Sequence
 
+from sentry.notifications.class_manager import register
 from sentry.notifications.notifications.organization_request import OrganizationRequestNotification
 from sentry.notifications.notifications.strategies.owner_recipient_strategy import (
     OwnerRecipientStrategy,
@@ -33,6 +34,7 @@ def get_url(organization: Organization, provider_type: str, provider_slug: str) 
     return url
 
 
+@register()
 class IntegrationRequestNotification(OrganizationRequestNotification):
     # TODO: switch to a strategy based on the integration write scope
     RoleBasedRecipientStrategyClass = OwnerRecipientStrategy

--- a/src/sentry/notifications/notifications/organization_request/join_request.py
+++ b/src/sentry/notifications/notifications/organization_request/join_request.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from sentry.notifications.class_manager import register
+
 from .abstract_invite_request import AbstractInviteRequestNotification
 
 if TYPE_CHECKING:
     from sentry.models import Team, User
 
 
+@register()
 class JoinRequestNotification(AbstractInviteRequestNotification):
     analytics_event = "join_request.sent"
     referrer_base = "join_request"


### PR DESCRIPTION
Making notifications happen async will be a better experience for users