### PR TITLE
fix(page-filters): Restore datetime when pinned

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -99,7 +99,7 @@ function getProjectIdFromProject(project: MinimalProject) {
 }
 
 /**
- * Merges two date time objects, where the `base` object takes presidence, and
+ * Merges two date time objects, where the `base` object takes precedence, and
  * the `fallback` values are used when the base values are null or undefined.
  */
 function mergeDatetime(
@@ -180,6 +180,7 @@ export function initializeUrlState({
   }
 
   const storedPageFilters = skipLoadLastUsed ? null : getPageFilterStorage(orgSlug);
+  let shouldUsePinnedDatetime = false;
 
   // We may want to restore some page filters from local storage. In the new
   // world when they are pinned, and in the old world as long as
@@ -202,8 +203,8 @@ export function initializeUrlState({
     }
 
     if (!hasDatetimeInUrl && filtersToRestore.has('datetime')) {
-      const storedDatetime = getDatetimeFromState(storedState);
-      pageFilters.datetime = mergeDatetime(pageFilters.datetime, storedDatetime);
+      pageFilters.datetime = getDatetimeFromState(storedState);
+      shouldUsePinnedDatetime = true;
     }
   }
 
@@ -251,8 +252,11 @@ export function initializeUrlState({
 
   const newDatetime = {
     ...datetime,
-    period: !parsed.start && !parsed.end && !parsed.period ? null : datetime.period,
-    utc: !parsed.utc ? null : datetime.utc,
+    period:
+      parsed.start || parsed.end || parsed.period || shouldUsePinnedDatetime
+        ? datetime.period
+        : null,
+    utc: parsed.utc || shouldUsePinnedDatetime ? datetime.utc : null,
   };
 
   updateParams({project, environment, ...newDatetime}, router, {

--- a/tests/js/spec/actionCreators/pageFilters.spec.jsx
+++ b/tests/js/spec/actionCreators/pageFilters.spec.jsx
@@ -247,10 +247,10 @@ describe('PageFilters ActionCreators', function () {
             environment: ['prod'],
             start: null,
             end: null,
-            period: '14d',
+            period: '7d',
             utc: null,
           },
-          pinnedFilters: new Set(['environments']),
+          pinnedFilters: new Set(['environments', 'datetime', 'projects']),
         });
 
       // Initialize state with a page that uses pinned filters
@@ -266,7 +266,8 @@ describe('PageFilters ActionCreators', function () {
         expect.objectContaining({
           query: {
             environment: ['prod'],
-            project: [],
+            project: ['1'],
+            statsPeriod: '7d',
           },
         })
       );


### PR DESCRIPTION
Datetime wasn't being properly restored when pinned, added some logic to do so.