### PR TITLE
feat(dashboard): Add duplicate widget button in dashboard edit mode

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -309,7 +309,9 @@ class Dashboard extends Component<Props, State> {
   handleDuplicateWidget = (widget: Widget, index: number) => () => {
     const {dashboard, onUpdate, isEditing, handleUpdateWidgetList} = this.props;
 
-    const widgetCopy = cloneDeep(assignTempId({...widget, id: undefined}));
+    const widgetCopy = cloneDeep(
+      assignTempId({...widget, id: undefined, tempId: undefined})
+    );
 
     let nextList = [...dashboard.widgets];
     nextList.splice(index, 0, widgetCopy);

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -31,6 +31,7 @@ import {DataSet} from './widgetBuilder/utils';
 import AddWidget, {ADD_WIDGET_BUTTON_DRAG_ID} from './addWidget';
 import {
   assignDefaultLayout,
+  assignTempId,
   calculateColumnDepths,
   constructGridItemKey,
   DEFAULT_WIDGET_WIDTH,
@@ -306,16 +307,15 @@ class Dashboard extends Component<Props, State> {
   };
 
   handleDuplicateWidget = (widget: Widget, index: number) => () => {
-    const {dashboard, isEditing, handleUpdateWidgetList} = this.props;
+    const {dashboard, onUpdate, isEditing, handleUpdateWidgetList} = this.props;
 
-    const widgetCopy = cloneDeep(widget);
-    widgetCopy.id = undefined;
-    widgetCopy.tempId = undefined;
+    const widgetCopy = cloneDeep(assignTempId({...widget, id: undefined}));
 
     let nextList = [...dashboard.widgets];
     nextList.splice(index, 0, widgetCopy);
     nextList = generateWidgetsAfterCompaction(nextList);
 
+    onUpdate(nextList);
     if (!!!isEditing) {
       handleUpdateWidgetList(nextList);
     }

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -84,7 +84,7 @@ class WidgetCard extends React.Component<Props> {
           <IconClick data-test-id="widget-edit" onClick={onEdit}>
             <IconEdit color="textColor" />
           </IconClick>
-          <IconClick data-test-id="widget-duplicate" onClick={onDuplicate}>
+          <IconClick aria-label={t('Duplicate Widget')} onClick={onDuplicate}>
             <IconCopy color="textColor" />
           </IconClick>
           <IconClick data-test-id="widget-delete" onClick={onDelete}>

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -11,7 +11,7 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import {Panel} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import Tooltip from 'sentry/components/tooltip';
-import {IconDelete, IconEdit, IconGrabbable} from 'sentry/icons';
+import {IconCopy, IconDelete, IconEdit, IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
@@ -54,8 +54,15 @@ type Props = WithRouterProps & {
 
 class WidgetCard extends React.Component<Props> {
   renderToolbar() {
-    const {onEdit, onDelete, draggableProps, hideToolbar, isEditing, isMobile} =
-      this.props;
+    const {
+      onEdit,
+      onDelete,
+      onDuplicate,
+      draggableProps,
+      hideToolbar,
+      isEditing,
+      isMobile,
+    } = this.props;
 
     if (!isEditing) {
       return null;
@@ -76,6 +83,9 @@ class WidgetCard extends React.Component<Props> {
           )}
           <IconClick data-test-id="widget-edit" onClick={onEdit}>
             <IconEdit color="textColor" />
+          </IconClick>
+          <IconClick data-test-id="widget-duplicate" onClick={onDuplicate}>
+            <IconCopy color="textColor" />
           </IconClick>
           <IconClick data-test-id="widget-delete" onClick={onDelete}>
             <IconDelete color="textColor" />

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -225,12 +225,12 @@ describe('Dashboards > Dashboard', () => {
 
   describe('Edit mode', () => {
     const widgets = [newWidget];
-    const mount = (dashboard, mockedOrg = initialData.organization) => {
+    const mount = dashboard => {
       const getDashboardComponent = () => (
         <Dashboard
           paramDashboardId="1"
           dashboard={dashboard}
-          organization={mockedOrg}
+          organization={initialData.organization}
           isEditing
           onUpdate={newWidgets => {
             widgets.splice(0, widgets.length, ...newWidgets);
@@ -249,13 +249,13 @@ describe('Dashboards > Dashboard', () => {
 
     it('displays the copy widget button in edit mode', () => {
       const dashboardWithOneWidget = {...mockDashboard, widgets};
-      mount(dashboardWithOneWidget, organization);
+      mount(dashboardWithOneWidget);
       expect(screen.getByLabelText('Duplicate Widget')).toBeInTheDocument();
     });
 
     it('duplicates the widget', async () => {
       const dashboardWithOneWidget = {...mockDashboard, widgets};
-      const {rerender} = mount(dashboardWithOneWidget, organization);
+      const {rerender} = mount(dashboardWithOneWidget);
       userEvent.click(screen.getByLabelText('Duplicate Widget'));
       rerender();
       expect(screen.getAllByText('Test Discover Widget')).toHaveLength(2);

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -250,13 +250,13 @@ describe('Dashboards > Dashboard', () => {
     it('displays the copy widget button in edit mode', () => {
       const dashboardWithOneWidget = {...mockDashboard, widgets};
       mount(dashboardWithOneWidget, organization);
-      expect(screen.getByTestId('widget-duplicate')).toBeInTheDocument();
+      expect(screen.getByLabelText('Duplicate Widget')).toBeInTheDocument();
     });
 
     it('duplicates the widget', async () => {
       const dashboardWithOneWidget = {...mockDashboard, widgets};
       const {rerender} = mount(dashboardWithOneWidget, organization);
-      userEvent.click(screen.getByTestId('widget-duplicate'));
+      userEvent.click(screen.getByLabelText('Duplicate Widget'));
       rerender();
       expect(screen.getAllByText('Test Discover Widget')).toHaveLength(2);
     });

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -4,7 +4,6 @@ import {
   mountWithTheme as rtlMountWithTheme,
   screen,
   userEvent,
-  waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
 import MemberListStore from 'sentry/stores/memberListStore';
@@ -259,9 +258,7 @@ describe('Dashboards > Dashboard', () => {
       const {rerender} = mount(dashboardWithOneWidget, organization);
       userEvent.click(screen.getByTestId('widget-duplicate'));
       rerender();
-      await waitFor(() => {
-        expect(screen.getAllByText('Test Discover Widget')).toHaveLength(2);
-      });
+      expect(screen.getAllByText('Test Discover Widget')).toHaveLength(2);
     });
   });
 });

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -224,7 +224,7 @@ describe('Dashboards > Dashboard', () => {
   });
 
   describe('Edit mode', () => {
-    const widgets = [newWidget];
+    let widgets: Widget[];
     const mount = dashboard => {
       const getDashboardComponent = () => (
         <Dashboard
@@ -246,6 +246,10 @@ describe('Dashboards > Dashboard', () => {
       const {rerender} = rtlMountWithTheme(getDashboardComponent());
       return {rerender: () => rerender(getDashboardComponent())};
     };
+
+    beforeEach(() => {
+      widgets = [newWidget];
+    });
 
     it('displays the copy widget button in edit mode', () => {
       const dashboardWithOneWidget = {...mockDashboard, widgets};


### PR DESCRIPTION
Adds a duplicate widget button to Dashboard Widgets in Edit mode
![image](https://user-images.githubusercontent.com/83961295/153673629-9782617e-154f-4e24-a4c8-32e12881f1c7.png)
