### PR TITLE
fix(perf): Normalizing search conditions on performance product

### DIFF
--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -23,7 +23,6 @@ import {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import EventView, {EventData, isFieldSortable} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {fieldAlignment, getAggregateAlias} from 'sentry/utils/discover/fields';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'sentry/views/eventsV2/table/cellAction';
 import {TableColumn} from 'sentry/views/eventsV2/table/types';
 
@@ -31,7 +30,10 @@ import TransactionThresholdModal, {
   modalCss,
   TransactionThresholdMetric,
 } from './transactionSummary/transactionThresholdModal';
-import {transactionSummaryRouteWithQuery} from './transactionSummary/utils';
+import {
+  normalizeSearchConditionsWithTransactionName,
+  transactionSummaryRouteWithQuery,
+} from './transactionSummary/utils';
 import {COLUMN_TITLES} from './data';
 
 export function getProjectID(
@@ -125,10 +127,9 @@ class _Table extends React.Component<Props, State> {
         return;
       }
 
-      const searchConditions = new MutableSearch(eventView.query);
-
-      // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeFilter('event.type');
+      const searchConditions = normalizeSearchConditionsWithTransactionName(
+        eventView.query
+      );
 
       updateQuery(searchConditions, action, column, value);
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -28,12 +28,15 @@ import {
   isSpanOperationBreakdownField,
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 } from 'sentry/utils/discover/fields';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'sentry/views/eventsV2/table/cellAction';
 import {TableColumn} from 'sentry/views/eventsV2/table/types';
 
 import {COLUMN_TITLES} from '../../data';
-import {generateTraceLink, generateTransactionLink} from '../utils';
+import {
+  generateTraceLink,
+  generateTransactionLink,
+  normalizeSearchConditions,
+} from '../utils';
 
 import OperationSort, {TitleProps} from './operationSort';
 
@@ -103,10 +106,7 @@ class EventsTable extends React.Component<Props, State> {
         action,
       });
 
-      const searchConditions = new MutableSearch(eventView.query);
-
-      // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeFilter('event.type');
+      const searchConditions = normalizeSearchConditions(eventView.query);
 
       updateQuery(searchConditions, action, column, value);
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -26,7 +26,6 @@ import {
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 } from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withProjects from 'sentry/utils/withProjects';
 import {Actions, updateQuery} from 'sentry/views/eventsV2/table/cellAction';
 import {TableColumn} from 'sentry/views/eventsV2/table/types';
@@ -47,6 +46,7 @@ import Filter, {
 import {
   generateTraceLink,
   generateTransactionLink,
+  normalizeSearchConditions,
   SidebarSpacer,
   TransactionFilterOptions,
 } from '../utils';
@@ -114,13 +114,7 @@ function SummaryContent({
 
   function handleCellAction(column: TableColumn<React.ReactText>) {
     return (action: Actions, value: React.ReactText) => {
-      const searchConditions = new MutableSearch(eventView.query);
-
-      // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeFilter('event.type');
-
-      // no need to include transaction as its already in the query params
-      searchConditions.removeFilter('transaction');
+      const searchConditions = normalizeSearchConditions(eventView.query);
 
       updateQuery(searchConditions, action, column, value);
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -40,6 +40,7 @@ import {
   SpanOperationBreakdownFilter,
 } from '../filter';
 import {tagsRouteWithQuery} from '../transactionTags/utils';
+import {normalizeSearchConditions} from '../utils';
 
 const TAGS_CURSOR_NAME = 'tags_cursor';
 
@@ -303,10 +304,7 @@ class _TagExplorer extends React.Component<Props> {
         organization_id: parseInt(organization.id, 10),
       });
 
-      const searchConditions = new MutableSearch(eventView.query);
-
-      // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeFilter('event.type');
+      const searchConditions = normalizeSearchConditions(eventView.query);
 
       updateQuery(searchConditions, action, {...column, name: actionRow.id}, tagValue);
 

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -28,6 +28,7 @@ import {TableColumn} from 'sentry/views/eventsV2/table/types';
 
 import {PerformanceDuration} from '../../utils';
 import {TagValue} from '../transactionOverview/tagExplorer';
+import {normalizeSearchConditions} from '../utils';
 
 import {
   TAGS_TABLE_COLUMN_ORDER,
@@ -132,9 +133,7 @@ export class TagValueTable extends Component<Props, State> {
       const {eventView, location, organization} = this.props;
       trackTagPageInteraction(organization);
 
-      const searchConditions = new MutableSearch(eventView.query);
-
-      searchConditions.removeFilter('event.type');
+      const searchConditions = normalizeSearchConditions(eventView.query);
 
       updateQuery(searchConditions, action, {...column, name: actionRow.id}, tagValue);
 

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -22,11 +22,19 @@ export function generateTransactionSummaryRoute({orgSlug}: {orgSlug: String}): s
   return `/organizations/${orgSlug}/performance/summary/`;
 }
 
-function cleanTransactionSummaryFilter(query: string): string {
+// normalizes search conditions by removing any redundant search conditions before presenting them in:
+// - query strings
+// - search UI
+export function normalizeSearchConditions(query: string): MutableSearch {
   const filterParams = new MutableSearch(query);
+
+  // no need to include transaction as its already in the query params
   filterParams.removeFilter('transaction');
+
+  // remove any event.type queries since it is implied to apply to only transactions
   filterParams.removeFilter('event.type');
-  return filterParams.formatString();
+
+  return filterParams;
 }
 
 export function transactionSummaryRouteWithQuery({
@@ -58,7 +66,7 @@ export function transactionSummaryRouteWithQuery({
 
   let searchFilter: typeof query.query;
   if (typeof query.query === 'string') {
-    searchFilter = cleanTransactionSummaryFilter(query.query);
+    searchFilter = normalizeSearchConditions(query.query).formatString();
   } else {
     searchFilter = query.query;
   }

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -26,10 +26,19 @@ export function generateTransactionSummaryRoute({orgSlug}: {orgSlug: String}): s
 // - query strings
 // - search UI
 export function normalizeSearchConditions(query: string): MutableSearch {
-  const filterParams = new MutableSearch(query);
+  const filterParams = normalizeSearchConditionsWithTransactionName(query);
 
   // no need to include transaction as its already in the query params
   filterParams.removeFilter('transaction');
+
+  return filterParams;
+}
+
+// normalizes search conditions by removing any redundant search conditions, but retains any transaction name
+export function normalizeSearchConditionsWithTransactionName(
+  query: string
+): MutableSearch {
+  const filterParams = new MutableSearch(query);
 
   // remove any event.type queries since it is implied to apply to only transactions
   filterParams.removeFilter('event.type');

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -33,6 +33,7 @@ import {TableColumn} from 'sentry/views/eventsV2/table/types';
 
 import {DisplayModes} from '../transactionSummary/transactionOverview/charts';
 import {
+  normalizeSearchConditionsWithTransactionName,
   TransactionFilterOptions,
   transactionSummaryRouteWithQuery,
 } from '../transactionSummary/utils';
@@ -109,10 +110,9 @@ class Table extends React.Component<Props, State> {
         action,
       });
 
-      const searchConditions = new MutableSearch(eventView.query);
-
-      // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeFilter('event.type');
+      const searchConditions = normalizeSearchConditionsWithTransactionName(
+        eventView.query
+      );
 
       updateQuery(searchConditions, action, column, value);
 


### PR DESCRIPTION
This pull request introduces two utility functions to normalize search conditions by removing fields/tags before serializing them for the search bar UI or query strings:

- `normalizeSearchConditions()` - removes `event.type` and `transaction` fields. Used for any components within the transaction summary page.
- `normalizeSearchConditionsWithTransactionName()` - removes only the `event.type` field. Used for any components outside of the transaction summary page (i.e. landing page and vitals details pages).

----

This resolves issues like inadvertently introducing fields/tags such as `transaction` when they should be omitted (video by @shruthilayaj ):


https://user-images.githubusercontent.com/139499/156087083-7fc58316-86a8-4467-983d-dca5b89ebef2.mp4


