### PR TITLE
fix(ui): Keep highlight dropdownAutoComplete list element in view

### DIFF
--- a/static/app/components/dropdownAutoComplete/row.tsx
+++ b/static/app/components/dropdownAutoComplete/row.tsx
@@ -37,11 +37,14 @@ function Row<T extends Item>({
     );
   }
 
+  const active = index === highlightedIndex;
+
   return (
     <AutoCompleteItem
       itemSize={itemSize}
       disabled={item.disabled}
-      isHighlighted={index === highlightedIndex}
+      isHighlighted={active}
+      ref={element => active && element?.scrollIntoView?.({block: 'nearest'})}
       {...getItemProps({item, index, style})}
     >
       {typeof item.label === 'function' ? item.label({inputValue}) : item.label}
@@ -92,6 +95,7 @@ const AutoCompleteItem = styled('div')<{
   display: flex;
   flex-direction: column;
   justify-content: center;
+  scroll-margin: 20px 0;
 
   font-size: 0.9em;
   background-color: ${p => (p.isHighlighted ? p.theme.hover : 'transparent')};


### PR DESCRIPTION
This uses the `scroll-margin` css-prop and `scrollIntoView` method to to
keep the element in vie

Before

https://user-images.githubusercontent.com/1421724/155815305-62857ef2-d557-436d-9a0e-4eb9fe4cb5f7.mov

After

https://user-images.githubusercontent.com/1421724/155815368-059e8430-d3a8-4bb3-949b-fb00219851e7.mov
