### PR TITLE
fix(jira): Webhook Response

### DIFF
--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -18,7 +18,7 @@ class JiraIssueUpdatedWebhook(JiraEndpointBase):
         if isinstance(exc, ApiError):
             response_option = handle_jira_api_error(exc, " to get email")
             if response_option:
-                return self.get_response(response_option)
+                return self.respond(response_option)
 
         return super().handle_exception(request, exc)
 


### PR DESCRIPTION
Fix the response when there is a Jira error.

Fixes [SENTRY-TDG](https://sentry.io/organizations/sentry/issues/3048449601).