### PR TITLE
feat(alertStatus): Initial sidebar for alert status page

### DIFF
--- a/static/app/views/alerts/details/ruleDetails.tsx
+++ b/static/app/views/alerts/details/ruleDetails.tsx
@@ -12,7 +12,8 @@ import {IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {IssueAlertRule} from 'sentry/types/alerts';
-import Sidebar from 'sentry/views/alerts/details/sidebar';
+
+import Sidebar from './sidebar';
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;

--- a/static/app/views/alerts/details/ruleDetails.tsx
+++ b/static/app/views/alerts/details/ruleDetails.tsx
@@ -12,6 +12,7 @@ import {IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {IssueAlertRule} from 'sentry/types/alerts';
+import Sidebar from 'sentry/views/alerts/details/sidebar';
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;
@@ -78,7 +79,7 @@ class TeamStability extends AsyncComponent<Props, State> {
         <StyledLayoutBody>
           <Layout.Main>Main Content</Layout.Main>
           <Layout.Side>
-            <h3>Sidebar content</h3>
+            <Sidebar rule={rule} />
           </Layout.Side>
         </StyledLayoutBody>
       </Fragment>

--- a/static/app/views/alerts/details/sidebar.tsx
+++ b/static/app/views/alerts/details/sidebar.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import {Fragment, PureComponent} from 'react';
 import styled from '@emotion/styled';
 
+import AlertBadge from 'sentry/components/alertBadge';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
@@ -11,7 +11,6 @@ import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
 import {Actor} from 'sentry/types';
 import {IssueAlertRule} from 'sentry/types/alerts';
-import AlertBadge from 'sentry/views/alerts/alertBadge';
 
 type Props = {
   rule: IssueAlertRule;

--- a/static/app/views/alerts/details/sidebar.tsx
+++ b/static/app/views/alerts/details/sidebar.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import {Fragment, PureComponent} from 'react';
+import styled from '@emotion/styled';
+
+import ActorAvatar from 'sentry/components/avatar/actorAvatar';
+import {SectionHeading} from 'sentry/components/charts/styles';
+import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
+import TimeSince from 'sentry/components/timeSince';
+import {t} from 'sentry/locale';
+import overflowEllipsis from 'sentry/styles/overflowEllipsis';
+import space from 'sentry/styles/space';
+import {Actor} from 'sentry/types';
+import {IssueAlertRule} from 'sentry/types/alerts';
+import AlertBadge from 'sentry/views/alerts/alertBadge';
+
+type Props = {
+  rule: IssueAlertRule;
+};
+
+class Sidebar extends PureComponent<Props> {
+  render() {
+    const {rule} = this.props;
+    const dateTriggered = new Date(0);
+    const dateModified = new Date(0);
+
+    const ownerId = rule.owner?.split(':')[1];
+    const teamActor = ownerId && {type: 'team' as Actor['type'], id: ownerId, name: ''};
+
+    return (
+      <Fragment>
+        <StatusContainer>
+          <HeaderItem>
+            <Heading noMargin>{t('Alert Status')}</Heading>
+            <Status>
+              <AlertBadge status={undefined} />
+            </Status>
+          </HeaderItem>
+          <HeaderItem>
+            <Heading noMargin>{t('Last Triggered')}</Heading>
+            <Status>
+              {dateTriggered ? (
+                <TimeSince date={dateTriggered} />
+              ) : (
+                t('No alerts triggered')
+              )}
+            </Status>
+          </HeaderItem>
+        </StatusContainer>
+        <SidebarGroup>
+          <Heading>{t('Alert Conditions')}</Heading>
+          <p>When if then</p>
+        </SidebarGroup>
+        <SidebarGroup>
+          <Heading>{t('Alert Rule Details')}</Heading>
+          <KeyValueTable>
+            <KeyValueTableRow
+              keyName={t('Alert Rule Created')}
+              value={<TimeSince date={rule.dateCreated} suffix={t('ago')} />}
+            />
+            {rule.createdBy && (
+              <KeyValueTableRow
+                keyName={t('Created By')}
+                value={<CreatedBy>{rule.createdBy.name ?? '-'}</CreatedBy>}
+              />
+            )}
+            {dateModified && (
+              <KeyValueTableRow
+                keyName={t('Last Modified')}
+                value={<TimeSince date={dateModified} suffix={t('ago')} />}
+              />
+            )}
+            <KeyValueTableRow
+              keyName={t('Team')}
+              value={
+                teamActor ? <ActorAvatar actor={teamActor} size={24} /> : 'Unassigned'
+              }
+            />
+          </KeyValueTable>
+        </SidebarGroup>
+      </Fragment>
+    );
+  }
+}
+
+export default Sidebar;
+
+const SidebarGroup = styled('div')`
+  margin-bottom: ${space(3)};
+`;
+
+const HeaderItem = styled('div')`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+
+  > *:nth-child(2) {
+    flex: 1;
+    display: flex;
+    align-items: center;
+  }
+`;
+
+const Status = styled('div')`
+  position: relative;
+  display: grid;
+  grid-template-columns: auto auto auto;
+  gap: ${space(0.5)};
+  font-size: ${p => p.theme.fontSizeLarge};
+`;
+
+const StatusContainer = styled('div')`
+  height: 60px;
+  display: flex;
+  margin-bottom: ${space(1.5)};
+`;
+
+const Heading = styled(SectionHeading)<{noMargin?: boolean}>`
+  display: grid;
+  grid-template-columns: auto auto;
+  justify-content: flex-start;
+  margin-top: ${p => (p.noMargin ? 0 : space(2))};
+  margin-bottom: ${space(0.5)};
+  line-height: 1;
+  gap: ${space(1)};
+`;
+
+const CreatedBy = styled('div')`
+  ${overflowEllipsis}
+`;


### PR DESCRIPTION
This is the initial incident alert rule status page sidebar, includes everything except conditions. Using placeholders for missing properties on the incident rule.


![Screen Shot 2022-02-17 at 10 53 49 PM](https://user-images.githubusercontent.com/15015880/154633066-f17624cf-efcc-4676-91cc-8f2ed27232f0.png)

Jira: [WOR-1616](https://getsentry.atlassian.net/browse/WOR-1616)