### PR TITLE
feat(dx): add apidocs build to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,11 @@ repos:
       language: system
       files: requirements-base.txt
       pass_filenames: false
+    - id: build-api-docs
+      name: build-api-docs
+      entry: make build-spectacular-docs
+      language: system
+      types: [python]
     - id: pyright
       name: pyright
       entry: pyright


### PR DESCRIPTION
catch API doc build issues before being pushed up to CI by building them in pre-commit. this does take a few seconds to run, so it may not be worth it, as most changes won't modify the docs. will keep open and see if CI issues with API docs builds are common.