### PR TITLE
feat(email): Select weekly email template based on feature flag

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -161,6 +161,7 @@ default_manager.add("organizations:transaction-metrics-extraction", Organization
 default_manager.add("organizations:unhandled-issue-flag", OrganizationFeature)
 default_manager.add("organizations:unified-span-view", OrganizationFeature, True)
 default_manager.add("organizations:weekly-report-debugging", OrganizationFeature, True)
+default_manager.add("organizations:new-weekly-report", OrganizationFeature, True)
 default_manager.add("organizations:widget-library", OrganizationFeature, True)
 default_manager.add("organizations:widget-viewer-modal", OrganizationFeature, True)
 

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -843,6 +843,12 @@ def build_message(timestamp, duration, organization, user, reports):
     start, stop = interval = _to_interval(timestamp, duration)
 
     duration_spec = durations[duration]
+    html_template = None
+    if features.has("organizations:new-weekly-report", organization, actor=user):
+        html_template = "sentry/emails/reports/new.html"
+    else:
+        html_template = "sentry/emails/reports/body.html"
+
     message = MessageBuilder(
         subject="{} Report for {}: {} - {}".format(
             duration_spec.adjective.title(),
@@ -851,7 +857,7 @@ def build_message(timestamp, duration, organization, user, reports):
             date_format(stop),
         ),
         template="sentry/emails/reports/body.txt",
-        html_template="sentry/emails/reports/body.html",
+        html_template=html_template,
         type="report.organization",
         context={
             "duration": duration_spec,


### PR DESCRIPTION
This creates a new feature flag `organizations:new-weekly-report`. We use the new email template when the feature flag was activated.