### PR TITLE
fix(sessions): Use first non-empty result to determine groups [INGEST-963]

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -486,6 +486,7 @@ def _get_snuba_query_data(
             #    the results of the second totals query instead.
             break
 
+        assert snuba_query is not None
         limit_state.update(snuba_query.groupby, query_data)
         yield (metric_key, query_data)
 


### PR DESCRIPTION
Since https://github.com/getsentry/sentry/pull/31392, the sessions V2 API only returns the Top-N groups identified by the first snuba query. The order of the groups is defined by the first requested `&field=`. But if the first requested field is `count_unique(user)`, this means that in the metrics-based implementation, the entire result may become empty for projects that do not track individual users.

This PR ensures that empty results are discarded for group selection, using the first non-empty totals query instead.