### PR TITLE
ref(sdk): Set _reportAllChanges to false

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -33,7 +33,7 @@ function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
         : {}),
       idleTimeout: 5000,
       _metricOptions: {
-        _reportAllChanges: true,
+        _reportAllChanges: false,
       },
     }),
   ];


### PR DESCRIPTION
To see the impact from 6.17.8-beta.0 on our LCP values, we want to stop
reporting intermediate LCP values.