### PR TITLE
feat(performance): Add dropdown menu to web vitals content page

### DIFF
--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -154,7 +154,7 @@ class VitalDetailContent extends Component<Props, State> {
               query: {
                 ...location.query,
                 vitalName: newVitalName,
-                curor: undefined,
+                cursor: undefined,
               },
             });
           },

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -7,16 +7,17 @@ import omit from 'lodash/omit';
 import {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
-import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {getInterval} from 'sentry/components/charts/utils';
 import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
+import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
+import {MenuItemProps} from 'sentry/components/dropdownMenuItemV2';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
-import {IconCheckmark, IconChevron, IconClose} from 'sentry/icons';
+import {IconCheckmark, IconClose} from 'sentry/icons';
 import {IconFlag} from 'sentry/icons/iconFlag';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -40,6 +41,7 @@ import {getTransactionSearchQuery} from '../utils';
 
 import Table from './table';
 import {
+  vitalAbbreviations,
   vitalDescription,
   vitalMap,
   vitalSupportedBrowsers,
@@ -141,36 +143,44 @@ class VitalDetailContent extends Component<Props, State> {
       return null;
     }
 
-    const previousDisabled = position === 0;
-    const nextDisabled = position === FRONTEND_VITALS.length - 1;
-
-    const switchVital = newVitalName => {
-      return () => {
-        browserHistory.push({
-          pathname: location.pathname,
-          query: {
-            ...location.query,
-            vitalName: newVitalName,
+    const items: MenuItemProps[] = FRONTEND_VITALS.reduce(
+      (acc: MenuItemProps[], newVitalName) => {
+        const itemProps = {
+          key: newVitalName,
+          label: vitalAbbreviations[newVitalName],
+          onAction: function switchWebVital() {
+            browserHistory.push({
+              pathname: location.pathname,
+              query: {
+                ...location.query,
+                vitalName: newVitalName,
+                curor: undefined,
+              },
+            });
           },
-        });
-      };
-    };
+        };
+
+        if (vitalName === newVitalName) {
+          acc.unshift(itemProps);
+        } else {
+          acc.push(itemProps);
+        }
+
+        return acc;
+      },
+      []
+    );
 
     return (
-      <ButtonBar merged>
-        <Button
-          icon={<IconChevron direction="left" size="sm" />}
-          aria-label={t('Previous')}
-          disabled={previousDisabled}
-          onClick={switchVital(FRONTEND_VITALS[position - 1])}
-        />
-        <Button
-          icon={<IconChevron direction="right" size="sm" />}
-          aria-label={t('Next')}
-          disabled={nextDisabled}
-          onClick={switchVital(FRONTEND_VITALS[position + 1])}
-        />
-      </ButtonBar>
+      <DropdownMenuControlV2
+        items={items}
+        triggerLabel={vitalAbbreviations[vitalName]}
+        triggerProps={{
+          'aria-label': `Web Vitals: ${vitalAbbreviations[vitalName]}`,
+          prefix: t('Web Vitals'),
+        }}
+        placement="bottom left"
+      />
     );
   }
 
@@ -363,10 +373,10 @@ class VitalDetailContent extends Component<Props, State> {
           <Layout.HeaderActions>
             <ButtonBar gap={1}>
               <MetricsSwitch onSwitch={() => this.handleSearch('')} />
+              {this.renderVitalSwitcher()}
               <Feature organization={organization} features={['incidents']}>
                 {({hasFeature}) => hasFeature && this.renderCreateAlertButton()}
               </Feature>
-              {this.renderVitalSwitcher()}
             </ButtonBar>
           </Layout.HeaderActions>
         </Layout.Header>

--- a/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
+++ b/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
@@ -510,7 +510,7 @@ describe('Performance > VitalDetail', function () {
     expect(screen.getByText('TODO')).toBeInTheDocument();
   });
 
-  it('switch vitals with dropdown menu', async function () {
+  it('can switch vitals with dropdown menu', async function () {
     const newRouter = {
       ...router,
       location: {

--- a/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
+++ b/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
@@ -510,7 +510,7 @@ describe('Performance > VitalDetail', function () {
     expect(screen.getByText('TODO')).toBeInTheDocument();
   });
 
-  it('Pagination links exist to switch between vitals', async function () {
+  it('switch vitals with dropdown menu', async function () {
     const newRouter = {
       ...router,
       location: {
@@ -536,9 +536,13 @@ describe('Performance > VitalDetail', function () {
       organization: org,
     });
 
-    expect(await screen.findByLabelText('Previous')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {name: 'Web Vitals: LCP'})
+    ).toBeInTheDocument();
+    userEvent.click(screen.getByRole('button', {name: 'Web Vitals: LCP'}));
 
-    userEvent.click(screen.getByLabelText('Previous'));
+    expect(await screen.findByRole('menuitemradio', {name: 'FCP'})).toBeInTheDocument();
+    userEvent.click(screen.getByRole('menuitemradio', {name: 'FCP'}));
 
     expect(browserHistory.push).toHaveBeenCalledTimes(1);
     expect(browserHistory.push).toHaveBeenCalledWith({


### PR DESCRIPTION
Replace the pagination buttons with a dropdown menu so that it's obvious you can navigate between web vitals.

https://user-images.githubusercontent.com/139499/155640055-7921aa35-503a-4218-9f2a-45313d5db85a.mp4

