### PR TITLE
fix(release_health): Adjust all code such that the current timestamp is determined exactly once [INGEST-784]

### DIFF
--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -312,7 +312,9 @@ class ReleaseHealthBackend(Service):  # type: ignore
         raise NotImplementedError()
 
     def check_has_health_data(
-        self, projects_list: Sequence[ProjectOrRelease]
+        self,
+        projects_list: Sequence[ProjectOrRelease],
+        now: Optional[datetime] = None,
     ) -> Set[ProjectOrRelease]:
         """
         Function that returns a set of all project_ids or (project, release) if they have health data
@@ -345,6 +347,7 @@ class ReleaseHealthBackend(Service):  # type: ignore
         summary_stats_period: Optional[StatsPeriod] = None,
         health_stats_period: Optional[StatsPeriod] = None,
         stat: Optional[Literal["users", "sessions"]] = None,
+        now: Optional[datetime] = None,
     ) -> Mapping[ProjectRelease, ReleaseHealthOverview]:
         """Checks quickly for which of the given project releases we have
         health data available.  The argument is a tuple of `(project_id, release_name)`
@@ -360,12 +363,14 @@ class ReleaseHealthBackend(Service):  # type: ignore
         release: ReleaseName,
         start: datetime,
         environments: Optional[Sequence[EnvironmentName]] = None,
+        now: Optional[datetime] = None,
     ) -> Sequence[CrashFreeBreakdown]:
         """Get stats about crash free sessions and stats for the last 1, 2, 7, 14 and 30 days"""
 
     def get_changed_project_release_model_adoptions(
         self,
         project_ids: Sequence[ProjectId],
+        now: Optional[datetime] = None,
     ) -> Sequence[ProjectRelease]:
         """
         Returns a sequence of tuples (ProjectId, ReleaseName) with the
@@ -374,7 +379,9 @@ class ReleaseHealthBackend(Service):  # type: ignore
         raise NotImplementedError()
 
     def get_oldest_health_data_for_releases(
-        self, project_releases: Sequence[ProjectRelease]
+        self,
+        project_releases: Sequence[ProjectRelease],
+        now: Optional[datetime] = None,
     ) -> Mapping[ProjectRelease, str]:
         """Returns the oldest health data we have observed in a release
         in 90 days.  This is used for backfilling.
@@ -388,6 +395,7 @@ class ReleaseHealthBackend(Service):  # type: ignore
         scope: str,
         stats_period: Optional[str] = None,
         environments: Optional[Sequence[EnvironmentName]] = None,
+        now: Optional[datetime] = None,
     ) -> int:
         """
         Fetches the total count of releases/project combinations
@@ -442,6 +450,7 @@ class ReleaseHealthBackend(Service):  # type: ignore
         scope: str,
         stats_period: Optional[str] = None,
         environments: Optional[Sequence[str]] = None,
+        now: Optional[datetime] = None,
     ) -> Sequence[ProjectRelease]:
         """Given some project IDs returns adoption rates that should be updated
         on the postgres tables.

--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -395,7 +395,6 @@ class ReleaseHealthBackend(Service):  # type: ignore
         scope: str,
         stats_period: Optional[str] = None,
         environments: Optional[Sequence[EnvironmentName]] = None,
-        now: Optional[datetime] = None,
     ) -> int:
         """
         Fetches the total count of releases/project combinations

--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -619,7 +619,7 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
         if now is None:
             now = datetime.now(pytz.utc)
 
-        should_compare = lambda _: now - timedelta(hours=24) > self.metrics_start  # type: ignore
+        should_compare = lambda _: now - timedelta(hours=24) > self.metrics_start
 
         if org_id is not None:
             organization = self._org_from_id(org_id)
@@ -740,7 +740,7 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
 
         rollup = self.DEFAULT_ROLLUP  # not used
         schema = {ComparatorType.Exact}
-        should_compare = lambda _: now - timedelta(days=90) > self.metrics_start  # type: ignore
+        should_compare = lambda _: now - timedelta(days=90) > self.metrics_start
         organization = self._org_from_projects(projects_list)
         return self._dispatch_call(  # type: ignore
             "check_has_health_data",
@@ -801,7 +801,7 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
         if now is None:
             now = datetime.now(pytz.utc)
 
-        should_compare = lambda _: now - timedelta(days=1) > self.metrics_start  # type: ignore
+        should_compare = lambda _: now - timedelta(days=1) > self.metrics_start
         organization = self._org_from_projects(project_releases)
         return self._dispatch_call(  # type: ignore
             "get_release_health_data_overview",
@@ -889,7 +889,7 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
 
         rollup = self.DEFAULT_ROLLUP  # TODO check if this is correct ?
         schema = {"*": ComparatorType.DateTime}
-        should_compare = lambda _: now - timedelta(days=90) > self.metrics_start  # type: ignore
+        should_compare = lambda _: now - timedelta(days=90) > self.metrics_start
         organization = self._org_from_projects(project_releases)
         return self._dispatch_call(  # type: ignore
             "get_oldest_health_data_for_releases",
@@ -1051,7 +1051,7 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
             now = datetime.now(pytz.utc)
 
         rollup, stats_start, _ = get_rollup_starts_and_buckets(stats_period, now=now)
-        should_compare = lambda _: now > self.metrics_start  # type: ignore
+        should_compare = lambda _: now > self.metrics_start
         organization = self._org_from_projects(project_ids)
 
         return self._dispatch_call(  # type: ignore

--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -702,7 +702,6 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
         release: ReleaseName,
         org_id: OrganizationId,
         environments: Optional[Sequence[EnvironmentName]] = None,
-        now: Optional[datetime] = None,
     ) -> ReleaseSessionsTimeBounds:
         rollup = self.DEFAULT_ROLLUP  # TODO is this the proper ROLLUP ?
         schema = {
@@ -719,9 +718,6 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
 
         organization = self._org_from_id(org_id)
 
-        if now is None:
-            now = datetime.now(pytz.utc)
-
         return self._dispatch_call(  # type: ignore
             "get_release_sessions_time_bounds",
             should_compare,
@@ -732,7 +728,6 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
             release,
             org_id,
             environments,
-            now,
         )
 
     def check_has_health_data(

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -414,15 +414,11 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         release: ReleaseName,
         org_id: OrganizationId,
         environments: Optional[Sequence[EnvironmentName]] = None,
-        now: Optional[datetime] = None,
     ) -> ReleaseSessionsTimeBounds:
         select: List[SelectableExpression] = [
             Function("min", [Column("timestamp")], "min"),
             Function("max", [Column("timestamp")], "max"),
         ]
-
-        if now is None:
-            now = datetime.now(pytz.utc)
 
         try:
             where: List[Condition] = [
@@ -432,7 +428,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 Condition(
                     Column("timestamp"), Op.GTE, datetime(2008, 5, 8)
                 ),  # Date of sentry's first commit
-                Condition(Column("timestamp"), Op.LT, now),
+                Condition(
+                    Column("timestamp"), Op.LT, datetime.now(pytz.utc) + timedelta(seconds=10)
+                ),
             ]
 
             if environments is not None:

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -857,7 +857,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         session_init_tag_value = resolve_weak("init")
 
         stats_rollup, stats_start, stats_buckets = get_rollup_starts_and_buckets(
-            health_stats_period
+            health_stats_period, now=now
         )
 
         aggregates: List[SelectableExpression] = [
@@ -927,7 +927,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         if now is None:
             now = datetime.now(pytz.utc)
 
-        _, summary_start, _ = get_rollup_starts_and_buckets(summary_stats_period or "24h")
+        _, summary_start, _ = get_rollup_starts_and_buckets(summary_stats_period or "24h", now=now)
         rollup = LEGACY_SESSIONS_DEFAULT_ROLLUP
 
         org_id = self._get_org_id([x for x, _ in project_releases])
@@ -1324,7 +1324,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         if scope.endswith("_24h"):
             stats_period = "24h"
 
-        granularity, stats_start, _ = get_rollup_starts_and_buckets(stats_period)
+        granularity, stats_start, _ = get_rollup_starts_and_buckets(stats_period, now=now)
         where = [
             Condition(Column("timestamp"), Op.GTE, stats_start),
             Condition(Column("timestamp"), Op.LT, now),
@@ -1863,7 +1863,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         if now is None:
             now = datetime.now(pytz.utc)
 
-        granularity, stats_start, _ = get_rollup_starts_and_buckets(stats_period)
+        granularity, stats_start, _ = get_rollup_starts_and_buckets(stats_period, now=now)
 
         query_cols = [
             Column("project_id"),

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -414,11 +414,15 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         release: ReleaseName,
         org_id: OrganizationId,
         environments: Optional[Sequence[EnvironmentName]] = None,
+        now: Optional[datetime] = None,
     ) -> ReleaseSessionsTimeBounds:
         select: List[SelectableExpression] = [
             Function("min", [Column("timestamp")], "min"),
             Function("max", [Column("timestamp")], "max"),
         ]
+
+        if now is None:
+            now = datetime.now(pytz.utc)
 
         try:
             where: List[Condition] = [
@@ -428,7 +432,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 Condition(
                     Column("timestamp"), Op.GTE, datetime(2008, 5, 8)
                 ),  # Date of sentry's first commit
-                Condition(Column("timestamp"), Op.LT, datetime.now(pytz.utc)),
+                Condition(Column("timestamp"), Op.LT, now),
             ]
 
             if environments is not None:
@@ -542,9 +546,13 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         }
 
     def check_has_health_data(
-        self, projects_list: Sequence[ProjectOrRelease]
+        self,
+        projects_list: Sequence[ProjectOrRelease],
+        now: Optional[datetime] = None,
     ) -> Set[ProjectOrRelease]:
-        now = datetime.now(pytz.utc)
+        if now is None:
+            now = datetime.now(pytz.utc)
+
         start = now - timedelta(days=3)
 
         projects_list = list(projects_list)
@@ -911,11 +919,14 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         summary_stats_period: Optional[StatsPeriod] = None,
         health_stats_period: Optional[StatsPeriod] = None,
         stat: Optional[OverviewStat] = None,
+        now: Optional[datetime] = None,
     ) -> Mapping[ProjectRelease, ReleaseHealthOverview]:
         if stat is None:
             stat = "sessions"
         assert stat in ("sessions", "users")
-        now = datetime.now(pytz.utc)
+        if now is None:
+            now = datetime.now(pytz.utc)
+
         _, summary_start, _ = get_rollup_starts_and_buckets(summary_stats_period or "24h")
         rollup = LEGACY_SESSIONS_DEFAULT_ROLLUP
 
@@ -1152,11 +1163,14 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         release: ReleaseName,
         start: datetime,
         environments: Optional[Sequence[EnvironmentName]] = None,
+        now: Optional[datetime] = None,
     ) -> Sequence[CrashFreeBreakdown]:
 
         org_id = self._get_org_id([project_id])
 
-        now = datetime.now(pytz.utc)
+        if now is None:
+            now = datetime.now(pytz.utc)
+
         query_fn = self._get_crash_free_breakdown_fn(
             org_id, project_id, release, start, environments
         )
@@ -1187,9 +1201,12 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
     def get_changed_project_release_model_adoptions(
         self,
         project_ids: Sequence[ProjectId],
+        now: Optional[datetime] = None,
     ) -> Sequence[ProjectRelease]:
 
-        now = datetime.now(pytz.utc)
+        if now is None:
+            now = datetime.now(pytz.utc)
+
         start = now - timedelta(days=3)
 
         project_ids = list(project_ids)
@@ -1232,9 +1249,11 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
     def get_oldest_health_data_for_releases(
         self,
         project_releases: Sequence[ProjectRelease],
+        now: Optional[datetime] = None,
     ) -> Mapping[ProjectRelease, str]:
+        if now is None:
+            now = datetime.now(pytz.utc)
 
-        now = datetime.now(pytz.utc)
         # TODO: assumption about retention?
         start = now - timedelta(days=90)
 
@@ -1292,7 +1311,11 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         scope: str,
         stats_period: Optional[str] = None,
         environments: Optional[Sequence[EnvironmentName]] = None,
+        now: Optional[datetime] = None,
     ) -> int:
+
+        if now is None:
+            now = datetime.now(pytz.utc)
 
         if stats_period is None:
             stats_period = "24h"
@@ -1304,7 +1327,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         granularity, stats_start, _ = get_rollup_starts_and_buckets(stats_period)
         where = [
             Condition(Column("timestamp"), Op.GTE, stats_start),
-            Condition(Column("timestamp"), Op.LT, datetime.now()),
+            Condition(Column("timestamp"), Op.LT, now),
             Condition(Column("project_id"), Op.IN, project_ids),
             Condition(Column("org_id"), Op.EQ, organization_id),
         ]
@@ -1813,6 +1836,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         scope: str,
         stats_period: Optional[str] = None,
         environments: Optional[Sequence[str]] = None,
+        now: Optional[datetime] = None,
     ) -> Sequence[ProjectRelease]:
 
         if len(project_ids) == 0:
@@ -1836,7 +1860,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             scope = scope[:-4]
             stats_period = "24h"
 
-        now = datetime.now(pytz.utc)
+        if now is None:
+            now = datetime.now(pytz.utc)
+
         granularity, stats_start, _ = get_rollup_starts_and_buckets(stats_period)
 
         query_cols = [

--- a/src/sentry/release_health/sessions.py
+++ b/src/sentry/release_health/sessions.py
@@ -105,9 +105,11 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
         )
 
     def check_has_health_data(
-        self, projects_list: Sequence[ProjectOrRelease]
+        self,
+        projects_list: Sequence[ProjectOrRelease],
+        now: Optional[datetime] = None,
     ) -> Set[ProjectOrRelease]:
-        return _check_has_health_data(projects_list)  # type: ignore
+        return _check_has_health_data(projects_list, now=now)  # type: ignore
 
     def check_releases_have_health_data(
         self,
@@ -149,9 +151,10 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
         release: ReleaseName,
         start: datetime,
         environments: Optional[Sequence[EnvironmentName]] = None,
+        now: Optional[datetime] = None,
     ) -> Sequence[CrashFreeBreakdown]:
         return _get_crash_free_breakdown(  # type: ignore
-            project_id=project_id, release=release, start=start, environments=environments
+            project_id=project_id, release=release, start=start, environments=environments, now=now
         )
 
     def get_changed_project_release_model_adoptions(
@@ -164,8 +167,9 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
     def get_oldest_health_data_for_releases(
         self,
         project_releases: Sequence[ProjectRelease],
+        now: Optional[datetime] = None,
     ) -> Mapping[ProjectRelease, str]:
-        return _get_oldest_health_data_for_releases(project_releases)  # type: ignore
+        return _get_oldest_health_data_for_releases(project_releases, now=now)  # type: ignore
 
     def get_project_releases_count(
         self,

--- a/src/sentry/release_health/sessions.py
+++ b/src/sentry/release_health/sessions.py
@@ -155,8 +155,9 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
     def get_changed_project_release_model_adoptions(
         self,
         project_ids: Sequence[ProjectId],
+        now: Optional[datetime] = None,
     ) -> Sequence[ProjectRelease]:
-        return _get_changed_project_release_model_adoptions(project_ids)  # type: ignore
+        return _get_changed_project_release_model_adoptions(project_ids, now=now)  # type: ignore
 
     def get_oldest_health_data_for_releases(
         self,

--- a/src/sentry/release_health/sessions.py
+++ b/src/sentry/release_health/sessions.py
@@ -132,6 +132,7 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
         summary_stats_period: Optional[StatsPeriod] = None,
         health_stats_period: Optional[StatsPeriod] = None,
         stat: Optional[OverviewStat] = None,
+        now: Optional[datetime] = None,
     ) -> Mapping[ProjectRelease, ReleaseHealthOverview]:
         return _get_release_health_data_overview(  # type: ignore
             project_releases=project_releases,
@@ -139,6 +140,7 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
             summary_stats_period=summary_stats_period,
             health_stats_period=health_stats_period,
             stat=stat,
+            now=now,
         )
 
     def get_crash_free_breakdown(
@@ -241,7 +243,8 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
         scope: str,
         stats_period: Optional[str] = None,
         environments: Optional[Sequence[str]] = None,
+        now: Optional[datetime] = None,
     ) -> Sequence[ProjectRelease]:
         return _get_project_releases_by_stability(  # type: ignore
-            project_ids, offset, limit, scope, stats_period, environments
+            project_ids, offset, limit, scope, stats_period, environments, now
         )

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -274,13 +274,15 @@ STATS_PERIODS = {
 }
 
 
-def get_rollup_starts_and_buckets(period):
+def get_rollup_starts_and_buckets(period, now=None):
     if period is None:
         return None, None, None
     if period not in STATS_PERIODS:
         raise TypeError("Invalid stats period")
     seconds, buckets = STATS_PERIODS[period]
-    start = datetime.now(pytz.utc) - timedelta(seconds=seconds * buckets)
+    if now is None:
+        now = datetime.now(pytz.utc)
+    start = now - timedelta(seconds=seconds * buckets)
     return seconds, start, buckets
 
 

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -31,9 +31,12 @@ def _get_conditions_and_filter_keys(project_releases, environments):
     return conditions, filter_keys
 
 
-def _get_changed_project_release_model_adoptions(project_ids):
+def _get_changed_project_release_model_adoptions(project_ids, now=None):
     """Returns the last 72 hours worth of releases."""
-    start = datetime.now(pytz.utc) - timedelta(days=3)
+    if now is None:
+        now = datetime.now(pytz.utc)
+
+    start = now - timedelta(days=3)
     rv = []
 
     # Find all releases with adoption in the last 48 hours

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -154,7 +154,13 @@ def _check_releases_have_health_data(
 
 
 def _get_project_releases_by_stability(
-    project_ids, offset, limit, scope, stats_period=None, environments=None
+    project_ids,
+    offset,
+    limit,
+    scope,
+    stats_period=None,
+    environments=None,
+    now=None,
 ):
     """Given some project IDs returns adoption rates that should be updated
     on the postgres tables.
@@ -167,7 +173,7 @@ def _get_project_releases_by_stability(
         scope = scope[:-4]
         stats_period = "24h"
 
-    _, stats_start, _ = get_rollup_starts_and_buckets(stats_period)
+    _, stats_start, _ = get_rollup_starts_and_buckets(stats_period, now=now)
 
     orderby = {
         "crash_free_sessions": [["-divide", ["sessions_crashed", "sessions"]]],
@@ -373,6 +379,7 @@ def _get_release_health_data_overview(
     summary_stats_period=None,
     health_stats_period=None,
     stat=None,
+    now=None,
 ):
     """Checks quickly for which of the given project releases we have
     health data available.  The argument is a tuple of `(project_id, release_name)`
@@ -383,10 +390,12 @@ def _get_release_health_data_overview(
         stat = "sessions"
     assert stat in ("sessions", "users")
 
-    _, summary_start, _ = get_rollup_starts_and_buckets(summary_stats_period or "24h")
+    _, summary_start, _ = get_rollup_starts_and_buckets(summary_stats_period or "24h", now=now)
     conditions, filter_keys = _get_conditions_and_filter_keys(project_releases, environments)
 
-    stats_rollup, stats_start, stats_buckets = get_rollup_starts_and_buckets(health_stats_period)
+    stats_rollup, stats_start, stats_buckets = get_rollup_starts_and_buckets(
+        health_stats_period, now=now
+    )
 
     missing_releases = set(project_releases)
     rv = {}

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -15,6 +15,12 @@ from sentry.utils.dates import to_timestamp
 
 
 def parametrize_backend(cls):
+    """
+    hack to parametrize test-classes by backend. Ideally we'd move
+    over to pytest-style tests so we can use `pytest.mark.parametrize`, but
+    hopefully we won't have more than one backend in the future.
+    """
+
     class MetricsTest(SessionMetricsTestCase, cls):
         __doc__ = f"Repeat tests from {cls} with metrics"
         backend = MetricsReleaseHealthBackend()

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -21,6 +21,9 @@ def parametrize_backend(cls):
     hopefully we won't have more than one backend in the future.
     """
 
+    assert not hasattr(cls, "backend")
+    cls.backend = SessionsReleaseHealthBackend()
+
     class MetricsTest(SessionMetricsTestCase, cls):
         __doc__ = f"Repeat tests from {cls} with metrics"
         backend = MetricsReleaseHealthBackend()
@@ -54,8 +57,6 @@ def make_24h_stats(ts):
 
 @parametrize_backend
 class SnubaSessionsTest(TestCase, SnubaTestCase):
-    backend = SessionsReleaseHealthBackend()
-
     def setUp(self):
         super().setUp()
         self.received = time.time()
@@ -920,8 +921,6 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
         In the previous 24h (>24h & <48h) -> 4 Exited + 1 Crashed / 5 Total Sessions -> 80%
     """
 
-    backend = SessionsReleaseHealthBackend()
-
     def setUp(self):
         super().setUp()
         self.session_started = time.time() // 60 * 60
@@ -1049,8 +1048,6 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
 
 @parametrize_backend
 class GetProjectReleasesCountTest(TestCase, SnubaTestCase):
-    backend = SessionsReleaseHealthBackend()
-
     def test_empty(self):
         # Test no errors when no session data
         org = self.create_organization()
@@ -1117,8 +1114,6 @@ class GetProjectReleasesCountTest(TestCase, SnubaTestCase):
 
 @parametrize_backend
 class CheckReleasesHaveHealthDataTest(TestCase, SnubaTestCase):
-    backend = SessionsReleaseHealthBackend()
-
     def run_test(self, expected, projects, releases, start=None, end=None):
         if not start:
             start = datetime.now() - timedelta(days=1)
@@ -1162,8 +1157,6 @@ class CheckReleasesHaveHealthDataTest(TestCase, SnubaTestCase):
 
 @parametrize_backend
 class CheckNumberOfSessions(TestCase, SnubaTestCase):
-    backend = SessionsReleaseHealthBackend()
-
     def setUp(self):
         super().setUp()
         self.dev_env = self.create_environment(name="development", project=self.project)


### PR DESCRIPTION
Basically pass around a bunch of `now` parameters where it makes sense.

Additionally I refactored tests such that the duplex backend is also tested. I verified that all tests run because pytest previously saw 68 of them, now it's 102, which is exactly 150%.