### PR TITLE
feat(new-widget-builder-experience): Additional error handling - [DD-536]

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -17,6 +17,7 @@ type Props = {
   autoSelect?: boolean;
   errorMessage?: React.ReactNode;
   isDisabled?: boolean;
+  maxLength?: number;
   name?: string;
   successMessage?: React.ReactNode;
 };
@@ -27,6 +28,7 @@ function EditableText({
   name,
   errorMessage,
   successMessage,
+  maxLength,
   isDisabled = false,
   autoSelect = false,
 }: Props) {
@@ -151,6 +153,7 @@ function EditableText({
             value={inputValue}
             onChange={handleInputChange}
             onFocus={event => autoSelect && event.target.select()}
+            maxLength={maxLength}
           />
           <InputLabel>{inputValue}</InputLabel>
         </InputWrapper>

--- a/static/app/views/dashboardsV2/widgetBuilder/displayTypeSelector.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/displayTypeSelector.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+
+import Field from 'sentry/components/forms/field';
+import SelectControl from 'sentry/components/forms/selectControl';
+import {DisplayType} from 'sentry/views/dashboardsV2/types';
+
+import {displayTypes} from './utils';
+
+const DISPLAY_TYPES_OPTIONS = Object.keys(displayTypes).map(value => ({
+  label: displayTypes[value],
+  value,
+}));
+
+type Props = {
+  displayType: DisplayType;
+  onChange: (option: {label: string; value: DisplayType}) => void;
+  error?: string;
+};
+
+export function DisplayTypeSelector({displayType, onChange, error}: Props) {
+  return (
+    <StyledField error={error} inline={false} flexibleControlStateSize stacked required>
+      <SelectControl
+        name="displayType"
+        options={DISPLAY_TYPES_OPTIONS}
+        value={displayType}
+        onChange={onChange}
+      />
+    </StyledField>
+  );
+}
+
+const StyledField = styled(Field)`
+  padding-right: 0;
+`;

--- a/static/app/views/dashboardsV2/widgetBuilder/header.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/header.tsx
@@ -54,6 +54,7 @@ export function Header({
             value={title}
             onChange={onChangeTitle}
             errorMessage={t('Please set a title for this widget')}
+            maxLength={255}
           />
         </Layout.Title>
       </Layout.HeaderContent>

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -431,6 +431,8 @@ function WidgetBuilder({
 
       onSave([...dashboard.widgets, widgetData]);
       addSuccessMessage(t('Added widget.'));
+
+      goBack();
     } catch (err) {
       errors = mapErrors(err?.responseJSON ?? {}, {});
     } finally {
@@ -440,8 +442,6 @@ function WidgetBuilder({
         submitFromSelectedDashboard(errors, widgetData);
         return;
       }
-
-      goBack();
     }
   }
 
@@ -715,7 +715,7 @@ function WidgetBuilder({
                         inline={false}
                         flexibleControlStateSize
                         stacked
-                        error={state.errors?.[queryIndex]?.conditions}
+                        error={state.errors?.queries?.[queryIndex]?.conditions}
                       >
                         <SearchConditionsWrapper>
                           <Search

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -73,11 +73,11 @@ import WidgetCard from '../widgetCard';
 import BuildStep from './buildStep';
 import {ColumnFields} from './columnFields';
 import {DashboardSelector} from './dashboardSelector';
+import {DisplayTypeSelector} from './displayTypeSelector';
 import {Header} from './header';
 import {
   DataSet,
   DisplayType,
-  displayTypes,
   FlatValidationError,
   mapErrors,
   normalizeQueries,
@@ -89,11 +89,6 @@ const DATASET_CHOICES: [DataSet, string][] = [
   [DataSet.ISSUES, t('Issues (States, Assignment, Time, etc.)')],
   // [DataSet.METRICS, t('Metrics (Release Health)')],
 ];
-
-const DISPLAY_TYPES_OPTIONS = Object.keys(displayTypes).map(value => ({
-  label: displayTypes[value],
-  value,
-}));
 
 const QUERIES = {
   [DataSet.EVENTS]: {
@@ -596,13 +591,12 @@ function WidgetBuilder({
                 )}
               >
                 <VisualizationWrapper>
-                  <DisplayTypeOptions
-                    name="displayType"
-                    options={DISPLAY_TYPES_OPTIONS}
-                    value={state.displayType}
+                  <DisplayTypeSelector
+                    displayType={state.displayType}
                     onChange={(option: {label: string; value: DisplayType}) => {
                       setState({...state, displayType: option.value});
                     }}
+                    error={state.errors?.displayType}
                   />
                   <WidgetCard
                     organization={organization}
@@ -882,10 +876,6 @@ const DataSetChoices = styled(RadioGroup)`
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
     grid-auto-flow: column;
   }
-`;
-
-const DisplayTypeOptions = styled(SelectControl)`
-  margin-bottom: ${space(1)};
 `;
 
 const SearchConditionsWrapper = styled('div')`

--- a/tests/js/spec/components/editableText.spec.tsx
+++ b/tests/js/spec/components/editableText.spec.tsx
@@ -6,9 +6,9 @@ import EditableText from 'sentry/components/editableText';
 
 const currentValue = 'foo';
 
-function renderedComponent(onChange: () => void, newValue = 'bar') {
+function renderedComponent(onChange: () => void, newValue = 'bar', maxLength?: number) {
   const wrapper = mountWithTheme(
-    <EditableText value={currentValue} onChange={onChange} />
+    <EditableText value={currentValue} onChange={onChange} maxLength={maxLength} />
   );
 
   let label = wrapper.find('Label');
@@ -167,6 +167,12 @@ describe('EditableText', function () {
       expect(updatedLabel.length).toEqual(1);
 
       expect(updatedLabel.text()).toEqual(currentValue);
+    });
+
+    it('enforces a max length if provided', function () {
+      const wrapper = renderedComponent(jest.fn(), '', 4);
+      const input = wrapper.find('input');
+      expect(input.prop('maxLength')).toBe(4);
     });
   });
 });


### PR DESCRIPTION
I tried to trigger a bunch of errors and they seem to be handled properly in most cases.

## Problems 
### Max Length
The max length for title is 255 characters. The modal sets a maxLength of 255 so users can't type beyond that. In the builder, users could enter more than 255 characters and then clicking Add Widget would fail the request, but still move us back to the dashboard.

### Display Types
DisplayTypes has an error field in the modal, but we weren't handling any displayType error

### Queries
We weren't showing the errors when the queries are invalid.

## Solutions
### Max Length
The only real issue was we weren't protecting against users pushing the character limit. I added `maxLength` to `EditableText` so users can't input more than that. When testing this I also noticed the page navigated back to the dashboard even if validation failed, so I moved `goBack` to the end of the try block.

The modal still accepts an `errors?.title`, so if I increase the `maxLength` in my devtools in prod, it still shows an error message. I think this is probably lower priority but maybe we need to think of an error state for the header.

![Screen Shot 2022-02-23 at 6 39 58 PM](https://user-images.githubusercontent.com/22846452/155429233-11efe487-07b6-44cd-aa01-c37c94ab0573.png)

### Display Types
I don't think really think there's going to be an issue with submitting an invalid display type, but the modal handles it in case there is one so I thought we should port it over. I was able to force this by making the backend not accept any display types. Since errors are displayed using the `Field` component, I created a separate component for the display type options to keep its footprint small in `widgetBuilder.tsx`

### Queries
Each additional query can have errors, and these errors are nested under a `queries` key that we missed, just added that in and errors are showing up when the queries are invalid, same as the modal.

## TODO:
I still haven't found a case where the errors come back in an array, I'm going to ask the team tomorrow but maybe we can iterate and do that in a different PR