### PR TITLE
fix(slack): Return better error message

### DIFF
--- a/src/sentry/integrations/slack/endpoints/action.py
+++ b/src/sentry/integrations/slack/endpoints/action.py
@@ -403,7 +403,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
         except IdentityProvider.DoesNotExist:
             identity = None
         if not identity:
-            return self.respond(status=403)
+            return self.respond_with_text(NO_IDENTITY_MESSAGE)
 
         NotificationSetting.objects.enable_settings_for_user(
             recipient=identity.user, provider=ExternalProviders.SLACK

--- a/tests/sentry/integrations/slack/endpoints/actions/test_enable_notifications.py
+++ b/tests/sentry/integrations/slack/endpoints/actions/test_enable_notifications.py
@@ -1,4 +1,7 @@
-from sentry.integrations.slack.endpoints.action import ENABLE_SLACK_SUCCESS_MESSAGE
+from sentry.integrations.slack.endpoints.action import (
+    ENABLE_SLACK_SUCCESS_MESSAGE,
+    NO_IDENTITY_MESSAGE,
+)
 from sentry.models import Identity, NotificationSetting
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.types.integrations import ExternalProviders
@@ -18,7 +21,8 @@ class EnableNotificationsActionTest(BaseEventTest):
             action_data=[{"name": "enable_notifications", "value": "all_slack"}]
         )
 
-        assert response.status_code == 403, response.content
+        assert response.status_code == 200, response.content
+        assert response.data["text"] == NO_IDENTITY_MESSAGE
 
     def test_enable_all_slack_already_enabled(self):
         NotificationSetting.objects.update_settings(


### PR DESCRIPTION
When a user clicks the Nudge Notification on Slack, if there is a problem with their identity, don't fail silently.
![image](https://user-images.githubusercontent.com/31750075/153964248-63f6d692-8e31-4915-8c45-47701d20d27a.png)
