### PR TITLE
chore(auth): Enable automatic IdP migration for all users

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -549,16 +549,15 @@ class AuthIdentityHandler:
         if self._logged_in_user:
             return self._logged_in_user, "auth-confirm-link"
 
-        if features.has("organizations:idp-automatic-migration", self.organization):
-            if self._app_user and not self._has_usable_password():
-                send_one_time_account_confirm_link(
-                    self._app_user,
-                    self.organization,
-                    self.auth_provider,
-                    self.identity["email"],
-                    self.identity["id"],
-                )
-                return self.user, "auth-confirm-account"
+        if self._app_user and not self._has_usable_password():
+            send_one_time_account_confirm_link(
+                self._app_user,
+                self.organization,
+                self.auth_provider,
+                self.identity["email"],
+                self.identity["id"],
+            )
+            return self.user, "auth-confirm-account"
 
         self.request.session.set_test_cookie()
         return None if is_new_account else self.user, "auth-confirm-identity"

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1012,8 +1012,6 @@ SENTRY_FEATURES = {
     "organizations:metric-alert-builder-aggregate": False,
     # Enable threshold period in metric alert rule builder
     "organizations:metric-alert-threshold-period": False,
-    # Enable migrating auth identities between providers automatically
-    "organizations:idp-automatic-migration": False,
     # Enable integration functionality to create and link groups to issues on
     # external services.
     "organizations:integrations-issue-basic": True,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -87,7 +87,6 @@ default_manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature,
 default_manager.add("organizations:grouping-title-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-tree-ui", OrganizationFeature, True)
 default_manager.add("organizations:higher-ownership-limit", OrganizationFeature)
-default_manager.add("organizations:idp-automatic-migration", OrganizationFeature, True)
 default_manager.add("organizations:images-loaded-v2", OrganizationFeature)
 default_manager.add("organizations:improved-search", OrganizationFeature, True)
 default_manager.add("organizations:incidents", OrganizationFeature)

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -331,8 +331,7 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
         existing_user = self.create_user(email=self.email)
         existing_user.update(password="")
 
-        with self.feature("organizations:idp-automatic-migration"):
-            context = self._test_simple(mock_render, "sentry/auth-confirm-account.html")
+        context = self._test_simple(mock_render, "sentry/auth-confirm-account.html")
         mock_create_key.assert_called_with(
             existing_user, self.organization, self.auth_provider, self.email, "1234"
         )
@@ -343,8 +342,7 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
     @mock.patch("sentry.auth.helper.send_one_time_account_confirm_link")
     def test_does_not_migrate_user_with_password(self, mock_create_key, mock_render):
         existing_user = self.create_user(email=self.email)
-        with self.feature("organizations:idp-automatic-migration"):
-            context = self._test_simple(mock_render, "sentry/auth-confirm-identity.html")
+        context = self._test_simple(mock_render, "sentry/auth-confirm-identity.html")
         assert not mock_create_key.called
         assert context["existing_user"] == existing_user
         assert "login_form" in context

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -636,9 +636,9 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         path = reverse("sentry-auth-sso")
 
         resp = self.client.post(path, {"email": "bar@example.com"})
-        self.assertTemplateUsed(resp, "sentry/auth-confirm-identity.html")
+        self.assertTemplateUsed(resp, "sentry/auth-confirm-account.html")
         assert resp.status_code == 200
-        assert resp.context["existing_user"] is None
+        assert resp.context["existing_user"] == user
 
     def test_flow_managed_duplicate_users_without_membership(self):
         """
@@ -1010,7 +1010,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         assert resp.redirect_chain == [("/auth/2fa/", 302)]
 
-    @with_feature("organizations:idp-automatic-migration")
     def test_anonymous_user_with_automatic_migration(self):
         AuthProvider.objects.create(organization=self.organization, provider="dummy")
         resp = self.client.post(self.path, {"init": True})
@@ -1049,7 +1048,6 @@ class OrganizationAuthLoginNoPasswordTest(AuthProviderTestCase):
         self.auth_sso_path = reverse("sentry-auth-sso")
         UserEmail.objects.filter(user=self.user, email="bar@example.com").update(is_verified=False)
 
-    @with_feature("organizations:idp-automatic-migration")
     @mock.patch("sentry.auth.idpmigration.MessageBuilder")
     def test_flow_verify_and_link_without_password_sends_email(self, email):
         assert not self.user.has_usable_password()
@@ -1087,7 +1085,6 @@ class OrganizationAuthLoginNoPasswordTest(AuthProviderTestCase):
         auth_identity = AuthIdentity.objects.get(auth_provider=self.auth_provider)
         assert self.user == auth_identity.user
 
-    @with_feature("organizations:idp-automatic-migration")
     @mock.patch("sentry.auth.idpmigration.MessageBuilder")
     def test_flow_verify_without_org_membership(self, email):
         assert not self.user.has_usable_password()
@@ -1129,7 +1126,6 @@ class OrganizationAuthLoginNoPasswordTest(AuthProviderTestCase):
             organization=self.organization, user=self.user
         ).exists()
 
-    @with_feature("organizations:idp-automatic-migration")
     @mock.patch("sentry.auth.idpmigration.MessageBuilder")
     def test_flow_verify_and_link_without_password_login_success(self, email):
         assert not self.user.has_usable_password()
@@ -1172,7 +1168,6 @@ class OrganizationAuthLoginNoPasswordTest(AuthProviderTestCase):
         assert not getattr(member.flags, "sso:invalid")
         assert not getattr(member.flags, "member-limit:restricted")
 
-    @with_feature("organizations:idp-automatic-migration")
     @mock.patch("sentry.auth.idpmigration.MessageBuilder")
     def test_flow_verify_and_link_without_password_need_2fa(self, email):
         assert not self.user.has_usable_password()


### PR DESCRIPTION
Remove the `"organizations:idp-automatic-migration"` feature flag.

Change `test_flow_authenticated_without_verified_without_password` assertions to match flow that previously required the feature flag.