### PR TITLE
feat(transitional-serializer): write to sessions as JSON obj

### DIFF
--- a/src/sentry/utils/transitional_serializer.py
+++ b/src/sentry/utils/transitional_serializer.py
@@ -13,12 +13,8 @@ class TransitionalSerializer:
         self.json_serializer = JSONSerializer()
 
     def dumps(self, obj: Dict[str, Any]) -> bytes:
-        # need to rollback json write
-        # metrics.incr("transitional_serializer.json_write")
-        # return self.json_serializer.dumps(obj)
-
-        metrics.incr("transitional_serializer.pickle_write")
-        return self.pickle_serializer.dumps(obj)
+        metrics.incr("transitional_serializer.json_write")
+        return self.json_serializer.dumps(obj)
 
     def loads(self, data: bytes) -> Dict[str, Any]:
         try:

--- a/tests/sentry/utils/test_transitional_serializer.py
+++ b/tests/sentry/utils/test_transitional_serializer.py
@@ -20,6 +20,5 @@ class TransitionalSerializerTest(TestCase):
     def test_read_pickle(self):
         assert self.transitional_serializer.loads(self.pickle_obj) == self.obj
 
-    # need to rollback json write
-    # def test_write(self):
-    #     assert self.transitional_serializer.dumps(self.obj) == self.json_obj
+    def test_write(self):
+        assert self.transitional_serializer.dumps(self.obj) == self.json_obj


### PR DESCRIPTION
Transitional serializer now writes a json object to sessions. 

Was reverted due to a problem with the social_auth backend obj being in session. Waited 2 weeks for that to be a non issue
https://github.com/getsentry/sentry/pull/31549