### PR TITLE
feat(pageFilters): Store desynced filters in store

### DIFF
--- a/static/app/actions/pageFiltersActions.tsx
+++ b/static/app/actions/pageFiltersActions.tsx
@@ -6,6 +6,7 @@ const PageFiltersActions = Reflux.createActions([
   'updateProjects',
   'updateDateTime',
   'updateEnvironments',
+  'updateDesyncedFilters',
   'pin',
 ]);
 

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -50,6 +50,7 @@ describe('DatePageFilter', function () {
     );
     expect(PageFiltersStore.getState()).toEqual({
       isReady: true,
+      desyncedFilters: new Set(),
       pinnedFilters: new Set(),
       selection: {
         datetime: {

--- a/tests/js/spec/stores/pageFiltersStore.spec.jsx
+++ b/tests/js/spec/stores/pageFiltersStore.spec.jsx
@@ -19,6 +19,7 @@ describe('PageFiltersStore', function () {
   it('getState()', function () {
     expect(PageFiltersStore.getState()).toEqual({
       isReady: false,
+      desyncedFilters: new Set(),
       pinnedFilters: new Set(),
       selection: {
         projects: [],


### PR DESCRIPTION
Supersedes #31743

This stores the desynced filter list in the page filters store, which allows us to mark filters as being 'desynchronized' from the pinned state.