### PR TITLE
ref(rtl-tests): Remove duplicate OrganizationContext.Provider and minor improvements

### DIFF
--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -39,13 +39,9 @@ function makeAllTheProviders({context, organization}: ProviderOptions) {
       <ContextProvider>
         <CacheProvider value={cache}>
           <ThemeProvider theme={lightTheme}>
-            {organization ? (
-              <OrganizationContext.Provider value={organization}>
-                {children}
-              </OrganizationContext.Provider>
-            ) : (
-              children
-            )}
+            <OrganizationContext.Provider value={organization ?? null}>
+              {children}
+            </OrganizationContext.Provider>
           </ThemeProvider>
         </CacheProvider>
       </ContextProvider>

--- a/tests/js/spec/components/IssueList.spec.tsx
+++ b/tests/js/spec/components/IssueList.spec.tsx
@@ -1,9 +1,4 @@
-import {
-  mountWithTheme,
-  screen,
-  userEvent,
-  waitFor,
-} from 'sentry-test/reactTestingLibrary';
+import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {IssueList} from 'sentry/components/issueList';
 

--- a/tests/js/spec/components/IssueList.spec.tsx
+++ b/tests/js/spec/components/IssueList.spec.tsx
@@ -77,9 +77,7 @@ describe('IssueList', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-error-message')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('loading-error-message')).toBeInTheDocument();
 
     userEvent.click(screen.getByText('Retry'));
 

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -4,7 +4,6 @@ import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary
 import DatePageFilter from 'sentry/components/datePageFilter';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('DatePageFilter', function () {
   const {organization, router, routerContext} = initializeOrg({

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -32,14 +32,10 @@ describe('DatePageFilter', function () {
   );
 
   it('can change period', function () {
-    mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <DatePageFilter />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<DatePageFilter />, {
+      context: routerContext,
+      organization,
+    });
 
     expect(screen.getByText('7D')).toBeInTheDocument();
     userEvent.click(screen.getByText('7D'));
@@ -64,14 +60,10 @@ describe('DatePageFilter', function () {
   });
 
   it('can pin datetime', async function () {
-    mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <DatePageFilter />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<DatePageFilter />, {
+      context: routerContext,
+      organization,
+    });
 
     // Confirm no filters are pinned
     expect(PageFiltersStore.getState()).toEqual(

--- a/tests/js/spec/components/environmentPageFilter.spec.tsx
+++ b/tests/js/spec/components/environmentPageFilter.spec.tsx
@@ -41,14 +41,10 @@ describe('EnvironmentPageFilter', function () {
   });
 
   it('can pick environment', function () {
-    mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <EnvironmentPageFilter />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<EnvironmentPageFilter />, {
+      context: routerContext,
+      organization,
+    });
 
     // Open the environment dropdown
     expect(screen.getByText('All Environments')).toBeInTheDocument();
@@ -68,14 +64,10 @@ describe('EnvironmentPageFilter', function () {
   });
 
   it('can pin environment', async function () {
-    mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <EnvironmentPageFilter />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<EnvironmentPageFilter />, {
+      context: routerContext,
+      organization,
+    });
     // Confirm no filters are pinned
     expect(PageFiltersStore.getState()).toEqual(
       expect.objectContaining({
@@ -101,14 +93,10 @@ describe('EnvironmentPageFilter', function () {
   });
 
   it('can quick select', async function () {
-    mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <EnvironmentPageFilter />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<EnvironmentPageFilter />, {
+      context: routerContext,
+      organization,
+    });
 
     // Open the environment dropdown
     expect(screen.getByText('All Environments')).toBeInTheDocument();

--- a/tests/js/spec/components/environmentPageFilter.spec.tsx
+++ b/tests/js/spec/components/environmentPageFilter.spec.tsx
@@ -5,7 +5,6 @@ import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('EnvironmentPageFilter', function () {
   const {organization, router, routerContext} = initializeOrg({

--- a/tests/js/spec/components/projectPageFilter.spec.tsx
+++ b/tests/js/spec/components/projectPageFilter.spec.tsx
@@ -5,7 +5,6 @@ import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('ProjectPageFilter', function () {
   const {organization, router, routerContext} = initializeOrg({
@@ -40,14 +39,10 @@ describe('ProjectPageFilter', function () {
   });
 
   it('can pick project', function () {
-    mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <ProjectPageFilter />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<ProjectPageFilter />, {
+      context: routerContext,
+      organization,
+    });
 
     // Open the project dropdown
     expect(screen.getByText('My Projects')).toBeInTheDocument();
@@ -70,14 +65,10 @@ describe('ProjectPageFilter', function () {
   });
 
   it('can pin selection', async function () {
-    mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <ProjectPageFilter />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<ProjectPageFilter />, {
+      context: routerContext,
+      organization,
+    });
 
     // Open the project dropdown
     expect(screen.getByText('My Projects')).toBeInTheDocument();
@@ -97,14 +88,10 @@ describe('ProjectPageFilter', function () {
   });
 
   it('can quick select', async function () {
-    mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <ProjectPageFilter />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<ProjectPageFilter />, {
+      context: routerContext,
+      organization,
+    });
 
     // Open the project dropdown
     expect(screen.getByText('My Projects')).toBeInTheDocument();
@@ -139,14 +126,10 @@ describe('ProjectPageFilter', function () {
   });
 
   it('will change projects when page filter selection changes, e.g. from back button nav', async function () {
-    mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <ProjectPageFilter />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<ProjectPageFilter />, {
+      context: routerContext,
+      organization,
+    });
 
     // Confirm initial selection
     expect(screen.getByText('My Projects')).toBeInTheDocument();

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -3,26 +3,13 @@ import React from 'react';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Organization} from 'sentry/types';
 import {
   DashboardDetails,
   DashboardWidgetSource,
   DisplayType,
   Widget,
 } from 'sentry/views/dashboardsV2/types';
-import WidgetBuilder, {WidgetBuilderProps} from 'sentry/views/dashboardsV2/widgetBuilder';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-
-function TestComponent({
-  organization,
-  ...props
-}: WidgetBuilderProps & {organization: Organization}) {
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <WidgetBuilder {...props} />
-    </OrganizationContext.Provider>
-  );
-}
+import WidgetBuilder from 'sentry/views/dashboardsV2/widgetBuilder';
 
 describe('WidgetBuilder', function () {
   it('no feature access', function () {
@@ -37,7 +24,7 @@ describe('WidgetBuilder', function () {
     };
 
     mountWithTheme(
-      <TestComponent
+      <WidgetBuilder
         route={{}}
         router={router}
         routes={router.routes}
@@ -45,11 +32,11 @@ describe('WidgetBuilder', function () {
         location={router.location}
         dashboard={dashboard}
         onSave={jest.fn()}
-        organization={organization}
         params={{orgId: organization.slug}}
       />,
       {
         context: routerContext,
+        organization,
       }
     );
 
@@ -101,7 +88,7 @@ describe('WidgetBuilder', function () {
     };
 
     mountWithTheme(
-      <TestComponent
+      <WidgetBuilder
         route={{}}
         router={router}
         routes={router.routes}
@@ -110,11 +97,11 @@ describe('WidgetBuilder', function () {
         dashboard={dashboard}
         onSave={jest.fn()}
         widget={widget}
-        organization={organization}
         params={{orgId: organization.slug, widgetId: Number(widget.id)}}
       />,
       {
         context: routerContext,
+        organization,
       }
     );
 
@@ -145,7 +132,7 @@ describe('WidgetBuilder', function () {
     };
 
     mountWithTheme(
-      <TestComponent
+      <WidgetBuilder
         route={{}}
         router={router}
         routes={router.routes}
@@ -153,11 +140,11 @@ describe('WidgetBuilder', function () {
         location={router.location}
         dashboard={dashboard}
         onSave={jest.fn()}
-        organization={organization}
         params={{orgId: organization.slug}}
       />,
       {
         context: routerContext,
+        organization,
       }
     );
 

--- a/tests/js/spec/views/organizationStats/teamInsights/health.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/health.spec.jsx
@@ -163,14 +163,10 @@ describe('TeamStatsHealth', () => {
     const context = TestStubs.routerContext([{organization}]);
     TeamStore.loadInitialData(teams, false, null);
 
-    return mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <TeamStatsHealth router={mockRouter} location={{}} />
-      </OrganizationContext.Provider>,
-      {
-        context,
-      }
-    );
+    return mountWithTheme(<TeamStatsHealth router={mockRouter} location={{}} />, {
+      context,
+      organization,
+    });
   }
 
   it('defaults to first team', () => {

--- a/tests/js/spec/views/organizationStats/teamInsights/health.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/health.spec.jsx
@@ -4,7 +4,6 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import localStorage from 'sentry/utils/localStorage';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import TeamStatsHealth from 'sentry/views/organizationStats/teamInsights/health';
 
 jest.mock('sentry/utils/localStorage');

--- a/tests/js/spec/views/organizationStats/teamInsights/issues.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/issues.spec.jsx
@@ -4,7 +4,6 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import localStorage from 'sentry/utils/localStorage';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import TeamStatsIssues from 'sentry/views/organizationStats/teamInsights/issues';
 
 jest.mock('sentry/utils/localStorage');
@@ -131,14 +130,10 @@ describe('TeamStatsIssues', () => {
     const context = TestStubs.routerContext([{organization}]);
     TeamStore.loadInitialData(teams, false, null);
 
-    return mountWithTheme(
-      <OrganizationContext.Provider value={organization}>
-        <TeamStatsIssues router={mockRouter} location={{}} />
-      </OrganizationContext.Provider>,
-      {
-        context,
-      }
-    );
+    return mountWithTheme(<TeamStatsIssues router={mockRouter} location={{}} />, {
+      context,
+      organization,
+    });
   }
 
   it('defaults to first team', () => {

--- a/tests/js/spec/views/performance/landing/queryBatcher.spec.tsx
+++ b/tests/js/spec/views/performance/landing/queryBatcher.spec.tsx
@@ -5,7 +5,6 @@ import {mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
 import {GenericQueryBatcher} from 'sentry/utils/performance/contexts/genericQueryBatcher';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import WidgetContainer from 'sentry/views/performance/landing/widgets/components/widgetContainer';
 import {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets/widgetDefinitions';
 import {PROJECT_PERFORMANCE_TYPE} from 'sentry/views/performance/utils';
@@ -30,19 +29,17 @@ const BASIC_QUERY_PARAMS = {
 const WrappedComponent = ({data, ...rest}) => {
   return (
     <PerformanceDisplayProvider value={{performanceType: PROJECT_PERFORMANCE_TYPE.ANY}}>
-      <OrganizationContext.Provider value={data.organization}>
-        <WidgetContainer
-          allowedCharts={[
-            PerformanceWidgetSetting.TPM_AREA,
-            PerformanceWidgetSetting.FAILURE_RATE_AREA,
-            PerformanceWidgetSetting.USER_MISERY_AREA,
-          ]}
-          rowChartSettings={[]}
-          forceDefaultChartSetting
-          {...data}
-          {...rest}
-        />
-      </OrganizationContext.Provider>
+      <WidgetContainer
+        allowedCharts={[
+          PerformanceWidgetSetting.TPM_AREA,
+          PerformanceWidgetSetting.FAILURE_RATE_AREA,
+          PerformanceWidgetSetting.USER_MISERY_AREA,
+        ]}
+        rowChartSettings={[]}
+        forceDefaultChartSetting
+        {...data}
+        {...rest}
+      />
     </PerformanceDisplayProvider>
   );
 };
@@ -135,7 +132,10 @@ describe('Performance > Widgets > Query Batching', function () {
       <WrappedComponent
         data={data}
         defaultChartSetting={PerformanceWidgetSetting.TPM_AREA}
-      />
+      />,
+      {
+        organization: data.organization,
+      }
     );
 
     expect(await screen.findByTestId('performance-widget-title')).toBeInTheDocument();
@@ -170,7 +170,10 @@ describe('Performance > Widgets > Query Batching', function () {
           data={data}
           defaultChartSetting={PerformanceWidgetSetting.USER_MISERY_AREA}
         />
-      </Fragment>
+      </Fragment>,
+      {
+        organization: data.organization,
+      }
     );
 
     expect(await screen.findAllByTestId('performance-widget-title')).toHaveLength(3);
@@ -193,22 +196,23 @@ describe('Performance > Widgets > Query Batching', function () {
     const data = initializeData();
 
     mountWithTheme(
-      <OrganizationContext.Provider value={data.organization}>
-        <GenericQueryBatcher>
-          <WrappedComponent
-            data={data}
-            defaultChartSetting={PerformanceWidgetSetting.TPM_AREA}
-          />
-          <WrappedComponent
-            data={data}
-            defaultChartSetting={PerformanceWidgetSetting.FAILURE_RATE_AREA}
-          />
-          <WrappedComponent
-            data={data}
-            defaultChartSetting={PerformanceWidgetSetting.USER_MISERY_AREA}
-          />
-        </GenericQueryBatcher>
-      </OrganizationContext.Provider>
+      <GenericQueryBatcher>
+        <WrappedComponent
+          data={data}
+          defaultChartSetting={PerformanceWidgetSetting.TPM_AREA}
+        />
+        <WrappedComponent
+          data={data}
+          defaultChartSetting={PerformanceWidgetSetting.FAILURE_RATE_AREA}
+        />
+        <WrappedComponent
+          data={data}
+          defaultChartSetting={PerformanceWidgetSetting.USER_MISERY_AREA}
+        />
+      </GenericQueryBatcher>,
+      {
+        organization: data.organization,
+      }
     );
 
     expect(await screen.findAllByTestId('performance-widget-title')).toHaveLength(3);
@@ -239,22 +243,23 @@ describe('Performance > Widgets > Query Batching', function () {
     const data = initializeData();
 
     mountWithTheme(
-      <OrganizationContext.Provider value={data.organization}>
-        <GenericQueryBatcher>
-          <WrappedComponent
-            data={data}
-            defaultChartSetting={PerformanceWidgetSetting.TPM_AREA}
-          />
-          <WrappedComponent
-            data={data}
-            defaultChartSetting={PerformanceWidgetSetting.FAILURE_RATE_AREA}
-          />
-          <WrappedComponent
-            data={data}
-            defaultChartSetting={PerformanceWidgetSetting.USER_MISERY_AREA}
-          />
-        </GenericQueryBatcher>
-      </OrganizationContext.Provider>
+      <GenericQueryBatcher>
+        <WrappedComponent
+          data={data}
+          defaultChartSetting={PerformanceWidgetSetting.TPM_AREA}
+        />
+        <WrappedComponent
+          data={data}
+          defaultChartSetting={PerformanceWidgetSetting.FAILURE_RATE_AREA}
+        />
+        <WrappedComponent
+          data={data}
+          defaultChartSetting={PerformanceWidgetSetting.USER_MISERY_AREA}
+        />
+      </GenericQueryBatcher>,
+      {
+        organization: data.organization,
+      }
     );
 
     expect(await screen.findAllByTestId('performance-widget-title')).toHaveLength(3);

--- a/tests/js/spec/views/performance/transactionAnomalies/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionAnomalies/index.spec.tsx
@@ -2,10 +2,9 @@ import {
   initializeData as _initializeData,
   initializeDataSettings,
 } from 'sentry-test/performance/initializePerformanceData';
-import {act, cleanup, mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
+import {act, mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import TransactionAnomalies from 'sentry/views/performance/transactionSummary/transactionAnomalies';
 
 const initializeData = (settings: initializeDataSettings) => {
@@ -15,27 +14,22 @@ const initializeData = (settings: initializeDataSettings) => {
   return data;
 };
 
-const WrappedComponent = data => {
-  return (
-    <OrganizationContext.Provider value={data.organization}>
-      <TransactionAnomalies {...data} />,
-    </OrganizationContext.Provider>
-  );
-};
-
 describe('AnomaliesTab', function () {
-  afterEach(cleanup);
   it('renders basic UI elements with flag', async function () {
     const initialData = initializeData({
       features: ['performance-view', 'performance-anomaly-detection-ui'],
       query: {project: '1', transaction: 'transaction'},
     });
+
     mountWithTheme(
-      <WrappedComponent
+      <TransactionAnomalies
         organization={initialData.organization}
         location={initialData.router.location}
       />,
-      {context: initialData.routerContext}
+      {
+        context: initialData.routerContext,
+        organization: initialData.organization,
+      }
     );
 
     expect(await screen.findByText('Transaction Count')).toBeInTheDocument();

--- a/tests/js/spec/views/performance/transactionAnomalies/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionAnomalies/index.spec.tsx
@@ -21,16 +21,10 @@ describe('AnomaliesTab', function () {
       query: {project: '1', transaction: 'transaction'},
     });
 
-    mountWithTheme(
-      <TransactionAnomalies
-        organization={initialData.organization}
-        location={initialData.router.location}
-      />,
-      {
-        context: initialData.routerContext,
-        organization: initialData.organization,
-      }
-    );
+    mountWithTheme(<TransactionAnomalies location={initialData.router.location} />, {
+      context: initialData.routerContext,
+      organization: initialData.organization,
+    });
 
     expect(await screen.findByText('Transaction Count')).toBeInTheDocument();
   });

--- a/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
@@ -80,13 +80,10 @@ describe('Performance > Transaction Spans', function () {
       const initialData = initializeData({
         query: {sort: SpanSortOthers.SUM_EXCLUSIVE_TIME},
       });
-      mountWithTheme(
-        <TransactionSpans
-          organization={initialData.organization}
-          location={initialData.router.location}
-        />,
-        {context: initialData.routerContext, organization: initialData.organization}
-      );
+      mountWithTheme(<TransactionSpans location={initialData.router.location} />, {
+        context: initialData.routerContext,
+        organization: initialData.organization,
+      });
 
       expect(
         await screen.findByText('No results found for your query')
@@ -106,16 +103,10 @@ describe('Performance > Transaction Spans', function () {
       const initialData = initializeData({
         query: {sort: SpanSortOthers.SUM_EXCLUSIVE_TIME},
       });
-      mountWithTheme(
-        <TransactionSpans
-          organization={initialData.organization}
-          location={initialData.router.location}
-        />,
-        {
-          context: initialData.routerContext,
-          organization: initialData.organization,
-        }
-      );
+      mountWithTheme(<TransactionSpans location={initialData.router.location} />, {
+        context: initialData.routerContext,
+        organization: initialData.organization,
+      });
 
       // default visible columns
       const grid = await screen.findByTestId('grid-editable');
@@ -143,16 +134,10 @@ describe('Performance > Transaction Spans', function () {
     ].forEach(({sort, label}) => {
       it('renders the right percentile header', async function () {
         const initialData = initializeData({query: {sort}});
-        mountWithTheme(
-          <TransactionSpans
-            organization={initialData.organization}
-            location={initialData.router.location}
-          />,
-          {
-            context: initialData.routerContext,
-            organization: initialData.organization,
-          }
-        );
+        mountWithTheme(<TransactionSpans location={initialData.router.location} />, {
+          context: initialData.routerContext,
+          organization: initialData.organization,
+        });
 
         const grid = await screen.findByTestId('grid-editable');
         expect(await within(grid).findByText('Span Operation')).toBeInTheDocument();
@@ -166,16 +151,10 @@ describe('Performance > Transaction Spans', function () {
 
     it('renders the right count header', async function () {
       const initialData = initializeData({query: {sort: SpanSortOthers.COUNT}});
-      mountWithTheme(
-        <TransactionSpans
-          organization={initialData.organization}
-          location={initialData.router.location}
-        />,
-        {
-          context: initialData.routerContext,
-          organization: initialData.organization,
-        }
-      );
+      mountWithTheme(<TransactionSpans location={initialData.router.location} />, {
+        context: initialData.routerContext,
+        organization: initialData.organization,
+      });
 
       const grid = await screen.findByTestId('grid-editable');
       expect(await within(grid).findByText('Span Operation')).toBeInTheDocument();
@@ -188,16 +167,10 @@ describe('Performance > Transaction Spans', function () {
 
     it('renders the right avg occurrence header', async function () {
       const initialData = initializeData({query: {sort: SpanSortOthers.AVG_OCCURRENCE}});
-      mountWithTheme(
-        <TransactionSpans
-          organization={initialData.organization}
-          location={initialData.router.location}
-        />,
-        {
-          context: initialData.routerContext,
-          organization: initialData.organization,
-        }
-      );
+      mountWithTheme(<TransactionSpans location={initialData.router.location} />, {
+        context: initialData.routerContext,
+        organization: initialData.organization,
+      });
 
       const grid = await screen.findByTestId('grid-editable');
       expect(await within(grid).findByText('Span Operation')).toBeInTheDocument();

--- a/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
@@ -3,8 +3,6 @@ import {generateSuspectSpansResponse} from 'sentry-test/performance/initializePe
 import {act, mountWithTheme, screen, within} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {Organization} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import TransactionSpans from 'sentry/views/performance/transactionSummary/transactionSpans';
 import {
   SpanSortOthers,
@@ -33,19 +31,6 @@ function initializeData({query} = {query: {}}) {
   act(() => void ProjectsStore.loadInitialData(initialData.organization.projects));
   return initialData;
 }
-
-const TestComponent = ({
-  organization,
-  ...props
-}: Omit<React.ComponentProps<typeof TransactionSpans>, 'organization'> & {
-  organization: Organization;
-}) => {
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <TransactionSpans organization={organization} {...props} />
-    </OrganizationContext.Provider>
-  );
-};
 
 describe('Performance > Transaction Spans', function () {
   let eventsV2Mock;
@@ -96,11 +81,11 @@ describe('Performance > Transaction Spans', function () {
         query: {sort: SpanSortOthers.SUM_EXCLUSIVE_TIME},
       });
       mountWithTheme(
-        <TestComponent
+        <TransactionSpans
           organization={initialData.organization}
           location={initialData.router.location}
         />,
-        {context: initialData.routerContext}
+        {context: initialData.routerContext, organization: initialData.organization}
       );
 
       expect(
@@ -122,11 +107,14 @@ describe('Performance > Transaction Spans', function () {
         query: {sort: SpanSortOthers.SUM_EXCLUSIVE_TIME},
       });
       mountWithTheme(
-        <TestComponent
+        <TransactionSpans
           organization={initialData.organization}
           location={initialData.router.location}
         />,
-        {context: initialData.routerContext}
+        {
+          context: initialData.routerContext,
+          organization: initialData.organization,
+        }
       );
 
       // default visible columns
@@ -156,11 +144,14 @@ describe('Performance > Transaction Spans', function () {
       it('renders the right percentile header', async function () {
         const initialData = initializeData({query: {sort}});
         mountWithTheme(
-          <TestComponent
+          <TransactionSpans
             organization={initialData.organization}
             location={initialData.router.location}
           />,
-          {context: initialData.routerContext}
+          {
+            context: initialData.routerContext,
+            organization: initialData.organization,
+          }
         );
 
         const grid = await screen.findByTestId('grid-editable');
@@ -176,11 +167,14 @@ describe('Performance > Transaction Spans', function () {
     it('renders the right count header', async function () {
       const initialData = initializeData({query: {sort: SpanSortOthers.COUNT}});
       mountWithTheme(
-        <TestComponent
+        <TransactionSpans
           organization={initialData.organization}
           location={initialData.router.location}
         />,
-        {context: initialData.routerContext}
+        {
+          context: initialData.routerContext,
+          organization: initialData.organization,
+        }
       );
 
       const grid = await screen.findByTestId('grid-editable');
@@ -195,11 +189,14 @@ describe('Performance > Transaction Spans', function () {
     it('renders the right avg occurrence header', async function () {
       const initialData = initializeData({query: {sort: SpanSortOthers.AVG_OCCURRENCE}});
       mountWithTheme(
-        <TestComponent
+        <TransactionSpans
           organization={initialData.organization}
           location={initialData.router.location}
         />,
-        {context: initialData.routerContext}
+        {
+          context: initialData.routerContext,
+          organization: initialData.organization,
+        }
       );
 
       const grid = await screen.findByTestId('grid-editable');

--- a/tests/js/spec/views/performance/transactionSummary.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.tsx
@@ -1,14 +1,12 @@
 import {browserHistory} from 'react-router';
 
-import {enforceActOnUseLegacyStoreHook} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {Organization, Project} from 'sentry/types';
+import {Project} from 'sentry/types';
 import {TransactionMetric} from 'sentry/utils/metrics/fields';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import {MetricsSwitchContext} from 'sentry/views/performance/metricsSwitch';
 import TransactionSummary from 'sentry/views/performance/transactionSummary/transactionOverview';
 
@@ -51,25 +49,19 @@ function initializeData({
 }
 
 const TestComponent = ({
-  organization,
   isMetricsData = false,
   ...props
-}: Omit<React.ComponentProps<typeof TransactionSummary>, 'organization'> & {
-  organization: Organization;
+}: React.ComponentProps<typeof TransactionSummary> & {
   isMetricsData?: boolean;
 }) => {
   return (
-    <OrganizationContext.Provider value={organization}>
-      <MetricsSwitchContext.Provider value={{isMetricsData, setIsMetricsData: jest.fn()}}>
-        <TransactionSummary organization={organization} {...props} />
-      </MetricsSwitchContext.Provider>
-    </OrganizationContext.Provider>
+    <MetricsSwitchContext.Provider value={{isMetricsData, setIsMetricsData: jest.fn()}}>
+      <TransactionSummary {...props} />
+    </MetricsSwitchContext.Provider>
   );
 };
 
 describe('Performance > TransactionSummary', function () {
-  enforceActOnUseLegacyStoreHook();
-
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
@@ -292,12 +284,10 @@ describe('Performance > TransactionSummary', function () {
   it('renders basic UI elements', async function () {
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     //  It shows the header
     await screen.findByText('Transaction Summary');
@@ -333,12 +323,10 @@ describe('Performance > TransactionSummary', function () {
       features: ['incidents'],
     });
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     // Ensure create alert from discover is shown with metric alerts
     expect(screen.getByRole('button', {name: 'Create Alert'})).toBeInTheDocument();
@@ -353,12 +341,10 @@ describe('Performance > TransactionSummary', function () {
       },
     });
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     // It renders the web vitals widget
     await screen.findByRole('heading', {name: 'Web Vitals'});
@@ -432,16 +418,10 @@ describe('Performance > TransactionSummary', function () {
       },
     });
 
-    mountWithTheme(
-      <TestComponent
-        organization={organization}
-        location={router.location}
-        isMetricsData
-      />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} isMetricsData />, {
+      context: routerContext,
+      organization,
+    });
 
     // It renders the web vitals widget
     await screen.findByRole('heading', {name: 'Web Vitals'});
@@ -477,12 +457,10 @@ describe('Performance > TransactionSummary', function () {
   it('renders sidebar widgets', async function () {
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     // Renders Apdex widget
     await screen.findByRole('heading', {name: 'Apdex'});
@@ -540,16 +518,10 @@ describe('Performance > TransactionSummary', function () {
 
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TestComponent
-        organization={organization}
-        location={router.location}
-        isMetricsData
-      />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} isMetricsData />, {
+      context: routerContext,
+      organization,
+    });
 
     // Renders Apdex widget
     await screen.findByRole('heading', {name: 'Apdex'});
@@ -615,12 +587,10 @@ describe('Performance > TransactionSummary', function () {
       },
     });
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     expect(getTransactionThresholdMock).toHaveBeenCalledTimes(1);
     expect(getProjectThresholdMock).not.toHaveBeenCalled();
@@ -644,12 +614,10 @@ describe('Performance > TransactionSummary', function () {
       },
     });
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     await screen.findByText('Transaction Summary');
 
@@ -660,12 +628,10 @@ describe('Performance > TransactionSummary', function () {
   it('triggers a navigation on search', async function () {
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     // Fill out the search box, and submit it.
     userEvent.type(screen.getByLabelText('Search events'), 'user.email:uhoh*{enter}');
@@ -687,12 +653,10 @@ describe('Performance > TransactionSummary', function () {
   it('can mark a transaction as key', async function () {
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     const mockUpdate = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/key-transactions/`,
@@ -714,12 +678,10 @@ describe('Performance > TransactionSummary', function () {
   it('triggers a navigation on transaction filter', async function () {
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     await screen.findByText('Transaction Summary');
 
@@ -743,12 +705,10 @@ describe('Performance > TransactionSummary', function () {
   it('renders pagination buttons', async function () {
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     await screen.findByText('Transaction Summary');
 
@@ -778,12 +738,10 @@ describe('Performance > TransactionSummary', function () {
       query: {query: 'tag:value'},
     });
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     await screen.findByText('Transaction Summary');
 
@@ -806,12 +764,10 @@ describe('Performance > TransactionSummary', function () {
       query: {query: 'tag:value event.type:transaction'},
     });
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     await screen.findByText('Transaction Summary');
 
@@ -828,12 +784,10 @@ describe('Performance > TransactionSummary', function () {
       features: ['performance-suspect-spans-view'],
     });
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     expect(await screen.findByText('Suspect Spans')).toBeInTheDocument();
   });
@@ -841,12 +795,10 @@ describe('Performance > TransactionSummary', function () {
   it('adds search condition on transaction status when clicking on status breakdown', async function () {
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     await screen.findByTestId('status-ok');
 
@@ -865,12 +817,10 @@ describe('Performance > TransactionSummary', function () {
   it('appends tag value to existing query when clicked', async function () {
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TestComponent organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-      }
-    );
+    mountWithTheme(<TestComponent location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     await screen.findByText('Tag Summary');
 

--- a/tests/js/spec/views/performance/transactionTags/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionTags/index.spec.tsx
@@ -4,8 +4,6 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, mountWithTheme, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {Organization} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import TransactionTags from 'sentry/views/performance/transactionSummary/transactionTags';
 
 const TEST_RELEASE_NAME = 'test-project@1.0.0';
@@ -36,19 +34,6 @@ function initializeData({query} = {query: {}}) {
 
   return initialData;
 }
-
-const WrappedComponent = ({
-  organization,
-  ...props
-}: Omit<React.ComponentProps<typeof TransactionTags>, 'organization'> & {
-  organization: Organization;
-}) => {
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <TransactionTags organization={organization} {...props} />
-    </OrganizationContext.Provider>
-  );
-};
 
 describe('Performance > Transaction Tags', function () {
   let histogramMock: Record<string, any>;
@@ -153,9 +138,10 @@ describe('Performance > Transaction Tags', function () {
     const {organization, router, routerContext} = initializeData();
 
     mountWithTheme(
-      <WrappedComponent organization={organization} location={router.location} />,
+      <TransactionTags organization={organization} location={router.location} />,
       {
         context: routerContext,
+        organization,
       }
     );
 
@@ -185,9 +171,10 @@ describe('Performance > Transaction Tags', function () {
     const {organization, router, routerContext} = initializeData();
 
     mountWithTheme(
-      <WrappedComponent organization={organization} location={router.location} />,
+      <TransactionTags organization={organization} location={router.location} />,
       {
         context: routerContext,
+        organization,
       }
     );
 
@@ -224,9 +211,10 @@ describe('Performance > Transaction Tags', function () {
     });
 
     mountWithTheme(
-      <WrappedComponent organization={organization} location={router.location} />,
+      <TransactionTags organization={organization} location={router.location} />,
       {
         context: routerContext,
+        organization,
       }
     );
 
@@ -261,11 +249,14 @@ describe('Performance > Transaction Tags', function () {
     const initialData = initializeData({query: {tagKey: 'release'}});
 
     mountWithTheme(
-      <WrappedComponent
+      <TransactionTags
         organization={initialData.organization}
         location={initialData.router.location}
       />,
-      {context: initialData.routerContext}
+      {
+        context: initialData.routerContext,
+        organization: initialData.organization,
+      }
     );
 
     await waitFor(() => {

--- a/tests/js/spec/views/performance/transactionTags/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionTags/index.spec.tsx
@@ -137,13 +137,10 @@ describe('Performance > Transaction Tags', function () {
   it('renders basic UI elements', async function () {
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TransactionTags organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-        organization,
-      }
-    );
+    mountWithTheme(<TransactionTags location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     // It shows the sidebar
     expect(await screen.findByText('Suspect Tags')).toBeInTheDocument();
@@ -170,13 +167,10 @@ describe('Performance > Transaction Tags', function () {
   it('Default tagKey is set when loading the page without one', async function () {
     const {organization, router, routerContext} = initializeData();
 
-    mountWithTheme(
-      <TransactionTags organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-        organization,
-      }
-    );
+    mountWithTheme(<TransactionTags location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     await waitFor(() => {
       // Table is loaded.
@@ -210,13 +204,10 @@ describe('Performance > Transaction Tags', function () {
       query: {tagKey: 'effectiveConnectionType'},
     });
 
-    mountWithTheme(
-      <TransactionTags organization={organization} location={router.location} />,
-      {
-        context: routerContext,
-        organization,
-      }
-    );
+    mountWithTheme(<TransactionTags location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     await waitFor(() => {
       // Table is loaded.

--- a/tests/js/spec/views/performance/transactionTags/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionTags/index.spec.tsx
@@ -239,16 +239,10 @@ describe('Performance > Transaction Tags', function () {
   it('creates links to releases if the release tag is selected', async () => {
     const initialData = initializeData({query: {tagKey: 'release'}});
 
-    mountWithTheme(
-      <TransactionTags
-        organization={initialData.organization}
-        location={initialData.router.location}
-      />,
-      {
-        context: initialData.routerContext,
-        organization: initialData.organization,
-      }
-    );
+    mountWithTheme(<TransactionTags location={initialData.router.location} />, {
+      context: initialData.routerContext,
+      organization: initialData.organization,
+    });
 
     await waitFor(() => {
       // Table is loaded.

--- a/tests/js/spec/views/settings/projectDebugFiles/customRepositories.spec.tsx
+++ b/tests/js/spec/views/settings/projectDebugFiles/customRepositories.spec.tsx
@@ -4,7 +4,7 @@ import {
   mountWithTheme,
   screen,
   userEvent,
-  waitFor,
+  waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -135,11 +135,9 @@ describe('Custom Repositories', function () {
     // Close Modal
     userEvent.click(screen.getByLabelText('Close Modal'));
 
-    await waitFor(() => {
-      expect(
-        screen.queryByText('This feature is not enabled on your Sentry installation.')
-      ).not.toBeInTheDocument();
-    });
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText('This feature is not enabled on your Sentry installation.')
+    );
 
     // Renders disabled repository list
     rerender(


### PR DESCRIPTION
An `OrganizationContext.Provider `was already being used inside https://github.com/getsentry/sentry/blob/1dc93884e98eee15a8870d985a706ebfee5ffde3/tests/js/sentry-test/reactTestingLibrary.tsx#L35 

This PR removes the `OrganizationContext.Provider ` wrappers and pass organization in the provide options instead  and do some minor improvements