### PR TITLE
feat(ui): Add empty state for "For Review" tab

### DIFF
--- a/static/app/views/issueList/noGroupsHandler/index.tsx
+++ b/static/app/views/issueList/noGroupsHandler/index.tsx
@@ -7,6 +7,7 @@ import Placeholder from 'sentry/components/placeholder';
 import {DEFAULT_QUERY} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
+import {Query} from 'sentry/views/issueList/utils';
 
 import NoUnresolvedIssues from './noUnresolvedIssues';
 
@@ -150,7 +151,23 @@ class NoGroupsHandler extends React.Component<Props, State> {
       return this.renderAwaitingEvents(firstEventProjects);
     }
     if (query === DEFAULT_QUERY) {
-      return <NoUnresolvedIssues />;
+      return (
+        <NoUnresolvedIssues
+          title={t("We couldn't find any issues that matched your filters.")}
+          subtitle={t('Get out there and write some broken code!')}
+        />
+      );
+    }
+
+    if (query === Query.FOR_REVIEW) {
+      return (
+        <NoUnresolvedIssues
+          title={t('Well, would you look at that.')}
+          subtitle={t(
+            'No more issues to review. Better get back out there and write some broken code.'
+          )}
+        />
+      );
     }
 
     return this.renderEmpty();

--- a/static/app/views/issueList/noGroupsHandler/noUnresolvedIssues.tsx
+++ b/static/app/views/issueList/noGroupsHandler/noUnresolvedIssues.tsx
@@ -13,12 +13,16 @@ const Placeholder = () => (
   />
 );
 
-const Message = () => (
+const Message = ({
+  title,
+  subtitle,
+}: {
+  subtitle: React.ReactNode;
+  title: React.ReactNode;
+}) => (
   <React.Fragment>
-    <EmptyMessage>
-      {t("We couldn't find any issues that matched your filters.")}
-    </EmptyMessage>
-    <p>{t('Get out there and write some broken code!')}</p>
+    <EmptyMessage>{title}</EmptyMessage>
+    <p>{subtitle}</p>
   </React.Fragment>
 );
 
@@ -53,14 +57,20 @@ class ErrorBoundary extends React.Component<{children: React.ReactNode}, State> 
   }
 }
 
-const NoUnresolvedIssues = () => (
+const NoUnresolvedIssues = ({
+  title,
+  subtitle,
+}: {
+  subtitle: React.ReactNode;
+  title: React.ReactNode;
+}) => (
   <Wrapper>
     <ErrorBoundary>
       <React.Suspense fallback={<Placeholder />}>
         <CongratsRobotsVideo />
       </React.Suspense>
     </ErrorBoundary>
-    <Message />
+    <Message title={title} subtitle={subtitle} />
   </Wrapper>
 );
 


### PR DESCRIPTION
This adds an empty state to "For Review" tab when there are no events to take action on, this only shows up when there are other events, if the first event isn't sent we still show the robot with the link to set up events.

Before:
![Screen Shot 2022-02-14 at 7 37 05 AM](https://user-images.githubusercontent.com/15015880/153895349-4f282fd0-54f6-437c-ae79-ee0bfabdc482.png)

After:
![Screen Shot 2022-02-14 at 7 36 21 AM](https://user-images.githubusercontent.com/15015880/153895381-ee9f055e-be94-4553-a639-59c79dffbc2f.png)

[WOR-345](https://getsentry.atlassian.net/browse/WOR-345)

