### PR TITLE
feat(dashboards): Widget Viewer style improvements and use GridEditable component

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -44,6 +44,7 @@ type Props = ModalRenderProps &
 
 const FULL_TABLE_ITEM_LIMIT = 20;
 const HALF_TABLE_ITEM_LIMIT = 10;
+const GEO_COUNTRY_CODE = 'geo.country_code';
 
 function WidgetViewerModal(props: Props) {
   const {organization, widget, selection, location, Footer, Body, Header, onEdit} = props;
@@ -53,8 +54,16 @@ function WidgetViewerModal(props: Props) {
 
     // Create Table widget
     const tableWidget = {...cloneDeep(widget), displayType: DisplayType.TABLE};
+    const fields = tableWidget.queries[0].fields;
+
+    // World Map view should always have geo.country in the table chart
+    if (
+      widget.displayType === DisplayType.WORLD_MAP &&
+      !fields.includes(GEO_COUNTRY_CODE)
+    ) {
+      fields.unshift(GEO_COUNTRY_CODE);
+    }
     if (!isTableWidget) {
-      const fields = tableWidget.queries[0].fields;
       // Updates fields by adding any individual terms from equation fields as a column
       const equationFields = getFieldsFromEquations(fields);
       equationFields.forEach(term => {

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -47,17 +47,9 @@ const HALF_TABLE_ITEM_LIMIT = 10;
 
 function WidgetViewerModal(props: Props) {
   const {organization, widget, selection, location, Footer, Body, Header, onEdit} = props;
-  const eventView = eventViewFromWidget(
-    widget.title,
-    widget.queries[0],
-    selection,
-    widget.displayType
-  );
   const isTableWidget = widget.displayType === DisplayType.TABLE;
   const renderWidgetViewer = () => {
     const api = useApi();
-    const columnOrder = eventView.getColumns();
-    const columnSortBy = eventView.getSorts();
 
     // Create Table widget
     const tableWidget = {...cloneDeep(widget), displayType: DisplayType.TABLE};
@@ -71,6 +63,14 @@ function WidgetViewerModal(props: Props) {
         }
       });
     }
+    const eventView = eventViewFromWidget(
+      tableWidget.title,
+      tableWidget.queries[0],
+      selection,
+      tableWidget.displayType
+    );
+    const columnOrder = eventView.getColumns();
+    const columnSortBy = eventView.getSorts();
     return (
       <React.Fragment>
         {widget.displayType !== DisplayType.TABLE && (

--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+import {Location, LocationDescriptorObject} from 'history';
+
+import {GridColumnOrder} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
+import Tooltip from 'sentry/components/tooltip';
+import Truncate from 'sentry/components/truncate';
+import {Organization, PageFilters} from 'sentry/types';
+import {defined} from 'sentry/utils';
+import {getIssueFieldRenderer} from 'sentry/utils/dashboards/issueFieldRenderers';
+import {TableDataRow, TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import {isFieldSortable} from 'sentry/utils/discover/eventView';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {
+  fieldAlignment,
+  getAggregateAlias,
+  getEquationAliasIndex,
+  isEquationAlias,
+} from 'sentry/utils/discover/fields';
+import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';
+import {eventViewFromWidget} from 'sentry/views/dashboardsV2/utils';
+import {ISSUE_FIELDS} from 'sentry/views/dashboardsV2/widgetBuilder/issueWidget/fields';
+import TopResultsIndicator from 'sentry/views/eventsV2/table/topResultsIndicator';
+import {TableColumn} from 'sentry/views/eventsV2/table/types';
+
+// Dashboards only supports top 5 for now
+const DEFAULT_NUM_TOP_EVENTS = 5;
+
+type Props = {
+  location: Location;
+  organization: Organization;
+  selection: PageFilters;
+  widget: Widget;
+  tableData?: TableDataWithTitle;
+};
+
+export const renderGridHeaderCell =
+  ({selection, widget, tableData}: Props) =>
+  (column: TableColumn<keyof TableDataRow>, _columnIndex: number): React.ReactNode => {
+    const eventView = eventViewFromWidget(
+      widget.title,
+      widget.queries[0],
+      selection,
+      widget.displayType
+    );
+    const tableMeta = tableData?.meta;
+    const align = fieldAlignment(column.name, column.type, tableMeta);
+    const field = {field: column.name, width: column.width};
+    function generateSortLink(): LocationDescriptorObject | undefined {
+      // TODO: need write sort link generation for widget viewer
+      return undefined;
+    }
+    const currentSort = eventView.sortForField(field, tableMeta);
+    const canSort = isFieldSortable(field, tableMeta);
+    const titleText = isEquationAlias(column.name)
+      ? eventView.getEquations()[getEquationAliasIndex(column.name)]
+      : column.name;
+
+    return (
+      <SortLink
+        align={align}
+        title={
+          <StyledTooltip title={titleText}>
+            <Truncate value={titleText} maxLength={60} expandable={false} />
+          </StyledTooltip>
+        }
+        direction={currentSort ? currentSort.kind : undefined}
+        canSort={canSort}
+        generateSortLink={generateSortLink}
+      />
+    );
+  };
+
+export const renderGridBodyCell =
+  ({location, organization, widget, tableData}: Props) =>
+  (
+    column: GridColumnOrder,
+    dataRow: Record<string, any>,
+    rowIndex: number,
+    columnIndex: number
+  ): React.ReactNode => {
+    const columnKey = String(column.key);
+    const isTopEvents = widget.displayType === DisplayType.TOP_N;
+    let cell: React.ReactNode;
+    switch (widget.widgetType) {
+      case WidgetType.ISSUE:
+        cell = (
+          getIssueFieldRenderer(columnKey) ?? getFieldRenderer(columnKey, ISSUE_FIELDS)
+        )(dataRow, {organization, location});
+        break;
+      case WidgetType.DISCOVER:
+      default:
+        if (!tableData || !tableData.meta) {
+          return dataRow[column.key];
+        }
+        cell = getFieldRenderer(columnKey, tableData.meta)(dataRow, {
+          organization,
+          location,
+        });
+
+        const fieldName = getAggregateAlias(columnKey);
+        const value = dataRow[fieldName];
+        if (tableData.meta[fieldName] === 'integer' && defined(value) && value > 999) {
+          return (
+            <Tooltip
+              title={value.toLocaleString()}
+              containerDisplayMode="block"
+              position="right"
+            >
+              {cell}
+            </Tooltip>
+          );
+        }
+        break;
+    }
+
+    return (
+      <React.Fragment>
+        {isTopEvents && rowIndex < DEFAULT_NUM_TOP_EVENTS && columnIndex === 0 ? (
+          <TopResultsIndicator count={DEFAULT_NUM_TOP_EVENTS} index={rowIndex} />
+        ) : null}
+        {cell}
+      </React.Fragment>
+    );
+  };
+
+const StyledTooltip = styled(Tooltip)`
+  display: initial;
+`;

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -24,7 +24,7 @@ jest.mock('echarts-for-react/lib/core', () => {
 
 const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
 
-function mountModal({initialData, widget}) {
+function mountModal({initialData: {organization, routerContext}, widget}) {
   return mountWithTheme(
     <div style={{padding: space(4)}}>
       <WidgetViewerModal
@@ -33,10 +33,14 @@ function mountModal({initialData, widget}) {
         Body={stubEl as ModalRenderProps['Body']}
         CloseButton={stubEl}
         closeModal={() => undefined}
-        organization={initialData.organization}
+        organization={organization}
         widget={widget}
       />
-    </div>
+    </div>,
+    {
+      context: routerContext,
+      organization,
+    }
   );
 }
 
@@ -46,7 +50,9 @@ describe('Modals -> WidgetViewerModal', function () {
       features: ['discover-query', 'widget-viewer-modal'],
       apdexThreshold: 400,
     },
-    router: {},
+    router: {
+      location: {query: {}},
+    },
     project: 1,
     projects: [],
   });


### PR DESCRIPTION
Changes to some of the style in the Widget Viewer.
Also updates the Widget Viewer to use the `GridEditable` component to enable resizing headers.

This change also allows us to enable sort by clicking column headers, which will be completed in another PR.
Pagination is also todo

Relying on existing snapshot tests since this change is mostly visual.

![image](https://user-images.githubusercontent.com/83961295/155615412-96fbf98a-b8cf-47ff-9906-f3f0b017dc92.png)
