### PR TITLE
ref(sdk): Add temp long task check inside VCD

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -43,7 +43,7 @@ export const VisuallyCompleteWithData = ({
   const longTaskCount = useRef(0);
 
   useEffect(() => {
-    if (!PerformanceObserver || !browserPerformanceTimeOrigin) {
+    if (!window.PerformanceObserver || !browserPerformanceTimeOrigin) {
       return () => {};
     }
     const timeOrigin = browserPerformanceTimeOrigin / 1000;


### PR DESCRIPTION
### Summary
This adds a long-task observer inside the visuallyCompleteData component that will show long tasks while the component is mounted. Adding this will hopefully shed some light on LCP measurements that are inexplicably longer than VCD measurements when no other spans exists.

#### Screenshot of LCP - VCD
![Screen Shot 2022-02-25 at 9 59 50 AM](https://user-images.githubusercontent.com/6111995/155739676-71d5a804-373f-44ec-b598-8cde28fb2a33.png)

