### PR TITLE
ci: Change machineType for Google Cloud Build to E2_HIGHCPU_8

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -94,7 +94,7 @@ artifacts:
     paths: ['dist/*.whl']
 options:
   # We need more memory for Webpack builds & e2e self-hosted tests
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_8'
   env:
     - 'CI=1'
     - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'


### PR DESCRIPTION
We are mostly concerned about the memory usage and `e2-highcpu-8` is not only ~15% cheaper, but it has 8GB of memory, instead of 7.2GB in `n1-highcpu-8`.
As used in Craft now - https://github.com/getsentry/craft/blob/bc2654af882ff2a4d649faeb8e3e573ec7267c0b/cloudbuild.yaml#L46

H/T to @BYK for the idea to update this build too 🎩 🙏 

ref: https://cloud.google.com/compute/vm-instance-pricing