### PR TITLE
ref(dashboards): Remove duplication from widget refetch logic

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -144,7 +144,6 @@ class WidgetQueries extends React.Component<Props, State> {
       !isEqual(widget.displayType, prevProps.widget.displayType) ||
       !isEqual(widget.interval, prevProps.widget.interval) ||
       !isEqual(widgetQueries, prevWidgetQueries) ||
-      !isEqual(widget.displayType, prevProps.widget.displayType) ||
       !isSelectionEqual(selection, prevProps.selection)
     ) {
       this.fetchData();


### PR DESCRIPTION
`!isEqual(widget.displayType, prevProps.widget.displayType)` was there 2 times.