### PR TITLE
fix(ui): Use a 16px `margin-bottom` for alerts

### DIFF
--- a/static/app/components/alert.tsx
+++ b/static/app/components/alert.tsx
@@ -42,7 +42,7 @@ const alertStyles = ({
   return css`
     display: flex;
     flex-direction: column;
-    margin: 0 0 ${space(3)};
+    margin: 0 0 ${space(2)};
     padding: ${space(1.5)} ${space(2)};
     font-size: ${theme.fontSizeLarge};
     box-shadow: ${theme.dropShadowLight};


### PR DESCRIPTION
**Before:**
<img width="290" alt="Screen Shot 2022-02-15 at 12 07 52 PM" src="https://user-images.githubusercontent.com/44172267/154140710-fa82c3ed-18df-4d43-b51c-8fcdf680212d.png">

**After:**
<img width="290" alt="Screen Shot 2022-02-15 at 12 07 28 PM" src="https://user-images.githubusercontent.com/44172267/154140637-a725c69d-8265-462f-803b-e777c9469e53.png">
