### PR TITLE
ref(alerts): Remove withProjects from builder breadcrumbs

### DIFF
--- a/static/app/views/alerts/builder/builderBreadCrumbs.tsx
+++ b/static/app/views/alerts/builder/builderBreadCrumbs.tsx
@@ -1,82 +1,82 @@
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
+import type {Location} from 'history';
 
 import Breadcrumbs, {Crumb, CrumbDropdown} from 'sentry/components/breadcrumbs';
 import IdBadge from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Project} from 'sentry/types';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import recreateRoute from 'sentry/utils/recreateRoute';
-import withProjects from 'sentry/utils/withProjects';
+import useProjects from 'sentry/utils/useProjects';
 import MenuItem from 'sentry/views/settings/components/settingsBreadcrumb/menuItem';
-import {RouteWithName} from 'sentry/views/settings/components/settingsBreadcrumb/types';
+import type {RouteWithName} from 'sentry/views/settings/components/settingsBreadcrumb/types';
 
 type Props = {
   location: Location;
   orgSlug: string;
   projectSlug: string;
-  projects: Project[];
   routes: RouteWithName[];
   title: string;
   alertName?: string;
   canChangeProject?: boolean;
 };
 
-function BuilderBreadCrumbs(props: Props) {
-  const {
-    orgSlug,
-    title,
-    alertName,
-    projectSlug,
-    projects,
-    routes,
-    canChangeProject,
-    location,
-  } = props;
-  const project = projects.find(({slug}) => projectSlug === slug);
+function BuilderBreadCrumbs({
+  orgSlug,
+  title,
+  alertName,
+  projectSlug,
+  routes,
+  canChangeProject,
+  location,
+}: Props) {
+  const {projects} = useProjects();
   const isSuperuser = isActiveSuperuser();
+  const project = projects.find(({slug}) => projectSlug === slug);
 
   const label = (
     <IdBadge project={project ?? {slug: projectSlug}} avatarSize={18} disableLink />
   );
 
-  const projectCrumbLink = {
+  const projectCrumbLink: Crumb = {
     to: `/organizations/${orgSlug}/alerts/rules/?project=${project?.id}`,
     label,
-    preserveGlobalSelection: true,
   };
-  const projectCrumbDropdown = {
-    onSelect: ({value}) => {
-      browserHistory.push(
-        recreateRoute('', {
-          routes,
-          params: {orgId: orgSlug, projectId: value},
-          location,
-        })
-      );
-    },
-    label,
-    items: projects
-      .filter(proj => proj.isMember || isSuperuser)
-      .map((proj, index) => ({
-        index,
-        value: proj.slug,
-        label: (
-          <MenuItem>
-            <IdBadge
-              project={proj}
-              avatarProps={{consistentWidth: true}}
-              avatarSize={18}
-              disableLink
-            />
-          </MenuItem>
-        ),
-        searchKey: proj.slug,
-      })),
-  };
-  const projectCrumb = canChangeProject ? projectCrumbDropdown : projectCrumbLink;
+
+  function getChangeableCrumb(): CrumbDropdown {
+    return {
+      onSelect: ({value}) => {
+        browserHistory.push(
+          recreateRoute('', {
+            routes,
+            params: {orgId: orgSlug, projectId: value},
+            location,
+          })
+        );
+      },
+      label,
+      items: projects
+        .filter(proj => proj.isMember || isSuperuser)
+        .map((proj, index) => ({
+          index,
+          value: proj.slug,
+          label: (
+            <MenuItem>
+              <IdBadge
+                project={proj}
+                avatarProps={{consistentWidth: true}}
+                avatarSize={18}
+                disableLink
+              />
+            </MenuItem>
+          ),
+          searchKey: proj.slug,
+        })),
+    };
+  }
+
+  const projectCrumb = canChangeProject ? getChangeableCrumb() : projectCrumbLink;
 
   const crumbs: (Crumb | CrumbDropdown)[] = [
     {
@@ -107,4 +107,4 @@ const StyledBreadcrumbs = styled(Breadcrumbs)`
   margin-bottom: ${space(3)};
 `;
 
-export default withProjects(BuilderBreadCrumbs);
+export default BuilderBreadCrumbs;

--- a/static/app/views/alerts/builder/builderBreadCrumbs.tsx
+++ b/static/app/views/alerts/builder/builderBreadCrumbs.tsx
@@ -44,7 +44,7 @@ function BuilderBreadCrumbs({
     label,
   };
 
-  function getChangeableCrumb(): CrumbDropdown {
+  function getProjectDropdownCrumb(): CrumbDropdown {
     return {
       onSelect: ({value}) => {
         browserHistory.push(
@@ -76,7 +76,7 @@ function BuilderBreadCrumbs({
     };
   }
 
-  const projectCrumb = canChangeProject ? getChangeableCrumb() : projectCrumbLink;
+  const projectCrumb = canChangeProject ? getProjectDropdownCrumb() : projectCrumbLink;
 
   const crumbs: (Crumb | CrumbDropdown)[] = [
     {

--- a/static/app/views/alerts/builder/builderBreadCrumbs.tsx
+++ b/static/app/views/alerts/builder/builderBreadCrumbs.tsx
@@ -12,7 +12,7 @@ import useProjects from 'sentry/utils/useProjects';
 import MenuItem from 'sentry/views/settings/components/settingsBreadcrumb/menuItem';
 import type {RouteWithName} from 'sentry/views/settings/components/settingsBreadcrumb/types';
 
-type Props = {
+interface Props {
   location: Location;
   orgSlug: string;
   projectSlug: string;
@@ -20,7 +20,7 @@ type Props = {
   title: string;
   alertName?: string;
   canChangeProject?: boolean;
-};
+}
 
 function BuilderBreadCrumbs({
   orgSlug,


### PR DESCRIPTION
some cleanup, going to re-use this on alert status page