### PR TITLE
feat(accesslogs) fix organization id not being logged in api access logs

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -51,9 +51,7 @@ def _create_api_access_log(
         request_user = getattr(request, "user", None)
         user_id = getattr(request_user, "id", None)
         is_app = getattr(request_user, "is_sentry_app", None)
-
-        request_access = getattr(request, "access", None)
-        org_id = getattr(request_access, "organization_id", None)
+        org_id = getattr(getattr(request, "organization", None), "id", None)
 
         request_auth = _get_request_auth(request)
         auth_id = getattr(request_auth, "id", None)

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -87,10 +87,6 @@ class LogCaptureAPITestCase(APITestCase):
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @property
-    def captured_logs(self):
-        return [r for r in self._caplog.records if r.name == "sentry.access.api"]
-
     def assert_access_log_recorded(self):
         sentinel = object()
         for record in self.captured_logs:

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -65,8 +65,6 @@ class MyOrganizationEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
         return Response({"ok": True})
 
-    pass
-
 
 urlpatterns = [
     url(r"^/dummy$", DummyEndpoint.as_view(), name="dummy-endpoint"),


### PR DESCRIPTION
What used to work in the endpoint does not work in middleware. The issue was reproducible in test and using a local instance of sentry. After this is deployed I'll make sure we are logging organization ID again