### PR TITLE
ref(test): investigate timeout

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -161,7 +161,7 @@ const config: Config.InitialOptions = {
     '<rootDir>/tests/js/setupFramework.ts',
     '@testing-library/jest-dom/extend-expect',
   ],
-  testMatch: testMatch || ['<rootDir>/tests/js/**/*(*.)@(spec|test).(js|ts)?(x)'],
+  testMatch: ['tests/js/spec/views/alerts/create.spec.jsx'] || testMatch,
   testPathIgnorePatterns: ['<rootDir>/tests/sentry/lang/javascript/'],
 
   unmockedModulePathPatterns: [

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -161,7 +161,7 @@ const config: Config.InitialOptions = {
     '<rootDir>/tests/js/setupFramework.ts',
     '@testing-library/jest-dom/extend-expect',
   ],
-  testMatch: ['tests/js/spec/views/alerts/create.spec.jsx'] || testMatch,
+  testMatch: ['<rootDir>/tests/js/spec/views/alerts/create.spec.jsx'] || testMatch,
   testPathIgnorePatterns: ['<rootDir>/tests/sentry/lang/javascript/'],
 
   unmockedModulePathPatterns: [

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "babel-gettext-extractor": "^4.1.3",
     "babel-jest": "27.0.6",
     "babel-plugin-dynamic-import-node": "^2.2.0",
+    "babel-timing": "^0.9.1",
     "csstype": "^3.0.8",
     "eslint": "5.11.1",
     "eslint-config-sentry-app": "1.76.0",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -19,6 +19,8 @@ const jest = require('jest');
 
 const argv = process.argv.slice(2);
 
+argv.push('--verbose');
+
 // Watch unless on CI or in coverage mode
 if (!process.env.CI && !process.env.SENTRY_PRECOMMIT && argv.indexOf('--coverage') < 0) {
   argv.push('--watch');

--- a/static/app/views/alerts/builder/projectProvider.tsx
+++ b/static/app/views/alerts/builder/projectProvider.tsx
@@ -29,6 +29,7 @@ function AlertBuilderProjectProvider(props: Props) {
   const {projects, initiallyLoaded, fetching, fetchError} = useProjects({
     slugs: [projectId],
   });
+
   const project = projects.find(({slug}) => slug === projectId);
 
   useEffect(() => {

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -41,13 +41,11 @@ type State = {
 
 class Create extends Component<Props, State> {
   state = this.getInitialState();
-
   getInitialState(): State {
     const {organization, location, project} = this.props;
     const {createFromDiscover, createFromWizard, aggregate, dataset, eventTypes} =
       location?.query ?? {};
     let alertType: AlertType = 'issue';
-
     // Alerts can only be created via create from discover or alert wizard
     if (createFromDiscover) {
       alertType = 'metric';
@@ -63,10 +61,8 @@ class Create extends Component<Props, State> {
         `/organizations/${organization.slug}/alerts/${project.slug}/wizard`
       );
     }
-
     return {alertType};
   }
-
   componentDidMount() {
     const {organization, project} = this.props;
     trackAdvancedAnalyticsEvent('new_alert_rule.viewed', {
@@ -76,10 +72,8 @@ class Create extends Component<Props, State> {
       alert_type: this.state.alertType,
     });
   }
-
   /** Used to track analytics within one visit to the creation page */
   sessionId = uniqueId();
-
   render() {
     const {
       hasMetricAlerts,
@@ -94,20 +88,16 @@ class Create extends Component<Props, State> {
       location?.query ?? {};
     const wizardTemplate: WizardRuleTemplate = {aggregate, dataset, eventTypes};
     const eventView = createFromDiscover ? EventView.fromLocation(location) : undefined;
-
     let wizardAlertType: undefined | WizardAlertType;
     if (createFromWizard && alertType === 'metric') {
       wizardAlertType = wizardTemplate
         ? getAlertTypeFromAggregateDataset(wizardTemplate)
         : 'issues';
     }
-
     const title = t('New Alert Rule');
-
     return (
       <Fragment>
         <SentryDocumentTitle title={title} projectSlug={projectId} />
-
         <Layout.Header>
           <StyledHeaderContent>
             <BuilderBreadCrumbs
@@ -139,7 +129,6 @@ class Create extends Component<Props, State> {
                         userTeamIds={teams.map(({id}) => id)}
                       />
                     )}
-
                     {hasMetricAlerts && alertType === 'metric' && (
                       <IncidentRulesCreate
                         {...this.props}

--- a/static/app/views/alerts/incidentRules/create.tsx
+++ b/static/app/views/alerts/incidentRules/create.tsx
@@ -12,13 +12,13 @@ import {WizardRuleTemplate} from 'sentry/views/alerts/wizard/options';
 
 import RuleForm from './ruleForm';
 
-type RouteParams = {
+interface RouteParams {
   orgId: string;
   projectId: string;
   ruleId?: string;
-};
+}
 
-type Props = {
+interface IncidentRulesCreateProps extends RouteComponentProps<RouteParams, {}> {
   eventView: EventView | undefined;
   organization: Organization;
   project: Project;
@@ -26,23 +26,21 @@ type Props = {
   isCustomMetric?: boolean;
   sessionId?: string;
   wizardTemplate?: WizardRuleTemplate;
-} & RouteComponentProps<RouteParams, {}>;
+}
 
 /**
  * Show metric rules form with an empty rule. Redirects to alerts list after creation.
  */
-function IncidentRulesCreate(props: Props) {
+function IncidentRulesCreate(props: IncidentRulesCreateProps) {
   function handleSubmitSuccess() {
     const {router, project} = props;
     const {orgId} = props.params;
-
     metric.endTransaction({name: 'saveAlertRule'});
     router.push({
       pathname: `/organizations/${orgId}/alerts/rules/`,
       query: {project: project.id},
     });
   }
-
   const {project, eventView, wizardTemplate, sessionId, userTeamIds, ...otherProps} =
     props;
   const defaultRule = eventView
@@ -50,11 +48,9 @@ function IncidentRulesCreate(props: Props) {
     : wizardTemplate
     ? createRuleFromWizardTemplate(wizardTemplate)
     : createDefaultRule();
-
   const projectTeamIds = new Set(project.teams.map(({id}) => id));
   const defaultOwnerId = userTeamIds.find(id => projectTeamIds.has(id)) ?? null;
   defaultRule.owner = defaultOwnerId && `team:${defaultOwnerId}`;
-
   return (
     <RuleForm
       onSubmitSuccess={handleSubmitSuccess}

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -673,8 +673,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       comparisonDelta,
       comparisonType,
     };
-    const alertType = getAlertTypeFromAggregateDataset({aggregate, dataset});
 
+    const alertType = getAlertTypeFromAggregateDataset({aggregate, dataset});
     const wizardBuilderChart = (
       <TriggersChart
         {...chartProps}

--- a/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
@@ -210,6 +210,7 @@ class TriggersChart extends React.PureComponent<Props, State> {
   async fetchTotalCount() {
     const {api, organization, environment, projects, query} = this.props;
     const statsPeriod = this.getStatsPeriod();
+
     try {
       const totalCount = await fetchTotalCount(api, organization.slug, {
         field: [],

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -35,67 +35,97 @@ jest.mock('sentry/utils/analytics', () => ({
 }));
 jest.mock('sentry/utils/analytics/trackAdvancedAnalyticsEvent');
 
-describe('ProjectAlertsCreate', function () {
-  TeamStore.loadInitialData([], false, null);
-  const projectAlertRuleDetailsRoutes = [
-    {
-      path: '/organizations/:orgId/alerts/',
-      name: 'Organization Alerts',
-      indexRoute: {},
-      childRoutes: [
-        {
-          path: 'rules/',
-          name: 'Rules',
-          childRoutes: [
-            {
-              name: 'Project',
-              path: ':projectId/',
-              childRoutes: [
-                {
-                  name: 'New Alert Rule',
-                  path: 'new/',
-                },
-                {
-                  name: 'Edit Alert Rule',
-                  path: ':ruleId/',
-                },
-              ],
-            },
-          ],
-        },
-        {
-          path: 'metric-rules',
-          name: 'Metric Rules',
-          childRoutes: [
-            {
-              name: 'Project',
-              path: ':projectId/',
-              childRoutes: [
-                {
-                  name: 'New Alert Rule',
-                  path: 'new/',
-                },
-                {
-                  name: 'Edit Alert Rule',
-                  path: ':ruleId/',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      name: 'Project',
-      path: ':projectId/',
-    },
-    {
-      name: 'New Alert Rule',
-      path: 'new/',
-    },
-  ];
+const projectAlertRuleDetailsRoutes = [
+  {
+    path: '/organizations/:orgId/alerts/',
+    name: 'Organization Alerts',
+    indexRoute: {},
+    childRoutes: [
+      {
+        path: 'rules/',
+        name: 'Rules',
+        childRoutes: [
+          {
+            name: 'Project',
+            path: ':projectId/',
+            childRoutes: [
+              {
+                name: 'New Alert Rule',
+                path: 'new/',
+              },
+              {
+                name: 'Edit Alert Rule',
+                path: ':ruleId/',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        path: 'metric-rules',
+        name: 'Metric Rules',
+        childRoutes: [
+          {
+            name: 'Project',
+            path: ':projectId/',
+            childRoutes: [
+              {
+                name: 'New Alert Rule',
+                path: 'new/',
+              },
+              {
+                name: 'Edit Alert Rule',
+                path: ':ruleId/',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Project',
+    path: ':projectId/',
+  },
+  {
+    name: 'New Alert Rule',
+    path: 'new/',
+  },
+];
 
-  beforeEach(function () {
+const createWrapper = (props = {}, location = {}) => {
+  const {organization, project, routerContext, router} = initializeOrg(props);
+  ProjectsStore.loadInitialData([project]);
+  const params = {orgId: organization.slug, projectId: project.slug};
+  const wrapper = mountWithTheme(
+    <AlertsContainer>
+      <AlertBuilderProjectProvider params={params}>
+        <ProjectAlertsCreate
+          params={params}
+          location={{
+            pathname: `/organizations/org-slug/alerts/rules/${project.slug}/new/`,
+            query: {createFromWizard: true},
+            ...location,
+          }}
+          routes={projectAlertRuleDetailsRoutes}
+          router={router}
+        />
+      </AlertBuilderProjectProvider>
+    </AlertsContainer>,
+    {context: routerContext, organization}
+  );
+  mockRouterPush(wrapper, router);
+
+  return {
+    wrapper,
+    organization,
+    project,
+    router,
+  };
+};
+
+describe('ProjectAlertsCreate', () => {
+  beforeEach(() => {
     memberActionCreators.fetchOrgMembers = jest.fn();
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/rules/configuration/',
@@ -120,41 +150,12 @@ describe('ProjectAlertsCreate', function () {
     metric.startTransaction.mockClear();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     MockApiClient.clearMockResponses();
     trackAdvancedAnalyticsEvent.mockClear();
   });
 
-  const createWrapper = (props = {}, location = {}) => {
-    const {organization, project, routerContext, router} = initializeOrg(props);
-    ProjectsStore.loadInitialData([project]);
-    const params = {orgId: organization.slug, projectId: project.slug};
-    const wrapper = mountWithTheme(
-      <AlertsContainer>
-        <AlertBuilderProjectProvider params={params}>
-          <ProjectAlertsCreate
-            params={params}
-            location={{
-              pathname: `/organizations/org-slug/alerts/rules/${project.slug}/new/`,
-              query: {createFromWizard: true},
-              ...location,
-            }}
-            routes={projectAlertRuleDetailsRoutes}
-            router={router}
-          />
-        </AlertBuilderProjectProvider>
-      </AlertsContainer>,
-      {context: routerContext, organization}
-    );
-    mockRouterPush(wrapper, router);
-
-    return {
-      wrapper,
-      organization,
-      project,
-      router,
-    };
-  };
+  TeamStore.loadInitialData([], false, null);
 
   it('redirects to wizard', async function () {
     const location = {query: {}};
@@ -166,266 +167,266 @@ describe('ProjectAlertsCreate', function () {
     });
   });
 
-  describe('Issue Alert', function () {
-    it('loads default values', async function () {
-      createWrapper();
+  // describe('Issue Alert', function () {
+  //   it('loads default values', async function () {
+  //     createWrapper();
 
-      expect(await screen.findByDisplayValue('__all_environments__')).toBeInTheDocument();
-      expect(screen.getByDisplayValue('all')).toBeInTheDocument();
-      expect(screen.getByDisplayValue('30')).toBeInTheDocument();
-    });
+  //     expect(await screen.findByDisplayValue('__all_environments__')).toBeInTheDocument();
+  //     expect(screen.getByDisplayValue('all')).toBeInTheDocument();
+  //     expect(screen.getByDisplayValue('30')).toBeInTheDocument();
+  //   });
 
-    it('can remove filters', async function () {
-      createWrapper({
-        organization: {
-          features: ['alert-filters'],
-        },
-      });
-      const mock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/rules/',
-        method: 'POST',
-        body: TestStubs.ProjectAlertRule(),
-      });
+  //   it('can remove filters', async function () {
+  //     createWrapper({
+  //       organization: {
+  //         features: ['alert-filters'],
+  //       },
+  //     });
+  //     const mock = MockApiClient.addMockResponse({
+  //       url: '/projects/org-slug/project-slug/rules/',
+  //       method: 'POST',
+  //       body: TestStubs.ProjectAlertRule(),
+  //     });
 
-      await waitFor(() => {
-        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
-      });
+  //     await waitFor(() => {
+  //       expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
+  //     });
 
-      // Change name of alert rule
-      userEvent.type(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
+  //     // Change name of alert rule
+  //     userEvent.type(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
-      // Add a filter and remove it
-      await selectEvent.select(screen.getByText('Add optional filter...'), [
-        'The issue is {comparison_type} than {value} {time}',
-      ]);
+  //     // Add a filter and remove it
+  //     await selectEvent.select(screen.getByText('Add optional filter...'), [
+  //       'The issue is {comparison_type} than {value} {time}',
+  //     ]);
 
-      userEvent.click(screen.getByLabelText('Delete Node'));
+  //     userEvent.click(screen.getByLabelText('Delete Node'));
 
-      userEvent.click(screen.getByText('Save Rule'));
+  //     userEvent.click(screen.getByText('Save Rule'));
 
-      await waitFor(() => {
-        expect(mock).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            data: {
-              actionMatch: 'all',
-              actions: [],
-              conditions: [],
-              filterMatch: 'all',
-              filters: [],
-              frequency: 30,
-              name: 'My Rule Name',
-              owner: null,
-            },
-          })
-        );
-      });
-    });
+  //     await waitFor(() => {
+  //       expect(mock).toHaveBeenCalledWith(
+  //         expect.any(String),
+  //         expect.objectContaining({
+  //           data: {
+  //             actionMatch: 'all',
+  //             actions: [],
+  //             conditions: [],
+  //             filterMatch: 'all',
+  //             filters: [],
+  //             frequency: 30,
+  //             name: 'My Rule Name',
+  //             owner: null,
+  //           },
+  //         })
+  //       );
+  //     });
+  //   });
 
-    it('can remove conditions', async function () {
-      const {organization} = createWrapper({
-        organization: {
-          features: ['alert-filters'],
-        },
-      });
-      const mock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/rules/',
-        method: 'POST',
-        body: TestStubs.ProjectAlertRule(),
-      });
+  //   it('can remove conditions', async function () {
+  //     const {organization} = createWrapper({
+  //       organization: {
+  //         features: ['alert-filters'],
+  //       },
+  //     });
+  //     const mock = MockApiClient.addMockResponse({
+  //       url: '/projects/org-slug/project-slug/rules/',
+  //       method: 'POST',
+  //       body: TestStubs.ProjectAlertRule(),
+  //     });
 
-      await waitFor(() => {
-        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
-      });
+  //     await waitFor(() => {
+  //       expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
+  //     });
 
-      // Change name of alert rule
-      userEvent.type(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
+  //     // Change name of alert rule
+  //     userEvent.type(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
-      // Add a condition and remove it
-      await selectEvent.select(screen.getByText('Add optional condition...'), [
-        'A new issue is created',
-      ]);
+  //     // Add a condition and remove it
+  //     await selectEvent.select(screen.getByText('Add optional condition...'), [
+  //       'A new issue is created',
+  //     ]);
 
-      userEvent.click(screen.getByLabelText('Delete Node'));
+  //     userEvent.click(screen.getByLabelText('Delete Node'));
 
-      expect(trackAdvancedAnalyticsEvent).toHaveBeenCalledWith(
-        'edit_alert_rule.add_row',
-        {
-          name: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
-          organization,
-          project_id: '2',
-          type: 'conditions',
-        }
-      );
+  //     expect(trackAdvancedAnalyticsEvent).toHaveBeenCalledWith(
+  //       'edit_alert_rule.add_row',
+  //       {
+  //         name: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+  //         organization,
+  //         project_id: '2',
+  //         type: 'conditions',
+  //       }
+  //     );
 
-      userEvent.click(screen.getByText('Save Rule'));
+  //     userEvent.click(screen.getByText('Save Rule'));
 
-      await waitFor(() => {
-        expect(mock).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            data: {
-              actionMatch: 'all',
-              actions: [],
-              conditions: [],
-              filterMatch: 'all',
-              filters: [],
-              frequency: 30,
-              name: 'My Rule Name',
-              owner: null,
-            },
-          })
-        );
-      });
-    });
+  //     await waitFor(() => {
+  //       expect(mock).toHaveBeenCalledWith(
+  //         expect.any(String),
+  //         expect.objectContaining({
+  //           data: {
+  //             actionMatch: 'all',
+  //             actions: [],
+  //             conditions: [],
+  //             filterMatch: 'all',
+  //             filters: [],
+  //             frequency: 30,
+  //             name: 'My Rule Name',
+  //             owner: null,
+  //           },
+  //         })
+  //       );
+  //     });
+  //   });
 
-    it('can remove actions', async function () {
-      createWrapper({
-        organization: {
-          features: ['alert-filters'],
-        },
-      });
-      const mock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/rules/',
-        method: 'POST',
-        body: TestStubs.ProjectAlertRule(),
-      });
+  //   it('can remove actions', async function () {
+  //     createWrapper({
+  //       organization: {
+  //         features: ['alert-filters'],
+  //       },
+  //     });
+  //     const mock = MockApiClient.addMockResponse({
+  //       url: '/projects/org-slug/project-slug/rules/',
+  //       method: 'POST',
+  //       body: TestStubs.ProjectAlertRule(),
+  //     });
 
-      await waitFor(() => {
-        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
-      });
+  //     await waitFor(() => {
+  //       expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
+  //     });
 
-      // Change name of alert rule
-      userEvent.type(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
+  //     // Change name of alert rule
+  //     userEvent.type(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
-      // Add an action and remove it
-      await selectEvent.select(screen.getByText('Add action...'), [
-        'Send a notification (for all legacy integrations)',
-      ]);
+  //     // Add an action and remove it
+  //     await selectEvent.select(screen.getByText('Add action...'), [
+  //       'Send a notification (for all legacy integrations)',
+  //     ]);
 
-      userEvent.click(screen.getByLabelText('Delete Node'));
+  //     userEvent.click(screen.getByLabelText('Delete Node'));
 
-      userEvent.click(screen.getByText('Save Rule'));
+  //     userEvent.click(screen.getByText('Save Rule'));
 
-      await waitFor(() => {
-        expect(mock).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            data: {
-              actionMatch: 'all',
-              actions: [],
-              conditions: [],
-              filterMatch: 'all',
-              filters: [],
-              frequency: 30,
-              name: 'My Rule Name',
-              owner: null,
-            },
-          })
-        );
-      });
-    });
+  //     await waitFor(() => {
+  //       expect(mock).toHaveBeenCalledWith(
+  //         expect.any(String),
+  //         expect.objectContaining({
+  //           data: {
+  //             actionMatch: 'all',
+  //             actions: [],
+  //             conditions: [],
+  //             filterMatch: 'all',
+  //             filters: [],
+  //             frequency: 30,
+  //             name: 'My Rule Name',
+  //             owner: null,
+  //           },
+  //         })
+  //       );
+  //     });
+  //   });
 
-    it('updates values and saves', async function () {
-      const {router} = createWrapper({
-        organization: {
-          features: ['alert-filters'],
-        },
-      });
-      const mock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/rules/',
-        method: 'POST',
-        body: TestStubs.ProjectAlertRule(),
-      });
+  //   it('updates values and saves', async function () {
+  //     const {router} = createWrapper({
+  //       organization: {
+  //         features: ['alert-filters'],
+  //       },
+  //     });
+  //     const mock = MockApiClient.addMockResponse({
+  //       url: '/projects/org-slug/project-slug/rules/',
+  //       method: 'POST',
+  //       body: TestStubs.ProjectAlertRule(),
+  //     });
 
-      await waitFor(() => {
-        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
-      });
+  //     await waitFor(() => {
+  //       expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
+  //     });
 
-      // Change target environment
-      await selectEvent.select(screen.getByText('All Environments'), ['production']);
+  //     // Change target environment
+  //     await selectEvent.select(screen.getByText('All Environments'), ['production']);
 
-      // Change actionMatch and filterMatch dropdown
-      await selectEvent.select(screen.getAllByText('all')[0], ['any']);
-      await selectEvent.select(screen.getAllByText('all')[0], ['any']);
+  //     // Change actionMatch and filterMatch dropdown
+  //     await selectEvent.select(screen.getAllByText('all')[0], ['any']);
+  //     await selectEvent.select(screen.getAllByText('all')[0], ['any']);
 
-      // `userEvent.paste` isn't really ideal, but since `userEvent.type` doesn't provide good performance and
-      // the purpose of this test is not focused on how the user interacts with the fields,
-      // but rather on whether the form will be saved and updated, we decided use `userEvent.paste`
-      // so that this test does not time out from the default jest value of 5000ms
+  //     // `userEvent.paste` isn't really ideal, but since `userEvent.type` doesn't provide good performance and
+  //     // the purpose of this test is not focused on how the user interacts with the fields,
+  //     // but rather on whether the form will be saved and updated, we decided use `userEvent.paste`
+  //     // so that this test does not time out from the default jest value of 5000ms
 
-      // Change name of alert rule
-      userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
+  //     // Change name of alert rule
+  //     userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
-      // Add another condition
-      await selectEvent.select(screen.getByText('Add optional condition...'), [
-        "An event's tags match {key} {match} {value}",
-      ]);
-      // Edit new Condition
-      userEvent.paste(screen.getByPlaceholderText('key'), 'conditionKey');
+  //     // Add another condition
+  //     await selectEvent.select(screen.getByText('Add optional condition...'), [
+  //       "An event's tags match {key} {match} {value}",
+  //     ]);
+  //     // Edit new Condition
+  //     userEvent.paste(screen.getByPlaceholderText('key'), 'conditionKey');
 
-      userEvent.paste(screen.getByPlaceholderText('value'), 'conditionValue');
-      await selectEvent.select(screen.getByText('equals'), ['does not equal']);
+  //     userEvent.paste(screen.getByPlaceholderText('value'), 'conditionValue');
+  //     await selectEvent.select(screen.getByText('equals'), ['does not equal']);
 
-      // Add a new filter
-      await selectEvent.select(screen.getByText('Add optional filter...'), [
-        'The issue is {comparison_type} than {value} {time}',
-      ]);
-      userEvent.paste(screen.getByPlaceholderText('10'), '12');
+  //     // Add a new filter
+  //     await selectEvent.select(screen.getByText('Add optional filter...'), [
+  //       'The issue is {comparison_type} than {value} {time}',
+  //     ]);
+  //     userEvent.paste(screen.getByPlaceholderText('10'), '12');
 
-      // Add a new action
-      await selectEvent.select(screen.getByText('Add action...'), [
-        'Send a notification via {service}',
-      ]);
+  //     // Add a new action
+  //     await selectEvent.select(screen.getByText('Add action...'), [
+  //       'Send a notification via {service}',
+  //     ]);
 
-      // Update action interval
-      await selectEvent.select(screen.getByText('30 minutes'), ['60 minutes']);
+  //     // Update action interval
+  //     await selectEvent.select(screen.getByText('30 minutes'), ['60 minutes']);
 
-      userEvent.click(screen.getByText('Save Rule'));
+  //     userEvent.click(screen.getByText('Save Rule'));
 
-      await waitFor(() => {
-        expect(mock).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            data: {
-              actionMatch: 'any',
-              filterMatch: 'any',
-              actions: [
-                {
-                  id: 'sentry.rules.actions.notify_event_service.NotifyEventServiceAction',
-                  service: 'mail',
-                },
-              ],
-              conditions: [
-                {
-                  id: 'sentry.rules.conditions.tagged_event.TaggedEventCondition',
-                  key: 'conditionKey',
-                  match: 'ne',
-                  value: 'conditionValue',
-                },
-              ],
-              filters: [
-                {
-                  id: 'sentry.rules.filters.age_comparison.AgeComparisonFilter',
-                  comparison_type: 'older',
-                  time: 'minute',
-                  value: '12',
-                },
-              ],
-              environment: 'production',
-              frequency: '60',
-              name: 'My Rule Name',
-              owner: null,
-            },
-          })
-        );
-      });
-      expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
+  //     await waitFor(() => {
+  //       expect(mock).toHaveBeenCalledWith(
+  //         expect.any(String),
+  //         expect.objectContaining({
+  //           data: {
+  //             actionMatch: 'any',
+  //             filterMatch: 'any',
+  //             actions: [
+  //               {
+  //                 id: 'sentry.rules.actions.notify_event_service.NotifyEventServiceAction',
+  //                 service: 'mail',
+  //               },
+  //             ],
+  //             conditions: [
+  //               {
+  //                 id: 'sentry.rules.conditions.tagged_event.TaggedEventCondition',
+  //                 key: 'conditionKey',
+  //                 match: 'ne',
+  //                 value: 'conditionValue',
+  //               },
+  //             ],
+  //             filters: [
+  //               {
+  //                 id: 'sentry.rules.filters.age_comparison.AgeComparisonFilter',
+  //                 comparison_type: 'older',
+  //                 time: 'minute',
+  //                 value: '12',
+  //               },
+  //             ],
+  //             environment: 'production',
+  //             frequency: '60',
+  //             name: 'My Rule Name',
+  //             owner: null,
+  //           },
+  //         })
+  //       );
+  //     });
+  //     expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
 
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/alerts/rules/',
-        query: {project: '2'},
-      });
-    });
-  });
+  //     expect(router.push).toHaveBeenCalledWith({
+  //       pathname: '/organizations/org-slug/alerts/rules/',
+  //       query: {project: '2'},
+  //     });
+  //   });
+  // });
 });

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -304,7 +304,6 @@ describe('ProjectAlertsCreate', function () {
       ]);
 
       userEvent.click(screen.getByLabelText('Delete Node'));
-
       userEvent.click(screen.getByText('Save Rule'));
 
       await waitFor(() => {
@@ -421,7 +420,6 @@ describe('ProjectAlertsCreate', function () {
         );
       });
       expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
-
       expect(router.push).toHaveBeenCalledWith({
         pathname: '/organizations/org-slug/alerts/rules/',
         query: {project: '2'},

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -304,6 +304,7 @@ describe('ProjectAlertsCreate', function () {
       ]);
 
       userEvent.click(screen.getByLabelText('Delete Node'));
+
       userEvent.click(screen.getByText('Save Rule'));
 
       await waitFor(() => {
@@ -420,6 +421,7 @@ describe('ProjectAlertsCreate', function () {
         );
       });
       expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
+
       expect(router.push).toHaveBeenCalledWith({
         pathname: '/organizations/org-slug/alerts/rules/',
         query: {project: '2'},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "allowJs": true
   },
-  "include": ["static", "tests/js", "docs-ui"],
+  "include": ["static/app/views/alerts", "tests/js", "docs-ui"],
   "exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,6 +114,13 @@
     "@jridgewell/trace-mapping" "^0.2.2"
     sourcemap-codec "1.4.8"
 
+"@ampproject/remapping@^2.1.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.1.2.tgz#4edca94973ded9630d20101cd8559cedb8d8bd34"
+  integrity sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.0"
+
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -176,6 +183,27 @@
     json5 "^2.1.2"
     semver "^6.3.0"
 
+"@babel/core@^7.12.9":
+  version "7.17.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.5.tgz#6cd2e836058c28f06a4ca8ee7ed955bbf37c8225"
+  integrity sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.3"
+    "@babel/helper-compilation-targets" "^7.16.7"
+    "@babel/helper-module-transforms" "^7.16.7"
+    "@babel/helpers" "^7.17.2"
+    "@babel/parser" "^7.17.3"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+
 "@babel/core@~7.15.5":
   version "7.15.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.5.tgz#f8ed9ace730722544609f90c9bb49162dc3bf5b9"
@@ -201,6 +229,15 @@
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.0.tgz#7bd890ba706cd86d3e2f727322346ffdbf98f65e"
   integrity sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.3.tgz#a2c30b0c4f89858cb87050c3ffdfd36bdf443200"
+  integrity sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==
   dependencies:
     "@babel/types" "^7.17.0"
     jsesc "^2.5.1"
@@ -430,6 +467,15 @@
     "@babel/traverse" "^7.17.0"
     "@babel/types" "^7.17.0"
 
+"@babel/helpers@^7.17.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.17.2.tgz#23f0a0746c8e287773ccd27c14be428891f63417"
+  integrity sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==
+  dependencies:
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.17.0"
+    "@babel/types" "^7.17.0"
+
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
   version "7.16.10"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
@@ -443,6 +489,11 @@
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.0.tgz#f0ac33eddbe214e4105363bb17c3341c5ffcc43c"
   integrity sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==
+
+"@babel/parser@^7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.3.tgz#b07702b982990bf6fdc1da5049a23fece4c5c3d0"
+  integrity sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.15.4":
   version "7.15.4"
@@ -1254,6 +1305,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
+  integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.3"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.14.5", "@babel/types@^7.14.9", "@babel/types@^7.15.4", "@babel/types@^7.15.6", "@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
@@ -1834,6 +1901,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz#b876e3feefb9c8d3aa84014da28b5e52a0640d72"
   integrity sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==
 
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz#771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec"
+  integrity sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==
+
 "@jridgewell/trace-mapping@^0.2.2":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.2.5.tgz#d5061cc513fd3a0a949feb56b8073989865b1abe"
@@ -1841,6 +1913,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     sourcemap-codec "1.4.8"
+
+"@jridgewell/trace-mapping@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz#f6a0832dffd5b8a6aaa633b7d9f8e8e94c83a0c3"
+  integrity sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@mdx-js/loader@^1.6.22":
   version "1.6.22"
@@ -4278,6 +4358,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/minimatch@^3.0.3":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
+  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
 "@types/minimist@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
@@ -5178,6 +5263,15 @@ ansi-colors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
+ansi-diff-stream@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-diff-stream/-/ansi-diff-stream-1.2.1.tgz#e75f98dc43c6ba3d63af481e693e89fd4262ac58"
+  integrity sha512-PaKs34INoKpTzcjyKd2GM/CCEeTyDgWKuHSgF0z7ywjpbBFj/pzQf/30v+TR6VBBLia6Mso+W2ygU22ljqbi6A==
+  dependencies:
+    ansi-regex "^2.0.0"
+    buffer-from "^1.0.0"
+    through2 "^2.0.1"
+
 ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -5316,6 +5410,11 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-differ@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
+  integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
 
 array-filter@^1.0.0:
   version "1.0.0"
@@ -5711,6 +5810,28 @@ babel-preset-jest@^27.0.6:
   dependencies:
     babel-plugin-jest-hoist "^27.0.6"
     babel-preset-current-node-syntax "^1.0.0"
+
+babel-timing@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/babel-timing/-/babel-timing-0.9.1.tgz#2031109276dda9710c6fc0ad72db73a1128eec16"
+  integrity sha512-OuCXcxu4yQvfhq2aVChLEh9ZR5uVBnT09CFVdPKurLpvmAxb6BFM91okfK9pc+7GilYYfMYNW1G/lIF9n09k1Q==
+  dependencies:
+    "@babel/core" "^7.12.9"
+    ansi-diff-stream "^1.2.1"
+    babel-loader "^8.1.0"
+    cli-table3 "^0.6.0"
+    colors "^1.4.0"
+    commander "^6.1.0"
+    find-babel-config "^1.2.0"
+    find-cache-dir "^3.3.1"
+    glob "^7.1.6"
+    lodash.chunk "^4.2.0"
+    lodash.defaults "^4.2.0"
+    lodash.mergewith "^4.6.2"
+    minimatch "^3.0.4"
+    multimatch "^4.0.0"
+    rimraf "^3.0.2"
+    webpack "^4.44.2"
 
 bail@^1.0.0:
   version "1.0.4"
@@ -6330,7 +6451,7 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-table3@^0.6.1:
+cli-table3@^0.6.0, cli-table3@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.1.tgz#36ce9b7af4847f288d3cdd081fbd09bf7bd237b8"
   integrity sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==
@@ -6470,7 +6591,7 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
 
-colors@1.4.0:
+colors@1.4.0, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -6497,7 +6618,7 @@ commander@^4.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^6.2.0, commander@^6.2.1:
+commander@^6.1.0, commander@^6.2.0, commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -8444,6 +8565,14 @@ finalhandler@~1.1.2:
     parseurl "~1.3.3"
     statuses "~1.5.0"
     unpipe "~1.0.0"
+
+find-babel-config@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
+  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
 
 find-cache-dir@^2.0.0:
   version "2.1.0"
@@ -10764,7 +10893,7 @@ json3@^3.3.3:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
@@ -11036,6 +11165,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.chunk@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
+  integrity sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -11050,6 +11184,11 @@ lodash.deburr@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
   integrity sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
 
 lodash.escape@^4.0.1:
   version "4.0.1"
@@ -11075,6 +11214,11 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.truncate@^4.4.2:
   version "4.4.2"
@@ -11599,6 +11743,17 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+multimatch@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-4.0.0.tgz#8c3c0f6e3e8449ada0af3dd29efb491a375191b3"
+  integrity sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    array-differ "^3.0.0"
+    array-union "^2.1.0"
+    arrify "^2.0.1"
+    minimatch "^3.0.4"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -13603,7 +13758,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -15191,6 +15346,14 @@ throttle-debounce@^3.0.1:
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
   integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
 
+through2@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
+
 through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -16049,7 +16212,7 @@ webpack-virtual-modules@^0.2.2, webpack-virtual-modules@^0.4.1, webpack-virtual-
   resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.3.tgz#cd597c6d51d5a5ecb473eea1983a58fa8a17ded9"
   integrity sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==
 
-webpack@4, webpack@5.66.0, webpack@^4.44.1, webpack@^5, webpack@^5.9.0:
+webpack@4, webpack@5.66.0, webpack@^4.44.1, webpack@^4.44.2, webpack@^5, webpack@^5.9.0:
   version "5.66.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.66.0.tgz#789bf36287f407fc92b3e2d6f978ddff1bfc2dbb"
   integrity sha512-NJNtGT7IKpGzdW7Iwpn/09OXz9inIkeIQ/ibY6B+MdV1x6+uReqz/5z1L89ezWnpPDWpXF0TY5PCYKQdWVn8Vg==
@@ -16262,7 +16425,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@^4.0.0, xtend@^4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
 @chadwhitacre reported test that timed out at ~20 seconds https://github.com/getsentry/sentry/pull/31732#issuecomment-1039580269 - this should rule out any timeouts caused by waitFor because those have a default timeout of 5 seconds.

Each test tests that memberActionCreators.fetchOrgMembers, since that uses a singleton, maybe we sometimes re-run the fetch call when we rerender a component during our test, which could fail the next test?

Next step: 
- run the test in isolation in CI and see if we can collect some simple timings
- run the same test locally and see if I can reproduce the slow test

Results:
- CI test finished in 50 seconds (https://github.com/getsentry/sentry/runs/5337873654?check_suite_focus=true)
- I managed to reproduce a somewhat slow run locally by clearing jest cache. Cached runs took ~5seconds on an M1 machine. Without cache, it takes ~15 seconds. It wouldn't be too unreasonable to think that on a less beefy non M1 machine the tests would take 50seconds if they are somehow CPU or memory bounds (this is a bit of a far fetched hypothesis for now), I will try to determine which test is actually slow next

Next step:
Run the test with --verbose both locally and in CI

Results:

CI
```
PASS tests/js/spec/views/alerts/create.spec.jsx (52.[84](https://github.com/getsentry/sentry/runs/5338214794?check_suite_focus=true#step:9:84)5 s)
  ProjectAlertsCreate
    ✓ redirects to wizard (532 ms)
    Issue Alert
      ✓ loads default values (213 ms)
      ✓ can remove filters (2362 ms)
      ✓ can remove conditions (2051 ms)
      ✓ can remove actions (1957 ms)
      ✓ updates values and saves (2492 ms)
```

Local:
```
 PASS  tests/js/spec/views/alerts/create.spec.jsx (13.602 s)
  ProjectAlertsCreate
    ✓ redirects to wizard (197 ms)
    Issue Alert
      ✓ loads default values (79 ms)
      ✓ can remove filters (987 ms)
      ✓ can remove conditions (876 ms)
      ✓ can remove actions (982 ms)
      ✓ updates values and saves (950 ms)
```

Tests seem fast (or not slow enough to cause timeouts). We have an error from jest saying
`Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?`.

I think at this point, we can rule out the actual test code to be the bottleneck and we need to see if we can find the open handles.

Next:
Run jest with --detectOpenHandles

Result:
Nothing actionable - I comment out all the test and run them 1 by 1 to see if I can isolate the problem to a single test. The command I'm running each time is `yarn run jest --clearCache && yarn run jest --runInBand --detectOpenHandles --verbose`
```
 PASS  tests/js/spec/views/alerts/create.spec.jsx (20.133 s)
  ProjectAlertsCreate
    ✓ redirects to wizard (204 ms)
 ```
 
 Arf, I need to find out the best way to isolate the open handlers. I'll go and remove components 1 by 1 till the test timing doesnt drop.

Result:
I removed all tests until I had just this left - the imported code was still included.
```
// import {browserHistory} from 'react-router';
// import selectEvent from 'react-select-event';

import {initializeOrg} from 'sentry-test/initializeOrg';
import {mockRouterPush} from 'sentry-test/mockRouterPush';
import {mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';

import * as memberActionCreators from 'sentry/actionCreators/members';
import ProjectsStore from 'sentry/stores/projectsStore';
import TeamStore from 'sentry/stores/teamStore';
import {metric} from 'sentry/utils/analytics';
import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
import AlertsContainer from 'sentry/views/alerts';
import AlertBuilderProjectProvider from 'sentry/views/alerts/builder/projectProvider';
import ProjectAlertsCreate from 'sentry/views/alerts/create';

describe("test", () => {
  it("test", () => {
     mountWithTheme(<p>Test</p>);
     expect(await screen.findByText('Test')).toBeInTheDocument();
   })
})
```
Even with the following code, the test still took 20 seconds to run. I'm starting to suspect that the timeout could actually be caused by babel/tsc when running jest. I will remove each import till timings drop to isolate the culprit

🚀 we have a winner - `import ProjectAlertsCreate from 'sentry/views/alerts/create'` takes 13sec to process. TBD if this is typescript or babel. Will run tsc and just try and compile this file with --generateTrace. Side note: since this is all isolated, the increase could maybe be attributed to just the tsc/babel init time...

Going down the rabbit hole, I ended up at `static/app/views/alerts/incidentRules/ruleForm/index.tsx` which seems 😨... TSC does not show anything useful, because I need to compile all the files anyways... I have tried using https://github.com/toomuchdesign/babel-timing, but I didnt get it to play nice with typescript

Ndb --prof show that the CPU seems to float around ~70% with occasional spike - seems like it's just waiting for files most of the time...
<img width="1254" alt="CleanShot 2022-02-25 at 23 38 04@2x" src="https://user-images.githubusercontent.com/9317857/155812633-08eaeff0-de49-4c62-a511-06f05cb384cb.png">

node --inspect-brk can give us a bit more details and confirms that basically all 80% of the test time is spent loading files.
<img width="1242" alt="CleanShot 2022-02-26 at 08 46 59@2x" src="https://user-images.githubusercontent.com/9317857/155835000-5000812c-d679-4462-a724-2b27e8477365.png">

I tried running jest with esbuild-runner pkg and the results look promising (functionality is not exactly 100% on par, I removed the emotion css calls as esbuild-runner doesnt support plugins yet). A change like this would be out of the scope of this PR obviously
<img width="937" alt="CleanShot 2022-02-26 at 10 06 48@2x" src="https://user-images.githubusercontent.com/9317857/155837345-bb4996a5-5211-441a-a4a6-09440976fd1d.png">
