### PR TITLE
feat(flamegraph): select a thread

### DIFF
--- a/docs-ui/stories/components/profiling/flamegraphZoomView.stories.js
+++ b/docs-ui/stories/components/profiling/flamegraphZoomView.stories.js
@@ -2,10 +2,12 @@ import * as React from 'react';
 
 import {FlamegraphOptionsMenu} from 'sentry/components/profiling/FlamegraphOptionsMenu';
 import {FlamegraphSearch} from 'sentry/components/profiling/FlamegraphSearch';
+import {FlamegraphToolbar} from 'sentry/components/profiling/FlamegraphToolbar';
 import {FlamegraphViewSelectMenu} from 'sentry/components/profiling/FlamegraphViewSelectMenu';
 import {FlamegraphZoomView} from 'sentry/components/profiling/FlamegraphZoomView';
 import {FlamegraphZoomViewMinimap} from 'sentry/components/profiling/FlamegraphZoomViewMinimap';
 import {ProfileDragDropImport} from 'sentry/components/profiling/ProfileDragDropImport';
+import {ThreadMenuSelector} from 'sentry/components/profiling/ThreadSelector';
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/FlamegraphThemeProvider';
@@ -38,6 +40,15 @@ export const EventedTrace = () => {
     [view.inverted, view.leftHeavy]
   );
 
+  const onProfileIndexChange = React.useCallback(
+    index => {
+      setFlamegraph(
+        new Flamegraph(profiles.profiles[index], index, view.inverted, view.leftHeavy)
+      );
+    },
+    [view.inverted, view.leftHeavy]
+  );
+
   React.useEffect(() => {
     setFlamegraph(new Flamegraph(profiles.profiles[0], 0, view.inverted, view.leftHeavy));
   }, [view.inverted, view.leftHeavy]);
@@ -53,14 +64,7 @@ export const EventedTrace = () => {
           overscrollBehavior: 'contain',
         }}
       >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-            marginBottom: 8,
-          }}
-        >
+        <FlamegraphToolbar>
           <FlamegraphViewSelectMenu
             view={view.inverted ? 'bottom up' : 'top down'}
             sorting={view.leftHeavy ? 'left heavy' : 'call order'}
@@ -71,6 +75,11 @@ export const EventedTrace = () => {
               setView({...view, inverted: v === 'bottom up'});
             }}
           />
+          <ThreadMenuSelector
+            profileGroup={profiles}
+            activeProfileIndex={flamegraph.profileIndex}
+            onProfileIndexChange={onProfileIndexChange}
+          />
           <FlamegraphOptionsMenu
             colorCoding={colorCoding}
             onColorCodingChange={setColorCoding}
@@ -78,7 +87,8 @@ export const EventedTrace = () => {
             onHighlightRecursionChange={setHighlightRecursion}
             canvasPoolManager={canvasPoolManager}
           />
-        </div>
+          <div />
+        </FlamegraphToolbar>
         <div style={{height: 100, position: 'relative'}}>
           <FlamegraphZoomViewMinimap
             flamegraph={flamegraph}

--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -81,7 +81,7 @@ type Props<T> = typeof defaultProps & {
   /**
    * Must be a function that returns a component
    */
-  children: (props: ChildrenProps<T>) => React.ReactElement;
+  children: (props: ChildrenProps<T>) => React.ReactElement | null;
   disabled: boolean;
   defaultHighlightedIndex?: number;
   defaultInputValue?: string;

--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -265,6 +265,15 @@ class AutoComplete<T extends Item> extends React.Component<Props<T>, State<T>> {
       this.handleSelect(item, e);
     };
 
+  handleItemMouseEnter =
+    ({item, index}: GetItemArgs<T>) =>
+    (_e: React.MouseEvent) => {
+      if (item.disabled) {
+        return;
+      }
+      this.setState({highlightedIndex: index});
+    };
+
   handleMenuMouseDown = () => {
     // Cancel close menu from input blur (mouseDown event can occur before input blur :()
     setTimeout(() => {
@@ -377,6 +386,7 @@ class AutoComplete<T extends Item> extends React.Component<Props<T>, State<T>> {
       ...props,
       'data-test-id': item['data-test-id'],
       onClick: this.handleItemClick({item, index: newIndex, ...props}),
+      onMouseEnter: this.handleItemMouseEnter({item, index: newIndex, ...props}),
     };
   };
 

--- a/static/app/components/profiling/FlamegraphToolbar.tsx
+++ b/static/app/components/profiling/FlamegraphToolbar.tsx
@@ -1,12 +1,10 @@
 import styled from '@emotion/styled';
 
-function FlamegraphToolbar(props): React.ReactElement {
-  return <FlamegraphToolbarContainer>{props.children}</FlamegraphToolbarContainer>;
+interface FlamegraphToolbarProps {
+  children: React.ReactNode;
 }
 
-export {FlamegraphToolbar};
-
-const FlamegraphToolbarContainer = styled('div')`
+export const FlamegraphToolbar = styled('div')<FlamegraphToolbarProps>`
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/static/app/components/profiling/FlamegraphToolbar.tsx
+++ b/static/app/components/profiling/FlamegraphToolbar.tsx
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+function FlamegraphToolbar(props): React.ReactElement {
+  return <FlamegraphToolbarContainer>{props.children}</FlamegraphToolbarContainer>;
+}
+
+export {FlamegraphToolbar};
+
+const FlamegraphToolbarContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;

--- a/static/app/components/profiling/ThreadSelector.tsx
+++ b/static/app/components/profiling/ThreadSelector.tsx
@@ -93,7 +93,8 @@ function ThreadMenuSelector(props: ThreadSelectorProps): React.ReactElement | nu
   return (
     <div>
       <Button size="zero" borderless onClick={() => setOpen(true)}>
-        {props.profileGroup.profiles[props.activeProfileIndex]?.name ?? t('Select Thread')}
+        {props.profileGroup.profiles[props.activeProfileIndex]?.name ??
+          t('Select Thread')}
       </Button>
       <AutoComplete
         // @ts-ignore the type is typed as any

--- a/static/app/components/profiling/ThreadSelector.tsx
+++ b/static/app/components/profiling/ThreadSelector.tsx
@@ -93,7 +93,7 @@ function ThreadMenuSelector(props: ThreadSelectorProps): React.ReactElement | nu
   return (
     <div>
       <Button size="zero" borderless onClick={() => setOpen(true)}>
-        {props.profileGroup.profiles[props.activeProfileIndex]?.name ?? 'Select Thread'}
+        {props.profileGroup.profiles[props.activeProfileIndex]?.name ?? t('Select Thread')}
       </Button>
       <AutoComplete
         // @ts-ignore the type is typed as any

--- a/static/app/components/profiling/ThreadSelector.tsx
+++ b/static/app/components/profiling/ThreadSelector.tsx
@@ -155,9 +155,7 @@ function ThreadMenuSelector(props: ThreadSelectorProps): React.ReactElement | nu
                 )}
               </DropdownBox>
             </ThreadSelectorContainer>
-          ) : (
-            <div />
-          );
+          ) : null;
         }}
       </AutoComplete>
     </div>

--- a/static/app/components/profiling/ThreadSelector.tsx
+++ b/static/app/components/profiling/ThreadSelector.tsx
@@ -1,0 +1,222 @@
+import * as React from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import Fuse from 'fuse.js';
+
+import AutoComplete from 'sentry/components/autoComplete';
+import Button from 'sentry/components/button';
+import Input from 'sentry/components/forms/controls/input';
+import {IconCheckmark} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
+import {Profile} from 'sentry/utils/profiling/profile/profile';
+import useOnClickOutside from 'sentry/utils/useOnClickOutside';
+
+const sortProfiles = (profiles: ReadonlyArray<Profile>): ProfileGroup['profiles'] => {
+  return [...profiles].sort((a, b) => {
+    if (!b.duration) {
+      return -1;
+    }
+    if (!a.duration) {
+      return 1;
+    }
+
+    if (a.name.startsWith('(tid') && b.name.startsWith('(tid')) {
+      return -1;
+    }
+    if (a.name.startsWith('(tid')) {
+      return -1;
+    }
+    if (b.name.startsWith('(tid')) {
+      return -1;
+    }
+    if (a.name.includes('main')) {
+      return -1;
+    }
+    if (b.name.includes('main')) {
+      return 1;
+    }
+    return a.name > b.name ? -1 : 1;
+  });
+};
+
+interface ThreadSelectorProps {
+  activeProfileIndex: ProfileGroup['activeProfileIndex'];
+  onProfileIndexChange: (index: number) => void;
+  profileGroup: ProfileGroup;
+}
+
+function ThreadMenuSelector(props: ThreadSelectorProps): React.ReactElement | null {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [open, setOpen] = React.useState<boolean>(false);
+
+  const handleSelectItem = React.useCallback(
+    (p: Fuse.FuseResultWithMatches<Profile & {index: number}>) => {
+      const index = props.profileGroup.profiles.findIndex(
+        profile => profile.name === p.item.name
+      );
+      if (index === -1) {
+        return;
+      }
+      props.onProfileIndexChange(index);
+    },
+    [props.onProfileIndexChange, props.profileGroup]
+  );
+
+  React.useEffect(() => {
+    const tagNamesToPreventStealingFocusFrom = new Set<Element['tagName']>([
+      'INPUT',
+      'TEXTAREA',
+    ]);
+    function handleKeyDown(evt) {
+      if (tagNamesToPreventStealingFocusFrom.has(evt.target.tagName)) {
+        return;
+      }
+      if (evt.key === 't' && !open) {
+        evt.preventDefault();
+        setOpen(true);
+      }
+      if (evt.key === 'Escape' && open) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
+
+  useOnClickOutside(containerRef, () => {
+    setOpen(false);
+  });
+
+  return (
+    <div>
+      <Button size="zero" borderless onClick={() => setOpen(true)}>
+        {props.profileGroup.profiles[props.activeProfileIndex]?.name ?? 'Select Thread'}
+      </Button>
+      <AutoComplete
+        // @ts-ignore the type is typed as any
+        onSelect={handleSelectItem}
+        closeOnSelect={false}
+        isOpen={open}
+      >
+        {({getInputProps, getItemProps, isOpen, inputValue, highlightedIndex}) => {
+          const sortedProfiles = sortProfiles(props.profileGroup.profiles);
+          const filteredProfiles = inputValue
+            ? new Fuse(sortedProfiles, {includeMatches: true, keys: ['name']}).search(
+                inputValue
+              )
+            : sortedProfiles.map(p => ({item: p, matches: [], score: 1}));
+
+          return isOpen ? (
+            <ThreadSelectorContainer ref={containerRef}>
+              <Input
+                type="search"
+                autoFocus
+                {...getInputProps({
+                  onKeyDown: evt => {
+                    if (evt.key === 'Escape') {
+                      setOpen(false);
+                    }
+                  },
+                })}
+              />
+              <DropdownBox>
+                {filteredProfiles.length > 0 ? (
+                  filteredProfiles.map((profile, index) => {
+                    const activeProfile =
+                      props.profileGroup.profiles[props.activeProfileIndex];
+
+                    return (
+                      <SearchResult
+                        key={index}
+                        highlighted={index === highlightedIndex}
+                        ref={ref =>
+                          index === highlightedIndex
+                            ? ref?.scrollIntoView({block: 'nearest'})
+                            : null
+                        }
+                        {...getItemProps({
+                          // @ts-ignore the type is typed as any
+                          item: profile,
+                          index,
+                        })}
+                      >
+                        {activeProfile.name === profile.item.name ? (
+                          <IconCheckmark size="sm" style={{marginRight: space(1)}} />
+                        ) : null}
+                        {profile.item.name}
+                      </SearchResult>
+                    );
+                  })
+                ) : (
+                  <EmptyItem>{t('No results found')}</EmptyItem>
+                )}
+              </DropdownBox>
+            </ThreadSelectorContainer>
+          ) : (
+            <div />
+          );
+        }}
+      </AutoComplete>
+    </div>
+  );
+}
+
+const SearchResult = styled('li')<{highlighted: boolean}>`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  color: ${p => p.theme.textColor};
+  padding: ${space(1)} ${space(2)};
+
+  ${p =>
+    p.highlighted &&
+    css`
+      color: ${p.theme.purple300};
+      background: ${p.theme.backgroundSecondary};
+    `};
+
+  &:not(:first-child) {
+    border-top: 1px solid ${p => p.theme.innerBorder};
+  }
+`;
+
+const EmptyItem = styled('li')`
+  text-align: center;
+  padding: 16px;
+  opacity: 0.5;
+`;
+
+const DropdownBox = styled('ul')`
+  list-style-type: none;
+  padding: 0;
+  background: ${p => p.theme.background};
+  border: 1px solid ${p => p.theme.border};
+  box-shadow: ${p => p.theme.dropShadowHeavy};
+  right: 0;
+  width: 100%;
+  max-height: 60vh;
+  border-radius: 5px;
+  position: absolute;
+  overflow-y: auto;
+  top: 40px;
+`;
+
+const ThreadSelectorContainer = styled('div')`
+  z-index: ${p => p.theme.zIndex.dropdown};
+  border-radius: ${p => p.theme.borderRadius};
+  position: absolute;
+  max-width: 540px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+  height: 80vh;
+  left: 50%;
+  transform: translate(-50%, 0);
+  top: 60px;
+`;
+
+export {ThreadMenuSelector};


### PR DESCRIPTION
I reused the Autocomplete component and slightly tweaked it so that when we move a mouse over an element, that element receives the highlightedIndex - before nothing would change unless you clicked on the element.

![CleanShot 2022-02-16 at 16 46 46](https://user-images.githubusercontent.com/9317857/154303142-17d2b94b-adae-4480-bec8-dc3216dfe2b4.gif)

Styling is not final, we are missing a few elements on the right side of the toolbar so it looks a bit offset right now which is expected