### PR TITLE
test(alertStatus): Add missing context to test for router

### DIFF
--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -36,7 +36,7 @@ describe('AlertRuleDetails', () => {
           {...props}
         />
       </RuleDetailsContainer>,
-      {organization}
+      {context: context.routerContext, organization}
     );
   };
 


### PR DESCRIPTION
fixes
```
FAIL tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
  ● AlertRuleDetails › displays alert rule with list of issues

    TypeError: Cannot read properties of undefined (reading 'pathname')
```