### PR TITLE
fix(metrics-consumer): Set auto.offset.reset properly

### DIFF
--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -67,6 +67,7 @@ def get_config(topic: str, group_id: str, auto_offset_reset: str) -> MutableMapp
     consumer_config: MutableMapping[Any, Any] = kafka_config.get_kafka_consumer_cluster_options(
         cluster_name,
         override_params={
+            "auto.offset.reset": auto_offset_reset,
             "enable.auto.commit": False,
             "enable.auto.offset.store": False,
             "group.id": group_id,

--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -71,6 +71,8 @@ def get_config(topic: str, group_id: str, auto_offset_reset: str) -> MutableMapp
             "enable.auto.commit": False,
             "enable.auto.offset.store": False,
             "group.id": group_id,
+            # `default.topic.config` is now deprecated.
+            # More details: https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#kafka-client-configuration)
             "default.topic.config": {"auto.offset.reset": auto_offset_reset},
             # overridden to reduce memory usage when there's a large backlog
             "queued.max.messages.kbytes": DEFAULT_QUEUED_MAX_MESSAGE_KBYTES,


### PR DESCRIPTION
Had a problem with --auto-offset-reset not working properly, and after some investigation realized that `auto.offset.reset` was not used when passed as a subkey of `default.topic.config`.
Looks like `default.topic.config` is now deprecated (https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#kafka-client-configuration), so the suggested fix is to keep `auto.offset.reset` in both places (as a root level key, and as a subkey of `default.topic.config`, assuming that older confluent/librdkafka versions might use it).

**Note**: we have a few more places in the code where we use `default.topic.config` (and potentially ignore it):
* https://github.com/getsentry/sentry/blob/63d8e59a5e81a0bbed65b08fc59430865a0c00e6/src/sentry/utils/batching_kafka_consumer.py#L288
* https://github.com/getsentry/sentry/blob/e4b20a92b8241225196648466bf92db6c08fa098/src/sentry/eventstream/kafka/consumer.py#L71