### PR TITLE
fix(api): Fix seq scan on teams table

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -80,9 +80,9 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     queryset = queryset.filter(slug__in=value)
                 elif key == "team":
                     team_list = list(Team.objects.filter(slug__in=value))
-                    queryset = queryset.filter(teams__in=team_list)
+                    queryset = queryset.filter(organization=organization, teams__in=team_list)
                 elif key == "!team":
-                    team_list = list(Team.objects.filter(slug__in=value))
+                    team_list = list(Team.objects.filter(organization=organization, slug__in=value))
                     queryset = queryset.exclude(teams__in=team_list)
                 elif key == "is_member":
                     queryset = queryset.filter(teams__organizationmember__user=request.user)

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -79,8 +79,8 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 elif key == "slug":
                     queryset = queryset.filter(slug__in=value)
                 elif key == "team":
-                    team_list = list(Team.objects.filter(slug__in=value))
-                    queryset = queryset.filter(organization=organization, teams__in=team_list)
+                    team_list = list(Team.objects.filter(organization=organization, slug__in=value))
+                    queryset = queryset.filter(teams__in=team_list)
                 elif key == "!team":
                     team_list = list(Team.objects.filter(organization=organization, slug__in=value))
                     queryset = queryset.exclude(teams__in=team_list)


### PR DESCRIPTION
This fixes an issue where we forgot to filter on `organization` when filtering by slug on team. This
isn't a security issue since we filter the `Project` by organization already, but still better to
not seq scan here.