### PR TITLE
fix(metric_alerts): Make sure critical triggers resolve properly when no action is set on a warning trigger

### DIFF
--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -580,15 +580,15 @@ class AlertRuleTriggerAction(Model):
         else:
             metrics.incr(f"alert_rule_trigger.unhandled_type.{self.type}")
 
-    def fire(self, action, incident, project, metric_value):
+    def fire(self, action, incident, project, metric_value, new_status):
         handler = self.build_handler(action, incident, project)
         if handler:
-            return handler.fire(metric_value)
+            return handler.fire(metric_value, new_status)
 
-    def resolve(self, action, incident, project, metric_value):
+    def resolve(self, action, incident, project, metric_value, new_status):
         handler = self.build_handler(action, incident, project)
         if handler:
-            return handler.resolve(metric_value)
+            return handler.resolve(metric_value, new_status)
 
     @classmethod
     def register_type(cls, slug, type, supported_target_types, integration_provider=None):

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -162,22 +162,6 @@ class SubscriptionProcessor:
 
         return trigger.alert_threshold + resolve_add
 
-    def find_active_warning_trigger(self, alert_operator, aggregation_value):
-        """
-        Finds and returns an active warning trigger, if one exists on this alert
-        """
-        for it in self.incident_triggers.values():
-            current_trigger = it.alert_rule_trigger
-            # Check if there is a Warning incident trigger that is active, and then check if the
-            # aggregation value is above the threshold
-            if (
-                it.status == TriggerStatus.ACTIVE.value
-                and current_trigger.label == WARNING_TRIGGER_LABEL
-                and alert_operator(aggregation_value, current_trigger.alert_threshold)
-            ):
-                metrics.incr("incidents.alert_rules.threshold", tags={"type": "alert"})
-                return it
-
     def get_comparison_aggregation_value(self, subscription_update, aggregation_value):
         # For comparison alerts run a query over the comparison period and use it to calculate the
         # % change.
@@ -427,25 +411,7 @@ class SubscriptionProcessor:
                     incident_trigger = self.trigger_resolve_threshold(trigger, aggregation_value)
 
                     if incident_trigger is not None:
-                        # Check that ensures that we are resolving a Critical trigger and that after
-                        # resolving it, we still have active triggers i.e. self.incident_triggers
-                        # was not cleared out, which means that we are probably still above the
-                        # warning threshold, and so we will check if we are above the warning
-                        # threshold and if so fire a warning alert
-                        # This is mainly for handling transition from Critical -> Warning
-                        active_warning_it = None
-                        if (
-                            incident_trigger.alert_rule_trigger.label == CRITICAL_TRIGGER_LABEL
-                            and self.incident_triggers
-                        ):
-                            active_warning_it = self.find_active_warning_trigger(
-                                alert_operator=alert_operator, aggregation_value=aggregation_value
-                            )
-                            if active_warning_it is not None:
-                                fired_incident_triggers.append(active_warning_it)
-
-                        if active_warning_it is None:
-                            fired_incident_triggers.append(incident_trigger)
+                        fired_incident_triggers.append(incident_trigger)
                 else:
                     self.trigger_resolve_counts[trigger.id] = 0
 

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
-from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL, get_incident_aggregates
+from sentry.incidents.logic import get_incident_aggregates
 from sentry.incidents.models import INCIDENT_STATUS, IncidentStatus, IncidentTrigger
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
@@ -17,28 +17,11 @@ QUERY_AGGREGATION_DISPLAY = {
 }
 
 
-def incident_status_info(incident, metric_value, action, method):
-    if action and method:
-        # Get status from trigger
-        incident_status = (
-            IncidentStatus.CLOSED
-            if method == "resolve"
-            else (
-                IncidentStatus.CRITICAL
-                if action.alert_rule_trigger.label == CRITICAL_TRIGGER_LABEL
-                else IncidentStatus.WARNING
-            )
-        )
-    else:
-        incident_status = incident.status
-    return IncidentStatus(incident_status)
-
-
-def incident_attachment_info(incident, metric_value=None, action=None, method=None):
+def incident_attachment_info(incident, new_status: IncidentStatus, metric_value=None):
     logo_url = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
     alert_rule = incident.alert_rule
 
-    status = INCIDENT_STATUS[incident_status_info(incident, metric_value, action, method)]
+    status = INCIDENT_STATUS[new_status]
 
     agg_display_key = alert_rule.snuba_query.aggregate
 

--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -682,8 +682,8 @@ def build_unlinked_card():
     }
 
 
-def build_incident_attachment(action, incident, metric_value=None, method=None):
-    data = incident_attachment_info(incident, metric_value, action=action, method=method)
+def build_incident_attachment(incident, new_status, metric_value=None):
+    data = incident_attachment_info(incident, new_status, metric_value)
 
     colors = {"Resolved": "good", "Warning": "warning", "Critical": "attention"}
 

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -1,6 +1,7 @@
 import enum
 import logging
 
+from sentry.incidents.models import IncidentStatus
 from sentry.models import Integration
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.compat import filter
@@ -71,12 +72,12 @@ def get_channel_id(organization, integration_id, name):
     return None
 
 
-def send_incident_alert_notification(action, incident, metric_value, method):
+def send_incident_alert_notification(action, incident, metric_value, new_status: IncidentStatus):
     from .card_builder import build_incident_attachment
 
     channel = action.target_identifier
     integration = action.integration
-    attachment = build_incident_attachment(action, incident, metric_value, method)
+    attachment = build_incident_attachment(incident, new_status, metric_value)
     client = MsTeamsClient(integration)
     try:
         client.send_card(channel, attachment)

--- a/src/sentry/integrations/slack/unfurl/incidents.py
+++ b/src/sentry/integrations/slack/unfurl/incidents.py
@@ -45,10 +45,7 @@ def unfurl_incidents(
         return {}
 
     return {
-        link.url: build_incident_attachment(
-            action=None,
-            incident=results[link.args["incident_id"]],
-        )
+        link.url: build_incident_attachment(results[link.args["incident_id"]])
         for link in links
         if link.args["incident_id"] in results
     }

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Mapping
 
 from sentry.constants import ObjectStatus
-from sentry.incidents.models import AlertRuleTriggerAction, Incident
+from sentry.incidents.models import AlertRuleTriggerAction, Incident, IncidentStatus
 from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.models import Integration
@@ -17,7 +17,7 @@ def send_incident_alert_notification(
     action: AlertRuleTriggerAction,
     incident: Incident,
     metric_value: int,
-    method: str,
+    new_status: IncidentStatus,
 ) -> None:
     # Make sure organization integration is still active:
     try:
@@ -31,7 +31,7 @@ def send_incident_alert_notification(
         return
 
     channel = action.target_identifier
-    attachment = SlackIncidentsMessageBuilder(incident, action, metric_value, method).build()
+    attachment = SlackIncidentsMessageBuilder(incident, new_status, metric_value).build()
     payload = {
         "token": integration.metadata["access_token"],
         "channel": channel,

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -10,8 +10,8 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.app_platform_event import AppPlatformEvent
 from sentry.api.serializers.models.incident import IncidentSerializer
 from sentry.constants import SentryAppInstallationStatus
-from sentry.incidents.models import INCIDENT_STATUS
-from sentry.integrations.metric_alerts import incident_attachment_info, incident_status_info
+from sentry.incidents.models import INCIDENT_STATUS, IncidentStatus
+from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.models import SentryApp, SentryAppInstallation
 from sentry.plugins.base import plugins
 from sentry.rules.actions.base import EventAction
@@ -24,13 +24,13 @@ logger = logging.getLogger("sentry.integrations.sentry_app")
 PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS = ["PagerDuty", "Slack"]
 
 
-def build_incident_attachment(action, incident, metric_value=None, method=None):
+def build_incident_attachment(incident, new_status: IncidentStatus, metric_value=None):
     from sentry.api.serializers.rest_framework.base import (
         camel_to_snake_case,
         convert_dict_key_case,
     )
 
-    data = incident_attachment_info(incident, metric_value, action=action, method=method)
+    data = incident_attachment_info(incident, new_status, metric_value)
     return {
         "metric_alert": convert_dict_key_case(
             serialize(incident, serializer=IncidentSerializer()), camel_to_snake_case
@@ -41,7 +41,9 @@ def build_incident_attachment(action, incident, metric_value=None, method=None):
     }
 
 
-def send_incident_alert_notification(action, incident, metric_value=None, method=None):
+def send_incident_alert_notification(
+    action, incident, new_status: IncidentStatus, metric_value=None
+):
     """
     When a metric alert is triggered, send incident data to the SentryApp's webhook.
     :param action: The triggered `AlertRuleTriggerAction`.
@@ -74,11 +76,9 @@ def send_incident_alert_notification(action, incident, metric_value=None, method
 
     app_platform_event = AppPlatformEvent(
         resource="metric_alert",
-        action=INCIDENT_STATUS[
-            incident_status_info(incident, metric_value, action, method)
-        ].lower(),
+        action=INCIDENT_STATUS[new_status].lower(),
         install=install,
-        data=build_incident_attachment(action, incident, metric_value, method),
+        data=build_incident_attachment(incident, new_status, metric_value),
     )
 
     # Can raise errors if client returns >= 400

--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
@@ -36,7 +36,7 @@ class DebugIncidentTriggerEmailView(View):
         trigger = AlertRuleTrigger(alert_rule=alert_rule)
 
         context = generate_incident_trigger_email_context(
-            project, incident, trigger, TriggerStatus.ACTIVE
+            project, incident, trigger, TriggerStatus.ACTIVE, IncidentStatus(incident.status)
         )
 
         return MailPreview(

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -467,7 +467,7 @@ class AlertRuleTriggerActionActivateTest:
 
     def test_no_handler(self):
         trigger = AlertRuleTriggerAction(type=AlertRuleTriggerAction.Type.EMAIL.value)
-        assert trigger.fire(Mock(), Mock(), Mock(), 123) is None
+        assert trigger.fire(Mock(), Mock(), Mock(), 123, IncidentStatus.CRITICAL) is None
 
     def test_handler(self):
         mock_handler = Mock()
@@ -477,7 +477,8 @@ class AlertRuleTriggerActionActivateTest:
         AlertRuleTriggerAction.register_type("something", type, [])(mock_handler)
         trigger = AlertRuleTriggerAction(type=type.value)
         assert (
-            getattr(trigger, self.method)(Mock(), Mock(), Mock(), 123) == mock_method.return_value
+            getattr(trigger, self.method)(Mock(), Mock(), Mock(), 123, IncidentStatus.CRITICAL)
+            == mock_method.return_value
         )
 
 

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -7,6 +7,7 @@ from exam import fixture, patcher
 from freezegun import freeze_time
 
 from sentry.incidents.logic import (
+    CRITICAL_TRIGGER_LABEL,
     create_alert_rule_trigger,
     create_alert_rule_trigger_action,
     create_incident_activity,
@@ -146,7 +147,7 @@ class HandleTriggerActionTest(TestCase):
 
     @fixture
     def trigger(self):
-        return create_alert_rule_trigger(self.alert_rule, "", 100)
+        return create_alert_rule_trigger(self.alert_rule, CRITICAL_TRIGGER_LABEL, 100)
 
     @fixture
     def action(self):
@@ -189,7 +190,9 @@ class HandleTriggerActionTest(TestCase):
                     self.action.id, incident.id, self.project.id, "fire", metric_value=metric_value
                 )
             mock_handler.assert_called_once_with(self.action, incident, self.project)
-            mock_handler.return_value.fire.assert_called_once_with(metric_value)
+            mock_handler.return_value.fire.assert_called_once_with(
+                metric_value, IncidentStatus.CRITICAL
+            )
 
 
 class TestHandleSubscriptionMetricsLogger(TestCase):

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -7,6 +7,7 @@ from django.test import RequestFactory
 from sentry.charts.types import ChartType
 from sentry.discover.models import DiscoverSavedQuery
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
+from sentry.incidents.models import IncidentStatus
 from sentry.integrations.slack.message_builder.discover import SlackDiscoverMessageBuilder
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
@@ -82,7 +83,7 @@ class UnfurlTest(TestCase):
         )
         incident.update(identifier=123)
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
-        action = self.create_alert_rule_trigger_action(
+        self.create_alert_rule_trigger_action(
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
 
@@ -94,7 +95,10 @@ class UnfurlTest(TestCase):
         ]
         unfurls = link_handlers[LinkType.INCIDENTS].fn(self.request, self.integration, links)
 
-        assert unfurls[links[0].url] == SlackIncidentsMessageBuilder(incident, action).build()
+        assert (
+            unfurls[links[0].url]
+            == SlackIncidentsMessageBuilder(incident, IncidentStatus.CLOSED).build()
+        )
 
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
     def test_unfurl_discover(self, mock_generate_chart):

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -12,7 +12,11 @@ from sentry.incidents.action_handlers import (
     EmailActionHandler,
     generate_incident_trigger_email_context,
 )
-from sentry.incidents.logic import create_alert_rule_trigger, create_alert_rule_trigger_action
+from sentry.incidents.logic import (
+    CRITICAL_TRIGGER_LABEL,
+    create_alert_rule_trigger,
+    create_alert_rule_trigger_action,
+)
 from sentry.incidents.models import (
     AlertRuleTriggerAction,
     Incident,
@@ -57,7 +61,7 @@ class HandleSnubaQueryUpdateTest(TestCase):
                 threshold_period=1,
                 resolve_threshold=10,
             )
-            trigger = create_alert_rule_trigger(rule, "hi", 100)
+            trigger = create_alert_rule_trigger(rule, CRITICAL_TRIGGER_LABEL, 100)
             create_alert_rule_trigger_action(
                 trigger,
                 AlertRuleTriggerAction.Type.EMAIL,
@@ -143,6 +147,7 @@ class HandleSnubaQueryUpdateTest(TestCase):
                 handler.incident,
                 handler.action.alert_rule_trigger,
                 TriggerStatus.ACTIVE,
+                IncidentStatus.CRITICAL,
             ),
             TriggerStatus.ACTIVE,
             self.user.id,


### PR DESCRIPTION
### Problem
If we have an alert set up like:
- Warning: 50. Action: None
- Critical: 100. Action: Slack

Then if we go from critical -> warning state the slack resolve action will fail to fire.

### Cause
The reason this happens is related to a previous fix. For an alert like
- Warning: 50. Action: Slack
- Critical: 100. Action: Slack

When going from critical -> warning the critical action would be marked as resolved. This would
cause a slack notification with `Resolved` to be sent to the channel. This is misleading, because
the alert is still active, just in the warning state. What we want here is to fire a warning
notification instead.

The initial fix for this was that when we resolved a critical trigger, we’d check and see whether
there was an active warning trigger. If so, we’d send a warning trigger fire to our actions, rather
than a critical trigger resolve. This works ok for many cases, but fails when the actions on the
warning trigger are different to those on the critical trigger.

### Fix
Substituting the warning trigger for the critical trigger causes us subtle bugs. So, instead of
this, when triggering fires/resolves on our action handlers we will also pass along the incident
state change that the trigger/resolve caused the incident to go into.

So if a critical trigger resolves, we check what state it would have put the incident in. If
there’s a warning trigger, then the state is warning. If no warning trigger, the state is closed.
This state is then used to appropriately generate the messages that we send to users via our
various actions.

So now, If we have an alert set up like:
- Warning: 50. Action: None
- Critical: 100. Action: Slack

If this goes from
- critical -> warning OR critical -> resolved we will send `IncidentStatus.WARNING` to any actions
related to the critical trigger. 
- warning -> resolved We do nothing since there are no actions on the warning trigger

If we have an alert set up like:
- Warning: 50. Action: Slack
- Critical: 100. Action: Slack

If this goes from:
- critical -> warning: critical trigger, `IncidentStatus.Warning`
- warning -> resolved: warning trigger, `IncidentStatus.Closed`
- critical -> resolved: Since we de-dupe triggers to avoid spamming the user, we will select the
warning trigger here, and send `IncidentStatus.closed`

If we have an alert set up like:
- Warning: 50. Action: Slack
- Critical: 100. Action: Pagerduty

If this goes from:
- critical -> warning: critical trigger, `IncidentStatus.Warning` sent to Pagerduty. Nothing sent
to Slack
- warning -> resolved: warning trigger, `IncidentStatus.Closed` sent to Slack. Nothing sent to
Pagerduty
- critical -> resolved: Critical trigger, `IncidentStatus.Warning` sent to Pagerduty. Warning
trigger, `IncidentStatus.Closed` sent to Slack. We don’t de-dupe here since the actions are
different.