### PR TITLE
ref(dashboards-metrics): Add types to filterAggregateParameters

### DIFF
--- a/static/app/components/dashboards/widgetQueryFields.tsx
+++ b/static/app/components/dashboards/widgetQueryFields.tsx
@@ -14,7 +14,7 @@ import {
 } from 'sentry/utils/discover/fields';
 import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';
 import ColumnEditCollection from 'sentry/views/eventsV2/table/columnEditCollection';
-import {QueryField} from 'sentry/views/eventsV2/table/queryField';
+import {FieldValueOption, QueryField} from 'sentry/views/eventsV2/table/queryField';
 import {FieldValueKind} from 'sentry/views/eventsV2/table/types';
 import {generateFieldOptions} from 'sentry/views/eventsV2/utils';
 
@@ -140,37 +140,38 @@ function WidgetQueryFields({
     return option.value.kind === FieldValueKind.FUNCTION;
   };
 
-  const filterAggregateParameters = fieldValue => option => {
-    // Only validate function parameters for timeseries widgets and
-    // world map widgets.
-    if (doNotValidateYAxis) {
-      return true;
-    }
+  const filterAggregateParameters =
+    (fieldValue: QueryFieldValue) => (option: FieldValueOption) => {
+      // Only validate function parameters for timeseries widgets and
+      // world map widgets.
+      if (doNotValidateYAxis) {
+        return true;
+      }
 
-    if (fieldValue.kind !== 'function') {
-      return true;
-    }
+      if (fieldValue.kind !== 'function') {
+        return true;
+      }
 
-    if (isMetricWidget) {
-      return true;
-    }
+      if (isMetricWidget || option.value.kind === FieldValueKind.METRICS) {
+        return true;
+      }
 
-    const functionName = fieldValue.function[0];
-    const primaryOutput = aggregateFunctionOutputType(
-      functionName as string,
-      option.value.meta.name
-    );
-    if (primaryOutput) {
-      return isLegalYAxisType(primaryOutput);
-    }
+      const functionName = fieldValue.function[0];
+      const primaryOutput = aggregateFunctionOutputType(
+        functionName as string,
+        option.value.meta.name
+      );
+      if (primaryOutput) {
+        return isLegalYAxisType(primaryOutput);
+      }
 
-    if (option.value.kind === FieldValueKind.FUNCTION) {
-      // Functions are not legal options as an aggregate/function parameter.
-      return false;
-    }
+      if (option.value.kind === FieldValueKind.FUNCTION) {
+        // Functions are not legal options as an aggregate/function parameter.
+        return false;
+      }
 
-    return isLegalYAxisType(option.value.meta.dataType);
-  };
+      return isLegalYAxisType(option.value.meta.dataType);
+    };
 
   const hideAddYAxisButton =
     (['world_map', 'big_number'].includes(displayType) && fields.length === 1) ||


### PR DESCRIPTION
The value of `option.value.meta.dataType` can contain metrics types. Namely `set` and `counter` which aren't compatible with the call signature of `isLegalYAxisType`.

I handled these extra cases in the same check for `isMetricsWidget`