### PR TITLE
feat(leaky-bucket): allow disabled member to leave org

### DIFF
--- a/src/sentry/api/endpoints/organization_member_details.py
+++ b/src/sentry/api/endpoints/organization_member_details.py
@@ -73,6 +73,11 @@ class RelaxedMemberPermission(OrganizationPermission):
         "DELETE": ["member:read", "member:write", "member:admin"],
     }
 
+    # Allow deletions to happen for disabled members so they can remove themselves
+    # allowing other methods should be fine as well even if we don't strictly need to allow them
+    def is_member_disabled_from_limit(self, request: Request, organization):
+        return False
+
 
 class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
     permission_classes = [RelaxedMemberPermission]

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -54,6 +54,7 @@ ERR_JOIN_REQUESTS_DISABLED = "Your organization does not allow requests to join.
 class OrganizationMemberManager(BaseManager):
     def get_contactable_members_for_org(self, organization_id: int) -> QuerySet:
         """Get a list of members we can contact for an organization through email."""
+        # TODO(Steve): check member-limit:restricted
         return self.select_related("user").filter(
             organization_id=organization_id,
             invite_status=InviteStatus.APPROVED.value,

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -441,6 +441,22 @@ class DeleteOrganizationMemberTest(OrganizationMemberTestBase):
         self.get_error_response(self.organization.slug, join_request.id, status_code=404)
         self.get_error_response(self.organization.slug, invite_request.id, status_code=404)
 
+    def test_disabled_member_can_remove(self):
+        other_user = self.create_user("bar@example.com")
+        self.create_member(
+            organization=self.organization,
+            role="member",
+            user=other_user,
+            flags=OrganizationMember.flags["member-limit:restricted"],
+        )
+
+        self.login_as(other_user)
+        self.get_success_response(self.organization.slug, "me")
+
+        assert not OrganizationMember.objects.filter(
+            user=other_user, organization=self.organization
+        ).exists()
+
 
 class ResetOrganizationMember2faTest(APITestCase):
     def setUp(self):


### PR DESCRIPTION
This PR opens up the member details route to disabled members. I've opened up all types of requests to the organization member details endpoint for the purpose of simplicity and fewer edge cases.