### PR TITLE
fix(sessions): Prevent empty array in WHERE clause

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -346,8 +346,9 @@ class _LimitState:
 
     @property
     def limiting_conditions(self) -> Optional[List[Condition]]:
-        if not self.initialized:
-            # First query may run without limiting conditions:
+        if not self.initialized or not self._groups:
+            # First query may run without limiting conditions
+            # When there are no groups there is nothing to limit
             return None
 
         group_columns = [col for col in self._groupby if col not in self.skip_columns]
@@ -360,6 +361,7 @@ class _LimitState:
             Function("tuple", [row[column.name] for column in group_columns])
             for row in self._groups
         ]
+
         return [
             # E.g. (release, environment) IN [(1, 2), (3, 4), ...]
             Condition(Function("tuple", group_columns), Op.IN, group_values)
@@ -380,8 +382,11 @@ def _get_snuba_query(
     series: bool,
     limit_state: _LimitState,
     extra_conditions: List[Condition],
-) -> Query:
-    """Build the snuba query"""
+) -> Optional[Query]:
+    """Build the snuba query
+
+    Return None if the results from the initial totals query was empty.
+    """
     conditions = [
         Condition(Column("org_id"), Op.EQ, org_id),
         Condition(Column("project_id"), Op.IN, query.filter_keys["project_id"]),
@@ -427,6 +432,10 @@ def _get_snuba_query(
             query_args["limit"] = Limit(max_groups)
             query_args["orderby"] = [OrderBy(columns[0], Direction.DESC)]
         else:
+            if limit_state.limiting_conditions is None:
+                # Initial query returned no results, no need to run any more queries
+                return None
+
             query_args["where"] += limit_state.limiting_conditions
             query_args["limit"] = Limit(SNUBA_LIMIT)
 
@@ -457,9 +466,11 @@ def _get_snuba_query_data(
             extra_conditions=extra_conditions or [],
         )
         referrer = REFERRERS[metric_key][query_type]
-        query_data = raw_snql_query(snuba_query, referrer=referrer)["data"]
-
-        limit_state.update(snuba_query.groupby, query_data)
+        if snuba_query is None:
+            query_data = []
+        else:
+            query_data = raw_snql_query(snuba_query, referrer=referrer)["data"]
+            limit_state.update(snuba_query.groupby, query_data)
 
         yield (metric_key, query_data)
 

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -451,9 +451,13 @@ def _run_sessions_query(query):
         referrer="sessions.totals",
     )
 
-    # We only get the time series for groups which also have a total:
     totals = result_totals["data"]
-    if totals and query.query_groupby:
+    if not totals:
+        # No need to query time series if totals is already empty
+        return [], []
+
+    # We only get the time series for groups which also have a total:
+    if query.query_groupby:
         # E.g. (release, environment) IN [(1, 2), (3, 4), ...]
         groups = {tuple(row[column] for column in query.query_groupby) for row in totals}
         extra_conditions = [[["tuple", query.query_groupby], "IN", groups]] + [

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -397,6 +397,21 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
         ]
 
     @freeze_time("2021-01-14T12:27:28.303Z")
+    def test_filter_unknown_release(self):
+        response = self.do_request(
+            {
+                "project": [-1],
+                "statsPeriod": "1d",
+                "interval": "1h",
+                "field": ["sum(session)"],
+                "query": "release:foo@6.6.6",
+                "groupBy": "session.status",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+
+    @freeze_time("2021-01-14T12:27:28.303Z")
     def test_groupby_project(self):
         response = self.do_request(
             {


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/31392 introduced logic to limit the number of groups returned by the sessions V2 API. The groups returned by the `totals` query are used as a filter for the `series` query, which for the metrics-based implementation resulted in an empty array when `totals` is empty:

```
    "              in(",
    "                tuple(",
    "(                  tags AS `_snuba_tags`)['135'] AS `_snuba_tags[135]`",
    "                ),",
    "                array(",
    "                )",
    "              ),",
```

This PR prevents `... IN array()` conditions by not running additional snuba queries at all when the initial `totals` is empty.

See also https://sentry.io/organizations/sentry/performance/trace/17d9689b2bf34c538362a85f144f0206/.