### PR TITLE
wip: feat(dashboard-layout): Add analytics events for resizing on save

### DIFF
--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -44,7 +44,7 @@ export type DashboardsEventParameters = {
     widget_type: string;
   };
   'dashboards_views.widget.resize': {
-    displayType: DisplayType;
+    display_type: DisplayType;
     height: ResizeChange;
     width: ResizeChange;
   };

--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -1,3 +1,7 @@
+import {DisplayType} from 'sentry/views/dashboardsV2/types';
+
+export type ResizeChange = 'smaller' | 'unchanged' | 'larger';
+
 export type DashboardsEventParameters = {
   'dashboards_manage.change_sort': {
     sort: string;
@@ -39,6 +43,11 @@ export type DashboardsEventParameters = {
   'dashboards_views.query_selector.selected': {
     widget_type: string;
   };
+  'dashboards_views.widget.resize': {
+    displayType: DisplayType;
+    height: ResizeChange;
+    width: ResizeChange;
+  };
   'dashboards_views.widget_library.add': {
     num_widgets: number;
   };
@@ -69,6 +78,7 @@ export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
     'Dashboards2: Widget saved directly to Dashboard from Add Widget to Dashboard modal',
   'dashboards_views.edit_widget_modal.confirm':
     'Dashboards2: Edit Dashboard Widget modal form submitted',
+  'dashboards_views.widget.resize': 'Dashboards2: Widget Resized',
   'dashboards_views.widget_library.add': 'Dashboards2: Number of prebuilt widgets added',
   'dashboards_views.widget_library.add_widget':
     'Dashboards2: Title of prebuilt widget added',

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -35,6 +35,7 @@ import {
   assignDefaultLayout,
   calculateColumnDepths,
   getDashboardLayout,
+  trackDashboardResizes,
 } from './layoutUtils';
 import DashboardTitle from './title';
 import {
@@ -399,6 +400,11 @@ class DashboardDetail extends Component<Props, State> {
                 eventName: 'Dashboards2: Create complete',
                 organization_id: parseInt(organization.id, 10),
               });
+              trackDashboardResizes(
+                organization,
+                [], // New dashboards have no previous widgets
+                newDashboard.widgets
+              );
               this.setState({
                 dashboardState: DashboardState.VIEW,
               });
@@ -437,6 +443,11 @@ class DashboardDetail extends Component<Props, State> {
                 eventName: 'Dashboards2: Edit complete',
                 organization_id: parseInt(organization.id, 10),
               });
+              trackDashboardResizes(
+                organization,
+                dashboard.widgets,
+                newDashboard.widgets
+              );
               this.setState({
                 dashboardState: DashboardState.VIEW,
                 modifiedDashboard: null,

--- a/static/app/views/dashboardsV2/layoutUtils.tsx
+++ b/static/app/views/dashboardsV2/layoutUtils.tsx
@@ -291,7 +291,7 @@ export function trackDashboardResizes(
     if (heightOrWidthChanged) {
       trackAdvancedAnalyticsEvent('dashboards_views.widget.resize', {
         organization,
-        displayType: newSavedWidget.displayType,
+        display_type: newSavedWidget.displayType,
         height: heightChange,
         width: widthChange,
       });

--- a/tests/js/spec/views/dashboardsV2/gridLayout/layoutUtils.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/layoutUtils.spec.tsx
@@ -1,9 +1,15 @@
 import {Layout} from 'react-grid-layout';
 
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {
   calculateColumnDepths,
   getNextAvailablePosition,
+  getWidgetComparisonSizes,
+  trackDashboardResizes,
 } from 'sentry/views/dashboardsV2/layoutUtils';
+import {DisplayType} from 'sentry/views/dashboardsV2/types';
+
+jest.mock('sentry/utils/analytics/trackAdvancedAnalyticsEvent');
 
 describe('Dashboards > Utils', () => {
   describe('calculateColumnDepths', () => {
@@ -114,6 +120,183 @@ describe('Dashboards > Utils', () => {
       getNextAvailablePosition(columnDepths, 4);
 
       expect(columnDepths).toEqual([1, 1, 1, 1, 1, 1]);
+    });
+  });
+
+  describe('getWidgetComparisonSizes', () => {
+    // @ts-ignore
+    const testNewWidget = TestStubs.Widget(
+      [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+      {
+        id: '1',
+        title: 'Default Widget 1',
+        interval: '1d',
+        layout: {x: 0, y: 0, w: 3, h: 4},
+      }
+    );
+
+    it('returns the size of the new widget and the previous widget if one matches', () => {
+      // @ts-ignore
+      const testPrevWidget = TestStubs.Widget(
+        [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+        {
+          id: '1',
+          title: 'Default Widget 1',
+          interval: '1d',
+          layout: {x: 0, y: 0, w: 6, h: 6},
+        }
+      );
+
+      const {newSize, previousSize} = getWidgetComparisonSizes(testNewWidget, [
+        testPrevWidget,
+      ]);
+
+      expect(newSize).toEqual({w: 3, h: 4});
+      expect(previousSize).toEqual({w: 6, h: 6});
+    });
+
+    it.each`
+      displayType               | expectedHeight
+      ${DisplayType.BIG_NUMBER} | ${1}
+      ${DisplayType.AREA}       | ${2}
+    `(
+      'returns a previousSize using the display type of the new widget if there is no previous match',
+      ({displayType, expectedHeight}) => {
+        // @ts-ignore
+        const newBigNumberWidget = TestStubs.Widget(
+          [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+          {
+            id: '1',
+            title: 'Default Widget 1',
+            interval: '1d',
+            displayType,
+            layout: {x: 0, y: 0, w: 3, h: 4},
+          }
+        );
+        const {newSize, previousSize} = getWidgetComparisonSizes(newBigNumberWidget, []);
+
+        expect(newSize).toEqual({w: 3, h: 4});
+        expect(previousSize).toEqual({w: 2, h: expectedHeight});
+      }
+    );
+
+    it.each`
+      displayType               | expectedHeight
+      ${DisplayType.BIG_NUMBER} | ${1}
+      ${DisplayType.AREA}       | ${2}
+    `(
+      'returns the default size for a display type when there is a match but no previous layout',
+      ({displayType, expectedHeight}) => {
+        // @ts-ignore
+        const testPrevWidget = TestStubs.Widget(
+          [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+          {
+            id: '1',
+            title: 'Default Widget 1',
+            interval: '1d',
+            layout: null,
+            displayType,
+          }
+        );
+
+        const {newSize, previousSize} = getWidgetComparisonSizes(testNewWidget, [
+          testPrevWidget,
+        ]);
+
+        expect(newSize).toEqual({w: 3, h: 4});
+        expect(previousSize).toEqual({w: 2, h: expectedHeight});
+      }
+    );
+  });
+
+  describe('trackDashboardResize', () => {
+    let organization;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      organization = TestStubs.Organization();
+    });
+
+    it('does not send a tracking event if no resize occurred', () => {
+      // @ts-ignore
+      const previousWidget = TestStubs.Widget(
+        [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+        {
+          id: '1',
+          title: 'Default Widget 1',
+          interval: '1d',
+          layout: {x: 0, y: 0, w: 2, h: 2},
+          displayType: DisplayType.BIG_NUMBER,
+        }
+      );
+      trackDashboardResizes(organization, [previousWidget], [previousWidget]);
+      expect(trackAdvancedAnalyticsEvent).not.toHaveBeenCalled();
+    });
+
+    it('sends a tracking event if resize occurred', () => {
+      // @ts-ignore
+      const previousWidget = TestStubs.Widget(
+        [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+        {
+          id: '1',
+          title: 'Default Widget 1',
+          interval: '1d',
+          layout: {x: 0, y: 0, w: 2, h: 2},
+          displayType: DisplayType.BIG_NUMBER,
+        }
+      );
+      // @ts-ignore
+      const nextWidget = TestStubs.Widget(
+        [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+        {
+          id: '1',
+          title: 'Default Widget 1',
+          interval: '1d',
+          layout: {x: 0, y: 0, w: 4, h: 1},
+          displayType: DisplayType.BIG_NUMBER,
+        }
+      );
+      trackDashboardResizes(organization, [previousWidget], [nextWidget]);
+      expect(trackAdvancedAnalyticsEvent).toHaveBeenCalledWith(
+        'dashboards_views.widget.resize',
+        {
+          organization,
+          displayType: DisplayType.BIG_NUMBER,
+          height: 'smaller',
+          width: 'larger',
+        }
+      );
+    });
+
+    it('sends multiple tracking events with multiple widgets', () => {
+      // @ts-ignore
+      const previousWidget = TestStubs.Widget(
+        [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+        {
+          id: '1',
+          title: 'Default Widget 1',
+          interval: '1d',
+          layout: {x: 0, y: 0, w: 2, h: 2},
+          displayType: DisplayType.BIG_NUMBER,
+        }
+      );
+      // @ts-ignore
+      const nextWidget = TestStubs.Widget(
+        [{name: '', conditions: 'event.type:error', fields: ['count()']}],
+        {
+          id: '1',
+          title: 'Default Widget 1',
+          interval: '1d',
+          layout: {x: 0, y: 0, w: 4, h: 1},
+          displayType: DisplayType.BIG_NUMBER,
+        }
+      );
+      trackDashboardResizes(
+        organization,
+        [previousWidget],
+        [nextWidget, {...nextWidget, id: '2'}] // Override the id as if a new widget was added
+      );
+      expect(trackAdvancedAnalyticsEvent).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
Add an analytics event to track when a user has resized widgets after they save the dashboard.

Question: This will send a request for every widget that gets resized. Is there a way I can get around this?

There are a number of cases to handle when figuring out the sizes to compare:
1. It's a resized widget and the previous widget had a layout (happy path)
2. It's a resized widget and the previous widget did not have a layout (i.e. from a dashboard before grid layout)
3. It's a new widget so there is no previous widget

In 1. we can just return the previous `w` and `h` easily for comparison.

In 2. we need to calculate defaults. We know all default widths are currently set to 2 columns and since it was a previous widget, we can derive the height from its display type.

In 3. since there's no previous widget, we have to derive the height from the display type that's currently set. Again, the width to compare the new widget against is the default width.