### PR TITLE
feat(dropdown-menu-v2): Add min width to menu

### DIFF
--- a/static/app/components/dropdownMenuControlV2.tsx
+++ b/static/app/components/dropdownMenuControlV2.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useButton} from '@react-aria/button';
 import {AriaMenuOptions, useMenuTrigger} from '@react-aria/menu';
@@ -95,7 +95,7 @@ function MenuControl({
   className,
   ...props
 }: Props) {
-  const ref = useRef(null);
+  const ref = useRef<HTMLButtonElement>(null);
   const isDisabled = disabledProp ?? (!items || items.length === 0);
 
   // Control the menu open state. See:
@@ -120,6 +120,14 @@ function MenuControl({
     },
     ref
   );
+
+  // Calculate the current trigger element's width. This will be used as
+  // the min width for the menu.
+  const [triggerWidth, setTriggerWidth] = useState<number>();
+  useEffect(() => {
+    const newTriggerWidth = ref.current?.offsetWidth;
+    !isSubmenu && newTriggerWidth && setTriggerWidth(newTriggerWidth);
+  }, [trigger, triggerLabel, triggerProps]);
 
   // Recursively remove hidden items, including those nested in submenus
   function removeHiddenItems(source) {
@@ -159,6 +167,7 @@ function MenuControl({
         {...props}
         {...menuProps}
         triggerRef={ref}
+        triggerWidth={triggerWidth}
         isSubmenu={isSubmenu}
         isDismissable={!isSubmenu && props.isDismissable}
         shouldCloseOnBlur={!isSubmenu && props.shouldCloseOnBlur}

--- a/static/app/components/dropdownMenuControlV2.tsx
+++ b/static/app/components/dropdownMenuControlV2.tsx
@@ -1,8 +1,9 @@
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useButton} from '@react-aria/button';
 import {AriaMenuOptions, useMenuTrigger} from '@react-aria/menu';
 import {AriaPositionProps, OverlayProps} from '@react-aria/overlays';
+import {useResizeObserver} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
 import {useMenuTriggerState} from '@react-stately/menu';
 import {MenuTriggerProps} from '@react-types/menu';
@@ -124,10 +125,20 @@ function MenuControl({
   // Calculate the current trigger element's width. This will be used as
   // the min width for the menu.
   const [triggerWidth, setTriggerWidth] = useState<number>();
-  useEffect(() => {
+  // Update triggerWidth when its size changes using useResizeObserver
+  const updateTriggerWidth = useCallback(() => {
     const newTriggerWidth = ref.current?.offsetWidth;
     !isSubmenu && newTriggerWidth && setTriggerWidth(newTriggerWidth);
   }, [trigger, triggerLabel, triggerProps]);
+  useResizeObserver({ref, onResize: updateTriggerWidth});
+  // If ResizeObserver is not available, manually update the width
+  // when any of [trigger, triggerLabel, triggerProps] changes.
+  useEffect(() => {
+    if (typeof window.ResizeObserver !== 'undefined') {
+      return;
+    }
+    updateTriggerWidth();
+  }, [updateTriggerWidth]);
 
   // Recursively remove hidden items, including those nested in submenus
   function removeHiddenItems(source) {

--- a/static/app/components/dropdownMenuV2.tsx
+++ b/static/app/components/dropdownMenuV2.tsx
@@ -48,6 +48,11 @@ type Props = {
    */
   menuTitle?: string;
   onClose?: () => void;
+  /**
+   * Current width of the trigger element. This is used as the menu's minumum
+   * width.
+   */
+  triggerWidth?: number;
 } & AriaMenuOptions<MenuItemProps> &
   Partial<OverlayProps> &
   Partial<AriaPositionProps>;
@@ -59,6 +64,7 @@ function Menu({
   placement = 'bottom left',
   closeOnSelect = true,
   triggerRef,
+  triggerWidth,
   isSubmenu,
   menuTitle,
   closeRootMenu,
@@ -224,7 +230,10 @@ function Menu({
         <MenuWrap
           ref={menuRef}
           {...modifiedMenuProps}
-          style={{maxHeight: positionProps.style?.maxHeight}}
+          style={{
+            maxHeight: positionProps.style?.maxHeight,
+            minWidth: triggerWidth,
+          }}
         >
           {menuTitle && <MenuTitle>{menuTitle}</MenuTitle>}
           {renderCollection(stateCollection)}


### PR DESCRIPTION
Make `DropdownMenuV2` span at least the width of its trigger button.

Before:
<img width="164" alt="Screen Shot 2022-02-24 at 7 22 14 PM" src="https://user-images.githubusercontent.com/44172267/155647728-3321ab50-b179-4355-967f-23d4c34a1975.png">

After:
<img width="164" alt="Screen Shot 2022-02-24 at 7 13 03 PM" src="https://user-images.githubusercontent.com/44172267/155647745-d315155c-1f48-4af5-aee4-3507407e9f62.png">

