### PR TITLE
ref(tests): drop dead code

### DIFF
--- a/static/app/components/globalSelectionLink.tsx
+++ b/static/app/components/globalSelectionLink.tsx
@@ -65,8 +65,9 @@ function GlobalSelectionLink(props: Props) {
     queryStringObject = {...queryStringObject, ...to.query};
   }
 
+  const queryString = qs.stringify(queryStringObject);
   const url =
-    (typeof to === 'string' ? to : to.pathname) + '?' + qs.stringify(queryStringObject);
+    (typeof to === 'string' ? to : to.pathname) + (queryString ? `?${queryString}` : '');
 
   return <a {...props} href={url} />;
 }

--- a/tests/js/spec/components/acl/featureDisabled.spec.jsx
+++ b/tests/js/spec/components/acl/featureDisabled.spec.jsx
@@ -3,15 +3,12 @@ import {fireEvent, mountWithTheme, screen} from 'sentry-test/reactTestingLibrary
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 
 describe('FeatureDisabled', function () {
-  const routerContext = TestStubs.routerContext();
-
   it('renders', function () {
     mountWithTheme(
       <FeatureDisabled
         features={['organization:my-features']}
         featureName="Some Feature"
-      />,
-      {context: routerContext}
+      />
     );
 
     expect(
@@ -27,8 +24,7 @@ describe('FeatureDisabled', function () {
         message={customMessage}
         features={['organization:my-features']}
         featureName="Some Feature"
-      />,
-      {context: routerContext}
+      />
     );
 
     expect(screen.getByText(customMessage)).toBeInTheDocument();
@@ -41,8 +37,7 @@ describe('FeatureDisabled', function () {
         alert={customAlert}
         features={['organization:my-features']}
         featureName="Some Feature"
-      />,
-      {context: routerContext}
+      />
     );
     expect(customAlert).toHaveBeenCalled();
   });
@@ -53,8 +48,7 @@ describe('FeatureDisabled', function () {
         alert
         features={['organization:my-features']}
         featureName="Some Feature"
-      />,
-      {context: routerContext}
+      />
     );
     fireEvent.click(screen.getByText('Help'));
     expect(

--- a/tests/js/spec/components/actions/ignore.spec.jsx
+++ b/tests/js/spec/components/actions/ignore.spec.jsx
@@ -4,17 +4,12 @@ import {mountGlobalModal} from 'sentry-test/modal';
 import IgnoreActions from 'sentry/components/actions/ignore';
 
 describe('IgnoreActions', function () {
-  const routerContext = TestStubs.routerContext();
-
   describe('disabled', function () {
     let component, button;
     const spy = jest.fn();
 
     beforeEach(function () {
-      component = mountWithTheme(
-        <IgnoreActions onUpdate={spy} disabled />,
-        routerContext
-      );
+      component = mountWithTheme(<IgnoreActions onUpdate={spy} disabled />);
       button = component.find('IgnoreButton');
     });
 
@@ -32,10 +27,7 @@ describe('IgnoreActions', function () {
     let component;
     const spy = jest.fn();
     beforeEach(function () {
-      component = mountWithTheme(
-        <IgnoreActions onUpdate={spy} isIgnored />,
-        routerContext
-      );
+      component = mountWithTheme(<IgnoreActions onUpdate={spy} isIgnored />);
     });
 
     it('displays ignored view', function () {
@@ -56,7 +48,7 @@ describe('IgnoreActions', function () {
     const spy = jest.fn();
 
     beforeEach(function () {
-      component = mountWithTheme(<IgnoreActions onUpdate={spy} />, routerContext);
+      component = mountWithTheme(<IgnoreActions onUpdate={spy} />);
     });
 
     it('calls spy with ignore details when clicked', function () {
@@ -73,8 +65,7 @@ describe('IgnoreActions', function () {
 
     beforeEach(function () {
       component = mountWithTheme(
-        <IgnoreActions onUpdate={spy} shouldConfirm confirmMessage="confirm me" />,
-        routerContext
+        <IgnoreActions onUpdate={spy} shouldConfirm confirmMessage="confirm me" />
       );
       button = component.find('IgnoreButton');
     });

--- a/tests/js/spec/components/actions/resolve.spec.jsx
+++ b/tests/js/spec/components/actions/resolve.spec.jsx
@@ -20,8 +20,7 @@ describe('ResolveActions', function () {
           hasRelease={false}
           orgSlug="org-1"
           projectSlug="proj-1"
-        />,
-        TestStubs.routerContext()
+        />
       );
       button = component.find('ResolveButton').first();
     });
@@ -48,8 +47,7 @@ describe('ResolveActions', function () {
           hasRelease={false}
           orgSlug="org-1"
           projectSlug="proj-1"
-        />,
-        TestStubs.routerContext()
+        />
       );
     });
 
@@ -82,8 +80,7 @@ describe('ResolveActions', function () {
           orgSlug="org-1"
           projectSlug="proj-1"
           isResolved
-        />,
-        TestStubs.routerContext()
+        />
       );
     });
 
@@ -111,8 +108,7 @@ describe('ResolveActions', function () {
           projectSlug="proj-1"
           isResolved
           isAutoResolved
-        />,
-        TestStubs.routerContext()
+        />
       );
 
       component.find('button[aria-label="Unresolve"]').simulate('click');
@@ -130,8 +126,7 @@ describe('ResolveActions', function () {
           hasRelease={false}
           orgSlug="org-1"
           projectSlug="proj-1"
-        />,
-        TestStubs.routerContext()
+        />
       );
     });
 
@@ -163,8 +158,7 @@ describe('ResolveActions', function () {
             shouldConfirm
             confirmMessage="Are you sure???"
           />
-        </Fragment>,
-        TestStubs.routerContext()
+        </Fragment>
       );
     });
 
@@ -203,8 +197,7 @@ describe('ResolveActions', function () {
           projectSlug="project-slug"
           onUpdate={onUpdate}
         />
-      </Fragment>,
-      TestStubs.routerContext()
+      </Fragment>
     );
 
     await selectDropdownMenuItem({

--- a/tests/js/spec/components/activity/note/input.spec.jsx
+++ b/tests/js/spec/components/activity/note/input.spec.jsx
@@ -4,8 +4,6 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import NoteInput from 'sentry/components/activity/note/input';
 
 describe('NoteInput', function () {
-  const routerContext = TestStubs.routerContext();
-
   describe('New item', function () {
     const props = {
       group: {project: {}, id: 'groupId'},
@@ -14,15 +12,12 @@ describe('NoteInput', function () {
     };
 
     it('renders', function () {
-      mountWithTheme(<NoteInput {...props} />, routerContext);
+      mountWithTheme(<NoteInput {...props} />);
     });
 
     it('submits when meta + enter is pressed', function () {
       const onCreate = jest.fn();
-      const wrapper = mountWithTheme(
-        <NoteInput {...props} onCreate={onCreate} />,
-        routerContext
-      );
+      const wrapper = mountWithTheme(<NoteInput {...props} onCreate={onCreate} />);
 
       const input = wrapper.find('textarea');
 
@@ -34,10 +29,7 @@ describe('NoteInput', function () {
 
     it('submits when ctrl + enter is pressed', function () {
       const onCreate = jest.fn();
-      const wrapper = mountWithTheme(
-        <NoteInput {...props} onCreate={onCreate} />,
-        routerContext
-      );
+      const wrapper = mountWithTheme(<NoteInput {...props} onCreate={onCreate} />);
 
       const input = wrapper.find('textarea');
 
@@ -49,10 +41,7 @@ describe('NoteInput', function () {
 
     it('does not submit when nothing is entered', function () {
       const onCreate = jest.fn();
-      const wrapper = mountWithTheme(
-        <NoteInput {...props} onCreate={onCreate} />,
-        routerContext
-      );
+      const wrapper = mountWithTheme(<NoteInput {...props} onCreate={onCreate} />);
 
       const input = wrapper.find('textarea');
       input.simulate('keyDown', {key: 'Enter', metaKey: true});
@@ -62,8 +51,7 @@ describe('NoteInput', function () {
     it('handles errors', function () {
       const errorJSON = {detail: {message: '', code: 401, extra: ''}};
       const wrapper = mountWithTheme(
-        <NoteInput {...props} error={!!errorJSON} errorJSON={errorJSON} />,
-        routerContext
+        <NoteInput {...props} error={!!errorJSON} errorJSON={errorJSON} />
       );
 
       const input = wrapper.find('textarea');
@@ -78,8 +66,7 @@ describe('NoteInput', function () {
     it('has a disabled submit button when no text is entered', function () {
       const errorJSON = {detail: {message: '', code: 401, extra: ''}};
       const wrapper = mountWithTheme(
-        <NoteInput {...props} error={!!errorJSON} errorJSON={errorJSON} />,
-        routerContext
+        <NoteInput {...props} error={!!errorJSON} errorJSON={errorJSON} />
       );
 
       expect(wrapper.find('button[type="submit"]').prop('disabled')).toBe(true);
@@ -88,8 +75,7 @@ describe('NoteInput', function () {
     it('enables the submit button when text is entered', function () {
       const errorJSON = {detail: {message: '', code: 401, extra: ''}};
       const wrapper = mountWithTheme(
-        <NoteInput {...props} error={!!errorJSON} errorJSON={errorJSON} />,
-        routerContext
+        <NoteInput {...props} error={!!errorJSON} errorJSON={errorJSON} />
       );
 
       changeReactMentionsInput(wrapper, 'something');
@@ -108,7 +94,7 @@ describe('NoteInput', function () {
     };
 
     const createWrapper = props =>
-      mountWithTheme(<NoteInput {...defaultProps} {...props} />, routerContext);
+      mountWithTheme(<NoteInput {...defaultProps} {...props} />);
 
     it('edits existing message', function () {
       const onUpdate = jest.fn();

--- a/tests/js/spec/components/activity/note/inputWithStorage.spec.jsx
+++ b/tests/js/spec/components/activity/note/inputWithStorage.spec.jsx
@@ -14,10 +14,9 @@ describe('NoteInputWithStorage', function () {
     memberList: [],
     teams: [],
   };
-  const routerContext = TestStubs.routerContext();
 
   const createWrapper = props =>
-    mountWithTheme(<NoteInputWithStorage {...defaultProps} {...props} />, routerContext);
+    mountWithTheme(<NoteInputWithStorage {...defaultProps} {...props} />);
 
   it('loads draft item from local storage when mounting', function () {
     localStorage.getItem.mockImplementation(() => JSON.stringify({item1: 'saved item'}));

--- a/tests/js/spec/components/assigneeSelector.spec.jsx
+++ b/tests/js/spec/components/assigneeSelector.spec.jsx
@@ -102,10 +102,7 @@ describe('AssigneeSelector', function () {
     MemberListStore.state = [];
     MemberListStore.loaded = false;
 
-    assigneeSelector = mountWithTheme(
-      <AssigneeSelectorComponent id={GROUP_1.id} />,
-      TestStubs.routerContext()
-    );
+    assigneeSelector = mountWithTheme(<AssigneeSelectorComponent id={GROUP_1.id} />);
 
     openMenu = () => assigneeSelector.find('DropdownButton').simulate('click');
   });
@@ -117,8 +114,7 @@ describe('AssigneeSelector', function () {
   describe('render with props', function () {
     it('renders members from the prop when present', async function () {
       assigneeSelector = mountWithTheme(
-        <AssigneeSelectorComponent id={GROUP_1.id} memberList={[USER_2, USER_3]} />,
-        TestStubs.routerContext()
+        <AssigneeSelectorComponent id={GROUP_1.id} memberList={[USER_2, USER_3]} />
       );
       MemberListStore.loadInitialData([USER_1]);
       openMenu();
@@ -326,8 +322,7 @@ describe('AssigneeSelector', function () {
     jest.spyOn(GroupStore, 'get').mockImplementation(() => GROUP_2);
     const onAssign = jest.fn();
     assigneeSelector = mountWithTheme(
-      <AssigneeSelectorComponent id={GROUP_2.id} onAssign={onAssign} />,
-      TestStubs.routerContext()
+      <AssigneeSelectorComponent id={GROUP_2.id} onAssign={onAssign} />
     );
     MemberListStore.loadInitialData([USER_1, USER_2, USER_3]);
 
@@ -367,10 +362,7 @@ describe('AssigneeSelector', function () {
 
   it('renders unassigned', async function () {
     jest.spyOn(GroupStore, 'get').mockImplementation(() => GROUP_2);
-    assigneeSelector = mountWithTheme(
-      <AssigneeSelectorComponent id={GROUP_2.id} />,
-      TestStubs.routerContext()
-    );
+    assigneeSelector = mountWithTheme(<AssigneeSelectorComponent id={GROUP_2.id} />);
     const avatarTooltip = mountWithTheme(assigneeSelector.find('Tooltip').prop('title'));
     expect(avatarTooltip.text()).toContain('Unassigned');
   });

--- a/tests/js/spec/components/assistant/guideAnchor.spec.jsx
+++ b/tests/js/spec/components/assistant/guideAnchor.spec.jsx
@@ -14,8 +14,6 @@ describe('GuideAnchor', function () {
     },
   ];
 
-  const routerContext = TestStubs.routerContext();
-
   beforeEach(function () {
     ConfigStore.config = {
       user: {
@@ -24,8 +22,8 @@ describe('GuideAnchor', function () {
       },
     };
 
-    wrapper = mountWithTheme(<GuideAnchor target="issue_title" />, routerContext);
-    wrapper2 = mountWithTheme(<GuideAnchor target="exception" />, routerContext);
+    wrapper = mountWithTheme(<GuideAnchor target="issue_title" />);
+    wrapper2 = mountWithTheme(<GuideAnchor target="exception" />);
   });
 
   afterEach(function () {
@@ -118,8 +116,7 @@ describe('GuideAnchor', function () {
     const wrapper3 = mountWithTheme(
       <GuideAnchorWrapper disabled target="exception">
         <div data-test-id="child-div" />
-      </GuideAnchorWrapper>,
-      routerContext
+      </GuideAnchorWrapper>
     );
 
     GuideActions.fetchSucceeded(serverGuide);

--- a/tests/js/spec/components/button.spec.tsx
+++ b/tests/js/spec/components/button.spec.tsx
@@ -3,41 +3,33 @@ import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary
 import Button from 'sentry/components/button';
 
 describe('Button', function () {
-  const routerContext = TestStubs.routerContext();
-
   it('renders', function () {
     const {container} = mountWithTheme(<Button priority="primary">Button</Button>);
     expect(container).toSnapshot();
   });
 
   it('renders react-router link', function () {
-    const {container} = mountWithTheme(<Button to="/some/route">Router Link</Button>, {
-      context: routerContext,
-    });
+    const {container} = mountWithTheme(<Button to="/some/route">Router Link</Button>);
     expect(container).toSnapshot();
   });
 
   it('renders normal link', function () {
     const {container} = mountWithTheme(
-      <Button href="/some/relative/url">Normal Link</Button>,
-      {context: routerContext}
+      <Button href="/some/relative/url">Normal Link</Button>
     );
     expect(container).toSnapshot();
   });
 
   it('renders disabled normal link', function () {
     const {container} = mountWithTheme(
-      <Button href="/some/relative/url">Normal Link</Button>,
-      {context: routerContext}
+      <Button href="/some/relative/url">Normal Link</Button>
     );
     expect(container).toSnapshot();
   });
 
   it('calls `onClick` callback', function () {
     const spy = jest.fn();
-    mountWithTheme(<Button onClick={spy}>Click me</Button>, {
-      context: routerContext,
-    });
+    mountWithTheme(<Button onClick={spy}>Click me</Button>);
     userEvent.click(screen.getByText('Click me'));
 
     expect(spy).toHaveBeenCalled();
@@ -48,8 +40,7 @@ describe('Button', function () {
     mountWithTheme(
       <Button onClick={spy} disabled>
         Click me
-      </Button>,
-      {context: routerContext}
+      </Button>
     );
     userEvent.click(screen.getByText('Click me'));
 

--- a/tests/js/spec/components/charts/baseChartHeightResize.spec.tsx
+++ b/tests/js/spec/components/charts/baseChartHeightResize.spec.tsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/reactTestingLibrary';
 
 import BaseChart from 'sentry/components/charts/baseChart';
@@ -23,13 +22,11 @@ const TestContainer = ({children}) => (
 );
 
 describe('BaseChart', function () {
-  const {routerContext} = initializeOrg();
   it('can scale to full parent height when given autoHeightResize', async () => {
     const {container} = mountWithTheme(
       <TestContainer>
         <BaseChart autoHeightResize />
-      </TestContainer>,
-      {context: routerContext}
+      </TestContainer>
     );
 
     expect(container).toSnapshot();
@@ -39,8 +36,7 @@ describe('BaseChart', function () {
     const {container} = mountWithTheme(
       <TestContainer>
         <BaseChart />
-      </TestContainer>,
-      {context: routerContext}
+      </TestContainer>
     );
 
     expect(container).toSnapshot();

--- a/tests/js/spec/components/confirm.spec.jsx
+++ b/tests/js/spec/components/confirm.spec.jsx
@@ -9,8 +9,7 @@ describe('Confirm', function () {
     const wrapper = shallow(
       <Confirm message="Are you sure?" onConfirm={mock}>
         <button>Confirm?</button>
-      </Confirm>,
-      TestStubs.routerContext()
+      </Confirm>
     );
 
     expect(wrapper).toSnapshot();
@@ -29,8 +28,7 @@ describe('Confirm', function () {
         )}
       >
         <button data-test-id="trigger-btn">Confirm?</button>
-      </Confirm>,
-      TestStubs.routerContext()
+      </Confirm>
     );
     wrapper.find('button[data-test-id="trigger-btn"]').simulate('click');
     const modal = await mountGlobalModal();
@@ -55,8 +53,7 @@ describe('Confirm', function () {
         )}
       >
         <button data-test-id="trigger-btn">Confirm?</button>
-      </Confirm>,
-      TestStubs.routerContext()
+      </Confirm>
     );
     wrapper.find('button[data-test-id="trigger-btn"]').simulate('click');
     const modal = await mountGlobalModal();
@@ -73,8 +70,7 @@ describe('Confirm', function () {
     const wrapper = shallow(
       <Confirm message="Are you sure?" onConfirm={mock}>
         <button>Confirm?</button>
-      </Confirm>,
-      TestStubs.routerContext()
+      </Confirm>
     );
 
     wrapper.find('button').simulate('click');
@@ -89,8 +85,7 @@ describe('Confirm', function () {
     const wrapper = mountWithTheme(
       <Confirm message="Are you sure?" onConfirm={mock}>
         <button>Confirm?</button>
-      </Confirm>,
-      TestStubs.routerContext()
+      </Confirm>
     );
 
     expect(mock).not.toHaveBeenCalled();
@@ -115,8 +110,7 @@ describe('Confirm', function () {
     const wrapper = shallow(
       <Confirm message="Are you sure?" onConfirm={mock} stopPropagation>
         <button>Confirm?</button>
-      </Confirm>,
-      TestStubs.routerContext()
+      </Confirm>
     );
 
     expect(mock).not.toHaveBeenCalled();

--- a/tests/js/spec/components/confirmDelete.spec.jsx
+++ b/tests/js/spec/components/confirmDelete.spec.jsx
@@ -9,8 +9,7 @@ describe('ConfirmDelete', function () {
     const wrapper = mountWithTheme(
       <ConfirmDelete message="Are you sure?" onConfirm={mock} confirmInput="CoolOrg">
         <button>Confirm?</button>
-      </ConfirmDelete>,
-      TestStubs.routerContext()
+      </ConfirmDelete>
     );
     wrapper.find('button').simulate('click');
 
@@ -25,8 +24,7 @@ describe('ConfirmDelete', function () {
     const wrapper = mountWithTheme(
       <ConfirmDelete message="Are you sure?" onConfirm={mock} confirmInput="CoolOrg">
         <button>Confirm?</button>
-      </ConfirmDelete>,
-      TestStubs.routerContext()
+      </ConfirmDelete>
     );
 
     wrapper.find('button').simulate('click');
@@ -42,8 +40,7 @@ describe('ConfirmDelete', function () {
     const wrapper = mountWithTheme(
       <ConfirmDelete message="Are you sure?" onConfirm={mock} confirmInput="CoolOrg">
         <button>Confirm?</button>
-      </ConfirmDelete>,
-      TestStubs.routerContext()
+      </ConfirmDelete>
     );
     wrapper.find('button').simulate('click');
 
@@ -58,8 +55,7 @@ describe('ConfirmDelete', function () {
     const wrapper = mountWithTheme(
       <ConfirmDelete message="Are you sure?" onConfirm={mock} confirmInput="CoolOrg">
         <button>Confirm?</button>
-      </ConfirmDelete>,
-      TestStubs.routerContext()
+      </ConfirmDelete>
     );
     wrapper.find('button').simulate('click');
 

--- a/tests/js/spec/components/contextPickerModal.spec.jsx
+++ b/tests/js/spec/components/contextPickerModal.spec.jsx
@@ -62,7 +62,7 @@ describe('ContextPickerModal', function () {
       url: `/organizations/${org2.slug}/projects/`,
       body: [],
     });
-    const wrapper = mountWithTheme(getComponent(), TestStubs.routerContext());
+    const wrapper = mountWithTheme(getComponent());
 
     expect(onFinish).toHaveBeenCalledWith('/test/org2/path/');
     await tick();
@@ -84,8 +84,7 @@ describe('ContextPickerModal', function () {
         needOrg: true,
         needProject: true,
         nextPath: '/test/:orgId/path/:projectId/',
-      }),
-      TestStubs.routerContext()
+      })
     );
 
     expect(fetchProjectsForOrg).toHaveBeenCalled();
@@ -102,7 +101,7 @@ describe('ContextPickerModal', function () {
 
   it('selects an org and calls `onFinish` with URL with organization slug', async function () {
     OrganizationsStore.load([org]);
-    const wrapper = mountWithTheme(getComponent({}), TestStubs.routerContext());
+    const wrapper = mountWithTheme(getComponent({}));
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/projects/`,
       body: [],
@@ -199,8 +198,7 @@ describe('ContextPickerModal', function () {
         needProject: true,
         nextPath: '/test/:orgId/path/:projectId/',
         organizations,
-      }),
-      TestStubs.routerContext()
+      })
     );
 
     await tick();
@@ -277,8 +275,7 @@ describe('ContextPickerModal', function () {
         needProject: false,
         nextPath: `/settings/${org.slug}/integrations/${provider.slug}/`,
         configUrl,
-      }),
-      TestStubs.routerContext()
+      })
     );
 
     expect(fetchGithubConfigs).toHaveBeenCalled();
@@ -318,8 +315,7 @@ describe('ContextPickerModal', function () {
         needProject: false,
         nextPath: `/settings/${org.slug}/integrations/${provider.slug}/`,
         configUrl,
-      }),
-      TestStubs.routerContext()
+      })
     );
 
     expect(fetchGithubConfigs).toHaveBeenCalled();
@@ -356,8 +352,7 @@ describe('ContextPickerModal', function () {
         needProject: false,
         nextPath: `/settings/${org.slug}/integrations/${provider.slug}/`,
         configUrl,
-      }),
-      TestStubs.routerContext()
+      })
     );
 
     expect(fetchGithubConfigs).toHaveBeenCalled();

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -20,8 +20,7 @@ function generateWrappedComponent(organization, eventView) {
       projects={[TestStubs.Project()]}
       onIncompatibleQuery={onIncompatibleQueryMock}
       onSuccess={onSuccessMock}
-    />,
-    TestStubs.routerContext()
+    />
   );
 }
 

--- a/tests/js/spec/components/customResolutionModal.spec.jsx
+++ b/tests/js/spec/components/customResolutionModal.spec.jsx
@@ -23,8 +23,7 @@ describe('CustomResolutionModal', function () {
         projectSlug="project-slug"
         onSelected={onSelected}
         closeModal={jest.fn()}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     expect(releasesMock).toHaveBeenCalled();

--- a/tests/js/spec/components/deprecatedforms/formField.spec.jsx
+++ b/tests/js/spec/components/deprecatedforms/formField.spec.jsx
@@ -7,7 +7,6 @@ import TextField from 'sentry/components/forms/textField';
 describe('FormField + model', function () {
   let model;
   let wrapper;
-  const routerContext = TestStubs.routerContext();
 
   beforeEach(function () {
     model = new FormModel();
@@ -17,8 +16,7 @@ describe('FormField + model', function () {
     wrapper = mountWithTheme(
       <Form model={model}>
         <TextField name="fieldName" />
-      </Form>,
-      routerContext
+      </Form>
     );
     expect(wrapper).toSnapshot();
   });
@@ -27,8 +25,7 @@ describe('FormField + model', function () {
     wrapper = mountWithTheme(
       <Form model={model} initialData={{fieldName: 'test'}}>
         <TextField name="fieldName" />
-      </Form>,
-      routerContext
+      </Form>
     );
 
     expect(model.initialData.fieldName).toBe('test');
@@ -38,8 +35,7 @@ describe('FormField + model', function () {
     wrapper = mountWithTheme(
       <Form model={model}>
         <TextField name="fieldName" defaultValue="foo" />
-      </Form>,
-      routerContext
+      </Form>
     );
 
     expect(model.initialData.fieldName).toBe('foo');
@@ -50,8 +46,7 @@ describe('FormField + model', function () {
     wrapper = mountWithTheme(
       <Form model={model} initialData={{fieldName: 'test'}}>
         <TextField name="fieldName" defaultValue="foo" />
-      </Form>,
-      routerContext
+      </Form>
     );
 
     expect(model.initialData.fieldName).toBe('test');
@@ -62,8 +57,7 @@ describe('FormField + model', function () {
     wrapper = mountWithTheme(
       <Form model={model}>
         <TextField name="fieldName" defaultValue="foo" setValue={v => `${v}${v}`} />
-      </Form>,
-      routerContext
+      </Form>
     );
 
     expect(model.initialData.fieldName).toBe('foofoo');
@@ -74,8 +68,7 @@ describe('FormField + model', function () {
     wrapper = mountWithTheme(
       <Form model={model} initialData={{fieldName: 'test'}}>
         <TextField name="fieldName" required />
-      </Form>,
-      routerContext
+      </Form>
     );
 
     expect(model.getDescriptor('fieldName', 'required')).toBe(true);
@@ -85,8 +78,7 @@ describe('FormField + model', function () {
     wrapper = mountWithTheme(
       <Form model={model} initialData={{fieldName: 'test'}}>
         <TextField name="fieldName" required />
-      </Form>,
-      routerContext
+      </Form>
     );
     expect(model.fieldDescriptor.has('fieldName')).toBe(true);
 

--- a/tests/js/spec/components/deprecatedforms/tableField.spec.jsx
+++ b/tests/js/spec/components/deprecatedforms/tableField.spec.jsx
@@ -24,8 +24,7 @@ describe('TableField', function () {
             columnLabels={columnLabels}
             addButtonText="Add Thing"
           />
-        </Form>,
-        TestStubs.routerContext()
+        </Form>
       );
     });
     it('renders without form context', function () {
@@ -34,8 +33,7 @@ describe('TableField', function () {
           name="fieldName"
           columnKeys={columnKeys}
           columnLabels={columnLabels}
-        />,
-        TestStubs.routerContext()
+        />
       );
       expect(wrapper).toSnapshot();
     });

--- a/tests/js/spec/components/dropdownAutoComplete.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoComplete.spec.jsx
@@ -3,7 +3,6 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
 
 describe('DropdownAutoComplete', function () {
-  const routerContext = TestStubs.routerContext();
   const items = [
     {
       value: 'apple',
@@ -21,8 +20,7 @@ describe('DropdownAutoComplete', function () {
 
   it('has actor wrapper', function () {
     const wrapper = mountWithTheme(
-      <DropdownAutoComplete items={items}>{() => 'Click Me!'}</DropdownAutoComplete>,
-      routerContext
+      <DropdownAutoComplete items={items}>{() => 'Click Me!'}</DropdownAutoComplete>
     );
     expect(wrapper.find('div[role="button"]')).toHaveLength(1);
     expect(wrapper.find('div[role="button"]').text()).toBe('Click Me!');
@@ -30,8 +28,7 @@ describe('DropdownAutoComplete', function () {
 
   it('opens dropdown menu when actor is clicked', function () {
     const wrapper = mountWithTheme(
-      <DropdownAutoComplete items={items}>{() => 'Click Me!'}</DropdownAutoComplete>,
-      routerContext
+      <DropdownAutoComplete items={items}>{() => 'Click Me!'}</DropdownAutoComplete>
     );
     wrapper.find('Actor[role="button"]').simulate('click');
     expect(wrapper.find('BubbleWithMinWidth')).toHaveLength(1);
@@ -44,8 +41,7 @@ describe('DropdownAutoComplete', function () {
     const wrapper = mountWithTheme(
       <DropdownAutoComplete allowActorToggle items={items}>
         {() => 'Click Me!'}
-      </DropdownAutoComplete>,
-      routerContext
+      </DropdownAutoComplete>
     );
     wrapper.find('Actor[role="button"]').simulate('click');
     expect(wrapper.find('BubbleWithMinWidth')).toHaveLength(1);

--- a/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
@@ -3,7 +3,6 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import DropdownAutoCompleteMenu from 'sentry/components/dropdownAutoComplete/menu';
 
 describe('DropdownAutoCompleteMenu', function () {
-  const routerContext = TestStubs.routerContext();
   const items = [
     {
       value: 'apple',
@@ -22,8 +21,7 @@ describe('DropdownAutoCompleteMenu', function () {
     const wrapper = mountWithTheme(
       <DropdownAutoCompleteMenu isOpen items={items}>
         {() => 'Click Me!'}
-      </DropdownAutoCompleteMenu>,
-      routerContext
+      </DropdownAutoCompleteMenu>
     );
     expect(wrapper).toSnapshot();
   });
@@ -51,8 +49,7 @@ describe('DropdownAutoCompleteMenu', function () {
         ]}
       >
         {() => 'Click Me!'}
-      </DropdownAutoCompleteMenu>,
-      routerContext
+      </DropdownAutoCompleteMenu>
     );
     expect(wrapper).toSnapshot();
   });
@@ -83,8 +80,7 @@ describe('DropdownAutoCompleteMenu', function () {
         onSelect={mock}
       >
         {({selectedItem}) => (selectedItem ? selectedItem.label : 'Click me!')}
-      </DropdownAutoCompleteMenu>,
-      routerContext
+      </DropdownAutoCompleteMenu>
     );
 
     wrapper.find('AutoCompleteItem').last().simulate('click');
@@ -106,8 +102,7 @@ describe('DropdownAutoCompleteMenu', function () {
         isOpen
       >
         {({selectedItem}) => (selectedItem ? selectedItem.label : 'Click me!')}
-      </DropdownAutoCompleteMenu>,
-      routerContext
+      </DropdownAutoCompleteMenu>
     );
 
     expect(wrapper.find('EmptyMessage')).toHaveLength(1);
@@ -121,8 +116,7 @@ describe('DropdownAutoCompleteMenu', function () {
     const wrapper = mountWithTheme(
       <DropdownAutoCompleteMenu isOpen items={items} emptyMessage="No items!">
         {({selectedItem}) => (selectedItem ? selectedItem.label : 'Click me!')}
-      </DropdownAutoCompleteMenu>,
-      routerContext
+      </DropdownAutoCompleteMenu>
     );
 
     wrapper.find('StyledInput').simulate('change', {target: {value: 'U-S-A'}});
@@ -139,8 +133,7 @@ describe('DropdownAutoCompleteMenu', function () {
         noResultsMessage="No search results"
       >
         {({selectedItem}) => (selectedItem ? selectedItem.label : 'Click me!')}
-      </DropdownAutoCompleteMenu>,
-      routerContext
+      </DropdownAutoCompleteMenu>
     );
 
     wrapper.find('StyledInput').simulate('change', {target: {value: 'U-S-A'}});
@@ -151,8 +144,7 @@ describe('DropdownAutoCompleteMenu', function () {
     const wrapper = mountWithTheme(
       <DropdownAutoCompleteMenu isOpen items={items} hideInput>
         {() => 'Click Me!'}
-      </DropdownAutoCompleteMenu>,
-      routerContext
+      </DropdownAutoCompleteMenu>
     );
 
     expect(wrapper.find('StyledInput')).toHaveLength(0);
@@ -162,8 +154,7 @@ describe('DropdownAutoCompleteMenu', function () {
     const wrapper = mountWithTheme(
       <DropdownAutoCompleteMenu isOpen items={items} filterValue="Apple">
         {() => 'Click Me!'}
-      </DropdownAutoCompleteMenu>,
-      routerContext
+      </DropdownAutoCompleteMenu>
     );
     wrapper.find('StyledInput').simulate('change', {target: {value: 'U-S-A'}});
     expect(wrapper.find('EmptyMessage')).toHaveLength(0);

--- a/tests/js/spec/components/eventOrGroupHeader.spec.tsx
+++ b/tests/js/spec/components/eventOrGroupHeader.spec.tsx
@@ -32,15 +32,14 @@ const event = TestStubs.Event({
 });
 
 describe('EventOrGroupHeader', function () {
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, router} = initializeOrg({
     router: {orgId: 'orgId'},
   } as Parameters<typeof initializeOrg>[0]);
 
   describe('Group', function () {
     it('renders with `type = error`', function () {
       const {container} = mountWithTheme(
-        <EventOrGroupHeader organization={organization} data={group} {...router} />,
-        {context: routerContext}
+        <EventOrGroupHeader organization={organization} data={group} {...router} />
       );
 
       expect(container).toSnapshot();
@@ -55,8 +54,7 @@ describe('EventOrGroupHeader', function () {
             type: EventOrGroupType.CSP,
           }}
           {...router}
-        />,
-        {context: routerContext}
+        />
       );
 
       expect(container).toSnapshot();
@@ -75,8 +73,7 @@ describe('EventOrGroupHeader', function () {
             },
           }}
           {...router}
-        />,
-        {context: routerContext}
+        />
       );
 
       expect(container).toSnapshot();
@@ -91,8 +88,7 @@ describe('EventOrGroupHeader', function () {
             type: EventOrGroupType.ERROR,
           }}
           {...router}
-        />,
-        {context: routerContext}
+        />
       );
 
       expect(screen.getByText('metadata value')).toBeInTheDocument();
@@ -111,8 +107,7 @@ describe('EventOrGroupHeader', function () {
             type: EventOrGroupType.ERROR,
           }}
           {...router}
-        />,
-        {context: routerContext}
+        />
       );
 
       expect(
@@ -131,8 +126,7 @@ describe('EventOrGroupHeader', function () {
             type: EventOrGroupType.ERROR,
           }}
           {...router}
-        />,
-        {context: routerContext}
+        />
       );
       expect(container).toSnapshot();
     });
@@ -146,8 +140,7 @@ describe('EventOrGroupHeader', function () {
             type: EventOrGroupType.CSP,
           }}
           {...router}
-        />,
-        {context: routerContext}
+        />
       );
       expect(container).toSnapshot();
     });
@@ -165,8 +158,7 @@ describe('EventOrGroupHeader', function () {
             },
           }}
           {...router}
-        />,
-        {context: routerContext}
+        />
       );
       expect(container).toSnapshot();
     });
@@ -186,8 +178,7 @@ describe('EventOrGroupHeader', function () {
             },
           }}
           {...router}
-        />,
-        {context: routerContext}
+        />
       );
       expect(container).toSnapshot();
     });

--- a/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
+++ b/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
@@ -9,7 +9,7 @@ jest.mock('sentry/utils/analytics');
 
 describe('EventCauseEmpty', function () {
   let putMock;
-  const routerContext = TestStubs.routerContext();
+
   const organization = TestStubs.Organization();
   const project = TestStubs.Project({
     platform: 'javascript',
@@ -39,8 +39,7 @@ describe('EventCauseEmpty', function () {
 
   it('renders', async function () {
     const wrapper = mountWithTheme(
-      <EventCauseEmpty event={event} organization={organization} project={project} />,
-      routerContext
+      <EventCauseEmpty event={event} organization={organization} project={project} />
     );
 
     await tick();
@@ -68,8 +67,7 @@ describe('EventCauseEmpty', function () {
       eventID: 'ABCDEFABCDEFABCDEFABCDEFABCDEFAB',
     };
     const wrapper = mountWithTheme(
-      <EventCauseEmpty event={newEvent} organization={organization} project={project} />,
-      routerContext
+      <EventCauseEmpty event={newEvent} organization={organization} project={project} />
     );
 
     await tick();
@@ -81,8 +79,7 @@ describe('EventCauseEmpty', function () {
 
   it('can be snoozed', async function () {
     const wrapper = mountWithTheme(
-      <EventCauseEmpty event={event} organization={organization} project={project} />,
-      routerContext
+      <EventCauseEmpty event={event} organization={organization} project={project} />
     );
 
     await tick();
@@ -127,8 +124,7 @@ describe('EventCauseEmpty', function () {
     });
 
     const wrapper = mountWithTheme(
-      <EventCauseEmpty event={event} organization={organization} project={project} />,
-      routerContext
+      <EventCauseEmpty event={event} organization={organization} project={project} />
     );
 
     await tick();
@@ -147,8 +143,7 @@ describe('EventCauseEmpty', function () {
     });
 
     const wrapper = mountWithTheme(
-      <EventCauseEmpty event={event} organization={organization} project={project} />,
-      routerContext
+      <EventCauseEmpty event={event} organization={organization} project={project} />
     );
 
     await tick();
@@ -159,8 +154,7 @@ describe('EventCauseEmpty', function () {
 
   it('can be dismissed', async function () {
     const wrapper = mountWithTheme(
-      <EventCauseEmpty event={event} organization={organization} project={project} />,
-      routerContext
+      <EventCauseEmpty event={event} organization={organization} project={project} />
     );
 
     await tick();
@@ -203,8 +197,7 @@ describe('EventCauseEmpty', function () {
     });
 
     const wrapper = mountWithTheme(
-      <EventCauseEmpty event={event} organization={organization} project={project} />,
-      routerContext
+      <EventCauseEmpty event={event} organization={organization} project={project} />
     );
 
     await tick();
@@ -215,8 +208,7 @@ describe('EventCauseEmpty', function () {
 
   it('can capture analytics on docs click', async function () {
     const wrapper = mountWithTheme(
-      <EventCauseEmpty event={event} organization={organization} project={project} />,
-      routerContext
+      <EventCauseEmpty event={event} organization={organization} project={project} />
     );
 
     await tick();

--- a/tests/js/spec/components/events/interfaces/frame/openInContextLine.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frame/openInContextLine.spec.jsx
@@ -43,8 +43,7 @@ describe('OpenInContextLine', function () {
   describe('with stacktrace-link component', function () {
     it('renders multiple buttons', function () {
       const wrapper = mountWithTheme(
-        <OpenInContextLine filename={filename} lineNo={lineNo} components={components} />,
-        TestStubs.routerContext()
+        <OpenInContextLine filename={filename} lineNo={lineNo} components={components} />
       );
       expect(wrapper.props().components[0].schema.url).toEqual(
         `http://localhost:5000/redirection?installationId=${install.uuid}&projectSlug=${group.project.slug}`

--- a/tests/js/spec/components/events/interfaces/frame/stacktraceLink.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frame/stacktraceLink.spec.jsx
@@ -39,8 +39,7 @@ describe('StacktraceLink', function () {
         projects={[project]}
         organization={memberOrg}
         lineNo={frame.lineNo}
-      />,
-      TestStubs.routerContext()
+      />
     );
     await tick();
     wrapper.update();
@@ -65,8 +64,7 @@ describe('StacktraceLink', function () {
         projects={[project]}
         organization={org}
         lineNo={frame.lineNo}
-      />,
-      TestStubs.routerContext()
+      />
     );
     await tick();
     wrapper.update();
@@ -88,8 +86,7 @@ describe('StacktraceLink', function () {
         projects={[project]}
         organization={org}
         lineNo={frame.lineNo}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper.state('match').sourceUrl).toEqual('https://something.io');
     expect(wrapper.find('OpenInName').text()).toEqual('GitHub');
@@ -114,8 +111,7 @@ describe('StacktraceLink', function () {
         projects={[project]}
         organization={org}
         lineNo={frame.lineNo}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper.state('match').sourceUrl).toBeFalsy();
     expect(wrapper.find('CodeMappingButtonContainer').text()).toContain(
@@ -142,8 +138,7 @@ describe('StacktraceLink', function () {
         projects={[project]}
         organization={org}
         lineNo={frame.lineNo}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper.state('match').sourceUrl).toBeFalsy();
     expect(wrapper.find('CodeMappingButtonContainer').text()).toContain(
@@ -168,8 +163,7 @@ describe('StacktraceLink', function () {
         projects={[project]}
         organization={org}
         lineNo={frame.lineNo}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper.state('match').sourceUrl).toBeFalsy();
     expect(wrapper.find('CodeMappingButtonContainer').text()).toContain(

--- a/tests/js/spec/components/events/interfaces/frame/stacktraceLinkModal.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frame/stacktraceLinkModal.spec.jsx
@@ -53,8 +53,7 @@ describe('StacktraceLinkModal', function () {
         integrations={[integration]}
         organization={org}
         project={project}
-      />,
-      TestStubs.routerContext()
+      />
     );
   };
 

--- a/tests/js/spec/components/eventsTable/eventsTable.spec.jsx
+++ b/tests/js/spec/components/eventsTable/eventsTable.spec.jsx
@@ -15,8 +15,7 @@ describe('EventsTable', function () {
         projectId="projectId"
         groupId="groupId"
         events={TestStubs.DetailedEvents()}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper).toSnapshot();
   });

--- a/tests/js/spec/components/eventsTable/eventsTableRow.spec.jsx
+++ b/tests/js/spec/components/eventsTable/eventsTableRow.spec.jsx
@@ -14,8 +14,7 @@ describe('EventsTableRow', function () {
             event={TestStubs.DetailedEvents()[0]}
           />
         </tbody>
-      </table>,
-      TestStubs.routerContext()
+      </table>
     );
     expect(wrapper).toSnapshot();
   });

--- a/tests/js/spec/components/globalSelectionLink.spec.tsx
+++ b/tests/js/spec/components/globalSelectionLink.spec.tsx
@@ -36,10 +36,8 @@ describe('GlobalSelectionLink', function () {
   });
 
   it('does not have global selection values in query', function () {
-    const context = TestStubs.routerContext();
     const {container} = mountWithTheme(
-      <GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>,
-      {context}
+      <GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>
     );
 
     expect(screen.getByText('Go somewhere!')).toHaveAttribute('href', path);

--- a/tests/js/spec/components/group/externalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueActions.spec.jsx
@@ -14,9 +14,7 @@ describe('ExternalIssueActions', function () {
         group={group}
         configurations={configurations}
         onChange={() => {}}
-      />,
-
-      TestStubs.routerContext()
+      />
     );
 
     // console.log(configurations);
@@ -64,8 +62,7 @@ describe('ExternalIssueActions', function () {
         group={group}
         configurations={configurations}
         onChange={() => {}}
-      />,
-      TestStubs.routerContext()
+      />
     );
     it('renders', function () {
       expect(wrapper.find('IssueSyncElement')).toHaveLength(0);

--- a/tests/js/spec/components/group/externalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueForm.spec.jsx
@@ -47,8 +47,7 @@ describe('ExternalIssueForm', () => {
         group={group}
         integration={integration}
         onChange={onChange}
-      />,
-      TestStubs.routerContext()
+      />
     );
     component.instance().handleClick(action);
     return component;

--- a/tests/js/spec/components/group/sentryAppExternalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/sentryAppExternalIssueActions.spec.jsx
@@ -49,8 +49,7 @@ describe('SentryAppExternalIssueActions', () => {
             sentryAppInstallation={install}
             sentryAppComponent={component}
           />
-        </Fragment>,
-        TestStubs.routerContext()
+        </Fragment>
       );
     });
 
@@ -175,8 +174,7 @@ describe('SentryAppExternalIssueActions', () => {
           sentryAppComponent={component}
           sentryAppInstallation={install}
           externalIssue={externalIssue}
-        />,
-        TestStubs.routerContext()
+        />
       );
     });
 

--- a/tests/js/spec/components/group/sentryAppExternalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/sentryAppExternalIssueForm.spec.jsx
@@ -43,8 +43,7 @@ describe('SentryAppExternalIssueForm', () => {
           config={component.schema.create}
           action="create"
           api={new Client()}
-        />,
-        TestStubs.routerContext()
+        />
       );
     });
 
@@ -106,8 +105,7 @@ describe('SentryAppExternalIssueForm', () => {
           config={component.schema.link}
           action="link"
           api={new Client()}
-        />,
-        TestStubs.routerContext()
+        />
       );
     });
 
@@ -181,8 +179,7 @@ describe('SentryAppExternalIssueForm Async Field', () => {
           config={component.schema.create}
           action="create"
           api={new Client()}
-        />,
-        TestStubs.routerContext()
+        />
       );
 
       const thisInput = wrapper.find('input').at(0);
@@ -221,8 +218,7 @@ describe('SentryAppExternalIssueForm Dependent fields', () => {
         config={component.schema.create}
         action="create"
         api={new Client()}
-      />,
-      TestStubs.routerContext()
+      />
     );
   });
 

--- a/tests/js/spec/components/highlight.spec.jsx
+++ b/tests/js/spec/components/highlight.spec.jsx
@@ -22,17 +22,13 @@ describe('Highlight', function () {
   });
 
   it('does not have highlighted text if `text` prop is empty', function () {
-    mountWithTheme(<HighlightComponent text="">billy@sentry.io</HighlightComponent>, {
-      context: TestStubs.routerContext(),
-    });
+    mountWithTheme(<HighlightComponent text="">billy@sentry.io</HighlightComponent>);
 
     expect(screen.getByText('billy@sentry.io')).toBeInTheDocument();
   });
 
   it('does not have highlighted text if `disabled` prop is true', function () {
-    mountWithTheme(<HighlightComponent text="">billy@sentry.io</HighlightComponent>, {
-      context: TestStubs.routerContext(),
-    });
+    mountWithTheme(<HighlightComponent text="">billy@sentry.io</HighlightComponent>);
 
     expect(screen.getByText('billy@sentry.io')).toBeInTheDocument();
   });

--- a/tests/js/spec/components/highlight.spec.jsx
+++ b/tests/js/spec/components/highlight.spec.jsx
@@ -5,8 +5,7 @@ import {HighlightComponent} from 'sentry/components/highlight';
 describe('Highlight', function () {
   it('highlights text', function () {
     const wrapper = mountWithTheme(
-      <HighlightComponent text="ILL">billy@sentry.io</HighlightComponent>,
-      {context: TestStubs.routerContext()}
+      <HighlightComponent text="ILL">billy@sentry.io</HighlightComponent>
     );
     expect(wrapper.container.childNodes).toHaveLength(3);
     expect(wrapper.container.childNodes[0]).toHaveTextContent('b');
@@ -16,8 +15,7 @@ describe('Highlight', function () {
 
   it('does not have highlighted text if `text` prop is not found in main text', function () {
     mountWithTheme(
-      <HighlightComponent text="invalid">billy@sentry.io</HighlightComponent>,
-      {context: TestStubs.routerContext()}
+      <HighlightComponent text="invalid">billy@sentry.io</HighlightComponent>
     );
 
     expect(screen.getByText('billy@sentry.io')).toBeInTheDocument();

--- a/tests/js/spec/components/hook.spec.jsx
+++ b/tests/js/spec/components/hook.spec.jsx
@@ -7,7 +7,6 @@ describe('Hook', function () {
   const Wrapper = function Wrapper(props) {
     return <div data-test-id="wrapper" {...props} />;
   };
-  const context = TestStubs.routerContext();
 
   beforeEach(function () {
     HookStore.add('footer', ({organization} = {}) => (
@@ -26,8 +25,7 @@ describe('Hook', function () {
     mountWithTheme(
       <div>
         <Hook name="footer" organization={TestStubs.Organization()} />
-      </div>,
-      {context}
+      </div>
     );
 
     expect(HookStore.hooks.footer).toHaveLength(1);
@@ -40,8 +38,7 @@ describe('Hook', function () {
       <div>
         <Hook name="invalid-hook" organization={TestStubs.Organization()} />
         invalid
-      </div>,
-      {context}
+      </div>
     );
 
     expect(screen.queryByText('org-slug')).not.toBeInTheDocument();
@@ -52,8 +49,7 @@ describe('Hook', function () {
     mountWithTheme(
       <div>
         <Hook name="footer" organization={TestStubs.Organization()} />
-      </div>,
-      {context}
+      </div>
     );
 
     expect(screen.getByTestId('wrapper')).toBeInTheDocument();
@@ -75,8 +71,7 @@ describe('Hook', function () {
         <Hook name="footer" organization={TestStubs.Organization()}>
           {({hooks}) => hooks.map((hook, i) => <Wrapper key={i}>{hook}</Wrapper>)}
         </Hook>
-      </div>,
-      {context}
+      </div>
     );
 
     HookStore.add('footer', () => (

--- a/tests/js/spec/components/idBadge/baseBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/baseBadge.spec.jsx
@@ -8,8 +8,7 @@ describe('BadgeBadge', function () {
       <BaseBadge
         organization={TestStubs.Organization()}
         displayName={<span id="test">display name</span>}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper.find('#test')).toHaveLength(1);
     expect(wrapper.find('#test').text()).toBe('display name');
@@ -17,8 +16,7 @@ describe('BadgeBadge', function () {
 
   it('can hide avatar', function () {
     const wrapper = mountWithTheme(
-      <BaseBadge organization={TestStubs.Organization()} hideAvatar />,
-      TestStubs.routerContext()
+      <BaseBadge organization={TestStubs.Organization()} hideAvatar />
     );
     expect(wrapper.find('StyledAvatar')).toHaveLength(0);
   });
@@ -29,8 +27,7 @@ describe('BadgeBadge', function () {
         organization={TestStubs.Organization()}
         hideName
         displayName={<span id="test">display name</span>}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper.find('#test')).toHaveLength(0);
   });

--- a/tests/js/spec/components/idBadge/index.spec.jsx
+++ b/tests/js/spec/components/idBadge/index.spec.jsx
@@ -3,38 +3,31 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import IdBadge from 'sentry/components/idBadge';
 
 describe('IdBadge', function () {
-  const routerContext = TestStubs.routerContext();
   it('renders the correct component when `user` property is passed', function () {
-    const wrapper = mountWithTheme(<IdBadge user={TestStubs.User()} />, routerContext);
+    const wrapper = mountWithTheme(<IdBadge user={TestStubs.User()} />);
 
     expect(wrapper.find('UserBadge')).toHaveLength(1);
   });
 
   it('renders the correct component when `team` property is passed', function () {
-    const wrapper = mountWithTheme(<IdBadge team={TestStubs.Team()} />, routerContext);
+    const wrapper = mountWithTheme(<IdBadge team={TestStubs.Team()} />);
 
     expect(wrapper.find('[data-test-id="team-badge"]')).toHaveLength(1);
   });
 
   it('renders the correct component when `project` property is passed', function () {
-    const wrapper = mountWithTheme(
-      <IdBadge project={TestStubs.Project()} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<IdBadge project={TestStubs.Project()} />);
 
     expect(wrapper.find('ProjectBadge')).toHaveLength(1);
   });
 
   it('renders the correct component when `organization` property is passed', function () {
-    const wrapper = mountWithTheme(
-      <IdBadge organization={TestStubs.Organization()} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<IdBadge organization={TestStubs.Organization()} />);
 
     expect(wrapper.find('OrganizationBadge')).toHaveLength(1);
   });
 
   it('throws when no valid properties are passed', function () {
-    expect(() => mountWithTheme(<IdBadge />, routerContext)).toThrow();
+    expect(() => mountWithTheme(<IdBadge />)).toThrow();
   });
 });

--- a/tests/js/spec/components/idBadge/organizationBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/organizationBadge.spec.jsx
@@ -5,8 +5,7 @@ import OrganizationBadge from 'sentry/components/idBadge/organizationBadge';
 describe('OrganizationBadge', function () {
   it('renders with Avatar and organization name', function () {
     const wrapper = mountWithTheme(
-      <OrganizationBadge organization={TestStubs.Organization()} />,
-      TestStubs.routerContext()
+      <OrganizationBadge organization={TestStubs.Organization()} />
     );
     expect(wrapper.find('StyledAvatar')).toHaveLength(1);
     expect(wrapper.find('BadgeDisplayName').text()).toEqual('org-slug');

--- a/tests/js/spec/components/idBadge/projectBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/projectBadge.spec.jsx
@@ -4,10 +4,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 
 describe('ProjectBadge', function () {
   it('renders with Avatar and team name', function () {
-    const wrapper = mountWithTheme(
-      <ProjectBadge project={TestStubs.Project()} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<ProjectBadge project={TestStubs.Project()} />);
     expect(wrapper.find('StyledAvatar')).toHaveLength(1);
     expect(wrapper.find('PlatformList')).toHaveLength(1);
     expect(wrapper.find('BadgeDisplayName').text()).toEqual('project-slug');

--- a/tests/js/spec/components/indicators.spec.jsx
+++ b/tests/js/spec/components/indicators.spec.jsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   act,
   mountWithTheme,
@@ -28,8 +27,7 @@ describe('Indicators', function () {
   let wrapper;
 
   beforeEach(function () {
-    const {routerContext} = initializeOrg();
-    wrapper = mountWithTheme(<Indicators />, {context: routerContext});
+    wrapper = mountWithTheme(<Indicators />);
 
     clearIndicators();
     act(jest.runAllTimers);

--- a/tests/js/spec/components/issueDiff.spec.jsx
+++ b/tests/js/spec/components/issueDiff.spec.jsx
@@ -6,7 +6,6 @@ jest.mock('sentry/api');
 
 describe('IssueDiff', function () {
   const entries = TestStubs.Entries();
-  const routerContext = TestStubs.routerContext();
   const api = new MockApiClient();
   const project = TestStubs.ProjectDetails();
 
@@ -66,8 +65,7 @@ describe('IssueDiff', function () {
         targetIssueId="target"
         orgId="org-slug"
         project={project}
-      />,
-      routerContext
+      />
     );
 
     await tick();
@@ -100,8 +98,7 @@ describe('IssueDiff', function () {
         targetIssueId="target"
         orgId="org-slug"
         project={project}
-      />,
-      routerContext
+      />
     );
 
     await tick();

--- a/tests/js/spec/components/modals/createTeamModal.spec.jsx
+++ b/tests/js/spec/components/modals/createTeamModal.spec.jsx
@@ -32,8 +32,7 @@ describe('CreateTeamModal', function () {
         closeModal={closeModal}
         onClose={onClose}
         onSuccess={onSuccess}
-      />,
-      {context: TestStubs.routerContext()}
+      />
     );
 
     userEvent.type(screen.getByText('Team Name'), 'new-team');

--- a/tests/js/spec/components/modals/dashboardWidgetLibraryModal.spec.jsx
+++ b/tests/js/spec/components/modals/dashboardWidgetLibraryModal.spec.jsx
@@ -14,7 +14,6 @@ jest.mock('sentry/actionCreators/modal', () => ({
 }));
 
 function mountModal({initialData}, onApply, closeModal, widgets = []) {
-  const routerContext = TestStubs.routerContext();
   return mountWithTheme(
     <DashboardWidgetLibraryModal
       Header={stubEl}
@@ -30,8 +29,7 @@ function mountModal({initialData}, onApply, closeModal, widgets = []) {
       })}
       onAddWidget={onApply}
       closeModal={closeModal}
-    />,
-    {context: routerContext}
+    />
   );
 }
 

--- a/tests/js/spec/components/modals/emailVerificationModal.spec.js
+++ b/tests/js/spec/components/modals/emailVerificationModal.spec.js
@@ -6,8 +6,7 @@ describe('Email Verification Modal', function () {
   let wrapper;
   beforeEach(function () {
     wrapper = mountWithTheme(
-      <EmailVerificationModal Body={p => p.children} Header={p => p.children} />,
-      TestStubs.routerContext()
+      <EmailVerificationModal Body={p => p.children} Header={p => p.children} />
     );
   });
 
@@ -27,8 +26,7 @@ describe('Email Verification Modal', function () {
         Body={p => p.children}
         Header={p => p.children}
         actionMessage="accepting the tenet"
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper.find('TextBlock').text()).toEqual(
       'Please verify your email before accepting the tenet, or go to your email settings.'

--- a/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
+++ b/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
@@ -41,8 +41,7 @@ describe('InviteMembersModal', function () {
 
   it('renders', async function () {
     const wrapper = mountWithTheme(
-      <InviteMembersModal {...modalProps} organization={org} />,
-      TestStubs.routerContext()
+      <InviteMembersModal {...modalProps} organization={org} />
     );
 
     // Starts with one invite row
@@ -57,8 +56,7 @@ describe('InviteMembersModal', function () {
   it('renders without organization.access', async function () {
     const organization = TestStubs.Organization({access: undefined});
     const wrapper = mountWithTheme(
-      <InviteMembersModal {...modalProps} organization={organization} />,
-      TestStubs.routerContext()
+      <InviteMembersModal {...modalProps} organization={organization} />
     );
 
     expect(wrapper.find('StyledInviteRow').exists()).toBe(true);
@@ -66,8 +64,7 @@ describe('InviteMembersModal', function () {
 
   it('can add a second row', async function () {
     const wrapper = mountWithTheme(
-      <InviteMembersModal {...modalProps} organization={org} />,
-      TestStubs.routerContext()
+      <InviteMembersModal {...modalProps} organization={org} />
     );
 
     expect(wrapper.find('StyledInviteRow')).toHaveLength(1);
@@ -77,8 +74,7 @@ describe('InviteMembersModal', function () {
 
   it('errors on duplicate emails', async function () {
     const wrapper = mountWithTheme(
-      <InviteMembersModal {...modalProps} organization={org} />,
-      TestStubs.routerContext()
+      <InviteMembersModal {...modalProps} organization={org} />
     );
 
     wrapper.find('AddButton').simulate('click');
@@ -103,8 +99,7 @@ describe('InviteMembersModal', function () {
 
   it('indicates the total invites on the invite button', function () {
     const wrapper = mountWithTheme(
-      <InviteMembersModal {...modalProps} organization={org} />,
-      TestStubs.routerContext()
+      <InviteMembersModal {...modalProps} organization={org} />
     );
 
     wrapper
@@ -123,8 +118,7 @@ describe('InviteMembersModal', function () {
     const close = jest.fn();
 
     const wrapper = mountWithTheme(
-      <InviteMembersModal {...modalProps} organization={org} closeModal={close} />,
-      TestStubs.routerContext()
+      <InviteMembersModal {...modalProps} organization={org} closeModal={close} />
     );
 
     wrapper.find('Button[data-test-id="cancel"]').simulate('click');
@@ -138,8 +132,7 @@ describe('InviteMembersModal', function () {
     });
 
     const wrapper = mountWithTheme(
-      <InviteMembersModal {...modalProps} organization={org} />,
-      TestStubs.routerContext()
+      <InviteMembersModal {...modalProps} organization={org} />
     );
 
     wrapper.find('AddButton').simulate('click');
@@ -212,8 +205,7 @@ describe('InviteMembersModal', function () {
     });
 
     const wrapper = mountWithTheme(
-      <InviteMembersModal {...modalProps} organization={org} />,
-      TestStubs.routerContext()
+      <InviteMembersModal {...modalProps} organization={org} />
     );
 
     const inviteRowProps = wrapper.find('StyledInviteRow').first().props();
@@ -245,8 +237,7 @@ describe('InviteMembersModal', function () {
     const initialData = [{emails: new Set([initialEmail])}];
 
     const wrapper = mountWithTheme(
-      <InviteMembersModal {...modalProps} organization={org} initialData={initialData} />,
-      TestStubs.routerContext()
+      <InviteMembersModal {...modalProps} organization={org} initialData={initialData} />
     );
 
     expect(wrapper.find('MultiValue').first().text().includes(initialEmail)).toBe(true);
@@ -278,8 +269,7 @@ describe('InviteMembersModal', function () {
     ];
 
     const wrapper = mountWithTheme(
-      <InviteMembersModal {...modalProps} organization={org} initialData={initialData} />,
-      TestStubs.routerContext()
+      <InviteMembersModal {...modalProps} organization={org} initialData={initialData} />
     );
 
     expect(
@@ -317,8 +307,7 @@ describe('InviteMembersModal', function () {
   describe('member invite request mode', function () {
     it('has adjusted wording', function () {
       const wrapper = mountWithTheme(
-        <InviteMembersModal {...modalProps} organization={noWriteOrg} />,
-        TestStubs.routerContext()
+        <InviteMembersModal {...modalProps} organization={noWriteOrg} />
       );
 
       expect(wrapper.find('Button[data-test-id="send-invites"]').text()).toBe(
@@ -335,8 +324,7 @@ describe('InviteMembersModal', function () {
       });
 
       const wrapper = mountWithTheme(
-        <InviteMembersModal {...modalProps} organization={noWriteOrg} />,
-        TestStubs.routerContext()
+        <InviteMembersModal {...modalProps} organization={noWriteOrg} />
       );
 
       const inviteRowProps = wrapper.find('StyledInviteRow').first().props();

--- a/tests/js/spec/components/modals/recoveryOptionsModal.spec.jsx
+++ b/tests/js/spec/components/modals/recoveryOptionsModal.spec.jsx
@@ -22,8 +22,7 @@ describe('RecoveryOptionsModal', function () {
         authenticatorName="Authenticator App"
         closeModal={closeModal}
         onClose={onClose}
-      />,
-      TestStubs.routerContext()
+      />
     );
   });
 
@@ -73,8 +72,7 @@ describe('RecoveryOptionsModal', function () {
         authenticatorName="Authenticator App"
         closeModal={closeModal}
         onClose={onClose}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const mockId = TestStubs.Authenticators().Recovery().authId;
     expect(

--- a/tests/js/spec/components/modals/redirectToProject.spec.jsx
+++ b/tests/js/spec/components/modals/redirectToProject.spec.jsx
@@ -27,8 +27,7 @@ describe('RedirectToProjectModal', function () {
         slug="new-slug"
         Header={p => p.children}
         Body={p => p.children}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     jest.advanceTimersByTime(4900);

--- a/tests/js/spec/components/modals/sentryAppDetailsModal.spec.jsx
+++ b/tests/js/spec/components/modals/sentryAppDetailsModal.spec.jsx
@@ -20,8 +20,7 @@ describe('SentryAppDetailsModal', function () {
         onInstall={onInstall}
         isInstalled={isInstalled}
         closeModal={closeModal}
-      />,
-      TestStubs.routerContext()
+      />
     );
   }
 

--- a/tests/js/spec/components/modals/sudoModal.spec.jsx
+++ b/tests/js/spec/components/modals/sudoModal.spec.jsx
@@ -45,10 +45,7 @@ describe('Sudo Modal', function () {
   it('can delete an org with sudo flow', async function () {
     setHasPasswordAuth(true);
 
-    const wrapper = mountWithTheme(
-      <App>{<div>placeholder content</div>}</App>,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<App>{<div>placeholder content</div>}</App>);
 
     const api = new Client();
     const successCb = jest.fn();
@@ -130,10 +127,7 @@ describe('Sudo Modal', function () {
   it('shows button to redirect if user does not have password auth', async function () {
     setHasPasswordAuth(false);
 
-    const wrapper = mountWithTheme(
-      <App>{<div>placeholder content</div>}</App>,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<App>{<div>placeholder content</div>}</App>);
 
     const api = new Client();
     const successCb = jest.fn();

--- a/tests/js/spec/components/modals/teamAccessRequestModal.spec.jsx
+++ b/tests/js/spec/components/modals/teamAccessRequestModal.spec.jsx
@@ -28,8 +28,7 @@ describe('TeamAccessRequestModal', function () {
         teamId={teamId}
         memberId={memberId}
         {...modalRenderProps}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     createMock = MockApiClient.addMockResponse({

--- a/tests/js/spec/components/platformPicker.spec.jsx
+++ b/tests/js/spec/components/platformPicker.spec.jsx
@@ -82,10 +82,7 @@ describe('PlatformPicker', function () {
         ...baseProps,
       };
 
-      const wrapper = mountWithTheme(
-        <PlatformPicker {...props} />,
-        TestStubs.routerContext()
-      );
+      const wrapper = mountWithTheme(<PlatformPicker {...props} />);
 
       const testListLink = wrapper.find('ListLink').last().find('a');
       expect(wrapper.state().category).toBe('popular');
@@ -101,10 +98,7 @@ describe('PlatformPicker', function () {
         setPlatform: jest.fn(),
       };
 
-      const wrapper = mountWithTheme(
-        <PlatformPicker {...props} />,
-        TestStubs.routerContext()
-      );
+      const wrapper = mountWithTheme(<PlatformPicker {...props} />);
 
       wrapper.find('ClearButton').simulate('click');
       expect(props.setPlatform).toHaveBeenCalledWith(null);

--- a/tests/js/spec/components/projects/bookmarkStar.spec.jsx
+++ b/tests/js/spec/components/projects/bookmarkStar.spec.jsx
@@ -10,8 +10,7 @@ describe('BookmarkStar', function () {
       <BookmarkStar
         organization={TestStubs.Organization()}
         project={TestStubs.Project()}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     projectMock = MockApiClient.addMockResponse({
@@ -53,8 +52,7 @@ describe('BookmarkStar', function () {
         project={TestStubs.Project({
           isBookmarked: true,
         })}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const star = wrapper.find('BookmarkStar');
 
@@ -78,8 +76,7 @@ describe('BookmarkStar', function () {
         organization={TestStubs.Organization()}
         project={TestStubs.Project()}
         isBookmarked
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const star = wrapper.find('BookmarkStar');

--- a/tests/js/spec/components/search/sources/apiSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/apiSource.spec.jsx
@@ -84,8 +84,7 @@ describe('ApiSource', function () {
     wrapper = mountWithTheme(
       <ApiSource params={{orgId: org.slug}} query="foo">
         {mock}
-      </ApiSource>,
-      TestStubs.routerContext()
+      </ApiSource>
     );
 
     expect(orgsMock).toHaveBeenCalled();
@@ -101,8 +100,7 @@ describe('ApiSource', function () {
     wrapper = mountWithTheme(
       <ApiSource params={{orgId: org.slug}} query="test-">
         {mock}
-      </ApiSource>,
-      TestStubs.routerContext()
+      </ApiSource>
     );
 
     await tick();
@@ -146,8 +144,7 @@ describe('ApiSource', function () {
     wrapper = mountWithTheme(
       <ApiSource params={{orgId: org.slug}} query="1234567890123456789012345678901">
         {mock}
-      </ApiSource>,
-      TestStubs.routerContext()
+      </ApiSource>
     );
 
     await tick();
@@ -192,8 +189,7 @@ describe('ApiSource', function () {
     wrapper = mountWithTheme(
       <ApiSource params={{}} query="foo">
         {mock}
-      </ApiSource>,
-      TestStubs.routerContext()
+      </ApiSource>
     );
 
     expect(orgsMock).toHaveBeenCalled();
@@ -207,8 +203,7 @@ describe('ApiSource', function () {
     wrapper = mountWithTheme(
       <ApiSource params={{orgId: org.slug}} organization={org} query="foo">
         {mock}
-      </ApiSource>,
-      TestStubs.routerContext()
+      </ApiSource>
     );
 
     await tick();
@@ -295,8 +290,7 @@ describe('ApiSource', function () {
     wrapper = mountWithTheme(
       <ApiSource params={{orgId: org.slug}} query="foo">
         {mock}
-      </ApiSource>,
-      TestStubs.routerContext()
+      </ApiSource>
     );
 
     await tick();
@@ -338,8 +332,7 @@ describe('ApiSource', function () {
     wrapper = mountWithTheme(
       <ApiSource params={{orgId: org.slug}} query="foo">
         {mock}
-      </ApiSource>,
-      TestStubs.routerContext()
+      </ApiSource>
     );
 
     await tick();
@@ -367,8 +360,7 @@ describe('ApiSource', function () {
       wrapper = mountWithTheme(
         <ApiSource params={{orgId: org.slug}} query="">
           {mock}
-        </ApiSource>,
-        TestStubs.routerContext()
+        </ApiSource>
       );
     });
 

--- a/tests/js/spec/components/settingsBreadcrumbDropdown.spec.jsx
+++ b/tests/js/spec/components/settingsBreadcrumbDropdown.spec.jsx
@@ -14,8 +14,7 @@ describe('Settings Breadcrumb Dropdown', function () {
 
   beforeEach(function () {
     wrapper = mountWithTheme(
-      <BreadcrumbDropdown items={items} name="Test" hasMenu onSelect={selectMock} />,
-      TestStubs.routerContext()
+      <BreadcrumbDropdown items={items} name="Test" hasMenu onSelect={selectMock} />
     );
   });
 

--- a/tests/js/spec/components/sidebar/switchOrganization.spec.jsx
+++ b/tests/js/spec/components/sidebar/switchOrganization.spec.jsx
@@ -3,16 +3,12 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {SwitchOrganization} from 'sentry/components/sidebar/sidebarDropdown/switchOrganization';
 
 describe('SwitchOrganization', function () {
-  const routerContext = TestStubs.routerContext();
-  const {organization} = routerContext.context;
-
   it('can list organizations', function () {
     jest.useFakeTimers();
     const wrapper = mountWithTheme(
       <SwitchOrganization
-        organizations={[organization, TestStubs.Organization({slug: 'org2'})]}
-      />,
-      routerContext
+        organizations={[TestStubs.Organization(), TestStubs.Organization({slug: 'org2'})]}
+      />
     );
 
     wrapper.find('SwitchOrganizationMenuActor').simulate('mouseEnter');
@@ -27,10 +23,9 @@ describe('SwitchOrganization', function () {
     jest.useFakeTimers();
     const wrapper = mountWithTheme(
       <SwitchOrganization
-        organizations={[organization, TestStubs.Organization({slug: 'org2'})]}
+        organizations={[TestStubs.Organization(), TestStubs.Organization({slug: 'org2'})]}
         canCreateOrganization
-      />,
-      routerContext
+      />
     );
 
     wrapper.find('SwitchOrganizationMenuActor').simulate('mouseEnter');
@@ -46,10 +41,9 @@ describe('SwitchOrganization', function () {
     jest.useFakeTimers();
     const wrapper = mountWithTheme(
       <SwitchOrganization
-        organizations={[organization, TestStubs.Organization({slug: 'org2'})]}
+        organizations={[TestStubs.Organization(), TestStubs.Organization({slug: 'org2'})]}
         canCreateOrganization={false}
-      />,
-      routerContext
+      />
     );
 
     wrapper.find('SwitchOrganizationMenuActor').simulate('mouseEnter');

--- a/tests/js/spec/components/tooltip.spec.jsx
+++ b/tests/js/spec/components/tooltip.spec.jsx
@@ -23,12 +23,10 @@ describe('Tooltip', function () {
   });
 
   it('updates title', async function () {
-    const context = TestStubs.routerContext();
     const {rerender} = mountWithTheme(
       <Tooltip delay={0} title="test">
         <span>My Button</span>
-      </Tooltip>,
-      {context}
+      </Tooltip>
     );
 
     // Change title

--- a/tests/js/spec/components/tooltip.spec.jsx
+++ b/tests/js/spec/components/tooltip.spec.jsx
@@ -49,8 +49,7 @@ describe('Tooltip', function () {
     mountWithTheme(
       <Tooltip delay={0} title="test" disabled>
         <span>My Button</span>
-      </Tooltip>,
-      {context: TestStubs.routerContext()}
+      </Tooltip>
     );
 
     userEvent.hover(screen.getByText('My Button'));
@@ -64,8 +63,7 @@ describe('Tooltip', function () {
     mountWithTheme(
       <Tooltip delay={0} title="">
         <span>My Button</span>
-      </Tooltip>,
-      {context: TestStubs.routerContext()}
+      </Tooltip>
     );
     userEvent.hover(screen.getByText('My Button'));
 
@@ -80,8 +78,7 @@ describe('Tooltip', function () {
     mountWithTheme(
       <Tooltip delay={0} title="test" showOnlyOnOverflow>
         <div>This text overflows</div>
-      </Tooltip>,
-      {context: TestStubs.routerContext()}
+      </Tooltip>
     );
 
     userEvent.hover(screen.getByText('This text overflows'));
@@ -96,8 +93,7 @@ describe('Tooltip', function () {
     mountWithTheme(
       <Tooltip delay={0} title="test" showOnlyOnOverflow>
         <div>This text does not overflow</div>
-      </Tooltip>,
-      {context: TestStubs.routerContext()}
+      </Tooltip>
     );
 
     userEvent.hover(screen.getByText('This text does not overflow'));

--- a/tests/js/spec/components/version.spec.tsx
+++ b/tests/js/spec/components/version.spec.tsx
@@ -11,13 +11,13 @@ describe('Version', () => {
   });
 
   it('renders', () => {
-    const {container} = mountWithTheme(<Version version={VERSION} />, {context});
+    const {container} = mountWithTheme(<Version version={VERSION} />);
     expect(container).toSnapshot();
   });
 
   it('shows correct parsed version', () => {
     // component uses @sentry/release-parser package for parsing versions
-    mountWithTheme(<Version version={VERSION} />, {context});
+    mountWithTheme(<Version version={VERSION} />);
 
     expect(screen.getByText('1.0.0 (20200101)')).toBeInTheDocument();
   });

--- a/tests/js/spec/reactTestingLibrary.spec.tsx
+++ b/tests/js/spec/reactTestingLibrary.spec.tsx
@@ -18,10 +18,7 @@ describe('rerender', () => {
   };
 
   test('calling render with the same component on the same container does not remount', () => {
-    const {rerender} = mountWithTheme(<NumberDisplay number={1} />, {
-      // Passing a context caused rerender to re-mount if the wrapper is not setup correctly
-      context: TestStubs.routerContext(),
-    });
+    const {rerender} = mountWithTheme(<NumberDisplay number={1} />);
     expect(screen.getByTestId('number-display')).toHaveTextContent('1');
 
     // re-render the same component with different props

--- a/tests/js/spec/utils/eventWaiter.spec.jsx
+++ b/tests/js/spec/utils/eventWaiter.spec.jsx
@@ -29,8 +29,7 @@ describe('EventWaiter', function () {
         pollInterval={10}
       >
         {child}
-      </EventWaiter>,
-      TestStubs.routerContext()
+      </EventWaiter>
     );
 
     expect(child).toHaveBeenCalledWith({firstIssue: null});
@@ -104,8 +103,7 @@ describe('EventWaiter', function () {
         pollInterval={10}
       >
         {child}
-      </EventWaiter>,
-      TestStubs.routerContext()
+      </EventWaiter>
     );
 
     // We have to await *two* API calls. We could normally do this using tick(),
@@ -145,8 +143,7 @@ describe('EventWaiter', function () {
         disabled
       >
         {child}
-      </EventWaiter>,
-      TestStubs.routerContext()
+      </EventWaiter>
     );
 
     expect(child).toHaveBeenCalledWith({firstIssue: null});

--- a/tests/js/spec/utils/performance/contexts/pageError.spec.jsx
+++ b/tests/js/spec/utils/performance/contexts/pageError.spec.jsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {
@@ -18,10 +17,6 @@ function SimpleErrorButton() {
 }
 
 describe('Performance > Contexts > pageError', function () {
-  const {routerContext} = initializeOrg({
-    router: {orgId: 'orgId'},
-  });
-
   it('Check that pageError context will render error alert', async function () {
     mountWithTheme(
       <PageErrorProvider>
@@ -29,8 +24,7 @@ describe('Performance > Contexts > pageError', function () {
           <PageErrorAlert />
         </div>
         <SimpleErrorButton />
-      </PageErrorProvider>,
-      {context: routerContext}
+      </PageErrorProvider>
     );
 
     const button = await screen.findByTestId('pageErrorButton');

--- a/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
+++ b/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
@@ -26,8 +26,7 @@ describe('AcceptOrganizationInvite', function () {
     });
 
     const wrapper = mountWithTheme(
-      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />,
-      TestStubs.routerContext()
+      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />
     );
 
     const joinButton = wrapper.find('Button[aria-label="join-organization"]');
@@ -61,8 +60,7 @@ describe('AcceptOrganizationInvite', function () {
     });
 
     const wrapper = mountWithTheme(
-      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />,
-      TestStubs.routerContext()
+      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />
     );
 
     const joinButton = wrapper.find('Button[aria-label="join-organization"]');
@@ -87,8 +85,7 @@ describe('AcceptOrganizationInvite', function () {
     });
 
     const wrapper = mountWithTheme(
-      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />,
-      TestStubs.routerContext()
+      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />
     );
 
     const joinButton = wrapper.find('Button[aria-label="join-organization"]');
@@ -113,8 +110,7 @@ describe('AcceptOrganizationInvite', function () {
     });
 
     const wrapper = mountWithTheme(
-      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />,
-      TestStubs.routerContext()
+      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />
     );
 
     const joinButton = wrapper.find('Button[aria-label="join-organization"]');
@@ -139,8 +135,7 @@ describe('AcceptOrganizationInvite', function () {
     });
 
     const wrapper = mountWithTheme(
-      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />,
-      TestStubs.routerContext()
+      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />
     );
 
     const joinButton = wrapper.find('Button[aria-label="join-organization"]');
@@ -165,8 +160,7 @@ describe('AcceptOrganizationInvite', function () {
     });
 
     const wrapper = mountWithTheme(
-      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />,
-      TestStubs.routerContext()
+      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />
     );
 
     const existingMember = wrapper.find('[data-test-id="existing-member"]');
@@ -197,8 +191,7 @@ describe('AcceptOrganizationInvite', function () {
     });
 
     const wrapper = mountWithTheme(
-      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />,
-      TestStubs.routerContext()
+      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />
     );
 
     const ssoLink = wrapper.find('[data-test-id="action-info-sso"]');
@@ -219,8 +212,7 @@ describe('AcceptOrganizationInvite', function () {
     });
 
     const wrapper = mountWithTheme(
-      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />,
-      TestStubs.routerContext()
+      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />
     );
 
     const existingMember = wrapper.find('[data-test-id="existing-member"]');
@@ -251,8 +243,7 @@ describe('AcceptOrganizationInvite', function () {
     });
 
     const wrapper = mountWithTheme(
-      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />,
-      TestStubs.routerContext()
+      <AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />
     );
 
     expect(wrapper.find('[data-test-id="2fa-warning"]').exists()).toBe(true);

--- a/tests/js/spec/views/acceptProjectTransfer.spec.jsx
+++ b/tests/js/spec/views/acceptProjectTransfer.spec.jsx
@@ -32,8 +32,7 @@ describe('AcceptProjectTransfer', function () {
           pathname: 'endpoint',
           query: {data: 'XYZ'},
         }}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     expect(getMock).toHaveBeenCalled();
@@ -46,8 +45,7 @@ describe('AcceptProjectTransfer', function () {
           pathname: 'endpoint',
           query: {data: 'XYZ'},
         }}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     wrapper.find('form').simulate('submit');

--- a/tests/js/spec/views/accountClose.spec.jsx
+++ b/tests/js/spec/views/accountClose.spec.jsx
@@ -32,7 +32,7 @@ describe('AccountClose', function () {
   });
 
   it('lists all orgs user is an owner of', async function () {
-    const wrapper = mountWithTheme(<AccountClose />, TestStubs.routerContext());
+    const wrapper = mountWithTheme(<AccountClose />);
 
     // Input for single owner org
     expect(wrapper.find('input').first().prop('checked')).toBe(true);

--- a/tests/js/spec/views/accountDetail.spec.jsx
+++ b/tests/js/spec/views/accountDetail.spec.jsx
@@ -20,10 +20,7 @@ describe('AccountDetails', function () {
   });
 
   it('renders', function () {
-    const wrapper = mountWithTheme(
-      <AccountDetails location={{}} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<AccountDetails location={{}} />);
 
     expect(wrapper.find('input[name="name"]')).toHaveLength(1);
 
@@ -36,10 +33,7 @@ describe('AccountDetails', function () {
 
   it('has username field if it is different than email', function () {
     mockUserDetails({username: 'different@example.com'});
-    const wrapper = mountWithTheme(
-      <AccountDetails location={{}} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<AccountDetails location={{}} />);
 
     expect(wrapper.find('input[name="username"]')).toHaveLength(1);
     expect(wrapper.find('input[name="username"]').prop('disabled')).toBe(false);
@@ -48,10 +42,7 @@ describe('AccountDetails', function () {
   describe('Managed User', function () {
     it('does not have password fields', function () {
       mockUserDetails({isManaged: true});
-      const wrapper = mountWithTheme(
-        <AccountDetails location={{}} />,
-        TestStubs.routerContext()
-      );
+      const wrapper = mountWithTheme(<AccountDetails location={{}} />);
 
       expect(wrapper.find('input[name="name"]')).toHaveLength(1);
       expect(wrapper.find('input[name="password"]')).toHaveLength(0);
@@ -60,10 +51,7 @@ describe('AccountDetails', function () {
 
     it('has disabled username field if it is different than email', function () {
       mockUserDetails({isManaged: true, username: 'different@example.com'});
-      const wrapper = mountWithTheme(
-        <AccountDetails location={{}} />,
-        TestStubs.routerContext()
-      );
+      const wrapper = mountWithTheme(<AccountDetails location={{}} />);
 
       expect(wrapper.find('input[name="username"]')).toHaveLength(1);
       expect(wrapper.find('input[name="username"]').prop('disabled')).toBe(true);

--- a/tests/js/spec/views/accountEmails.spec.jsx
+++ b/tests/js/spec/views/accountEmails.spec.jsx
@@ -17,7 +17,7 @@ describe('AccountEmails', function () {
   });
 
   it('renders with emails', function () {
-    const wrapper = mountWithTheme(<AccountEmails />, TestStubs.routerContext());
+    const wrapper = mountWithTheme(<AccountEmails />);
 
     expect(wrapper).toSnapshot();
   });
@@ -29,7 +29,7 @@ describe('AccountEmails', function () {
       statusCode: 200,
     });
 
-    const wrapper = mountWithTheme(<AccountEmails />, TestStubs.routerContext());
+    const wrapper = mountWithTheme(<AccountEmails />);
 
     expect(mock).not.toHaveBeenCalled();
 
@@ -54,7 +54,7 @@ describe('AccountEmails', function () {
       statusCode: 200,
     });
 
-    const wrapper = mountWithTheme(<AccountEmails />, TestStubs.routerContext());
+    const wrapper = mountWithTheme(<AccountEmails />);
 
     expect(mock).not.toHaveBeenCalled();
 
@@ -79,7 +79,7 @@ describe('AccountEmails', function () {
       statusCode: 200,
     });
 
-    const wrapper = mountWithTheme(<AccountEmails />, TestStubs.routerContext());
+    const wrapper = mountWithTheme(<AccountEmails />);
 
     expect(mock).not.toHaveBeenCalled();
 
@@ -102,7 +102,7 @@ describe('AccountEmails', function () {
       method: 'POST',
       statusCode: 200,
     });
-    const wrapper = mountWithTheme(<AccountEmails />, TestStubs.routerContext());
+    const wrapper = mountWithTheme(<AccountEmails />);
 
     expect(mock).not.toHaveBeenCalled();
 

--- a/tests/js/spec/views/accountIdentities.spec.jsx
+++ b/tests/js/spec/views/accountIdentities.spec.jsx
@@ -18,7 +18,7 @@ describe('AccountIdentities', function () {
       body: [],
     });
 
-    const wrapper = mountWithTheme(<AccountIdentities />, TestStubs.routerContext());
+    const wrapper = mountWithTheme(<AccountIdentities />);
 
     expect(wrapper).toSnapshot();
   });
@@ -41,7 +41,7 @@ describe('AccountIdentities', function () {
       ],
     });
 
-    const wrapper = mountWithTheme(<AccountIdentities />, TestStubs.routerContext());
+    const wrapper = mountWithTheme(<AccountIdentities />);
     expect(wrapper).toSnapshot();
   });
 
@@ -63,7 +63,7 @@ describe('AccountIdentities', function () {
       ],
     });
 
-    const wrapper = mountWithTheme(<AccountIdentities />, TestStubs.routerContext());
+    const wrapper = mountWithTheme(<AccountIdentities />);
 
     const disconnectRequest = {
       url: `${ENDPOINT}social-identity/1/`,

--- a/tests/js/spec/views/addCodeOwnerModal.spec.jsx
+++ b/tests/js/spec/views/addCodeOwnerModal.spec.jsx
@@ -38,8 +38,7 @@ describe('AddCodeOwnerModal', function () {
         project={project}
         codeMappings={[codeMapping]}
         onSave={() => {}}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper.find('Button').prop('disabled')).toBe(true);
   });
@@ -58,8 +57,7 @@ describe('AddCodeOwnerModal', function () {
         project={project}
         codeMappings={[codeMapping]}
         onSave={() => {}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     selectByValue(wrapper, codeMapping.id, {name: 'codeMappingId'});
@@ -86,8 +84,7 @@ describe('AddCodeOwnerModal', function () {
         project={project}
         codeMappings={[codeMapping]}
         onSave={() => {}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     selectByValue(wrapper, codeMapping.id, {name: 'codeMappingId'});
@@ -118,8 +115,7 @@ describe('AddCodeOwnerModal', function () {
         project={project}
         codeMappings={[codeMapping]}
         onSave={() => {}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     selectByValue(wrapper, codeMapping.id, {name: 'codeMappingId'});

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -126,7 +126,7 @@ describe('ProjectAlertsCreate', function () {
   });
 
   const createWrapper = (props = {}, location = {}) => {
-    const {organization, project, routerContext, router} = initializeOrg(props);
+    const {organization, project, router} = initializeOrg(props);
     ProjectsStore.loadInitialData([project]);
     const params = {orgId: organization.slug, projectId: project.slug};
     const wrapper = mountWithTheme(
@@ -144,7 +144,7 @@ describe('ProjectAlertsCreate', function () {
           />
         </AlertBuilderProjectProvider>
       </AlertsContainer>,
-      {context: routerContext, organization}
+      {organization}
     );
     mockRouterPush(wrapper, router);
 

--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -34,7 +34,7 @@ describe('AlertRuleDetails', () => {
           {...props}
         />
       </RuleDetailsContainer>,
-      {context: context.routerContext, organization}
+      {organization}
     );
   };
 

--- a/tests/js/spec/views/alerts/incidentRules/create.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/create.spec.jsx
@@ -38,15 +38,14 @@ describe('Incident Rules Create', function () {
   });
 
   it('renders', function () {
-    const {organization, project, routerContext} = initializeOrg();
+    const {organization, project} = initializeOrg();
     mountWithTheme(
       <IncidentRulesCreate
         params={{orgId: organization.slug, projectId: project.slug}}
         organization={organization}
         project={project}
         userTeamIds={[]}
-      />,
-      {context: routerContext}
+      />
     );
 
     expect(eventStatsMock).toHaveBeenCalledWith(

--- a/tests/js/spec/views/alerts/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/details.spec.jsx
@@ -58,7 +58,7 @@ describe('Incident Rules Details', function () {
   });
 
   it('renders and edits trigger', async function () {
-    const {organization, project, routerContext} = initializeOrg();
+    const {organization, project} = initializeOrg();
     const rule = TestStubs.IncidentRule();
     const onChangeTitleMock = jest.fn();
     const req = MockApiClient.addMockResponse({
@@ -90,8 +90,7 @@ describe('Incident Rules Details', function () {
           onChangeTitle={onChangeTitleMock}
           project={project}
         />
-      </Fragment>,
-      {context: routerContext}
+      </Fragment>
     );
 
     // has existing trigger
@@ -163,7 +162,7 @@ describe('Incident Rules Details', function () {
   });
 
   it('clears trigger', async function () {
-    const {organization, project, routerContext} = initializeOrg();
+    const {organization, project} = initializeOrg();
     const rule = TestStubs.IncidentRule();
     rule.triggers.push({label: 'warning', alertThreshold: 13, actions: []});
     rule.resolveThreshold = 12;
@@ -198,8 +197,7 @@ describe('Incident Rules Details', function () {
           onChangeTitle={onChangeTitleMock}
           project={project}
         />
-      </Fragment>,
-      {context: routerContext}
+      </Fragment>
     );
 
     // has existing trigger

--- a/tests/js/spec/views/alerts/incidentRules/triggersChart.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/triggersChart.spec.jsx
@@ -31,7 +31,7 @@ describe('Incident Rules Create', () => {
   });
 
   it('renders a metric', async () => {
-    const {organization, project, routerContext} = initializeOrg();
+    const {organization, project} = initializeOrg();
     mountWithTheme(
       <TriggersChart
         api={api}
@@ -41,8 +41,7 @@ describe('Incident Rules Create', () => {
         timeWindow={1}
         aggregate="count()"
         triggers={[]}
-      />,
-      {context: routerContext}
+      />
     );
 
     await tick();

--- a/tests/js/spec/views/alerts/issueRuleEditor/sentryAppRuleModal.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/sentryAppRuleModal.spec.jsx
@@ -79,8 +79,7 @@ describe('SentryAppRuleModal', function () {
         action="create"
         onSubmitSuccess={() => {}}
         {...props}
-      />,
-      {context: TestStubs.routerContext()}
+      />
     );
   };
 

--- a/tests/js/spec/views/apiTokenRow.spec.jsx
+++ b/tests/js/spec/views/apiTokenRow.spec.jsx
@@ -5,8 +5,7 @@ import ApiTokenRow from 'sentry/views/settings/account/apiTokenRow';
 describe('ApiTokenRow', function () {
   it('renders', function () {
     const wrapper = mountWithTheme(
-      <ApiTokenRow onRemove={() => {}} token={TestStubs.ApiToken()} />,
-      TestStubs.routerContext()
+      <ApiTokenRow onRemove={() => {}} token={TestStubs.ApiToken()} />
     );
 
     // Should be loading
@@ -16,8 +15,7 @@ describe('ApiTokenRow', function () {
   it('calls onRemove callback when trash can is clicked', function () {
     const cb = jest.fn();
     const wrapper = mountWithTheme(
-      <ApiTokenRow onRemove={cb} token={TestStubs.ApiToken()} />,
-      TestStubs.routerContext()
+      <ApiTokenRow onRemove={cb} token={TestStubs.ApiToken()} />
     );
 
     wrapper.find('Button').simulate('click');

--- a/tests/js/spec/views/apiTokens.spec.jsx
+++ b/tests/js/spec/views/apiTokens.spec.jsx
@@ -6,8 +6,6 @@ import {ApiTokens} from 'sentry/views/settings/account/apiTokens';
 const organization = TestStubs.Organization();
 
 describe('ApiTokens', function () {
-  const routerContext = TestStubs.routerContext();
-
   beforeEach(function () {
     Client.clearMockResponses();
   });
@@ -18,10 +16,7 @@ describe('ApiTokens', function () {
       body: null,
     });
 
-    const wrapper = mountWithTheme(
-      <ApiTokens organization={organization} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<ApiTokens organization={organization} />);
 
     // Should be loading
     expect(wrapper).toSnapshot();
@@ -33,10 +28,7 @@ describe('ApiTokens', function () {
       body: [TestStubs.ApiToken()],
     });
 
-    const wrapper = mountWithTheme(
-      <ApiTokens organization={organization} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<ApiTokens organization={organization} />);
 
     // Should be loading
     expect(wrapper).toSnapshot();
@@ -55,10 +47,7 @@ describe('ApiTokens', function () {
 
     expect(mock).not.toHaveBeenCalled();
 
-    const wrapper = mountWithTheme(
-      <ApiTokens organization={organization} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<ApiTokens organization={organization} />);
 
     wrapper.find('button[aria-label="Remove"]').simulate('click');
 

--- a/tests/js/spec/views/auth/loginForm.spec.jsx
+++ b/tests/js/spec/views/auth/loginForm.spec.jsx
@@ -20,7 +20,6 @@ function doLogin(wrapper, apiRequest) {
 }
 
 describe('LoginForm', function () {
-  const routerContext = TestStubs.routerContext();
   const api = new MockApiClient();
 
   it('handles errors', async function () {
@@ -35,10 +34,7 @@ describe('LoginForm', function () {
 
     const authConfig = {};
 
-    const wrapper = mountWithTheme(
-      <LoginForm api={api} authConfig={authConfig} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<LoginForm api={api} authConfig={authConfig} />);
     doLogin(wrapper, mockRequest);
 
     await tick();
@@ -64,10 +60,7 @@ describe('LoginForm', function () {
     });
 
     const authConfig = {};
-    const wrapper = mountWithTheme(
-      <LoginForm api={api} authConfig={authConfig} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<LoginForm api={api} authConfig={authConfig} />);
 
     doLogin(wrapper, mockRequest);
 
@@ -83,10 +76,7 @@ describe('LoginForm', function () {
       githubLoginLink: '/githubLogin',
     };
 
-    const wrapper = mountWithTheme(
-      <LoginForm api={api} authConfig={authConfig} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<LoginForm api={api} authConfig={authConfig} />);
 
     expect(wrapper.find('ProviderWrapper Button').map(b => b.props().href)).toEqual(
       expect.arrayContaining(['/vstsLogin', '/githubLogin'])

--- a/tests/js/spec/views/auth/registerForm.spec.jsx
+++ b/tests/js/spec/views/auth/registerForm.spec.jsx
@@ -26,7 +26,6 @@ function doLogin(wrapper, apiRequest) {
 }
 
 describe('Register', function () {
-  const routerContext = TestStubs.routerContext();
   const api = new MockApiClient();
 
   it('handles errors', async function () {
@@ -41,10 +40,7 @@ describe('Register', function () {
 
     const authConfig = {};
 
-    const wrapper = mountWithTheme(
-      <RegisterForm api={api} authConfig={authConfig} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<RegisterForm api={api} authConfig={authConfig} />);
     doLogin(wrapper, mockRequest);
 
     await tick();
@@ -70,10 +66,7 @@ describe('Register', function () {
     });
 
     const authConfig = {};
-    const wrapper = mountWithTheme(
-      <RegisterForm api={api} authConfig={authConfig} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<RegisterForm api={api} authConfig={authConfig} />);
 
     doLogin(wrapper, mockRequest);
 

--- a/tests/js/spec/views/auth/ssoForm.spec.jsx
+++ b/tests/js/spec/views/auth/ssoForm.spec.jsx
@@ -16,7 +16,6 @@ function doSso(wrapper, apiRequest) {
 }
 
 describe('SsoForm', function () {
-  const routerContext = TestStubs.routerContext();
   const api = new MockApiClient();
 
   it('renders', function () {
@@ -24,10 +23,7 @@ describe('SsoForm', function () {
       serverHostname: 'testserver',
     };
 
-    const wrapper = mountWithTheme(
-      <SsoForm api={api} authConfig={authConfig} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<SsoForm api={api} authConfig={authConfig} />);
 
     expect(wrapper.find('.help-block').text()).toBe(
       'Your ID is the slug after the hostname. e.g. testserver/acme is acme.'
@@ -46,10 +42,7 @@ describe('SsoForm', function () {
 
     const authConfig = {};
 
-    const wrapper = mountWithTheme(
-      <SsoForm api={api} authConfig={authConfig} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<SsoForm api={api} authConfig={authConfig} />);
     doSso(wrapper, mockRequest);
 
     await tick();
@@ -69,10 +62,7 @@ describe('SsoForm', function () {
     });
 
     const authConfig = {};
-    const wrapper = mountWithTheme(
-      <SsoForm api={api} authConfig={authConfig} />,
-      routerContext
-    );
+    const wrapper = mountWithTheme(<SsoForm api={api} authConfig={authConfig} />);
 
     doSso(wrapper, mockRequest);
 

--- a/tests/js/spec/views/dashboardsV2/manage/index.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/manage/index.spec.jsx
@@ -90,8 +90,7 @@ describe('Dashboards > Detail', function () {
     const org = TestStubs.Organization({features: FEATURES});
 
     const wrapper = mountWithTheme(
-      <ManageDashboards organization={org} location={{query: {}}} router={{}} />,
-      TestStubs.routerContext()
+      <ManageDashboards organization={org} location={{query: {}}} router={{}} />
     );
     await tick();
 

--- a/tests/js/spec/views/dashboardsV2/metricsWidgetQueries.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/metricsWidgetQueries.spec.tsx
@@ -7,7 +7,7 @@ import {DisplayType, WidgetType} from 'sentry/views/dashboardsV2/types';
 import MetricsWidgetQueries from 'sentry/views/dashboardsV2/widgetCard/metricsWidgetQueries';
 
 describe('Dashboards > MetricsWidgetQueries', function () {
-  const {organization, routerContext} = initializeOrg();
+  const {organization} = initializeOrg();
 
   const badMessage = 'Bad request data';
 
@@ -79,10 +79,7 @@ describe('Dashboards > MetricsWidgetQueries', function () {
         selection={selection}
       >
         {children}
-      </MetricsWidgetQueries>,
-      {
-        context: routerContext,
-      }
+      </MetricsWidgetQueries>
     );
 
     expect(mock).toHaveBeenCalledTimes(1);
@@ -124,12 +121,8 @@ describe('Dashboards > MetricsWidgetQueries', function () {
         selection={selection}
       >
         {children}
-      </MetricsWidgetQueries>,
-      {
-        context: routerContext,
-      }
+      </MetricsWidgetQueries>
     );
-
     expect(mock).toHaveBeenCalledTimes(1);
 
     await waitFor(() =>
@@ -229,10 +222,7 @@ describe('Dashboards > MetricsWidgetQueries', function () {
         selection={selection}
       >
         {children}
-      </MetricsWidgetQueries>,
-      {
-        context: routerContext,
-      }
+      </MetricsWidgetQueries>
     );
 
     expect(mock).toHaveBeenCalledTimes(1);
@@ -282,12 +272,8 @@ describe('Dashboards > MetricsWidgetQueries', function () {
         selection={selection}
       >
         {() => <div data-test-id="child" />}
-      </MetricsWidgetQueries>,
-      {
-        context: routerContext,
-      }
+      </MetricsWidgetQueries>
     );
-
     // Child should be rendered and 2 requests should be sent.
     expect(screen.getByTestId('child')).toBeInTheDocument();
     expect(sessionMock).toHaveBeenCalledTimes(2);
@@ -341,8 +327,7 @@ describe('Dashboards > MetricsWidgetQueries', function () {
         selection={selection}
       >
         {children}
-      </MetricsWidgetQueries>,
-      {context: routerContext}
+      </MetricsWidgetQueries>
     );
 
     // Child should be rendered and 2 requests should be sent.
@@ -371,8 +356,7 @@ describe('Dashboards > MetricsWidgetQueries', function () {
         selection={{...selection, datetime: {...selection.datetime, period: '90d'}}}
       >
         {() => <div data-test-id="child" />}
-      </MetricsWidgetQueries>,
-      {context: routerContext}
+      </MetricsWidgetQueries>
     );
 
     expect(screen.getByTestId('child')).toBeInTheDocument();
@@ -407,8 +391,7 @@ describe('Dashboards > MetricsWidgetQueries', function () {
         selection={selection}
       >
         {children}
-      </MetricsWidgetQueries>,
-      {context: routerContext}
+      </MetricsWidgetQueries>
     );
 
     expect(mock).toHaveBeenCalledTimes(1);

--- a/tests/js/spec/views/dashboardsV2/widgetCard/issueWidgetQueries.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard/issueWidgetQueries.spec.tsx
@@ -5,7 +5,7 @@ import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';
 import IssueWidgetQueries from 'sentry/views/dashboardsV2/widgetCard/issueWidgetQueries';
 
 describe('IssueWidgetQueries', function () {
-  const {organization, routerContext} = initializeOrg({
+  const {organization} = initializeOrg({
     router: {orgId: 'orgId'},
   } as Parameters<typeof initializeOrg>[0]);
   const api = new MockApiClient();
@@ -72,8 +72,7 @@ describe('IssueWidgetQueries', function () {
         }}
       >
         {mockFunction}
-      </IssueWidgetQueries>,
-      {context: routerContext}
+      </IssueWidgetQueries>
     );
   });
 

--- a/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
@@ -117,8 +117,7 @@ describe('EventsV2 > EventDetails', function () {
         organization={TestStubs.Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{query: allEventsView.generateQueryStringObject()}}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const content = wrapper.find('EventHeader');
     expect(content.text()).toContain('Oh no something bad');
@@ -130,8 +129,7 @@ describe('EventsV2 > EventDetails', function () {
         organization={TestStubs.Organization()}
         params={{eventSlug: 'project-slug:abad1'}}
         location={{query: allEventsView.generateQueryStringObject()}}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const content = wrapper.find('NotFound');
     expect(content).toHaveLength(1);
@@ -143,8 +141,7 @@ describe('EventsV2 > EventDetails', function () {
         organization={TestStubs.Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{query: errorsView.generateQueryStringObject()}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     // loading state
@@ -167,8 +164,7 @@ describe('EventsV2 > EventDetails', function () {
         organization={TestStubs.Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{query: allEventsView.generateQueryStringObject()}}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const alert = wrapper.find('Alert');
     expect(alert).toHaveLength(1);

--- a/tests/js/spec/views/eventsV2/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/index.spec.jsx
@@ -76,8 +76,7 @@ describe('EventsV2 > Landing', function () {
         organization={TestStubs.Organization({features})}
         location={{query: {}}}
         router={{}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const content = wrapper.find('SentryDocumentTitle');
@@ -90,8 +89,7 @@ describe('EventsV2 > Landing', function () {
         organization={TestStubs.Organization()}
         location={{query: {}}}
         router={{}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const content = wrapper.find('PageContent');
@@ -102,8 +100,7 @@ describe('EventsV2 > Landing', function () {
     const org = TestStubs.Organization({features});
 
     const wrapper = mountWithTheme(
-      <DiscoverLanding organization={org} location={{query: {}}} router={{}} />,
-      TestStubs.routerContext()
+      <DiscoverLanding organization={org} location={{query: {}}} router={{}} />
     );
 
     const dropdownItems = wrapper.find('DropdownItem span');

--- a/tests/js/spec/views/eventsV2/queryList.spec.jsx
+++ b/tests/js/spec/views/eventsV2/queryList.spec.jsx
@@ -56,8 +56,7 @@ describe('EventsV2 > QueryList', function () {
         pageLinks=""
         onQueryChange={queryChangeMock}
         location={location}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const content = wrapper.find('QueryCard');
     // No queries
@@ -74,8 +73,7 @@ describe('EventsV2 > QueryList', function () {
         pageLinks=""
         onQueryChange={queryChangeMock}
         location={location}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const content = wrapper.find('QueryCard');
     // pre built + saved queries
@@ -90,8 +88,7 @@ describe('EventsV2 > QueryList', function () {
         pageLinks=""
         onQueryChange={queryChangeMock}
         location={location}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const card = wrapper.find('QueryCard').last();
     expect(card.find('QueryCardContent').text()).toEqual(savedQueries[1].name);
@@ -114,8 +111,7 @@ describe('EventsV2 > QueryList', function () {
         pageLinks=""
         onQueryChange={queryChangeMock}
         location={location}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const card = wrapper.find('QueryCard').last();
     expect(card.find('QueryCardContent').text()).toEqual(savedQueries[1].name);
@@ -138,8 +134,7 @@ describe('EventsV2 > QueryList', function () {
         pageLinks=""
         onQueryChange={queryChangeMock}
         location={location}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const card = wrapper.find('QueryCard').last();
     const link = card.find('Link').last().prop('to');
@@ -158,8 +153,7 @@ describe('EventsV2 > QueryList', function () {
         pageLinks=""
         onQueryChange={queryChangeMock}
         location={location}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const card = wrapper.find('QueryCard').last();
     expect(card.find('QueryCardContent').text()).toEqual(savedQueries[1].name);
@@ -189,8 +183,7 @@ describe('EventsV2 > QueryList', function () {
         pageLinks=""
         onQueryChange={queryChangeMock}
         location={location}
-      />,
-      TestStubs.routerContext()
+      />
     );
     let card = wrapper.find('QueryCard').last();
 
@@ -218,8 +211,7 @@ describe('EventsV2 > QueryList', function () {
         pageLinks=""
         onQueryChange={queryChangeMock}
         location={location}
-      />,
-      TestStubs.routerContext()
+      />
     );
     let card = wrapper.find('QueryCard').last();
 
@@ -254,8 +246,7 @@ describe('EventsV2 > QueryList', function () {
         pageLinks=""
         onQueryChange={queryChangeMock}
         location={location}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const miniGraph = wrapper.find('MiniGraph');

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -31,8 +31,7 @@ function generateWrappedComponent(
       disabled={disabled}
       updateCallback={() => {}}
       yAxis={yAxis}
-    />,
-    TestStubs.routerContext()
+    />
   );
 }
 

--- a/tests/js/spec/views/integrationOrganizationLink.spec.jsx
+++ b/tests/js/spec/views/integrationOrganizationLink.spec.jsx
@@ -37,8 +37,7 @@ describe('IntegrationOrganizationLink', () => {
 
     getMountedComponent = () =>
       mountWithTheme(
-        <IntegrationOrganizationLink params={{integrationSlug: 'vercel'}} />,
-        TestStubs.routerContext()
+        <IntegrationOrganizationLink params={{integrationSlug: 'vercel'}} />
       );
   });
 

--- a/tests/js/spec/views/integrationPipeline/pipelineView.spec.jsx
+++ b/tests/js/spec/views/integrationPipeline/pipelineView.spec.jsx
@@ -14,8 +14,7 @@ jest.mock(
 describe('PipelineView', () => {
   it('renders awsLambdaProjectSelect', () => {
     mountWithTheme(
-      <PipelineView pipelineName="awsLambdaProjectSelect" someField="someVal" />,
-      {context: TestStubs.routerContext()}
+      <PipelineView pipelineName="awsLambdaProjectSelect" someField="someVal" />
     );
 
     expect(screen.getByText('mock_AwsLambdaProjectSelect')).toBeInTheDocument();

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -99,7 +99,7 @@ describe('IssueListActions', function () {
             allResultsVisible={false}
             query=""
             queryCount={600}
-            organization={TestStubs.routerContext().context.organization}
+            organization={TestStubs.Organization()}
             projectId="1"
             selection={{
               projects: [1],
@@ -111,8 +111,7 @@ describe('IssueListActions', function () {
             onSelectStatsPeriod={function () {}}
             realtimeActive={false}
             statsPeriod="24h"
-          />,
-          TestStubs.routerContext()
+          />
         );
       });
 
@@ -167,7 +166,7 @@ describe('IssueListActions', function () {
             allResultsVisible
             query=""
             queryCount={15}
-            organization={TestStubs.routerContext().context.organization}
+            organization={TestStubs.Organization()}
             projectId="1"
             selection={{
               projects: [1],
@@ -179,8 +178,7 @@ describe('IssueListActions', function () {
             onSelectStatsPeriod={function () {}}
             realtimeActive={false}
             statsPeriod="24h"
-          />,
-          TestStubs.routerContext()
+          />
         );
       });
 
@@ -272,7 +270,7 @@ describe('IssueListActions', function () {
         <IssueListActions
           api={new MockApiClient()}
           query=""
-          organization={TestStubs.routerContext().context.organization}
+          organization={TestStubs.Organization()}
           projectId="1"
           selection={{
             projects: [1],
@@ -337,7 +335,7 @@ describe('IssueListActions', function () {
         <IssueListActions
           api={new MockApiClient()}
           query=""
-          organization={TestStubs.routerContext().context.organization}
+          organization={TestStubs.Organization()}
           groupIds={['1', '2', '3']}
           selection={{
             projects: [],
@@ -348,8 +346,7 @@ describe('IssueListActions', function () {
           onSelectStatsPeriod={function () {}}
           realtimeActive={false}
           statsPeriod="24h"
-        />,
-        TestStubs.routerContext()
+        />
       );
     });
 
@@ -376,7 +373,8 @@ describe('IssueListActions', function () {
     let issuesApiMock;
     beforeEach(async () => {
       SelectedGroupStore.records = {};
-      const {organization} = TestStubs.routerContext().context;
+      const organization = TestStubs.Organization();
+
       wrapper = mountWithTheme(
         <IssueListActions
           api={new MockApiClient()}
@@ -394,8 +392,7 @@ describe('IssueListActions', function () {
           statsPeriod="24h"
           queryCount={100}
           displayCount="3 of 3"
-        />,
-        TestStubs.routerContext()
+        />
       );
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',

--- a/tests/js/spec/views/issueList/createSavedSearchModal.spec.jsx
+++ b/tests/js/spec/views/issueList/createSavedSearchModal.spec.jsx
@@ -19,8 +19,7 @@ describe('CreateSavedSearchModal', function () {
         organization={organization}
         query="is:unresolved assigned:lyn@sentry.io"
         sort={IssueSortOptions.DATE}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     createMock = MockApiClient.addMockResponse({

--- a/tests/js/spec/views/issueList/header.spec.jsx
+++ b/tests/js/spec/views/issueList/header.spec.jsx
@@ -239,8 +239,7 @@ describe('IssueListHeader', () => {
         queryCounts={queryCounts}
         projectIds={[]}
         savedSearchList={[]}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const inboxTab = wrapper.find('Link').at(2);
     inboxTab.simulate('click');

--- a/tests/js/spec/views/issueList/organizationSavedSearchSelector.spec.jsx
+++ b/tests/js/spec/views/issueList/organizationSavedSearchSelector.spec.jsx
@@ -31,8 +31,7 @@ describe('IssueListSavedSearchSelector', function () {
         onSavedSearchSelect={onSelect}
         onSavedSearchDelete={onDelete}
         query="is:unresolved assigned:lyn@sentry.io"
-      />,
-      TestStubs.routerContext()
+      />
     );
   });
 

--- a/tests/js/spec/views/onboarding/components/firstEventIndicator.spec.jsx
+++ b/tests/js/spec/views/onboarding/components/firstEventIndicator.spec.jsx
@@ -6,10 +6,7 @@ describe('FirstEventIndicator', function () {
   it('renders waiting status', async function () {
     const org = TestStubs.Organization();
 
-    const wrapper = mountWithTheme(
-      <Indicator organization={org} firstIssue={null} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<Indicator organization={org} firstIssue={null} />);
 
     expect(wrapper.find('WaitingIndicator').exists()).toBe(true);
   });
@@ -19,8 +16,7 @@ describe('FirstEventIndicator', function () {
       const org = TestStubs.Organization();
 
       const wrapper = mountWithTheme(
-        <Indicator organization={org} firstIssue={{id: 1}} />,
-        TestStubs.routerContext()
+        <Indicator organization={org} firstIssue={{id: 1}} />
       );
 
       expect(wrapper.find('ReceivedIndicator').exists()).toBe(true);
@@ -31,8 +27,7 @@ describe('FirstEventIndicator', function () {
       const project = TestStubs.ProjectDetails({});
 
       const wrapper = mountWithTheme(
-        <Indicator organization={org} project={project} firstIssue />,
-        TestStubs.routerContext()
+        <Indicator organization={org} project={project} firstIssue />
       );
 
       // No button when there is no known issue ID

--- a/tests/js/spec/views/onboarding/onboarding.spec.jsx
+++ b/tests/js/spec/views/onboarding/onboarding.spec.jsx
@@ -46,10 +46,7 @@ describe('Onboarding', function () {
       orgId: 'org-bar',
     };
 
-    mountWithTheme(
-      <Onboarding steps={MOCKED_STEPS} params={params} />,
-      TestStubs.routerContext()
-    );
+    mountWithTheme(<Onboarding steps={MOCKED_STEPS} params={params} />);
 
     expect(browserHistory.replace).toHaveBeenCalledWith('/onboarding/org-bar/step1/');
   });
@@ -60,10 +57,7 @@ describe('Onboarding', function () {
       orgId: 'org-bar',
     };
 
-    const wrapper = mountWithTheme(
-      <Onboarding steps={MOCKED_STEPS} params={params} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<Onboarding steps={MOCKED_STEPS} params={params} />);
 
     // Validate that the first step is shown
     expect(wrapper.find('#step_name').text()).toEqual('step_1');
@@ -80,10 +74,7 @@ describe('Onboarding', function () {
       orgId: 'org-bar',
     };
 
-    const wrapper = mountWithTheme(
-      <Onboarding steps={MOCKED_STEPS} params={params} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<Onboarding steps={MOCKED_STEPS} params={params} />);
 
     wrapper.find('#complete').simulate('click');
     expect(browserHistory.push).toHaveBeenCalledWith('/onboarding/org-bar/step2/');
@@ -95,10 +86,7 @@ describe('Onboarding', function () {
       orgId: 'org-bar',
     };
 
-    const wrapper = mountWithTheme(
-      <Onboarding steps={MOCKED_STEPS} params={params} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<Onboarding steps={MOCKED_STEPS} params={params} />);
 
     // Validate that second step is visible
     expect(wrapper.find('#step_name').text()).toEqual('step_2');
@@ -113,10 +101,7 @@ describe('Onboarding', function () {
       orgId: 'org-bar',
     };
 
-    const wrapper = mountWithTheme(
-      <Onboarding steps={MOCKED_STEPS} params={params} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<Onboarding steps={MOCKED_STEPS} params={params} />);
 
     wrapper.find('Back Button').simulate('click');
     expect(browserHistory.replace).toHaveBeenCalledWith('/onboarding/org-bar/step1/');

--- a/tests/js/spec/views/onboarding/platform.spec.jsx
+++ b/tests/js/spec/views/onboarding/platform.spec.jsx
@@ -11,10 +11,7 @@ describe('OnboardingWelcome', function () {
   it('calls onUpdate when setting the platform', function () {
     const onUpdate = jest.fn();
 
-    const wrapper = mountWithTheme(
-      <OnboardingPlatform active onUpdate={onUpdate} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<OnboardingPlatform active onUpdate={onUpdate} />);
 
     wrapper.find('[data-test-id="platform-dotnet"]').first().simulate('click');
 
@@ -24,10 +21,7 @@ describe('OnboardingWelcome', function () {
   it('creates a project when no project exists', async function () {
     const onComplete = jest.fn();
 
-    const wrapper = mountWithTheme(
-      <OnboardingPlatform active onComplete={onComplete} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<OnboardingPlatform active onComplete={onComplete} />);
 
     const getButton = () => wrapper.find('Button[priority="primary"]');
 
@@ -68,8 +62,7 @@ describe('OnboardingWelcome', function () {
         project={{id: '1', slug: 'test'}}
         platform="dotnet"
         onComplete={onComplete}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const getButton = () => wrapper.find('Button[priority="primary"]');

--- a/tests/js/spec/views/onboarding/welcome.spec.jsx
+++ b/tests/js/spec/views/onboarding/welcome.spec.jsx
@@ -8,15 +8,12 @@ describe('OnboardingWelcome', function () {
     const name = 'Rick Snachez';
     ConfigStore.loadInitialData({user: {name, options: {}}});
 
-    mountWithTheme(<OnboardingWelcome />, TestStubs.routerContext());
+    mountWithTheme(<OnboardingWelcome />);
   });
 
   it('calls onComplete when progressing', function () {
     const onComplete = jest.fn();
-    const wrapper = mountWithTheme(
-      <OnboardingWelcome active onComplete={onComplete} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<OnboardingWelcome active onComplete={onComplete} />);
 
     wrapper.find('Button[priority="primary"]').first().simulate('click');
 

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -49,8 +49,7 @@ describe('OrganizationDetails', function () {
         includeSidebar={false}
       >
         <div />
-      </OrganizationDetails>,
-      {context: TestStubs.routerContext()}
+      </OrganizationDetails>
     );
 
     expect(getTeamsMock).toHaveBeenCalled();
@@ -73,8 +72,7 @@ describe('OrganizationDetails', function () {
       mountWithTheme(
         <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]}>
           <div />
-        </OrganizationDetails>,
-        {context: TestStubs.routerContext()}
+        </OrganizationDetails>
       );
 
       expect(await screen.findByText('Deletion Scheduled')).toBeInTheDocument();
@@ -102,8 +100,7 @@ describe('OrganizationDetails', function () {
       mountWithTheme(
         <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]}>
           <div />
-        </OrganizationDetails>,
-        {context: TestStubs.routerContext()}
+        </OrganizationDetails>
       );
 
       expect(await screen.findByText('Deletion Scheduled')).toBeInTheDocument();
@@ -132,8 +129,7 @@ describe('OrganizationDetails', function () {
     mountWithTheme(
       <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]}>
         <div />
-      </OrganizationDetails>,
-      {context: TestStubs.routerContext()}
+      </OrganizationDetails>
     );
 
     const inProgress = await screen.findByText(

--- a/tests/js/spec/views/organizationGroupDetails/organizationGroupEvents.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/organizationGroupEvents.spec.jsx
@@ -9,7 +9,6 @@ const OrganizationGroupEvents = GroupEvents;
 
 describe('groupEvents', function () {
   let request;
-  const routerContext = TestStubs.routerContext();
 
   beforeEach(function () {
     request = MockApiClient.addMockResponse({
@@ -57,8 +56,7 @@ describe('groupEvents', function () {
         group={TestStubs.Group()}
         params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
         location={{query: {}}}
-      />,
-      routerContext
+      />
     );
 
     expect(component).toSnapshot();

--- a/tests/js/spec/views/organizationGroupDetails/quickTrace.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/quickTrace.spec.jsx
@@ -9,7 +9,6 @@ jest.mock('sentry/utils/analytics');
 
 describe('ConfigureDistributedTracing', function () {
   let putMock;
-  const routerContext = TestStubs.routerContext();
   const organization = TestStubs.Organization({features: ['performance-view']});
   const project = TestStubs.Project({platform: 'javascript'});
   const event = TestStubs.Event({
@@ -39,8 +38,7 @@ describe('ConfigureDistributedTracing', function () {
         event={event}
         organization={organization}
         project={project}
-      />,
-      routerContext
+      />
     );
 
     await tick();
@@ -57,8 +55,7 @@ describe('ConfigureDistributedTracing', function () {
         event={event}
         organization={newOrganization}
         project={project}
-      />,
-      routerContext
+      />
     );
 
     await tick();
@@ -82,8 +79,7 @@ describe('ConfigureDistributedTracing', function () {
         event={newEvent}
         organization={organization}
         project={project}
-      />,
-      routerContext
+      />
     );
 
     await tick();
@@ -99,8 +95,7 @@ describe('ConfigureDistributedTracing', function () {
         event={event}
         organization={organization}
         project={newProject}
-      />,
-      routerContext
+      />
     );
 
     await tick();
@@ -115,8 +110,7 @@ describe('ConfigureDistributedTracing', function () {
         event={event}
         organization={organization}
         project={project}
-      />,
-      routerContext
+      />
     );
 
     await tick();
@@ -165,8 +159,7 @@ describe('ConfigureDistributedTracing', function () {
         event={event}
         organization={organization}
         project={project}
-      />,
-      routerContext
+      />
     );
 
     await tick();
@@ -181,8 +174,7 @@ describe('ConfigureDistributedTracing', function () {
         event={event}
         organization={organization}
         project={project}
-      />,
-      routerContext
+      />
     );
 
     await tick();
@@ -229,8 +221,7 @@ describe('ConfigureDistributedTracing', function () {
         event={event}
         organization={organization}
         project={project}
-      />,
-      routerContext
+      />
     );
 
     await tick();
@@ -245,8 +236,7 @@ describe('ConfigureDistributedTracing', function () {
         event={event}
         organization={organization}
         project={project}
-      />,
-      routerContext
+      />
     );
 
     await tick();

--- a/tests/js/spec/views/organizationIntegrations/integrationDetailedView.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationDetailedView.spec.jsx
@@ -14,7 +14,6 @@ const mockResponse = mocks => {
 
 describe('IntegrationDetailedView', function () {
   const org = TestStubs.Organization();
-  const routerContext = TestStubs.routerContext();
   let wrapper;
 
   beforeEach(() => {
@@ -86,8 +85,7 @@ describe('IntegrationDetailedView', function () {
       <IntegrationDetailedView
         params={{integrationSlug: 'bitbucket', orgId: org.slug}}
         location={{query: {}}}
-      />,
-      routerContext
+      />
     );
   });
   it('shows the Integration name and install status', async function () {
@@ -102,8 +100,7 @@ describe('IntegrationDetailedView', function () {
       <IntegrationDetailedView
         params={{integrationSlug: 'bitbucket', orgId: org.slug}}
         location={{query: {tab: 'configurations'}}}
-      />,
-      routerContext
+      />
     );
     expect(wrapper.find('InstallWrapper')).toHaveLength(1);
   });

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -7,7 +7,6 @@ import IntegrationRepos from 'sentry/views/organizationIntegrations/integrationR
 describe('IntegrationRepos', function () {
   const org = TestStubs.Organization();
   const integration = TestStubs.GitHubIntegration();
-  const routerContext = TestStubs.routerContext();
 
   beforeEach(() => {
     Client.clearMockResponses();
@@ -31,10 +30,7 @@ describe('IntegrationRepos', function () {
         body: [],
       });
 
-      const wrapper = mountWithTheme(
-        <IntegrationRepos integration={integration} />,
-        routerContext
-      );
+      const wrapper = mountWithTheme(<IntegrationRepos integration={integration} />);
       expect(wrapper.find('PanelBody')).toHaveLength(0);
       expect(wrapper.find('Alert')).toHaveLength(1);
     });
@@ -59,10 +55,7 @@ describe('IntegrationRepos', function () {
         body: [],
       });
 
-      const wrapper = mountWithTheme(
-        <IntegrationRepos integration={integration} />,
-        routerContext
-      );
+      const wrapper = mountWithTheme(<IntegrationRepos integration={integration} />);
       wrapper.find('DropdownButton').simulate('click');
 
       wrapper.find('StyledListElement').simulate('click');
@@ -109,10 +102,7 @@ describe('IntegrationRepos', function () {
         body: [],
       });
 
-      const wrapper = mountWithTheme(
-        <IntegrationRepos integration={integration} />,
-        routerContext
-      );
+      const wrapper = mountWithTheme(<IntegrationRepos integration={integration} />);
       wrapper.find('DropdownButton').simulate('click');
       wrapper.find('StyledListElement').simulate('click');
       await wrapper.update();
@@ -147,10 +137,7 @@ describe('IntegrationRepos', function () {
         url: `/organizations/${org.slug}/repos/4/`,
         body: {},
       });
-      const wrapper = mountWithTheme(
-        <IntegrationRepos integration={integration} />,
-        routerContext
-      );
+      const wrapper = mountWithTheme(<IntegrationRepos integration={integration} />);
 
       wrapper.find('DropdownButton').simulate('click');
       wrapper.find('StyledListElement').simulate('click');
@@ -183,10 +170,7 @@ describe('IntegrationRepos', function () {
         url: `/organizations/${org.slug}/repos/4/`,
         body: {},
       });
-      const wrapper = mountWithTheme(
-        <IntegrationRepos integration={integration} />,
-        routerContext
-      );
+      const wrapper = mountWithTheme(<IntegrationRepos integration={integration} />);
       wrapper.find('DropdownButton').simulate('click');
       wrapper.find('StyledListElement').simulate('click');
 

--- a/tests/js/spec/views/organizationIntegrations/integrationRow.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRow.spec.jsx
@@ -9,7 +9,6 @@ describe('IntegrationRow', function () {
   });
 
   const org = TestStubs.Organization();
-  const routerContext = TestStubs.routerContext();
 
   describe('SentryApp', function () {
     it('is an internal SentryApp', async function () {
@@ -23,8 +22,7 @@ describe('IntegrationRow', function () {
           publishStatus="internal"
           configurations={0}
           data-test-id="integration-row"
-        />,
-        routerContext
+        />
       );
       expect(wrapper.find('PluginIcon').props().pluginId).toEqual(
         'my-headband-washer-289499'
@@ -50,8 +48,7 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={0}
           data-test-id="integration-row"
-        />,
-        routerContext
+        />
       );
       expect(wrapper.find('PluginIcon').props().pluginId).toEqual('clickup');
       expect(wrapper.find('IntegrationName').props().children).toEqual('ClickUp');
@@ -74,8 +71,7 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={1}
           data-test-id="integration-row"
-        />,
-        routerContext
+        />
       );
       expect(wrapper.find('PluginIcon').props().pluginId).toEqual('bitbucket');
       expect(wrapper.find('IntegrationName').props().children).toEqual('Bitbucket');
@@ -98,8 +94,7 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={3}
           data-test-id="integration-row"
-        />,
-        routerContext
+        />
       );
       expect(wrapper.find('PluginIcon').props().pluginId).toEqual('bitbucket');
       expect(wrapper.find('IntegrationName').props().children).toEqual('Bitbucket');
@@ -122,8 +117,7 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={0}
           data-test-id="integration-row"
-        />,
-        routerContext
+        />
       );
       expect(wrapper.find('PluginIcon').props().pluginId).toEqual('github');
       expect(wrapper.find('IntegrationName').props().children).toEqual('Github');
@@ -147,8 +141,7 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={1}
           data-test-id="integration-row"
-        />,
-        routerContext
+        />
       );
       expect(wrapper.find('PluginIcon').props().pluginId).toEqual('twilio');
       expect(wrapper.find('IntegrationName').props().children).toEqual('Twilio (SMS) ');
@@ -171,8 +164,7 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={3}
           data-test-id="integration-row"
-        />,
-        routerContext
+        />
       );
       expect(wrapper.find('PluginIcon').props().pluginId).toEqual('twilio');
       expect(wrapper.find('IntegrationName').props().children).toEqual('Twilio (SMS) ');
@@ -195,8 +187,7 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={0}
           data-test-id="integration-row"
-        />,
-        routerContext
+        />
       );
       expect(wrapper.find('PluginIcon').props().pluginId).toEqual('amazon-sqs');
       expect(wrapper.find('IntegrationName').props().children).toEqual('Amazon SQS');

--- a/tests/js/spec/views/organizationIntegrations/pluginDetailedView.spec.js
+++ b/tests/js/spec/views/organizationIntegrations/pluginDetailedView.spec.js
@@ -15,7 +15,6 @@ const mockResponse = mocks => {
 
 describe('PluginDetailedView', function () {
   const org = TestStubs.Organization();
-  const routerContext = TestStubs.routerContext();
   let wrapper;
 
   beforeEach(() => {
@@ -72,8 +71,7 @@ describe('PluginDetailedView', function () {
       <PluginDetailedView
         params={{integrationSlug: 'pagerduty', orgId: org.slug}}
         location={{query: {}}}
-      />,
-      routerContext
+      />
     );
   });
   it('shows the Integration name and install status', async function () {
@@ -96,8 +94,7 @@ describe('PluginDetailedView', function () {
       <PluginDetailedView
         params={{integrationSlug: 'pagerduty', orgId: org.slug}}
         location={{query: {tab: 'configurations'}}}
-      />,
-      routerContext
+      />
     );
     expect(wrapper.find('InstalledPlugin')).toHaveLength(1);
   });

--- a/tests/js/spec/views/organizationIntegrations/sentryAppDetailedView.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/sentryAppDetailedView.spec.jsx
@@ -17,7 +17,7 @@ const mockResponse = mocks => {
 
 describe('SentryAppDetailedView', function () {
   const org = TestStubs.Organization();
-  const routerContext = TestStubs.routerContext();
+
   let wrapper;
   const {router} = initializeOrg({
     projects: [
@@ -108,8 +108,7 @@ describe('SentryAppDetailedView', function () {
         <SentryAppDetailedView
           params={{integrationSlug: 'clickup', orgId: org.slug}}
           location={{query: {}}}
-        />,
-        routerContext
+        />
       );
     });
 
@@ -222,8 +221,7 @@ describe('SentryAppDetailedView', function () {
           params={{integrationSlug: 'my-headband-washer-289499', orgId: org.slug}}
           location={{query: {}}}
           router={router}
-        />,
-        routerContext
+        />
       );
 
       mockRouterPush(wrapper, router);
@@ -308,8 +306,7 @@ describe('SentryAppDetailedView', function () {
         <SentryAppDetailedView
           params={{integrationSlug: 'la-croix-monitor', orgId: org.slug}}
           location={{query: {}}}
-        />,
-        routerContext
+        />
       );
     });
     it('shows the Integration name and install status', async function () {
@@ -397,8 +394,7 @@ describe('SentryAppDetailedView', function () {
           params={{integrationSlug: 'go-to-google', orgId: org.slug}}
           location={{query: {}}}
           router={router}
-        />,
-        routerContext
+        />
       );
       mockRouterPush(wrapper, router);
     });

--- a/tests/js/spec/views/organizationJoinRequest.spec.jsx
+++ b/tests/js/spec/views/organizationJoinRequest.spec.jsx
@@ -20,8 +20,7 @@ describe('OrganizationJoinRequest', function () {
 
   it('renders', function () {
     const wrapper = mountWithTheme(
-      <OrganizationJoinRequest params={{orgId: org.slug}} />,
-      TestStubs.routerContext()
+      <OrganizationJoinRequest params={{orgId: org.slug}} />
     );
 
     expect(wrapper.find('h3').text()).toBe('Request to Join');
@@ -41,8 +40,7 @@ describe('OrganizationJoinRequest', function () {
     });
 
     const wrapper = mountWithTheme(
-      <OrganizationJoinRequest params={{orgId: org.slug}} />,
-      TestStubs.routerContext()
+      <OrganizationJoinRequest params={{orgId: org.slug}} />
     );
 
     wrapper
@@ -68,8 +66,7 @@ describe('OrganizationJoinRequest', function () {
     });
 
     const wrapper = mountWithTheme(
-      <OrganizationJoinRequest params={{orgId: org.slug}} />,
-      TestStubs.routerContext()
+      <OrganizationJoinRequest params={{orgId: org.slug}} />
     );
 
     wrapper
@@ -91,8 +88,7 @@ describe('OrganizationJoinRequest', function () {
   it('cancels', function () {
     const spy = jest.spyOn(window.location, 'assign').mockImplementation(() => {});
     const wrapper = mountWithTheme(
-      <OrganizationJoinRequest params={{orgId: org.slug}} />,
-      TestStubs.routerContext()
+      <OrganizationJoinRequest params={{orgId: org.slug}} />
     );
 
     wrapper.find('button[aria-label="Cancel"]').simulate('click');

--- a/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
@@ -74,13 +74,13 @@ describe('TeamMisery', () => {
       },
       match: [MockApiClient.matchQuery({statsPeriod: '8w'})],
     });
-    const routerContext = TestStubs.routerContext();
+
     mountWithTheme(
       <TeamMisery
         organization={TestStubs.Organization()}
         projects={[project]}
         period="8w"
-        location={routerContext.context}
+        location={location}
       />
     );
 
@@ -102,13 +102,12 @@ describe('TeamMisery', () => {
   });
 
   it('should render empty state', async () => {
-    const routerContext = TestStubs.routerContext();
     mountWithTheme(
       <TeamMisery
         organization={TestStubs.Organization()}
         projects={[]}
         period="8w"
-        location={routerContext.context}
+        location={location}
       />
     );
 
@@ -124,13 +123,12 @@ describe('TeamMisery', () => {
       body: {},
     });
 
-    const routerContext = TestStubs.routerContext();
     mountWithTheme(
       <TeamMisery
         organization={TestStubs.Organization()}
         projects={[TestStubs.Project()]}
         period="8w"
-        location={routerContext.context}
+        location={location}
       />
     );
 

--- a/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
@@ -81,8 +81,7 @@ describe('TeamMisery', () => {
         projects={[project]}
         period="8w"
         location={routerContext.context}
-      />,
-      {context: routerContext}
+      />
     );
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
@@ -110,8 +109,7 @@ describe('TeamMisery', () => {
         projects={[]}
         period="8w"
         location={routerContext.context}
-      />,
-      {context: routerContext}
+      />
     );
 
     expect(
@@ -133,8 +131,7 @@ describe('TeamMisery', () => {
         projects={[TestStubs.Project()]}
         period="8w"
         location={routerContext.context}
-      />,
-      {context: routerContext}
+      />
     );
 
     await waitForElementToBeRemoved(screen.queryByTestId('loading-indicator'));

--- a/tests/js/spec/views/ownershipInput.spec.jsx
+++ b/tests/js/spec/views/ownershipInput.spec.jsx
@@ -39,8 +39,7 @@ describe('Project Ownership Input', function () {
         organization={org}
         initialText="url:src @dummy@example.com"
         project={project}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const submit = wrapper.find('SaveButton button');
@@ -67,8 +66,7 @@ describe('Project Ownership Input', function () {
         organization={org}
         initialText="url:src @dummy@example.com"
         project={project}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     // Set a path, as path is selected bu default.

--- a/tests/js/spec/views/performance/transactionDetails/index.spec.jsx
+++ b/tests/js/spec/views/performance/transactionDetails/index.spec.jsx
@@ -24,8 +24,7 @@ describe('EventDetails', () => {
         organization={organization}
         params={{orgId: organization.slug, eventSlug: `${project.slug}:${event.id}`}}
         location={routerContext.context.location}
-      />,
-      {context: routerContext}
+      />
     );
     expect(screen.getByText(alertText)).toBeInTheDocument();
   });
@@ -45,8 +44,7 @@ describe('EventDetails', () => {
         organization={organization}
         params={{orgId: organization.slug, eventSlug: `${project.slug}:${event.id}`}}
         location={routerContext.context.location}
-      />,
-      {context: routerContext}
+      />
     );
     expect(screen.queryByText(alertText)).not.toBeInTheDocument();
   });

--- a/tests/js/spec/views/performance/transactionSpans/spanDetails.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/spanDetails.spec.tsx
@@ -83,7 +83,7 @@ describe('Performance > Transaction Spans > Span Details', function () {
 
       const {container} = mountWithTheme(
         <SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />,
-        {context: data.routerContext, organization: data.organization}
+        {organization: data.organization}
       );
 
       expect(container).toBeEmptyDOMElement();
@@ -94,7 +94,7 @@ describe('Performance > Transaction Spans > Span Details', function () {
 
       const {container} = mountWithTheme(
         <SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />,
-        {context: data.routerContext, organization: data.organization}
+        {organization: data.organization}
       );
 
       expect(container).toBeEmptyDOMElement();

--- a/tests/js/spec/views/performance/transactionSummary/suspectSpans.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/suspectSpans.spec.tsx
@@ -29,6 +29,7 @@ function initializeData({query} = {query: {}}) {
       },
     },
   });
+
   act(() => void ProjectsStore.loadInitialData(initialData.organization.projects));
   return {
     ...initialData,
@@ -57,8 +58,7 @@ describe('SuspectSpans', function () {
           projectId="1"
           transactionName="Test Transaction"
           totals={{count: 1}}
-        />,
-        {context: initialData.routerContext}
+        />
       );
 
       expect(await screen.findByText('Suspect Spans')).toBeInTheDocument();
@@ -87,7 +87,6 @@ describe('SuspectSpans', function () {
     //       projectId="1"
     //       transactionName="Test Transaction"
     //     />,
-    //     {context: initialData.routerContext}
     //   );
 
     //   await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));

--- a/tests/js/spec/views/projectFilters.spec.jsx
+++ b/tests/js/spec/views/projectFilters.spec.jsx
@@ -25,8 +25,7 @@ describe('ProjectFilters', function () {
           params={{projectId: project.slug, orgId: org.slug}}
           location={{}}
           project={project}
-        />,
-        TestStubs.routerContext()
+        />
       );
     }
 
@@ -205,13 +204,11 @@ describe('ProjectFilters', function () {
         />,
         {
           context: {
-            ...TestStubs.routerContext().context,
             project: {
               ...project,
               features: ['custom-inbound-filters'],
             },
           },
-          childContextTypes: TestStubs.routerContext().childContextTypes,
         }
       )
     );
@@ -272,6 +269,8 @@ describe('ProjectFilters', function () {
       />,
       {
         context: {
+          // removing TestStubs.routerContext causes our test to fail. Should be investigated because it does not
+          // seem clear the routerContext should impact the project that we are passing as props.
           ...TestStubs.routerContext().context,
           project: {
             ...project,

--- a/tests/js/spec/views/projectOwnership.spec.jsx
+++ b/tests/js/spec/views/projectOwnership.spec.jsx
@@ -47,8 +47,7 @@ describe('Project Ownership', function () {
           params={{orgId: org.slug, projectId: project.slug}}
           organization={org}
           project={project}
-        />,
-        TestStubs.routerContext()
+        />
       );
       expect(wrapper).toSnapshot();
       // only rendered when `integrations-codeowners` feature flag enabled

--- a/tests/js/spec/views/projectPluginDetails.spec.jsx
+++ b/tests/js/spec/views/projectPluginDetails.spec.jsx
@@ -6,8 +6,10 @@ import ProjectPluginDetailsContainer, {
 
 describe('ProjectPluginDetails', function () {
   let component;
-  const routerContext = TestStubs.routerContext();
-  const {organization, project} = routerContext.context;
+
+  const organization = TestStubs.Organization();
+  const project = TestStubs.Project();
+
   const org = organization;
   const plugins = TestStubs.Plugins();
   const plugin = TestStubs.Plugin();
@@ -50,8 +52,7 @@ describe('ProjectPluginDetails', function () {
         project={project}
         params={{orgId: org.slug, projectId: project.slug, pluginId: 'amazon-sqs'}}
         location={TestStubs.location()}
-      />,
-      routerContext
+      />
     );
   });
 
@@ -73,8 +74,7 @@ describe('ProjectPluginDetails', function () {
         plugins={TestStubs.Plugins()}
         params={{orgId: org.slug, projectId: project.slug, pluginId: 'amazon-sqs'}}
         location={TestStubs.location()}
-      />,
-      routerContext
+      />
     );
 
     const btn = wrapper.find('button').at(1);

--- a/tests/js/spec/views/projectPlugins/index.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/index.spec.jsx
@@ -11,7 +11,6 @@ jest.mock('sentry/actionCreators/plugins', () => ({
 
 describe('ProjectPluginsContainer', function () {
   let org, project, plugins, wrapper, params, organization;
-  const routerContext = TestStubs.routerContext();
 
   beforeEach(function () {
     org = TestStubs.Organization();
@@ -50,8 +49,7 @@ describe('ProjectPluginsContainer', function () {
       method: 'DELETE',
     });
     wrapper = mountWithTheme(
-      <ProjectPlugins params={params} organization={organization} />,
-      routerContext
+      <ProjectPlugins params={params} organization={organization} />
     );
   });
 

--- a/tests/js/spec/views/projectPlugins/projectPlugins.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/projectPlugins.spec.jsx
@@ -4,7 +4,6 @@ import ProjectPlugins from 'sentry/views/settings/projectPlugins/projectPlugins'
 
 describe('ProjectPlugins', function () {
   let wrapper;
-  const routerContext = TestStubs.routerContext();
   const plugins = TestStubs.Plugins();
   const org = TestStubs.Organization();
   const project = TestStubs.Project();
@@ -14,19 +13,13 @@ describe('ProjectPlugins', function () {
   };
 
   it('renders', function () {
-    wrapper = mountWithTheme(
-      <ProjectPlugins params={params} plugins={plugins} />,
-      routerContext
-    );
+    wrapper = mountWithTheme(<ProjectPlugins params={params} plugins={plugins} />);
 
     expect(wrapper).toSnapshot();
   });
 
   it('has loading state', function () {
-    wrapper = mountWithTheme(
-      <ProjectPlugins params={params} loading plugins={[]} />,
-      routerContext
-    );
+    wrapper = mountWithTheme(<ProjectPlugins params={params} loading plugins={[]} />);
 
     expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
   });
@@ -38,8 +31,7 @@ describe('ProjectPlugins', function () {
         plugins={null}
         loading
         error={new Error('An error')}
-      />,
-      routerContext
+      />
     );
 
     expect(wrapper.find('RouteError')).toHaveLength(1);
@@ -52,8 +44,7 @@ describe('ProjectPlugins', function () {
         plugins={[]}
         loading
         error={new Error('An error')}
-      />,
-      routerContext
+      />
     );
     expect(wrapper.find('RouteError')).toHaveLength(1);
   });

--- a/tests/js/spec/views/projectSecurityHeaders/projectCspReports.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectCspReports.spec.jsx
@@ -33,8 +33,7 @@ describe('ProjectCspReports', function () {
           params: {orgId: org.slug, projectId: project.slug},
           location: TestStubs.location({pathname: routeUrl}),
         })}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper).toSnapshot();
   });
@@ -48,8 +47,7 @@ describe('ProjectCspReports', function () {
           params: {orgId: org.slug, projectId: project.slug},
           location: TestStubs.location({pathname: routeUrl}),
         })}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const mock = MockApiClient.addMockResponse({
@@ -84,8 +82,7 @@ describe('ProjectCspReports', function () {
           params: {orgId: org.slug, projectId: project.slug},
           location: TestStubs.location({pathname: routeUrl}),
         })}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const mock = MockApiClient.addMockResponse({

--- a/tests/js/spec/views/projectSecurityHeaders/projectExpectCtReports.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectExpectCtReports.spec.jsx
@@ -25,8 +25,7 @@ describe('ProjectExpectCtReports', function () {
           params: {orgId: org.slug, projectId: project.slug},
           location: TestStubs.location({pathname: url}),
         })}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper).toSnapshot();
   });

--- a/tests/js/spec/views/projectSecurityHeaders/projectHpkpReports.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectHpkpReports.spec.jsx
@@ -30,8 +30,7 @@ describe('ProjectHpkpReports', function () {
           params: {orgId: org.slug, projectId: project.slug},
           location: TestStubs.location({pathname: url}),
         })}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper).toSnapshot();
   });

--- a/tests/js/spec/views/projectSecurityHeaders/projectSecurityHeaders.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectSecurityHeaders.spec.jsx
@@ -25,8 +25,7 @@ describe('ProjectSecurityHeaders', function () {
           params: {orgId: org.slug, projectId: project.slug},
           location: TestStubs.location({pathname: url}),
         })}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(wrapper).toSnapshot();
   });

--- a/tests/js/spec/views/projectTags.spec.jsx
+++ b/tests/js/spec/views/projectTags.spec.jsx
@@ -24,8 +24,7 @@ describe('ProjectTags', function () {
 
   it('renders', function () {
     const wrapper = mountWithTheme(
-      <ProjectTags params={{orgId: org.slug, projectId: project.slug}} />,
-      TestStubs.routerContext()
+      <ProjectTags params={{orgId: org.slug, projectId: project.slug}} />
     );
 
     expect(wrapper).toSnapshot();
@@ -40,8 +39,7 @@ describe('ProjectTags', function () {
     });
 
     const wrapper = mountWithTheme(
-      <ProjectTags params={{orgId: org.slug, projectId: project.slug}} />,
-      TestStubs.routerContext()
+      <ProjectTags params={{orgId: org.slug, projectId: project.slug}} />
     );
 
     expect(wrapper.find('EmptyMessage')).toHaveLength(1);
@@ -62,8 +60,7 @@ describe('ProjectTags', function () {
 
   it('deletes tag', async function () {
     const wrapper = mountWithTheme(
-      <ProjectTags params={{orgId: org.slug, projectId: project.slug}} />,
-      TestStubs.routerContext()
+      <ProjectTags params={{orgId: org.slug, projectId: project.slug}} />
     );
 
     const tags = wrapper.state('tags').length;

--- a/tests/js/spec/views/projectTeams.spec.jsx
+++ b/tests/js/spec/views/projectTeams.spec.jsx
@@ -55,8 +55,7 @@ describe('ProjectTeams', function () {
       <ProjectTeams
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
-      />,
-      TestStubs.routerContext()
+      />
     );
     // Wait for team list to fetch.
     await wrapper.update();
@@ -89,8 +88,7 @@ describe('ProjectTeams', function () {
       <ProjectTeams
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
-      />,
-      TestStubs.routerContext()
+      />
     );
     // Wait for team list to fetch.
     await wrapper.update();
@@ -162,8 +160,7 @@ describe('ProjectTeams', function () {
       <ProjectTeams
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
-      />,
-      TestStubs.routerContext()
+      />
     );
     // Wait for team list to fetch.
     await wrapper.update();
@@ -210,8 +207,7 @@ describe('ProjectTeams', function () {
       <ProjectTeams
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
-      />,
-      TestStubs.routerContext()
+      />
     );
     // Wait for team list to fetch.
     await wrapper.update();
@@ -263,8 +259,7 @@ describe('ProjectTeams', function () {
           project={project}
           organization={org}
         />
-      </App>,
-      TestStubs.routerContext()
+      </App>
     );
     // Wait for team list to fetch.
     await wrapper.update();

--- a/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
@@ -21,8 +21,7 @@ describe('NoProjectMessage', function () {
     delete organization.projects;
     act(() => ProjectsStore.loadInitialData([project1, project2]));
     const wrapper = mountWithTheme(
-      <NoProjectMessage organization={organization}>{null}</NoProjectMessage>,
-      TestStubs.routerContext()
+      <NoProjectMessage organization={organization}>{null}</NoProjectMessage>
     );
     expect(wrapper.prop('children')).toBe(null);
     expect(wrapper.find('NoProjectMessage').exists()).toBe(true);
@@ -30,10 +29,7 @@ describe('NoProjectMessage', function () {
 
   it('shows "Create Project" button when there are no projects', function () {
     act(() => ProjectsStore.loadInitialData([]));
-    const wrapper = mountWithTheme(
-      <NoProjectMessage organization={org} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<NoProjectMessage organization={org} />);
     expect(
       wrapper.find('Button[to="/organizations/org-slug/projects/new/"]')
     ).toHaveLength(1);
@@ -42,8 +38,7 @@ describe('NoProjectMessage', function () {
   it('"Create Project" is disabled when no access to `project:write`', function () {
     act(() => ProjectsStore.loadInitialData([]));
     const wrapper = mountWithTheme(
-      <NoProjectMessage organization={TestStubs.Organization({access: []})} />,
-      TestStubs.routerContext()
+      <NoProjectMessage organization={TestStubs.Organization({access: []})} />
     );
     expect(
       wrapper.find('Button[to="/organizations/org-slug/projects/new/"]').prop('disabled')
@@ -51,27 +46,20 @@ describe('NoProjectMessage', function () {
   });
 
   it('has no "Join a Team" button when projects are missing', function () {
-    const wrapper = mountWithTheme(
-      <NoProjectMessage organization={org} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<NoProjectMessage organization={org} />);
     expect(wrapper.find('Button[to="/settings/org-slug/teams/"]')).toHaveLength(0);
   });
 
   it('has a "Join a Team" button when no projects but org has projects', function () {
     act(() => ProjectsStore.loadInitialData([TestStubs.Project({hasAccess: false})]));
-    const wrapper = mountWithTheme(
-      <NoProjectMessage organization={org} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<NoProjectMessage organization={org} />);
     expect(wrapper.find('Button[to="/settings/org-slug/teams/"]')).toHaveLength(1);
   });
 
   it('has a disabled "Join a Team" button if no access to `team:read`', function () {
     act(() => ProjectsStore.loadInitialData([TestStubs.Project({hasAccess: false})]));
     const wrapper = mountWithTheme(
-      <NoProjectMessage organization={{...org, access: []}} />,
-      TestStubs.routerContext()
+      <NoProjectMessage organization={{...org, access: []}} />
     );
     expect(wrapper.find('Button[to="/settings/org-slug/teams/"]').prop('disabled')).toBe(
       true
@@ -88,8 +76,7 @@ describe('NoProjectMessage', function () {
     const wrapper = mountWithTheme(
       <NoProjectMessage organization={org} superuserNeedsToBeProjectMember>
         {null}
-      </NoProjectMessage>,
-      TestStubs.routerContext()
+      </NoProjectMessage>
     );
     expect(wrapper.find('HelpMessage')).toHaveLength(1);
   });
@@ -116,8 +103,7 @@ describe('NoProjectMessage', function () {
     const wrapper = mountWithTheme(
       <NoProjectMessage organization={organization}>
         <MockComponent />
-      </NoProjectMessage>,
-      TestStubs.routerContext()
+      </NoProjectMessage>
     );
 
     // verify MockComponent is mounted once

--- a/tests/js/spec/views/projectsDashboard/projectCard.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/projectCard.spec.jsx
@@ -24,8 +24,7 @@ describe('ProjectCard', function () {
           platform: 'javascript',
         })}
         params={{orgId: 'org-slug'}}
-      />,
-      TestStubs.routerContext()
+      />
     );
   });
 
@@ -65,8 +64,7 @@ describe('ProjectCard', function () {
           latestDeploys,
         })}
         params={{orgId: 'org-slug'}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     expect(wrapper.find('Deploy')).toHaveLength(2);
@@ -98,8 +96,7 @@ describe('ProjectCard', function () {
           platform: 'javascript',
         })}
         params={{orgId: 'org-slug'}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const total = wrapper.find('a[data-test-id="project-errors"]');
@@ -127,8 +124,7 @@ describe('ProjectCard', function () {
           platform: 'javascript',
         })}
         params={{orgId: 'org-slug'}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const total = wrapper.find('a[data-test-id="project-errors"]');
@@ -145,8 +141,7 @@ describe('ProjectCard', function () {
         organization={TestStubs.Organization()}
         project={TestStubs.Project()}
         params={{orgId: 'org-slug'}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     expect(wrapper.find('Placeholder')).toHaveLength(1);

--- a/tests/js/spec/views/ruleBuilder.spec.jsx
+++ b/tests/js/spec/views/ruleBuilder.spec.jsx
@@ -70,8 +70,7 @@ describe('RuleBuilder', function () {
 
   it('renders', async function () {
     const wrapper = mountWithTheme(
-      <RuleBuilder project={project} organization={organization} onAddRule={handleAdd} />,
-      TestStubs.routerContext()
+      <RuleBuilder project={project} organization={organization} onAddRule={handleAdd} />
     );
 
     await tick();
@@ -110,8 +109,7 @@ describe('RuleBuilder', function () {
         onAddRule={handleAdd}
         urls={['example.com/a', 'example.com/a/foo']}
         paths={['a/bar', 'a/foo']}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     // Open the menu so we can do some assertions.

--- a/tests/js/spec/views/sentryAppExternalInstallation.spec.jsx
+++ b/tests/js/spec/views/sentryAppExternalInstallation.spec.jsx
@@ -55,8 +55,7 @@ describe('SentryAppExternalInstallation', () => {
 
     getMountedComponent = () =>
       mountWithTheme(
-        <SentryAppExternalInstallation params={{sentryAppSlug: sentryApp.slug}} />,
-        TestStubs.routerContext()
+        <SentryAppExternalInstallation params={{sentryAppSlug: sentryApp.slug}} />
       );
   });
 

--- a/tests/js/spec/views/settings/accountSettingsLayout.spec.jsx
+++ b/tests/js/spec/views/settings/accountSettingsLayout.spec.jsx
@@ -20,8 +20,7 @@ describe('AccountSettingsLayout', function () {
       url: `/organizations/${organization.slug}/`,
     });
     wrapper = mountWithTheme(
-      <AccountSettingsLayout router={TestStubs.router()} params={{}} />,
-      TestStubs.routerContext()
+      <AccountSettingsLayout router={TestStubs.router()} params={{}} />
     );
   });
 

--- a/tests/js/spec/views/settings/auditLogView.spec.jsx
+++ b/tests/js/spec/views/settings/auditLogView.spec.jsx
@@ -17,8 +17,7 @@ describe('OrganizationAuditLog', function () {
 
   it('renders', function (done) {
     const wrapper = mountWithTheme(
-      <OrganizationAuditLog location={{query: ''}} params={{orgId: org.slug}} />,
-      TestStubs.routerContext()
+      <OrganizationAuditLog location={{query: ''}} params={{orgId: org.slug}} />
     );
     wrapper.setState({loading: false});
     wrapper.update();
@@ -31,8 +30,7 @@ describe('OrganizationAuditLog', function () {
 
   it('displays whether an action was done by a superuser', function () {
     const wrapper = mountWithTheme(
-      <OrganizationAuditLog location={{query: ''}} params={{orgId: org.slug}} />,
-      TestStubs.routerContext()
+      <OrganizationAuditLog location={{query: ''}} params={{orgId: org.slug}} />
     );
     expect(wrapper.find('div[data-test-id="actor-name"]').at(0).text()).toEqual(
       expect.stringContaining('(Sentry Staff)')

--- a/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
@@ -19,8 +19,7 @@ describe('OrganizationApiKeysList', function () {
         params={{orgId: 'org-slug'}}
         routes={routes}
         keys={[TestStubs.ApiKey()]}
-      />,
-      {context: TestStubs.routerContext()}
+      />
     );
 
     // Click remove button

--- a/tests/js/spec/views/settings/organizationApiKeysView.spec.jsx
+++ b/tests/js/spec/views/settings/organizationApiKeysView.spec.jsx
@@ -11,7 +11,6 @@ const routes = [
 ];
 
 describe('OrganizationApiKeys', function () {
-  const routerContext = TestStubs.routerContext();
   let getMock, deleteMock;
 
   beforeEach(function () {
@@ -38,8 +37,7 @@ describe('OrganizationApiKeys', function () {
         location={TestStubs.location()}
         params={{orgId: 'org-slug'}}
         routes={routes}
-      />,
-      routerContext
+      />
     );
 
     expect(wrapper.find('AutoSelectTextInput')).toHaveLength(1);
@@ -52,8 +50,7 @@ describe('OrganizationApiKeys', function () {
         location={TestStubs.location()}
         params={{orgId: 'org-slug'}}
         routes={routes}
-      />,
-      routerContext
+      />
     );
 
     expect(deleteMock).toHaveBeenCalledTimes(0);

--- a/tests/js/spec/views/settings/organizationAuthList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationAuthList.spec.jsx
@@ -4,10 +4,7 @@ import OrganizationAuthList from 'sentry/views/settings/organizationAuth/organiz
 
 describe('OrganizationAuthList', function () {
   it('renders with no providers', function () {
-    const wrapper = mountWithTheme(
-      <OrganizationAuthList providerList={[]} />,
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(<OrganizationAuthList providerList={[]} />);
 
     expect(wrapper).toSnapshot();
   });
@@ -18,8 +15,7 @@ describe('OrganizationAuthList', function () {
         orgId="org-slug"
         onSendReminders={() => {}}
         providerList={TestStubs.AuthProviders()}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     expect(wrapper).toSnapshot();

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -18,7 +18,6 @@ describe('Organization Developer Settings', function () {
       'org:write',
     ],
   });
-  const routerContext = TestStubs.routerContext();
 
   const publishButtonSelector = 'button[aria-label="Publish"]';
   const deleteButtonSelector = 'button[aria-label="Delete"]';
@@ -34,8 +33,7 @@ describe('Organization Developer Settings', function () {
     });
 
     const wrapper = mountWithTheme(
-      <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />,
-      routerContext
+      <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />
     );
 
     it('displays empty state', () => {
@@ -57,7 +55,7 @@ describe('Organization Developer Settings', function () {
 
       wrapper = mountWithTheme(
         <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />,
-        routerContext
+        {organization: org}
       );
     });
 
@@ -130,8 +128,7 @@ describe('Organization Developer Settings', function () {
       wrapper = mountWithTheme(
         <App>
           <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />
-        </App>,
-        routerContext
+        </App>
       );
 
       expect(wrapper.find(publishButtonSelector).prop('disabled')).toEqual(false);
@@ -186,8 +183,7 @@ describe('Organization Developer Settings', function () {
     });
 
     const wrapper = mountWithTheme(
-      <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />,
-      routerContext
+      <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />
     );
 
     it('shows the published status', () => {
@@ -212,8 +208,7 @@ describe('Organization Developer Settings', function () {
     });
 
     const wrapper = mountWithTheme(
-      <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />,
-      routerContext
+      <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />
     );
 
     it('public integration list is empty', () => {

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/permissionSelection.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/permissionSelection.spec.jsx
@@ -22,8 +22,7 @@ describe('PermissionSelection', () => {
           }}
           onChange={onChange}
         />
-      </Form>,
-      TestStubs.routerContext()
+      </Form>
     );
   });
 

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/permissionsObserver.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/permissionsObserver.spec.jsx
@@ -13,8 +13,7 @@ describe('PermissionsObserver', () => {
           scopes={['project:read', 'project:write', 'project:releases', 'org:admin']}
           events={['issue']}
         />
-      </Form>,
-      TestStubs.routerContext()
+      </Form>
     );
   });
 

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.jsx
@@ -23,8 +23,7 @@ describe('Resource Subscriptions', () => {
             }}
             onChange={onChange}
           />
-        </Form>,
-        TestStubs.routerContext()
+        </Form>
       );
     });
 
@@ -45,8 +44,7 @@ describe('Resource Subscriptions', () => {
       wrapper = mountWithTheme(
         <Form>
           <Subscriptions events={[]} permissions={permissions} onChange={onChange} />
-        </Form>,
-        TestStubs.routerContext()
+        </Form>
       );
 
       expect(
@@ -71,8 +69,7 @@ describe('Resource Subscriptions', () => {
             }}
             onChange={onChange}
           />
-        </Form>,
-        TestStubs.routerContext()
+        </Form>
       );
     });
 
@@ -97,8 +94,7 @@ describe('Resource Subscriptions', () => {
             permissions={permissions}
             onChange={onChange}
           />
-        </Form>,
-        TestStubs.routerContext()
+        </Form>
       );
 
       wrapper.setProps({permissions});

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.spec.jsx
@@ -70,8 +70,7 @@ describe('Sentry Application Dashboard', function () {
       });
 
       wrapper = mountWithTheme(
-        <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />,
-        TestStubs.routerContext()
+        <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />
       );
     });
 
@@ -127,8 +126,7 @@ describe('Sentry Application Dashboard', function () {
       });
 
       wrapper = mountWithTheme(
-        <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />,
-        TestStubs.routerContext()
+        <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />
       );
 
       expect(wrapper.find('PanelBody').exists('PanelItem')).toBeFalsy();
@@ -210,8 +208,7 @@ describe('Sentry Application Dashboard', function () {
       });
 
       wrapper = mountWithTheme(
-        <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />,
-        TestStubs.routerContext()
+        <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />
       );
     });
 
@@ -240,8 +237,7 @@ describe('Sentry Application Dashboard', function () {
       });
 
       wrapper = mountWithTheme(
-        <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />,
-        TestStubs.routerContext()
+        <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />
       );
 
       expect(wrapper.find('PanelBody').exists('PanelItem')).toBeFalsy();

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
@@ -16,8 +16,7 @@ describe('SubscriptionBox', () => {
         disabledFromPermissions={false}
         onChange={onChange}
         organization={org}
-      />,
-      TestStubs.routerContext()
+      />
     );
   });
 
@@ -45,8 +44,7 @@ describe('SubscriptionBox', () => {
           disabledFromPermissions={false}
           onChange={onChange}
           organization={org}
-        />,
-        TestStubs.routerContext()
+        />
       );
     });
 
@@ -67,8 +65,7 @@ describe('SubscriptionBox', () => {
           disabledFromPermissions={false}
           onChange={onChange}
           organization={org}
-        />,
-        TestStubs.routerContext()
+        />
       );
       expect(wrapper.find('Checkbox').prop('disabled')).toBe(false);
     });
@@ -82,8 +79,7 @@ describe('SubscriptionBox', () => {
           disabledFromPermissions={false}
           onChange={onChange}
           organization={org}
-        />,
-        TestStubs.routerContext()
+        />
       );
       expect(wrapper.find('Tooltip').prop('disabled')).toBe(true);
     });
@@ -98,8 +94,7 @@ describe('SubscriptionBox', () => {
         webhookDisabled
         onChange={onChange}
         organization={org}
-      />,
-      TestStubs.routerContext()
+      />
     );
     const tooltip = wrapper.find('Tooltip');
     expect(tooltip.prop('disabled')).toBe(false);

--- a/tests/js/spec/views/settings/organizationIntegrations/addIntegration.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/addIntegration.spec.jsx
@@ -7,8 +7,6 @@ describe('AddIntegration', function () {
   const provider = TestStubs.GitHubIntegrationProvider();
   const integration = TestStubs.GitHubIntegration();
 
-  const routerContext = TestStubs.routerContext();
-
   it('Adds an integration on dialog completion', function () {
     const onAdd = jest.fn();
 
@@ -23,8 +21,7 @@ describe('AddIntegration', function () {
             Click
           </a>
         )}
-      </AddIntegration>,
-      routerContext
+      </AddIntegration>
     );
 
     const newIntegration = {

--- a/tests/js/spec/views/settings/organizationIntegrations/addIntegrationButton.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/addIntegrationButton.spec.jsx
@@ -6,8 +6,6 @@ import AddIntegrationButton from 'sentry/views/organizationIntegrations/addInteg
 describe('AddIntegrationButton', function () {
   const provider = TestStubs.GitHubIntegrationProvider();
 
-  const routerContext = TestStubs.routerContext();
-
   it('Opens the setup dialog on click', function () {
     const onAdd = jest.fn();
 
@@ -16,8 +14,7 @@ describe('AddIntegrationButton', function () {
     global.open = open;
 
     const wrapper = mountWithTheme(
-      <AddIntegrationButton provider={provider} onAddIntegration={onAdd} />,
-      routerContext
+      <AddIntegrationButton provider={provider} onAddIntegration={onAdd} />
     );
 
     wrapper.find('Button').simulate('click');

--- a/tests/js/spec/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
@@ -56,8 +56,7 @@ describe('OrganizationMembersWrapper', function () {
 
   it('can invite member', function () {
     const wrapper = mountWithTheme(
-      <OrganizationMembersWrapper organization={organization} {...defaultProps} />,
-      TestStubs.routerContext()
+      <OrganizationMembersWrapper organization={organization} {...defaultProps} />
     );
 
     const inviteButton = wrapper.find('StyledButton');
@@ -75,8 +74,7 @@ describe('OrganizationMembersWrapper', function () {
     });
 
     const wrapper = mountWithTheme(
-      <OrganizationMembersWrapper organization={org} {...defaultProps} />,
-      TestStubs.routerContext()
+      <OrganizationMembersWrapper organization={org} {...defaultProps} />
     );
 
     const inviteButton = wrapper.find('StyledButton');
@@ -94,8 +92,7 @@ describe('OrganizationMembersWrapper', function () {
     const wrapper = mountWithTheme(
       <OrganizationMembersWrapper organization={organization} {...defaultProps}>
         <OrganizationMembersList {...defaultProps} router={{routes: []}} />
-      </OrganizationMembersWrapper>,
-      TestStubs.routerContext()
+      </OrganizationMembersWrapper>
     );
 
     expect(wrapper.find('OrganizationMembersList').exists()).toBe(true);

--- a/tests/js/spec/views/settings/organizationProjects.spec.jsx
+++ b/tests/js/spec/views/settings/organizationProjects.spec.jsx
@@ -37,8 +37,7 @@ describe('OrganizationProjects', function () {
 
   it('should render the projects in the store', function () {
     const wrapper = mountWithTheme(
-      <OrganizationProjectsContainer params={{orgId: org.slug}} location={{query: {}}} />,
-      routerContext
+      <OrganizationProjectsContainer params={{orgId: org.slug}} location={{query: {}}} />
     );
     expect(wrapper).toSnapshot();
 

--- a/tests/js/spec/views/settings/organizationRateLimits.spec.jsx
+++ b/tests/js/spec/views/settings/organizationRateLimits.spec.jsx
@@ -23,7 +23,7 @@ describe('Organization Rate Limits', function () {
   });
 
   it('renders with initialData', function () {
-    const wrapper = mountWithTheme(creator(), TestStubs.routerContext());
+    const wrapper = mountWithTheme(creator());
 
     expect(wrapper.find("RangeSlider[name='accountRateLimit']").prop('value')).toBe(
       70000
@@ -39,10 +39,7 @@ describe('Organization Rate Limits', function () {
         maxRateInterval: 60,
       },
     };
-    const wrapper = mountWithTheme(
-      creator({organization: org}),
-      TestStubs.routerContext()
-    );
+    const wrapper = mountWithTheme(creator({organization: org}));
 
     expect(wrapper.find('RangeSlider')).toHaveLength(1);
 
@@ -56,7 +53,7 @@ describe('Organization Rate Limits', function () {
       statusCode: 200,
     });
 
-    const wrapper = mountWithTheme(creator(), TestStubs.routerContext());
+    const wrapper = mountWithTheme(creator());
 
     expect(mock).not.toHaveBeenCalled();
 
@@ -86,7 +83,7 @@ describe('Organization Rate Limits', function () {
       statusCode: 200,
     });
 
-    const wrapper = mountWithTheme(creator(), TestStubs.routerContext());
+    const wrapper = mountWithTheme(creator());
 
     expect(mock).not.toHaveBeenCalled();
 

--- a/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
+++ b/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
@@ -35,8 +35,7 @@ describe('OrganizationSettingsForm', function () {
         access={new Set('org:admin')}
         initialData={TestStubs.Organization()}
         onSave={onSave}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const input = wrapper.find('input[name="name"]');
@@ -100,8 +99,7 @@ describe('OrganizationSettingsForm', function () {
         access={new Set('org:admin')}
         initialData={TestStubs.Organization()}
         onSave={onSave}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     wrapper

--- a/tests/js/spec/views/settings/projectDebugFiles/index.spec.tsx
+++ b/tests/js/spec/views/settings/projectDebugFiles/index.spec.tsx
@@ -5,7 +5,7 @@ import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary
 import ProjectDebugFiles from 'sentry/views/settings/projectDebugFiles';
 
 describe('ProjectDebugFiles', function () {
-  const {organization, project, routerContext, router} = initializeOrg();
+  const {organization, project, router} = initializeOrg();
 
   const props = {
     organization,
@@ -33,7 +33,7 @@ describe('ProjectDebugFiles', function () {
   });
 
   it('renders', function () {
-    mountWithTheme(<ProjectDebugFiles {...props} />, {context: routerContext});
+    mountWithTheme(<ProjectDebugFiles {...props} />);
 
     expect(screen.getByText('Debug Information Files')).toBeInTheDocument();
 
@@ -48,7 +48,7 @@ describe('ProjectDebugFiles', function () {
       body: [],
     });
 
-    mountWithTheme(<ProjectDebugFiles {...props} />, {context: routerContext});
+    mountWithTheme(<ProjectDebugFiles {...props} />);
 
     // Uploaded debug files content
     expect(
@@ -64,7 +64,7 @@ describe('ProjectDebugFiles', function () {
       }`,
     });
 
-    mountWithTheme(<ProjectDebugFiles {...props} />, {context: routerContext});
+    mountWithTheme(<ProjectDebugFiles {...props} />);
 
     // Delete button
     userEvent.click(screen.getByTestId('delete-dif'));

--- a/tests/js/spec/views/settings/projectEnvironments.spec.jsx
+++ b/tests/js/spec/views/settings/projectEnvironments.spec.jsx
@@ -19,8 +19,7 @@ function mountComponent(isHidden) {
       }}
       location={{pathname}}
       routes={[]}
-    />,
-    TestStubs.routerContext()
+    />
   );
 }
 

--- a/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
@@ -83,8 +83,7 @@ describe('projectGeneralSettings', function () {
 
   it('renders form fields', function () {
     wrapper = mountWithTheme(
-      <ProjectGeneralSettings params={{orgId: org.slug, projectId: project.slug}} />,
-      TestStubs.routerContext()
+      <ProjectGeneralSettings params={{orgId: org.slug, projectId: project.slug}} />
     );
 
     expect(wrapper.find('Input[name="slug"]').prop('value')).toBe('project-slug');
@@ -123,8 +122,7 @@ describe('projectGeneralSettings', function () {
     });
 
     wrapper = mountWithTheme(
-      <ProjectGeneralSettings params={{orgId: org.slug, projectId: project.slug}} />,
-      TestStubs.routerContext()
+      <ProjectGeneralSettings params={{orgId: org.slug, projectId: project.slug}} />
     );
 
     const removeBtn = wrapper.find('.ref-remove-project').first();
@@ -150,8 +148,7 @@ describe('projectGeneralSettings', function () {
     });
 
     wrapper = mountWithTheme(
-      <ProjectGeneralSettings params={{orgId: org.slug, projectId: project.slug}} />,
-      TestStubs.routerContext()
+      <ProjectGeneralSettings params={{orgId: org.slug, projectId: project.slug}} />
     );
 
     const removeBtn = wrapper.find('.ref-transfer-project').first();
@@ -191,8 +188,7 @@ describe('projectGeneralSettings', function () {
     });
 
     wrapper = mountWithTheme(
-      <ProjectGeneralSettings params={{orgId: org.slug, projectId: project.slug}} />,
-      TestStubs.routerContext()
+      <ProjectGeneralSettings params={{orgId: org.slug, projectId: project.slug}} />
     );
 
     const removeBtn = wrapper.find('.ref-transfer-project').first();

--- a/tests/js/spec/views/settings/projectKeys/details/index.spec.jsx
+++ b/tests/js/spec/views/settings/projectKeys/details/index.spec.jsx
@@ -70,7 +70,6 @@ describe('ProjectKeyDetails', function () {
       url: `/projects/${org.slug}/${project.slug}/keys/${projectKeys[0].id}/`,
       method: 'DELETE',
     });
-    const routerContext = TestStubs.routerContext();
 
     wrapper = mountWithTheme(
       <ProjectKeyDetails
@@ -82,13 +81,10 @@ describe('ProjectKeyDetails', function () {
         }}
       />,
       {
-        ...routerContext,
         context: {
-          ...routerContext.context,
           project: TestStubs.Project(),
         },
         childContextTypes: {
-          ...routerContext.childContextTypes,
           project: PropTypes.object,
         },
       }

--- a/tests/js/spec/views/settings/projectKeys/list/index.spec.jsx
+++ b/tests/js/spec/views/settings/projectKeys/list/index.spec.jsx
@@ -25,18 +25,14 @@ describe('ProjectKeys', function () {
       url: `/projects/${org.slug}/${project.slug}/keys/${projectKeys[0].id}/`,
       method: 'DELETE',
     });
-    const routerContext = TestStubs.routerContext();
 
     wrapper = mountWithTheme(
       <ProjectKeys routes={[]} params={{orgId: org.slug, projectId: project.slug}} />,
       {
-        ...routerContext,
         context: {
-          ...routerContext.context,
           project: TestStubs.Project(),
         },
         childContextTypes: {
-          ...routerContext.childContextTypes,
           project: PropTypes.object,
         },
       }
@@ -52,8 +48,7 @@ describe('ProjectKeys', function () {
     });
 
     wrapper = mountWithTheme(
-      <ProjectKeys routes={[]} params={{orgId: org.slug, projectId: project.slug}} />,
-      TestStubs.routerContext()
+      <ProjectKeys routes={[]} params={{orgId: org.slug, projectId: project.slug}} />
     );
 
     expect(wrapper.find('EmptyMessage')).toHaveLength(1);

--- a/tests/js/spec/views/settings/projectPerformance.spec.jsx
+++ b/tests/js/spec/views/settings/projectPerformance.spec.jsx
@@ -43,8 +43,7 @@ describe('projectPerformance', function () {
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
         project={project}
-      />,
-      TestStubs.routerContext()
+      />
     );
     await tick();
     expect(wrapper.find('input[name="threshold"]').prop('value')).toBe('300');
@@ -58,8 +57,7 @@ describe('projectPerformance', function () {
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
         project={project}
-      />,
-      TestStubs.routerContext()
+      />
     );
     await tick();
     wrapper
@@ -84,8 +82,7 @@ describe('projectPerformance', function () {
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
         project={project}
-      />,
-      TestStubs.routerContext()
+      />
     );
     await tick();
 

--- a/tests/js/spec/views/settings/projectReleaseTracking.spec.jsx
+++ b/tests/js/spec/views/settings/projectReleaseTracking.spec.jsx
@@ -39,8 +39,7 @@ describe('ProjectReleaseTracking', function () {
         project={project}
         plugins={{loading: false, plugins: TestStubs.Plugins()}}
         params={{orgId: org.slug, projectId: project.slug}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     expect(wrapper.find('TextCopyInput').prop('children')).toBe('token token token');
@@ -53,8 +52,7 @@ describe('ProjectReleaseTracking', function () {
         project={project}
         plugins={{loading: false, plugins: TestStubs.Plugins()}}
         params={{orgId: org.slug, projectId: project.slug}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     const mock = MockApiClient.addMockResponse({
@@ -94,8 +92,7 @@ describe('ProjectReleaseTracking', function () {
         organization={org}
         project={project}
         params={{orgId: org.slug, projectId: project.slug}}
-      />,
-      TestStubs.routerContext()
+      />
     );
     expect(fetchPlugins).toHaveBeenCalled();
 

--- a/tests/js/spec/views/settings/settingsIndex.spec.jsx
+++ b/tests/js/spec/views/settings/settingsIndex.spec.jsx
@@ -63,10 +63,7 @@ describe('SettingsIndex', function () {
         url: `/organizations/${organization.slug}/`,
       });
       ConfigStore.config.isSelfHosted = false;
-      wrapper = mountWithTheme(
-        <SettingsIndex router={TestStubs.router()} params={{}} />,
-        TestStubs.routerContext()
-      );
+      wrapper = mountWithTheme(<SettingsIndex router={TestStubs.router()} params={{}} />);
     });
 
     it('fetches org details for SidebarDropdown', function () {

--- a/tests/js/spec/views/team/teamSettings.spec.jsx
+++ b/tests/js/spec/views/team/teamSettings.spec.jsx
@@ -22,15 +22,13 @@ describe('TeamSettings', function () {
       url: `/teams/org/${team.slug}/`,
       method: 'PUT',
     });
-    const mountOptions = TestStubs.routerContext();
 
     const wrapper = mountWithTheme(
       <TeamSettings
         team={team}
         onTeamChange={() => {}}
         params={{orgId: 'org', teamId: team.slug}}
-      />,
-      mountOptions
+      />
     );
 
     wrapper
@@ -92,8 +90,7 @@ describe('TeamSettings', function () {
         params={{orgId: 'org', teamId: team.slug}}
         team={team}
         onTeamChange={() => {}}
-      />,
-      TestStubs.routerContext()
+      />
     );
 
     // Click "Remove Team button

--- a/tests/js/spec/views/userFeedback/userFeedbackEmpty.spec.jsx
+++ b/tests/js/spec/views/userFeedback/userFeedbackEmpty.spec.jsx
@@ -3,23 +3,18 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {UserFeedbackEmpty} from 'sentry/views/userFeedback/userFeedbackEmpty';
 
 describe('UserFeedbackEmpty', function () {
-  const routerContext = TestStubs.routerContext();
   const project = TestStubs.Project({id: '1'});
   const projectWithReports = TestStubs.Project({id: '2', hasUserReports: true});
   const projectWithoutReports = TestStubs.Project({id: '3'});
   const organization = TestStubs.Organization();
 
   it('renders empty', function () {
-    mountWithTheme(
-      <UserFeedbackEmpty projects={[]} organization={organization} />,
-      routerContext
-    );
+    mountWithTheme(<UserFeedbackEmpty projects={[]} organization={organization} />);
   });
 
   it('renders landing for project with no user feedback', function () {
     const wrapper = mountWithTheme(
-      <UserFeedbackEmpty projects={[project]} organization={organization} />,
-      routerContext
+      <UserFeedbackEmpty projects={[project]} organization={organization} />
     );
 
     expect(wrapper.find('OnboardingPanel').exists()).toBe(true);
@@ -27,8 +22,7 @@ describe('UserFeedbackEmpty', function () {
 
   it('renders warning for project with any user feedback', function () {
     const wrapper = mountWithTheme(
-      <UserFeedbackEmpty projects={[projectWithReports]} organization={organization} />,
-      routerContext
+      <UserFeedbackEmpty projects={[projectWithReports]} organization={organization} />
     );
 
     expect(wrapper.find('EmptyStateWarning').exists()).toBe(true);
@@ -39,8 +33,7 @@ describe('UserFeedbackEmpty', function () {
       <UserFeedbackEmpty
         projects={[project, projectWithReports]}
         organization={organization}
-      />,
-      routerContext
+      />
     );
 
     expect(wrapper.find('EmptyStateWarning').exists()).toBe(true);
@@ -52,8 +45,7 @@ describe('UserFeedbackEmpty', function () {
         projects={[project, projectWithReports]}
         organization={organization}
         projectIds={[projectWithReports.id]}
-      />,
-      routerContext
+      />
     );
 
     expect(wrapper.find('EmptyStateWarning').exists()).toBe(true);
@@ -65,8 +57,7 @@ describe('UserFeedbackEmpty', function () {
         projects={[project, projectWithReports]}
         organization={organization}
         projectIds={[project.id]}
-      />,
-      routerContext
+      />
     );
 
     expect(wrapper.find('OnboardingPanel').exists()).toBe(true);
@@ -78,8 +69,7 @@ describe('UserFeedbackEmpty', function () {
         projects={[project, projectWithReports]}
         organization={organization}
         projectIds={[project.id, projectWithReports.id]}
-      />,
-      routerContext
+      />
     );
 
     expect(wrapper.find('EmptyStateWarning').exists()).toBe(true);
@@ -91,8 +81,7 @@ describe('UserFeedbackEmpty', function () {
         projects={[project, projectWithoutReports]}
         organization={organization}
         projectIds={[project.id, projectWithoutReports.id]}
-      />,
-      routerContext
+      />
     );
 
     expect(wrapper.find('UserFeedbackEmpty').exists()).toBe(true);


### PR DESCRIPTION
Related to the discussion in the [TSC ](https://www.notion.so/sentry/2022-02-24-53bbb562b24a44f0824146d86a78d984#e487093775b14ea786f953616088eacd), went over to check what prevents us from dropping the legacy context that we are creating in our `mountWithTheme` function. I suspected that there may be some usages where the legacy context that were just copied from the mountWithTheme doc comment, so I went ahead and removed it in each file that I found it and validated that the tests still pass - where the tests failed, I noted the failure reason and kept the context. This PR removed just dead code.

The major reasons the tests failed when removing legacy context:
**1. we have assertions that test router.push**
This be fixed by rewriting the assertion call to spy on browserHistory (or not assert that navigation was done at all, idk how reasonable that is anyways).

**2. Feature component was used (it pulls organization from the legacy withOrganization context)**
This highlights that we have a partial "migration" state where we are using withOrganization as well as useOrganization. If we search the repo for `withOrganization`, we find a 158 components. It would be a large undertaking if we had to rewrite all the components, but luckily only 42 (`rg -Ul --multiline-dotall 'React.Component.*withOrganization' **/*.tsx`) of those components are *not* already written as function components, meaning that removing withOrganization would simply mean using useOrganization hook instead. TBD if we want to tackle this as most of the components seem quite large.

**3. Tested code was accessing some state on location `const query = useRef(location.query)`**
I need to investigate the react router docs to see if there's better ways that we can pass location here (ideas welcome)

I think that the removed code highlights the impact of any default functionality we add to our code (or comments) as it will eventually result in unnecessary code and confusion down the line. I do think think there is good value in avoiding boilerplate code, but I would rather that we do it in a more lazy way and when we feel the pain 😅 
