### PR TITLE
ref(sentry apps): Don't display 'published' status

### DIFF
--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
@@ -105,7 +105,7 @@ const getFullActionTitle = ({
   'type' | 'integrationName' | 'sentryAppName' | 'status'
 >) => {
   if (sentryAppName) {
-    if (status) {
+    if (status && status !== 'published') {
       return `${sentryAppName} (${status})`;
     }
     return `${sentryAppName}`;


### PR DESCRIPTION
If a sentry app has been published, don't show the status in the metric alert dropdown.

**Before**
<img width="1043" alt="Screen Shot 2022-02-14 at 5 33 44 PM" src="https://user-images.githubusercontent.com/29959063/153976202-547af884-3b35-41e8-8d54-42171b40ea79.png">
**After**
<img width="1064" alt="Screen Shot 2022-02-14 at 5 34 32 PM" src="https://user-images.githubusercontent.com/29959063/153976214-f6c22e69-23ca-4e7d-a017-aa0c0cebacaf.png">
