### PR TITLE
ref(page-filters): Use custom dropdown button for date page filter

### DIFF
--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 import {pinFilter, updateDateTime} from 'sentry/actionCreators/pageFilters';
 import Button from 'sentry/components/button';
+import DropdownButton from 'sentry/components/dropdownButton';
 import TimeRangeSelector, {
   ChangeData,
 } from 'sentry/components/organizations/timeRangeSelector';
@@ -66,6 +67,28 @@ function DatePageFilter({router, resetParamsOnChange, ...props}: Props) {
     pinFilter('datetime', !isDatePinned);
   };
 
+  const customDropdownButton = ({getActorProps, isOpen}) => {
+    let label;
+    if (start && end) {
+      const startString = start.toLocaleString('default', {
+        month: 'short',
+        day: 'numeric',
+      });
+      const endString = end.toLocaleString('default', {month: 'short', day: 'numeric'});
+      label = `${startString} - ${endString}`;
+    } else {
+      label = period?.toUpperCase();
+    }
+
+    return (
+      <StyledDropdownButton isOpen={isOpen} icon={<IconCalendar />} {...getActorProps()}>
+        <DropdownTitle>
+          <TitleContainer>{label}</TitleContainer>
+        </DropdownTitle>
+      </StyledDropdownButton>
+    );
+  };
+
   return (
     <DateSelectorContainer>
       <StyledPageTimeRangeSelector
@@ -77,6 +100,7 @@ function DatePageFilter({router, resetParamsOnChange, ...props}: Props) {
         onUpdate={handleUpdate}
         label={<IconCalendar color="textColor" />}
         dateSummary={getDateSummary}
+        customDropdownButton={customDropdownButton}
         {...props}
       />
       <PinButton
@@ -102,6 +126,29 @@ const DateSelectorContainer = styled('div')`
 const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
   height: 40px;
   font-weight: 600;
+  background: ${p => p.theme.background};
+  border: none;
+  box-shadow: none;
+`;
+
+const StyledDropdownButton = styled(DropdownButton)`
+  width: 100%;
+  height: 40px;
+  text-overflow: ellipsis;
+`;
+
+const TitleContainer = styled('div')`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  flex: 1 1 0%;
+`;
+
+const DropdownTitle = styled('div')`
+  display: flex;
+  overflow: hidden;
+  align-items: center;
+  flex: 1;
 `;
 
 const PinButton = styled(Button)`

--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -1,6 +1,5 @@
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
-import moment from 'moment';
 
 import {pinFilter, updateDateTime} from 'sentry/actionCreators/pageFilters';
 import Button from 'sentry/components/button';
@@ -8,15 +7,12 @@ import DropdownButton from 'sentry/components/dropdownButton';
 import TimeRangeSelector, {
   ChangeData,
 } from 'sentry/components/organizations/timeRangeSelector';
-import {getRelativeSummary} from 'sentry/components/organizations/timeRangeSelector/utils';
 import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
-import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {IconCalendar, IconPin} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
-import {defined} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = Omit<
@@ -36,22 +32,6 @@ function DatePageFilter({router, resetParamsOnChange, ...props}: Props) {
   const {start, end, period, utc} = selection.datetime;
 
   const isDatePinned = pinnedFilters.has('datetime');
-
-  const getDateSummary = (timeData: ChangeData) => {
-    const {relativeOptions, defaultPeriod} = props;
-    const {relative} = timeData;
-
-    if (defined(start) && defined(end)) {
-      const formattedStart = moment(timeData.start).local().format('ll');
-      const formattedEnd = moment(timeData.end).local().format('ll');
-      return `${formattedStart} - ${formattedEnd}`;
-    }
-
-    return getRelativeSummary(
-      relative || defaultPeriod || DEFAULT_STATS_PERIOD,
-      relativeOptions
-    );
-  };
 
   const handleUpdate = (timePeriodUpdate: ChangeData) => {
     const {relative, ...startEndUtc} = timePeriodUpdate;
@@ -99,7 +79,6 @@ function DatePageFilter({router, resetParamsOnChange, ...props}: Props) {
         utc={utc}
         onUpdate={handleUpdate}
         label={<IconCalendar color="textColor" />}
-        dateSummary={getDateSummary}
         customDropdownButton={customDropdownButton}
         {...props}
       />

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -110,11 +110,6 @@ type Props = WithRouterProps & {
   }) => React.ReactElement;
 
   /**
-   * Optional function to replace default date summary in dropdown header with
-   */
-  dateSummary?: (dateState: ChangeData) => React.ReactNode;
-
-  /**
    * Set an optional default value to prefill absolute date with
    */
   defaultAbsolute?: {end?: Date; start?: Date};
@@ -359,7 +354,6 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
 
   render() {
     const {
-      dateSummary,
       defaultPeriod,
       showAbsolute,
       showRelative,
@@ -416,7 +410,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
               {...getActorProps()}
             >
               {getDynamicText({
-                value: dateSummary ? dateSummary({start, end, relative}) : summary,
+                value: summary,
                 fixed: 'start to end',
               })}
             </StyledHeaderItem>

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -30,21 +30,21 @@ describe('DatePageFilter', function () {
     new Set()
   );
 
-  it('can change period', function () {
+  it('can change period', async function () {
     mountWithTheme(<DatePageFilter />, {
       context: routerContext,
       organization,
     });
 
     // Open time period dropdown
-    expect(screen.getByText('Last 7 days')).toBeInTheDocument();
-    userEvent.click(screen.getByText('Last 7 days'));
+    expect(screen.getByText('7D')).toBeInTheDocument();
+    userEvent.click(screen.getByText('7D'));
 
     // Click 30 day period
     userEvent.click(screen.getByText('Last 30 days'));
 
     // Confirm selection changed visible text and query params
-    expect(screen.getByText('Last 30 days')).toBeInTheDocument();
+    expect(await screen.findByText('30D')).toBeInTheDocument();
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({query: {statsPeriod: '30d'}})
     );
@@ -52,12 +52,7 @@ describe('DatePageFilter', function () {
       isReady: true,
       pinnedFilters: new Set(),
       selection: {
-        datetime: {
-          period: '7d',
-          utc: null,
-          start: null,
-          end: null,
-        },
+        datetime: {period: '30d'},
         environments: [],
         projects: [],
       },


### PR DESCRIPTION
Add a `customDropdownButton` prop to `TimeRangeSelector`, allowing us to render a `DropdownButton` component as the dropdown's trigger, which is more in line with the triggers for the project and environment selector.

Before:
<img width="874" alt="Screen Shot 2022-02-23 at 11 57 16 AM" src="https://user-images.githubusercontent.com/44172267/155397937-f493c543-b430-4c3a-bb31-39313be08109.png">

After:
<img width="1027" alt="Screen Shot 2022-02-23 at 11 57 58 AM" src="https://user-images.githubusercontent.com/44172267/155398037-8b16a594-f563-45c6-86e7-96b1d5f36795.png">

