### PR TITLE
fix(releasehealth-duplex): Log strings and prevent division by zero [INGEST-784]

### DIFF
--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -119,6 +119,8 @@ class ComparisonError:
         if sessions:
             return (metrics - sessions) / abs(sessions)
 
+        return None
+
     def __str__(self) -> str:
         return self._message
 


### PR DESCRIPTION
Clean up after https://github.com/getsentry/sentry/pull/32036.