### PR TITLE
fix(apidocs): __future__ annotations compatibility

### DIFF
--- a/src/sentry/apidocs/extensions.py
+++ b/src/sentry/apidocs/extensions.py
@@ -1,5 +1,4 @@
-import inspect
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, get_type_hints
 
 from drf_spectacular.extensions import OpenApiAuthenticationExtension, OpenApiSerializerExtension
 from drf_spectacular.openapi import AutoSchema
@@ -49,8 +48,11 @@ class SentryResponseSerializerExtension(OpenApiSerializerExtension):  # type: ig
         return name
 
     def map_serializer(self, auto_schema: AutoSchema, direction: Direction) -> Any:
-        serializer_signature = inspect.signature(self.target.serialize)
-        return resolve_type_hint(serializer_signature.return_annotation)
+        type_hints = get_type_hints(self.target.serialize)
+        if "return" not in type_hints:
+            raise TypeError("Please type the return value of the serializer with a TypedDict")
+
+        return resolve_type_hint(type_hints["return"])
 
 
 class SentryInlineResponseSerializerExtension(OpenApiSerializerExtension):  # type: ignore

--- a/tests/apidocs/spectacular_extensions/unit_tests.py
+++ b/tests/apidocs/spectacular_extensions/unit_tests.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from typing import List, Optional, Union
 
+import pytest
 from drf_spectacular.utils import extend_schema_serializer
 from typing_extensions import Literal, TypedDict
 
@@ -33,6 +36,11 @@ class BasicSerializerResponse(BasicSerializerOptional):
 
 class BasicSerializer(Serializer):
     def serialize() -> BasicSerializerResponse:
+        return {"a": 1, "b": "test", "c": True, "d": [1], "e": {"zz": "test"}}
+
+
+class FailSerializer(Serializer):
+    def serialize():
         return {"a": 1, "b": "test", "c": True, "d": [1], "e": {"zz": "test"}}
 
 
@@ -83,3 +91,9 @@ def test_sentry_inline_response_serializer_extension():
             "required": ["b", "c", "d", "e", "f", "g", "h"],
         },
     }
+
+
+def test_sentry_fails_when_serializer_not_typed():
+    seralizer_extension = SentryResponseSerializerExtension(FailSerializer)
+    with pytest.raises(TypeError):
+        seralizer_extension.map_serializer(None, None)


### PR DESCRIPTION
- Fix an issue caused by the usage of `inpect_signature`, and replace it with `get_type_hint`, which works correctly with `from __future__ import annotations`

See https://bugs.python.org/issue43355 for more info.