### PR TITLE
fix(ui): Fix thresholds section title in alert details

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -211,7 +211,7 @@ export default class DetailsBody extends React.Component<Props> {
         </SidebarGroup>
 
         <SidebarGroup>
-          <Heading>{t('Thresholds and Actions')}</Heading>
+          <Heading>{t('Thresholds')}</Heading>
           {typeof criticalTrigger?.alertThreshold === 'number' &&
             this.renderTrigger(
               criticalTrigger.label,


### PR DESCRIPTION
Forgotten fix from https://github.com/getsentry/sentry/pull/29565