### PR TITLE
fix(dam): Specify both limit and orderBy

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/metricsWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/metricsWidgetQueries.tsx
@@ -163,10 +163,7 @@ class MetricsWidgetQueries extends React.Component<Props, State> {
         // groupBy: query.groupBy // TODO(dam): add backend groupBy support
         interval,
         limit: this.limit,
-        orderBy:
-          query.orderby || widget.displayType === DisplayType.BIG_NUMBER
-            ? query.fields[0]
-            : undefined,
+        orderBy: query.orderby || this.limit ? query.fields[0] : undefined,
         project: projects,
         query: query.conditions,
         start,


### PR DESCRIPTION
`limit (per_page)` can be used in metrics API only in combination with `orderBy`.

Fixes
![image](https://user-images.githubusercontent.com/9060071/155323196-181c3625-191e-4eb6-9755-e1bb0458e565.png)