### PR TITLE
feat(alert-rule): Render rules even when SentryApp actions are failing

### DIFF
--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -50,7 +50,7 @@ export type IssueAlertRuleAction = Omit<
   dynamic_form_fields?: IssueConfigField[];
 } & {
   // These are the same values as the keys in `formFields` for a template
-  [key: string]: number | string | boolean;
+  [key: string]: any;
 };
 
 export type IssueAlertRuleCondition = Omit<

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -50,7 +50,7 @@ export type IssueAlertRuleAction = Omit<
   dynamic_form_fields?: IssueConfigField[];
 } & {
   // These are the same values as the keys in `formFields` for a template
-  [key: string]: number | string;
+  [key: string]: number | string | boolean;
 };
 
 export type IssueAlertRuleCondition = Omit<
@@ -83,6 +83,7 @@ export type IssueAlertRule = UnsavedIssueAlertRule & {
   dateCreated: string;
   id: string;
   projects: string[];
+  errors?: {detail: string}[];
 };
 
 export enum MailActionTargetType {

--- a/static/app/views/alerts/incidentRules/details.tsx
+++ b/static/app/views/alerts/incidentRules/details.tsx
@@ -1,5 +1,6 @@
 import {RouteComponentProps} from 'react-router';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Organization, Project} from 'sentry/types';
 import {metric} from 'sentry/utils/analytics';
 import RuleForm from 'sentry/views/alerts/incidentRules/ruleForm';
@@ -41,6 +42,13 @@ class IncidentRulesDetails extends AsyncView<Props, State> {
   onRequestSuccess({stateKey, data}) {
     if (stateKey === 'rule' && data.name) {
       this.props.onChangeTitle(data.name);
+    }
+  }
+
+  onLoadAllEndpointsSuccess() {
+    const {rule} = this.state;
+    if (rule?.errors) {
+      (rule?.errors || []).map(({detail}) => addErrorMessage(detail, {append: true}));
     }
   }
 

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
@@ -293,6 +293,8 @@ class ActionsPanel extends PureComponent<Props> {
         </PerformActionsListItem>
         {loading && <LoadingIndicator />}
         {actions.map(({action, actionIdx, triggerIndex, availableAction}) => {
+          const actionDisabled =
+            triggers[triggerIndex].actions[actionIdx]?.disabled || disabled;
           return (
             <div key={action.id ?? action.unsavedId}>
               <RuleRowContainer>
@@ -347,6 +349,7 @@ class ActionsPanel extends PureComponent<Props> {
                       <Button
                         icon={<IconSettings />}
                         type="button"
+                        disabled={actionDisabled}
                         onClick={() => {
                           openModal(
                             deps => (

--- a/static/app/views/alerts/incidentRules/types.tsx
+++ b/static/app/views/alerts/incidentRules/types.tsx
@@ -90,6 +90,7 @@ export type SavedIncidentRule = UnsavedIncidentRule & {
   name: string;
   status: number;
   createdBy?: {email: string; id: number; name: string} | null;
+  errors?: {detail: string}[];
   originalAlertRuleId?: number | null;
 };
 
@@ -231,6 +232,11 @@ type SavedActionFields = {
    * model id of the action
    */
   id: string;
+
+  /**
+   *  Could not fetch details from SentryApp. Show the rule but make it disabled.
+   */
+  disabled?: boolean;
 };
 
 type UnsavedAction = {

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -176,6 +176,14 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     }
   }
 
+  onLoadAllEndpointsSuccess() {
+    const {rule} = this.state;
+    if (rule) {
+      ((rule as IssueAlertRule)?.errors || []).map(({detail}) =>
+        addErrorMessage(detail, {append: true})
+      );
+    }
+  }
   pollHandler = async (quitTime: number) => {
     if (Date.now() > quitTime) {
       addErrorMessage(t('Looking for that channel took too long :('));

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -109,12 +109,15 @@ class RuleNode extends React.Component<Props> {
 
   getTextField = (name: string, fieldConfig: FormField) => {
     const {data, index, onPropertyChange, disabled} = this.props;
-
+    const value =
+      data && data[name] && typeof data[name] !== 'boolean'
+        ? (data[name] as string | number)
+        : '';
     return (
       <InlineInput
         type="text"
         name={name}
-        value={(data && data[name]) ?? ''}
+        value={value}
         placeholder={`${fieldConfig.placeholder}`}
         disabled={disabled}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -126,12 +129,15 @@ class RuleNode extends React.Component<Props> {
 
   getNumberField = (name: string, fieldConfig: FormField) => {
     const {data, index, onPropertyChange, disabled} = this.props;
-
+    const value =
+      data && data[name] && typeof data[name] !== 'boolean'
+        ? (data[name] as string | number)
+        : '';
     return (
       <InlineNumberInput
         type="number"
         name={name}
-        value={(data && data[name]) ?? ''}
+        value={value}
         placeholder={`${fieldConfig.placeholder}`}
         disabled={disabled}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -425,6 +431,7 @@ class RuleNode extends React.Component<Props> {
                 size="small"
                 icon={<IconSettings size="xs" />}
                 type="button"
+                disabled={Boolean(data?.disabled) || disabled}
                 onClick={() => {
                   openModal(
                     deps => (


### PR DESCRIPTION
## Objective:

https://user-images.githubusercontent.com/10491193/156094365-45aaa5af-b6e4-46f1-8823-1c26886006fd.mov



Frontend portion

Gracefully render the alert rule and render the failing SentryApp node. Render error toasts. And prevents user from adjusting the settings.

Backend PR: https://github.com/getsentry/sentry/pull/32142