### PR TITLE
fix(trace-view): The query limit on trace view should be 100

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -232,6 +232,7 @@ def query_trace_data(
             # We want to guarantee at least getting the root, and hopefully events near it with timestamp
             # id is just for consistent results
             orderby=["-root", "timestamp", "id"],
+            limit=MAX_TRACE_SIZE,
         )
         error_query = QueryBuilder(
             Dataset.Events,
@@ -251,6 +252,7 @@ def query_trace_data(
             # Don't add timestamp to this orderby as snuba will have to split the time range up and make multiple queries
             orderby=["id"],
             auto_fields=False,
+            limit=MAX_TRACE_SIZE,
         )
         results = bulk_snql_query(
             [transaction_query.get_snql_query(), error_query.get_snql_query()],


### PR DESCRIPTION
The query limit was originally 100, but was dropped to 50 unintentionally during
the snql migration.