### PR TITLE
fix(migrations): Fix bug where migration checks can't be disabled

### DIFF
--- a/src/sentry/new_migrations/migrations.py
+++ b/src/sentry/new_migrations/migrations.py
@@ -10,5 +10,6 @@ class CheckedMigration(Migration):
     checked = True
 
     def apply(self, project_state, schema_editor, collect_sql=False):
-        schema_editor.safe = True
+        if self.checked:
+            schema_editor.safe = True
         return super().apply(project_state, schema_editor, collect_sql)


### PR DESCRIPTION
`checked` is never used currently, so anything subclassing `CheckedMigration` is always checked for
safety.