### PR TITLE
chore(dx): make api-owners less noisy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /src/sentry/migrations/  @getsentry/owners-migrations
 
 # API Owners for unowned endpoints / serializers
-endpoints/                      @getsentry/owners-api
+/src/**/endpoints/              @getsentry/owners-api
 /src/sentry/api/                @getsentry/owners-api
 
 # Snuba


### PR DESCRIPTION
Only look at endpoint folders within the `src` directory, as before the group was being tagged a lot of PRs via test changes.