### PR TITLE
Adjust acceptOrganizationInvite.tsx content

### DIFF
--- a/static/app/views/acceptOrganizationInvite.tsx
+++ b/static/app/views/acceptOrganizationInvite.tsx
@@ -101,7 +101,7 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
         {!inviteDetails.requireSso && (
           <p data-test-id="action-info-general">
             {t(
-              `To continue, you must either create a new account, or login to an
+              `To continue, you must either create a new account, or log in to an
               existing Sentry account.`
             )}
           </p>
@@ -158,7 +158,7 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
               openInNewTab={false}
               data-test-id="link-with-existing"
             >
-              {t('Login using an existing account')}
+              {t('Log in using an existing account')}
             </ExternalLink>
           )}
         </Actions>


### PR DESCRIPTION
[use "Log in" instead of "login"](https://github.com/getsentry/sentry/commit/d29d5a0e8728334498622176d04712329f31d519):
- A customer noted that we're using the noun "login" on this page, when we should be using the phrasal verb "log in".