### PR TITLE
feat(ui): Change resolve threshold to not use threshold control

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -695,6 +695,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const canEdit =
       isActiveSuperuser() || (ownerId ? userTeamIds.includes(ownerId) : true);
 
+    const hasAlertWizardV3 =
+      Boolean(isCustomMetric) && organization.features.includes('alert-wizard-v3');
+
     const triggerForm = (hasAccess: boolean) => (
       <Triggers
         disabled={!hasAccess || !canEdit}
@@ -710,15 +713,13 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         organization={organization}
         ruleId={ruleId}
         availableActions={this.state.availableActions}
+        hasAlertWizardV3={hasAlertWizardV3}
         onChange={this.handleChangeTriggers}
         onThresholdTypeChange={this.handleThresholdTypeChange}
         onThresholdPeriodChange={this.handleThresholdPeriodChange}
         onResolveThresholdChange={this.handleResolveThresholdChange}
       />
     );
-
-    const hasAlertWizardV3 =
-      Boolean(isCustomMetric) && organization.features.includes('alert-wizard-v3');
 
     const ruleNameOwnerForm = (hasAccess: boolean) => (
       <RuleNameOwnerForm

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -84,9 +84,7 @@ type State = {
   projects: Project[];
   query: string;
   resolveThreshold: UnsavedIncidentRule['resolveThreshold'];
-
   thresholdPeriod: UnsavedIncidentRule['thresholdPeriod'];
-
   thresholdType: UnsavedIncidentRule['thresholdType'];
   timeWindow: number;
   triggerErrors: Map<number, {[fieldName: string]: string}>;

--- a/static/app/views/alerts/incidentRules/triggers/form.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/form.tsx
@@ -48,10 +48,6 @@ type Props = {
    * Map of fieldName -> errorMessage
    */
   error?: {[fieldName: string]: string};
-  /**
-   * Map of fieldName -> errorMessage
-   */
-  error?: {[fieldName: string]: string};
 
   hideControl?: boolean;
 };

--- a/static/app/views/alerts/incidentRules/triggers/form.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/form.tsx
@@ -48,9 +48,15 @@ type Props = {
    * Map of fieldName -> errorMessage
    */
   error?: {[fieldName: string]: string};
+  /**
+   * Map of fieldName -> errorMessage
+   */
+  error?: {[fieldName: string]: string};
+
+  hideControl?: boolean;
 };
 
-class TriggerForm extends React.PureComponent<Props> {
+class TriggerFormItem extends React.PureComponent<Props> {
   /**
    * Handler for threshold changes coming from slider or chart.
    * Needs to sync state with the form.
@@ -75,6 +81,7 @@ class TriggerForm extends React.PureComponent<Props> {
       isCritical,
       thresholdType,
       thresholdPeriod,
+      hideControl,
       comparisonType,
       fieldHelp,
       triggerLabel,
@@ -96,6 +103,7 @@ class TriggerForm extends React.PureComponent<Props> {
           type={trigger.label}
           thresholdType={thresholdType}
           thresholdPeriod={thresholdPeriod}
+          hideControl={hideControl}
           threshold={trigger.alertThreshold}
           comparisonType={comparisonType}
           placeholder={placeholder}
@@ -109,7 +117,7 @@ class TriggerForm extends React.PureComponent<Props> {
 }
 
 type TriggerFormContainerProps = Omit<
-  React.ComponentProps<typeof TriggerForm>,
+  React.ComponentProps<typeof TriggerFormItem>,
   | 'onChange'
   | 'isCritical'
   | 'error'
@@ -120,6 +128,7 @@ type TriggerFormContainerProps = Omit<
   | 'triggerLabel'
   | 'placeholder'
 > & {
+  hasAlertWizardV3: boolean;
   onChange: (triggerIndex: number, trigger: Trigger, changeObj: Partial<Trigger>) => void;
   onResolveThresholdChange: (
     resolveThreshold: UnsavedIncidentRule['resolveThreshold']
@@ -194,6 +203,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
       aggregate,
       resolveThreshold,
       projects,
+      hasAlertWizardV3,
       onThresholdTypeChange,
       onThresholdPeriodChange,
     } = this.props;
@@ -213,7 +223,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
           // eslint-disable-next-line no-use-before-define
           const TriggerIndicator = isCritical ? CriticalIndicator : WarningIndicator;
           return (
-            <TriggerForm
+            <TriggerFormItem
               key={index}
               api={api}
               config={config}
@@ -257,7 +267,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
             />
           );
         })}
-        <TriggerForm
+        <TriggerFormItem
           api={api}
           config={config}
           disabled={disabled}
@@ -266,6 +276,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
           // Flip rule thresholdType to opposite
           thresholdPeriod={thresholdPeriod}
           thresholdType={+!thresholdType}
+          hideControl={hasAlertWizardV3}
           comparisonType={comparisonType}
           aggregate={aggregate}
           resolveThreshold={resolveThreshold}

--- a/static/app/views/alerts/incidentRules/triggers/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/index.tsx
@@ -23,6 +23,7 @@ type Props = {
   currentProject: string;
   disabled: boolean;
   errors: Map<number, {[fieldName: string]: string}>;
+  hasAlertWizardV3: boolean;
   onChange: (
     triggers: Trigger[],
     triggerIndex?: number,
@@ -104,6 +105,7 @@ class Triggers extends Component<Props> {
       thresholdPeriod,
       comparisonType,
       resolveThreshold,
+      hasAlertWizardV3,
       onThresholdTypeChange,
       onResolveThresholdChange,
       onThresholdPeriodChange,
@@ -125,6 +127,7 @@ class Triggers extends Component<Props> {
               thresholdType={thresholdType}
               thresholdPeriod={thresholdPeriod}
               comparisonType={comparisonType}
+              hasAlertWizardV3={hasAlertWizardV3}
               onChange={this.handleChangeTrigger}
               onThresholdTypeChange={onThresholdTypeChange}
               onResolveThresholdChange={onResolveThresholdChange}

--- a/static/app/views/alerts/incidentRules/triggers/thresholdControl.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/thresholdControl.tsx
@@ -24,6 +24,7 @@ type Props = ThresholdControlValue & {
   placeholder: string;
   thresholdPeriod: number | null;
   type: string;
+  hideControl?: boolean;
 };
 
 type State = {
@@ -99,6 +100,7 @@ class ThresholdControl extends React.Component<Props, State> {
       thresholdPeriod,
       thresholdType,
       comparisonType,
+      hideControl,
       threshold,
       placeholder,
       type,
@@ -121,14 +123,22 @@ class ThresholdControl extends React.Component<Props, State> {
                   value: AlertRuleThresholdType.BELOW,
                   label:
                     comparisonType === AlertRuleComparisonType.COUNT
-                      ? t('Below')
+                      ? hideControl
+                        ? t('When below Critical or Warning')
+                        : t('Below')
+                      : hideControl
+                      ? t('When lower than Critical or Warning')
                       : t('Lower than'),
                 },
                 {
                   value: AlertRuleThresholdType.ABOVE,
                   label:
                     comparisonType === AlertRuleComparisonType.COUNT
-                      ? t('Above')
+                      ? hideControl
+                        ? t('When above Critical or Warning')
+                        : t('Above')
+                      : hideControl
+                      ? t('When higher than Critical or Warning')
                       : t('Higher than'),
                 },
               ]}
@@ -147,37 +157,42 @@ class ThresholdControl extends React.Component<Props, State> {
               onChange={this.handleTypeChange}
             />
           </SelectContainer>
-
-          <ThresholdContainer comparisonType={comparisonType}>
-            <ThresholdInput>
-              <StyledInput
-                disabled={disabled}
-                name={`${type}Threshold`}
-                data-test-id={`${type}-threshold`}
-                placeholder={placeholder}
-                value={currentValue ?? threshold ?? ''}
-                onChange={this.handleThresholdChange}
-                onBlur={this.handleThresholdBlur}
-                // Disable lastpass autocomplete
-                data-lpignore="true"
-              />
-              <DragContainer>
-                <Tooltip
-                  title={tct(
-                    'Drag to adjust threshold[break]You can hold shift to fine tune',
-                    {
-                      break: <br />,
-                    }
-                  )}
-                >
-                  <NumberDragControl step={5} axis="y" onChange={this.handleDragChange} />
-                </Tooltip>
-              </DragContainer>
-            </ThresholdInput>
-            {comparisonType === AlertRuleComparisonType.CHANGE && (
+          {!hideControl && (
+            <ThresholdContainer comparisonType={comparisonType}>
+              <ThresholdInput>
+                <StyledInput
+                  disabled={disabled}
+                  name={`${type}Threshold`}
+                  data-test-id={`${type}-threshold`}
+                  placeholder={placeholder}
+                  value={currentValue ?? threshold ?? ''}
+                  onChange={this.handleThresholdChange}
+                  onBlur={this.handleThresholdBlur}
+                  // Disable lastpass autocomplete
+                  data-lpignore="true"
+                />
+                <DragContainer>
+                  <Tooltip
+                    title={tct(
+                      'Drag to adjust threshold[break]You can hold shift to fine tune',
+                      {
+                        break: <br />,
+                      }
+                    )}
+                  >
+                    <NumberDragControl
+                      step={5}
+                      axis="y"
+                      onChange={this.handleDragChange}
+                    />
+                  </Tooltip>
+                </DragContainer>
+              </ThresholdInput>
+              {comparisonType === AlertRuleComparisonType.CHANGE && (
               <PercentWrapper>%</PercentWrapper>
             )}
-          </ThresholdContainer>
+            </ThresholdContainer>
+          )}
         </Container>
         <Feature features={['metric-alert-threshold-period']}>
           <SelectContainer>

--- a/static/app/views/alerts/incidentRules/triggers/thresholdControl.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/thresholdControl.tsx
@@ -189,8 +189,8 @@ class ThresholdControl extends React.Component<Props, State> {
                 </DragContainer>
               </ThresholdInput>
               {comparisonType === AlertRuleComparisonType.CHANGE && (
-              <PercentWrapper>%</PercentWrapper>
-            )}
+                <PercentWrapper>%</PercentWrapper>
+              )}
             </ThresholdContainer>
           )}
         </Container>


### PR DESCRIPTION
This updates the resolve threshold control in trigger form in the alert wizard. It is part of the alert wizard v3 changes.

Before:
![Screen Shot 2022-02-15 at 2 50 33 PM](https://user-images.githubusercontent.com/15015880/154163353-e2c1e2ce-69a7-45c6-b424-410dba899b95.png)


After:
![Screen Shot 2022-02-15 at 2 52 00 PM](https://user-images.githubusercontent.com/15015880/154163369-1ac7cc85-318a-4ed8-be7c-c2f0eb53374a.png)

