### PR TITLE
ref(profiling): Cleanup flamegraph renderering logic

### DIFF
--- a/static/app/components/profiling/FlamegraphZoomView.tsx
+++ b/static/app/components/profiling/FlamegraphZoomView.tsx
@@ -28,18 +28,17 @@ function FlamegraphZoomView({
   canvasPoolManager,
 }: FlamegraphZoomViewProps): React.ReactElement {
   const flamegraphPreferences = useFlamegraphPreferencesValue();
+  const flamegraphTheme = useFlamegraphTheme();
 
-  const [scheduler, setScheduler] = useState<CanvasScheduler | null>(null);
   const [flamegraphCanvasRef, setFlamegraphCanvasRef] =
     useState<HTMLCanvasElement | null>(null);
   const [flamegraphOverlayCanvasRef, setFlamegraphOverlayCanvasRef] =
     useState<HTMLCanvasElement | null>(null);
 
-  const [gridRenderer, setGridRenderer] = useState<GridRenderer | null>(null);
-  const [textRenderer, setTextRenderer] = useState<TextRenderer | null>(null);
-  const [canvasBounds, setCanvasBounds] = useState<Rect>(Rect.Empty());
+  const scheduler = useMemo(() => new CanvasScheduler(), []);
 
-  const flamegraphTheme = useFlamegraphTheme();
+  const [canvasBounds, setCanvasBounds] = useState<Rect>(Rect.Empty());
+  const [searchResults, setSearchResults] = useState<Record<string, FlamegraphFrame>>({});
 
   const flamegraphRenderer = useMemoWithPrevious<FlamegraphRenderer | null>(
     previousRenderer => {
@@ -86,190 +85,30 @@ function FlamegraphZoomView({
     ]
   );
 
-  useEffect(() => {
-    if (
-      flamegraphCanvasRef === null ||
-      flamegraphOverlayCanvasRef === null ||
-      flamegraphRenderer === null
-    ) {
-      return undefined;
+  const textRenderer: TextRenderer | null = useMemo(() => {
+    if (!flamegraphOverlayCanvasRef) {
+      return null;
     }
+    return new TextRenderer(flamegraphOverlayCanvasRef, flamegraph, flamegraphTheme);
+  }, [flamegraphOverlayCanvasRef, flamegraph, flamegraphTheme]);
 
-    const newTextRenderer = new TextRenderer(
-      flamegraphOverlayCanvasRef,
-      flamegraph,
-      flamegraphTheme
-    );
-
-    const newGridRenderer = new GridRenderer(
+  const gridRenderer: GridRenderer | null = useMemo(() => {
+    if (!flamegraphOverlayCanvasRef) {
+      return null;
+    }
+    return new GridRenderer(
       flamegraphOverlayCanvasRef,
       flamegraphTheme,
       flamegraph.formatter
     );
+  }, [flamegraphOverlayCanvasRef, flamegraph, flamegraphTheme]);
 
-    const newScheduler = new CanvasScheduler();
-
-    setSelectedNode(null);
-    setConfigSpaceCursor(null);
-    setScheduler(newScheduler);
-    setTextRenderer(newTextRenderer);
-    setGridRenderer(newGridRenderer);
-
-    function clearOverlayCanvas() {
-      if (flamegraphRenderer) {
-        newTextRenderer.context.clearRect(
-          0,
-          0,
-          flamegraphRenderer!.physicalSpace.width,
-          flamegraphRenderer!.physicalSpace.height
-        );
-      }
+  const selectedFrameRenderer = useMemo(() => {
+    if (!flamegraphOverlayCanvasRef) {
+      return null;
     }
-
-    function drawText() {
-      if (flamegraphRenderer) {
-        newTextRenderer.draw(
-          flamegraphRenderer.configView,
-          flamegraphRenderer.configSpace,
-          flamegraphRenderer.configToPhysicalSpace
-        );
-      }
-    }
-
-    function drawRectangles() {
-      if (flamegraphRenderer) {
-        flamegraphRenderer.draw(null);
-      }
-    }
-
-    function drawGrid() {
-      if (flamegraphRenderer) {
-        newGridRenderer.draw(
-          flamegraphRenderer.configView,
-          flamegraphRenderer.physicalSpace,
-          flamegraphRenderer.configToPhysicalSpace
-        );
-      }
-    }
-
-    function onConfigViewChange(rect: Rect) {
-      if (flamegraphRenderer) {
-        flamegraphRenderer.setConfigView(rect);
-        newScheduler.draw();
-      }
-    }
-
-    function onTransformConfigView(mat: mat3) {
-      if (flamegraphRenderer) {
-        flamegraphRenderer.transformConfigView(mat);
-        newScheduler.draw();
-      }
-    }
-
-    newScheduler.on('setConfigView', onConfigViewChange);
-    newScheduler.on('transformConfigView', onTransformConfigView);
-    newScheduler.on('resetZoom', () => {
-      flamegraphRenderer.setConfigView(
-        flamegraph.inverted
-          ? flamegraphRenderer.configView
-              .translateY(
-                flamegraphRenderer.configSpace.height -
-                  flamegraphRenderer.configView.height +
-                  1
-              )
-              .translate(0, 0)
-              .withWidth(flamegraph.configSpace.width)
-          : flamegraphRenderer.configView
-              .translate(0, 0)
-              .withWidth(flamegraph.configSpace.width)
-      );
-
-      setConfigSpaceCursor(null);
-      newScheduler.draw();
-    });
-
-    newScheduler.on('zoomIntoFrame', (frame: FlamegraphFrame) => {
-      flamegraphRenderer.setConfigView(
-        new Rect(
-          frame.start,
-          flamegraph.inverted
-            ? flamegraphRenderer.configSpace.height -
-              flamegraphRenderer.configView.height -
-              frame.depth +
-              1
-            : frame.depth,
-          frame.end - frame.start,
-          flamegraphRenderer.configView.height
-        )
-      );
-
-      setConfigSpaceCursor(null);
-      setSelectedNode(frame);
-
-      newScheduler.draw();
-    });
-
-    newScheduler.on('searchResults', (results: Record<string, FlamegraphFrame>) => {
-      newScheduler.unregisterBeforeFrameCallback(drawRectangles);
-
-      function newDrawRectangles() {
-        if (flamegraphRenderer) {
-          flamegraphRenderer.draw(results);
-        }
-      }
-      newScheduler.registerBeforeFrameCallback(newDrawRectangles);
-
-      newScheduler.onDispose(() =>
-        newScheduler.unregisterBeforeFrameCallback(newDrawRectangles)
-      );
-      newScheduler.draw();
-    });
-
-    newScheduler.registerBeforeFrameCallback(clearOverlayCanvas);
-    newScheduler.registerBeforeFrameCallback(drawRectangles);
-    newScheduler.registerAfterFrameCallback(drawText);
-    newScheduler.registerAfterFrameCallback(drawGrid);
-
-    const observer = watchForResize(
-      [flamegraphCanvasRef, flamegraphOverlayCanvasRef],
-      () => {
-        const bounds = flamegraphOverlayCanvasRef.getBoundingClientRect();
-        setCanvasBounds(new Rect(bounds.x, bounds.y, bounds.width, bounds.height));
-
-        flamegraphRenderer.onResizeUpdateSpace();
-        canvasPoolManager.dispatch('setConfigView', [flamegraphRenderer.configView]);
-        newScheduler.drawSync();
-      }
-    );
-
-    canvasPoolManager.registerScheduler(newScheduler);
-
-    return () => {
-      setScheduler(null);
-      newScheduler.unregisterBeforeFrameCallback(clearOverlayCanvas);
-      newScheduler.unregisterBeforeFrameCallback(drawRectangles);
-      newScheduler.unregisterAfterFrameCallback(drawText);
-      newScheduler.unregisterAfterFrameCallback(drawGrid);
-
-      canvasPoolManager.unregisterScheduler(newScheduler);
-      observer.disconnect();
-    };
-  }, [
-    canvasPoolManager,
-    flamegraph,
-    flamegraphTheme,
-    flamegraphCanvasRef,
-    flamegraphOverlayCanvasRef,
-    flamegraphRenderer,
-  ]);
-
-  const selectedFrameRenderer = useMemo(
-    () =>
-      flamegraphOverlayCanvasRef
-        ? new SelectedFrameRenderer(flamegraphOverlayCanvasRef)
-        : null,
-    [flamegraphOverlayCanvasRef, flamegraph, flamegraphTheme]
-  );
+    return new SelectedFrameRenderer(flamegraphOverlayCanvasRef);
+  }, [flamegraphOverlayCanvasRef, flamegraph, flamegraphTheme]);
 
   const [selectedNode, setSelectedNode] = useState<FlamegraphFrame | null>(null);
   const [configSpaceCursor, setConfigSpaceCursor] = useState<[number, number] | null>(
@@ -285,40 +124,36 @@ function FlamegraphZoomView({
   );
 
   useEffect(() => {
-    if (
-      !selectedFrameRenderer ||
-      !flamegraphRenderer ||
-      !scheduler ||
-      !textRenderer ||
-      !gridRenderer
-    ) {
+    if (!flamegraphRenderer) {
       return undefined;
     }
 
-    function drawSelectedFrameBorder() {
-      // We are doing this because of typescript, in reality we are creating a scope
-      // where flamegraphRenderer is not null (see check on L86)
-      if (
-        textRenderer === null ||
-        flamegraphRenderer === null ||
-        gridRenderer === null ||
-        selectedFrameRenderer === null
-      ) {
-        return;
-      }
+    const drawRectangles = () => {
+      flamegraphRenderer.draw(searchResults);
+    };
 
-      // If no node is selected or hovered, then dont draw anything
-      if (!selectedNode && !hoveredNode) {
-        return;
-      }
+    scheduler.registerBeforeFrameCallback(drawRectangles);
 
+    return () => {
+      scheduler.unregisterBeforeFrameCallback(drawRectangles);
+    };
+  }, [scheduler, flamegraphRenderer, searchResults]);
+
+  useEffect(() => {
+    if (!flamegraphRenderer || !textRenderer || !gridRenderer || !selectedFrameRenderer) {
+      return undefined;
+    }
+
+    const clearOverlayCanvas = () => {
       textRenderer.context.clearRect(
         0,
         0,
         flamegraphRenderer.physicalSpace.width,
         flamegraphRenderer.physicalSpace.height
       );
+    };
 
+    const drawSelectedFrameBorder = () => {
       if (selectedNode) {
         selectedFrameRenderer.draw(
           new Rect(
@@ -337,6 +172,7 @@ function FlamegraphZoomView({
           flamegraphRenderer.configToPhysicalSpace
         );
       }
+
       if (hoveredNode && selectedNode !== hoveredNode) {
         selectedFrameRenderer.draw(
           new Rect(
@@ -355,35 +191,144 @@ function FlamegraphZoomView({
           flamegraphRenderer.configToPhysicalSpace
         );
       }
+    };
 
+    const drawText = () => {
       textRenderer.draw(
         flamegraphRenderer.configView,
-        flamegraphRenderer.physicalSpace,
+        flamegraphRenderer.configSpace,
         flamegraphRenderer.configToPhysicalSpace
       );
+    };
+
+    const drawGrid = () => {
       gridRenderer.draw(
         flamegraphRenderer.configView,
         flamegraphRenderer.physicalSpace,
         flamegraphRenderer.configToPhysicalSpace
       );
-    }
+    };
 
+    scheduler.registerBeforeFrameCallback(clearOverlayCanvas);
     scheduler.registerBeforeFrameCallback(drawSelectedFrameBorder);
-    scheduler.draw();
+    scheduler.registerAfterFrameCallback(drawText);
+    scheduler.registerAfterFrameCallback(drawGrid);
 
     return () => {
+      scheduler.unregisterBeforeFrameCallback(clearOverlayCanvas);
       scheduler.unregisterBeforeFrameCallback(drawSelectedFrameBorder);
+      scheduler.unregisterAfterFrameCallback(drawText);
+      scheduler.unregisterAfterFrameCallback(drawGrid);
     };
   }, [
-    textRenderer,
-    gridRenderer,
-    selectedFrameRenderer,
-    selectedNode,
-    hoveredNode,
     scheduler,
     flamegraphRenderer,
-    flamegraph,
+    textRenderer,
+    gridRenderer,
+    selectedNode,
+    hoveredNode,
   ]);
+
+  useEffect(() => {
+    if (!flamegraphRenderer) {
+      return undefined;
+    }
+
+    const onConfigViewChange = (rect: Rect) => {
+      flamegraphRenderer.setConfigView(rect);
+      scheduler.draw();
+    };
+
+    const onTransformConfigView = (mat: mat3) => {
+      flamegraphRenderer.transformConfigView(mat);
+      scheduler.draw();
+    };
+
+    const onResetZoom = () => {
+      flamegraphRenderer.setConfigView(
+        flamegraph.inverted
+          ? flamegraphRenderer.configView
+              .translateY(
+                flamegraphRenderer.configSpace.height -
+                  flamegraphRenderer.configView.height +
+                  1
+              )
+              .translate(0, 0)
+              .withWidth(flamegraph.configSpace.width)
+          : flamegraphRenderer.configView
+              .translate(0, 0)
+              .withWidth(flamegraph.configSpace.width)
+      );
+
+      setConfigSpaceCursor(null);
+      scheduler.draw();
+    };
+
+    const onZoomIntoFrame = (frame: FlamegraphFrame) => {
+      flamegraphRenderer.setConfigView(
+        new Rect(
+          frame.start,
+          flamegraph.inverted
+            ? flamegraphRenderer.configSpace.height -
+              flamegraphRenderer.configView.height -
+              frame.depth +
+              1
+            : frame.depth,
+          frame.end - frame.start,
+          flamegraphRenderer.configView.height
+        )
+      );
+
+      setConfigSpaceCursor(null);
+      setSelectedNode(frame);
+
+      scheduler.draw();
+    };
+
+    const onSearchResultsChange = (results: Record<string, FlamegraphFrame>) => {
+      setSearchResults(results);
+      scheduler.draw();
+    };
+
+    scheduler.on('setConfigView', onConfigViewChange);
+    scheduler.on('transformConfigView', onTransformConfigView);
+    scheduler.on('resetZoom', onResetZoom);
+    scheduler.on('zoomIntoFrame', onZoomIntoFrame);
+    scheduler.on('searchResults', onSearchResultsChange);
+
+    return () => {
+      scheduler.off('setConfigView', onConfigViewChange);
+      scheduler.off('transformConfigView', onTransformConfigView);
+      scheduler.off('resetZoom', onResetZoom);
+      scheduler.off('zoomIntoFrame', onZoomIntoFrame);
+      scheduler.off('searchResults', onSearchResultsChange);
+    };
+  }, [scheduler, flamegraphRenderer]);
+
+  useEffect(() => {
+    if (!flamegraphCanvasRef || !flamegraphOverlayCanvasRef || !flamegraphRenderer) {
+      return undefined;
+    }
+
+    const observer = watchForResize(
+      [flamegraphCanvasRef, flamegraphOverlayCanvasRef],
+      () => {
+        const bounds = flamegraphOverlayCanvasRef.getBoundingClientRect();
+        setCanvasBounds(new Rect(bounds.x, bounds.y, bounds.width, bounds.height));
+
+        flamegraphRenderer.onResizeUpdateSpace();
+        canvasPoolManager.dispatch('setConfigView', [flamegraphRenderer.configView]);
+        scheduler.drawSync();
+      }
+    );
+    return () => observer.disconnect();
+  }, [scheduler, flamegraphCanvasRef, flamegraphOverlayCanvasRef, flamegraphRenderer]);
+
+  useEffect(() => {
+    canvasPoolManager.registerScheduler(scheduler);
+    scheduler.draw();
+    return () => canvasPoolManager.unregisterScheduler(scheduler);
+  }, [canvasPoolManager, scheduler]);
 
   const onCanvasClick = useCallback(
     (evt: React.MouseEvent<HTMLCanvasElement>) => {

--- a/static/app/components/profiling/FlamegraphZoomView.tsx
+++ b/static/app/components/profiling/FlamegraphZoomView.tsx
@@ -115,13 +115,12 @@ function FlamegraphZoomView({
     null
   );
 
-  const hoveredNode = useMemo(
-    () =>
-      configSpaceCursor && flamegraphRenderer
-        ? flamegraphRenderer.getHoveredNode(configSpaceCursor)
-        : null,
-    [configSpaceCursor, flamegraphRenderer]
-  );
+  const hoveredNode = useMemo(() => {
+    if (!configSpaceCursor || !flamegraphRenderer) {
+      return null;
+    }
+    return flamegraphRenderer.getHoveredNode(configSpaceCursor);
+  }, [configSpaceCursor, flamegraphRenderer]);
 
   useEffect(() => {
     if (!flamegraphRenderer) {
@@ -213,6 +212,8 @@ function FlamegraphZoomView({
     scheduler.registerBeforeFrameCallback(drawSelectedFrameBorder);
     scheduler.registerAfterFrameCallback(drawText);
     scheduler.registerAfterFrameCallback(drawGrid);
+
+    scheduler.draw();
 
     return () => {
       scheduler.unregisterBeforeFrameCallback(clearOverlayCanvas);
@@ -326,7 +327,6 @@ function FlamegraphZoomView({
 
   useEffect(() => {
     canvasPoolManager.registerScheduler(scheduler);
-    scheduler.draw();
     return () => canvasPoolManager.unregisterScheduler(scheduler);
   }, [canvasPoolManager, scheduler]);
 

--- a/static/app/components/profiling/FlamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/FlamegraphZoomViewMinimap.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {mat3, vec2} from 'gl-matrix';
 
@@ -22,15 +22,17 @@ function FlamegraphZoomViewMinimap({
   flamegraph,
 }: FlamegraphZoomViewMinimapProps): React.ReactElement {
   const flamegraphPreferences = useFlamegraphPreferencesValue();
-  const [flamegraphMiniMapCanvasRef, setFlamegraphMiniMapRef] =
-    React.useState<HTMLCanvasElement | null>(null);
-  const [flamegraphMiniMapOverlayCanvasRef, setFlamegraphMiniMapOverlayCanvasRef] =
-    React.useState<HTMLCanvasElement | null>(null);
-  const [configSpaceCursor, setConfigSpaceCursor] = React.useState<
-    [number, number] | null
-  >(null);
-
   const flamegraphTheme = useFlamegraphTheme();
+
+  const [flamegraphMiniMapCanvasRef, setFlamegraphMiniMapRef] =
+    useState<HTMLCanvasElement | null>(null);
+  const [flamegraphMiniMapOverlayCanvasRef, setFlamegraphMiniMapOverlayCanvasRef] =
+    useState<HTMLCanvasElement | null>(null);
+  const [configSpaceCursor, setConfigSpaceCursor] = useState<[number, number] | null>(
+    null
+  );
+
+  const scheduler = useMemo(() => new CanvasScheduler(), []);
 
   const flamegraphMiniMapRenderer = useMemoWithPrevious<FlamegraphRenderer | null>(
     previousRenderer => {
@@ -42,25 +44,19 @@ function FlamegraphZoomViewMinimap({
         flamegraphTheme.SIZES.MINIMAP_HEIGHT /
         (flamegraph.depth + flamegraphTheme.SIZES.FLAMEGRAPH_DEPTH_OFFSET);
 
-      const flamegraphMinimapRenderer = new FlamegraphRenderer(
-        flamegraphMiniMapCanvasRef,
-        flamegraph,
-        {
-          ...flamegraphTheme,
-          SIZES: {
-            ...flamegraphTheme.SIZES,
-            BAR_HEIGHT,
-          },
-        }
-      );
+      const renderer = new FlamegraphRenderer(flamegraphMiniMapCanvasRef, flamegraph, {
+        ...flamegraphTheme,
+        SIZES: {
+          ...flamegraphTheme.SIZES,
+          BAR_HEIGHT,
+        },
+      });
 
-      if (
-        previousRenderer?.flamegraph.name === flamegraphMinimapRenderer.flamegraph.name
-      ) {
-        flamegraphMinimapRenderer.setConfigView(previousRenderer.configView);
+      if (previousRenderer?.flamegraph.name === renderer.flamegraph.name) {
+        renderer.setConfigView(previousRenderer.configView);
       }
 
-      return flamegraphMinimapRenderer;
+      return renderer;
     },
     [
       flamegraphMiniMapCanvasRef,
@@ -70,31 +66,47 @@ function FlamegraphZoomViewMinimap({
     ]
   );
 
-  const [startDragVector, setStartDragConfigSpaceCursor] = React.useState<vec2 | null>(
-    null
-  );
-  const [lastDragVector, setLastDragVector] = React.useState<vec2 | null>(null);
-
-  React.useEffect(() => {
-    if (
-      !flamegraphMiniMapCanvasRef ||
-      !flamegraphMiniMapOverlayCanvasRef ||
-      !flamegraphMiniMapRenderer
-    ) {
-      return undefined;
+  const positionIndicatorRenderer: PositionIndicatorRenderer | null = useMemo(() => {
+    if (!flamegraphMiniMapOverlayCanvasRef) {
+      return null;
     }
 
-    const scheduler = new CanvasScheduler();
-
-    const positionIndicatorRenderer = new PositionIndicatorRenderer(
+    return new PositionIndicatorRenderer(
       flamegraphMiniMapOverlayCanvasRef,
       flamegraphTheme
     );
+  }, [flamegraphMiniMapOverlayCanvasRef, flamegraphTheme]);
+
+  useEffect(() => {
+    if (!flamegraphMiniMapRenderer) {
+      return undefined;
+    }
 
     const drawRectangles = () => {
       flamegraphMiniMapRenderer.draw(
         null,
         flamegraphMiniMapRenderer.configSpaceToPhysicalSpace
+      );
+    };
+
+    scheduler.registerBeforeFrameCallback(drawRectangles);
+
+    return () => {
+      scheduler.unregisterBeforeFrameCallback(drawRectangles);
+    };
+  }, [scheduler, flamegraphMiniMapRenderer]);
+
+  useEffect(() => {
+    if (!flamegraphMiniMapRenderer || !positionIndicatorRenderer) {
+      return undefined;
+    }
+
+    const clearOverlayCanvas = () => {
+      positionIndicatorRenderer.context.clearRect(
+        0,
+        0,
+        flamegraphMiniMapRenderer.physicalSpace.width,
+        flamegraphMiniMapRenderer.physicalSpace.height
       );
     };
 
@@ -106,14 +118,19 @@ function FlamegraphZoomViewMinimap({
       );
     };
 
-    const clearOverlayCanvas = () => {
-      positionIndicatorRenderer.context.clearRect(
-        0,
-        0,
-        flamegraphMiniMapRenderer.physicalSpace.width,
-        flamegraphMiniMapRenderer.physicalSpace.height
-      );
+    scheduler.registerBeforeFrameCallback(clearOverlayCanvas);
+    scheduler.registerAfterFrameCallback(drawPosition);
+
+    return () => {
+      scheduler.unregisterBeforeFrameCallback(clearOverlayCanvas);
+      scheduler.unregisterAfterFrameCallback(drawPosition);
     };
+  }, [scheduler, flamegraphMiniMapRenderer, positionIndicatorRenderer]);
+
+  useEffect(() => {
+    if (!flamegraphMiniMapRenderer) {
+      return undefined;
+    }
 
     const onConfigViewChange = (rect: Rect) => {
       flamegraphMiniMapRenderer.setConfigView(rect);
@@ -125,9 +142,7 @@ function FlamegraphZoomViewMinimap({
       scheduler.draw();
     };
 
-    scheduler.on('setConfigView', onConfigViewChange);
-    scheduler.on('transformConfigView', onTransformConfigView);
-    scheduler.on('zoomIntoFrame', (frame: FlamegraphFrame) => {
+    const onZoomIntoFrame = (frame: FlamegraphFrame) => {
       flamegraphMiniMapRenderer.setConfigView(
         new Rect(
           frame.start,
@@ -144,8 +159,9 @@ function FlamegraphZoomViewMinimap({
 
       setConfigSpaceCursor(null);
       scheduler.draw();
-    });
-    scheduler.on('resetZoom', () => {
+    };
+
+    const onResetZoom = () => {
       flamegraphMiniMapRenderer.setConfigView(
         flamegraph.inverted
           ? flamegraphMiniMapRenderer.configView
@@ -162,11 +178,32 @@ function FlamegraphZoomViewMinimap({
       );
       setConfigSpaceCursor(null);
       scheduler.draw();
-    });
+    };
 
-    scheduler.registerBeforeFrameCallback(drawRectangles);
-    scheduler.registerBeforeFrameCallback(clearOverlayCanvas);
-    scheduler.registerAfterFrameCallback(drawPosition);
+    scheduler.on('setConfigView', onConfigViewChange);
+    scheduler.on('transformConfigView', onTransformConfigView);
+    scheduler.on('zoomIntoFrame', onZoomIntoFrame);
+    scheduler.on('resetZoom', onResetZoom);
+
+    return () => {
+      scheduler.off('setConfigView', onConfigViewChange);
+      scheduler.off('transformConfigView', onTransformConfigView);
+      scheduler.off('zoomIntoFrame', onZoomIntoFrame);
+      scheduler.off('resetZoom', onResetZoom);
+    };
+  }, [scheduler, flamegraphMiniMapRenderer]);
+
+  const [startDragVector, setStartDragConfigSpaceCursor] = useState<vec2 | null>(null);
+  const [lastDragVector, setLastDragVector] = useState<vec2 | null>(null);
+
+  useEffect(() => {
+    if (
+      !flamegraphMiniMapCanvasRef ||
+      !flamegraphMiniMapOverlayCanvasRef ||
+      !flamegraphMiniMapRenderer
+    ) {
+      return undefined;
+    }
 
     const observer = watchForResize(
       [flamegraphMiniMapCanvasRef, flamegraphMiniMapOverlayCanvasRef],
@@ -176,29 +213,28 @@ function FlamegraphZoomViewMinimap({
       }
     );
 
-    canvasPoolManager.registerScheduler(scheduler);
-
-    return () => {
-      observer.disconnect();
-      canvasPoolManager.unregisterScheduler(scheduler);
-    };
+    return () => observer.disconnect();
   }, [
-    canvasPoolManager,
-    flamegraph,
-    flamegraphTheme,
-    flamegraphMiniMapRenderer,
+    scheduler,
     flamegraphMiniMapCanvasRef,
     flamegraphMiniMapOverlayCanvasRef,
+    flamegraphMiniMapRenderer,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
+    canvasPoolManager.registerScheduler(scheduler);
+    scheduler.draw();
+    return () => canvasPoolManager.unregisterScheduler(scheduler);
+  }, [scheduler]);
+
+  useEffect(() => {
     window.addEventListener('mouseup', () => {
       setLastDragVector(null);
       setStartDragConfigSpaceCursor(null);
     });
   }, []);
 
-  const onMouseDrag = React.useCallback(
+  const onMouseDrag = useCallback(
     (evt: React.MouseEvent<HTMLCanvasElement>) => {
       if (!lastDragVector || !flamegraphMiniMapRenderer) {
         return;
@@ -244,7 +280,7 @@ function FlamegraphZoomViewMinimap({
     [flamegraphMiniMapRenderer, lastDragVector, canvasPoolManager]
   );
 
-  const onMinimapCanvasMouseMove = React.useCallback(
+  const onMinimapCanvasMouseMove = useCallback(
     (evt: React.MouseEvent<HTMLCanvasElement>) => {
       if (!flamegraphMiniMapRenderer || !flamegraphMiniMapRenderer.frames.length) {
         return;
@@ -283,7 +319,7 @@ function FlamegraphZoomViewMinimap({
     ]
   );
 
-  const onMinimapScroll = React.useCallback(
+  const onMinimapScroll = useCallback(
     (evt: WheelEvent) => {
       if (!flamegraphMiniMapRenderer || !flamegraphMiniMapRenderer.frames.length) {
         return;
@@ -316,7 +352,7 @@ function FlamegraphZoomViewMinimap({
     [flamegraphMiniMapRenderer, canvasPoolManager]
   );
 
-  const onMinimapZoom = React.useCallback(
+  const onMinimapZoom = useCallback(
     (evt: WheelEvent) => {
       if (!flamegraphMiniMapRenderer || !flamegraphMiniMapRenderer.frames.length) {
         return;
@@ -350,7 +386,7 @@ function FlamegraphZoomViewMinimap({
     [flamegraphMiniMapRenderer, canvasPoolManager]
   );
 
-  const onMinimapCanvasMouseDown = React.useCallback(
+  const onMinimapCanvasMouseDown = useCallback(
     evt => {
       if (!configSpaceCursor || !flamegraphMiniMapRenderer || !canvasPoolManager) {
         return;
@@ -383,13 +419,13 @@ function FlamegraphZoomViewMinimap({
     [configSpaceCursor, flamegraphMiniMapRenderer, canvasPoolManager]
   );
 
-  const onMinimapCanvasMouseUp = React.useCallback(() => {
+  const onMinimapCanvasMouseUp = useCallback(() => {
     setConfigSpaceCursor(null);
     setStartDragConfigSpaceCursor(null);
     setLastDragVector(null);
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!flamegraphMiniMapCanvasRef) {
       return undefined;
     }

--- a/static/app/components/profiling/FlamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/FlamegraphZoomViewMinimap.tsx
@@ -121,6 +121,8 @@ function FlamegraphZoomViewMinimap({
     scheduler.registerBeforeFrameCallback(clearOverlayCanvas);
     scheduler.registerAfterFrameCallback(drawPosition);
 
+    scheduler.draw();
+
     return () => {
       scheduler.unregisterBeforeFrameCallback(clearOverlayCanvas);
       scheduler.unregisterAfterFrameCallback(drawPosition);
@@ -223,7 +225,6 @@ function FlamegraphZoomViewMinimap({
 
   useEffect(() => {
     canvasPoolManager.registerScheduler(scheduler);
-    scheduler.draw();
     return () => canvasPoolManager.unregisterScheduler(scheduler);
   }, [scheduler]);
 


### PR DESCRIPTION
Previously, most of the logic was handled within a single useEffect. This change
breaks the useEffect into several parts.

1. Use useMemo to create all the renderers
2. Use separate useEffect to register the draw call for each canvas
3. Use an useEffect to register all the listeners on the scheduer
4. Use an useEffect to watch the canvas for any resize changes
5. Use an useEffect to register the scheduler and trigger the initial draw

This achieves a few things

- logical separation between where each canvas is being drawn
- remove the hack where the searchResults was explicitly changing drawRectangles
- remove extra draw calls to the overlay around the selectedFrameRenderer