### PR TITLE
fix(metrics-api): Only paginate with orderBy

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -105,6 +105,8 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
     Based on `OrganizationSessionsEndpoint`.
     """
 
+    default_per_page = 50
+
     def get(self, request: Request, organization) -> Response:
         if not features.has("organizations:metrics", organization, actor=request.user):
             return Response(status=404)
@@ -124,7 +126,7 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
         return self.paginate(
             request,
             paginator=MetricsDataSeriesPaginator(data_fn=data_fn),
-            default_per_page=50,
+            default_per_page=self.default_per_page,
             max_per_page=100,
         )
 

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -416,7 +416,6 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
             for key, snuba_query in queries.items():
                 if snuba_query is None:
                     continue
-
                 results[entity][key] = raw_snql_query(
                     snuba_query, use_cache=False, referrer=f"api.metrics.{key}"
                 )

--- a/src/sentry/snuba/metrics/helpers.py
+++ b/src/sentry/snuba/metrics/helpers.py
@@ -220,27 +220,21 @@ class QueryDefinition:
         return (op, metric_name), direction
 
     def _parse_limit(self, query_params, paginator_kwargs):
-        limit = paginator_kwargs.get("limit")
-        if not self.orderby:
+        if self.orderby:
+            return paginator_kwargs.get("limit")
+        else:
             per_page = query_params.get("per_page")
             if per_page is not None:
                 # If order by is not None, it means we will have a `series` query which cannot be
                 # paginated, and passing a `per_page` url param to paginate the results is not
                 # possible
                 raise InvalidParams("'per_page' is only supported in combination with 'orderBy'")
-
-        if limit is not None:
-            try:
-                limit = int(limit)
-                if limit < 1:
-                    raise ValueError
-            except (ValueError, TypeError):
-                raise InvalidParams("'limit' must be integer >= 1")
-
-        return limit
+            return None
 
     def _parse_offset(self, query_params, paginator_kwargs):
-        if not self.orderby:
+        if self.orderby:
+            return paginator_kwargs.get("offset")
+        else:
             cursor = query_params.get("cursor")
             if cursor is not None:
                 # If order by is not None, it means we will have a `series` query which cannot be
@@ -248,7 +242,6 @@ class QueryDefinition:
                 # possible
                 raise InvalidParams("'cursor' is only supported in combination with 'orderBy'")
             return None
-        return paginator_kwargs.get("offset")
 
 
 class TimeRange(Protocol):


### PR DESCRIPTION
We disallow pagination parameters `per_page` and `cursor` except when there is also an `orderBy`.
But the default `per_page` of 50 was still accidentally applied as a limit in any other case, leading to incomplete time series filled with zeros, e.g.

```
460,
0,
0,
449,
0,
0,
405,
412,
```

instead of 

```
460,
479,
458,
449,
421,
394,
405,
412,
```

With this PR, the default limit provided by the paginator is now ignored unless there is an `orderBy`.