### PR TITLE
[RFC]: export a base provider component

### DIFF
--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import React, {Component, Fragment} from 'react';
 import {cache} from '@emotion/css';
 import {CacheProvider, ThemeProvider} from '@emotion/react';
 // eslint-disable-next-line no-restricted-imports
@@ -34,6 +34,21 @@ function createProvider(contextDefs: Record<string, any>) {
       return this.props.children;
     }
   };
+}
+
+export function BaseProviders(props: {
+  children: React.ReactNode;
+  organization?: Organization;
+}): React.ReactElement {
+  return (
+    <CacheProvider value={cache}>
+      <ThemeProvider theme={lightTheme}>
+        <OrganizationContext.Provider value={props.organization ?? null}>
+          {props.children}
+        </OrganizationContext.Provider>
+      </ThemeProvider>
+    </CacheProvider>
+  );
 }
 
 function makeAllTheProviders({context, organization}: ProviderOptions) {

--- a/tests/js/spec/components/globalSdkUpdateAlert.spec.tsx
+++ b/tests/js/spec/components/globalSdkUpdateAlert.spec.tsx
@@ -1,6 +1,7 @@
 import moment from 'moment';
 
 import {
+  BaseProviders,
   mountWithTheme,
   screen,
   userEvent,
@@ -64,8 +65,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     const {rerender} = mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <BaseProviders organization={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </BaseProviders>
     );
 
     expect(
@@ -99,8 +101,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <BaseProviders organization={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </BaseProviders>
     );
 
     expect(
@@ -125,8 +128,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <BaseProviders organization={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </BaseProviders>
     );
 
     await waitFor(() =>
@@ -153,8 +157,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <BaseProviders organization={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </BaseProviders>
     );
 
     expect(
@@ -179,8 +184,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <BaseProviders organization={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </BaseProviders>
     );
 
     await waitFor(() =>
@@ -205,8 +211,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <BaseProviders organization={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </BaseProviders>
     );
 
     expect(
@@ -228,8 +235,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <BaseProviders organization={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </BaseProviders>
     );
 
     userEvent.click(await screen.findByText(/Remind me later/));


### PR DESCRIPTION
RFC for [discussion](https://www.notion.so/sentry/2022-02-24-53bbb562b24a44f0824146d86a78d984#e487093775b14ea786f953616088eacd)

A declarative approach where we import a BaseProvider component instead of using the 2nd parameter to mountWithTheme