### PR TITLE
feat(dashboards): hides the widget viewer button when in edit mode

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -143,6 +143,7 @@ class WidgetCard extends React.Component<Props> {
       noLazyLoad,
       showWidgetViewerButton,
       onEdit,
+      isEditing,
     } = this.props;
     return (
       <ErrorBoundary
@@ -153,7 +154,7 @@ class WidgetCard extends React.Component<Props> {
             <Tooltip title={widget.title} containerDisplayMode="grid" showOnlyOnOverflow>
               <WidgetTitle>{widget.title}</WidgetTitle>
             </Tooltip>
-            {showWidgetViewerButton && (
+            {showWidgetViewerButton && !isEditing && (
               <OpenWidgetViewerButton
                 onClick={() => {
                   openWidgetViewerModal({


### PR DESCRIPTION
Hides the Widget Viewer button when in edit mode
![image](https://user-images.githubusercontent.com/83961295/156032151-3b926f99-4932-49d2-a3d9-0af194e8934a.png)
![image](https://user-images.githubusercontent.com/83961295/156032161-ce38d123-f9fc-484e-b3d1-6645efd0eba8.png)
