### PR TITLE
feat(ratelimits): Limit by group as opposed to by endpoint by default

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -21,7 +21,7 @@ from rest_framework.views import APIView
 from sentry import analytics, tsdb
 from sentry.auth import access
 from sentry.models import Environment
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
 from sentry.utils import json
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.cursors import Cursor
@@ -102,7 +102,7 @@ class Endpoint(APIView):
 
     # Default Rate Limit Values, override in subclass
     # Should be of format: { <http function>: { <category>: RateLimit(limit, window) } }
-    rate_limits: Mapping[str, Mapping[RateLimitCategory | str, RateLimit]] = {}
+    rate_limits: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG
     enforce_rate_limit: bool = settings.SENTRY_RATELIMITER_ENABLED
 
     def build_cursor_link(self, request: Request, name, cursor):

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -100,8 +100,6 @@ class Endpoint(APIView):
 
     cursor_name = "cursor"
 
-    # Default Rate Limit Values, override in subclass
-    # Should be of format: { <http function>: { <category>: RateLimit(limit, window) } }
     rate_limits: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG
     enforce_rate_limit: bool = settings.SENTRY_RATELIMITER_ENABLED
 

--- a/src/sentry/ratelimits/config.py
+++ b/src/sentry/ratelimits/config.py
@@ -15,8 +15,10 @@ class InvalidRateLimitConfig(Exception):
     pass
 
 
-RateLimitOverrideDict = Mapping[str, Mapping[RateLimitCategory, RateLimit]]
 GroupName = str
+HttpMethodName = str
+
+RateLimitOverrideDict = Mapping[HttpMethodName, Mapping[RateLimitCategory, RateLimit]]
 
 # This default value is going to shrink over time
 _SENTRY_RATELIMITER_DEFAULT = 620

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -83,9 +83,13 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
     # If IP address doesn't exist, skip ratelimiting for now
     else:
         return None
-    # TODO: remove view from this key, it's not necessary
     group = rate_limit_config.group if rate_limit_config else "default"
-    return f"{category}:{group}:{view}:{http_method}:{id}"
+    if rate_limit_config and rate_limit_config.has_custom_limit():
+        # if there is a custom rate limit on the endpoint, we add view to the key
+        # otherwise we just use what's default for the group
+        return f"{category}:{group}:{view}:{http_method}:{id}"
+    else:
+        return f"{category}:{group}:{http_method}:{id}"
 
 
 def get_organization_id_from_token(token_id: str) -> int | None:


### PR DESCRIPTION
The rate limiter currently rate limits on a per endpoint basis. This was agreed to be contrary to the goals of rate limiting by the API TSC ([doc](https://www.notion.so/sentry/Rate-Limiting-Dimensions-449d8d5d1fa34bc5bc5c723d6cd06e28)). 

This code change makes it so that unless an endpoint has custom limits applied to it, it will use the rate limit of the group. This means that all endpoints (unless otherwise configured) will go into the same group. The current rate limit is very permissive (620 rps) however it will be shrunk week over week as soon as this PR is merged to 40RPS. 