### PR TITLE
fix(perf): Transaction is missing in perfForSentry

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -53,6 +53,9 @@ export const VisuallyCompleteWithData = ({
   useEffect(() => {
     try {
       const transaction: any = getCurrentSentryReactTransaction(); // Using any to override types for private api.
+      if (!transaction) {
+        return;
+      }
 
       if (!isVisuallyCompleteSet.current) {
         const time = performance.now();


### PR DESCRIPTION
### Summary
The transaction is sometimes missing when 'useEffect' gets called, add a guard and return to stop issues later on in the function.

Refs JAVASCRIPT-26NY
Refs JAVASCRIPT-26P0