### PR TITLE
ref(sdk): Setting our idleTimeout to default as a test

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -31,7 +31,7 @@ function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
             ),
           }
         : {}),
-      idleTimeout: 5000,
+      idleTimeout: 1000,
       _metricOptions: {
         _reportAllChanges: false,
       },


### PR DESCRIPTION
### Summary
We're testing how idleTimeout works with it's default value now that we have the beta branch of sdk with modified idleTimeout behaviour. We'll track how changing idleTimeout affects LCP rates over a day or so then return it back to normal if it affects LCP too heavily.