### PR TITLE
feat(profiling): Add options menu

### DIFF
--- a/docs-ui/stories/components/profiling/flamegraphZoomView.stories.js
+++ b/docs-ui/stories/components/profiling/flamegraphZoomView.stories.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {FlamegraphOptionsMenu} from 'sentry/components/profiling/FlamegraphOptionsMenu';
 import {FlamegraphSearch} from 'sentry/components/profiling/FlamegraphSearch';
 import {FlamegraphViewSelectMenu} from 'sentry/components/profiling/FlamegraphViewSelectMenu';
 import {FlamegraphZoomView} from 'sentry/components/profiling/FlamegraphZoomView';
@@ -21,6 +22,8 @@ const profiles = importProfile(trace);
 export const EventedTrace = () => {
   const canvasPoolManager = new CanvasPoolManager();
 
+  const [colorCoding, setColorCoding] = React.useState('by symbol name');
+  const [highlightRecursion, setHighlightRecursion] = React.useState(false);
   const [view, setView] = React.useState({inverted: false, leftHeavy: false});
   const [flamegraph, setFlamegraph] = React.useState(
     new Flamegraph(profiles.profiles[0], 0, view.inverted, view.leftHeavy)
@@ -50,7 +53,14 @@ export const EventedTrace = () => {
           overscrollBehavior: 'contain',
         }}
       >
-        <div>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            marginBottom: 8,
+          }}
+        >
           <FlamegraphViewSelectMenu
             view={view.inverted ? 'bottom up' : 'top down'}
             sorting={view.leftHeavy ? 'left heavy' : 'call order'}
@@ -61,12 +71,19 @@ export const EventedTrace = () => {
               setView({...view, inverted: v === 'bottom up'});
             }}
           />
+          <FlamegraphOptionsMenu
+            colorCoding={colorCoding}
+            onColorCodingChange={setColorCoding}
+            highlightRecursion={highlightRecursion}
+            onHighlightRecursionChange={setHighlightRecursion}
+            canvasPoolManager={canvasPoolManager}
+          />
         </div>
         <div style={{height: 100, position: 'relative'}}>
           <FlamegraphZoomViewMinimap
             flamegraph={flamegraph}
-            highlightRecursion={false}
-            colorCoding="by symbol name"
+            highlightRecursion={highlightRecursion}
+            colorCoding={colorCoding}
             canvasPoolManager={canvasPoolManager}
           />
         </div>
@@ -74,8 +91,8 @@ export const EventedTrace = () => {
           <ProfileDragDropImport onImport={onImport}>
             <FlamegraphZoomView
               flamegraph={flamegraph}
-              highlightRecursion={false}
-              colorCoding="by symbol name"
+              highlightRecursion={highlightRecursion}
+              colorCoding={colorCoding}
               canvasPoolManager={canvasPoolManager}
             />
             <FlamegraphSearch

--- a/static/app/components/profiling/FlamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/FlamegraphOptionsMenu.tsx
@@ -1,0 +1,78 @@
+import styled from '@emotion/styled';
+
+import Button from 'sentry/components/button';
+import DropdownButton from 'sentry/components/dropdownButton';
+import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {ColorCoding} from 'sentry/types/profiling/core';
+import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
+
+interface FlamegraphOptionsMenuProps {
+  canvasPoolManager: CanvasPoolManager;
+  colorCoding: ColorCoding;
+  highlightRecursion: boolean;
+  onColorCodingChange: (value: ColorCoding) => void;
+  onHighlightRecursionChange: (value: boolean) => void;
+}
+
+function FlamegraphOptionsMenu({
+  canvasPoolManager,
+  colorCoding,
+  highlightRecursion,
+  onColorCodingChange,
+  onHighlightRecursionChange,
+}: FlamegraphOptionsMenuProps): React.ReactElement {
+  return (
+    <OptionsMenuContainer>
+      <DropdownControl
+        button={({isOpen, getActorProps}) => (
+          <DropdownButton
+            {...getActorProps()}
+            isOpen={isOpen}
+            prefix={t('Color Coding')}
+            size="xsmall"
+          >
+            {COLOR_CODINGS[colorCoding]}
+          </DropdownButton>
+        )}
+      >
+        {Object.entries(COLOR_CODINGS).map(([value, label]) => (
+          <DropdownItem
+            key={value}
+            onSelect={onColorCodingChange}
+            eventKey={value}
+            isActive={value === colorCoding}
+          >
+            {label}
+          </DropdownItem>
+        ))}
+      </DropdownControl>
+      <Button
+        priority={highlightRecursion ? 'primary' : 'default'}
+        size="xsmall"
+        onClick={() => onHighlightRecursionChange(!highlightRecursion)}
+      >
+        {t('Highlight Recursion')}
+      </Button>
+      <Button size="xsmall" onClick={() => canvasPoolManager.dispatch('resetZoom', [])}>
+        {t('Reset Zoom')}
+      </Button>
+    </OptionsMenuContainer>
+  );
+}
+
+const COLOR_CODINGS: Record<ColorCoding, string> = {
+  'by symbol name': t('By Symbol Name'),
+  'by library': t('By Library'),
+  'by system / application': t('By System / Application'),
+};
+
+const OptionsMenuContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(0.5)};
+  justify-content: flex-start;
+`;
+
+export {FlamegraphOptionsMenu};

--- a/static/app/components/profiling/FlamegraphViewSelectMenu.tsx
+++ b/static/app/components/profiling/FlamegraphViewSelectMenu.tsx
@@ -1,6 +1,9 @@
+import styled from '@emotion/styled';
+
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
 
 interface FlamegraphViewSelectMenuProps {
   onSortingChange: (sorting: FlamegraphViewSelectMenuProps['sorting']) => void;
@@ -16,37 +19,40 @@ function FlamegraphViewSelectMenu({
   onSortingChange,
 }: FlamegraphViewSelectMenuProps): React.ReactElement {
   return (
-    <ButtonBar merged>
-      <Button
-        size="xsmall"
-        priority={sorting === 'call order' ? 'primary' : undefined}
-        onClick={() => onSortingChange('call order')}
-      >
-        {t('Call Order')}
-      </Button>
-      <Button
-        size="xsmall"
-        priority={sorting === 'left heavy' ? 'primary' : undefined}
-        onClick={() => onSortingChange('left heavy')}
-      >
-        {t('Left Heavy')}
-      </Button>
-      <Button
-        size="xsmall"
-        priority={view === 'bottom up' ? 'primary' : undefined}
-        onClick={() => onViewChange('bottom up')}
-      >
-        {t('Bottom Up')}
-      </Button>
-      <Button
-        size="xsmall"
-        priority={view === 'top down' ? 'primary' : undefined}
-        onClick={() => onViewChange('top down')}
-      >
-        {t('Top Down')}
-      </Button>
-    </ButtonBar>
+    <SelectMenuContainer>
+      <ButtonBar merged active={sorting}>
+        <Button
+          barId="call order"
+          size="xsmall"
+          onClick={() => onSortingChange('call order')}
+        >
+          {t('Call Order')}
+        </Button>
+        <Button
+          barId="left heavy"
+          size="xsmall"
+          onClick={() => onSortingChange('left heavy')}
+        >
+          {t('Left Heavy')}
+        </Button>
+      </ButtonBar>
+      <ButtonBar merged active={view}>
+        <Button barId="bottom up" size="xsmall" onClick={() => onViewChange('bottom up')}>
+          {t('Bottom Up')}
+        </Button>
+        <Button barId="top down" size="xsmall" onClick={() => onViewChange('top down')}>
+          {t('Top Down')}
+        </Button>
+      </ButtonBar>
+    </SelectMenuContainer>
   );
 }
+
+const SelectMenuContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(0.5)};
+  justify-content: flex-start;
+`;
 
 export {FlamegraphViewSelectMenu};

--- a/static/app/components/profiling/FlamegraphZoomView.tsx
+++ b/static/app/components/profiling/FlamegraphZoomView.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import {mat3, vec2} from 'gl-matrix';
 
+import {ColorCoding} from 'sentry/types/profiling/core';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {DifferentialFlamegraph} from 'sentry/utils/profiling/differentialFlamegraph';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
@@ -18,7 +19,7 @@ import {BoundTooltip} from './BoundTooltip';
 
 interface FlamegraphZoomViewProps {
   canvasPoolManager: CanvasPoolManager;
-  colorCoding: 'by symbol name' | 'by system / application' | 'by library';
+  colorCoding: ColorCoding;
   flamegraph: Flamegraph | DifferentialFlamegraph;
   highlightRecursion: boolean;
   showSelectedNodeStack?: boolean;

--- a/static/app/components/profiling/FlamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/FlamegraphZoomViewMinimap.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import {mat3, vec2} from 'gl-matrix';
 
+import {ColorCoding} from 'sentry/types/profiling/core';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
@@ -13,7 +14,7 @@ import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
 
 interface FlamegraphZoomViewMinimapProps {
   canvasPoolManager: CanvasPoolManager;
-  colorCoding: 'by symbol name' | 'by system / application' | 'by library';
+  colorCoding: ColorCoding;
   flamegraph: Flamegraph;
   highlightRecursion: boolean;
   searchResults: Record<string, FlamegraphFrame>;

--- a/static/app/types/profiling/core.tsx
+++ b/static/app/types/profiling/core.tsx
@@ -1,3 +1,5 @@
+export type ColorCoding = 'by symbol name' | 'by system / application' | 'by library';
+
 type Annotation = {
   key: string;
   values: string[];

--- a/static/app/views/profiling/landing/profilingScatterChart.tsx
+++ b/static/app/views/profiling/landing/profilingScatterChart.tsx
@@ -17,7 +17,7 @@ import {getSeriesSelection} from 'sentry/components/charts/utils';
 import {Panel} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
 import {Series, SeriesDataUnit} from 'sentry/types/echarts';
-import {Trace} from 'sentry/types/profiling/trace';
+import {Trace} from 'sentry/types/profiling/core';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {Theme} from 'sentry/utils/theme';
 

--- a/static/app/views/profiling/landing/profilingTable.tsx
+++ b/static/app/views/profiling/landing/profilingTable.tsx
@@ -2,7 +2,7 @@ import {Location} from 'history';
 
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import {t} from 'sentry/locale';
-import {Trace} from 'sentry/types/profiling/trace';
+import {Trace} from 'sentry/types/profiling/core';
 
 import {ProfilingTableCell} from './profilingTableCell';
 import {TableColumnKey, TableColumnOrders} from './types';

--- a/static/app/views/profiling/landing/types.tsx
+++ b/static/app/views/profiling/landing/types.tsx
@@ -1,5 +1,5 @@
 import {GridColumnOrder} from 'sentry/components/gridEditable';
-import {Trace} from 'sentry/types/profiling/trace';
+import {Trace} from 'sentry/types/profiling/core';
 
 export type TableColumnKey = keyof Trace;
 


### PR DESCRIPTION
This adds the options menu for a flamegraph with support for changing color
coding, highlight recursion, and reset zoom.

https://user-images.githubusercontent.com/10239353/154354685-f90a3885-83ac-4b8f-8d10-bf4a91b4634e.mp4