### PR TITLE
fix(dashboards): Use title styles for general dashboard title

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -504,11 +504,13 @@ class DashboardDetail extends Component<Props, State> {
         <PageContent>
           <NoProjectMessage organization={organization}>
             <StyledPageHeader>
-              <DashboardTitle
-                dashboard={modifiedDashboard ?? dashboard}
-                onUpdate={this.setModifiedDashboard}
-                isEditing={this.isEditing}
-              />
+              <StyledTitle>
+                <DashboardTitle
+                  dashboard={modifiedDashboard ?? dashboard}
+                  onUpdate={this.setModifiedDashboard}
+                  isEditing={this.isEditing}
+                />
+              </StyledTitle>
               <Controls
                 organization={organization}
                 dashboards={dashboards}
@@ -663,6 +665,10 @@ const StyledPageHeader = styled('div')`
     grid-column-gap: ${space(2)};
     height: 40px;
   }
+`;
+
+const StyledTitle = styled(Layout.Title)`
+  margin-top: 0;
 `;
 
 const StyledPageContent = styled(PageContent)`


### PR DESCRIPTION
Before:
<img width="1255" alt="Screen Shot 2022-02-24 at 9 51 29 AM" src="https://user-images.githubusercontent.com/44172267/155579717-240619a9-4686-43ff-8880-7685fa1aa310.png">


After:
<img width="1255" alt="Screen Shot 2022-02-24 at 9 50 56 AM" src="https://user-images.githubusercontent.com/44172267/155579659-e2f98e11-4821-49d0-8b2e-bbb05c78e9de.png">

