### PR TITLE
feat(perf): Add anomalies backend and summary graphs

### DIFF
--- a/static/app/utils/performance/anomalies/anomaliesQuery.tsx
+++ b/static/app/utils/performance/anomalies/anomaliesQuery.tsx
@@ -1,12 +1,10 @@
-import {EventsStatsData} from 'sentry/types';
-import {
+import {EventsStatsData, Organization} from 'sentry/types';
+import GenericDiscoverQuery, {
   DiscoverQueryProps,
   GenericChildrenProps,
 } from 'sentry/utils/discover/genericDiscoverQuery';
-import localStorage from 'sentry/utils/localStorage';
 import withApi from 'sentry/utils/withApi';
-
-const transformedAnomalyDevKey = 'dev.anomalyPayload.transformed';
+import {ANOMALY_FLAG} from 'sentry/views/performance/transactionSummary/transactionAnomalies/utils';
 
 type AnomaliesProps = {};
 type RequestProps = DiscoverQueryProps & AnomaliesProps;
@@ -15,11 +13,12 @@ export type ChildrenProps = Omit<GenericChildrenProps<AnomaliesProps>, 'tableDat
   data: AnomalyPayload | null;
 };
 
-type Props = RequestProps & {
+type Props = Omit<RequestProps, 'orgSlug'> & {
   children: (props: ChildrenProps) => React.ReactNode;
+  organization: Organization;
 };
 
-type AnomalyConfidence = 'high' | 'low';
+export type AnomalyConfidence = 'high' | 'low';
 
 // Should match events stats data in format.
 type AnomalyStatsData = {
@@ -28,6 +27,7 @@ type AnomalyStatsData = {
   start?: number;
 };
 
+// Anomaly info describes what the anomaly service determines is an 'anomaly area'.
 export type AnomalyInfo = {
   confidence: AnomalyConfidence;
   end: number;
@@ -41,7 +41,7 @@ export type AnomalyPayload = {
   anomalies: AnomalyInfo[];
   y: AnomalyStatsData;
   yhat_lower: AnomalyStatsData;
-  yhat_upper: AnomalyStatsData; // Anomaly info describes what the anomaly service determines is an 'anomaly area'.
+  yhat_upper: AnomalyStatsData;
 };
 
 function transformStatsTimes(stats: AnomalyStatsData) {
@@ -56,41 +56,40 @@ function transformAnomaliesTimes(anoms: AnomalyInfo[]) {
   return anoms;
 }
 
-/**
- * All this code is temporary while in development so a local dev env isn't required.
- * TODO(k-fish): Remove this after EA.
- */
-function getLocalPayload(): AnomalyPayload | null {
-  const rawTransformed = localStorage.getItem(transformedAnomalyDevKey);
-  if (rawTransformed) {
-    const transformedData: AnomalyPayload = JSON.parse(rawTransformed || '{}');
-
-    if (transformedData) {
-      transformedData.y = transformStatsTimes(transformedData.y);
-      transformedData.yhat_upper = transformStatsTimes(transformedData.yhat_upper);
-      transformedData.yhat_lower = transformStatsTimes(transformedData.yhat_lower);
-      transformedData.anomalies = transformAnomaliesTimes(transformedData.anomalies);
-      return transformedData;
-    }
+function transformPayload(payload: AnomalyPayload): AnomalyPayload {
+  const newPayload = {...payload};
+  if (!payload.y || !payload.yhat_lower || !payload.yhat_upper || !payload.anomalies) {
+    return newPayload;
   }
 
-  localStorage.setItem(transformedAnomalyDevKey, ''); // Set the key so it shows up automatically if this feature is enabled.
-
-  return null;
+  newPayload.y = transformStatsTimes(payload.y);
+  newPayload.yhat_upper = transformStatsTimes(payload.yhat_upper);
+  newPayload.yhat_lower = transformStatsTimes(payload.yhat_lower);
+  newPayload.anomalies = transformAnomaliesTimes(payload.anomalies);
+  return newPayload;
 }
 
 function AnomaliesSeriesQuery(props: Props) {
-  const data = getLocalPayload(); // TODO(k-fish): Replace with api request when service is enabled.
+  if (!props.organization.features.includes(ANOMALY_FLAG)) {
+    return (
+      <div>
+        {props.children({data: null, isLoading: false, error: null, pageLinks: null})}
+      </div>
+    );
+  }
 
   return (
-    <div>
-      {props.children({
-        data,
-        isLoading: false,
-        error: null,
-        pageLinks: null,
-      })}
-    </div>
+    <GenericDiscoverQuery<AnomalyPayload, {}>
+      route="transaction-anomaly-detection"
+      {...props}
+    >
+      {({tableData, ...rest}) => {
+        return props.children({
+          data: tableData && tableData.y ? transformPayload(tableData) : null,
+          ...rest,
+        });
+      }}
+    </GenericDiscoverQuery>
   );
 }
 

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/anomaliesTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/anomaliesTable.tsx
@@ -2,12 +2,15 @@ import {ReactNode} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import Count from 'sentry/components/count';
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   GridColumnOrder,
 } from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
+import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {ColumnType, fieldAlignment} from 'sentry/utils/discover/fields';
@@ -79,10 +82,35 @@ function renderBodyCellWithMeta(location: Location, organization: Organization) 
         </ConfidenceCell>
       );
     }
+    if (column.key === 'expected') {
+      return (
+        <NumberCell>
+          <Count value={dataRow.expected} />
+        </NumberCell>
+      );
+    }
+    if (column.key === 'received') {
+      return (
+        <NumberCell>
+          <Count value={dataRow.received} />
+          <IconArrow
+            size="sm"
+            direction={dataRow.received > dataRow.expected ? 'up' : 'down'}
+          />
+        </NumberCell>
+      );
+    }
 
     return fieldRenderer(dataRow, {location, organization});
   };
 }
+
+const NumberCell = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: ${space(0.5)};
+`;
 
 const LowConfidence = styled('div')`
   color: ${p => p.theme.yellow300};

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/utils.tsx
@@ -1,12 +1,16 @@
 import {Location, Query} from 'history';
 
 import EventView from 'sentry/utils/discover/eventView';
+import {AnomalyConfidence} from 'sentry/utils/performance/anomalies/anomaliesQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {Theme} from 'sentry/utils/theme';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
 export function generateAnomaliesRoute({orgSlug}: {orgSlug: String}): string {
   return `/organizations/${orgSlug}/performance/summary/anomalies/`;
 }
+
+export const ANOMALY_FLAG = 'performance-anomaly-detection-ui';
 
 export function anomaliesRouteWithQuery({
   orgSlug,
@@ -35,6 +39,15 @@ export function anomaliesRouteWithQuery({
       query: query.query,
     },
   };
+}
+
+export function anomalyToColor(anomalyConfidence: AnomalyConfidence, theme: Theme) {
+  // Map inside function so it's reactive to theme.
+  const map: Record<AnomalyConfidence, string> = {
+    high: theme.red300,
+    low: theme.yellow300,
+  };
+  return map[anomalyConfidence];
 }
 
 export function generateAnomaliesEventView({

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -389,6 +389,7 @@ function SummaryContent({
           totals={totalValues}
           eventView={eventView}
           isMetricsData={isMetricsData}
+          transactionName={transactionName}
         />
         <SidebarSpacer />
         <Tags

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
-import {InjectedRouter, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory, InjectedRouter, withRouter, WithRouterProps} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import color from 'color';
 import {Location} from 'history';
 
 import ChartZoom from 'sentry/components/charts/chartZoom';
+import MarkPoint from 'sentry/components/charts/components/markPoint';
 import ErrorPanel from 'sentry/components/charts/errorPanel';
 import EventsRequest from 'sentry/components/charts/eventsRequest';
 import LineChart from 'sentry/components/charts/lineChart';
@@ -29,10 +31,18 @@ import {
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {TransactionMetric} from 'sentry/utils/metrics/fields';
 import MetricsRequest from 'sentry/utils/metrics/metricsRequest';
+import AnomaliesQuery from 'sentry/utils/performance/anomalies/anomaliesQuery';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
 import {transformMetricsToArea} from 'sentry/views/performance/landing/widgets/transforms/transformMetricsToArea';
+
+import {
+  anomaliesRouteWithQuery,
+  ANOMALY_FLAG,
+  anomalyToColor,
+} from '../transactionAnomalies/utils';
 
 type ContainerProps = WithRouterProps & {
   error: string | null;
@@ -41,6 +51,7 @@ type ContainerProps = WithRouterProps & {
   location: Location;
   organization: Organization;
   totals: Record<string, number> | null;
+  transactionName: string;
   isMetricsData?: boolean;
 };
 
@@ -55,7 +66,10 @@ type Props = Pick<
     reloading: boolean;
     series: React.ComponentProps<typeof LineChart>['series'];
   };
+  eventView: EventView;
+  location: Location;
   router: InjectedRouter;
+  transactionName: string;
   utc: boolean;
   end?: Date;
   start?: Date;
@@ -74,7 +88,11 @@ function SidebarCharts({
   statsPeriod,
   chartData,
   isMetricsData,
+  eventView,
+  location,
+  transactionName,
 }: Props) {
+  const theme = useTheme();
   return (
     <RelativeBox>
       <ChartLabel top="0px">
@@ -132,38 +150,81 @@ function SidebarCharts({
         />
       </ChartLabel>
 
-      <ChartZoom
-        router={router}
-        period={statsPeriod}
-        start={start}
-        end={end}
-        utc={utc}
-        xAxisIndex={[0, 1, 2]}
+      <AnomaliesQuery
+        location={location}
+        organization={organization}
+        eventView={eventView}
       >
-        {zoomRenderProps => {
-          const {errored, loading, reloading, chartOptions, series} = chartData;
+        {results => (
+          <ChartZoom
+            router={router}
+            period={statsPeriod}
+            start={start}
+            end={end}
+            utc={utc}
+            xAxisIndex={[0, 1, 2]}
+          >
+            {zoomRenderProps => {
+              const {errored, loading, reloading, chartOptions, series} = chartData;
 
-          if (errored) {
-            return (
-              <ErrorPanel height="580px">
-                <IconWarning color="gray300" size="lg" />
-              </ErrorPanel>
-            );
-          }
+              if (errored) {
+                return (
+                  <ErrorPanel height="580px">
+                    <IconWarning color="gray300" size="lg" />
+                  </ErrorPanel>
+                );
+              }
 
-          return (
-            <TransitionChart loading={loading} reloading={reloading} height="580px">
-              <TransparentLoadingMask visible={reloading} />
-              {getDynamicText({
-                value: (
-                  <LineChart {...zoomRenderProps} {...chartOptions} series={series} />
-                ),
-                fixed: <Placeholder height="480px" testId="skeleton-ui" />,
-              })}
-            </TransitionChart>
-          );
-        }}
-      </ChartZoom>
+              if (organization.features.includes(ANOMALY_FLAG)) {
+                const epmSeries = series.find(
+                  s => s.seriesName.includes('epm') || s.seriesName.includes('tpm')
+                );
+                if (epmSeries && results.data) {
+                  epmSeries.markPoint = MarkPoint({
+                    data: results.data.anomalies.map(a => ({
+                      name: a.id,
+                      yAxis: epmSeries.data.find(({name}) => name > (a.end + a.start) / 2)
+                        ?.value,
+                      // TODO: the above is O(n*m), remove after we change the api to include the midpoint of y.
+                      xAxis: a.start,
+                      itemStyle: {
+                        borderColor: color(anomalyToColor(a.confidence, theme)).string(),
+                        color: color(anomalyToColor(a.confidence, theme))
+                          .alpha(0.2)
+                          .rgb()
+                          .string(),
+                      },
+                      onClick: () => {
+                        const target = anomaliesRouteWithQuery({
+                          orgSlug: organization.slug,
+                          query: location.query,
+                          projectID: decodeScalar(location.query.project),
+                          transaction: transactionName,
+                        });
+                        browserHistory.push(target);
+                      },
+                    })),
+                    symbol: 'circle',
+                    symbolSize: 16,
+                  });
+                }
+              }
+
+              return (
+                <TransitionChart loading={loading} reloading={reloading} height="580px">
+                  <TransparentLoadingMask visible={reloading} />
+                  {getDynamicText({
+                    value: (
+                      <LineChart {...zoomRenderProps} {...chartOptions} series={series} />
+                    ),
+                    fixed: <Placeholder height="480px" testId="skeleton-ui" />,
+                  })}
+                </TransitionChart>
+              );
+            }}
+          </ChartZoom>
+        )}
+      </AnomaliesQuery>
     </RelativeBox>
   );
 }
@@ -177,6 +238,7 @@ function SidebarChartsContainer({
   error,
   totals,
   isMetricsData,
+  transactionName,
 }: ContainerProps) {
   const api = useApi();
   const theme = useTheme();
@@ -369,6 +431,8 @@ function SidebarChartsContainer({
                 return (
                   <SidebarCharts
                     {...contentCommonProps}
+                    location={location}
+                    transactionName={transactionName}
                     totals={{
                       failure_rate: failureRateData.dataMean?.[0].mean ?? 0,
                       tpm: tpmData.dataMean?.[0].mean ?? 0,
@@ -379,6 +443,7 @@ function SidebarChartsContainer({
                         ? t('Error fetching metrics data')
                         : null
                     }
+                    eventView={eventView}
                     chartData={{
                       loading: failureRateRequestProps.loading || tpmRequestProps.loading,
                       reloading:
@@ -427,6 +492,9 @@ function SidebarChartsContainer({
         return (
           <SidebarCharts
             {...contentCommonProps}
+            transactionName={transactionName}
+            location={location}
+            eventView={eventView}
             chartData={{series, errored, loading, reloading, chartOptions}}
           />
         );

--- a/tests/js/spec/views/performance/transactionAnomalies/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionAnomalies/index.spec.tsx
@@ -2,7 +2,7 @@ import {
   initializeData as _initializeData,
   initializeDataSettings,
 } from 'sentry-test/performance/initializePerformanceData';
-import {act, mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
+import {act, cleanup, mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TransactionAnomalies from 'sentry/views/performance/transactionSummary/transactionAnomalies';
@@ -15,6 +15,31 @@ const initializeData = (settings: initializeDataSettings) => {
 };
 
 describe('AnomaliesTab', function () {
+  let anomaliesMock: any;
+
+  beforeEach(function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sdk-updates/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-has-measurements/',
+      body: {measurements: false},
+    });
+    anomaliesMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/transaction-anomaly-detection/',
+      body: {},
+    });
+  });
+  afterEach(cleanup);
   it('renders basic UI elements with flag', async function () {
     const initialData = initializeData({
       features: ['performance-view', 'performance-anomaly-detection-ui'],
@@ -27,5 +52,22 @@ describe('AnomaliesTab', function () {
     });
 
     expect(await screen.findByText('Transaction Count')).toBeInTheDocument();
+
+    expect(anomaliesMock).toHaveBeenCalledTimes(1);
+
+    expect(anomaliesMock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          environment: [],
+          field: ['tpm()'],
+          per_page: 50,
+          project: ['1'],
+          query: 'transaction:transaction',
+          statsPeriod: '14d',
+        }),
+      })
+    );
   });
 });


### PR DESCRIPTION
### Summary
This hooks up the actual anomalies backend and adds anomalies to the transaction summary tpm graph.

#### Other
This is a pre-internal PR for the anomalies UI, behind a feature flag, to get this onto prod for others/data to test early.
Still needs some extra work on tests etc. but this should be enough to play with for now.