### PR TITLE
test(alerts): Speed up create alert rule test

### DIFF
--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -192,7 +192,7 @@ describe('ProjectAlertsCreate', function () {
       });
 
       // Change name of alert rule
-      userEvent.type(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
+      userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
       // Add a filter and remove it
       await selectEvent.select(screen.getByText('Add optional filter...'), [
@@ -239,7 +239,7 @@ describe('ProjectAlertsCreate', function () {
       });
 
       // Change name of alert rule
-      userEvent.type(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
+      userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
       // Add a condition and remove it
       await selectEvent.select(screen.getByText('Add optional condition...'), [
@@ -296,7 +296,7 @@ describe('ProjectAlertsCreate', function () {
       });
 
       // Change name of alert rule
-      userEvent.type(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
+      userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
       // Add an action and remove it
       await selectEvent.select(screen.getByText('Add action...'), [

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -2,7 +2,6 @@ import {browserHistory} from 'react-router';
 import selectEvent from 'react-select-event';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {mockRouterPush} from 'sentry-test/mockRouterPush';
 import {
   mountWithTheme,
   screen,
@@ -10,7 +9,6 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
-import * as memberActionCreators from 'sentry/actionCreators/members';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {metric} from 'sentry/utils/analytics';
@@ -20,6 +18,7 @@ import AlertBuilderProjectProvider from 'sentry/views/alerts/builder/projectProv
 import ProjectAlertsCreate from 'sentry/views/alerts/create';
 
 jest.unmock('sentry/utils/recreateRoute');
+jest.mock('sentry/actionCreators/members');
 jest.mock('react-router');
 jest.mock('sentry/utils/analytics', () => ({
   metric: {
@@ -37,66 +36,8 @@ jest.mock('sentry/utils/analytics/trackAdvancedAnalyticsEvent');
 
 describe('ProjectAlertsCreate', function () {
   TeamStore.loadInitialData([], false, null);
-  const projectAlertRuleDetailsRoutes = [
-    {
-      path: '/organizations/:orgId/alerts/',
-      name: 'Organization Alerts',
-      indexRoute: {},
-      childRoutes: [
-        {
-          path: 'rules/',
-          name: 'Rules',
-          childRoutes: [
-            {
-              name: 'Project',
-              path: ':projectId/',
-              childRoutes: [
-                {
-                  name: 'New Alert Rule',
-                  path: 'new/',
-                },
-                {
-                  name: 'Edit Alert Rule',
-                  path: ':ruleId/',
-                },
-              ],
-            },
-          ],
-        },
-        {
-          path: 'metric-rules',
-          name: 'Metric Rules',
-          childRoutes: [
-            {
-              name: 'Project',
-              path: ':projectId/',
-              childRoutes: [
-                {
-                  name: 'New Alert Rule',
-                  path: 'new/',
-                },
-                {
-                  name: 'Edit Alert Rule',
-                  path: ':ruleId/',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      name: 'Project',
-      path: ':projectId/',
-    },
-    {
-      name: 'New Alert Rule',
-      path: 'new/',
-    },
-  ];
 
   beforeEach(function () {
-    memberActionCreators.fetchOrgMembers = jest.fn();
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/rules/configuration/',
       body: TestStubs.ProjectAlertRuleConfiguration(),
@@ -110,19 +51,14 @@ describe('ProjectAlertsCreate', function () {
       body: TestStubs.Environments(),
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/users/',
-      body: [TestStubs.User()],
-    });
-    MockApiClient.addMockResponse({
       url: `/projects/org-slug/project-slug/?expand=hasAlertIntegration`,
       body: {},
     });
-    metric.startTransaction.mockClear();
   });
 
   afterEach(function () {
     MockApiClient.clearMockResponses();
-    trackAdvancedAnalyticsEvent.mockClear();
+    jest.clearAllMocks();
   });
 
   const createWrapper = (props = {}, location = {}) => {
@@ -139,14 +75,12 @@ describe('ProjectAlertsCreate', function () {
               query: {createFromWizard: true},
               ...location,
             }}
-            routes={projectAlertRuleDetailsRoutes}
             router={router}
           />
         </AlertBuilderProjectProvider>
       </AlertsContainer>,
       {context: routerContext, organization}
     );
-    mockRouterPush(wrapper, router);
 
     return {
       wrapper,
@@ -156,21 +90,20 @@ describe('ProjectAlertsCreate', function () {
     };
   };
 
-  it('redirects to wizard', async function () {
+  it('redirects to wizard', function () {
     const location = {query: {}};
     createWrapper(undefined, location);
-    await waitFor(() => {
-      expect(browserHistory.replace).toHaveBeenCalledWith(
-        '/organizations/org-slug/alerts/project-slug/wizard'
-      );
-    });
+
+    expect(browserHistory.replace).toHaveBeenCalledWith(
+      '/organizations/org-slug/alerts/project-slug/wizard'
+    );
   });
 
   describe('Issue Alert', function () {
-    it('loads default values', async function () {
+    it('loads default values', function () {
       createWrapper();
 
-      expect(await screen.findByDisplayValue('__all_environments__')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('__all_environments__')).toBeInTheDocument();
       expect(screen.getByDisplayValue('all')).toBeInTheDocument();
       expect(screen.getByDisplayValue('30')).toBeInTheDocument();
     });
@@ -187,10 +120,6 @@ describe('ProjectAlertsCreate', function () {
         body: TestStubs.ProjectAlertRule(),
       });
 
-      await waitFor(() => {
-        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
-      });
-
       // Change name of alert rule
       userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
@@ -203,23 +132,21 @@ describe('ProjectAlertsCreate', function () {
 
       userEvent.click(screen.getByText('Save Rule'));
 
-      await waitFor(() => {
-        expect(mock).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            data: {
-              actionMatch: 'all',
-              actions: [],
-              conditions: [],
-              filterMatch: 'all',
-              filters: [],
-              frequency: 30,
-              name: 'My Rule Name',
-              owner: null,
-            },
-          })
-        );
-      });
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          data: {
+            actionMatch: 'all',
+            actions: [],
+            conditions: [],
+            filterMatch: 'all',
+            filters: [],
+            frequency: 30,
+            name: 'My Rule Name',
+            owner: null,
+          },
+        })
+      );
     });
 
     it('can remove conditions', async function () {
@@ -232,10 +159,6 @@ describe('ProjectAlertsCreate', function () {
         url: '/projects/org-slug/project-slug/rules/',
         method: 'POST',
         body: TestStubs.ProjectAlertRule(),
-      });
-
-      await waitFor(() => {
-        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
       });
 
       // Change name of alert rule
@@ -260,23 +183,21 @@ describe('ProjectAlertsCreate', function () {
 
       userEvent.click(screen.getByText('Save Rule'));
 
-      await waitFor(() => {
-        expect(mock).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            data: {
-              actionMatch: 'all',
-              actions: [],
-              conditions: [],
-              filterMatch: 'all',
-              filters: [],
-              frequency: 30,
-              name: 'My Rule Name',
-              owner: null,
-            },
-          })
-        );
-      });
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          data: {
+            actionMatch: 'all',
+            actions: [],
+            conditions: [],
+            filterMatch: 'all',
+            filters: [],
+            frequency: 30,
+            name: 'My Rule Name',
+            owner: null,
+          },
+        })
+      );
     });
 
     it('can remove actions', async function () {
@@ -291,10 +212,6 @@ describe('ProjectAlertsCreate', function () {
         body: TestStubs.ProjectAlertRule(),
       });
 
-      await waitFor(() => {
-        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
-      });
-
       // Change name of alert rule
       userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
@@ -307,23 +224,21 @@ describe('ProjectAlertsCreate', function () {
 
       userEvent.click(screen.getByText('Save Rule'));
 
-      await waitFor(() => {
-        expect(mock).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            data: {
-              actionMatch: 'all',
-              actions: [],
-              conditions: [],
-              filterMatch: 'all',
-              filters: [],
-              frequency: 30,
-              name: 'My Rule Name',
-              owner: null,
-            },
-          })
-        );
-      });
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          data: {
+            actionMatch: 'all',
+            actions: [],
+            conditions: [],
+            filterMatch: 'all',
+            filters: [],
+            frequency: 30,
+            name: 'My Rule Name',
+            owner: null,
+          },
+        })
+      );
     });
 
     it('updates values and saves', async function () {
@@ -338,16 +253,14 @@ describe('ProjectAlertsCreate', function () {
         body: TestStubs.ProjectAlertRule(),
       });
 
-      await waitFor(() => {
-        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
-      });
-
       // Change target environment
       await selectEvent.select(screen.getByText('All Environments'), ['production']);
 
       // Change actionMatch and filterMatch dropdown
-      await selectEvent.select(screen.getAllByText('all')[0], ['any']);
-      await selectEvent.select(screen.getAllByText('all')[0], ['any']);
+      const allDropdowns = screen.getAllByText('all');
+      expect(allDropdowns).toHaveLength(2);
+      await selectEvent.select(allDropdowns[0], ['any']);
+      await selectEvent.select(allDropdowns[1], ['any']);
 
       // `userEvent.paste` isn't really ideal, but since `userEvent.type` doesn't provide good performance and
       // the purpose of this test is not focused on how the user interacts with the fields,
@@ -383,48 +296,48 @@ describe('ProjectAlertsCreate', function () {
 
       userEvent.click(screen.getByText('Save Rule'));
 
-      await waitFor(() => {
-        expect(mock).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            data: {
-              actionMatch: 'any',
-              filterMatch: 'any',
-              actions: [
-                {
-                  id: 'sentry.rules.actions.notify_event_service.NotifyEventServiceAction',
-                  service: 'mail',
-                },
-              ],
-              conditions: [
-                {
-                  id: 'sentry.rules.conditions.tagged_event.TaggedEventCondition',
-                  key: 'conditionKey',
-                  match: 'ne',
-                  value: 'conditionValue',
-                },
-              ],
-              filters: [
-                {
-                  id: 'sentry.rules.filters.age_comparison.AgeComparisonFilter',
-                  comparison_type: 'older',
-                  time: 'minute',
-                  value: '12',
-                },
-              ],
-              environment: 'production',
-              frequency: '60',
-              name: 'My Rule Name',
-              owner: null,
-            },
-          })
-        );
-      });
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          data: {
+            actionMatch: 'any',
+            filterMatch: 'any',
+            actions: [
+              {
+                id: 'sentry.rules.actions.notify_event_service.NotifyEventServiceAction',
+                service: 'mail',
+              },
+            ],
+            conditions: [
+              {
+                id: 'sentry.rules.conditions.tagged_event.TaggedEventCondition',
+                key: 'conditionKey',
+                match: 'ne',
+                value: 'conditionValue',
+              },
+            ],
+            filters: [
+              {
+                id: 'sentry.rules.filters.age_comparison.AgeComparisonFilter',
+                comparison_type: 'older',
+                time: 'minute',
+                value: '12',
+              },
+            ],
+            environment: 'production',
+            frequency: '60',
+            name: 'My Rule Name',
+            owner: null,
+          },
+        })
+      );
       expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
 
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/alerts/rules/',
-        query: {project: '2'},
+      await waitFor(() => {
+        expect(router.push).toHaveBeenCalledWith({
+          pathname: '/organizations/org-slug/alerts/rules/',
+          query: {project: '2'},
+        });
       });
     });
   });


### PR DESCRIPTION
Switch to paste event as userEvent.type in our forms has performance issues, shaves 2 seconds off this one test.


Can see the typing happening 3 times each taking most of the time of the entire test. It looks like we have already used paste a few times in this file for this reason.

<img width="559" alt="image" src="https://user-images.githubusercontent.com/1400464/155820859-1e9f96c1-eea8-43df-a9d2-4f09a75f9aa1.png">


- cleans up some `waitFor` that weren't needed
- removes a few things that weren't used anymore like the routes