### PR TITLE
feat(alertWizard): Remove legend and make labels consistent with Alerts graph

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -12,6 +12,7 @@ import {fetchOrganizationTags} from 'sentry/actionCreators/tags';
 import Access from 'sentry/components/acl/access';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import Button from 'sentry/components/button';
+import CircleIndicator from 'sentry/components/circleIndicator';
 import Confirm from 'sentry/components/confirm';
 import Form from 'sentry/components/forms/form';
 import FormModel from 'sentry/components/forms/model';
@@ -683,7 +684,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
             <AlertName>{AlertWizardAlertNames[alertType]}</AlertName>
             {dataset !== Dataset.SESSIONS && (
               <AlertInfo>
-                {aggregate} | event.type:{eventTypes?.join(',')}
+                <StyledCircleIndicator size={8} />
+                <Aggregate>{aggregate}</Aggregate>
+                event.type:{eventTypes?.join(',')}
               </AlertInfo>
             )}
           </ChartHeader>
@@ -824,10 +827,20 @@ const AlertName = styled('div')`
 `;
 
 const AlertInfo = styled('div')`
-  font-size: ${p => p.theme.fontSizeMedium};
-  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-family: ${p => p.theme.text.family};
   font-weight: normal;
-  color: ${p => p.theme.subText};
+  color: ${p => p.theme.textColor};
+`;
+
+const StyledCircleIndicator = styled(CircleIndicator)`
+  background: ${p => p.theme.formText};
+  height: ${space(1)};
+  margin-right: ${space(0.5)};
+`;
+
+const Aggregate = styled('span')`
+  margin-right: ${space(1)};
 `;
 
 export default RuleFormContainer;

--- a/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -329,21 +329,6 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
       })
     );
 
-    // Disable all lines by default but the 1st one
-    const selected: Record<string, boolean> = dataWithoutRecentBucket.reduce(
-      (acc, {seriesName}, index) => {
-        acc[seriesName] = index === 0;
-        return acc;
-      },
-      {}
-    );
-    const legend = {
-      right: 10,
-      top: 0,
-      selected,
-      data: data.map(d => ({name: d.seriesName})),
-    };
-
     const chartOptions = {
       tooltip: {
         // use the main aggregate for all series (main, min, max, avg, comparison)
@@ -432,7 +417,6 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
         forwardedRef={this.handleRef}
         grid={CHART_GRID}
         {...chartOptions}
-        legend={legend}
         graphic={Graphic({
           elements: flatten(
             triggers.map((trigger: Trigger) => [


### PR DESCRIPTION
Remove the legend because we already have the aggregate in the label. Also update the chart labels to be consistent with the Alerts graph labels.

[FIXES WOR-1591](https://getsentry.atlassian.net/browse/WOR-1591)

# Before
<img width="1019" alt="Screen Shot 2022-02-23 at 4 57 47 PM" src="https://user-images.githubusercontent.com/20312973/155437388-515b834b-4d5d-4aad-b1d1-8d8ba884f03a.png">

# After
<img width="1033" alt="Screen Shot 2022-02-23 at 4 56 29 PM" src="https://user-images.githubusercontent.com/20312973/155437406-1da7b72c-0b04-4894-87a1-a2b395db5a0c.png">


