### PR TITLE
feat(projects): Add crash free user rate card to project details

### DIFF
--- a/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
@@ -31,7 +31,7 @@ function ProjectScoreCards({
         selection={selection}
         isProjectStabilized={isProjectStabilized}
         hasSessions={hasSessions}
-        field="sum(session)"
+        field={SessionField.SESSIONS}
         query={query}
       />
 
@@ -40,7 +40,7 @@ function ProjectScoreCards({
         selection={selection}
         isProjectStabilized={isProjectStabilized}
         hasSessions={hasSessions}
-        field="count_unique(user)"
+        field={SessionField.USERS}
         query={query}
         field={SessionField.SESSIONS}
       />

--- a/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
@@ -31,6 +31,16 @@ function ProjectScoreCards({
         selection={selection}
         isProjectStabilized={isProjectStabilized}
         hasSessions={hasSessions}
+        field="sum(session)"
+        query={query}
+      />
+
+      <ProjectStabilityScoreCard
+        organization={organization}
+        selection={selection}
+        isProjectStabilized={isProjectStabilized}
+        hasSessions={hasSessions}
+        field="count_unique(user)"
         query={query}
         field={SessionField.SESSIONS}
       />

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -49,7 +49,7 @@ class ProjectStabilityScoreCard extends AsyncComponent<Props, State> {
   }
 
   getEndpoints() {
-    const {organization, selection, isProjectStabilized, hasSessions, query, field} =
+    const {organization, selection, isProjectStabilized, hasSessions, field, query, field} =
       this.props;
 
     if (!isProjectStabilized || !hasSessions) {
@@ -61,10 +61,10 @@ class ProjectStabilityScoreCard extends AsyncComponent<Props, State> {
     const commonQuery = {
       environment,
       project: projects[0],
+      field: field || 'sum(session)',
       groupBy: 'session.status',
       interval: getDiffInMinutes(datetime) > 24 * 60 ? '1d' : '1h',
       query,
-      field,
     };
 
     // Unfortunately we can't do something like statsPeriod=28d&interval=14d to get scores for this and previous interval with the single request


### PR DESCRIPTION
This adds a new card to the project details page with crash free user percentage.

Before:
![Screen Shot 2022-02-11 at 9 31 47 AM](https://user-images.githubusercontent.com/15015880/153640201-599b0c27-5aea-4c53-a573-15575a83efd9.png)


After:
![Screen Shot 2022-02-11 at 9 40 22 AM](https://user-images.githubusercontent.com/15015880/153641436-e46b588b-852e-4320-82dd-1c781f4a958b.png)




Jira: [WOR-1052](https://getsentry.atlassian.net/browse/WOR-1052)