### PR TITLE
fix(page-filters): Project page filter now responds to store changes

### DIFF
--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -1,6 +1,7 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
+import isEqual from 'lodash/isEqual';
 import partition from 'lodash/partition';
 
 import {updateProjects} from 'sentry/actionCreators/pageFilters';
@@ -69,6 +70,12 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const organization = useOrganization();
   const {selection, pinnedFilters, isReady} = useLegacyStore(PageFiltersStore);
+
+  useEffect(() => {
+    if (!isEqual(selection.projects, currentSelectedProjects)) {
+      setCurrentSelectedProjects(selection.projects);
+    }
+  }, [selection.projects]);
 
   const handleChangeProjects = (newProjects: number[]) => {
     setCurrentSelectedProjects(newProjects);

--- a/tests/js/spec/components/projectPageFilter.spec.tsx
+++ b/tests/js/spec/components/projectPageFilter.spec.tsx
@@ -137,4 +137,26 @@ describe('ProjectPageFilter', function () {
       })
     );
   });
+
+  it('will change projects when page filter selection changes, e.g. from back button nav', async function () {
+    mountWithTheme(
+      <OrganizationContext.Provider value={organization}>
+        <ProjectPageFilter />
+      </OrganizationContext.Provider>,
+      {
+        context: routerContext,
+      }
+    );
+
+    // Confirm initial selection
+    expect(screen.getByText('My Projects')).toBeInTheDocument();
+
+    // Edit page filter project selection
+    act(() => {
+      PageFiltersStore.updateProjects([2], []);
+    });
+
+    // Page filter selection change should affect project page filter
+    expect(await screen.findByText('project-2')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Previously the project page filter didn't properly react to page filter store changes. This is most clearly seen when the page filter store would change on navigation and the project page filter would not change its selected project.

Before:
![Kapture 2022-02-13 at 17 04 35](https://user-images.githubusercontent.com/9372512/153784033-ee543912-46cf-4360-8c5c-a691c931c738.gif)

After:
![Kapture 2022-02-13 at 17 07 35](https://user-images.githubusercontent.com/9372512/153784172-30ce6f36-f94e-4206-b586-c394298c5d6e.gif)

