### PR TITLE
fix(ui): Use 14px font size in Add Widget modal

### DIFF
--- a/static/app/components/forms/selectControl.tsx
+++ b/static/app/components/forms/selectControl.tsx
@@ -138,7 +138,6 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
   const defaultStyles: StylesConfig = {
     control: (_, state: any) => ({
       height: '100%',
-      fontSize: theme.fontSizeLarge,
       lineHeight: theme.text.lineHeightBody,
       display: 'flex',
       // @ts-ignore Ignore merge errors as only defining the property once

--- a/static/app/components/globalModal/components.tsx
+++ b/static/app/components/globalModal/components.tsx
@@ -48,7 +48,7 @@ const CloseButton = styled(
 `;
 
 const ModalBody = styled('section')`
-  font-size: 15px;
+  font-size: ${p => p.theme.fontSizeMedium};
 
   p:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
Right now, the Add Widget modal has a weird mix of inputs with text at `14px` (the tab bar), `15px` (text fields) and `16px` (select fields). That's because:
 * The tab bar font size has been set to `14px`, which is correct
 * Modal bodies have a hardcoded container font size of `15px`, which is out of spec. Text fields inherit font sizes from their containers, so in this case they too have a font size of `15px`.
 * Select fields have control buttons set at `16px` (this is declared in `selectControl.tsx`).

We should correct the modal body font size to `14px`. Select fields should have `14px` controls. However, since we haven't fully updated the general UI to use a 14px base font size, the solution with the least impact on the existing UI is to just let select controls inherit the font size from their parents. In this case, that inherited size is `14px`, from the modal body.

**Before:**
<img width="701" alt="Screen Shot 2022-02-11 at 11 15 07 AM" src="https://user-images.githubusercontent.com/44172267/153655121-2dc3a042-ccb2-4061-a259-19cbec6be5e0.png">

**After:**
<img width="701" alt="Screen Shot 2022-02-11 at 11 15 24 AM" src="https://user-images.githubusercontent.com/44172267/153655156-fdc48db0-22f0-4396-a146-832f6b70ddfd.png">

