### PR TITLE
fix(jira): Set Badge

### DIFF
--- a/src/sentry/integrations/jira/utils/__init__.py
+++ b/src/sentry/integrations/jira/utils/__init__.py
@@ -1,10 +1,17 @@
-from .api import get_assignee_email, handle_assignee_change, handle_status_change, set_badge
+from .api import (
+    get_assignee_email,
+    handle_assignee_change,
+    handle_jira_api_error,
+    handle_status_change,
+    set_badge,
+)
 from .choice import build_user_choice
 
 __all__ = (
     "build_user_choice",
     "get_assignee_email",
     "handle_assignee_change",
+    "handle_jira_api_error",
     "handle_status_change",
     "set_badge",
 )

--- a/src/sentry/integrations/jira/utils/api.py
+++ b/src/sentry/integrations/jira/utils/api.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Mapping
 
+from rest_framework.response import Response
+
 from sentry.integrations.utils import sync_group_assignee_inbound
-from sentry.shared_integrations.exceptions import ApiHostError, IntegrationError
 
 from ..client import JiraApiClient, JiraCloud
 
@@ -15,16 +16,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def set_badge(integration, issue_key, group_link_num):
-    client = JiraApiClient(
+def _get_client(integration: Integration) -> JiraApiClient:
+    return JiraApiClient(
         integration.metadata["base_url"],
         JiraCloud(integration.metadata["shared_secret"]),
         verify_ssl=True,
     )
-    try:
-        return client.set_issue_property(issue_key, group_link_num)
-    except ApiHostError:
-        raise IntegrationError("Cannot reach host to set badge.")
+
+
+def set_badge(integration: Integration, issue_key: str, group_link_num: int) -> Response:
+    client = _get_client(integration)
+    return client.set_issue_property(issue_key, group_link_num)
 
 
 def get_assignee_email(
@@ -36,15 +38,8 @@ def get_assignee_email(
     email = assignee.get("emailAddress")
     if not email and use_email_scope:
         account_id = assignee.get("accountId")
-        client = JiraApiClient(
-            integration.metadata["base_url"],
-            JiraCloud(integration.metadata["shared_secret"]),
-            verify_ssl=True,
-        )
-        try:
-            email = client.get_email(account_id)
-        except ApiHostError:
-            raise IntegrationError("Cannot reach host to get email.")
+        client = _get_client(integration)
+        email = client.get_email(account_id)
     return email
 
 

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -1,14 +1,13 @@
 import logging
 
 from django.conf import settings
-from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.integrations.utils import get_integration_from_jwt
 from sentry.shared_integrations.exceptions import ApiError
 
-from ..utils import handle_assignee_change, handle_status_change
+from ..utils import handle_assignee_change, handle_jira_api_error, handle_status_change
 from .base import JiraEndpointBase
 
 logger = logging.getLogger("sentry.integrations.jira.webhooks")
@@ -17,17 +16,9 @@ logger = logging.getLogger("sentry.integrations.jira.webhooks")
 class JiraIssueUpdatedWebhook(JiraEndpointBase):
     def handle_exception(self, request: Request, exc: Exception) -> Response:
         if isinstance(exc, ApiError):
-            if exc.code in (
-                status.HTTP_500_INTERNAL_SERVER_ERROR,
-                status.HTTP_503_SERVICE_UNAVAILABLE,
-            ):
-                return self.get_response({"error_message": "Cannot reach host to get email."})
-
-            if exc.code in (
-                status.HTTP_403_FORBIDDEN,
-                status.HTTP_404_NOT_FOUND,
-            ):
-                return self.get_response({"error_message": "User lacks permissions to get email."})
+            response_option = handle_jira_api_error(exc, " to get email")
+            if response_option:
+                return self.get_response(response_option)
 
         return super().handle_exception(request, exc)
 

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -9,7 +9,14 @@ from rest_framework.response import Response
 
 from .base import ApiError
 
-__all__ = ("ApiError",)
+__all__ = (
+    "ApiError",
+    "ApiHostError",
+    "ApiTimeoutError",
+    "ApiUnauthorized",
+    "ApiRateLimitedError",
+    "IntegrationError",
+)
 
 
 class ApiHostError(ApiError):


### PR DESCRIPTION
`handle_exception()` was not being used correctly.  This way should actually intercept Jira error and return sane error messages.

Fixes [SENTRY-TC0](https://sentry.io/organizations/sentry/issues/3022492736/events/482a93d0709441b2920095931ed9dc40/).