### PR TITLE
ref(metrics): Track if a request is from the frontend

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -63,6 +63,7 @@ def _create_api_access_log(
             user_id=str(user_id),
             is_app=str(is_app),
             token_type=str(_get_token_name(request_auth)),
+            is_frontend_request=str(bool(getattr(request, "COOKIES", {}))),
             organization_id=str(org_id),
             auth_id=str(auth_id),
             path=str(request.path),

--- a/src/sentry/middleware/stats.py
+++ b/src/sentry/middleware/stats.py
@@ -67,7 +67,13 @@ class RequestTimingMiddleware(MiddlewareMixin):
             return
 
         tags = request._metric_tags if hasattr(request, "_metric_tags") else {}
-        tags.update({"method": request.method, "status_code": status_code})
+        tags.update(
+            {
+                "method": request.method,
+                "status_code": status_code,
+                "ui_request": bool(getattr(request, "COOKIES", {})),
+            }
+        )
 
         metrics.incr("view.response", instance=request._view_path, tags=tags, skip_internal=False)
 

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -23,7 +23,23 @@ class RequestTimingMiddlewareTest(TestCase):
         incr.assert_called_with(
             "view.response",
             instance=request._view_path,
-            tags={"method": "GET", "status_code": 200},
+            tags={"method": "GET", "status_code": 200, "ui_request": False},
+            skip_internal=False,
+        )
+
+    @patch("sentry.utils.metrics.incr")
+    def test_records_ui_request(self, incr):
+        request = self.factory.get("/")
+        request._view_path = "/"
+        response = Mock(status_code=200)
+        request.COOKIES = {"foo": "bar"}
+
+        self.middleware.process_response(request, response)
+
+        incr.assert_called_with(
+            "view.response",
+            instance=request._view_path,
+            tags={"method": "GET", "status_code": 200, "ui_request": True},
             skip_internal=False,
         )
 
@@ -40,7 +56,7 @@ class RequestTimingMiddlewareTest(TestCase):
         incr.assert_called_with(
             "view.response",
             instance=request._view_path,
-            tags={"method": "GET", "status_code": 200, "a": "b"},
+            tags={"method": "GET", "status_code": 200, "ui_request": False, "a": "b"},
             skip_internal=False,
         )
 
@@ -58,6 +74,6 @@ class RequestTimingMiddlewareTest(TestCase):
         incr.assert_called_with(
             "view.response",
             instance=request._view_path,
-            tags={"method": "GET", "status_code": 200, "foo": "bar"},
+            tags={"method": "GET", "status_code": 200, "ui_request": False, "foo": "bar"},
             skip_internal=False,
         )


### PR DESCRIPTION
This change checks if an incoming request has `COOKIES`. If so, we'll mark it as such in metrics logging and the access logs