### PR TITLE
fix(mep): Properly calculate granularity & interval for timeseries

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -99,7 +99,6 @@ class QueryBuilder:
         turbo: bool = False,
         sample_rate: Optional[float] = None,
         equation_config: Optional[Dict[str, bool]] = None,
-        granularity: Optional[int] = None,
     ):
         self.dataset = dataset
         self.params = params
@@ -141,7 +140,6 @@ class QueryBuilder:
             selected_columns=selected_columns,
             equations=equations,
             orderby=orderby,
-            granularity=granularity,
         )
 
     def resolve_query(
@@ -151,7 +149,6 @@ class QueryBuilder:
         selected_columns: Optional[List[str]] = None,
         equations: Optional[List[str]] = None,
         orderby: Optional[List[str]] = None,
-        granularity: Optional[int] = None,
     ) -> None:
         self.where, self.having = self.resolve_conditions(
             query, use_aggregate_conditions=use_aggregate_conditions
@@ -161,7 +158,6 @@ class QueryBuilder:
         self.columns = self.resolve_select(selected_columns, equations)
         self.orderby = self.resolve_orderby(orderby)
         self.groupby = self.resolve_groupby()
-        self.granularity = self.resolve_granularity(granularity)
 
     def load_config(
         self,
@@ -189,9 +185,6 @@ class QueryBuilder:
         search_filter_converter = self.config.search_filter_converter
 
         return field_alias_converter, function_converter, search_filter_converter
-
-    def resolve_granularity(self, _: Optional[int] = None) -> Optional[Granularity]:
-        return None
 
     def resolve_limit(self, limit: Optional[int]) -> Optional[Limit]:
         return None if limit is None else Limit(limit)
@@ -1099,7 +1092,6 @@ class UnresolvedQuery(QueryBuilder):
         self,
         dataset: Dataset,
         params: ParamsType,
-        granularity: Optional[int] = None,
         query: Optional[str] = None,
         selected_columns: Optional[List[str]] = None,
         equations: Optional[List[str]] = None,
@@ -1117,7 +1109,6 @@ class UnresolvedQuery(QueryBuilder):
         super().__init__(
             dataset=dataset,
             params=params,
-            granularity=granularity,
             query=query,
             selected_columns=selected_columns,
             equations=equations,
@@ -1140,7 +1131,6 @@ class UnresolvedQuery(QueryBuilder):
         selected_columns: Optional[List[str]] = None,
         equations: Optional[List[str]] = None,
         orderby: Optional[List[str]] = None,
-        granularity: Optional[int] = None,
     ) -> None:
         pass
 
@@ -1152,7 +1142,7 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
         self,
         dataset: Dataset,
         params: ParamsType,
-        granularity: int,
+        interval: int,
         query: Optional[str] = None,
         selected_columns: Optional[List[str]] = None,
         equations: Optional[List[str]] = None,
@@ -1162,7 +1152,6 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
         super().__init__(
             dataset,
             params,
-            granularity=granularity,
             query=query,
             selected_columns=selected_columns,
             equations=equations,
@@ -1171,15 +1160,12 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
             equation_config={"auto_add": True, "aggregates_only": True},
         )
 
+        self.granularity = Granularity(interval)
+
         self.limit = None if limit is None else Limit(limit)
 
         # This is a timeseries, the groupby will always be time
         self.groupby = [self.time_column]
-
-    def resolve_granularity(self, granularity: Optional[int] = None) -> Optional[Granularity]:
-        if granularity is None:
-            raise InvalidSearchQuery("Cannot query a timeseries without granularity")
-        return Granularity(granularity)
 
     def resolve_query(
         self,
@@ -1188,14 +1174,12 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
         selected_columns: Optional[List[str]] = None,
         equations: Optional[List[str]] = None,
         orderby: Optional[List[str]] = None,
-        granularity: Optional[int] = None,
     ) -> None:
         self.where, self.having = self.resolve_conditions(query, use_aggregate_conditions=False)
 
         # params depends on parse_query, and conditions being resolved first since there may be projects in conditions
         self.where += self.resolve_params()
         self.columns = self.resolve_select(selected_columns, equations)
-        self.granularity = self.resolve_granularity(granularity)
 
     @property
     def select(self) -> List[SelectType]:
@@ -1265,7 +1249,7 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
         self,
         dataset: Dataset,
         params: ParamsType,
-        granularity: int,
+        interval: int,
         top_events: List[Dict[str, Any]],
         other: bool = False,
         query: Optional[str] = None,
@@ -1282,7 +1266,7 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
         super().__init__(
             dataset,
             params,
-            granularity=granularity,
+            interval=interval,
             query=query,
             selected_columns=list(set(selected_columns + timeseries_functions)),
             equations=list(set(equations + timeseries_equations)),
@@ -1471,8 +1455,9 @@ class MetricsQueryBuilder(QueryBuilder):
             *args,
             **kwargs,
         )
+        self.granularity = self.resolve_granularity()
 
-    def resolve_granularity(self, _: Optional[int] = None) -> Optional[Granularity]:
+    def resolve_granularity(self) -> Optional[Granularity]:
         """Granularity impacts metric queries even when they aren't timeseries because the data needs to be
         pre-aggregated
 
@@ -1744,32 +1729,65 @@ class MetricsQueryBuilder(QueryBuilder):
 
 class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
     time_alias = "time"
-    time_column = AliasedExpression(Column("timestamp"), time_alias)
 
     def __init__(
         self,
         params: ParamsType,
-        granularity: int,
+        interval: int,
         query: Optional[str] = None,
         selected_columns: Optional[List[str]] = None,
         functions_acl: Optional[List[str]] = None,
     ):
         super().__init__(
             params=params,
-            granularity=granularity,
             query=query,
             selected_columns=selected_columns,
             auto_fields=False,
             functions_acl=functions_acl,
         )
 
+        self.time_column = self.resolve_time_column(interval)
+
         # This is a timeseries, the groupby will always be time
         self.groupby = [self.time_column]
 
-    def resolve_granularity(self, granularity: Optional[int] = None) -> Optional[Granularity]:
-        if granularity is None:
-            raise InvalidSearchQuery("Cannot query a timeseries without granularity")
-        return Granularity(granularity)
+    def resolve_time_column(self, interval: int) -> Function:
+        """Need to round the timestamp to the interval requested
+
+        We commonly use interval & granularity interchangeably, but in the case of the metrics dataset they must be
+        considered as two separate things. The reason being the way we store metrics will rarely align with the
+        start&end of the query.
+        This means that we'll need to select granularity for data accuracy, and then use the clickhouse
+        toStartOfInterval function to group results by their displayed interval
+
+        eg.
+        See test_builder.test_run_query_with_hour_interval for this in test form
+        we have a query from yesterday at 15:30 -> today at 15:30
+        there is 1 event at 15:45
+        and we want the timeseries displayed at 1 hour intervals
+
+        The event is in the quantized hour-aligned metrics bucket of 15:00, since the bounds of the query are
+        (Yesterday 15:30, Today 15:30) the condition > Yesterday 15:30 means using the hour-aligned bucket you'd
+        miss that event.
+
+        So instead in this case we want the minute-aligned bucket, while rounding timestamp to the hour, so we'll
+        only get data that is relevant because of the timestamp filters. And Snuba will merge the datasketches for
+        us to get correct data.
+        """
+        if interval < 10:
+            raise IncompatibleMetricsQuery(
+                "Interval must be at least 10s because our smallest granularity is 10s"
+            )
+
+        return Function(
+            "toStartOfInterval",
+            [
+                Column("timestamp"),
+                Function("toIntervalSecond", [interval]),
+                "Universal",
+            ],
+            self.time_alias,
+        )
 
     def get_snql_query(self) -> List[Query]:
         """Because of the way metrics are structured a single request can result in >1 snql query
@@ -1790,7 +1808,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
                         where=self.where,
                         having=self.having,
                         groupby=self.groupby,
-                        orderby=[OrderBy(self.time_column.exp, Direction.ASC)],
+                        orderby=[OrderBy(self.time_column, Direction.ASC)],
                         granularity=self.granularity,
                         limit=self.limit,
                     )

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -36,6 +36,7 @@ from sentry.models.project import Project
 from sentry.search.events.constants import (
     ARRAY_FIELDS,
     EQUALITY_OPERATORS,
+    METRICS_GRANULARITIES,
     METRICS_MAX_LIMIT,
     NO_CONVERSION_FIELDS,
     PROJECT_THRESHOLD_CONFIG_ALIAS,
@@ -1457,7 +1458,7 @@ class MetricsQueryBuilder(QueryBuilder):
         )
         self.granularity = self.resolve_granularity()
 
-    def resolve_granularity(self) -> Optional[Granularity]:
+    def resolve_granularity(self) -> Granularity:
         """Granularity impacts metric queries even when they aren't timeseries because the data needs to be
         pre-aggregated
 
@@ -1745,6 +1746,11 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
             auto_fields=False,
             functions_acl=functions_acl,
         )
+        if self.granularity.granularity > interval:
+            for granularity in METRICS_GRANULARITIES:
+                if granularity <= interval:
+                    self.granularity = Granularity(granularity)
+                    break
 
         self.time_column = self.resolve_time_column(interval)
 

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -135,3 +135,4 @@ METRICS_MAP = {
 }
 # 50 to match the size of tables in the UI + 1 for pagination reasons
 METRICS_MAX_LIMIT = 51
+METRICS_GRANULARITIES = [86400, 3600, 60, 10]

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -791,7 +791,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
 
         # If we're doing atleast day and its midnight we should use the daily bucket
         start = datetime.datetime(2015, 5, 18, 0, 0, 0, tzinfo=timezone.utc)
-        end = datetime.datetime(2015, 5, 18, 0, 0, 0, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 19, 0, 0, 0, tzinfo=timezone.utc)
         assert get_granularity(start, end) == 86400, "A day at midnight"
 
         # If we're on the start of the hour we should use the hour granularity
@@ -1112,7 +1112,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
 
         # If we're doing atleast day and its midnight we should use the daily bucket
         start = datetime.datetime(2015, 5, 18, 0, 0, 0, tzinfo=timezone.utc)
-        end = datetime.datetime(2015, 5, 18, 0, 0, 0, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 19, 0, 0, 0, tzinfo=timezone.utc)
         assert get_granularity(start, end) == 86400, "A day at midnight"
 
         # If we're on the start of the hour we should use the hour granularity

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1084,24 +1084,57 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
 class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
     def test_get_query(self):
         query = TimeseriesMetricQueryBuilder(
-            self.params, granularity=900, query="", selected_columns=["p50(transaction.duration)"]
+            self.params, interval=900, query="", selected_columns=["p50(transaction.duration)"]
         )
         snql_query = query.get_snql_query()
         assert len(snql_query) == 1
         assert snql_query[0].select == [_metric_percentile_definition("50")]
         assert snql_query[0].match.name == "metrics_distributions"
-        assert snql_query[0].granularity.granularity == 900
+        assert snql_query[0].granularity.granularity == 60
 
     def test_default_conditions(self):
         query = TimeseriesMetricQueryBuilder(
-            self.params, granularity=900, query="", selected_columns=[]
+            self.params, interval=900, query="", selected_columns=[]
         )
         self.assertCountEqual(query.where, self.default_conditions)
+
+    def test_granularity(self):
+        # Need to pick granularity based on the period
+        def get_granularity(start, end):
+            params = {
+                "organization_id": self.organization.id,
+                "project_id": self.projects,
+                "start": start,
+                "end": end,
+            }
+            query = TimeseriesMetricQueryBuilder(params, interval=3600)
+            return query.granularity.granularity
+
+        # If we're doing atleast day and its midnight we should use the daily bucket
+        start = datetime.datetime(2015, 5, 18, 0, 0, 0, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 18, 0, 0, 0, tzinfo=timezone.utc)
+        assert get_granularity(start, end) == 86400, "A day at midnight"
+
+        # If we're on the start of the hour we should use the hour granularity
+        start = datetime.datetime(2015, 5, 18, 23, 0, 0, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 20, 1, 0, 0, tzinfo=timezone.utc)
+        assert get_granularity(start, end) == 3600, "On the hour"
+
+        # Even though this is >24h of data, because its a random hour in the middle of the day to the next we use minute
+        # granularity
+        start = datetime.datetime(2015, 5, 18, 10, 15, 1, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 19, 15, 15, 1, tzinfo=timezone.utc)
+        assert get_granularity(start, end) == 60, "A few hours, but random minute"
+
+        # Less than a minute, no reason to work hard for such a small window, just use a minute
+        start = datetime.datetime(2015, 5, 18, 10, 15, 1, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 19, 10, 15, 34, tzinfo=timezone.utc)
+        assert get_granularity(start, end) == 60, "less than a minute"
 
     def test_transaction_in_filter(self):
         query = TimeseriesMetricQueryBuilder(
             self.params,
-            granularity=900,
+            interval=900,
             query="transaction:[foo_transaction, bar_transaction]",
             selected_columns=["p95(transaction.duration)"],
         )
@@ -1124,7 +1157,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         ):
             TimeseriesMetricQueryBuilder(
                 self.params,
-                granularity=900,
+                interval=900,
                 query="transaction:something_else",
                 selected_columns=["project", "p95(transaction.duration)"],
             )
@@ -1136,7 +1169,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         ):
             TimeseriesMetricQueryBuilder(
                 self.params,
-                granularity=900,
+                interval=900,
                 query="transaction:[something_else, something_else2]",
                 selected_columns=["p95(transaction.duration)"],
             )
@@ -1144,7 +1177,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
     def test_project_filter(self):
         query = TimeseriesMetricQueryBuilder(
             self.params,
-            granularity=900,
+            interval=900,
             query=f"project:{self.project.slug}",
             selected_columns=["p95(transaction.duration)"],
         )
@@ -1156,14 +1189,14 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
     def test_meta(self):
         query = TimeseriesMetricQueryBuilder(
             self.params,
-            granularity=900,
+            interval=900,
             selected_columns=["p50(transaction.duration)", "count_unique(user)"],
         )
         result = query.run_query("test_query")
         self.assertCountEqual(
             result["meta"],
             [
-                {"name": "time", "type": "DateTime"},
+                {"name": "time", "type": "DateTime('Universal')"},
                 {"name": "p50_transaction_duration", "type": "Float64"},
                 {"name": "count_unique_user", "type": "UInt64"},
             ],
@@ -1172,7 +1205,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
     def test_with_aggregate_filter(self):
         query = TimeseriesMetricQueryBuilder(
             self.params,
-            granularity=900,
+            interval=900,
             query="p50(transaction.duration):>100",
             selected_columns=["p50(transaction.duration)", "count_unique(user)"],
         )
@@ -1189,7 +1222,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             )
         query = TimeseriesMetricQueryBuilder(
             self.params,
-            granularity=900,
+            interval=900,
             query="",
             selected_columns=["p50(transaction.duration)", "count_unique(user)"],
         )
@@ -1224,9 +1257,45 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         self.assertCountEqual(
             result["meta"],
             [
-                {"name": "time", "type": "DateTime"},
+                {"name": "time", "type": "DateTime('Universal')"},
                 {"name": "p50_transaction_duration", "type": "Float64"},
                 {"name": "count_unique_user", "type": "UInt64"},
+            ],
+        )
+
+    def test_run_query_with_hour_interval(self):
+        # See comment on resolve_time_column for explaination of this test
+        self.start = datetime.datetime(2015, 1, 1, 15, 30, 0, tzinfo=timezone.utc)
+        self.end = datetime.datetime(2015, 1, 2, 15, 30, 0, tzinfo=timezone.utc)
+        self.params = {
+            "organization_id": self.organization.id,
+            "project_id": self.projects,
+            "start": self.start,
+            "end": self.end,
+        }
+
+        for i in range(5):
+            self.store_metric(
+                100,
+                timestamp=self.start + datetime.timedelta(minutes=i * 15),
+            )
+
+        query = TimeseriesMetricQueryBuilder(
+            self.params,
+            interval=3600,
+            query="",
+            selected_columns=["epm(3600)"],
+        )
+        result = query.run_query("test_query")
+        assert result["data"] == [
+            {"time": "2015-01-01T15:00:00+00:00", "epm_3600": 2 / (3600 / 60)},
+            {"time": "2015-01-01T16:00:00+00:00", "epm_3600": 3 / (3600 / 60)},
+        ]
+        self.assertCountEqual(
+            result["meta"],
+            [
+                {"name": "time", "type": "DateTime('Universal')"},
+                {"name": "epm_3600", "type": "Float64"},
             ],
         )
 
@@ -1244,7 +1313,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             )
         query = TimeseriesMetricQueryBuilder(
             self.params,
-            granularity=900,
+            interval=900,
             query="transaction:foo_transaction",
             selected_columns=["p50(transaction.duration)"],
         )
@@ -1259,7 +1328,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         self.assertCountEqual(
             result["meta"],
             [
-                {"name": "time", "type": "DateTime"},
+                {"name": "time", "type": "DateTime('Universal')"},
                 {"name": "p50_transaction_duration", "type": "Float64"},
             ],
         )


### PR DESCRIPTION
- This fixes how the `time` column and granularity are determined for timeseries queries
  - In these cases, we don't want to just select `timestamp` as-is, but instead round them to the "interval" that the frontend is selecting. And then use the same logic as the MetricQueryBuilder to determine the correct granularity to use
  - This is because if we set granularity == interval, there will be events that we'll miss since granularities because of the way buckets are aligned
  

More indepth explaination (also on the resolve_time_column docstring):
We commonly use interval & granularity interchangeably, but in the case of the metrics dataset they must be considered as two separate things. The reason being the way we store metrics will rarely align with the start&end of the query.

This means that we'll need to select granularity for data accuracy, and then use the clickhouse toStartOfInterval function to group results by their displayed interval

eg.
See test_builder.test_run_query_with_hour_interval for this in test form
we have a query from yesterday at 15:30 -> today at 15:30
there is 1 event at 15:45
and we want the timeseries displayed at 1 hour intervals

The event is in the quantized hour-aligned metrics bucket of 15:00, since the bounds of the query are (Yesterday 15:30, Today 15:30) the condition > Yesterday 15:30 means using the hour-aligned bucket you'd miss that event.

So instead in this case we want the minute-aligned bucket, while rounding timestamp to the hour, so we'll only get data that is relevant because of the timestamp filters. And Snuba will merge the datasketches for us to get correct data.