### PR TITLE
feat(page-filters): Change time selector to dropdown from button bar

### DIFF
--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -1,224 +1,65 @@
-import React, {useState} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import moment from 'moment';
 
 import {pinFilter, updateDateTime} from 'sentry/actionCreators/pageFilters';
 import Button from 'sentry/components/button';
-import ButtonBar from 'sentry/components/buttonBar';
-import DropdownButton from 'sentry/components/dropdownButton';
-import {Content} from 'sentry/components/dropdownControl';
-import DropdownMenu from 'sentry/components/dropdownMenu';
-import HookOrDefault from 'sentry/components/hookOrDefault';
-import MultipleSelectorSubmitRow from 'sentry/components/organizations/multipleSelectorSubmitRow';
-import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
-import DateRange from 'sentry/components/organizations/timeRangeSelector/dateRange';
-import {
-  DEFAULT_RELATIVE_PERIODS_PAGE_FILTER,
-  DEFAULT_STATS_PERIOD,
-} from 'sentry/constants';
-import {IconPin} from 'sentry/icons';
+import TimeRangeSelector, {
+  ChangeData,
+} from 'sentry/components/organizations/timeRangeSelector';
+import {getRelativeSummary} from 'sentry/components/organizations/timeRangeSelector/utils';
+import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
+import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import {IconCalendar, IconPin} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
-import {
-  getDateWithTimezoneInUtc,
-  getInternalDate,
-  getLocalToSystem,
-  getPeriodAgo,
-  getUserTimezone,
-  getUtcToSystem,
-  parsePeriodToHours,
-} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 
-const DateRangeHook = HookOrDefault({
-  hookName: 'component:header-date-range',
-  defaultComponent: DateRange,
-});
-
-type DateRangeChangeData = Parameters<
-  React.ComponentProps<typeof DateRange>['onChange']
->[0];
-
-type Props = {
+type Props = Omit<
+  React.ComponentProps<typeof TimeRangeSelector>,
+  'organization' | 'start' | 'end' | 'utc' | 'relative' | 'onUpdate'
+> & {
   router: WithRouterProps['router'];
-  /**
-   * Set an optional default value to prefill absolute date with
-   */
-  defaultAbsolute?: {end?: Date; start?: Date};
-  /**
-   * Override DEFAULT_STATS_PERIOD
-   */
-  defaultPeriod?: string;
-  /**
-   * The maximum number of days in the past you can pick
-   */
-  maxPickableDays?: number;
-  /**
-   * Override defaults from DEFAULT_RELATIVE_PERIODS_PAGE_FILTER
-   */
-  relativeOptions?: Record<string, React.ReactChild>;
   /**
    * Reset these URL params when we fire actions (custom routing only)
    */
   resetParamsOnChange?: string[];
-  /**
-   * Show absolute date selection
-   */
-  showAbsolute?: boolean;
-  /**
-   * Show relative date options
-   */
-  showRelative?: boolean;
 };
 
-function DatePageFilter({
-  router,
-  defaultAbsolute,
-  defaultPeriod,
-  maxPickableDays,
-  relativeOptions,
-  resetParamsOnChange = [],
-  showAbsolute = true,
-  showRelative = true,
-}: Props) {
-  const organization = useOrganization();
+function DatePageFilter({router, resetParamsOnChange, ...props}: Props) {
   const {selection, pinnedFilters} = useLegacyStore(PageFiltersStore);
+  const organization = useOrganization();
+  const {start, end, period, utc} = selection.datetime;
 
   const isDatePinned = pinnedFilters.has('datetime');
 
-  const getStartFromRelativePeriod = () => {
-    return defaultAbsolute?.start
-      ? defaultAbsolute.start
-      : getPeriodAgo(
-          'hours',
-          parsePeriodToHours(
-            selection.datetime.period || defaultPeriod || DEFAULT_STATS_PERIOD
-          )
-        ).toDate();
-  };
+  const getDateSummary = (timeData: ChangeData) => {
+    const {relativeOptions, defaultPeriod} = props;
+    const {relative} = timeData;
 
-  const getEndFromRelativePeriod = () => {
-    return defaultAbsolute?.end ? defaultAbsolute.end : new Date();
-  };
-
-  const selectionStart = selection.datetime.start;
-  const selectionEnd = selection.datetime.end;
-  // if utc is not null and not undefined, then use value of `selection.datetime.utc` (it can be false)
-  // otherwise if no value is supplied, the default should be the user's timezone preference
-  const selectionUtc = defined(selection.datetime.utc)
-    ? selection.datetime.utc
-    : getUserTimezone() === 'UTC';
-
-  // convert current selection.datetime start values into dates for the DateRange hook
-  // or generate them from the currently selected relative period
-  const startDate =
-    selectionStart && selectionEnd
-      ? getInternalDate(selectionStart, selectionUtc)
-      : getStartFromRelativePeriod();
-  const endDate =
-    selectionStart && selectionEnd
-      ? getInternalDate(selectionEnd, selectionUtc)
-      : getEndFromRelativePeriod();
-
-  const [selectedTimePeriod, setSelectedTimePeriod] = useState<ChangeData>({
-    relative: selection.datetime.period,
-    start: startDate,
-    end: endDate,
-    utc: selectionUtc,
-  });
-  const [hasChanges, setHasChanges] = useState<boolean>(false);
-  const [hasDateErrors, setHasDateErrors] = useState<boolean>(false);
-
-  const getDateSummary = () => {
-    const {relative, start, end} = selectedTimePeriod;
-    if (relative || !start || !end) {
-      return t('Custom');
+    if (defined(start) && defined(end)) {
+      const formattedStart = moment(timeData.start).local().format('ll');
+      const formattedEnd = moment(timeData.end).local().format('ll');
+      return `${formattedStart} - ${formattedEnd}`;
     }
 
-    const formattedStart = moment(start).local().format('MMM DD');
-    const formattedEnd = moment(end).local().format('MMM DD');
-    return `${formattedStart} - ${formattedEnd}`;
+    return getRelativeSummary(
+      relative || defaultPeriod || DEFAULT_STATS_PERIOD,
+      relativeOptions
+    );
   };
 
   const handleUpdate = (timePeriodUpdate: ChangeData) => {
-    const {relative, start, end, utc} = timePeriodUpdate;
+    const {relative, ...startEndUtc} = timePeriodUpdate;
     const newTimePeriod = {
       period: relative,
-      start,
-      end,
-      utc,
+      ...startEndUtc,
     };
 
     updateDateTime(newTimePeriod, router, {save: true, resetParams: resetParamsOnChange});
-    setHasChanges(false);
-  };
-
-  const handleChangeDateRange = ({
-    start,
-    end,
-    hasDateRangeErrors = false,
-  }: DateRangeChangeData) => {
-    if (hasDateRangeErrors) {
-      setHasDateErrors(hasDateRangeErrors);
-      return;
-    }
-
-    const newDateTime: ChangeData = {
-      relative: null,
-      start,
-      end,
-      utc: selectedTimePeriod.utc,
-    };
-
-    setHasChanges(true);
-    setHasDateErrors(hasDateRangeErrors);
-    setSelectedTimePeriod(newDateTime);
-  };
-
-  const handleCloseDateSelector = () => {
-    if (!hasChanges) {
-      return;
-    }
-
-    handleUpdate(selectedTimePeriod);
-  };
-
-  const handleUseUtc = () => {
-    const utc = !selectedTimePeriod.utc;
-    let {start, end} = selection.datetime;
-
-    if (!start) {
-      start = getDateWithTimezoneInUtc(selectedTimePeriod.start, utc);
-    }
-
-    if (!end) {
-      end = getDateWithTimezoneInUtc(selectedTimePeriod.end, utc);
-    }
-
-    const newDateTime = {
-      relative: null,
-      start: utc ? getLocalToSystem(start) : getUtcToSystem(start),
-      end: utc ? getLocalToSystem(end) : getUtcToSystem(end),
-      utc,
-    };
-
-    setHasChanges(true);
-    setSelectedTimePeriod(newDateTime);
-  };
-
-  const handleSelectRelative = (value: string) => {
-    const newDateTime: ChangeData = {
-      relative: value,
-      start: undefined,
-      end: undefined,
-    };
-
-    setSelectedTimePeriod(newDateTime);
-    handleUpdate(newDateTime);
   };
 
   const handlePinClick = () => {
@@ -227,62 +68,17 @@ function DatePageFilter({
 
   return (
     <DateSelectorContainer>
-      <ButtonBar merged>
-        {showRelative &&
-          Object.entries(relativeOptions ?? DEFAULT_RELATIVE_PERIODS_PAGE_FILTER).map(
-            ([value, label]) => (
-              <RelativePeriodButton
-                key={value}
-                selected={value === selection.datetime.period}
-                onClick={() => handleSelectRelative(value)}
-              >
-                {label}
-              </RelativePeriodButton>
-            )
-          )}
-        {showAbsolute && (
-          <CustomDateOption>
-            <DropdownMenu keepMenuOpen onClose={handleCloseDateSelector}>
-              {({isOpen, getActorProps, getMenuProps, actions}) => (
-                <React.Fragment>
-                  <CustomPeriodButton
-                    isOpen={isOpen}
-                    {...getActorProps()}
-                    selected={!selection.datetime.period}
-                    showRelative={showRelative}
-                  >
-                    {getDateSummary()}
-                  </CustomPeriodButton>
-                  <Content
-                    {...getMenuProps()}
-                    alignMenu="right"
-                    width="350px"
-                    isOpen={isOpen}
-                    blendCorner
-                  >
-                    <DateRangeHook
-                      start={selectedTimePeriod.start ?? getStartFromRelativePeriod()}
-                      end={selectedTimePeriod.end ?? getEndFromRelativePeriod()}
-                      organization={organization}
-                      showTimePicker
-                      utc={selectedTimePeriod.utc}
-                      onChange={handleChangeDateRange}
-                      onChangeUtc={handleUseUtc}
-                      maxPickableDays={maxPickableDays}
-                    />
-                    <SubmitRow>
-                      <MultipleSelectorSubmitRow
-                        onSubmit={actions.close}
-                        disabled={!hasChanges || hasDateErrors}
-                      />
-                    </SubmitRow>
-                  </Content>
-                </React.Fragment>
-              )}
-            </DropdownMenu>
-          </CustomDateOption>
-        )}
-      </ButtonBar>
+      <StyledPageTimeRangeSelector
+        organization={organization}
+        start={start}
+        end={end}
+        relative={period}
+        utc={utc}
+        onUpdate={handleUpdate}
+        label={<IconCalendar color="textColor" />}
+        dateSummary={getDateSummary}
+        {...props}
+      />
       <PinButton
         aria-pressed={isDatePinned}
         aria-label={t('Pin')}
@@ -303,45 +99,15 @@ const DateSelectorContainer = styled('div')`
   grid-auto-columns: max-content;
 `;
 
+const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
+  height: 40px;
+  font-weight: 600;
+`;
+
 const PinButton = styled(Button)`
   display: block;
   color: ${p => p.theme.gray300};
   background: transparent;
-`;
-
-const RelativePeriodButton = styled(Button)<{selected?: boolean}>`
-  font-size: ${p => p.theme.fontSizeMedium};
-  font-weight: ${p => (p.selected ? 700 : 400)};
-  color: ${p => (p.selected ? p.theme.textColor : p.theme.subText)};
-  ${p => p.selected && `background-color: ${p.theme.bodyBackground}`};
-`;
-
-const CustomPeriodButton = styled(DropdownButton)<{
-  selected?: boolean;
-  showRelative?: boolean;
-}>`
-  font-size: ${p => p.theme.fontSizeMedium};
-  font-weight: ${p => (p.selected ? 700 : 400)};
-  color: ${p => (p.selected ? p.theme.textColor : p.theme.subText)};
-
-  ${p =>
-    p.showRelative &&
-    `
-    border-left: none;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  `}
-`;
-
-const CustomDateOption = styled('div')`
-  display: inline-block;
-  position: relative;
-`;
-
-const SubmitRow = styled('div')`
-  padding: ${space(0.5)} ${space(1)};
-  border-top: 1px solid ${p => p.theme.innerBorder};
-  border-left: 1px solid ${p => p.theme.border};
 `;
 
 export default withRouter(DatePageFilter);

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -101,6 +101,11 @@ type Props = WithRouterProps & {
   utc: boolean | null;
 
   /**
+   * Optional function to replace default date summary in dropdown header with
+   */
+  dateSummary?: (dateState: ChangeData) => React.ReactNode;
+
+  /**
    * Set an optional default value to prefill absolute date with
    */
   defaultAbsolute?: {end?: Date; start?: Date};
@@ -345,6 +350,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
 
   render() {
     const {
+      dateSummary,
       defaultPeriod,
       showAbsolute,
       showRelative,
@@ -397,7 +403,10 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
               hint={hint}
               {...getActorProps()}
             >
-              {getDynamicText({value: summary, fixed: 'start to end'})}
+              {getDynamicText({
+                value: dateSummary ? dateSummary({start, end, relative}) : summary,
+                fixed: 'start to end',
+              })}
             </StyledHeaderItem>
             {isOpen && (
               <Menu {...getMenuProps()} isAbsoluteSelected={isAbsoluteSelected}>

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -41,11 +41,17 @@ describe('DatePageFilter', function () {
       }
     );
 
-    expect(screen.getByText('7D')).toBeInTheDocument();
-    userEvent.click(screen.getByText('7D'));
+    // Open time period dropdown
+    expect(screen.getByText('Last 7 days')).toBeInTheDocument();
+    userEvent.click(screen.getByText('Last 7 days'));
 
+    // Click 30 day period
+    userEvent.click(screen.getByText('Last 30 days'));
+
+    // Confirm selection changed visible text and query params
+    expect(screen.getByText('Last 30 days')).toBeInTheDocument();
     expect(router.push).toHaveBeenCalledWith(
-      expect.objectContaining({query: {statsPeriod: '7d'}})
+      expect.objectContaining({query: {statsPeriod: '30d'}})
     );
     expect(PageFiltersStore.getState()).toEqual({
       isReady: true,


### PR DESCRIPTION
I rewrote the component as a dropdown so the diff is not that helpful. Might just be easier to only look at the new code.

Also added new prop to the `TimeRangeSelector` to allow for custom summary text to be provided

Previously was:
<img width="418" alt="image" src="https://user-images.githubusercontent.com/9372512/154586965-3ba1b7a5-53fe-4099-ad0a-9697e5d90912.png">

Changing to look like:
<img width="240" alt="image" src="https://user-images.githubusercontent.com/9372512/154586879-e2880725-a4e9-4049-b4e0-63472ef57181.png">

