### PR TITLE
fix(ci): Set pipefail in the tsc build step

### DIFF
--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -105,6 +105,7 @@ jobs:
       - name: tsc
         if: steps.dependencies.outcome == 'success' && steps.changes.outputs.frontend == 'true'
         run: |
+          set -o pipefail
           yarn tsc -p config/tsconfig.build.json --diagnostics | tee /tmp/typescript-monitor.log && node .github/workflows/scripts/monitor-typescript.js
 
       - name: storybook


### PR DESCRIPTION
Without this the return value of a pipeline is the exit status of the last command. So if we have tsc errors it would not fail the build.

tsc will have been reporting incorrectly since https://github.com/getsentry/sentry/pull/31757