### PR TITLE
feat(ci): monitor typescript perf

### DIFF
--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -105,7 +105,7 @@ jobs:
       - name: tsc
         if: steps.dependencies.outcome == 'success' && steps.changes.outputs.frontend == 'true'
         run: |
-          yarn tsc -p config/tsconfig.build.json
+          yarn tsc -p config/tsconfig.build.json | tee /tmp/typescript-monitor-log
 
       - name: storybook
         if: github.ref != 'refs/heads/master' && steps.changes.outputs.frontend == 'true'

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -105,7 +105,7 @@ jobs:
       - name: tsc
         if: steps.dependencies.outcome == 'success' && steps.changes.outputs.frontend == 'true'
         run: |
-          yarn tsc -p config/tsconfig.build.json | tee /tmp/typescript-monitor-log
+          yarn tsc -p config/tsconfig.build.json | tee /tmp/typescript-monitor-log && node .github/workflows/scripts/monitor-typescript.js
 
       - name: storybook
         if: github.ref != 'refs/heads/master' && steps.changes.outputs.frontend == 'true'

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -105,7 +105,7 @@ jobs:
       - name: tsc
         if: steps.dependencies.outcome == 'success' && steps.changes.outputs.frontend == 'true'
         run: |
-          yarn tsc -p config/tsconfig.build.json | tee /tmp/typescript-monitor-log && node .github/workflows/scripts/monitor-typescript.js
+          yarn tsc -p config/tsconfig.build.json --diagnostics | tee /tmp/typescript-monitor.log && node .github/workflows/scripts/monitor-typescript.js
 
       - name: storybook
         if: github.ref != 'refs/heads/master' && steps.changes.outputs.frontend == 'true'

--- a/.github/workflows/scripts/monitor-typescript.js
+++ b/.github/workflows/scripts/monitor-typescript.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  // jest project under Sentry organization (dev productivity team)
   dsn: 'https://3fe1dce93e3a4267979ebad67f3de327@sentry.io/4857230',
   tracesSampleRate: 1.0,
   environment: 'ci',

--- a/.github/workflows/scripts/monitor-typescript.js
+++ b/.github/workflows/scripts/monitor-typescript.js
@@ -1,0 +1,115 @@
+/* eslint-env node */
+
+// eslint-disable-next-line
+const fs = require('fs');
+// eslint-disable-next-line
+const crypto = require('crypto');
+
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: '',
+  tracesSampleRate: 1.0,
+});
+
+if (!fs.existsSync('/tmp/typescript-monitor.log')) {
+  // We failed to retrieve the log file, but we dont want to impact the pipeline so just exit.
+  // The absence of metrics in sentry should warn us here
+  process.exit(0);
+}
+
+const ALLOWED_KEYS = new Set([
+  'Files',
+  'Lines',
+  'Nodes',
+  'Identifiers',
+  'Symbols',
+  'Types',
+  'Instantiations',
+  'Memory used',
+  'I/O Read',
+  'I/O Write',
+  'Parse time',
+  'Bind time',
+  'Check time',
+  'Emit time',
+  'Total time',
+]);
+
+const tsLogFile = fs.readFileSync('/tmp/typescript-monitor.log', 'utf8');
+
+function toKeyValue(input) {
+  try {
+    return input
+      .split('\n')
+      .filter(n => !!n)
+      .reduce((acc, line) => {
+        const [k, v] = line.split(':');
+
+        if (typeof k !== 'string' || typeof v !== 'string') {
+          return acc;
+        }
+
+        const key = k.trim();
+        const value = v.trim();
+
+        if (ALLOWED_KEYS.has(key)) {
+          let number = parseFloat(value);
+          let unit = undefined;
+
+          if (!isNaN(number)) {
+            acc[key] = {value: number, unit};
+          }
+
+          if (/([a-zA-Z]$)/.test(value)) {
+            number = parseFloat(v.substring(0, v.length - 2));
+            unit = v.match(/([a-zA-Z]$)/)?.[0];
+            acc[key] = {value: number, unit};
+          }
+        }
+
+        return acc;
+      }, {});
+  } catch (e) {
+    return null;
+  }
+}
+
+const parsedDiagnostics = toKeyValue(tsLogFile);
+
+if (parsedDiagnostics === null) {
+  // We failed to parse here, but we dont want to impact the pipeline so just exit.
+  // The absence of metrics in sentry should warn us here
+  process.exit(0);
+}
+
+const bindTime = parsedDiagnostics['Bind time'];
+const checkTime = parsedDiagnostics['Check time'];
+const parseTime = parsedDiagnostics['Parse time'];
+const totalTime = parsedDiagnostics['Total time'];
+const memoryUsage = parsedDiagnostics['Memory used'];
+
+const now = new Date().getTime() / 1000;
+
+const totalTimeTransaction = {
+  event_id: crypto.randomBytes(16).toString('hex'),
+  environment: 'local',
+  timestamp: now,
+  start_timestamp: now - totalTime.value * 1000,
+  measurements: {
+    'time.check': {value: checkTime.value},
+    'time.bind': {value: bindTime.value},
+    'time.parse': {value: parseTime.value},
+    'time.total': {value: totalTime.value},
+    memory: {value: memoryUsage.value},
+  },
+  name: 'typescript.compilation',
+  transaction: 'typescript.compilation',
+  type: 'transaction',
+};
+
+Sentry.captureEvent(totalTimeTransaction);
+
+(async () => {
+  await Sentry.flush(5000);
+})();

--- a/.github/workflows/scripts/monitor-typescript.js
+++ b/.github/workflows/scripts/monitor-typescript.js
@@ -10,6 +10,7 @@ const Sentry = require('@sentry/node');
 Sentry.init({
   dsn: '',
   tracesSampleRate: 1.0,
+  debug: true,
 });
 
 if (!fs.existsSync('/tmp/typescript-monitor.log')) {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -201,6 +201,7 @@ const config: Config.InitialOptions = {
   testEnvironmentOptions: {
     sentryConfig: {
       init: {
+        // jest project under Sentry organization (dev productivity team)
         dsn: 'https://3fe1dce93e3a4267979ebad67f3de327@sentry.io/4857230',
         environment: !!CI ? 'ci' : 'local',
         tracesSampleRate: 1.0,


### PR DESCRIPTION
~~Cant get the transaction to work and show up in Sentry correctly + there is not support for custom measurements yet. We can start by monitoring just the entire duration (timestamp - startTimestamp) and progressively add the measurements. Will need some help from SDK or someone from performance team to figure out why it's not being ingested.~~

asked for --diagnostic clarification in https://github.com/microsoft/TypeScript-wiki/issues/293