### PR TITLE
feat(profiling): Fix typo in URLs

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1534,13 +1534,13 @@ urlpatterns = [
                     include(
                         [
                             url(
-                                r"^stacktraces/$",
-                                OrganizationProfilingFiltersEndpoint.as_view(),
+                                r"^profiles/$",
+                                OrganizationProfilingProfilesEndpoint.as_view(),
                                 name="sentry-api-0-organization-profiling-profiles",
                             ),
                             url(
                                 r"^filters/$",
-                                OrganizationProfilingProfilesEndpoint.as_view(),
+                                OrganizationProfilingFiltersEndpoint.as_view(),
                                 name="sentry-api-0-organization-profiling-filters",
                             ),
                         ],


### PR DESCRIPTION
No matter how much you look, there is always a typo. Took the occasion to change the route to the new name of the resource as well.