### PR TITLE
fix(ui): Add echarts toolbox to base chart

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -1,5 +1,6 @@
 import 'echarts/lib/component/grid';
 import 'echarts/lib/component/graphic';
+import 'echarts/lib/component/toolbox';
 import 'zrender/lib/svg/svg';
 
 import {forwardRef, useMemo} from 'react';

--- a/static/app/components/charts/components/toolBox.tsx
+++ b/static/app/components/charts/components/toolBox.tsx
@@ -1,8 +1,9 @@
-import 'echarts/lib/component/toolbox';
-
 import type {ToolboxComponentOption} from 'echarts';
 
-function getFeatures({dataZoom, ...features}) {
+function getFeatures({
+  dataZoom,
+  ...features
+}: ToolboxComponentOption['feature'] = {}): ToolboxComponentOption['feature'] {
   return {
     ...(dataZoom
       ? {
@@ -11,7 +12,6 @@ function getFeatures({dataZoom, ...features}) {
             title: {
               zoom: 'zoom',
               back: 'undo',
-              restore: 'reset',
             },
             ...dataZoom,
           },
@@ -23,7 +23,7 @@ function getFeatures({dataZoom, ...features}) {
 
 export default function ToolBox(
   options: ToolboxComponentOption,
-  features
+  features: ToolboxComponentOption['feature']
 ): ToolboxComponentOption {
   return {
     right: 0,


### PR DESCRIPTION
fixes a noisy error when the first chart is rendered, especially on the issues stream