### PR TITLE
fix(new-widget-builder-experience): Add back required indicator - [DD-536]

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -864,12 +864,17 @@ function WidgetBuilder({
                     description={t(
                       "Choose which dashboard you'd like to add this query to. It will appear as a widget."
                     )}
+                    required
                   >
                     <DashboardSelector
                       error={state.errors?.dashboard}
                       dashboards={state.dashboards}
                       onChange={selectedDashboard =>
-                        setState({...state, selectedDashboard})
+                        setState({
+                          ...state,
+                          selectedDashboard,
+                          errors: {...state.errors, dashboard: undefined},
+                        })
                       }
                       disabled={state.loading}
                     />


### PR DESCRIPTION
I accidentally removed some code fixing a merge conflict: https://github.com/getsentry/sentry/pull/32021/files#diff-59b84f4928f8e6a0c4e6ad9714a8a7cc3a8740f3575d65bec807be02b50dc513L864

This PR adds back the required badge and unsetting the errors