### PR TITLE
fix(release_health): Split up featureflag [INGEST-784]

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1008,8 +1008,11 @@ SENTRY_FEATURES = {
     "organizations:metrics-extraction": False,
     # Enable switch metrics button on Performance, allowing switch to unsampled transaction metrics
     "organizations:metrics-performance-ui": False,
-    # True if the metrics backend should be checked against the sessions backend
+    # True if release-health related queries should be run against both
+    # backends (sessions and metrics dataset)
     "organizations:release-health-check-metrics": False,
+    # True if differences between the metrics and sessions backend should be reported
+    "organizations:release-health-check-metrics-report": False,
     # Enable metric aggregate in metric alert rule builder
     "organizations:metric-alert-builder-aggregate": False,
     # Enable threshold period in metric alert rule builder

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -140,6 +140,7 @@ default_manager.add("organizations:relay", OrganizationFeature)
 default_manager.add("organizations:release-archives", OrganizationFeature)
 default_manager.add("organizations:release-comparison-performance", OrganizationFeature, True)
 default_manager.add("organizations:release-health-check-metrics", OrganizationFeature, True)
+default_manager.add("organizations:release-health-check-metrics-report", OrganizationFeature, True)
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature)
 default_manager.add("organizations:required-email-verification", OrganizationFeature, True)  # NOQA
 default_manager.add("organizations:rule-page", OrganizationFeature)

--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -536,7 +536,9 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
                 tags={"has_errors": str(bool(errors)), **tags},
                 sample_rate=1.0,
             )
-            if errors:
+            if errors and features.has(
+                "organizations-release-health-check-metrics-report", organization
+            ):
                 # We heavily rely on Sentry's message sanitization to properly deduplicate this
                 capture_message(f"{fn_name} - Release health metrics mismatch: {errors[0]}")
         except Exception:


### PR DESCRIPTION
We have recently enabled 100% of metrics extraction for release health,
and so we want to start querying that data to know how much load that
puts on ClickHouse.

While we do not have a full/proper dataset for all organizations yet
(which affects query performance), we can still start sending queries
unconditionally and filter out reports by another featureflag.

After this PR is merged, some changes in Flagr are necessary to continue
receiving reports:

1. organizations:release-heath-check-metrics needs to be renamed (or duplicated) to the new featureflag organizations:release-health-check-metrics-report
2. the old featureflag needs to be enabled for _at least_ the organizations we want to compare results of, but we probably just want to enable it for all.