### PR TITLE
ref(mep): Move setup for storing metrics to a testutil case

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -24,6 +24,7 @@ __all__ = (
     "OrganizationDashboardWidgetTestCase",
     "SCIMTestCase",
     "SCIMAzureTestCase",
+    "MetricsEnhancedPerformanceTestCase",
 )
 
 import hashlib
@@ -1091,7 +1092,7 @@ class SessionMetricsTestCase(SnubaTestCase):
         )
 
 
-class MetricsEnhancedPerformanceTestCase(SessionMetricsTestCase):
+class MetricsEnhancedPerformanceTestCase(SessionMetricsTestCase, TestCase):
     TYPE_MAP = {
         "metrics_distributions": "d",
         "metrics_sets": "s",
@@ -1141,7 +1142,7 @@ class MetricsEnhancedPerformanceTestCase(SessionMetricsTestCase):
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization_id,
+                    "org_id": self.organization.id,
                     "project_id": self.project.id,
                     "metric_id": indexer.resolve(internal_metric),
                     "timestamp": metric_timestamp,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import responses
 
 from sentry.utils.compat import zip
@@ -31,6 +33,7 @@ import os.path
 import time
 from contextlib import contextmanager
 from datetime import datetime
+from typing import Dict, List, Optional
 from unittest import mock
 from unittest.mock import patch
 from urllib.parse import urlencode
@@ -55,6 +58,7 @@ from django.utils.functional import cached_property
 from exam import Exam, before, fixture
 from pkg_resources import iter_entry_points
 from rest_framework.test import APITestCase as BaseAPITestCase
+from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 
 from sentry import auth, eventstore
 from sentry.auth.authenticators import TotpInterface
@@ -96,7 +100,9 @@ from sentry.models import (
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.plugins.base import plugins
 from sentry.rules import EventState
+from sentry.search.events.constants import METRICS_MAP
 from sentry.sentry_metrics import indexer
+from sentry.sentry_metrics.indexer.postgres import PGStringIndexer
 from sentry.sentry_metrics.sessions import SessionMetricKey
 from sentry.tagstore.snuba import SnubaTagStorage
 from sentry.testutils.helpers.datetime import iso_format
@@ -1082,6 +1088,70 @@ class SessionMetricsTestCase(SnubaTestCase):
                 data=json.dumps(buckets),
             ).status_code
             == 200
+        )
+
+
+class MetricsEnhancedPerformanceTestCase(SessionMetricsTestCase):
+    TYPE_MAP = {
+        "metrics_distributions": "d",
+        "metrics_sets": "s",
+        "metrics_counters": "c",
+    }
+    ENTITY_MAP = {"transaction.duration": "metrics_distributions", "user": "metrics_sets"}
+    METRIC_STRINGS = []
+    DEFAULT_METRIC_TIMESTAMP = datetime(2015, 1, 1, 10, 15, 0, tzinfo=timezone.utc)
+
+    def setUp(self):
+        super().setUp()
+        self._index_metric_strings()
+
+    def _index_metric_strings(self):
+        PGStringIndexer().bulk_record(
+            strings=[
+                "transaction",
+                "transaction.status",
+                *self.METRIC_STRINGS,
+                *list(SPAN_STATUS_NAME_TO_CODE.keys()),
+                *list(METRICS_MAP.values()),
+            ]
+        )
+
+    def store_metric(
+        self,
+        value: List[int] | int,
+        metric: str = "transaction.duration",
+        tags: Optional[Dict[str, str]] = None,
+        timestamp: Optional[datetime] = None,
+    ):
+        internal_metric = METRICS_MAP[metric]
+        entity = self.ENTITY_MAP[metric]
+        if tags is None:
+            tags = {}
+        else:
+            tags = {indexer.resolve(key): indexer.resolve(value) for key, value in tags.items()}
+
+        if timestamp is None:
+            metric_timestamp = self.DEFAULT_METRIC_TIMESTAMP.timestamp()
+        else:
+            metric_timestamp = timestamp.timestamp()
+
+        if not isinstance(value, list):
+            value = [value]
+
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization_id,
+                    "project_id": self.project.id,
+                    "metric_id": indexer.resolve(internal_metric),
+                    "timestamp": metric_timestamp,
+                    "tags": tags,
+                    "type": self.TYPE_MAP[entity],
+                    "value": value,
+                    "retention_days": 90,
+                }
+            ],
+            entity=entity,
         )
 
 

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -594,7 +594,7 @@ def _metric_percentile_definition(quantile, field="transaction.duration") -> Fun
     )
 
 
-class MetricBuilderBaseTest(MetricsEnhancedPerformanceTestCase, TestCase):
+class MetricBuilderBaseTest(MetricsEnhancedPerformanceTestCase):
     METRIC_STRINGS = [
         "foo_transaction",
         "bar_transaction",
@@ -609,9 +609,8 @@ class MetricBuilderBaseTest(MetricsEnhancedPerformanceTestCase, TestCase):
         self.start = datetime.datetime(2015, 1, 1, 10, 15, 0, tzinfo=timezone.utc)
         self.end = datetime.datetime(2015, 1, 19, 10, 15, 0, tzinfo=timezone.utc)
         self.projects = [self.project.id]
-        self.organization_id = 1
         self.params = {
-            "organization_id": self.organization_id,
+            "organization_id": self.organization.id,
             "project_id": self.projects,
             "start": self.start,
             "end": self.end,
@@ -621,7 +620,7 @@ class MetricBuilderBaseTest(MetricsEnhancedPerformanceTestCase, TestCase):
             Condition(Column("timestamp"), Op.GTE, self.start),
             Condition(Column("timestamp"), Op.LT, self.end),
             Condition(Column("project_id"), Op.IN, self.projects),
-            Condition(Column("org_id"), Op.EQ, self.organization_id),
+            Condition(Column("org_id"), Op.EQ, self.organization.id),
         ]
 
     def setup_orderby_data(self):
@@ -782,7 +781,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         # Need to pick granularity based on the period
         def get_granularity(start, end):
             params = {
-                "organization_id": self.organization_id,
+                "organization_id": self.organization.id,
                 "project_id": self.projects,
                 "start": start,
                 "end": end,

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -17,8 +17,7 @@ from sentry.search.events.builder import (
     TimeseriesMetricQueryBuilder,
 )
 from sentry.sentry_metrics import indexer
-from sentry.sentry_metrics.indexer.postgres import PGStringIndexer
-from sentry.testutils.cases import SessionMetricsTestCase, TestCase
+from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase, TestCase
 from sentry.utils.snuba import Dataset, QueryOutsideRetentionError
 
 
@@ -595,14 +594,18 @@ def _metric_percentile_definition(quantile, field="transaction.duration") -> Fun
     )
 
 
-class MetricBuilderBaseTest(TestCase, SessionMetricsTestCase):
-    TYPE_MAP = {
-        "metrics_distributions": "d",
-        "metrics_sets": "s",
-        "metrics_counters": "c",
-    }
+class MetricBuilderBaseTest(MetricsEnhancedPerformanceTestCase, TestCase):
+    METRIC_STRINGS = [
+        "foo_transaction",
+        "bar_transaction",
+        "baz_transaction",
+    ]
+    DEFAULT_METRIC_TIMESTAMP = datetime.datetime(
+        2015, 1, 1, 10, 15, 0, tzinfo=timezone.utc
+    ) + datetime.timedelta(minutes=1)
 
     def setUp(self):
+        super().setUp()
         self.start = datetime.datetime(2015, 1, 1, 10, 15, 0, tzinfo=timezone.utc)
         self.end = datetime.datetime(2015, 1, 19, 10, 15, 0, tzinfo=timezone.utc)
         self.projects = [self.project.id]
@@ -620,74 +623,23 @@ class MetricBuilderBaseTest(TestCase, SessionMetricsTestCase):
             Condition(Column("project_id"), Op.IN, self.projects),
             Condition(Column("org_id"), Op.EQ, self.organization_id),
         ]
-        PGStringIndexer().bulk_record(
-            strings=[
-                "transaction",
-                "transaction.status",
-                "ok",
-                "cancelled",
-                "internal_error",
-                "unknown",
-                "foo_transaction",
-                "bar_transaction",
-                "baz_transaction",
-            ]
-            + list(constants.METRICS_MAP.values())
-        )
-
-    def store_metric(
-        self,
-        value,
-        metric=constants.METRICS_MAP["transaction.duration"],
-        entity="metrics_distributions",
-        tags=None,
-        timestamp=None,
-    ):
-        if tags is None:
-            tags = {}
-        else:
-            tags = {indexer.resolve(key): indexer.resolve(value) for key, value in tags.items()}
-        if timestamp is None:
-            timestamp = (self.start + datetime.timedelta(minutes=1)).timestamp()
-        else:
-            timestamp = timestamp.timestamp()
-        if not isinstance(value, list):
-            value = [value]
-        self._send_buckets(
-            [
-                {
-                    "org_id": self.organization_id,
-                    "project_id": self.project.id,
-                    "metric_id": indexer.resolve(metric),
-                    "timestamp": timestamp,
-                    "tags": tags,
-                    "type": self.TYPE_MAP[entity],
-                    "value": value,
-                    "retention_days": 90,
-                }
-            ],
-            entity=entity,
-        )
 
     def setup_orderby_data(self):
         self.store_metric(100, tags={"transaction": "foo_transaction"})
         self.store_metric(
             1,
-            metric=constants.METRICS_MAP["user"],
-            entity="metrics_sets",
+            metric="user",
             tags={"transaction": "foo_transaction"},
         )
         self.store_metric(50, tags={"transaction": "bar_transaction"})
         self.store_metric(
             1,
-            metric=constants.METRICS_MAP["user"],
-            entity="metrics_sets",
+            metric="user",
             tags={"transaction": "bar_transaction"},
         )
         self.store_metric(
             2,
-            metric=constants.METRICS_MAP["user"],
-            entity="metrics_sets",
+            metric="user",
             tags={"transaction": "bar_transaction"},
         )
 
@@ -887,8 +839,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         self.store_metric(100, tags={"transaction": "foo_transaction"})
         self.store_metric(
             1,
-            metric=constants.METRICS_MAP["user"],
-            entity="metrics_sets",
+            metric="user",
             tags={"transaction": "foo_transaction"},
         )
         query = MetricsQueryBuilder(
@@ -1131,7 +1082,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             query.run_query("test_query")
 
 
-class TimeseresMetricQueryBuilderTest(MetricBuilderBaseTest):
+class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
     def test_get_query(self):
         query = TimeseriesMetricQueryBuilder(
             self.params, granularity=900, query="", selected_columns=["p50(transaction.duration)"]
@@ -1234,8 +1185,7 @@ class TimeseresMetricQueryBuilderTest(MetricBuilderBaseTest):
             self.store_metric(100, timestamp=self.start + datetime.timedelta(minutes=i * 15))
             self.store_metric(
                 1,
-                metric=constants.METRICS_MAP["user"],
-                entity="metrics_sets",
+                metric="user",
                 timestamp=self.start + datetime.timedelta(minutes=i * 15),
             )
         query = TimeseriesMetricQueryBuilder(


### PR DESCRIPTION
- This is so the code is easier to re-use for endpoint tests