### PR TITLE
feat(sentryapp): Sentry apps request with dependentData

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -60,7 +60,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
         )
 
         # Prepare Rule Actions that are SentryApp components using the meta fields
-        for action in serialized_rule.data.get("actions", []):
+        for action in serialized_rule.get("actions", []):
             if action.get("_sentry_app_installation") and action.get("_sentry_app_component"):
 
                 component = SentryAppInstallation(

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -29,7 +29,11 @@ class AlertRuleSerializer(Serializer):
 
         result = defaultdict(dict)
         triggers = AlertRuleTrigger.objects.filter(alert_rule__in=item_list).order_by("label")
-        serialized_triggers = serialize(list(triggers))
+        serialized_triggers = serialize(
+            list(triggers),
+            organization_id=item_list[0].organization_id,
+        )
+
         for trigger, serialized in zip(triggers, serialized_triggers):
             alert_rule_triggers = result[alert_rules[trigger.alert_rule_id]].setdefault(
                 "triggers", []
@@ -89,7 +93,7 @@ class AlertRuleSerializer(Serializer):
 
         return result
 
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, **kwargs):
         env = obj.snuba_query.environment
         # Temporary: Translate aggregate back here from `tags[sentry:user]` to `user` for the frontend.
         aggregate = translate_aggregate_field(obj.snuba_query.aggregate, reverse=True)
@@ -143,7 +147,7 @@ class DetailedAlertRuleSerializer(AlertRuleSerializer):
 
         return result
 
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, **kwargs):
         data = super().serialize(obj, attrs, user)
         data["excludedProjects"] = sorted(attrs.get("excluded_projects", []))
         data["eventTypes"] = sorted(attrs.get("event_types", []))

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -11,9 +11,16 @@ from sentry.incidents.models import (
     AlertRuleActivityType,
     AlertRuleExcludedProjects,
     AlertRuleTrigger,
+    AlertRuleTriggerAction,
     Incident,
 )
-from sentry.models import ACTOR_TYPES, Rule, actor_type_to_class, actor_type_to_string
+from sentry.models import (
+    ACTOR_TYPES,
+    Rule,
+    SentryAppInstallation,
+    actor_type_to_class,
+    actor_type_to_string,
+)
 from sentry.snuba.models import SnubaQueryEventType
 from sentry.utils.compat import zip
 
@@ -31,10 +38,30 @@ class AlertRuleSerializer(Serializer):
         triggers = AlertRuleTrigger.objects.filter(alert_rule__in=item_list).order_by("label")
         serialized_triggers = serialize(list(triggers), **kwargs)
 
+        trigger_actions = AlertRuleTriggerAction.objects.filter(
+            alert_rule_trigger__alert_rule_id__in=alert_rules.keys()
+        ).exclude(sentry_app_config__isnull=True, sentry_app_id__isnull=True)
+
+        sentry_app_installations_by_sentry_app_id = (
+            SentryAppInstallation.objects.get_related_sentry_app_components(
+                organization_id__in={
+                    alert_rule.organization_id for alert_rule in alert_rules.values()
+                },
+                sentry_app_ids=trigger_actions.values_list("sentry_app_id", flat=True),
+                type="alert-rule-action",
+            )
+        )
+
         for trigger, serialized in zip(triggers, serialized_triggers):
             alert_rule_triggers = result[alert_rules[trigger.alert_rule_id]].setdefault(
                 "triggers", []
             )
+            for action in serialized.get("actions", []):
+                install = sentry_app_installations_by_sentry_app_id.get(action.get("sentry_app_id"))
+                if install:
+                    action["_sentry_app_component"] = install.get("sentry_app_component")
+                    action["_sentry_app_installation"] = install.get("sentry_app_installation")
+
             alert_rule_triggers.append(serialized)
 
         alert_rule_projects = AlertRule.objects.filter(

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -61,7 +61,9 @@ class AlertRuleSerializer(Serializer):
                 if install:
                     action["_sentry_app_component"] = install.get("sentry_app_component")
                     action["_sentry_app_installation"] = install.get("sentry_app_installation")
-
+                    action["sentryAppInstallationUuid"] = install.get(
+                        "sentry_app_installation"
+                    ).get("uuid")
             alert_rule_triggers.append(serialized)
 
         alert_rule_projects = AlertRule.objects.filter(

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -44,7 +44,7 @@ class AlertRuleSerializer(Serializer):
 
         sentry_app_installations_by_sentry_app_id = (
             SentryAppInstallation.objects.get_related_sentry_app_components(
-                organization_id__in={
+                organization_ids={
                     alert_rule.organization_id for alert_rule in alert_rules.values()
                 },
                 sentry_app_ids=trigger_actions.values_list("sentry_app_id", flat=True),

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -57,7 +57,7 @@ class AlertRuleSerializer(Serializer):
                 "triggers", []
             )
             for action in serialized.get("actions", []):
-                install = sentry_app_installations_by_sentry_app_id.get(action.get("sentry_app_id"))
+                install = sentry_app_installations_by_sentry_app_id.get(action.get("sentryAppId"))
                 if install:
                     action["_sentry_app_component"] = install.get("sentry_app_component")
                     action["_sentry_app_installation"] = install.get("sentry_app_installation")

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -29,10 +29,7 @@ class AlertRuleSerializer(Serializer):
 
         result = defaultdict(dict)
         triggers = AlertRuleTrigger.objects.filter(alert_rule__in=item_list).order_by("label")
-        serialized_triggers = serialize(
-            list(triggers),
-            organization_id=item_list[0].organization_id,
-        )
+        serialized_triggers = serialize(list(triggers), **kwargs)
 
         for trigger, serialized in zip(triggers, serialized_triggers):
             alert_rule_triggers = result[alert_rules[trigger.alert_rule_id]].setdefault(

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -23,7 +23,7 @@ class AlertRuleTriggerSerializer(Serializer):
         actions = AlertRuleTriggerAction.objects.filter(alert_rule_trigger__in=item_list).order_by(
             "id"
         )
-        serialized_actions = serialize(list(actions))
+        serialized_actions = serialize(list(actions), **kwargs)
         for trigger, serialized in zip(actions, serialized_actions):
             triggers_actions = result[triggers[trigger.alert_rule_trigger_id]].setdefault(
                 "actions", []
@@ -32,7 +32,7 @@ class AlertRuleTriggerSerializer(Serializer):
 
         return result
 
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, **kwargs):
         return {
             "id": str(obj.id),
             "alertRuleId": str(obj.alert_rule_id),
@@ -58,7 +58,7 @@ class DetailedAlertRuleTriggerSerializer(AlertRuleTriggerSerializer):
             exclusions.append(project_slug)
         return result
 
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, **kwargs):
         data = super().serialize(obj, attrs, user)
         data["excludedProjects"] = sorted(attrs.get("excludedProjects", []))
         return data

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -59,6 +59,6 @@ class DetailedAlertRuleTriggerSerializer(AlertRuleTriggerSerializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
-        data = super().serialize(obj, attrs, user)
+        data = super().serialize(obj, attrs, user, **kwargs)
         data["excludedProjects"] = sorted(attrs.get("excludedProjects", []))
         return data

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from sentry.api.serializers import Serializer, register
 from sentry.incidents.models import AlertRuleTriggerAction
 
@@ -41,22 +39,6 @@ class AlertRuleTriggerActionSerializer(Serializer):
         """
         return action.target_identifier if action.type == action.Type.SLACK.value else None
 
-    def get_attrs(self, item_list, user, **kwargs):
-        result = defaultdict(dict)
-
-        if not kwargs.get("sentry_app_components_by_action_id"):
-            return result
-
-        for action in item_list:
-            component = kwargs["sentry_app_components_by_action_id"].get(action.id)
-
-            if not component:
-                continue
-
-            result[action] = {"formFields": component.schema.get("settings", {})}
-
-        return result
-
     def serialize(self, obj, attrs, user, **kwargs):
         from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING
 
@@ -80,6 +62,5 @@ class AlertRuleTriggerActionSerializer(Serializer):
         # Check if action is a Sentry App that has Alert Rule UI Component settings
         if obj.sentry_app_id and obj.sentry_app_config:
             result["settings"] = obj.sentry_app_config
-            result["formFields"] = attrs.get("formFields", {})
 
         return result

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -70,7 +70,7 @@ class RuleSerializer(Serializer):
 
         sentry_app_installations_by_uuid = (
             SentryAppInstallation.objects.get_related_sentry_app_components(
-                organization_id__in={rule.project.organization_id for rule in rules.values()},
+                organization_ids={rule.project.organization_id for rule in rules.values()},
                 sentry_app_ids=sentry_app_ids,
                 type="alert-rule-action",
                 group_by="uuid",

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -59,7 +59,9 @@ class RuleSerializer(Serializer):
         owners_by_type = defaultdict(list)
 
         sentry_app_uuids = {
-            action.get("sentryAppInstallationUuid") for rule in rules.values() for action in rule
+            action.get("sentryAppInstallationUuid")
+            for rule in rules.values()
+            for action in rule.get("actions", [])
         }
 
         sentry_app_ids = (

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -61,7 +61,7 @@ class RuleSerializer(Serializer):
         sentry_app_uuids = {
             action.get("sentryAppInstallationUuid")
             for rule in rules.values()
-            for action in rule.get("actions", [])
+            for action in rule.data.get("actions", [])
         }
 
         sentry_app_ids = (
@@ -94,7 +94,7 @@ class RuleSerializer(Serializer):
                 if rule.owner_id in resolved_actors[type]:
                     result[rule]["owner"] = f"{type}:{resolved_actors[type][rule.owner_id]}"
 
-            for action in rule.get("actions", []):
+            for action in rule.data.get("actions", []):
                 install = sentry_app_installations_by_uuid.get(
                     action.get("sentryAppInstallationUuid")
                 )

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -71,12 +71,12 @@ class RuleSerializer(Serializer):
                 if rule.owner_id in resolved_actors[type]:
                     result[rule]["owner"] = f"{type}:{resolved_actors[type][rule.owner_id]}"
 
-            if not kwargs.get("sentry_app_components_by_rule_id_by_sentry_app_uuid"):
+            if not kwargs.get("sentry_app_components_by_rule_id_by_installation_uuid"):
                 continue
 
             for action in rule.data.get("actions", []):
                 component = (
-                    kwargs["sentry_app_components_by_rule_id_by_sentry_app_uuid"]
+                    kwargs["sentry_app_components_by_rule_id_by_installation_uuid"]
                     .get(rule.id, {})
                     .get(action.get("sentryAppInstallationUuid"))
                 )

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -1,17 +1,13 @@
-from collections import defaultdict
-
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
 from sentry.incidents.logic import AlreadyDeletedError, delete_alert_rule
-from sentry.incidents.models import AlertRuleTriggerAction
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
-from sentry.models import OrganizationMemberTeam, SentryAppInstallation
+from sentry.models import OrganizationMemberTeam, SentryAppComponent, SentryAppInstallation
 from sentry.models.actor import ACTOR_TYPES
 
 
@@ -22,36 +18,32 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         ``````````````````
         :auth: required
         """
-        # Prepare AlertRuleTriggerActions that are SentryApp components
-        trigger_actions = AlertRuleTriggerAction.objects.filter(
-            alert_rule_trigger__alert_rule_id=alert_rule.id
-        ).exclude(sentry_app_config__isnull=True, sentry_app_id__isnull=True)
-
-        sentry_app_installations_by_sentry_app_id = (
-            SentryAppInstallation.objects.get_related_sentry_app_components(
-                organization_id=alert_rule.organization_id,
-                sentry_app_ids=trigger_actions.values_list("sentry_app_id", flat=True),
-                type="alert-rule-action",
-            )
-        )
-
-        sentry_app_components_by_action_id = defaultdict(dict)
-
-        for action in trigger_actions:
-            install = sentry_app_installations_by_sentry_app_id.get(action.sentry_app_id)
-            component = install["sentry_app_component"]
-            component = install["sentry_app_installation"].prepare_ui_component(
-                component, None, action.sentry_app_config
-            )
-            sentry_app_components_by_action_id[action.id] = component
-
-        data = serialize(
+        # Serialize Alert Rule
+        serialized_rule = serialize(
             alert_rule,
             request.user,
-            DetailedAlertRuleSerializer(),
-            sentry_app_components_by_action_id=sentry_app_components_by_action_id,
         )
-        return Response(data)
+        # Prepare AlertRuleTriggerActions that are SentryApp components
+
+        for trigger in serialized_rule.get("triggers", []):
+            for action in trigger.get("actions", []):
+                if action.get("_sentry_app_installation") and action.get("_sentry_app_component"):
+
+                    component = SentryAppInstallation(
+                        **action.get("_sentry_app_installation", {})
+                    ).prepare_ui_component(
+                        SentryAppComponent(**action.get("_sentry_app_component")),
+                        None,
+                        action.get("settings"),
+                    )
+
+                    action["formFields"] = component.schema.get("settings", {})
+
+                    # Delete meta fields
+                    del action["_sentry_app_installation"]
+                    del action["_sentry_app_component"]
+
+        return Response(serialized_rule)
 
     def put(self, request: Request, organization, alert_rule) -> Response:
         serializer = DrfAlertRuleSerializer(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
 from sentry.incidents.logic import AlreadyDeletedError, delete_alert_rule
@@ -19,10 +20,8 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         :auth: required
         """
         # Serialize Alert Rule
-        serialized_rule = serialize(
-            alert_rule,
-            request.user,
-        )
+        serialized_rule = serialize(alert_rule, request.user, DetailedAlertRuleSerializer())
+
         # Prepare AlertRuleTriggerActions that are SentryApp components
 
         for trigger in serialized_rule.get("triggers", []):

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -104,10 +104,9 @@ class SentryAppInstallation(ParanoidModel):
         from sentry.coreapi import APIError
         from sentry.mediators import sentry_app_components
 
+        if values is None:
+            values = []
         try:
-            if values is None:
-                values = []
-
             sentry_app_components.Preparer.run(
                 component=component, install=self, project=project, values=values
             )

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -89,8 +89,6 @@ class SentryAppInstallation(ParanoidModel):
         return super().save(*args, **kwargs)
 
     def prepare_sentry_app_components(self, component_type, project=None, values=None):
-        from sentry.coreapi import APIError
-        from sentry.mediators import sentry_app_components
         from sentry.models import SentryAppComponent
 
         try:
@@ -99,6 +97,12 @@ class SentryAppInstallation(ParanoidModel):
             )
         except SentryAppComponent.DoesNotExist:
             return None
+
+        return self.sentry_app_preparer(component, project, values)
+
+    def sentry_app_preparer(self, component, project=None, values=None):
+        from sentry.coreapi import APIError
+        from sentry.mediators import sentry_app_components
 
         try:
             if values is None:

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -88,7 +88,7 @@ class SentryAppInstallation(ParanoidModel):
         self.date_updated = timezone.now()
         return super().save(*args, **kwargs)
 
-    def prepare_sentry_app_components(self, component_type, project=None):
+    def prepare_sentry_app_components(self, component_type, project=None, values=None):
         from sentry.coreapi import APIError
         from sentry.mediators import sentry_app_components
         from sentry.models import SentryAppComponent
@@ -101,7 +101,12 @@ class SentryAppInstallation(ParanoidModel):
             return None
 
         try:
-            sentry_app_components.Preparer.run(component=component, install=self, project=project)
+            if values is None:
+                values = []
+
+            sentry_app_components.Preparer.run(
+                component=component, install=self, project=project, values=values
+            )
             return component
         except APIError:
             # TODO(nisanthan): For now, skip showing the UI Component if the API requests fail

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -134,10 +134,9 @@ class SentryAppInstallation(ParanoidModel):
     def to_dict(self):
         opts = self._meta
         data = {}
-        for field in chain(opts.concrete_fields, opts.private_fields):
-            data[field.name] = field.value_from_object(self)
-        for field in opts.many_to_many:
-            data[field.name] = [i.id for i in field.value_from_object(self)]
+        for field in chain(opts.concrete_fields, opts.private_fields, opts.many_to_many):
+            field_name = field.get_attname()
+            data[field_name] = self.serializable_value(field_name)
         return data
 
     def save(self, *args, **kwargs):

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -20,21 +20,25 @@ def default_uuid():
 
 
 class SentryAppInstallationForProviderManager(ParanoidManager):
-    def get_organization_filter_kwargs(self, organization_id: int):
+    def get_organization_filter_kwargs(self, organization_ids: List[int]):
         return {
-            "organization_id": organization_id,
+            "organization_id__in": organization_ids,
             "status": SentryAppInstallationStatus.INSTALLED,
             "date_deleted": None,
         }
 
     def get_installed_for_organization(self, organization_id: int) -> QuerySet:
-        return self.filter(**self.get_organization_filter_kwargs(organization_id))
+        return self.filter(**self.get_organization_filter_kwargs([organization_id]))
 
     def get_by_api_token(self, token_id: str) -> QuerySet:
         return self.filter(status=SentryAppInstallationStatus.INSTALLED, api_token_id=token_id)
 
     def get_related_sentry_app_components(
-        self, organization_id: int, sentry_app_ids: List[int], type: str, group_by="sentry_app_id"
+        self,
+        organization_ids: List[int],
+        sentry_app_ids: List[int],
+        type: str,
+        group_by="sentry_app_id",
     ):
         from sentry.models import SentryAppComponent
 
@@ -43,7 +47,7 @@ class SentryAppInstallationForProviderManager(ParanoidManager):
         )
 
         sentry_app_installations = (
-            self.filter(**self.get_organization_filter_kwargs(organization_id))
+            self.filter(**self.get_organization_filter_kwargs(organization_ids))
             .filter(sentry_app_id__in=sentry_app_ids)
             .annotate(
                 # Cannot annotate model object only individual fields. We can convert it into SentryAppComponent instance later.

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -3,7 +3,15 @@ from unittest.mock import patch
 import responses
 from django.urls import reverse
 
-from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType, RuleStatus
+from sentry.models import (
+    Environment,
+    Integration,
+    Rule,
+    RuleActivity,
+    RuleActivityType,
+    RuleStatus,
+    SentryAppComponent,
+)
 from sentry.testutils import APITestCase
 from sentry.utils import json
 
@@ -810,13 +818,17 @@ class UpdateProjectRuleTest(APITestCase):
 
         rule = Rule.objects.create(project=project, label="my super cool rule")
 
-        self.create_sentry_app(
+        sentry_app = self.create_sentry_app(
             name="Pied Piper",
             organization=project.organization,
             schema={"elements": [self.create_alert_rule_action_schema()]},
         )
         install = self.create_sentry_app_installation(
             slug="pied-piper", organization=project.organization
+        )
+
+        sentry_app_component = SentryAppComponent.objects.get(
+            sentry_app=sentry_app, type="alert-rule-action"
         )
 
         actions = [
@@ -839,25 +851,30 @@ class UpdateProjectRuleTest(APITestCase):
                 "rule_id": rule.id,
             },
         )
-
-        response = self.client.put(
-            url,
-            data={
-                "name": "my super cool rule",
-                "actionMatch": "any",
-                "filterMatch": "any",
-                "actions": actions,
-                "conditions": [],
-                "filters": [],
-            },
-            format="json",
-        )
+        with patch(
+            "sentry.mediators.sentry_app_components.Preparer.run", return_value=sentry_app_component
+        ):
+            response = self.client.put(
+                url,
+                data={
+                    "name": "my super cool rule",
+                    "actionMatch": "any",
+                    "filterMatch": "any",
+                    "actions": actions,
+                    "conditions": [],
+                    "filters": [],
+                },
+                format="json",
+            )
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == str(rule.id)
 
         rule = Rule.objects.get(id=rule.id)
         assert rule.data["actions"] == actions
+        assert response.data["actions"][0]["formFields"] == sentry_app_component.schema.get(
+            "settings"
+        )
 
         kwargs = {
             "install": install,

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -872,9 +872,6 @@ class UpdateProjectRuleTest(APITestCase):
 
         rule = Rule.objects.get(id=rule.id)
         assert rule.data["actions"] == actions
-        assert response.data["actions"][0]["formFields"] == sentry_app_component.schema.get(
-            "settings"
-        )
 
         kwargs = {
             "install": install,

--- a/tests/sentry/mediators/sentry_app_components/test_preparer.py
+++ b/tests/sentry/mediators/sentry_app_components/test_preparer.py
@@ -50,13 +50,22 @@ class TestPreparerIssueLink(TestCase):
 
         self.preparer.call()
 
-        assert call(install=self.install, project=self.project, uri="/sentry/foo") in run.mock_calls
-
         assert (
-            call(install=self.install, project=self.project, uri="/sentry/beep") in run.mock_calls
+            call(install=self.install, project=self.project, uri="/sentry/foo", dependent_data=None)
+            in run.mock_calls
         )
 
-        assert call(install=self.install, project=self.project, uri="/sentry/bar") in run.mock_calls
+        assert (
+            call(
+                install=self.install, project=self.project, uri="/sentry/beep", dependent_data=None
+            )
+            in run.mock_calls
+        )
+
+        assert (
+            call(install=self.install, project=self.project, uri="/sentry/bar", dependent_data=None)
+            in run.mock_calls
+        )
 
         assert (
             not call(install=self.install, project=self.project, uri="/sentry/baz")


### PR DESCRIPTION
## Objective:
This is the backend portion of the fix. Frontend is here: https://github.com/getsentry/sentry/pull/31881

This PR adds the `dependendData` query param for fields with a `depends_on` property. We also make the requests with the `dependentData` query param when loading a saved rule.