### PR TITLE
feat(ratelimits): Turn on rate limit enforcement

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1363,7 +1363,7 @@ SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE_OPTIONS = {}
 
 # Rate limiting backend
 SENTRY_RATELIMITER = "sentry.ratelimits.base.RateLimiter"
-SENTRY_RATELIMITER_ENABLED = False
+SENTRY_RATELIMITER_ENABLED = True
 SENTRY_RATELIMITER_OPTIONS = {}
 # These values were determined from analysis on one week of api access logs
 SENTRY_RATELIMITER_DEFAULT_IP = 620


### PR DESCRIPTION
After this commit deploys, users will be limited to 620 requests a second per endpoint by default.