### PR TITLE
feat(new-widget-builder-experience): Add disabled data set option - [DD-536]

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -354,10 +354,16 @@ function WidgetBuilder({
                 <DataSetChoices
                   label="dataSet"
                   value={state.dataSet}
-                  choices={
-                    state.displayType === DisplayType.TABLE
-                      ? DATASET_CHOICES
-                      : [DATASET_CHOICES[0]]
+                  choices={DATASET_CHOICES}
+                  disabledChoices={
+                    state.displayType !== DisplayType.TABLE
+                      ? [
+                          [
+                            DATASET_CHOICES[1][0],
+                            t('This data set is restricted to the table visualization.'),
+                          ],
+                        ]
+                      : undefined
                   }
                   onChange={handleDataSetChange}
                 />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29228205/154972482-ed8259c3-378c-48f1-b764-21965c5bf939.png)

**Note:** Currently, if the "Issues" dataset is selected and the visualization is changed to an option other than "Table", the data set option will not change. This issue will be fixed in PR https://github.com/getsentry/sentry/pull/31943