### PR TITLE
fix(perf): Use s.replace() instead of s.replaceAll()

### DIFF
--- a/static/app/views/performance/landing/widgets/components/queryHandler.tsx
+++ b/static/app/views/performance/landing/widgets/components/queryHandler.tsx
@@ -29,7 +29,7 @@ export function QueryHandler<T extends WidgetDataConstraint>(
 }
 
 function genericQueryReferrer(setting: PerformanceWidgetSetting) {
-  return `api.performance.generic-widget-chart.${setting.replace('_', '-')}`;
+  return `api.performance.generic-widget-chart.${setting.replace(/[_]+/g, '-')}`;
 }
 
 function SingleQueryHandler<T extends WidgetDataConstraint>(

--- a/static/app/views/performance/landing/widgets/components/queryHandler.tsx
+++ b/static/app/views/performance/landing/widgets/components/queryHandler.tsx
@@ -29,7 +29,7 @@ export function QueryHandler<T extends WidgetDataConstraint>(
 }
 
 function genericQueryReferrer(setting: PerformanceWidgetSetting) {
-  return `api.performance.generic-widget-chart.${setting.replace(/_+/g, '-')}`;
+  return `api.performance.generic-widget-chart.${setting.replace(/_/g, '-')}`;
 }
 
 function SingleQueryHandler<T extends WidgetDataConstraint>(

--- a/static/app/views/performance/landing/widgets/components/queryHandler.tsx
+++ b/static/app/views/performance/landing/widgets/components/queryHandler.tsx
@@ -29,7 +29,7 @@ export function QueryHandler<T extends WidgetDataConstraint>(
 }
 
 function genericQueryReferrer(setting: PerformanceWidgetSetting) {
-  return `api.performance.generic-widget-chart.${setting.replaceAll('_', '-')}`;
+  return `api.performance.generic-widget-chart.${setting.replace('_', '-')}`;
 }
 
 function SingleQueryHandler<T extends WidgetDataConstraint>(

--- a/static/app/views/performance/landing/widgets/components/queryHandler.tsx
+++ b/static/app/views/performance/landing/widgets/components/queryHandler.tsx
@@ -29,7 +29,7 @@ export function QueryHandler<T extends WidgetDataConstraint>(
 }
 
 function genericQueryReferrer(setting: PerformanceWidgetSetting) {
-  return `api.performance.generic-widget-chart.${setting.replace(/[_]+/g, '-')}`;
+  return `api.performance.generic-widget-chart.${setting.replace(/_+/g, '-')}`;
 }
 
 function SingleQueryHandler<T extends WidgetDataConstraint>(


### PR DESCRIPTION
String.prototype.replaceAll() isn't supported on some of
the older browser versions, so favouring replace()
instead.

Fixes JAVASCRIPT-26JR