### PR TITLE
fix(alertWizard): Omit transaction tags for event dataset filter

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -327,8 +327,15 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
       });
     }
 
-    const measurements = {...WebVital, ...MobileVital};
-    const eventOmitTags = dataset === 'events' ? Object.values(measurements) : [];
+    const transactionTags = [
+      'transaction',
+      'transaction.duration',
+      'transaction.op',
+      'transaction.status',
+    ];
+    const measurementTags = Object.values({...WebVital, ...MobileVital});
+    const eventOmitTags =
+      dataset === 'events' ? [...measurementTags, ...transactionTags] : [];
 
     const formElemBaseStyle = {
       padding: `${space(0.5)}`,


### PR DESCRIPTION
Omit transaction tags for event dataset filter. Follow-up to https://github.com/getsentry/sentry/pull/32014.

[FIXES WOR-1655](https://getsentry.atlassian.net/browse/WOR-1655)

# Before
<img width="1027" alt="Screen Shot 2022-02-23 at 5 39 02 PM" src="https://user-images.githubusercontent.com/20312973/155440983-f677f716-115b-42c5-9ebb-f9349789aeef.png">

# After
<img width="1015" alt="Screen Shot 2022-02-23 at 5 37 20 PM" src="https://user-images.githubusercontent.com/20312973/155441003-d66bd5e9-ca38-4d9c-9dca-3d35fcfcb9be.png">

