### PR TITLE
ref(access): Convert set attributes to derived properties of Access

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -191,10 +191,7 @@ class Access(abc.ABC):
 
 class OrganizationMemberAccess(Access):
     def __init__(self, member: OrganizationMember, *args, **kwargs) -> None:
-        has_global_access = (
-            bool(member.organization.flags.allow_joinleave) or roles.get(member.role).is_global
-        )
-        super().__init__(has_global_access=has_global_access, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._member = member
 
     @cached_property
@@ -410,6 +407,9 @@ def from_member(
         requires_sso=requires_sso,
         sso_is_valid=sso_is_valid,
         scopes=scopes,
+        has_global_access=(
+            bool(member.organization.flags.allow_joinleave) or roles.get(member.role).is_global
+        ),
         permissions=get_permissions_for_user(member.user_id) if is_superuser else frozenset(),
         role=member.role,
     )

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -273,6 +273,7 @@ class FromRequestTest(TestCase):
 
         assert result.role == "admin"
         assert result.is_active
+        assert result.has_global_access
 
         assert result.requires_sso
         assert not result.sso_is_valid

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -273,8 +273,6 @@ class FromRequestTest(TestCase):
 
         assert result.role == "admin"
         assert result.is_active
-        assert result.has_global_access
-        assert result.organization_id == org.id
 
         assert result.requires_sso
         assert not result.sso_is_valid
@@ -368,15 +366,15 @@ class FromSentryAppTest(TestCase):
 
     def test_no_deleted_projects(self):
         self.create_member(organization=self.org, user=self.user, role="owner", teams=[self.team])
-        project = self.create_project(
+        deleted_project = self.create_project(
             organization=self.org, status=ObjectStatus.PENDING_DELETION, teams=[self.team]
         )
         request = self.make_request(user=self.proxy_user)
         result = access.from_request(request, self.org)
-        assert result.has_project_access(project) is False
-        assert result.has_project_membership(project) is False
-        assert len(result.projects) == 1
-        assert list(result.projects)[0].id == self.project.id
+        assert result.has_project_access(deleted_project) is False
+        assert result.has_project_membership(deleted_project) is False
+        assert self.project in result.projects
+        assert deleted_project not in result.projects
 
 
 class DefaultAccessTest(TestCase):


### PR DESCRIPTION
    Convert Access to an abstract class, changing teams and projects to
    dervied properties, and the "has access" methods to abstract.

    Introduce OrganizationMemberAccess to represent the former base case
    where a user has access only to a subset of their organization's teams
    and projects. Push has_global_access down to here.

    Use OrganizationGlobalAccess in more places, to represent where
    superusers and Sentry apps have access to all an organization's teams
    and projects. Enumerate those sets of teams and projects as properties.

    Tweak the class structure as needed.

Lest this look like a lot of refactoring for refactoring's sake, the actual motivation is from https://github.com/getsentry/sentry/pull/31816#discussion_r808316557 -- it would simplify the representation of team-based roles if we didn't have to build sets of `Team` objects to represent having access to all teams in the `_from_sentry_app` case. The rest of the changes snowballed from there. But, I do think it leaves the base `Access` class a bit cleaner overall.