### PR TITLE
fix(performance): tableCursor should not persist when switching tags

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionTags/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/content.tsx
@@ -23,7 +23,7 @@ import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
 import {SpanOperationBreakdownFilter} from '../filter';
 import {getTransactionField} from '../transactionOverview/tagExplorer';
 
-import TagsDisplay from './tagsDisplay';
+import TagsDisplay, {TAG_PAGE_TABLE_CURSOR} from './tagsDisplay';
 import {decodeSelectedTagKey} from './utils';
 
 type Props = {
@@ -105,6 +105,7 @@ const InnerContent = (
     const queryParams = normalizeDateTimeParams({
       ...(location.query || {}),
       tagKey,
+      [TAG_PAGE_TABLE_CURSOR]: undefined,
     });
 
     browserHistory.replace({

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
@@ -28,7 +28,7 @@ type Props = {
 
 const HISTOGRAM_TAG_KEY_LIMIT = 8;
 const HISTOGRAM_BUCKET_LIMIT = 40;
-const TAG_PAGE_TABLE_CURSOR = 'tableCursor';
+export const TAG_PAGE_TABLE_CURSOR = 'tableCursor';
 
 export type TagsTableColumnKeys =
   | 'key'

--- a/tests/js/spec/views/performance/transactionTags/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionTags/index.spec.tsx
@@ -1,7 +1,13 @@
 import {browserHistory} from 'react-router';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, mountWithTheme, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  mountWithTheme,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TransactionTags from 'sentry/views/performance/transactionSummary/transactionTags';
@@ -52,8 +58,14 @@ describe('Performance > Transaction Tags', function () {
       url: '/organizations/org-slug/tags/user.email/values/',
       body: [],
     });
+
+    const pageLinks =
+      '<https://sentry.io/api/0/organizations/sentry/events-facets-performance/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
+      '<https://sentry.io//api/0/organizations/sentry/events-facets-performance/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:20:0"';
+
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-facets-performance/',
+      headers: {Link: pageLinks},
       body: {
         meta: {
           tags_key: 'string',
@@ -162,6 +174,8 @@ describe('Performance > Transaction Tags', function () {
         transaction: 'Test Transaction',
       },
     });
+
+    expect(screen.getByRole('radio', {name: 'hardwareConcurrency'})).toBeChecked();
   });
 
   it('Default tagKey is set when loading the page without one', async function () {
@@ -257,5 +271,63 @@ describe('Performance > Transaction Tags', function () {
         TEST_RELEASE_NAME
       )}?project=${initialData.router.location.query.project}`
     );
+  });
+
+  it('clears tableCursor when selecting a new tag', async function () {
+    const {organization, router, routerContext} = initializeData({
+      query: {
+        statsPeriod: '14d',
+        tagKey: 'hardwareConcurrency',
+      },
+    });
+
+    mountWithTheme(<TransactionTags location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
+
+    expect(await screen.findByText('Suspect Tags')).toBeInTheDocument();
+
+    expect(browserHistory.replace).toHaveBeenCalledWith({
+      query: {
+        project: '1',
+        statsPeriod: '14d',
+        tagKey: 'hardwareConcurrency',
+        transaction: 'Test Transaction',
+      },
+    });
+
+    expect(screen.getByRole('radio', {name: 'hardwareConcurrency'})).toBeChecked();
+    expect(screen.getByRole('button', {name: 'Next'})).toHaveAttribute(
+      'aria-disabled',
+      'false'
+    );
+
+    // Paginate the table
+    userEvent.click(screen.getByLabelText('Next'));
+
+    await waitFor(() =>
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        query: {
+          project: '1',
+          statsPeriod: '14d',
+          tagKey: 'hardwareConcurrency',
+          transaction: 'Test Transaction',
+          tableCursor: '0:20:0',
+        },
+      })
+    );
+
+    // Choose a different tag
+    userEvent.click(screen.getByRole('radio', {name: 'effectiveConnectionType'}));
+
+    expect(browserHistory.replace).toHaveBeenCalledWith({
+      query: {
+        project: '1',
+        statsPeriod: '14d',
+        tagKey: 'effectiveConnectionType',
+        transaction: 'Test Transaction',
+      },
+    });
   });
 });

--- a/tests/js/spec/views/performance/transactionTags/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionTags/index.spec.tsx
@@ -61,7 +61,7 @@ describe('Performance > Transaction Tags', function () {
 
     const pageLinks =
       '<https://sentry.io/api/0/organizations/sentry/events-facets-performance/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
-      '<https://sentry.io//api/0/organizations/sentry/events-facets-performance/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:20:0"';
+      '<https://sentry.io/api/0/organizations/sentry/events-facets-performance/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:20:0"';
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-facets-performance/',


### PR DESCRIPTION
When paginating tag values on the suspect tags tab of a transaction summary page, a table cursor (`tableCursor`) is added to the URL's query string. This gets persisted when switching to a new tag.

This pull requests omits the table cursor when switching tags.