### PR TITLE
feat(page-filters): Add top level alert for desynced filters

### DIFF
--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useRef} from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import isEqual from 'lodash/isEqual';
 import partition from 'lodash/partition';
@@ -9,6 +9,7 @@ import {
   updateEnvironments,
   updateProjects,
 } from 'sentry/actionCreators/pageFilters';
+import DesyncedFilterAlert from 'sentry/components/organizations/pageFilters/desyncedFiltersAlert';
 import ConfigStore from 'sentry/stores/configStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
@@ -62,7 +63,7 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
     hideGlobalHeader,
   } = props;
 
-  const {isReady} = useLegacyStore(PageFiltersStore);
+  const {isReady, desyncedFilters} = useLegacyStore(PageFiltersStore);
 
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
 
@@ -162,6 +163,9 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
     lastQuery.current = location.query;
   }, [location.query]);
 
+  const [hideDesyncedAlert, setHideDesyncedAlert] = useState<boolean>(false);
+  const showDesyncedAlert = desyncedFilters.size > 0 && !hideDesyncedAlert;
+
   // Wait for global selection to be ready before rendering chilren
   if (!isReady) {
     return <PageContent />;
@@ -170,6 +174,13 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
   return (
     <Fragment>
       {!hideGlobalHeader && <GlobalSelectionHeader {...props} {...additionalProps} />}
+      {hideGlobalHeader && showDesyncedAlert && (
+        <DesyncedFilterAlert
+          router={router}
+          organization={organization}
+          onClose={() => setHideDesyncedAlert(true)}
+        />
+      )}
       {children}
     </Fragment>
   );

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useRef, useState} from 'react';
+import {Fragment, useEffect, useRef} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import isEqual from 'lodash/isEqual';
 import partition from 'lodash/partition';
@@ -63,7 +63,7 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
     hideGlobalHeader,
   } = props;
 
-  const {isReady, desyncedFilters} = useLegacyStore(PageFiltersStore);
+  const {isReady} = useLegacyStore(PageFiltersStore);
 
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
 
@@ -163,9 +163,6 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
     lastQuery.current = location.query;
   }, [location.query]);
 
-  const [hideDesyncedAlert, setHideDesyncedAlert] = useState<boolean>(false);
-  const showDesyncedAlert = desyncedFilters.size > 0 && !hideDesyncedAlert;
-
   // Wait for global selection to be ready before rendering chilren
   if (!isReady) {
     return <PageContent />;
@@ -174,13 +171,7 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
   return (
     <Fragment>
       {!hideGlobalHeader && <GlobalSelectionHeader {...props} {...additionalProps} />}
-      {hideGlobalHeader && showDesyncedAlert && (
-        <DesyncedFilterAlert
-          router={router}
-          organization={organization}
-          onClose={() => setHideDesyncedAlert(true)}
-        />
-      )}
+      {hideGlobalHeader && <DesyncedFilterAlert router={router} />}
       {children}
     </Fragment>
   );

--- a/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
+++ b/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
@@ -1,0 +1,65 @@
+import {InjectedRouter} from 'react-router';
+import styled from '@emotion/styled';
+
+import {revertToPinnedFilters} from 'sentry/actionCreators/pageFilters';
+import Alert from 'sentry/components/alert';
+import {IconClose, IconInfo} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+
+type Props = {
+  onClose: () => void;
+  organization: Organization;
+  router: InjectedRouter;
+};
+
+export default function DesyncedFilterAlert({router, organization, onClose}: Props) {
+  const onRevertClick = () => {
+    revertToPinnedFilters(organization.slug, router);
+  };
+
+  return (
+    <Alert type="info" icon={<IconInfo size="md" />} system>
+      <AlertWrapper>
+        <AlertText>
+          {t(
+            "You're viewing a shared link. Certain queries and filters have been automatically filled from URL parameters."
+          )}
+        </AlertText>
+        <AlertActions>
+          <RevertText onClick={onRevertClick}>{t('Revert')}</RevertText>
+          <Divider>|</Divider>
+          <IconClose color="purple300" onClick={onClose} />
+        </AlertActions>
+      </AlertWrapper>
+    </Alert>
+  );
+}
+
+const AlertWrapper = styled('div')`
+  display: flex;
+`;
+
+const AlertText = styled('div')`
+  flex: 1;
+  line-height: 22px;
+`;
+
+const AlertActions = styled('div')`
+  display: grid;
+  gap: ${space(1.5)};
+  grid-auto-flow: column;
+  align-items: center;
+  cursor: pointer;
+`;
+
+const RevertText = styled('div')`
+  font-weight: bold;
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.purple300};
+`;
+
+const Divider = styled('div')`
+  color: ${p => p.theme.purple200};
+`;

--- a/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
+++ b/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 
 import {revertToPinnedFilters} from 'sentry/actionCreators/pageFilters';
 import Alert from 'sentry/components/alert';
+import Button from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import {IconClose, IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
@@ -18,13 +20,17 @@ type Props = {
 export default function DesyncedFilterAlert({router}: Props) {
   const {desyncedFilters} = useLegacyStore(PageFiltersStore);
   const organization = useOrganization();
-  const [hideAlert, setHideAlert] = useState<boolean>(false);
+  const [hideAlert, setHideAlert] = useState(false);
 
   const onRevertClick = () => {
     revertToPinnedFilters(organization.slug, router);
   };
 
-  return desyncedFilters.size > 0 && !hideAlert ? (
+  if (desyncedFilters.size === 0 || hideAlert) {
+    return null;
+  }
+
+  return (
     <Alert type="info" icon={<IconInfo size="md" />} system>
       <AlertWrapper>
         <AlertText>
@@ -32,14 +38,21 @@ export default function DesyncedFilterAlert({router}: Props) {
             "You're viewing a shared link. Certain queries and filters have been automatically filled from URL parameters."
           )}
         </AlertText>
-        <AlertActions>
-          <RevertText onClick={onRevertClick}>{t('Revert')}</RevertText>
-          <Divider>|</Divider>
-          <IconClose color="purple300" onClick={() => setHideAlert(true)} />
-        </AlertActions>
+        <ButtonBar gap={1.5}>
+          <RevertButton priority="link" size="zero" onClick={onRevertClick} borderless>
+            {t('Revert')}
+          </RevertButton>
+          <Button
+            priority="link"
+            size="zero"
+            icon={<IconClose color="purple300" />}
+            aria-label={t('Close Alert')}
+            onClick={() => setHideAlert(true)}
+          />
+        </ButtonBar>
       </AlertWrapper>
     </Alert>
-  ) : null;
+  );
 }
 
 const AlertWrapper = styled('div')`
@@ -51,20 +64,15 @@ const AlertText = styled('div')`
   line-height: 22px;
 `;
 
-const AlertActions = styled('div')`
-  display: grid;
-  gap: ${space(1.5)};
-  grid-auto-flow: column;
-  align-items: center;
-  cursor: pointer;
-`;
-
-const RevertText = styled('div')`
+const RevertButton = styled(Button)`
+  display: flex;
   font-weight: bold;
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => p.theme.purple300};
-`;
 
-const Divider = styled('div')`
-  color: ${p => p.theme.purple200};
+  &:after {
+    content: '|';
+    margin-left: ${space(2)};
+    color: ${p => p.theme.purple200};
+  }
 `;

--- a/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
+++ b/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -5,21 +6,25 @@ import {revertToPinnedFilters} from 'sentry/actionCreators/pageFilters';
 import Alert from 'sentry/components/alert';
 import {IconClose, IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
-import {Organization} from 'sentry/types';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
-  onClose: () => void;
-  organization: Organization;
   router: InjectedRouter;
 };
 
-export default function DesyncedFilterAlert({router, organization, onClose}: Props) {
+export default function DesyncedFilterAlert({router}: Props) {
+  const {desyncedFilters} = useLegacyStore(PageFiltersStore);
+  const organization = useOrganization();
+  const [hideAlert, setHideAlert] = useState<boolean>(false);
+
   const onRevertClick = () => {
     revertToPinnedFilters(organization.slug, router);
   };
 
-  return (
+  return desyncedFilters.size > 0 && !hideAlert ? (
     <Alert type="info" icon={<IconInfo size="md" />} system>
       <AlertWrapper>
         <AlertText>
@@ -30,11 +35,11 @@ export default function DesyncedFilterAlert({router, organization, onClose}: Pro
         <AlertActions>
           <RevertText onClick={onRevertClick}>{t('Revert')}</RevertText>
           <Divider>|</Divider>
-          <IconClose color="purple300" onClick={onClose} />
+          <IconClose color="purple300" onClick={() => setHideAlert(true)} />
         </AlertActions>
       </AlertWrapper>
     </Alert>
-  );
+  ) : null;
 }
 
 const AlertWrapper = styled('div')`

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -571,7 +571,10 @@ describe('GlobalSelectionHeader', function () {
     OrganizationActions.update(initializationObj.organization);
 
     wrapper = mountWithTheme(
-      <PageFiltersContainer organization={initializationObj.organization} />,
+      <PageFiltersContainer
+        organization={initializationObj.organization}
+        hideGlobalHeader
+      />,
       initializationObj.routerContext
     );
 
@@ -582,6 +585,9 @@ describe('GlobalSelectionHeader', function () {
     // Wait for desynced filters to update
     await tick();
     expect(PageFiltersStore.getState().desyncedFilters).toEqual(new Set(['projects']));
+
+    wrapper.update();
+    expect(wrapper.find('DesyncedFilterAlert')).toHaveLength(1);
   });
 
   /**

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -11,6 +11,7 @@ import OrganizationsStore from 'sentry/stores/organizationsStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {getItem} from 'sentry/utils/localStorage';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 
 const changeQuery = (routerContext, query) => ({
   ...routerContext,
@@ -571,10 +572,13 @@ describe('GlobalSelectionHeader', function () {
     OrganizationActions.update(initializationObj.organization);
 
     wrapper = mountWithTheme(
-      <PageFiltersContainer
-        organization={initializationObj.organization}
-        hideGlobalHeader
-      />,
+      <OrganizationContext.Provider value={initializationObj.organization}>
+        <PageFiltersContainer
+          organization={initializationObj.organization}
+          hideGlobalHeader
+        />
+      </OrganizationContext.Provider>,
+
       initializationObj.routerContext
     );
 


### PR DESCRIPTION
Makes use of the `desyncedFilters` store state to conditionally display an alert with the option to revert back to pinned filters https://github.com/getsentry/sentry/pull/32140

Example:
<img width="1220" alt="image" src="https://user-images.githubusercontent.com/9372512/156078251-363f8378-ce54-4387-85b3-881e033f9c6a.png">
