### PR TITLE
feat(mep): Connect the stats endpoint to metrics

### DIFF
--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -346,6 +346,7 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
             res["order"] = order
         elif "order" in result.data:
             res["order"] = result.data["order"]
+        res["mep"] = result.data.get("mep", False)
 
         if hasattr(result, "start") and hasattr(result, "end"):
             timeframe = calculateTimeframe(result.start, result.end, result.rollup)

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -346,7 +346,7 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
             res["order"] = order
         elif "order" in result.data:
             res["order"] = result.data["order"]
-        res["mep"] = result.data.get("mep", False)
+        res["isMetricsData"] = result.data.get("mep", False)
 
         if hasattr(result, "start") and hasattr(result, "end"):
             timeframe = calculateTimeframe(result.start, result.end, result.rollup)

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -346,7 +346,7 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
             res["order"] = order
         elif "order" in result.data:
             res["order"] = result.data["order"]
-        res["isMetricsData"] = result.data.get("mep", False)
+        res["isMetricsData"] = result.data.get("isMetricsData", False)
 
         if hasattr(result, "start") and hasattr(result, "end"):
             timeframe = calculateTimeframe(result.start, result.end, result.rollup)

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1550,7 +1550,11 @@ class MetricsQueryBuilder(QueryBuilder):
         operator = search_filter.operator
         value = search_filter.value.value
 
-        lhs = self.resolve_column(name)
+        try:
+            lhs = self.resolve_column(name)
+        except InvalidSearchQuery:
+            raise IncompatibleMetricsQuery("Column was not recognized in the metrics dataset")
+
         # resolve_column will try to resolve this name with indexer, and if its a tag the Column will be tags[1]
         is_tag = isinstance(lhs, Column) and lhs.subscriptable == "tags"
         if is_tag:

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -51,7 +51,10 @@ def timeseries_query(
                 else result["data"]
             )
             return SnubaTSResult(
-                {"data": result["data"], "mep": True}, params["start"], params["end"], rollup
+                {"data": result["data"], "isMetricsData": True},
+                params["start"],
+                params["end"],
+                rollup,
             )
         # raise Invalid Queries since the same thing will happen with discover
         except InvalidSearchQuery as error:

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -50,8 +50,9 @@ def timeseries_query(
                 if zerofill_results
                 else result["data"]
             )
-            # TODO: include meta in the response
-            return SnubaTSResult({"data": result["data"]}, params["start"], params["end"], rollup)
+            return SnubaTSResult(
+                {"data": result["data"], "mep": True}, params["start"], params["end"], rollup
+            )
         # raise Invalid Queries since the same thing will happen with discover
         except InvalidSearchQuery as error:
             raise error

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -1,0 +1,75 @@
+from datetime import timedelta
+from typing import Dict, List, Optional, Sequence
+
+from sentry.discover.arithmetic import categorize_columns
+from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
+from sentry.search.events.builder import TimeseriesMetricQueryBuilder
+from sentry.snuba import discover
+from sentry.utils.snuba import SnubaTSResult
+
+
+def timeseries_query(
+    selected_columns: Sequence[str],
+    query: str,
+    params: Dict[str, str],
+    rollup: int,
+    referrer: str,
+    zerofill_results: bool = True,
+    comparison_delta: Optional[timedelta] = None,
+    functions_acl: Optional[List[str]] = None,
+    use_snql: Optional[bool] = False,
+) -> SnubaTSResult:
+    """
+    High-level API for doing arbitrary user timeseries queries against events.
+    this API should match that of sentry.snuba.discover.timeseries_query
+    """
+    metrics_compatible = False
+    equations, columns = categorize_columns(selected_columns)
+    if comparison_delta is None and not equations:
+        metrics_compatible = True
+
+    if metrics_compatible:
+        try:
+            metrics_query = TimeseriesMetricQueryBuilder(
+                params,
+                rollup,
+                query=query,
+                selected_columns=columns,
+                functions_acl=functions_acl,
+            )
+            result = metrics_query.run_query(referrer + ".metrics-enhanced")
+            result = discover.transform_results(result, metrics_query.function_alias_map, {}, None)
+            result["data"] = (
+                discover.zerofill(
+                    result["data"],
+                    params["start"],
+                    params["end"],
+                    rollup,
+                    "time",
+                )
+                if zerofill_results
+                else result["data"]
+            )
+            # TODO: include meta in the response
+            return SnubaTSResult({"data": result["data"]}, params["start"], params["end"], rollup)
+        # raise Invalid Queries since the same thing will happen with discover
+        except InvalidSearchQuery as error:
+            raise error
+        # any remaining errors mean we should try again with discover
+        except IncompatibleMetricsQuery:
+            metrics_compatible = False
+
+    # This isn't a query we can enhance with metrics
+    if not metrics_compatible:
+        return discover.timeseries_query(
+            selected_columns,
+            query,
+            params,
+            rollup,
+            referrer,
+            zerofill_results,
+            comparison_delta,
+            functions_acl,
+            use_snql,
+        )
+    return SnubaTSResult()

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1098,7 +1098,11 @@ class MetricsEnhancedPerformanceTestCase(SessionMetricsTestCase, TestCase):
         "metrics_sets": "s",
         "metrics_counters": "c",
     }
-    ENTITY_MAP = {"transaction.duration": "metrics_distributions", "user": "metrics_sets"}
+    ENTITY_MAP = {
+        "transaction.duration": "metrics_distributions",
+        "measurements.lcp": "metrics_distributions",
+        "user": "metrics_sets",
+    }
     METRIC_STRINGS = []
     DEFAULT_METRIC_TIMESTAMP = datetime(2015, 1, 1, 10, 15, 0, tzinfo=timezone.utc)
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -950,7 +950,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             assert response.status_code == 200, response.content
             data = response.data["data"]
             assert len(data) == 6
-            assert response.data["mep"]
+            assert response.data["isMetricsData"]
 
             rows = data[0:6]
             for test in zip(event_counts, rows):
@@ -977,7 +977,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             assert response.status_code == 200, response.content
             data = response.data["data"]
             assert len(data) == 2
-            assert response.data["mep"]
+            assert response.data["isMetricsData"]
 
             assert data[0][1][0]["count"] == sum(event_counts) / (86400.0 / 60.0)
 
@@ -1004,7 +1004,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             assert response.status_code == 200, response.content
             data = response.data["data"]
             assert len(data) == 6
-            assert response.data["mep"]
+            assert response.data["isMetricsData"]
 
             rows = data[0:6]
             for test in zip(event_counts, rows):
@@ -1033,7 +1033,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             assert response.status_code == 200, response.content
             data = response.data["data"]
             assert len(data) == 6
-            assert response.data["mep"]
+            assert response.data["isMetricsData"]
 
             rows = data[0:6]
             for test in zip(event_counts, rows):
@@ -1061,7 +1061,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 6
-        assert response.data["mep"]
+        assert response.data["isMetricsData"]
         assert [attrs for time, attrs in response.data["data"]] == [
             [{"count": 0.5}],
             [{"count": 0.5}],
@@ -1091,9 +1091,9 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         lcp = response.data["p75(measurements.lcp)"]
         duration = response.data["p75(transaction.duration)"]
         assert len(duration["data"]) == 6
-        assert duration["mep"]
+        assert duration["isMetricsData"]
         assert len(lcp["data"]) == 6
-        assert lcp["mep"]
+        assert lcp["isMetricsData"]
         for item in duration["data"]:
             assert item[1][0]["count"] == 111
         for item in lcp["data"]:
@@ -1127,7 +1127,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             },
         )
         assert response.status_code == 200, response.content
-        assert response.data["mep"]
+        assert response.data["isMetricsData"]
         assert [attrs for time, attrs in response.data["data"]] == [[{"count": 1}], [{"count": 1}]]
 
     def test_non_mep_query_fallsback(self):
@@ -1144,7 +1144,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 },
             )
             assert response.status_code == 200, response.content
-            return response.data["mep"]
+            return response.data["isMetricsData"]
 
         assert get_mep(""), "empty query"
         assert get_mep("event.type:transaction"), "event type transaction"

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -14,7 +14,7 @@ from snuba_sdk.function import Function
 from sentry.constants import MAX_TOP_EVENTS
 from sentry.models.transaction_threshold import ProjectTransactionThreshold, TransactionMetric
 from sentry.snuba.discover import OTHER_KEY
-from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils import APITestCase, MetricsEnhancedPerformanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.samples import load_data
 
@@ -896,6 +896,231 @@ class OrganizationEventsStatsEndpointTestWithSnql(OrganizationEventsStatsEndpoin
             [{"count": None}],
             [{"count": None}],
         ]
+
+
+class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
+    MetricsEnhancedPerformanceTestCase
+):
+    endpoint = "sentry-api-0-organization-events-stats"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
+        self.DEFAULT_METRIC_TIMESTAMP = self.day_ago
+
+        self.url = reverse(
+            "sentry-api-0-organization-events-stats",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        self.features = {
+            "organizations:performance-use-metrics": True,
+            "organizations:discover-use-snql": True,
+        }
+        # referrer is used so we know when we can enable MEP or not
+        self.referrer = "api.performance.homepage.widget-chart"
+
+    def do_request(self, data, url=None, features=None):
+        if features is None:
+            features = {"organizations:discover-basic": True}
+        features.update(self.features)
+        with self.feature(features):
+            return self.client.get(self.url if url is None else url, data=data, format="json")
+
+    # These throughput tests should roughly match the ones in OrganizationEventsStatsEndpointTest
+    def test_throughput_epm_hour_rollup(self):
+        # Each of these denotes how many events to create in each hour
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for hour, count in enumerate(event_counts):
+            for minute in range(count):
+                self.store_metric(1, timestamp=self.day_ago + timedelta(hours=hour, minutes=minute))
+
+        for axis in ["epm()", "tpm()"]:
+            response = self.do_request(
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=6)),
+                    "interval": "1h",
+                    "yAxis": axis,
+                    "project": self.project.id,
+                    "referrer": self.referrer,
+                },
+            )
+            assert response.status_code == 200, response.content
+            data = response.data["data"]
+            assert len(data) == 6
+
+            rows = data[0:6]
+            for test in zip(event_counts, rows):
+                assert test[1][1][0]["count"] == test[0] / (3600.0 / 60.0)
+
+    def test_throughput_epm_day_rollup(self):
+        # Each of these denotes how many events to create in each minute
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for hour, count in enumerate(event_counts):
+            for minute in range(count):
+                self.store_metric(1, timestamp=self.day_ago + timedelta(hours=hour, minutes=minute))
+
+        for axis in ["epm()", "tpm()"]:
+            response = self.do_request(
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=24)),
+                    "interval": "24h",
+                    "yAxis": axis,
+                    "project": self.project.id,
+                    "referrer": self.referrer,
+                },
+            )
+            assert response.status_code == 200, response.content
+            data = response.data["data"]
+            assert len(data) == 2
+            print(data)
+
+            assert data[0][1][0]["count"] == sum(event_counts) / (86400.0 / 60.0)
+
+    def test_throughput_epm_hour_rollup_offset_of_hour(self):
+        # Each of these denotes how many events to create in each hour
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for hour, count in enumerate(event_counts):
+            for minute in range(count):
+                self.store_metric(
+                    1, timestamp=self.day_ago + timedelta(hours=hour, minutes=minute + 30)
+                )
+
+        for axis in ["tpm()", "epm()"]:
+            response = self.do_request(
+                data={
+                    "start": iso_format(self.day_ago + timedelta(minutes=30)),
+                    "end": iso_format(self.day_ago + timedelta(hours=6, minutes=30)),
+                    "interval": "1h",
+                    "yAxis": axis,
+                    "project": self.project.id,
+                    "referrer": self.referrer,
+                },
+            )
+            assert response.status_code == 200, response.content
+            data = response.data["data"]
+            assert len(data) == 6
+
+            rows = data[0:6]
+            for test in zip(event_counts, rows):
+                assert test[1][1][0]["count"] == test[0] / (3600.0 / 60.0)
+
+    def test_throughput_eps_minute_rollup(self):
+        # Each of these denotes how many events to create in each minute
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for minute, count in enumerate(event_counts):
+            for second in range(count):
+                self.store_metric(
+                    1, timestamp=self.day_ago + timedelta(minutes=minute, seconds=second)
+                )
+
+        for axis in ["eps()", "tps()"]:
+            response = self.do_request(
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(minutes=6)),
+                    "interval": "1m",
+                    "yAxis": axis,
+                    "project": self.project.id,
+                    "referrer": self.referrer,
+                },
+            )
+            assert response.status_code == 200, response.content
+            data = response.data["data"]
+            assert len(data) == 6
+
+            rows = data[0:6]
+            for test in zip(event_counts, rows):
+                assert test[1][1][0]["count"] == test[0] / 60.0
+
+    def test_failure_rate(self):
+        for hour in range(6):
+            timestamp = self.day_ago + timedelta(hours=hour, minutes=30)
+            self.store_metric(1, tags={"transaction.status": "ok"}, timestamp=timestamp)
+            if hour < 3:
+                self.store_metric(
+                    1, tags={"transaction.status": "internal_error"}, timestamp=timestamp
+                )
+
+        response = self.do_request(
+            data={
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=6)),
+                "interval": "1h",
+                "yAxis": ["failure_rate()"],
+                "project": self.project.id,
+                "referrer": self.referrer,
+            },
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 6
+        assert [attrs for time, attrs in response.data["data"]] == [
+            [{"count": 0.5}],
+            [{"count": 0.5}],
+            [{"count": 0.5}],
+            [{"count": 0}],
+            [{"count": 0}],
+            [{"count": 0}],
+        ]
+
+    def test_percentiles_multi_axis(self):
+        for hour in range(6):
+            timestamp = self.day_ago + timedelta(hours=hour, minutes=30)
+            self.store_metric(111, timestamp=timestamp)
+            self.store_metric(222, metric="measurements.lcp", timestamp=timestamp)
+
+        response = self.do_request(
+            data={
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=6)),
+                "interval": "1h",
+                "yAxis": ["p75(measurements.lcp)", "p75(transaction.duration)"],
+                "project": self.project.id,
+                "referrer": self.referrer,
+            },
+        )
+        assert response.status_code == 200, response.content
+        lcp = response.data["p75(measurements.lcp)"]
+        duration = response.data["p75(transaction.duration)"]
+        assert len(duration["data"]) == 6
+        assert len(lcp["data"]) == 6
+        for item in duration["data"]:
+            assert item[1][0]["count"] == 111
+        for item in lcp["data"]:
+            assert item[1][0]["count"] == 222
+
+    @mock.patch("sentry.snuba.metrics_enhanced_performance.timeseries_query", return_value={})
+    def test_multiple_yaxis_only_one_query(self, mock_query):
+        self.do_request(
+            data={
+                "project": self.project.id,
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=2)),
+                "interval": "1h",
+                "yAxis": ["epm()", "eps()", "tpm()", "p50(transaction.duration)"],
+                "referrer": self.referrer,
+            },
+        )
+
+        assert mock_query.call_count == 1
+
+    def test_aggregate_function_user_count(self):
+        self.store_metric(1, metric="user", timestamp=self.day_ago + timedelta(minutes=30))
+        self.store_metric(1, metric="user", timestamp=self.day_ago + timedelta(hours=1, minutes=30))
+        response = self.do_request(
+            data={
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=2)),
+                "interval": "1h",
+                "yAxis": "count_unique(user)",
+                "referrer": self.referrer,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert [attrs for time, attrs in response.data["data"]] == [[{"count": 1}], [{"count": 1}]]
 
 
 class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):


### PR DESCRIPTION
- This fixes a bug with the get_features locally not recognizing the metrics feature because of how batch_has doesn't check the settings
- This adds the metric referrers (ie. performance widget referrers) as accepted ones
- This adds a metrics_enhanced_performance file that will match closely to how discover works so that we can run queries either as plain discover or mep queries
~~- This hasn't added mep to the response meta yet, will do that in a follow up PR~~
Added mep to the response