### PR TITLE
fix(dropdown-menu-v2): Fix ResizeObserver loop limit error

### DIFF
--- a/static/app/components/dropdownMenuControlV2.tsx
+++ b/static/app/components/dropdownMenuControlV2.tsx
@@ -127,8 +127,10 @@ function MenuControl({
   const [triggerWidth, setTriggerWidth] = useState<number>();
   // Update triggerWidth when its size changes using useResizeObserver
   const updateTriggerWidth = useCallback(() => {
-    const newTriggerWidth = ref.current?.offsetWidth;
-    !isSubmenu && newTriggerWidth && setTriggerWidth(newTriggerWidth);
+    setTimeout(() => {
+      const newTriggerWidth = ref.current?.offsetWidth;
+      !isSubmenu && newTriggerWidth && setTriggerWidth(newTriggerWidth);
+    });
   }, [trigger, triggerLabel, triggerProps]);
   useResizeObserver({ref, onResize: updateTriggerWidth});
   // If ResizeObserver is not available, manually update the width

--- a/static/app/components/dropdownMenuControlV2.tsx
+++ b/static/app/components/dropdownMenuControlV2.tsx
@@ -126,11 +126,13 @@ function MenuControl({
   // the min width for the menu.
   const [triggerWidth, setTriggerWidth] = useState<number>();
   // Update triggerWidth when its size changes using useResizeObserver
-  const updateTriggerWidth = useCallback(() => {
-    setTimeout(() => {
-      const newTriggerWidth = ref.current?.offsetWidth;
-      !isSubmenu && newTriggerWidth && setTriggerWidth(newTriggerWidth);
-    });
+  const updateTriggerWidth = useCallback(async () => {
+    // Wait until the trigger element finishes rendering, otherwise
+    // ResizeObserver might throw an infinite loop error.
+    await new Promise(resolve => setTimeout(resolve));
+
+    const newTriggerWidth = ref.current?.offsetWidth;
+    !isSubmenu && newTriggerWidth && setTriggerWidth(newTriggerWidth);
   }, [trigger, triggerLabel, triggerProps]);
   useResizeObserver({ref, onResize: updateTriggerWidth});
   // If ResizeObserver is not available, manually update the width


### PR DESCRIPTION
[Sentry Issue.](https://sentry.io/organizations/sentry/issues/2485743992/?project=11276)

ResizeObserver (added in https://github.com/getsentry/sentry/pull/32061) throws an infinite loop error when we mount `DropdownMenuControlV2`. This only happens when the component is first mounted, not in subsequent updates. The loop may have been caused by `DropdownButton` rendering multiple times at different widths during mount. 

**Solution:** wrapping the contents of `updateTriggerWidth` inside a `setTimeout` seems to fix the issue. Doing this ensures that `updateTriggerWidth ` only runs once the trigger has finished rendering.

**Note: To see the infinite loop error in the console,** we need to add
```js
window.onerror = console.log;
```
to the code (anywhere is fine). The error isn't logged by default.