### PR TITLE
fix(project-details): Refetch velocity score card

### DIFF
--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -163,11 +163,12 @@ class ProjectVelocityScoreCard extends AsyncComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const {selection, isProjectStabilized} = this.props;
+    const {selection, isProjectStabilized, query} = this.props;
 
     if (
       prevProps.selection !== selection ||
-      prevProps.isProjectStabilized !== isProjectStabilized
+      prevProps.isProjectStabilized !== isProjectStabilized ||
+      prevProps.query !== query
     ) {
       this.remountComponent();
     }


### PR DESCRIPTION
We want to re-fetch the velocity score card every time the query changes.

Example: You have initially 31 releases in the score-card, then you filter by `release.package:release` and you want the score card to update with the number of relay releases.
