### PR TITLE
fix(alertWizard): Omit filter tags not relevant to event dataset

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -18,6 +18,7 @@ import {IconQuestion} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Environment, Organization, SelectValue} from 'sentry/types';
+import {MobileVital, WebVital} from 'sentry/utils/discover/fields';
 import {getDisplayName} from 'sentry/utils/environment';
 import theme from 'sentry/utils/theme';
 import {
@@ -326,6 +327,9 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
       });
     }
 
+    const measurements = {...WebVital, ...MobileVital};
+    const eventOmitTags = dataset === 'events' ? Object.values(measurements) : [];
+
     const formElemBaseStyle = {
       padding: `${space(0.5)}`,
       border: 'none',
@@ -436,6 +440,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                     'release.package',
                     'release.build',
                     'project',
+                    ...eventOmitTags,
                   ]}
                   includeSessionTagsValues={dataset === Dataset.SESSIONS}
                   disabled={disabled}


### PR DESCRIPTION
Omit filter tags that are not relevant to the event dataset.

[FIXES WOR-1589](https://getsentry.atlassian.net/browse/WOR-1589)

# Before

`measurements.*` tags included with `event.type:error`
<img width="1019" alt="Screen Shot 2022-02-23 at 3 44 37 PM" src="https://user-images.githubusercontent.com/20312973/155430070-64676afd-c007-4ad5-88f1-552384639fca.png">

# After
<img width="1030" alt="Screen Shot 2022-02-23 at 3 42 36 PM" src="https://user-images.githubusercontent.com/20312973/155430169-3ca2f2d0-480a-445c-9749-451de51a6e62.png">


