### PR TITLE
test(access): Add test coverage for org-scoped requests from superuser

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -264,7 +264,7 @@ def from_request(
         return Access(
             scopes=scopes if scopes is not None else settings.SENTRY_SCOPES,
             is_active=True,
-            organization_id=organization.id if organization else None,
+            organization_id=organization.id,
             sso_is_valid=sso_is_valid,
             requires_sso=requires_sso,
             has_global_access=True,


### PR DESCRIPTION
Exercises [lines 253-273](https://github.com/getsentry/sentry/blob/c9423dacaac327c2c8b0bee7cc1d3e1b8c5306ce/src/sentry/auth/access.py#L253-L273), which I believe are uncovered otherwise.