### PR TITLE
chore(perf): Remove performance landing widgets and mobile vitals flags

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1072,12 +1072,8 @@ SENTRY_FEATURES = {
     "organizations:prompt-dashboards": False,
     # Enable views for ops breakdown
     "organizations:performance-ops-breakdown": False,
-    # Enable landing improvements for performance
-    "organizations:performance-landing-widgets": False,
     # Enable interpolation of null data points in charts instead of zerofilling in performance
     "organizations:performance-chart-interpolation": False,
-    # Enable mobile vitals
-    "organizations:performance-mobile-vitals": False,
     # Enable views for suspect tags
     "organizations:performance-suspect-spans-view": False,
     # Enable views for anomaly detection

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -128,8 +128,6 @@ default_manager.add(
     "organizations:pagerduty-metric-alert-resolve-logging", OrganizationFeature, True
 )
 default_manager.add("organizations:performance-chart-interpolation", OrganizationFeature, True)
-default_manager.add("organizations:performance-landing-widgets", OrganizationFeature, True)
-default_manager.add("organizations:performance-mobile-vitals", OrganizationFeature, True)
 default_manager.add("organizations:performance-ops-breakdown", OrganizationFeature)
 default_manager.add("organizations:performance-suspect-spans-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-anomaly-detection-ui", OrganizationFeature, True)


### PR DESCRIPTION
This PR removes all references to `organizations:performance-landing-widgets` and `organizations:performance-mobile-vitals` feature flags in the **backend** since those features have been fully released.

Fixes-1191