### PR TITLE
fix(dashboards): open in discover sometimes not working for topn

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -104,9 +104,11 @@ function WidgetCardContextMenu({
         case DisplayType.TOP_N:
           discoverLocation.query.display = DisplayModes.TOP5;
           // Last field is used as the yAxis
-          discoverLocation.query.yAxis =
-            widget.queries[0].fields[widget.queries[0].fields.length - 1];
-          discoverLocation.query.field = widget.queries[0].fields.slice(0, -1);
+          const fields = widget.queries[0].fields;
+          discoverLocation.query.yAxis = fields[fields.length - 1];
+          if (fields.slice(0, -1).includes(fields[fields.length - 1])) {
+            discoverLocation.query.field = fields.slice(0, -1);
+          }
           break;
         default:
           break;

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -234,7 +234,7 @@ describe('Dashboards > WidgetCard', function () {
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     userEvent.click(screen.getByRole('menuitemradio', {name: 'Open in Discover'}));
     expect(router.push).toHaveBeenCalledWith(
-      '/organizations/org-slug/discover/results/?display=top5&environment=prod&field=transaction&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29'
+      '/organizations/org-slug/discover/results/?display=top5&environment=prod&field=transaction&field=count%28%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29'
     );
   });
 


### PR DESCRIPTION
fixes a case where opening in discover would sometimes not work for top n widgets if the y axis is count and not explicitly selected in the columns setting