### PR TITLE
fix(new-widget-builder-experience): Editing widgets - [DD-536]

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -970,7 +970,7 @@ function buildRoutes() {
         component={SafeLazyLoad}
       >
         <Route
-          path="widget/:widgetId/edit/"
+          path="widget/:widgetIndex/edit/"
           componentPromise={() => import('sentry/views/dashboardsV2/widgetBuilder')}
           component={SafeLazyLoad}
         />

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -327,7 +327,7 @@ class Dashboard extends Component<Props, State> {
     }
   };
 
-  handleEditWidget = (widget: Widget) => () => {
+  handleEditWidget = (widget: Widget, index: number) => () => {
     const {
       organization,
       dashboard,
@@ -344,7 +344,7 @@ class Dashboard extends Component<Props, State> {
 
       if (paramDashboardId) {
         router.push({
-          pathname: `/organizations/${organization.slug}/dashboard/${paramDashboardId}/widget/${widget.id}/edit/`,
+          pathname: `/organizations/${organization.slug}/dashboard/${paramDashboardId}/widget/${index}/edit/`,
           query: {
             ...location.query,
             source: DashboardWidgetSource.DASHBOARDS,
@@ -354,7 +354,7 @@ class Dashboard extends Component<Props, State> {
       }
 
       router.push({
-        pathname: `/organizations/${organization.slug}/dashboards/new/widget/${widget.id}/edit/`,
+        pathname: `/organizations/${organization.slug}/dashboards/new/widget/${index}/edit/`,
         query: {
           ...location.query,
           source: DashboardWidgetSource.DASHBOARDS,
@@ -397,7 +397,7 @@ class Dashboard extends Component<Props, State> {
       isEditing,
       widgetLimitReached,
       onDelete: this.handleDeleteWidget(widget),
-      onEdit: this.handleEditWidget(widget),
+      onEdit: this.handleEditWidget(widget, index),
       onDuplicate: this.handleDuplicateWidget(widget, index),
       isPreview,
     };

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -478,7 +478,7 @@ class DashboardDetail extends Component<Props, State> {
     return isValidElement(children)
       ? cloneElement(children, {
           dashboard: modifiedDashboard ?? dashboard,
-          onSave: this.onUpdateWidget,
+          onSave: this.isEditing ? this.onUpdateWidget : this.handleUpdateWidgetList,
           widget: widgetToBeUpdated,
         })
       : children;

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -123,7 +123,7 @@ const WIDGET_TYPE_TO_DATA_SET = {
 type RouteParams = {
   orgId: string;
   dashboardId?: string;
-  widgetId?: number;
+  widgetIndex?: number;
 };
 
 type QueryData = {
@@ -173,13 +173,13 @@ function WidgetBuilder({
   onSave,
   router,
 }: Props) {
-  const {widgetId, orgId, dashboardId} = params;
+  const {widgetIndex, orgId, dashboardId} = params;
   const {source, displayType, defaultTitle, defaultTableColumns} = location.query;
   const defaultWidgetQuery = getParsedDefaultWidgetQuery(
     location.query.defaultWidgetQuery
   );
 
-  const isEditing = defined(widgetId);
+  const isEditing = defined(widgetIndex);
   const orgSlug = organization.slug;
 
   // Construct PageFilters object using statsPeriod/start/end props so we can
@@ -555,7 +555,7 @@ function WidgetBuilder({
     });
   }
 
-  if (isEditing && !dashboard.widgets.some(({id}) => id === String(widgetId))) {
+  if (isEditing && widgetIndex >= dashboard.widgets.length) {
     return (
       <SentryDocumentTitle title={dashboard.title} orgSlug={orgSlug}>
         <PageContent>

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -97,7 +97,7 @@ describe('WidgetBuilder', function () {
         dashboard={dashboard}
         onSave={jest.fn()}
         widget={widget}
-        params={{orgId: organization.slug, widgetId: Number(widget.id)}}
+        params={{orgId: organization.slug, widgetIndex: 0}}
       />,
       {
         context: routerContext,


### PR DESCRIPTION
We have two handlers for editing widgets. One is called when in the edit state, and one is called when not.

The difference is the "non-edit state" handler actually triggers a PUT request because the user doesn't have a "Save and Finish" button to click.

The cases this PR handles covers combinations of edit/not-edit state and new/saved widgets. We should probably rename the methods to be more clear, sometimes I have a hard time telling them apart.

| Case | Solution |
| ------- | ------- |
| Edit, Saved | This should use `handleEditWidget` because the user hasn't committed the dashboard |
| Not Edit, Saved | This should use `handleUpdateWidgetList` because we're not in an edit state and the change should be immediately committed |
| Edit, Not Saved | This required updating the URL to use index instead of id, since newly added widgets don't have an ID.* This should use `handleEditWidget` |
| Not Edit, Not Saved | Not a possible state |

* Note: We discussed a little bit about making the ID just the max ID of the current widgets + 1, but I tried an API request to see what would happen if you add a widget with an ID that doesn't exist for that dashboard and it throws an error (I gave the last widget id: 9999):

![Screen Shot 2022-02-25 at 2 11 09 PM](https://user-images.githubusercontent.com/22846452/155800507-344a4a1f-db39-4b8f-b66a-5d77b8a08d5a.png)
