### PR TITLE
feat(ratelimit): Implement rate limit configuration groups

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -15,7 +15,6 @@ from urllib.parse import urlparse
 from django.conf.global_settings import *  # NOQA
 
 import sentry
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.celery import crontab_with_minute_jitter
 from sentry.utils.types import type_from_value
 
@@ -1365,15 +1364,6 @@ SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE_OPTIONS = {}
 SENTRY_RATELIMITER = "sentry.ratelimits.base.RateLimiter"
 SENTRY_RATELIMITER_ENABLED = True
 SENTRY_RATELIMITER_OPTIONS = {}
-# These values were determined from analysis on one week of api access logs
-SENTRY_RATELIMITER_DEFAULT_IP = 620
-SENTRY_RATELIMITER_DEFAULT_USER = 620
-SENTRY_RATELIMITER_DEFAULT_ORG = 620
-SENTRY_RATELIMITER_DEFAULTS = {
-    RateLimitCategory.IP: RateLimit(SENTRY_RATELIMITER_DEFAULT_IP, 1),
-    RateLimitCategory.USER: RateLimit(SENTRY_RATELIMITER_DEFAULT_USER, 1),
-    RateLimitCategory.ORGANIZATION: RateLimit(SENTRY_RATELIMITER_DEFAULT_ORG, 1),
-}
 
 # The default value for project-level quotas
 SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE = "90%"

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -5,12 +5,7 @@ from django.utils.deprecation import MiddlewareMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.ratelimits import (
-    above_rate_limit_check,
-    can_be_ratelimited,
-    get_rate_limit_key,
-    get_rate_limit_value,
-)
+from sentry.ratelimits import above_rate_limit_check, get_rate_limit_key, get_rate_limit_value
 from sentry.types.ratelimit import RateLimitCategory
 
 DEFAULT_ERROR_MESSAGE = (
@@ -26,9 +21,6 @@ class RatelimitMiddleware(MiddlewareMixin):
         """Check if the endpoint call will violate."""
         request.will_be_rate_limited = False
         request.rate_limit_category = None
-
-        if not can_be_ratelimited(request, view_func):
-            return
 
         key = get_rate_limit_key(view_func, request)
         if key is None:

--- a/src/sentry/ratelimits/__init__.py
+++ b/src/sentry/ratelimits/__init__.py
@@ -5,7 +5,6 @@ from sentry.utils.services import LazyServiceWrapper
 __all__ = (
     "for_organization_member_invite",
     "above_rate_limit_check",
-    "can_be_ratelimited",
     "get_rate_limit_key",
     "get_rate_limit_value",
     "RateLimiter",
@@ -20,7 +19,6 @@ backend.expose(locals())
 
 from .utils import (
     above_rate_limit_check,
-    can_be_ratelimited,
     for_organization_member_invite,
     get_rate_limit_key,
     get_rate_limit_value,

--- a/src/sentry/ratelimits/config.py
+++ b/src/sentry/ratelimits/config.py
@@ -23,7 +23,9 @@ _SENTRY_RATELIMITER_DEFAULT = 620
 
 
 _SENTRY_RATELIMITER_GROUP_DEFAULTS: Mapping[GroupName, Mapping[RateLimitCategory, RateLimit]] = {
-    "default": {RateLimitCategory.ORGANIZATION: RateLimit(_SENTRY_RATELIMITER_DEFAULT, 1)}
+    "default": {
+        category: RateLimit(_SENTRY_RATELIMITER_DEFAULT, 1) for category in RateLimitCategory
+    }
 }
 
 
@@ -37,14 +39,7 @@ def get_default_rate_limits_for_group(group_name: str, category: RateLimitCatego
     )
     if category in group_config:
         return group_config[category]
-    else:
-        # if the specific category is not configured, try and find one in order of the enum
-        for category in iter(RateLimitCategory):
-            limit = group_config.get(category, None)
-            if isinstance(limit, RateLimit):
-                return limit
-
-    return _SENTRY_RATELIMITER_GROUP_DEFAULTS["default"][RateLimitCategory.ORGANIZATION]
+    return _SENTRY_RATELIMITER_GROUP_DEFAULTS["default"][category]
 
 
 @dataclass(frozen=True)

--- a/src/sentry/ratelimits/config.py
+++ b/src/sentry/ratelimits/config.py
@@ -42,6 +42,8 @@ def get_default_rate_limits_for_group(group_name: str, category: RateLimitCatego
     group_config = group_defaults.get(group_name, None)
     if group_config and category in group_config:
         return group_config[category]
+    else:
+        _LOGGER.warning("Invalid group config for %s, %s", group_name, category)
     # if the config doesn't have the rate limit category always fall back to default
     # if the category is undefined, fall back to the default rate limit per organization
 

--- a/src/sentry/ratelimits/config.py
+++ b/src/sentry/ratelimits/config.py
@@ -1,36 +1,75 @@
+import logging
 from dataclasses import dataclass, field
 from typing import Mapping, Union
 
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+_LOGGER = logging.getLogger("sentry.ratelimits.config")
 
 
 class _sentinel:
     pass
 
 
+class InvalidRateLimitConfig(Exception):
+    pass
+
+
 RateLimitOverrideDict = Mapping[str, Mapping[RateLimitCategory, RateLimit]]
+GroupName = str
+
+# This default value is going to shrink over time
+_SENTRY_RATELIMITER_DEFAULT = 620
 
 
-def get_default_rate_limits_for_group(group_name: str) -> RateLimit:
-    # TODO: make group config
-    return RateLimit(window=1, limit=40, concurrent_limit=15)
+_SENTRY_RATELIMITER_GROUP_DEFAULTS: Mapping[GroupName, Mapping[RateLimitCategory, RateLimit]] = {
+    "default": {RateLimitCategory.ORGANIZATION: RateLimit(_SENTRY_RATELIMITER_DEFAULT, 1)}
+}
 
 
-@dataclass
+def get_default_rate_limits_for_group(group_name: str, category: RateLimitCategory) -> RateLimit:
+    # group rate limits are calculated as follows:
+
+    # If the group is not configured in _SENTRY_RATELIMITER_GROUP_DEFAULTS, use the "default" group
+    # config
+    group_config = _SENTRY_RATELIMITER_GROUP_DEFAULTS.get(
+        group_name, _SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]
+    )
+    if category in group_config:
+        return group_config[category]
+    else:
+        # if the specific category is not configured, try and find one in order of the enum
+        for category in iter(RateLimitCategory):
+            limit = group_config.get(category, None)
+            if isinstance(limit, RateLimit):
+                return limit
+
+    return _SENTRY_RATELIMITER_GROUP_DEFAULTS["default"][RateLimitCategory.ORGANIZATION]
+
+
+@dataclass(frozen=True)
 class RateLimitConfig:
     group: str = field(default="default")
     limit_overrides: Union[RateLimitOverrideDict, _sentinel] = field(default=_sentinel())
 
     def get_rate_limit(self, http_method: str, category: RateLimitCategory) -> RateLimit:
         if isinstance(self.limit_overrides, _sentinel):
-            return get_default_rate_limits_for_group(self.group)
+            return get_default_rate_limits_for_group(self.group, category)
         override_rate_limit = self.limit_overrides.get(http_method, {}).get(category, None)
         if isinstance(override_rate_limit, RateLimit):
             return override_rate_limit
-        return get_default_rate_limits_for_group(self.group)
+        return get_default_rate_limits_for_group(self.group, category)
 
     @classmethod
     def from_rate_limit_override_dict(
-        cls, rate_limit_override_dict: RateLimitOverrideDict
+        cls, rate_limit_override_dict: Union["RateLimitConfig", RateLimitOverrideDict]
     ) -> "RateLimitConfig":
-        return cls(limit_overrides=rate_limit_override_dict)
+        if isinstance(rate_limit_override_dict, cls):
+            return rate_limit_override_dict
+        elif isinstance(rate_limit_override_dict, dict):
+            _LOGGER.warning("deprecated rate limit specification %s", rate_limit_override_dict)
+            return cls(limit_overrides=rate_limit_override_dict)
+        raise InvalidRateLimitConfig
+
+
+DEFAULT_RATE_LIMIT_CONFIG = RateLimitConfig()

--- a/src/sentry/ratelimits/config.py
+++ b/src/sentry/ratelimits/config.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass, field
+from typing import Mapping, Union
+
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+
+class _sentinel:
+    pass
+
+
+RateLimitOverrideDict = Mapping[str, Mapping[RateLimitCategory, RateLimit]]
+
+
+def get_default_rate_limits_for_group(group_name: str) -> RateLimit:
+    # TODO: make group config
+    return RateLimit(window=1, limit=40, concurrent_limit=15)
+
+
+@dataclass
+class RateLimitConfig:
+    group: str = field(default="default")
+    limit_overrides: Union[RateLimitOverrideDict, _sentinel] = field(default=_sentinel())
+
+    def get_rate_limit(self, http_method: str, category: RateLimitCategory) -> RateLimit:
+        if isinstance(self.limit_overrides, _sentinel):
+            return get_default_rate_limits_for_group(self.group)
+        override_rate_limit = self.limit_overrides.get(http_method, {}).get(category, None)
+        if isinstance(override_rate_limit, RateLimit):
+            return override_rate_limit
+        return get_default_rate_limits_for_group(self.group)
+
+    @classmethod
+    def from_rate_limit_override_dict(
+        cls, rate_limit_override_dict: RateLimitOverrideDict
+    ) -> "RateLimitConfig":
+        return cls(limit_overrides=rate_limit_override_dict)

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -36,8 +36,8 @@ def can_be_ratelimited(request: Request, view_func: EndpointFunction) -> bool:
 
 def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | None:
     """Construct a consistent global rate limit key using the arguments provided"""
-
     view = view_func.__qualname__
+    rate_limit_config = get_rate_limit_config(view_func.view_class)
     http_method = request.method
 
     # This avoids touching user session, which means we avoid
@@ -84,7 +84,9 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
     # If IP address doesn't exist, skip ratelimiting for now
     else:
         return None
-    return f"{category}:{view}:{http_method}:{id}"
+    # TODO: remove view from this key, it's not necessary
+    group = rate_limit_config.group if rate_limit_config else "default"
+    return f"{category}:{group}:{view}:{http_method}:{id}"
 
 
 def get_organization_id_from_token(token_id: str) -> int | None:

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -28,16 +28,15 @@ DEFAULT_CONFIG = {
 }
 
 
-def can_be_ratelimited(request: Request, view_func: EndpointFunction) -> bool:
-    return hasattr(view_func, "view_class") and not request.path_info.startswith(
-        settings.ANONYMOUS_STATIC_PREFIXES
-    )
-
-
 def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | None:
     """Construct a consistent global rate limit key using the arguments provided"""
+    if not hasattr(view_func, "view_class") or request.path_info.startswith(
+        settings.ANONYMOUS_STATIC_PREFIXES
+    ):
+        return None
+
     view = view_func.__qualname__
-    rate_limit_config = get_rate_limit_config(view_func.view_class)
+    rate_limit_config = get_rate_limit_config(view_func.view_class)  # type: ignore
     http_method = request.method
 
     # This avoids touching user session, which means we avoid

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -46,11 +46,3 @@ class RateLimitMeta:
     limit: int
     window: int
     reset_time: int
-
-
-@dataclass
-class RateLimitConfig:
-    group: str = field(default="default")
-
-    def get_rate_limit(self, http_method: str, category: RateLimitCategory) -> RateLimit:
-        raise NotImplementedError

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
+from typing import Optional
 
 
 # Fixed set of rate limit categories
@@ -16,11 +17,13 @@ class RateLimit:
     Attributes:
         limit (int): Max number of hits allowed within the window
         window (int): Period of time in seconds that the rate limit applies for
+        concurrent_limit Optional(int): concurrent request limit (irrespective of window)
 
     """
 
     limit: int
     window: int
+    concurrent_limit: Optional[int] = field(default=None)
 
 
 @dataclass
@@ -43,3 +46,11 @@ class RateLimitMeta:
     limit: int
     window: int
     reset_time: int
+
+
+@dataclass
+class RateLimitConfig:
+    group: str = field(default="default")
+
+    def get_rate_limit(self, http_method: str, category: RateLimitCategory) -> RateLimit:
+        raise NotImplementedError

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
 from sentry.models import ApiToken
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.testutils import APITestCase
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -29,13 +30,16 @@ class DummyFailEndpoint(Endpoint):
 class RateLimitedEndpoint(Endpoint):
     permission_classes = (AllowAny,)
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(0, 1),
-            RateLimitCategory.USER: RateLimit(0, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(0, 1),
+    rate_limits = RateLimitConfig(
+        group="foo",
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(0, 1),
+                RateLimitCategory.USER: RateLimit(0, 1),
+                RateLimitCategory.ORGANIZATION: RateLimit(0, 1),
+            },
         },
-    }
+    )
 
     def get(self, request):
         return Response({"ok": True})

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -113,12 +113,13 @@ class RatelimitMiddlewareTest(TestCase):
     def test_get_rate_limit_key(self):
         # Import an endpoint
 
-        view = OrganizationGroupIndexEndpoint
+        view = OrganizationGroupIndexEndpoint.as_view()
 
         # Test for default IP
         request = self.factory.get("/")
         assert (
-            get_rate_limit_key(view, request) == "ip:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
+            get_rate_limit_key(view, request)
+            == "ip:default:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
         )
         # Test when IP address is missing
         request.META["REMOTE_ADDR"] = None
@@ -128,7 +129,7 @@ class RatelimitMiddlewareTest(TestCase):
         request.META["REMOTE_ADDR"] = "684D:1111:222:3333:4444:5555:6:77"
         assert (
             get_rate_limit_key(view, request)
-            == "ip:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+            == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
         # Test for users
@@ -136,7 +137,7 @@ class RatelimitMiddlewareTest(TestCase):
         request.user = self.user
         assert (
             get_rate_limit_key(view, request)
-            == f"user:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
+            == f"user:default:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
         )
 
         # Test for user auth tokens
@@ -145,14 +146,14 @@ class RatelimitMiddlewareTest(TestCase):
         request.user = self.user
         assert (
             get_rate_limit_key(view, request)
-            == f"user:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
+            == f"user:default:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
         )
 
         # Test for sentryapp auth tokens:
         self.populate_sentry_app_request(request)
         assert (
             get_rate_limit_key(view, request)
-            == f"org:OrganizationGroupIndexEndpoint:GET:{self.organization.id}"
+            == f"org:default:OrganizationGroupIndexEndpoint:GET:{self.organization.id}"
         )
 
         # Test for apikey
@@ -163,7 +164,7 @@ class RatelimitMiddlewareTest(TestCase):
         request.auth = api_key
         assert (
             get_rate_limit_key(view, request)
-            == "ip:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+            == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
 

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -194,9 +194,11 @@ class TestGetRateLimitValue(TestCase):
             }
 
         assert get_rate_limit_value("GET", TestEndpoint, "ip") == RateLimit(100, 5)
+        # get is not overriddent for user, hence we use the default
         assert get_rate_limit_value(
             "GET", TestEndpoint, "user"
         ) == get_default_rate_limits_for_group("default", category=RateLimitCategory.USER)
+        # get is not overriddent for IP, hence we use the default
         assert get_rate_limit_value(
             "POST", TestEndpoint, "ip"
         ) == get_default_rate_limits_for_group("default", category=RateLimitCategory.IP)

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -204,14 +204,6 @@ class TestGetRateLimitValue(TestCase):
         ) == get_default_rate_limits_for_group("default", category=RateLimitCategory.IP)
         assert get_rate_limit_value("POST", TestEndpoint, "user") == RateLimit(20, 4)
 
-    def test_non_endpoint(self):
-        """views that don't inherit Endpoint shouldn not return a value"""
-
-        class TestEndpoint:
-            pass
-
-        assert get_rate_limit_value("GET", TestEndpoint, "ip") is None
-
 
 class RateLimitHeaderTestEndpoint(Endpoint):
     permission_classes = (AllowAny,)

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -265,7 +265,7 @@ class TestRatelimitHeader(APITestCase):
             assert int(response["X-Sentry-Rate-Limit-Limit"]) == 2
             assert int(response["X-Sentry-Rate-Limit-Reset"]) == expected_reset_time
 
-    @patch("sentry.ratelimits.utils.can_be_ratelimited")
+    @patch("sentry.ratelimits.utils.get_rate_limit_key")
     def test_omit_header(self, can_be_ratelimited_patch):
         """
         Ensure that functions that can't be rate limited don't have rate limit headers
@@ -274,7 +274,7 @@ class TestRatelimitHeader(APITestCase):
             - UI Statistics Endpoints
             - Endpoints that don't inherit api.base.Endpoint
         """
-        can_be_ratelimited_patch.return_value = False
+        can_be_ratelimited_patch.return_value = None
         response = self.get_response()
         assert "X-Sentry-Rate-Limit-Remaining" not in response._headers
         assert "X-Sentry-Rate-Limit-Limit" not in response._headers

--- a/tests/sentry/ratelimits/test_config.py
+++ b/tests/sentry/ratelimits/test_config.py
@@ -1,0 +1,44 @@
+from unittest import TestCase, mock
+
+from sentry.ratelimits.config import RateLimitConfig, get_default_rate_limits_for_group
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+
+class TestRateLimitConfig(TestCase):
+    @mock.patch(
+        "sentry.ratelimits.config._get_group_defaults",
+        return_value={"blz": {RateLimitCategory.ORGANIZATION: RateLimit(420, 69)}},
+    )
+    def test_grouping(self, *m):
+        config = RateLimitConfig(group="blz")
+        assert config.get_rate_limit("GET", RateLimitCategory.ORGANIZATION) == RateLimit(420, 69)
+
+    def test_defaults(self):
+        config = RateLimitConfig()
+        for c in RateLimitCategory:
+            for method in ("POST", "GET", "PUT", "DELETE"):
+                assert isinstance(config.get_rate_limit(method, c), RateLimit)
+
+    def test_override(self):
+        config = RateLimitConfig(
+            group="default", limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(1, 1)}}
+        )
+        assert config.get_rate_limit("GET", RateLimitCategory.IP) == RateLimit(1, 1)
+        assert config.get_rate_limit(
+            "POST", RateLimitCategory.IP
+        ) == get_default_rate_limits_for_group("default", RateLimitCategory.IP)
+        assert config.get_rate_limit(
+            "GET", RateLimitCategory.ORGANIZATION
+        ) == get_default_rate_limits_for_group("default", RateLimitCategory.ORGANIZATION)
+
+    def test_backwards_compatibility(self):
+        override_dict = {"GET": {RateLimitCategory.IP: RateLimit(1, 1)}}
+        assert RateLimitConfig.from_rate_limit_override_dict(override_dict) == RateLimitConfig(
+            group="default", limit_overrides=override_dict
+        )
+
+    def test_invalid_config(self):
+        config = RateLimitConfig(group="default", limit_overrides={"GET": {"invalid": "invalid"}})  # type: ignore
+        assert config.get_rate_limit("bloop", "badcategory") == get_default_rate_limits_for_group(
+            "default", RateLimitCategory.ORGANIZATION
+        )

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -10,13 +10,13 @@ from sentry.testutils.cases import TestCase
 
 class GetRateLimitKeyTest(TestCase):
     def setUp(self) -> None:
-        self.view = OrganizationGroupIndexEndpoint
+        self.view = OrganizationGroupIndexEndpoint.as_view()
         self.request = RequestFactory().get("/")
 
     def test_default_ip(self):
         assert (
             get_rate_limit_key(self.view, self.request)
-            == "ip:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
+            == "ip:default:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
         )
 
     def test_ip_address_missing(self):
@@ -27,7 +27,7 @@ class GetRateLimitKeyTest(TestCase):
         self.request.META["REMOTE_ADDR"] = "684D:1111:222:3333:4444:5555:6:77"
         assert (
             get_rate_limit_key(self.view, self.request)
-            == "ip:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+            == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
     def test_system_token(self):
@@ -40,7 +40,7 @@ class GetRateLimitKeyTest(TestCase):
         self.request.user = user
         assert (
             get_rate_limit_key(self.view, self.request)
-            == f"user:OrganizationGroupIndexEndpoint:GET:{user.id}"
+            == f"user:default:OrganizationGroupIndexEndpoint:GET:{user.id}"
         )
 
     def test_organization(self):
@@ -65,5 +65,5 @@ class GetRateLimitKeyTest(TestCase):
 
         assert (
             get_rate_limit_key(self.view, self.request)
-            == f"org:OrganizationGroupIndexEndpoint:GET:{install.organization_id}"
+            == f"org:default:OrganizationGroupIndexEndpoint:GET:{install.organization_id}"
         )


### PR DESCRIPTION
* Enable grouping of rate limits
* Allow for dynamic rate limit calculations
* Add option for `RateLimit` to have a concurrent request value (unenforced currently)
* Remove the inherited class traversal that is used to retrieve rate limit config from an endpoint class. Instead either use what's defined on the class or default back to the group

Change is backwards compatible with old dictionary format. It will be replaced but in a separate PR.

What's left to do once we agree that the approach and interface are sound:

- [x] add tests for the RateLimitConfig class
- [x] add inline docs for the RatelimitConfig class