### PR TITLE
[RFC]: wrap with baseprovider and remove organizationcontext

### DIFF
--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -11,16 +11,9 @@ import * as reactHooks from '@testing-library/react-hooks'; // eslint-disable-li
 import userEvent from '@testing-library/user-event'; // eslint-disable-line no-restricted-imports
 
 import GlobalModal from 'sentry/components/globalModal';
-import {Organization} from 'sentry/types';
 import {lightTheme} from 'sentry/utils/theme';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
-type ProviderOptions = {
-  context?: Record<string, any>;
-  organization?: Organization;
-};
-
-type Options = ProviderOptions & RenderOptions;
+type Options = Record<string, any> & RenderOptions;
 
 function createProvider(contextDefs: Record<string, any>) {
   return class ContextProvider extends Component {
@@ -36,17 +29,13 @@ function createProvider(contextDefs: Record<string, any>) {
   };
 }
 
-function makeAllTheProviders({context, organization}: ProviderOptions) {
+function makeBaseProviders(context?: Record<string, any>) {
   const ContextProvider = context ? createProvider(context) : Fragment;
   return function ({children}: {children?: React.ReactNode}) {
     return (
       <ContextProvider>
         <CacheProvider value={cache}>
-          <ThemeProvider theme={lightTheme}>
-            <OrganizationContext.Provider value={organization ?? null}>
-              {children}
-            </OrganizationContext.Provider>
-          </ThemeProvider>
+          <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
         </CacheProvider>
       </ContextProvider>
     );
@@ -60,12 +49,14 @@ function makeAllTheProviders({context, organization}: ProviderOptions) {
  * After
  * mountWithTheme(<Something />, {context: routerContext});
  */
-function mountWithTheme(ui: React.ReactElement, options?: Options) {
-  const {context, organization, ...otherOptions} = options ?? {};
+function mountWithTheme(component: React.ReactElement, options: Options = {}) {
+  const {context, ...testingLibraryOptions} = options;
 
-  const AllTheProviders = makeAllTheProviders({context, organization});
+  const BaseProviders = makeBaseProviders(context);
 
-  return render(ui, {wrapper: AllTheProviders, ...otherOptions});
+  return render(<BaseProviders>{component}</BaseProviders>, {
+    ...testingLibraryOptions,
+  });
 }
 
 /**

--- a/tests/js/spec/components/globalSdkUpdateAlert.spec.tsx
+++ b/tests/js/spec/components/globalSdkUpdateAlert.spec.tsx
@@ -11,6 +11,7 @@ import {InnerGlobalSdkUpdateAlert} from 'sentry/components/globalSdkUpdateAlert'
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {PageFilters, ProjectSdkUpdates} from 'sentry/types';
 import {DEFAULT_SNOOZE_PROMPT_DAYS} from 'sentry/utils/promptIsDismissed';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 
 const makeFilterProps = (filters: Partial<PageFilters>): PageFilters => {
   return {
@@ -64,8 +65,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     const {rerender} = mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <OrganizationContext.Provider value={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </OrganizationContext.Provider>
     );
 
     expect(
@@ -99,8 +101,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <OrganizationContext.Provider value={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </OrganizationContext.Provider>
     );
 
     expect(
@@ -125,8 +128,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <OrganizationContext.Provider value={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </OrganizationContext.Provider>
     );
 
     await waitFor(() =>
@@ -153,8 +157,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <OrganizationContext.Provider value={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </OrganizationContext.Provider>
     );
 
     expect(
@@ -179,8 +184,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <OrganizationContext.Provider value={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </OrganizationContext.Provider>
     );
 
     await waitFor(() =>
@@ -205,8 +211,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <OrganizationContext.Provider value={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </OrganizationContext.Provider>
     );
 
     expect(
@@ -228,8 +235,9 @@ describe('GlobalSDKUpdateAlert', () => {
     });
 
     mountWithTheme(
-      <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />,
-      {organization: TestStubs.Organization()}
+      <OrganizationContext.Provider value={TestStubs.Organization()}>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} selection={filters} />
+      </OrganizationContext.Provider>
     );
 
     userEvent.click(await screen.findByText(/Remind me later/));


### PR DESCRIPTION
RFC for [discussion](https://www.notion.so/sentry/2022-02-24-53bbb562b24a44f0824146d86a78d984#e487093775b14ea786f953616088eacd)

Similar approach as [here](https://github.com/getsentry/sentry/pull/32065), but we remove the OrganizationContext from baseprovider. The idea is that probably all of the components we render should have a theme and cache, but not all require an org. If required, the OrganizationContex.provider should be added to the test files.