### PR TITLE
fix(apidocs): add description to SCIM members POST

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -366,6 +366,14 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         ],
     )
     def post(self, request: Request, organization) -> Response:
+        """
+        Create a new Organization Member via a SCIM Users POST Request.
+        - `userName` should be set to the SAML field used for email, and active should be set to `true`.
+        - Sentry's SCIM API doesn't currently support setting users to inactive,
+        and the member will be deleted if inactive is set to `false`.
+        - The API also does not support setting secondary emails.
+        """
+
         serializer = OrganizationMemberSerializer(
             data={
                 "email": request.data.get("userName"),


### PR DESCRIPTION
- forgot to add the description to this endpoint, which will cause our gatsby doc build to fail (didn't occur because we haven't deployed yet).

TODO:
- [ ] add validation that all endpoints have a description in our OpenAPI build step.
- [ ] look into adding a CI test for gatsby doc building on the Sentry repo.