### PR TITLE
fix(dashboard-layout): Add tempIds in orgDashboard.tsx renderBody

### DIFF
--- a/static/app/views/dashboardsV2/orgDashboards.tsx
+++ b/static/app/views/dashboardsV2/orgDashboards.tsx
@@ -122,12 +122,26 @@ class OrgDashboards extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {children} = this.props;
+    const {children, organization} = this.props;
     const {selectedDashboard, error} = this.state;
+    let dashboard = selectedDashboard;
+
+    if (organization.features.includes('dashboard-grid-layout')) {
+      // Ensure there are always tempIds for grid layout
+      // This is needed because there are cases where the dashboard
+      // renders before the onRequestSuccess setState is processed
+      // and will caused stacked widgets because of missing tempIds
+      dashboard = selectedDashboard
+        ? {
+            ...selectedDashboard,
+            widgets: selectedDashboard.widgets.map(assignTempId),
+          }
+        : null;
+    }
 
     return children({
       error,
-      dashboard: selectedDashboard,
+      dashboard,
       dashboards: this.getDashboards(),
       onDashboardUpdate: (updatedDashboard: DashboardDetails) =>
         this.onDashboardUpdate(updatedDashboard),

--- a/static/app/views/dashboardsV2/orgDashboards.tsx
+++ b/static/app/views/dashboardsV2/orgDashboards.tsx
@@ -89,15 +89,7 @@ class OrgDashboards extends AsyncComponent<Props, State> {
   onRequestSuccess({stateKey, data}) {
     const {params, organization, location} = this.props;
 
-    if (stateKey === 'selectedDashboard') {
-      if (organization.features.includes('dashboard-grid-layout')) {
-        // Ensure unique IDs even on viewing default dashboard
-        this.setState({[stateKey]: {...data, widgets: data.widgets.map(assignTempId)}});
-      }
-      return;
-    }
-
-    if (params.dashboardId) {
+    if (params.dashboardId || stateKey === 'selectedDashboard') {
       return;
     }
 

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -169,6 +169,11 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
         self.page.wait_until_loaded()
         self.browser.snapshot(f"{screenshot_name} (refresh)")
 
+    def test_default_overview_dashboard_layout(self):
+        with self.feature(FEATURE_NAMES + GRID_LAYOUT_FEATURE):
+            self.page.visit_default_overview()
+            self.browser.snapshot("dashboards - default overview layout")
+
     def test_add_and_move_new_widget_on_existing_dashboard(self):
         with self.feature(FEATURE_NAMES + EDIT_FEATURE + GRID_LAYOUT_FEATURE):
             self.page.visit_dashboard_detail()


### PR DESCRIPTION
There is a small gap, depending on the order of setState calls that
are processed, when the default overview dashboard will load before we can
assign tempIds. In those cases, the widgets become stacked*. In renderBody we can
ensure the data has tempIds even if the setState hasn't been processed
yet

*Specifically, the `onRequestSuccess` setState isn't completed and we render the dashboard once without having `tempId`s for our widgets. Since there also aren't layouts, the dashboard will calculate a default layout and assign that back to the state as `modifiedDashboard`. Even though `tempId`s get sent later on, this `modifiedDashboard` doesn't have `tempId`s, and it doesn't update to match this new dashboard prop.