### PR TITLE
fix(discover): Reintroduce sort on equation cols

### DIFF
--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -190,7 +190,7 @@ class TableView extends React.Component<TableViewProps> {
     const tableMeta = tableData?.meta;
 
     const align = fieldAlignment(column.name, column.type, tableMeta);
-    const field = {field: column.name, width: column.width};
+    const field = {field: column.key as string, width: column.width};
     function generateSortLink(): LocationDescriptorObject | undefined {
       if (!tableMeta) {
         return undefined;

--- a/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
@@ -147,9 +147,9 @@ describe('TableView > CellActions', function () {
   });
 
   it('handles add cell action on null value replace has condition', function () {
+    rows.data[0].title = null;
     const view = eventView.clone();
     view.query = 'tag:value has:title';
-    rows.data[0].title = null;
 
     const wrapper = makeWrapper(initialData, rows, view);
     const menu = openContextMenu(wrapper, 0);

--- a/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
@@ -16,7 +16,14 @@ describe('TableView > CellActions', function () {
     query: {
       id: '42',
       name: 'best query',
-      field: ['title', 'transaction', 'count()', 'timestamp', 'release'],
+      field: [
+        'title',
+        'transaction',
+        'count()',
+        'timestamp',
+        'release',
+        'equation|count() + 100',
+      ],
       sort: ['title'],
       query: '',
       project: [123],
@@ -59,6 +66,7 @@ describe('TableView > CellActions', function () {
 
   beforeEach(function () {
     browserHistory.push.mockReset();
+    browserHistory.replace.mockReset();
 
     const organization = TestStubs.Organization({
       features: ['discover-basic'],
@@ -80,6 +88,7 @@ describe('TableView > CellActions', function () {
         count: 'integer',
         timestamp: 'date',
         release: 'string',
+        'equation[0]': 'integer',
       },
       data: [
         {
@@ -88,6 +97,7 @@ describe('TableView > CellActions', function () {
           count: 9,
           timestamp: '2019-05-23T22:12:48+00:00',
           release: 'v1.0.2',
+          'equation[0]': 109,
         },
       ],
     };
@@ -95,6 +105,30 @@ describe('TableView > CellActions', function () {
 
   afterEach(() => {
     ProjectsStore.reset();
+  });
+
+  it('updates sort order on equation fields', async function () {
+    const view = eventView.clone();
+    const wrapper = makeWrapper(initialData, rows, view);
+    const equationSort = wrapper.find('SortLink').last();
+
+    expect(equationSort.find('StyledTooltip').props().title).toBe('count() + 100');
+    expect(equationSort.find('a').props().href).toBe(
+      '/organizations/org-slug/discover/results/?environment=staging&field=title&field=transaction&field=count%28%29&field=timestamp&field=release&field=equation%7Ccount%28%29%20%2B%20100&id=42&name=best%20query&project=123&query=&sort=-equation%5B0%5D&statsPeriod=14d&yAxis=p95'
+    );
+  });
+
+  it('updates sort order on non-equation fields', async function () {
+    const view = eventView.clone();
+    const wrapper = makeWrapper(initialData, rows, view);
+    const equationSort = wrapper.find('SortLink').at(1);
+
+    expect(equationSort.find('StyledTooltip').props().title).toBe('transaction');
+    equationSort.simulate('click');
+
+    expect(equationSort.find('a').props().href).toBe(
+      '/organizations/org-slug/discover/results/?environment=staging&field=title&field=transaction&field=count%28%29&field=timestamp&field=release&field=equation%7Ccount%28%29%20%2B%20100&id=42&name=best%20query&project=123&query=&sort=-transaction&statsPeriod=14d&yAxis=p95'
+    );
   });
 
   it('handles add cell action on null value', function () {
@@ -113,9 +147,9 @@ describe('TableView > CellActions', function () {
   });
 
   it('handles add cell action on null value replace has condition', function () {
-    rows.data[0].title = null;
     const view = eventView.clone();
     view.query = 'tag:value has:title';
+    rows.data[0].title = null;
 
     const wrapper = makeWrapper(initialData, rows, view);
     const menu = openContextMenu(wrapper, 0);


### PR DESCRIPTION
Updating column.name [here](https://github.com/getsentry/sentry/pull/31475)  regressed the sort order. 
Using column.key to determine the fields
for sort instead.