### PR TITLE
feat(aws): Add missing regions to AWS integration

### DIFF
--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -33,21 +33,27 @@ OPTION_LAYER_NAME = "layer-name"
 OPTION_ACCOUNT_NUMBER = "account-number"
 
 ALL_AWS_REGIONS = [
+    "af-south-1",
+    "ap-east-1",
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-northeast-3",
+    "ap-south-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ca-central-1",
+    "eu-central-1",
+    "eu-north-1",
+    "eu-south-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "me-south-1",
+    "sa-east-1",
     "us-east-1",
     "us-east-2",
     "us-west-1",
     "us-west-2",
-    "ap-south-1",
-    "ap-southeast-1",
-    "ap-southeast-2",
-    "ap-northeast-1",
-    "ap-northeast-2",
-    "ca-central-1",
-    "eu-central-1",
-    "eu-west-1",
-    "eu-west-2",
-    "eu-west-3",
-    "sa-east-1",
 ]
 
 


### PR DESCRIPTION
We publish layers to more regions than hardcoded here. This adds all the missing ones.
Fixes https://getsentry.atlassian.net/browse/ISSUE-1399

![image](https://user-images.githubusercontent.com/6536764/153605180-bfc7b447-bbb5-414f-a902-19a1fcc7f23c.png)
