### PR TITLE
fix(issues-index): Fix action dropdown's disable state

### DIFF
--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -228,6 +228,7 @@ const IgnoreActions = ({
         )}
         menuTitle={t('Ignore')}
         items={dropdownItems}
+        isDisabled={disabled}
       />
     </ButtonBar>
   );

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -165,6 +165,8 @@ class ResolveActions extends React.Component<Props> {
       },
     ];
 
+    const isDisabled = !projectSlug ? disabled : disableDropdown;
+
     return (
       <DropdownMenuControlV2
         items={items}
@@ -175,7 +177,7 @@ class ResolveActions extends React.Component<Props> {
             aria-label={t('More resolve options')}
             size="xsmall"
             icon={<IconChevron direction="down" size="xs" />}
-            disabled={!projectSlug ? disabled : disableDropdown}
+            disabled={isDisabled}
           />
         )}
         disabledKeys={
@@ -184,6 +186,7 @@ class ResolveActions extends React.Component<Props> {
             : []
         }
         menuTitle={t('Resolved In')}
+        isDisabled={isDisabled}
       />
     );
   }


### PR DESCRIPTION
In Chrome, the issue action dropdown button is still clickable even when it is disabled. We can use the `isDisabled` prop on `DropdownMenuControlV2` to fix this.

**Before - dropdown still clickable:**
<img width="365" alt="Screen Shot 2022-02-23 at 12 20 40 PM" src="https://user-images.githubusercontent.com/44172267/155401608-2605fb1f-4634-4895-9907-f343beac586c.png">

**After - dropdown no longer clickable:**
<img width="365" alt="Screen Shot 2022-02-23 at 12 23 13 PM" src="https://user-images.githubusercontent.com/44172267/155401981-875d2a49-37bd-41bb-aa69-f7b166c8bf08.png">

