### PR TITLE
feat(apidocs): validate description exists

### DIFF
--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -32,28 +32,9 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
 
 
 def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> Any:
-    def _check_tags() -> None:
-        if method_info.get("tags") is None:
-            raise SentryApiBuildError(
-                f"Please add a single tag to {path}. The list of tags is defined at OPENAPI_TAGS in src/sentry/apidocs/build.py "
-            )
-
-        num_of_tags = len(method_info["tags"])
-
-        if num_of_tags > 1:
-            raise SentryApiBuildError(
-                f"Please add only a single tag to {path}. Right now there are {num_of_tags}."
-            )
-        for tag in method_info["tags"]:
-            if tag not in _DEFINED_TAG_SET:
-                raise SentryApiBuildError(
-                    f"{tag} is not defined by OPENAPI_TAGS in src/sentry/apidocs/build.py. "
-                    "Please use a suitable tag or add a new one to OPENAPI_TAGS"
-                )
-
     for path, endpoints in result["paths"].items():
         for method_info in endpoints.values():
-            _check_tags()
+            _check_tag(path, method_info)
 
             if method_info.get("description") is None:
                 raise SentryApiBuildError(
@@ -61,3 +42,25 @@ def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> An
                 )
 
     return result
+
+
+def _check_tag(path, method_info) -> None:
+    if method_info.get("tags") is None:
+        raise SentryApiBuildError(
+            f"Please add a single tag to {path}. The list of tags is defined at OPENAPI_TAGS in src/sentry/apidocs/build.py "
+        )
+
+    num_of_tags = len(method_info["tags"])
+
+    if num_of_tags > 1:
+        raise SentryApiBuildError(
+            f"Please add only a single tag to {path}. Right now there are {num_of_tags}."
+        )
+
+    tag = method_info["tags"][0]
+
+    if tag not in _DEFINED_TAG_SET:
+        raise SentryApiBuildError(
+            f"{tag} is not defined by OPENAPI_TAGS in src/sentry/apidocs/build.py. "
+            "Please use a suitable tag or add a new one to OPENAPI_TAGS"
+        )

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Literal, Set, TypedDict
+from typing import Any, Dict, Literal, Mapping, Set, TypedDict
 
 from sentry.apidocs.build import OPENAPI_TAGS
 from sentry.apidocs.utils import SentryApiBuildError
@@ -44,7 +44,7 @@ def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> An
     return result
 
 
-def _check_tag(path, method_info) -> None:
+def _check_tag(path: str, method_info: Mapping[str, Any]) -> None:
     if method_info.get("tags") is None:
         raise SentryApiBuildError(
             f"Please add a single tag to {path}. The list of tags is defined at OPENAPI_TAGS in src/sentry/apidocs/build.py "

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -1,8 +1,7 @@
 from typing import Any, Dict, Literal, Set, TypedDict
 
-from drf_spectacular.plumbing import UnableToProceedError
-
 from sentry.apidocs.build import OPENAPI_TAGS
+from sentry.apidocs.utils import SentryApiBuildError
 
 HTTP_METHODS_SET = Set[
     Literal["GET", "POST", "PUT", "OPTIONS", "HEAD", "DELETE", "TRACE", "CONNECT", "PATCH"]
@@ -16,7 +15,7 @@ class EndpointRegistryType(TypedDict):
 PUBLIC_ENDPOINTS: Dict[str, EndpointRegistryType] = {}
 
 
-defined_tag_set = {t["name"] for t in OPENAPI_TAGS}
+_DEFINED_TAG_SET = {t["name"] for t in OPENAPI_TAGS}
 
 
 def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, rename
@@ -33,24 +32,32 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
 
 
 def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> Any:
+    def _check_tags():
+        if method_info.get("tags") is None:
+            raise SentryApiBuildError(
+                f"Please add a single tag to {path}. The list of tags is defined at OPENAPI_TAGS in src/sentry/apidocs/build.py "
+            )
+
+        num_of_tags = len(method_info["tags"])
+
+        if num_of_tags > 1:
+            raise SentryApiBuildError(
+                f"Please add only a single tag to {path}. Right now there are {num_of_tags}."
+            )
+        for tag in method_info["tags"]:
+            if tag not in _DEFINED_TAG_SET:
+                raise SentryApiBuildError(
+                    f"{tag} is not defined by OPENAPI_TAGS in src/sentry/apidocs/build.py. "
+                    "Please use a suitable tag or add a new one to OPENAPI_TAGS"
+                )
+
     for path, endpoints in result["paths"].items():
         for method_info in endpoints.values():
-            if method_info.get("tags") is None:
-                raise UnableToProceedError(
-                    f"Please add a single tag to {path}. The list of tags is defined at OPENAPI_TAGS in src/sentry/apidocs/build.py "
-                )
+            _check_tags()
 
-            num_of_tags = len(method_info["tags"])
-
-            if num_of_tags > 1:
-                raise UnableToProceedError(
-                    f"Please add only a single tag to {path}. Right now there are {num_of_tags}."
+            if method_info.get("description") is None:
+                raise SentryApiBuildError(
+                    "Please add a description to your endpoint method via a docstring"
                 )
-            for tag in method_info["tags"]:
-                if tag not in defined_tag_set:
-                    raise UnableToProceedError(
-                        f"{tag} is not defined by OPENAPI_TAGS in src/sentry/apidocs/build.py. "
-                        "Please use a suitable tag or add a new one to OPENAPI_TAGS"
-                    )
 
     return result

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -32,7 +32,7 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
 
 
 def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> Any:
-    def _check_tags():
+    def _check_tags() -> None:
         if method_info.get("tags") is None:
             raise SentryApiBuildError(
                 f"Please add a single tag to {path}. The list of tags is defined at OPENAPI_TAGS in src/sentry/apidocs/build.py "

--- a/src/sentry/apidocs/utils.py
+++ b/src/sentry/apidocs/utils.py
@@ -1,3 +1,5 @@
+from drf_spectacular.plumbing import UnableToProceedError
+
 from sentry.api.serializers import Serializer
 
 
@@ -34,6 +36,16 @@ def inline_sentry_response_serializer(name: str, t: type) -> type:
 
     serializer_class = type(name, (_RawSchema,), {"typeSchema": t})
     return serializer_class
+
+
+class SentryApiBuildError(UnableToProceedError):
+    def __init__(self, msg="", *args, **kwargs):
+        super().__init__(
+            msg
+            + "\nSee https://develop.sentry.dev/api/public/#how-to-make-an-endpoint-public for more information.",
+            *args,
+            **kwargs,
+        )
 
 
 # TODO: extend schema wrapper method here?

--- a/src/sentry/apidocs/utils.py
+++ b/src/sentry/apidocs/utils.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from drf_spectacular.plumbing import UnableToProceedError
 
 from sentry.api.serializers import Serializer
@@ -38,8 +42,8 @@ def inline_sentry_response_serializer(name: str, t: type) -> type:
     return serializer_class
 
 
-class SentryApiBuildError(UnableToProceedError):
-    def __init__(self, msg="", *args, **kwargs):
+class SentryApiBuildError(UnableToProceedError):  # type: ignore
+    def __init__(self, msg: str = "", *args: Any, **kwargs: Any) -> None:
         super().__init__(
             msg
             + "\nSee https://develop.sentry.dev/api/public/#how-to-make-an-endpoint-public for more information.",


### PR DESCRIPTION
- Don't allow developers to publish an OpenAPI endpoint without a description
- Create a `SentryApiBuildError` exception that will append link to docs on errors.