### PR TITLE
ref(Jira): Don't allow sprint field for ticket rules

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -669,6 +669,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         # Sort based on priority, then field name
         dynamic_fields.sort(key=lambda f: anti_gravity.get(f, (0, f)))
 
+        ignore_sprint = True
         # build up some dynamic fields based on required shit.
         for field in dynamic_fields:
             if field in standard_fields or field in [x.strip() for x in ignored_fields]:
@@ -677,6 +678,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
             mb_field = self.build_dynamic_field(issue_type_meta["fields"][field], group)
             if mb_field:
+                if mb_field["label"] == "Sprint" and ignore_sprint:
+                    continue
                 mb_field["name"] = field
                 fields.append(mb_field)
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -677,7 +677,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
             mb_field = self.build_dynamic_field(issue_type_meta["fields"][field], group)
             if mb_field:
-                if mb_field["label"] == "Sprint" and params.get("ignore_sprint"):
+                if mb_field["label"] in params.get("ignored", []):
                     continue
                 mb_field["name"] = field
                 fields.append(mb_field)

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -669,7 +669,6 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         # Sort based on priority, then field name
         dynamic_fields.sort(key=lambda f: anti_gravity.get(f, (0, f)))
 
-        ignore_sprint = True
         # build up some dynamic fields based on required shit.
         for field in dynamic_fields:
             if field in standard_fields or field in [x.strip() for x in ignored_fields]:
@@ -678,7 +677,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
             mb_field = self.build_dynamic_field(issue_type_meta["fields"][field], group)
             if mb_field:
-                if mb_field["label"] == "Sprint" and ignore_sprint:
+                if mb_field["label"] == "Sprint" and params.get("ignore_sprint"):
                     continue
                 mb_field["name"] = field
                 fields.append(mb_field)

--- a/static/app/views/alerts/issueRuleEditor/ticketRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ticketRuleModal.tsx
@@ -52,7 +52,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
           accumulator[name] = instance[name];
           return accumulator;
         },
-        {action: 'create'}
+        {action: 'create', ignore_sprint: true}
       );
     return [['integrationDetails', this.getEndPointString(), {query}]];
   }

--- a/static/app/views/alerts/issueRuleEditor/ticketRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ticketRuleModal.tsx
@@ -10,6 +10,8 @@ import {Choices, IssueConfigField, Organization} from 'sentry/types';
 import {IssueAlertRuleAction} from 'sentry/types/alerts';
 import AsyncView from 'sentry/views/asyncView';
 
+const IGNORED_FIELDS = ['Sprint'];
+
 type Props = {
   // Comes from the in-code definition of a `TicketEventAction`.
   formFields: {[key: string]: any};
@@ -75,7 +77,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
 
   getEndPointString(): string {
     const {instance, organization} = this.props;
-    return `/organizations/${organization.slug}/integrations/${instance.integration}/?ignore_sprint=true`;
+    return `/organizations/${organization.slug}/integrations/${instance.integration}/?ignored=${IGNORED_FIELDS}`;
   }
 
   /**

--- a/static/app/views/alerts/issueRuleEditor/ticketRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ticketRuleModal.tsx
@@ -52,7 +52,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
           accumulator[name] = instance[name];
           return accumulator;
         },
-        {action: 'create', ignore_sprint: true}
+        {action: 'create'}
       );
     return [['integrationDetails', this.getEndPointString(), {query}]];
   }
@@ -75,7 +75,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
 
   getEndPointString(): string {
     const {instance, organization} = this.props;
-    return `/organizations/${organization.slug}/integrations/${instance.integration}/`;
+    return `/organizations/${organization.slug}/integrations/${instance.integration}/?ignore_sprint=true`;
   }
 
   /**

--- a/tests/js/spec/views/alerts/issueRuleEditor/ticketRuleModal.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/ticketRuleModal.spec.jsx
@@ -47,7 +47,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
 
   const addMockConfigsAPICall = (otherFields = {}) => {
     return MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/integrations/1/',
+      url: '/organizations/org-slug/integrations/1/?ignored=Sprint',
       method: 'GET',
       body: {
         createIssueConfig: [


### PR DESCRIPTION
Jira doesn’t stop you from searching for old sprints, but also doesn’t allow you to create a ticket in a closed sprint. There is no data in the response from Jira indicating the status of the sprint for us to be able to determine if it's possible to create a ticket with the selected sprint, unfortunately (we just get the label and value). Given this, I don't think sprints are compatible with ticket rules since sprints are by definition a fixed time period, and ticket rules are more of a set it and forget it feature. If a user creates a ticket rule with a sprint, it will inevitably break when the sprint is closed and every time the rule fires, we'll try and fail to create a ticket. 

In this PR I pass an additional query param to the backend to ignore any field labeled "Sprint" for the `TicketRuleModal`. It still shows (if present) on the manual creation on the issue details page.

Manual creation on the issue details page includes sprint:
<img width="315" alt="Screen Shot 2022-02-16 at 10 19 39 AM" src="https://user-images.githubusercontent.com/29959063/154330445-aed77486-824b-44c1-9220-581732205db9.png">

Issue link settings in an alert rule action excludes sprint:
<img width="324" alt="Screen Shot 2022-02-16 at 10 20 27 AM" src="https://user-images.githubusercontent.com/29959063/154330453-23885086-bb98-413f-b75f-f4bfb046fad3.png">


Fixes [SENTRY-T3T](https://sentry.io/organizations/sentry/issues/2935342031/)