### PR TITLE
fix(dropdown-menu-v2): Fix submenus detached from their parents

### DIFF
--- a/static/app/components/dropdownMenuV2.tsx
+++ b/static/app/components/dropdownMenuV2.tsx
@@ -114,6 +114,10 @@ function Menu({
     placement,
     containerPadding,
     isOpen: true,
+    // useOverlayPosition's algorithm doesn't work well for submenus on viewport
+    // scroll. Changing the boundary element (document.body by default) seems to
+    // fix this.
+    boundaryElement: document.querySelector<HTMLElement>('.app') ?? undefined,
   });
 
   // Store whether this menu/submenu is the current focused one, which in a

--- a/static/less/layout.less
+++ b/static/less/layout.less
@@ -255,6 +255,9 @@ body.auth {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+
+  // Necessary for the correct positioning of dropdown menus/overlays
+  position: relative;
 }
 
 .container {


### PR DESCRIPTION
On window scroll, `DropdownMenuV2`'s submenus are detached from their immediate parent. This likely has something to do with `react-aria`'s positioning algorithm and the way we handle overflows in our app. Changing the `boundaryElement` prop (which is set to `document.body` by default) seems to fix this issue.

**Before:**
<img width="470" alt="Screen Shot 2022-02-28 at 9 32 08 AM" src="https://user-images.githubusercontent.com/44172267/156030443-922cbb47-c3ac-4807-b4e6-ec4e4329ce6f.png">

**After:**
<img width="470" alt="Screen Shot 2022-02-28 at 9 32 26 AM" src="https://user-images.githubusercontent.com/44172267/156030476-0b83dd1f-4b51-47cb-bae0-8cbd9e505a2e.png">

