### PR TITLE
ref(metrics-indexer): Increase commit batch time/size defaults

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -554,8 +554,8 @@ def metrics_consumer(**options):
 @click.option("--input-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--factory-name", default="default")
-@click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=7500)
-@click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=4000)
+@click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=50000)
+@click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=6000)
 def metrics_streaming_consumer(**options):
     from sentry.sentry_metrics.metrics_wrapper import MetricsWrapper
     from sentry.sentry_metrics.multiprocess import get_streaming_metrics_consumer

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -555,7 +555,7 @@ def metrics_consumer(**options):
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--factory-name", default="default")
 @click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=50000)
-@click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=6000)
+@click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=8000)
 def metrics_streaming_consumer(**options):
     from sentry.sentry_metrics.metrics_wrapper import MetricsWrapper
     from sentry.sentry_metrics.multiprocess import get_streaming_metrics_consumer


### PR DESCRIPTION
**context**
we are spending a lot of time on the produce step of the metrics indexer https://github.com/getsentry/sentry/blob/1b39c8cf5e7e5e9b27f13266e39a8834982133b5/src/sentry/sentry_metrics/multiprocess.py#L565-L568
while maxing out the batch size of `7500` (and sometimes the batch time of `4000` ms)

This PR increases both the `commit_max_batch_size` and `commit_max_batch_time` parameters to see if it will help with the performance. 

Note: There is also https://github.com/getsentry/sentry/pull/31779 which aims to help even further with the produce time, but let's see if this change helps first