### PR TITLE
fix(plugins): Silence error

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -7,7 +7,7 @@ from django import forms
 from requests.exceptions import HTTPError, SSLError
 
 from sentry import digests, ratelimits
-from sentry.exceptions import PluginError
+from sentry.exceptions import InvalidIdentity, PluginError
 from sentry.models import NotificationSetting
 from sentry.plugins.base import Notification, Plugin
 from sentry.plugins.base.configuration import react_plugin_config
@@ -62,7 +62,14 @@ class NotificationPlugin(Plugin):
             return self.notify_users(
                 event.group, event, triggering_rules=[r.label for r in notification.rules]
             )
-        except (SSLError, HTTPError, ApiError, PluginError, UrllibHTTPError) as err:
+        except (
+            ApiError,
+            HTTPError,
+            InvalidIdentity,
+            PluginError,
+            SSLError,
+            UrllibHTTPError,
+        ) as err:
             self.logger.info(
                 "notification-plugin.notify-failed",
                 extra={


### PR DESCRIPTION
Instead of calling `logger.error()` every time there is an invalid token, just use `logger.info()`.

Fixes [SENTRY-T1Z](https://sentry.io/organizations/sentry/issues/2928674511).