### PR TITLE
fix(ui): Use a 16px `margin-bottom` for panels

### DIFF
--- a/static/app/components/panels/panel.tsx
+++ b/static/app/components/panels/panel.tsx
@@ -13,7 +13,7 @@ const Panel = styled('div')<Props>`
   border: 1px
     ${p => (p.dashedBorder ? 'dashed' + p.theme.gray300 : 'solid ' + p.theme.border)};
   box-shadow: ${p => (p.dashedBorder ? 'none' : p.theme.dropShadowLight)};
-  margin-bottom: ${space(3)};
+  margin-bottom: ${space(2)};
   position: relative;
 `;
 


### PR DESCRIPTION
**Before:**
<img width="323" alt="Screen Shot 2022-02-15 at 11 55 03 AM" src="https://user-images.githubusercontent.com/44172267/154138758-8ed30645-93ca-48cf-b106-a812a0ca3bef.png">

**After:**
<img width="323" alt="Screen Shot 2022-02-15 at 11 55 22 AM" src="https://user-images.githubusercontent.com/44172267/154138815-a98b1f31-082c-48ed-a34e-52d77ed0e1c5.png">

