### PR TITLE
fix(deletions) Fix CodeOwners breaking deletions

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -134,13 +134,16 @@ def load_defaults():
     default_manager.register(models.ProjectKey, BulkModelDeletionTask)
     default_manager.register(models.PullRequest, BulkModelDeletionTask)
     default_manager.register(models.Release, defaults.ReleaseDeletionTask)
-    default_manager.register(models.Repository, defaults.RepositoryDeletionTask)
     default_manager.register(models.SavedSearch, BulkModelDeletionTask)
     default_manager.register(models.ReleaseCommit, BulkModelDeletionTask)
     default_manager.register(models.ReleaseEnvironment, BulkModelDeletionTask)
     default_manager.register(models.ReleaseProjectEnvironment, BulkModelDeletionTask)
     default_manager.register(models.ReleaseProject, BulkModelDeletionTask)
     default_manager.register(models.ReleaseHeadCommit, BulkModelDeletionTask)
+    default_manager.register(models.Repository, defaults.RepositoryDeletionTask)
+    default_manager.register(
+        models.RepositoryProjectPathConfig, defaults.RepositoryProjectPathConfigDeletionTask
+    )
     default_manager.register(models.SavedSearchUserDefault, BulkModelDeletionTask)
     default_manager.register(models.Team, defaults.TeamDeletionTask)
     default_manager.register(models.UserReport, BulkModelDeletionTask)

--- a/src/sentry/deletions/defaults/repositoryprojectpathconfig.py
+++ b/src/sentry/deletions/defaults/repositoryprojectpathconfig.py
@@ -1,0 +1,10 @@
+from ..base import ModelDeletionTask, ModelRelation
+
+
+class RepositoryProjectPathConfigDeletionTask(ModelDeletionTask):
+    def get_child_relations(self, instance):
+        from sentry.models import ProjectCodeOwners
+
+        return [
+            ModelRelation(ProjectCodeOwners, {"repository_project_path_config_id": instance.id}),
+        ]


### PR DESCRIPTION
There are a few organization deletions stuck on the protected relation with ProjectCodeOwners. When removing a repository we must remove the RepositoryProjectPathConfig which means we also need to remove the ProjectCodeOwner records. If we want to keep code owners configuration around we need to make the foreign key nullable.

Fixes SENTRY-S4Y