### PR TITLE
fix(ui): Disabled resolve/ignore tooltips when disabled

### DIFF
--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -205,7 +205,7 @@ const IgnoreActions = ({
     <ButtonBar merged>
       <IgnoreButton
         size="xsmall"
-        tooltipProps={{delay: 300}}
+        tooltipProps={{delay: 300, disabled}}
         title={t(
           'Silences alerts for this issue and removes it from the issue stream by default.'
         )}

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -234,7 +234,7 @@ class ResolveActions extends React.Component<Props> {
             title={t(
               'Resolves the issue. The issue will get unresolved if it happens again.'
             )}
-            tooltipProps={{delay: 300}}
+            tooltipProps={{delay: 300, disabled}}
             icon={<IconCheckmark size="xs" />}
             onClick={onResolve}
             disabled={disabled}


### PR DESCRIPTION
Fixes an issue with safari not being able to get the tooltips to go away. The tooltip isn't important if the buttons are disabled