### PR TITLE
feat(ui): Add crash free users to project details

### DIFF
--- a/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
@@ -32,7 +32,10 @@ import ProjectSessionsChartRequest from './projectSessionsChartRequest';
 
 type Props = {
   api: Client;
-  displayMode: DisplayModes.SESSIONS | DisplayModes.STABILITY;
+  displayMode:
+    | DisplayModes.SESSIONS
+    | DisplayModes.STABILITY_USERS
+    | DisplayModes.STABILITY;
   onTotalValuesChange: (value: number | null) => void;
   organization: Organization;
   router: InjectedRouter;
@@ -140,7 +143,10 @@ function ProjectBaseSessionsChart({
 }
 
 type ChartProps = {
-  displayMode: DisplayModes.SESSIONS | DisplayModes.STABILITY;
+  displayMode:
+    | DisplayModes.SESSIONS
+    | DisplayModes.STABILITY
+    | DisplayModes.STABILITY_USERS;
   releaseSeries: Series[];
   reloading: boolean;
   theme: Theme;
@@ -206,6 +212,12 @@ class Chart extends Component<ChartProps, ChartState> {
     );
   };
 
+  get isCrashFree() {
+    const {displayMode} = this.props;
+
+    return [DisplayModes.STABILITY, DisplayModes.STABILITY_USERS].includes(displayMode);
+  }
+
   get legend(): LegendComponentOption {
     const {theme, timeSeries, previousTimeSeries, releaseSeries} = this.props;
     const {seriesSelection} = this.state;
@@ -250,8 +262,6 @@ class Chart extends Component<ChartProps, ChartState> {
   }
 
   get chartOptions() {
-    const {displayMode} = this.props;
-
     return {
       grid: {left: '10px', right: '10px', top: '40px', bottom: '0px'},
       seriesOptions: {
@@ -265,32 +275,29 @@ class Chart extends Component<ChartProps, ChartState> {
             return '\u2014';
           }
 
-          if (displayMode === DisplayModes.STABILITY) {
+          if (this.isCrashFree) {
             return displayCrashFreePercent(value, 0, 3);
           }
 
           return typeof value === 'number' ? value.toLocaleString() : value;
         },
       },
-      yAxis:
-        displayMode === DisplayModes.STABILITY
-          ? {
-              axisLabel: {
-                formatter: (value: number) => displayCrashFreePercent(value),
-              },
-              scale: true,
-              max: 100,
-            }
-          : {min: 0},
+      yAxis: this.isCrashFree
+        ? {
+            axisLabel: {
+              formatter: (value: number) => displayCrashFreePercent(value),
+            },
+            scale: true,
+            max: 100,
+          }
+        : {min: 0},
     };
   }
 
   render() {
-    const {zoomRenderProps, timeSeries, previousTimeSeries, releaseSeries, displayMode} =
-      this.props;
+    const {zoomRenderProps, timeSeries, previousTimeSeries, releaseSeries} = this.props;
 
-    const ChartComponent =
-      displayMode === DisplayModes.STABILITY ? LineChart : StackedAreaChart;
+    const ChartComponent = this.isCrashFree ? LineChart : StackedAreaChart;
 
     return (
       <ChartComponent

--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -51,6 +51,7 @@ export enum DisplayModes {
   ERRORS = 'errors',
   TRANSACTIONS = 'transactions',
   STABILITY = 'crash_free',
+  STABILITY_USERS = 'crash_free_users',
   SESSIONS = 'sessions',
 }
 
@@ -136,6 +137,14 @@ class ProjectCharts extends Component<Props, State> {
         tooltip: !hasSessions ? noHealthTooltip : undefined,
       },
       {
+        value: DisplayModes.STABILITY_USERS,
+        label: t('Crash Free Users'),
+        disabled:
+          this.otherActiveDisplayModes.includes(DisplayModes.STABILITY_USERS) ||
+          !hasSessions,
+        tooltip: !hasSessions ? noHealthTooltip : undefined,
+      },
+      {
         value: DisplayModes.APDEX,
         label: t('Apdex'),
         disabled:
@@ -202,6 +211,8 @@ class ProjectCharts extends Component<Props, State> {
       case DisplayModes.STABILITY:
       case DisplayModes.SESSIONS:
         return t('Total Sessions');
+      case DisplayModes.STABILITY_USERS:
+        return t('Total Users');
       case DisplayModes.APDEX:
       case DisplayModes.FAILURE_RATE:
       case DisplayModes.TPM:
@@ -380,6 +391,18 @@ class ProjectCharts extends Component<Props, State> {
                 <ProjectBaseSessionsChart
                   title={t('Crash Free Sessions')}
                   help={getSessionTermDescription(SessionTerm.STABILITY, null)}
+                  router={router}
+                  api={api}
+                  organization={organization}
+                  onTotalValuesChange={this.handleTotalValuesChange}
+                  displayMode={displayMode}
+                  query={query}
+                />
+              )}
+              {displayMode === DisplayModes.STABILITY_USERS && (
+                <ProjectBaseSessionsChart
+                  title={t('Crash Free Users')}
+                  help={getSessionTermDescription(SessionTerm.CRASH_FREE_USERS, null)}
                   router={router}
                   api={api}
                   organization={organization}

--- a/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';
-import {Organization, PageFilters} from 'sentry/types';
+import {Organization, PageFilters, SessionField} from 'sentry/types';
 
 import ProjectApdexScoreCard from './projectApdexScoreCard';
 import ProjectStabilityScoreCard from './projectStabilityScoreCard';
@@ -32,6 +32,16 @@ function ProjectScoreCards({
         isProjectStabilized={isProjectStabilized}
         hasSessions={hasSessions}
         query={query}
+        field={SessionField.SESSIONS}
+      />
+
+      <ProjectStabilityScoreCard
+        organization={organization}
+        selection={selection}
+        isProjectStabilized={isProjectStabilized}
+        hasSessions={hasSessions}
+        query={query}
+        field={SessionField.USERS}
       />
 
       <ProjectVelocityScoreCard
@@ -54,8 +64,12 @@ function ProjectScoreCards({
 
 const CardWrapper = styled('div')`
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-column-gap: ${space(2)};
+
+  @media (max-width: 1600px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: 1fr;


### PR DESCRIPTION
This PR adds both crash-free users score-card and crash-free users line chart to project details.

![image](https://user-images.githubusercontent.com/9060071/155372283-15f0217d-0d1f-457a-830e-5ce166a27ec0.png)