### PR TITLE
fix(GitHub): Autosize comment textarea on issue link

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -43,7 +43,7 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
     def create_default_repo_choice(self, default_repo: str) -> tuple[str, str]:
         return default_repo, default_repo.split("/")[1]
 
-    def fget_create_issue_config(
+    def get_create_issue_config(
         self, group: Group, user: User, **kwargs: Any
     ) -> Sequence[Mapping[str, Any]]:
         kwargs["link_referrer"] = "github_integration"

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -43,7 +43,7 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
     def create_default_repo_choice(self, default_repo: str) -> tuple[str, str]:
         return default_repo, default_repo.split("/")[1]
 
-    def get_create_issue_config(
+    def fget_create_issue_config(
         self, group: Group, user: User, **kwargs: Any
     ) -> Sequence[Mapping[str, Any]]:
         kwargs["link_referrer"] = "github_integration"
@@ -146,6 +146,7 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
                 ),
                 "type": "textarea",
                 "required": False,
+                "autosize": True,
                 "help": "Leave blank if you don't want to add a comment to the GitHub issue.",
             },
         ]


### PR DESCRIPTION
The link issue comment text box was weirdly cut off, this sets `autosize` to true to make it not weird.

**Before**
<img width="641" alt="Screen Shot 2022-02-17 at 1 10 23 PM" src="https://user-images.githubusercontent.com/29959063/154586606-06ede015-f64f-4c12-a849-65bbc9023154.png">
**After**
<img width="639" alt="Screen Shot 2022-02-17 at 1 09 29 PM" src="https://user-images.githubusercontent.com/29959063/154586602-bc71fd03-a418-4b4d-9b7e-ef6182b41864.png">
