### PR TITLE
feat(ui): Alert wiz v3 threshold type selector with set thresholds

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -7,7 +7,6 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
 import SearchBar from 'sentry/components/events/searchBar';
-import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import FormField from 'sentry/components/forms/formField';
 import SelectControl from 'sentry/components/forms/selectControl';
 import SelectField from 'sentry/components/forms/selectField';
@@ -145,14 +144,12 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   renderInterval() {
     const {
       organization,
-      dataset,
       disabled,
       alertType,
       hasAlertWizardV3,
       timeWindow,
       comparisonDelta,
       comparisonType,
-      onComparisonTypeChange,
       onTimeWindowChange,
       onComparisonDeltaChange,
     } = this.props;
@@ -167,24 +164,6 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
 
     return (
       <Fragment>
-        {dataset !== Dataset.SESSIONS && (
-          <Feature features={['organizations:change-alerts']} organization={organization}>
-            <StyledListItem>{t('Select threshold type')}</StyledListItem>
-            <FormRow>
-              <RadioGroup
-                style={{flex: 1}}
-                disabled={disabled}
-                choices={[
-                  [AlertRuleComparisonType.COUNT, 'Count'],
-                  [AlertRuleComparisonType.CHANGE, 'Percent Change'],
-                ]}
-                value={comparisonType}
-                label={t('Threshold Type')}
-                onChange={onComparisonTypeChange}
-              />
-            </FormRow>
-          </Feature>
-        )}
         <StyledListItem>
           <StyledListTitle>
             <div>{intervalLabelText}</div>

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -26,6 +26,7 @@ import {defined} from 'sentry/utils';
 import {metric, trackAnalyticsEvent} from 'sentry/utils/analytics';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import RuleNameOwnerForm from 'sentry/views/alerts/incidentRules/ruleNameOwnerForm';
+import ThresholdTypeForm from 'sentry/views/alerts/incidentRules/thresholdTypeForm';
 import Triggers from 'sentry/views/alerts/incidentRules/triggers';
 import TriggersChart from 'sentry/views/alerts/incidentRules/triggers/chart';
 import {getEventTypeFilter} from 'sentry/views/alerts/incidentRules/utils/getEventTypeFilter';
@@ -732,6 +733,17 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       />
     );
 
+    const thresholdTypeForm = (hasAccess: boolean) => (
+      <ThresholdTypeForm
+        comparisonType={comparisonType}
+        dataset={dataset}
+        disabled={!hasAccess || !canEdit}
+        onComparisonTypeChange={this.handleComparisonTypeChange}
+        organization={organization}
+        hasAlertWizardV3={hasAlertWizardV3}
+      />
+    );
+
     return (
       <Access access={['alerts:write']}>
         {({hasAccess}) => (
@@ -795,7 +807,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                 }
                 onTimeWindowChange={value => this.handleFieldChange('timeWindow', value)}
               />
+              {!hasAlertWizardV3 && thresholdTypeForm(hasAccess)}
               <AlertListItem>{t('Set thresholds to trigger alert')}</AlertListItem>
+              {hasAlertWizardV3 && thresholdTypeForm(hasAccess)}
               {triggerForm(hasAccess)}
               {ruleNameOwnerForm(hasAccess)}
             </List>

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {ReactNode} from 'react';
 import {PlainRoute, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -619,7 +619,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     }
   };
 
-  handleRuleSaveFailure = (msg: React.ReactNode) => {
+  handleRuleSaveFailure = (msg: ReactNode) => {
     addErrorMessage(msg);
     metric.endTransaction({name: 'saveAlertRule'});
   };

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import {Fragment} from 'react';
+import {Fragment, PureComponent} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -20,7 +19,7 @@ type Props = {
   organization: Organization;
 };
 
-class ThresholdTypeForm extends React.PureComponent<Props> {
+class ThresholdTypeForm extends PureComponent<Props> {
   render() {
     const {
       organization,

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import Feature from 'sentry/components/acl/feature';
+import RadioGroup from 'sentry/components/forms/controls/radioGroup';
+import ListItem from 'sentry/components/list/listItem';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+
+import {AlertRuleComparisonType, Dataset} from './types';
+
+type Props = {
+  comparisonType: AlertRuleComparisonType;
+  dataset: Dataset;
+  disabled: boolean;
+  hasAlertWizardV3: boolean;
+  onComparisonTypeChange: (value: AlertRuleComparisonType) => void;
+  organization: Organization;
+};
+
+class ThresholdTypeForm extends React.PureComponent<Props> {
+  render() {
+    const {
+      organization,
+      dataset,
+      disabled,
+      comparisonType,
+      onComparisonTypeChange,
+      hasAlertWizardV3,
+    } = this.props;
+
+    return (
+      <Fragment>
+        {dataset !== Dataset.SESSIONS && (
+          <Feature features={['organizations:change-alerts']} organization={organization}>
+            {!hasAlertWizardV3 && (
+              <StyledListItem>{t('Select threshold type')}</StyledListItem>
+            )}
+            <FormRow>
+              <RadioGroup
+                style={{flex: 1}}
+                disabled={disabled}
+                choices={[
+                  [
+                    AlertRuleComparisonType.COUNT,
+                    hasAlertWizardV3 ? 'Static: above or below {x}' : 'Count',
+                  ],
+                  [
+                    AlertRuleComparisonType.CHANGE,
+                    hasAlertWizardV3
+                      ? 'Percent Change: {x%} higher or lower compared to previous period'
+                      : 'Percent Change',
+                  ],
+                ]}
+                value={comparisonType}
+                label={t('Threshold Type')}
+                onChange={onComparisonTypeChange}
+              />
+            </FormRow>
+          </Feature>
+        )}
+      </Fragment>
+    );
+  }
+}
+
+const StyledListItem = styled(ListItem)`
+  margin-bottom: ${space(1)};
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  line-height: 1.3;
+`;
+
+const FormRow = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: ${space(4)};
+`;
+
+export default ThresholdTypeForm;

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -1,4 +1,3 @@
-import {Fragment, PureComponent} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -19,51 +18,40 @@ type Props = {
   organization: Organization;
 };
 
-class ThresholdTypeForm extends PureComponent<Props> {
-  render() {
-    const {
-      organization,
-      dataset,
-      disabled,
-      comparisonType,
-      onComparisonTypeChange,
-      hasAlertWizardV3,
-    } = this.props;
-
-    return (
-      <Fragment>
-        {dataset !== Dataset.SESSIONS && (
-          <Feature features={['organizations:change-alerts']} organization={organization}>
-            {!hasAlertWizardV3 && (
-              <StyledListItem>{t('Select threshold type')}</StyledListItem>
-            )}
-            <FormRow>
-              <RadioGroup
-                style={{flex: 1}}
-                disabled={disabled}
-                choices={[
-                  [
-                    AlertRuleComparisonType.COUNT,
-                    hasAlertWizardV3 ? 'Static: above or below {x}' : 'Count',
-                  ],
-                  [
-                    AlertRuleComparisonType.CHANGE,
-                    hasAlertWizardV3
-                      ? 'Percent Change: {x%} higher or lower compared to previous period'
-                      : 'Percent Change',
-                  ],
-                ]}
-                value={comparisonType}
-                label={t('Threshold Type')}
-                onChange={onComparisonTypeChange}
-              />
-            </FormRow>
-          </Feature>
-        )}
-      </Fragment>
-    );
-  }
-}
+const ThresholdTypeForm = ({
+  organization,
+  dataset,
+  disabled,
+  comparisonType,
+  onComparisonTypeChange,
+  hasAlertWizardV3,
+}: Props) =>
+  dataset === Dataset.SESSIONS ? null : (
+    <Feature features={['organizations:change-alerts']} organization={organization}>
+      {!hasAlertWizardV3 && <StyledListItem>{t('Select threshold type')}</StyledListItem>}
+      <FormRow>
+        <RadioGroup
+          style={{flex: 1}}
+          disabled={disabled}
+          choices={[
+            [
+              AlertRuleComparisonType.COUNT,
+              hasAlertWizardV3 ? 'Static: above or below {x}' : 'Count',
+            ],
+            [
+              AlertRuleComparisonType.CHANGE,
+              hasAlertWizardV3
+                ? 'Percent Change: {x%} higher or lower compared to previous period'
+                : 'Percent Change',
+            ],
+          ]}
+          value={comparisonType}
+          label={t('Threshold Type')}
+          onChange={onComparisonTypeChange}
+        />
+      </FormRow>
+    </Feature>
+  );
 
 const StyledListItem = styled(ListItem)`
   margin-bottom: ${space(1)};


### PR DESCRIPTION
This moved the threshold type selector to "Set threshold" section in the alert wizard per Alert Wizard V3 designs.

Old:
![old-wiz](https://user-images.githubusercontent.com/15015880/156266080-e0e154e9-28a5-4002-bc38-69b118436cd4.png)


New:
![new-wiz](https://user-images.githubusercontent.com/15015880/156266101-32ef301c-c3e5-4cf0-ab5a-028445d1df40.png)


Jira: [WOR-1656](https://getsentry.atlassian.net/browse/WOR-1656)


