### PR TITLE
feat(apidocs): resolve TYPE_CHECKING imports while building api docs

### DIFF
--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -7,7 +7,6 @@ from sentry import roles
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.external_actor import ExternalActorResponse
 from sentry.api.serializers.models.user import UserSerializerResponse
-from sentry.api.serializers.types import SCIMMeta
 from sentry.models import (
     ExternalActor,
     OrganizationMember,
@@ -246,6 +245,10 @@ class OrganizationMemberSCIMSerializerOptional(TypedDict, total=False):
     """Sentry doesn't use this field but is expected by SCIM"""
 
     active: bool
+
+
+class SCIMMeta(TypedDict):
+    resourceType: str
 
 
 class OrganizationMemberSCIMSerializerResponse(OrganizationMemberSCIMSerializerOptional):

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -20,7 +20,7 @@ from typing_extensions import TypedDict
 
 from sentry import roles
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.api.serializers.types import SCIMMeta, SerializedAvatarFields
+from sentry.api.serializers.types import SerializedAvatarFields
 from sentry.app import env
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
         ExternalActorResponse,
         OrganizationSerializerResponse,
         ProjectSerializerResponse,
+        SCIMMeta,
     )
 
 from sentry.scim.endpoints.constants import SCIM_SCHEMA_GROUP

--- a/src/sentry/api/serializers/types.py
+++ b/src/sentry/api/serializers/types.py
@@ -6,7 +6,3 @@ from typing_extensions import TypedDict
 class SerializedAvatarFields(TypedDict):
     avatarType: str
     avatarUuid: Optional[str]
-
-
-class SCIMMeta(TypedDict):
-    resourceType: str

--- a/src/sentry/apidocs/spectacular_ports.py
+++ b/src/sentry/apidocs/spectacular_ports.py
@@ -5,7 +5,8 @@ import inspect
 import typing
 from collections import OrderedDict, defaultdict
 from enum import Enum
-from typing import Any, Literal, Union, get_type_hints
+from typing import Any, Literal, Union
+from typing import get_type_hints as _get_type_hints
 
 from drf_spectacular.drainage import get_override
 from drf_spectacular.plumbing import (
@@ -17,6 +18,8 @@ from drf_spectacular.plumbing import (
 )
 from drf_spectacular.types import OpenApiTypes
 from typing_extensions import _TypedDictMeta
+
+from sentry.apidocs.utils import reload_module_with_type_checking_enabled
 
 # Until we're on 3.9 we have to use the typing extention TypedDict as
 # we are unable to tell optional fields at run time via the regular 3.8
@@ -36,6 +39,15 @@ from typing_extensions import _TypedDictMeta
 #   support deprecated fields via extension
 #   map TypedDicts in schema registry
 #   add a case for datetime types
+
+
+def get_type_hints(hint, **kwargs):
+    try:
+        return _get_type_hints(hint, **kwargs)
+    except NameError:
+        # try to resolve a circular import from TYPE_CHECKING imports
+        reload_module_with_type_checking_enabled(hint.__module__)
+        return _get_type_hints(hint, **kwargs)
 
 
 def _get_type_hint_origin(hint):

--- a/src/sentry/apidocs/utils.py
+++ b/src/sentry/apidocs/utils.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
+import importlib
+import os
+import typing
+from contextlib import contextmanager
+from typing import Any, Generator
 
 from drf_spectacular.plumbing import UnableToProceedError
 

--- a/src/sentry/apidocs/utils.py
+++ b/src/sentry/apidocs/utils.py
@@ -53,3 +53,23 @@ class SentryApiBuildError(UnableToProceedError):  # type: ignore
 
 
 # TODO: extend schema wrapper method here?
+
+# below inspired by https://stackoverflow.com/a/54766405
+
+
+def reload_module_with_type_checking_enabled(module_name: str) -> None:
+    @contextmanager
+    def _patch_type_checking_const() -> Generator[None, None, None]:
+        try:
+            setattr(typing, "TYPE_CHECKING", True)
+            yield
+        finally:
+            setattr(typing, "TYPE_CHECKING", False)
+
+    if not os.environ.get("OPENAPIGENERATE", False):
+        raise RuntimeError("This function can only be ran when generating API docs.")
+
+    module = importlib.import_module(module_name)
+
+    with _patch_type_checking_const():
+        importlib.reload(module)


### PR DESCRIPTION
- Move SCIMMeta back to the organization_member serializer module, which would cause a NameError at runtime since TYPE_CHECKING is false when we build API docs.
- Introduce new behavior in our API docs type parser that will attempt to reload a module with TYPE_CHECKING enabled, if a NameError is thrown, causing the above issue to be resolved.
- This should work in most cases, as all of our serializer imports should be resolved when we attempt to reload.
- This function will throw an error if it is attempted to be used while we're not running the open API build command.

