### PR TITLE
feat(db): Support dict of params for raw SQL queries

### DIFF
--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -51,13 +51,13 @@ def clean_bad_params(params):
     # in raw SQL queries.
     if isinstance(params, dict):
         for key, param in params.items():
-            if isinstance(param, ((str,), bytes)):
+            if isinstance(param, (str, bytes)):
                 params[key] = remove_null(remove_surrogates(param))
         return params
 
     params = list(params)
     for idx, param in enumerate(params):
-        if isinstance(param, ((str,), bytes)):
+        if isinstance(param, (str, bytes)):
             params[idx] = remove_null(remove_surrogates(param))
     return params
 

--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -47,6 +47,14 @@ def remove_surrogates(value):
 
 
 def clean_bad_params(params):
+    # Support dictionary of parameters for %(key)s placeholders
+    # in raw SQL queries.
+    if isinstance(params, dict):
+        for key, param in params.items():
+            if isinstance(param, ((str,), bytes)):
+                params[key] = remove_null(remove_surrogates(param))
+        return params
+
     params = list(params)
     for idx, param in enumerate(params):
         if isinstance(param, ((str,), bytes)):


### PR DESCRIPTION
Support `%(key)s` placeholders for raw SQL queries where params is a dictionary.
https://docs.djangoproject.com/en/2.2/topics/db/sql/#passing-parameters-into-raw