### PR TITLE
feat(alert-rule): Handle case when SentryApp fails to fetch from partner

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -71,7 +71,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
                     action.get("settings"),
                 )
 
-                action["formFields"] = component.schema.get("settings", {})
+                action["formFields"] = component.get("schema", {}).get("settings", {})
 
                 # Delete meta fields
                 del action["_sentry_app_installation"]

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -59,23 +59,31 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
             request.user,
         )
 
+        errors = []
         # Prepare Rule Actions that are SentryApp components using the meta fields
         for action in serialized_rule.get("actions", []):
             if action.get("_sentry_app_installation") and action.get("_sentry_app_component"):
-
-                component = SentryAppInstallation(
-                    **action.get("_sentry_app_installation", {})
-                ).prepare_ui_component(
+                # print(action)
+                installation = SentryAppInstallation(**action.get("_sentry_app_installation", {}))
+                component = installation.prepare_ui_component(
                     SentryAppComponent(**action.get("_sentry_app_component")),
                     project,
                     action.get("settings"),
                 )
+                if component is None:
+                    errors.append(
+                        {"detail": f"Could not fetch details from {installation.sentry_app.name}"}
+                    )
+                    action["disabled"] = True
+                    continue
 
-                action["formFields"] = component.get("schema", {}).get("settings", {})
+                action["formFields"] = component.schema.get("settings", {})
 
                 # Delete meta fields
                 del action["_sentry_app_installation"]
                 del action["_sentry_app_component"]
+
+        serialized_rule["errors"] = errors
 
         return Response(serialized_rule)
 

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -63,7 +63,6 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
         # Prepare Rule Actions that are SentryApp components using the meta fields
         for action in serialized_rule.get("actions", []):
             if action.get("_sentry_app_installation") and action.get("_sentry_app_component"):
-                # print(action)
                 installation = SentryAppInstallation(**action.get("_sentry_app_installation", {}))
                 component = installation.prepare_ui_component(
                     SentryAppComponent(**action.get("_sentry_app_component")),
@@ -83,7 +82,8 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
                 del action["_sentry_app_installation"]
                 del action["_sentry_app_component"]
 
-        serialized_rule["errors"] = errors
+        if len(errors):
+            serialized_rule["errors"] = errors
 
         return Response(serialized_rule)
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -50,7 +50,8 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
                     del action["_sentry_app_installation"]
                     del action["_sentry_app_component"]
 
-        serialized_rule["errors"] = errors
+        if len(errors):
+            serialized_rule["errors"] = errors
 
         return Response(serialized_rule)
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -201,6 +201,7 @@ class ProjectRuleDetailsTest(APITestCase):
         response = self.client.get(url, format="json")
         assert len(responses.calls) == 1
 
+        assert response.status_code == 200
         # Returns errors while fetching
         assert len(response.data["errors"]) == 1
         assert response.data["errors"][0] == {

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -146,6 +146,71 @@ class ProjectRuleDetailsTest(APITestCase):
         assert len(response.data["filters"]) == 1
         assert response.data["filters"][0]["id"] == conditions[1]["id"]
 
+    @responses.activate
+    def test_with_unresponsive_sentryapp(self):
+        self.login_as(user=self.user)
+
+        self.sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            published=True,
+            verify_install=False,
+            name="Super Awesome App",
+            schema={"elements": [self.create_alert_rule_action_schema()]},
+        )
+        self.installation = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug, organization=self.organization, user=self.user
+        )
+
+        conditions = [
+            {"id": "sentry.rules.conditions.every_event.EveryEventCondition"},
+            {"id": "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter", "value": 10},
+        ]
+
+        actions = [
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "sentryAppInstallationUuid": self.installation.uuid,
+                "settings": [
+                    {"name": "title", "value": "An alert"},
+                    {"summary": "Something happened here..."},
+                    {"name": "points", "value": "3"},
+                    {"name": "assignee", "value": "Nisanthan"},
+                ],
+            }
+        ]
+        data = {
+            "conditions": conditions,
+            "actions": actions,
+            "filter_match": "all",
+            "action_match": "all",
+            "frequency": 30,
+        }
+
+        rule = Rule.objects.create(project=self.project, label="foo", data=data)
+
+        url = reverse(
+            "sentry-api-0-project-rule-details",
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+                "rule_id": rule.id,
+            },
+        )
+        responses.add(responses.GET, "http://example.com/sentry/members", json={}, status=404)
+
+        response = self.client.get(url, format="json")
+        assert len(responses.calls) == 1
+
+        # Returns errors while fetching
+        assert len(response.data["errors"]) == 1
+        assert response.data["errors"][0] == {
+            "detail": "Could not fetch details from Super Awesome App"
+        }
+
+        # Disables the SentryApp
+        assert response.data["actions"][0]["sentryAppInstallationUuid"] == self.installation.uuid
+        assert response.data["actions"][0]["disabled"] is True
+
 
 class UpdateProjectRuleTest(APITestCase):
     def test_simple(self):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -137,6 +137,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
 
         assert len(responses.calls) == 1
 
+        assert resp.status_code == 200
         # Returns errors while fetching
         assert len(resp.data["errors"]) == 1
         assert resp.data["errors"][0] == {


### PR DESCRIPTION
Fixes [SENTRY-TFB](https://sentry.io/organizations/sentry/issues/3056121071/events/3974d9080f3547f99660b08f20a6850f/?project=1&statsPeriod=14d)

## Objective
https://user-images.githubusercontent.com/10491193/156093558-7ab0efde-6f66-448b-8d9f-3fb5e092a9c4.mov

This issue caused when our SentryApp partner returns >= 400, so our Mediator swallows the ApiError and returns None.
Ideally we want to still render the rules and disable the affected actions.

Frontend PR: https://github.com/getsentry/sentry/pull/32147