### PR TITLE
fix(apidocs): fix indeterministic ordering of scopes in docs buliding

### DIFF
--- a/src/sentry/apidocs/extensions.py
+++ b/src/sentry/apidocs/extensions.py
@@ -23,7 +23,7 @@ class TokenAuthExtension(OpenApiAuthenticationExtension):  # type: ignore
             for s in permission.scope_map.get(auto_schema.method, []):
                 scopes.add(s)
 
-        return {self.name: list(scopes)}
+        return {self.name: list(scopes).sort()}
 
     def get_security_definition(
         self, auto_schema: AutoSchema

--- a/src/sentry/apidocs/extensions.py
+++ b/src/sentry/apidocs/extensions.py
@@ -23,7 +23,9 @@ class TokenAuthExtension(OpenApiAuthenticationExtension):  # type: ignore
             for s in permission.scope_map.get(auto_schema.method, []):
                 scopes.add(s)
 
-        return {self.name: list(scopes).sort()}
+        scope_list = list(scopes)
+        scope_list.sort()
+        return {self.name: scope_list}
 
     def get_security_definition(
         self, auto_schema: AutoSchema


### PR DESCRIPTION
- right now the ordering isn't deterministic, so lots of noisy diff checks being fired, simply sorting them should do the trick.