### PR TITLE
test(stacktracepreview): Fix typo in mock

### DIFF
--- a/tests/js/spec/components/stackTracePreview.spec.tsx
+++ b/tests/js/spec/components/stackTracePreview.spec.tsx
@@ -142,7 +142,7 @@ describe('StackTracePreview', () => {
                     registers: {},
                     framesOmitted: 0,
                     frames: [
-                      {colNo: 0, fileName: 'file.js', function: 'throwError', lineNo: 0},
+                      {colNo: 0, filename: 'file.js', function: 'throwError', lineNo: 0},
                     ],
                   },
                 },


### PR DESCRIPTION
`filename` should be lower case as per https://github.com/getsentry/sentry/blob/354e998b263cf9257e34f092fd2a4db72f4f3aaa/static/app/types/event.tsx#L107