### PR TITLE
fix(ADS): Deserialize response from internal service

### DIFF
--- a/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
+++ b/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
@@ -34,7 +34,7 @@ def get_anomalies(snuba_io):
         headers={"content-type": "application/json;charset=utf-8"},
     )
 
-    return Response(serialize(response.data), status=200)
+    return Response(serialize(json.loads(response.data)), status=200)
 
 
 def get_time_params(start, end):

--- a/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
+++ b/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
@@ -8,7 +8,6 @@ from urllib3 import Retry
 
 from sentry import features
 from sentry.api.bases import OrganizationEventsEndpointBase
-from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.net.http import connection_from_url
 from sentry.snuba.discover import timeseries_query
@@ -33,8 +32,7 @@ def get_anomalies(snuba_io):
         body=json.dumps(snuba_io),
         headers={"content-type": "application/json;charset=utf-8"},
     )
-
-    return Response(serialize(json.loads(response.data)), status=200)
+    return Response(json.loads(response.data), status=200)
 
 
 def get_time_params(start, end):


### PR DESCRIPTION
The ADS service response is a JSON string, which is currently serialized again when we return the response. This means that the response must be deserialized twice. This PR first deserializes the ADS response to avoid this. Also, remove the call to `serialize` as the ADS response will always be a dictionary of primitives.

Before:
```
r = requests.get("http://dev.getsentry.net:8000/api/0/organizations/sentry/transaction-anomaly-detection/?project=2&query=transaction.duration%3A%3C15m%20transaction=<unlabeled+transaction>&statsPeriod=14d", headers=headers)
>>> r.content
b'"{\\"anomalies\\":[],\\"y\\":{\\"data\\":[]},\\"yhat_lower\\":{\\"data\\":[]},\\"yhat_upper\\":{\\"data\\":[]}}\\n"'
>>> a = json.loads(r.content)
>>> a
'{"anomalies":[],"y":{"data":[]},"yhat_lower":{"data":[]},"yhat_upper":{"data":[]}}\n'
>>> b = json.loads(a)
>>> b
{'anomalies': [], 'y': {'data': []}, 'yhat_lower': {'data': []}, 'yhat_upper': {'data': []}}
```

After:

```
r = requests.get("http://dev.getsentry.net:8000/api/0/organizations/sentry/transaction-anomaly-detection/?project=2&query=transaction.duration%3A%3C15m%20transaction=<unlabeled+transaction>&statsPeriod=14d", headers=headers)
>>> r.content
b'{"anomalies":[],"y":{"data":[]},"yhat_lower":{"data":[]},"yhat_upper":{"data":[]}}'
>>> a = json.loads(r.content)
>>> a
{'anomalies': [], 'y': {'data': []}, 'yhat_lower': {'data': []}, 'yhat_upper': {'data': []}}
```

