### PR TITLE
ref(dam): Make getWidgetInterval reusable

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -4,11 +4,7 @@ import isEqual from 'lodash/isEqual';
 
 import {doEventsRequest} from 'sentry/actionCreators/events';
 import {Client} from 'sentry/api';
-import {
-  getDiffInMinutes,
-  getInterval,
-  isMultiSeriesStats,
-} from 'sentry/components/charts/utils';
+import {isMultiSeriesStats} from 'sentry/components/charts/utils';
 import {isSelectionEqual} from 'sentry/components/organizations/pageFilters/utils';
 import {t} from 'sentry/locale';
 import {
@@ -18,7 +14,6 @@ import {
   PageFilters,
 } from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
-import {parsePeriodToHours} from 'sentry/utils/dates';
 import {TableData, TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {getAggregateFields} from 'sentry/utils/discover/fields';
 import {
@@ -28,37 +23,9 @@ import {
 import {TOP_N} from 'sentry/utils/discover/types';
 
 import {DisplayType, Widget, WidgetQuery} from '../types';
-import {eventViewFromWidget} from '../utils';
+import {eventViewFromWidget, getWidgetInterval} from '../utils';
 
-// Don't fetch more than 66 bins as we're plotting on a small area.
-const MAX_BIN_COUNT = 66;
 const DEFAULT_ITEM_LIMIT = 5;
-
-function getWidgetInterval(
-  widget: Widget,
-  datetimeObj: Partial<PageFilters['datetime']>
-): string {
-  // Bars charts are daily totals to aligned with discover. It also makes them
-  // usefully different from line/area charts until we expose the interval control, or remove it.
-  let interval = widget.displayType === 'bar' ? '1d' : widget.interval;
-  if (!interval) {
-    // Default to 5 minutes
-    interval = '5m';
-  }
-  const desiredPeriod = parsePeriodToHours(interval);
-  const selectedRange = getDiffInMinutes(datetimeObj);
-
-  // selectedRange is in minutes, desiredPeriod is in hours
-  // convert desiredPeriod to minutes
-  if (selectedRange / (desiredPeriod * 60) > MAX_BIN_COUNT) {
-    const highInterval = getInterval(datetimeObj, 'high');
-    // Only return high fidelity interval if desired interval is higher fidelity
-    if (desiredPeriod < parsePeriodToHours(highInterval)) {
-      return highInterval;
-    }
-  }
-  return interval;
-}
 
 type RawResult = EventsStats | MultiSeriesEventsStats;
 


### PR DESCRIPTION
We'll be needing the same function for the metrics widget so just exporting the existing one so that it can be reused.