### PR TITLE
feat(ui): Move threshold selector to set thresholds percent option

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -55,7 +55,6 @@ type Props = {
   disabled: boolean;
   hasAlertWizardV3: boolean;
   onComparisonDeltaChange: (value: number) => void;
-  onComparisonTypeChange: (value: AlertRuleComparisonType) => void;
   onFilterSearch: (query: string) => void;
   onTimeWindowChange: (value: number) => void;
   organization: Organization;

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -211,31 +211,38 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             inline={false}
             flexibleControlStateSize
           />
-          <Feature features={['organizations:change-alerts']} organization={organization}>
-            {comparisonType === AlertRuleComparisonType.CHANGE && (
-              <ComparisonContainer>
-                {t(' compared to ')}
-                <SelectControl
-                  name="comparisonDelta"
-                  styles={{
-                    container: (provided: {[x: string]: string | number | boolean}) => ({
-                      ...provided,
-                      marginLeft: space(1),
-                    }),
-                    control: (provided: {[x: string]: string | number | boolean}) => ({
-                      ...provided,
-                      minWidth: 500,
-                      maxWidth: 1000,
-                    }),
-                  }}
-                  value={comparisonDelta}
-                  onChange={({value}) => onComparisonDeltaChange(value)}
-                  options={COMPARISON_DELTA_OPTIONS}
-                  required={comparisonType === AlertRuleComparisonType.CHANGE}
-                />
-              </ComparisonContainer>
-            )}
-          </Feature>
+          {!hasAlertWizardV3 && (
+            <Feature
+              features={['organizations:change-alerts']}
+              organization={organization}
+            >
+              {comparisonType === AlertRuleComparisonType.CHANGE && (
+                <ComparisonContainer>
+                  {t(' compared to ')}
+                  <SelectControl
+                    name="comparisonDelta"
+                    styles={{
+                      container: (provided: {
+                        [x: string]: string | number | boolean;
+                      }) => ({
+                        ...provided,
+                        marginLeft: space(1),
+                      }),
+                      control: (provided: {[x: string]: string | number | boolean}) => ({
+                        ...provided,
+                        minWidth: 500,
+                        maxWidth: 1000,
+                      }),
+                    }}
+                    value={comparisonDelta}
+                    onChange={({value}) => onComparisonDeltaChange(value)}
+                    options={COMPARISON_DELTA_OPTIONS}
+                    required={comparisonType === AlertRuleComparisonType.CHANGE}
+                  />
+                </ComparisonContainer>
+              )}
+            </Feature>
+          )}
         </FormRow>
       </Fragment>
     );

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -738,9 +738,13 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         comparisonType={comparisonType}
         dataset={dataset}
         disabled={!hasAccess || !canEdit}
+        onComparisonDeltaChange={value =>
+          this.handleFieldChange('comparisonDelta', value)
+        }
         onComparisonTypeChange={this.handleComparisonTypeChange}
         organization={organization}
         hasAlertWizardV3={hasAlertWizardV3}
+        comparisonDelta={comparisonDelta}
       />
     );
 

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -805,7 +805,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                 timeWindow={timeWindow}
                 comparisonType={comparisonType}
                 comparisonDelta={comparisonDelta}
-                onComparisonTypeChange={this.handleComparisonTypeChange}
                 onComparisonDeltaChange={value =>
                   this.handleFieldChange('comparisonDelta', value)
                 }

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -28,70 +28,70 @@ const ThresholdTypeForm = ({
   disabled,
   comparisonType,
   onComparisonDeltaChange,
-      onComparisonTypeChange,
-      hasAlertWizardV3,
-      comparisonDelta,
-    } : Props) =>
+  onComparisonTypeChange,
+  hasAlertWizardV3,
+  comparisonDelta,
+}: Props) =>
   dataset === Dataset.SESSIONS ? null : (
     <Feature features={['organizations:change-alerts']} organization={organization}>
       {!hasAlertWizardV3 && <StyledListItem>{t('Select threshold type')}</StyledListItem>}
       <FormRow hasAlertWizardV3={hasAlertWizardV3}>
         <StyledRadioGroup
           hasAlertWizardV3={hasAlertWizardV3}
-                disabled={disabled}
-                choices={[
-                  [
-                    AlertRuleComparisonType.COUNT,
-                    hasAlertWizardV3 ? 'Static: above or below {x}' : 'Count',
-                  ],
-                  [
-                    AlertRuleComparisonType.CHANGE,
-                    hasAlertWizardV3 ? (
+          disabled={disabled}
+          choices={[
+            [
+              AlertRuleComparisonType.COUNT,
+              hasAlertWizardV3 ? 'Static: above or below {x}' : 'Count',
+            ],
+            [
+              AlertRuleComparisonType.CHANGE,
+              hasAlertWizardV3 ? (
                 comparisonType === AlertRuleComparisonType.COUNT ? (
-                        'Percent Change: {x%} higher or lower compared to previous period'
-                      ) : (
-                        <ComparisonContainer>
-                          {t('Percent Change: {x%} higher or lower compared to')}
-                          <SelectControl
-                            name="comparisonDelta"
-                            styles={{
-                              container: (provided: {
-                                [x: string]: string | number | boolean;
-                              }) => ({
-                                ...provided,
-                                marginLeft: space(1),
-                              }),
-                              control: (provided: {
-                                [x: string]: string | number | boolean;
-                              }) => ({
-                                ...provided,
-                                minHeight: 30,
-                                minWidth: 500,
-                                maxWidth: 1000,
-                              }),
-                              valueContainer: (provided: {
-                                [x: string]: string | number | boolean;
-                              }) => ({
-                                ...provided,
-                                padding: 0,
-                              }),
-                              singleValue: (provided: {
-                                [x: string]: string | number | boolean;
-                              }) => ({
-                                ...provided,
-                              }),
-                            }}
-                            value={comparisonDelta}
-                            onClick={e => e.stopPropagation()}
-                            onChange={({value}) => onComparisonDeltaChange(value)}
-                            options={COMPARISON_DELTA_OPTIONS}
-                            required={comparisonType === AlertRuleComparisonType.CHANGE}
-                          />
-                        </ComparisonContainer>
-                      )
-                    ) : (
-                      'Percent Change'
-                    ),
+                  'Percent Change: {x%} higher or lower compared to previous period'
+                ) : (
+                  <ComparisonContainer>
+                    {t('Percent Change: {x%} higher or lower compared to')}
+                    <SelectControl
+                      name="comparisonDelta"
+                      styles={{
+                        container: (provided: {
+                          [x: string]: string | number | boolean;
+                        }) => ({
+                          ...provided,
+                          marginLeft: space(1),
+                        }),
+                        control: (provided: {
+                          [x: string]: string | number | boolean;
+                        }) => ({
+                          ...provided,
+                          minHeight: 30,
+                          minWidth: 500,
+                          maxWidth: 1000,
+                        }),
+                        valueContainer: (provided: {
+                          [x: string]: string | number | boolean;
+                        }) => ({
+                          ...provided,
+                          padding: 0,
+                        }),
+                        singleValue: (provided: {
+                          [x: string]: string | number | boolean;
+                        }) => ({
+                          ...provided,
+                        }),
+                      }}
+                      value={comparisonDelta}
+                      onClick={e => e.stopPropagation()}
+                      onChange={({value}) => onComparisonDeltaChange(value)}
+                      options={COMPARISON_DELTA_OPTIONS}
+                      required={comparisonType === AlertRuleComparisonType.CHANGE}
+                    />
+                  </ComparisonContainer>
+                )
+              ) : (
+                'Percent Change'
+              ),
             ],
           ]}
           value={comparisonType}

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -50,7 +50,8 @@ const ThresholdTypeForm = ({
                 comparisonType === AlertRuleComparisonType.COUNT ? (
                   'Percent Change: {x%} higher or lower compared to previous period'
                 ) : (
-                  <ComparisonContainer>
+                  // Prevent default to avoid dropdown menu closing on click
+                  <ComparisonContainer onClick={e => e.preventDefault()}>
                     {t('Percent Change: {x%} higher or lower compared to')}
                     <SelectControl
                       name="comparisonDelta"
@@ -82,7 +83,6 @@ const ThresholdTypeForm = ({
                         }),
                       }}
                       value={comparisonDelta}
-                      onClick={e => e.stopPropagation()}
                       onChange={({value}) => onComparisonDeltaChange(value)}
                       options={COMPARISON_DELTA_OPTIONS}
                       required={comparisonType === AlertRuleComparisonType.CHANGE}

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -48,7 +48,7 @@ const ThresholdTypeForm = ({
               AlertRuleComparisonType.CHANGE,
               hasAlertWizardV3 ? (
                 comparisonType === AlertRuleComparisonType.COUNT ? (
-                  'Percent Change: {x%} higher or lower compared to previous period'
+                  t('Percent Change: {x%} higher or lower compared to previous period')
                 ) : (
                   // Prevent default to avoid dropdown menu closing on click
                   <ComparisonContainer onClick={e => e.preventDefault()}>
@@ -90,7 +90,7 @@ const ThresholdTypeForm = ({
                   </ComparisonContainer>
                 )
               ) : (
-                'Percent Change'
+                t('Percent Change')
               ),
             ],
           ]}

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -2,10 +2,12 @@ import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
+import SelectControl from 'sentry/components/forms/selectControl';
 import ListItem from 'sentry/components/list/listItem';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
+import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/incidentRules/constants';
 
 import {AlertRuleComparisonType, Dataset} from './types';
 
@@ -14,8 +16,10 @@ type Props = {
   dataset: Dataset;
   disabled: boolean;
   hasAlertWizardV3: boolean;
+  onComparisonDeltaChange: (value: number) => void;
   onComparisonTypeChange: (value: AlertRuleComparisonType) => void;
   organization: Organization;
+  comparisonDelta?: number;
 };
 
 const ThresholdTypeForm = ({
@@ -23,26 +27,71 @@ const ThresholdTypeForm = ({
   dataset,
   disabled,
   comparisonType,
-  onComparisonTypeChange,
-  hasAlertWizardV3,
-}: Props) =>
+  onComparisonDeltaChange,
+      onComparisonTypeChange,
+      hasAlertWizardV3,
+      comparisonDelta,
+    } : Props) =>
   dataset === Dataset.SESSIONS ? null : (
     <Feature features={['organizations:change-alerts']} organization={organization}>
       {!hasAlertWizardV3 && <StyledListItem>{t('Select threshold type')}</StyledListItem>}
       <FormRow hasAlertWizardV3={hasAlertWizardV3}>
-        <RadioGroup
-          style={{flex: 1}}
-          disabled={disabled}
-          choices={[
-            [
-              AlertRuleComparisonType.COUNT,
-              hasAlertWizardV3 ? 'Static: above or below {x}' : 'Count',
-            ],
-            [
-              AlertRuleComparisonType.CHANGE,
-              hasAlertWizardV3
-                ? 'Percent Change: {x%} higher or lower compared to previous period'
-                : 'Percent Change',
+        <StyledRadioGroup
+          hasAlertWizardV3={hasAlertWizardV3}
+                disabled={disabled}
+                choices={[
+                  [
+                    AlertRuleComparisonType.COUNT,
+                    hasAlertWizardV3 ? 'Static: above or below {x}' : 'Count',
+                  ],
+                  [
+                    AlertRuleComparisonType.CHANGE,
+                    hasAlertWizardV3 ? (
+                comparisonType === AlertRuleComparisonType.COUNT ? (
+                        'Percent Change: {x%} higher or lower compared to previous period'
+                      ) : (
+                        <ComparisonContainer>
+                          {t('Percent Change: {x%} higher or lower compared to')}
+                          <SelectControl
+                            name="comparisonDelta"
+                            styles={{
+                              container: (provided: {
+                                [x: string]: string | number | boolean;
+                              }) => ({
+                                ...provided,
+                                marginLeft: space(1),
+                              }),
+                              control: (provided: {
+                                [x: string]: string | number | boolean;
+                              }) => ({
+                                ...provided,
+                                minHeight: 30,
+                                minWidth: 500,
+                                maxWidth: 1000,
+                              }),
+                              valueContainer: (provided: {
+                                [x: string]: string | number | boolean;
+                              }) => ({
+                                ...provided,
+                                padding: 0,
+                              }),
+                              singleValue: (provided: {
+                                [x: string]: string | number | boolean;
+                              }) => ({
+                                ...provided,
+                              }),
+                            }}
+                            value={comparisonDelta}
+                            onClick={e => e.stopPropagation()}
+                            onChange={({value}) => onComparisonDeltaChange(value)}
+                            options={COMPARISON_DELTA_OPTIONS}
+                            required={comparisonType === AlertRuleComparisonType.CHANGE}
+                          />
+                        </ComparisonContainer>
+                      )
+                    ) : (
+                      'Percent Change'
+                    ),
             ],
           ]}
           value={comparisonType}
@@ -65,6 +114,21 @@ const FormRow = styled('div')<{hasAlertWizardV3: boolean}>`
   align-items: center;
   flex-wrap: wrap;
   margin-bottom: ${p => (p.hasAlertWizardV3 ? space(2) : space(4))};
+`;
+
+const ComparisonContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const StyledRadioGroup = styled(RadioGroup)<{hasAlertWizardV3: boolean}>`
+  flex: 1;
+
+  ${p => p.hasAlertWizardV3 && 'gap: 0;'}
+  & > label {
+    ${p => p.hasAlertWizardV3 && 'height: 33px;'}
+  }
 `;
 
 export default ThresholdTypeForm;

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -96,7 +96,7 @@ const ThresholdTypeForm = ({
           ]}
           value={comparisonType}
           label={t('Threshold Type')}
-          onChange={onComparisonTypeChange}
+          onChange={value => onComparisonTypeChange(value as AlertRuleComparisonType)}
         />
       </FormRow>
     </Feature>

--- a/static/app/views/alerts/incidentRules/triggers/form.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/form.tsx
@@ -5,6 +5,7 @@ import {fetchOrgMembers} from 'sentry/actionCreators/members';
 import {Client} from 'sentry/api';
 import CircleIndicator from 'sentry/components/circleIndicator';
 import Field from 'sentry/components/forms/field';
+import {IconDiamond} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Config, Organization, Project} from 'sentry/types';
@@ -30,6 +31,7 @@ type Props = {
 
   disabled: boolean;
   fieldHelp: React.ReactNode;
+  hasAlertWizardV3: boolean;
   isCritical: boolean;
   onChange: (trigger: Trigger, changeObj: Partial<Trigger>) => void;
   onThresholdPeriodChange: (value: number) => void;
@@ -77,6 +79,7 @@ class TriggerFormItem extends React.PureComponent<Props> {
       isCritical,
       thresholdType,
       thresholdPeriod,
+      hasAlertWizardV3,
       hideControl,
       comparisonType,
       fieldHelp,
@@ -87,11 +90,12 @@ class TriggerFormItem extends React.PureComponent<Props> {
     } = this.props;
 
     return (
-      <Field
+      <StyledField
         label={triggerLabel}
         help={fieldHelp}
         required={isCritical}
         error={error && error.alertThreshold}
+        hasAlertWizardV3={hasAlertWizardV3}
       >
         <ThresholdControl
           disabled={disabled}
@@ -107,7 +111,7 @@ class TriggerFormItem extends React.PureComponent<Props> {
           onThresholdTypeChange={onThresholdTypeChange}
           onThresholdPeriodChange={onThresholdPeriodChange}
         />
-      </Field>
+      </StyledField>
     );
   }
 }
@@ -185,6 +189,32 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
     return '300';
   }
 
+  getIndicator(type: string) {
+    const {hasAlertWizardV3} = this.props;
+
+    if (type === 'critical') {
+      return hasAlertWizardV3 ? (
+        <StyledIconDiamond color="red300" size="sm" />
+      ) : (
+        <CriticalIndicator size={12} />
+      );
+    }
+
+    if (type === 'warning') {
+      return hasAlertWizardV3 ? (
+        <StyledIconDiamond color="yellow300" size="sm" />
+      ) : (
+        <WarningIndicator size={12} />
+      );
+    }
+
+    return hasAlertWizardV3 ? (
+      <StyledIconDiamond color="green300" size="sm" />
+    ) : (
+      <ResolvedIndicator size={12} />
+    );
+  }
+
   render() {
     const {
       api,
@@ -217,7 +247,6 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
         {triggers.map((trigger, index) => {
           const isCritical = index === 0;
           // eslint-disable-next-line no-use-before-define
-          const TriggerIndicator = isCritical ? CriticalIndicator : WarningIndicator;
           return (
             <TriggerFormItem
               key={index}
@@ -235,6 +264,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
               projects={projects}
               triggerIndex={index}
               isCritical={isCritical}
+              hasAlertWizardV3={hasAlertWizardV3}
               fieldHelp={
                 hasAlertWizardV3
                   ? null
@@ -247,10 +277,10 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
                     )
               }
               triggerLabel={
-                <React.Fragment>
-                  <TriggerIndicator size={12} />
+                <TriggerLabel>
+                  {this.getIndicator(isCritical ? 'critical' : 'warning')}
                   {isCritical ? t('Critical') : t('Warning')}
-                </React.Fragment>
+                </TriggerLabel>
               }
               placeholder={
                 isCritical
@@ -284,6 +314,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
           projects={projects}
           triggerIndex={2}
           isCritical={false}
+          hasAlertWizardV3={hasAlertWizardV3}
           fieldHelp={
             hasAlertWizardV3
               ? null
@@ -292,10 +323,10 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
                 })
           }
           triggerLabel={
-            <React.Fragment>
-              <ResolvedIndicator size={12} />
+            <TriggerLabel>
+              {this.getIndicator('resolved')}
               {t('Resolved')}
-            </React.Fragment>
+            </TriggerLabel>
           }
           placeholder={t('Automatic')}
           onChange={this.handleChangeResolveTrigger}
@@ -320,6 +351,27 @@ const WarningIndicator = styled(CircleIndicator)`
 const ResolvedIndicator = styled(CircleIndicator)`
   background: ${p => p.theme.green300};
   margin-right: ${space(1)};
+`;
+
+const TriggerLabel = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const StyledIconDiamond = styled(IconDiamond)`
+  margin-right: ${space(0.75)};
+`;
+
+const StyledField = styled(Field)<{hasAlertWizardV3: boolean}>`
+  & > label > div > span {
+    ${p =>
+      p.hasAlertWizardV3 &&
+      `
+      display: flex;
+      flex-direction: row;
+    `}
+  }
 `;
 
 export default withConfig(withApi(TriggerFormContainer));


### PR DESCRIPTION
This updates the threshold type selector to also include comparison delta selector, also updates the threshold section ui per Alert Wizard V3 designs.

Old:
![old-delt](https://user-images.githubusercontent.com/15015880/156268802-0a97b379-7a77-48a3-9707-c8d35e2b164b.png)

New:
![new-delt](https://user-images.githubusercontent.com/15015880/156268806-447f7d6a-e34e-4aed-83fe-c76467671a13.png)

