### PR TITLE
fix(part II): don't log error message

### DIFF
--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -388,7 +388,6 @@ def process_messages(
             try:
                 new_tags: Mapping[int, int] = {mapping[k]: mapping[v] for k, v in tags.items()}
             except KeyError:
-                logger.error("process_messages.key_error", extra={"tags": tags}, exc_info=True)
                 continue
 
             new_payload_value["tags"] = new_tags


### PR DESCRIPTION
original fix in https://github.com/getsentry/sentry/pull/31885.

This PR is for incase it turns out logging the error is happening too many times, then let's just handle the exception and not log the error. 