### PR TITLE
fix(grouping): Add secondary hierarchical hash to existing group [ISSUE-1398]

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1004,13 +1004,9 @@ def get_culprit(data):
 def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwargs):
     project = event.project
 
-    flat_grouphashes = []
-    new_grouphashes = []
-    for hash in hashes.hashes:
-        group_hash, created = GroupHash.objects.get_or_create(project=project, hash=hash)
-        flat_grouphashes.append(group_hash)
-        if created:
-            new_grouphashes.append(group_hash)
+    flat_grouphashes = [
+        GroupHash.objects.get_or_create(project=project, hash=hash)[0] for hash in hashes.hashes
+    ]
 
     # The root_hierarchical_hash is the least specific hash within the tree, so
     # typically hierarchical_hashes[0], unless a hash `n` has been split in
@@ -1023,11 +1019,9 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
     )
 
     if root_hierarchical_hash is not None:
-        root_hierarchical_grouphash, created = GroupHash.objects.get_or_create(
+        root_hierarchical_grouphash = GroupHash.objects.get_or_create(
             project=project, hash=root_hierarchical_hash
-        )
-        if created:
-            new_grouphashes.append(root_hierarchical_grouphash)
+        )[0]
 
         metadata.update(
             hashes.group_metadata_from_hash(
@@ -1084,11 +1078,9 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
             )
 
             if root_hierarchical_hash is not None:
-                root_hierarchical_grouphash, created = GroupHash.objects.get_or_create(
+                root_hierarchical_grouphash = GroupHash.objects.get_or_create(
                     project=project, hash=root_hierarchical_hash
-                )
-                if created:
-                    new_grouphashes.append(root_hierarchical_grouphash)
+                )[0]
             else:
                 root_hierarchical_grouphash = None
 
@@ -1120,7 +1112,12 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
                     **kwargs,
                 )
 
-                GroupHash.objects.filter(id__in=[h.id for h in new_grouphashes]).exclude(
+                if root_hierarchical_grouphash is not None:
+                    new_hashes = [root_hierarchical_grouphash]
+                else:
+                    new_hashes = list(flat_grouphashes)
+
+                GroupHash.objects.filter(id__in=[h.id for h in new_hashes]).exclude(
                     state=GroupHash.State.LOCKED_IN_MIGRATION
                 ).update(group=group)
 
@@ -1142,7 +1139,23 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
 
     is_new = False
 
-    if new_grouphashes:
+    if root_hierarchical_grouphash is None:
+        # No hierarchical grouping was run, only consider flat hashes
+        new_hashes = [h for h in flat_grouphashes if h.group_id is None]
+    elif root_hierarchical_grouphash.group_id is None:
+        # The root hash is not assigned to a group. This can have two reasons:
+        if existing_grouphash.hash in hashes.hierarchical_hashes:
+            # The group was previously split and is now associated with a deeper
+            # hierarchical hash
+            new_hashes = []
+        else:
+            # We ran multiple grouping algorithms
+            # (see secondary grouping), and the hierarchical hash is new
+            new_hashes = [root_hierarchical_grouphash]
+    else:
+        new_hashes = []
+
+    if new_hashes:
         # There may still be secondary hashes that we did not use to find an
         # existing group. A classic example is when grouping makes changes to
         # the app-hash (changes to in_app logic), but the system hash stays
@@ -1167,7 +1180,7 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
         # _save_aggregate had races around group creation which made this race
         # more user visible. For more context, see 84c6f75a and d0e22787, as
         # well as GH-5085.
-        GroupHash.objects.filter(id__in=[h.id for h in new_grouphashes]).exclude(
+        GroupHash.objects.filter(id__in=[h.id for h in new_hashes]).exclude(
             state=GroupHash.State.LOCKED_IN_MIGRATION
         ).update(group=group)
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1143,15 +1143,10 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
         # No hierarchical grouping was run, only consider flat hashes
         new_hashes = [h for h in flat_grouphashes if h.group_id is None]
     elif root_hierarchical_grouphash.group_id is None:
-        # The root hash is not assigned to a group. This can have two reasons:
-        if existing_grouphash.hash in hashes.hierarchical_hashes:
-            # The group was previously split and is now associated with a deeper
-            # hierarchical hash
-            new_hashes = []
-        else:
-            # We ran multiple grouping algorithms
-            # (see secondary grouping), and the hierarchical hash is new
-            new_hashes = [root_hierarchical_grouphash]
+        # The root hash is not assigned to a group.
+        # We ran multiple grouping algorithms
+        # (see secondary grouping), and the hierarchical hash is new
+        new_hashes = [root_hierarchical_grouphash]
     else:
         new_hashes = []
 
@@ -1218,6 +1213,9 @@ def _find_existing_grouphash(
 
             if group_hash is not None:
                 all_grouphashes.append(group_hash)
+
+                if group_hash.group_id is not None:
+                    break
 
         if root_hierarchical_hash is None:
             # All hashes were split, so we group by most specific hash. This is

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1202,6 +1202,11 @@ def _find_existing_grouphash(
             for h in GroupHash.objects.filter(project=project, hash__in=hierarchical_hashes)
         }
 
+        # Look for splits:
+        # 1. If we find a hash with SPLIT state at `n`, we want to use
+        #    `n + 1` as the root hash.
+        # 2. If we find a hash associated to a group that is more specific
+        #    than the primary hash, we want to use that hash as root hash.
         for hash in reversed(hierarchical_hashes):
             group_hash = hierarchical_grouphashes.get(hash)
 
@@ -1215,6 +1220,10 @@ def _find_existing_grouphash(
                 all_grouphashes.append(group_hash)
 
                 if group_hash.group_id is not None:
+                    # Even if we did not find a hash with SPLIT state, we want to use
+                    # the most specific hierarchical hash as root hash if it was already
+                    # associated to a group.
+                    # See `move_all_events` test case
                     break
 
         if root_hierarchical_hash is None:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1014,7 +1014,7 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
     # this for select_for_update mostly provides sufficient synchronization
     # when groups are created and also relieves contention by locking a more
     # specific hash than `hierarchical_hashes[0]`.
-    existing_grouphash, root_hierarchical_hash, found_split = _find_existing_grouphash(
+    existing_grouphash, root_hierarchical_hash = _find_existing_grouphash(
         project, flat_grouphashes, hashes.hierarchical_hashes
     )
 
@@ -1073,7 +1073,7 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
 
             flat_grouphashes = [gh for gh in all_hashes if gh.hash in hashes.hashes]
 
-            existing_grouphash, root_hierarchical_hash, found_split = _find_existing_grouphash(
+            existing_grouphash, root_hierarchical_hash = _find_existing_grouphash(
                 project, flat_grouphashes, hashes.hierarchical_hashes
             )
 
@@ -1144,7 +1144,7 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
         new_hashes = [h for h in flat_grouphashes if h.group_id is None]
     elif root_hierarchical_grouphash.group_id is None:
         # The root hash is not assigned to a group. This can have two reasons:
-        if found_split:
+        if existing_grouphash.hash in hashes.hierarchical_hashes:
             # The group was previously split and is now associated with a deeper
             # hierarchical hash
             new_hashes = []
@@ -1239,7 +1239,7 @@ def _find_existing_grouphash(
 
     for group_hash in all_grouphashes:
         if group_hash.group_id is not None:
-            return group_hash, root_hierarchical_hash, found_split
+            return group_hash, root_hierarchical_hash
 
         # When refactoring for hierarchical grouping, we noticed that a
         # tombstone may get ignored entirely if there is another hash *before*
@@ -1252,7 +1252,7 @@ def _find_existing_grouphash(
         if group_hash.group_tombstone_id is not None:
             raise HashDiscarded("Matches group tombstone %s" % group_hash.group_tombstone_id)
 
-    return None, root_hierarchical_hash, found_split
+    return None, root_hierarchical_hash
 
 
 def _handle_regression(group, event, release):

--- a/tests/sentry/event_manager/test_hierarchical_hashes.py
+++ b/tests/sentry/event_manager/test_hierarchical_hashes.py
@@ -72,7 +72,9 @@ def test_move_all_events(default_project, fast_save):
 
     # simulate split operation where all events of group are moved into a more specific hash
     GroupHash.objects.filter(group=group).delete()
-    GroupHash.objects.create(project=default_project, hash="f" * 32, group_id=group.id)
+    GroupHash.objects.create(
+        project=default_project, hash="f" * 32, group_id=group.id, state=GroupHash.State.SPLIT
+    )
 
     new_group, is_new, is_regression = fast_save("f")
     assert not is_new

--- a/tests/sentry/event_manager/test_hierarchical_hashes.py
+++ b/tests/sentry/event_manager/test_hierarchical_hashes.py
@@ -72,9 +72,7 @@ def test_move_all_events(default_project, fast_save):
 
     # simulate split operation where all events of group are moved into a more specific hash
     GroupHash.objects.filter(group=group).delete()
-    GroupHash.objects.create(
-        project=default_project, hash="f" * 32, group_id=group.id, state=GroupHash.State.SPLIT
-    )
+    GroupHash.objects.create(project=default_project, hash="f" * 32, group_id=group.id)
 
     new_group, is_new, is_regression = fast_save("f")
     assert not is_new


### PR DESCRIPTION
It seems that secondary grouping only assigned its group hash to an existing group if the _primary_ grouping algorithm was not hierarchical. This PR adds support for the case that an existing group hash has been found, but the group has not yet been associated to any hierarchical hash.