### PR TITLE
feat(metrics-api): Allow series with an orderBy clause [INGEST-933]

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -365,12 +365,9 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
 
                     # Set the limit of the second query to be the provided limits multiplied by
                     # the number of the metrics requested in the query in this specific entity
-                    secondary_query_limit = query.limit * len(snuba_query.select)
-                    # In a series query, we also need to factor in the len of the intervals array
-                    if key == "series":
-                        secondary_query_limit *= len(intervals)
-
-                    snuba_query = snuba_query.set_limit(secondary_query_limit)
+                    snuba_query = snuba_query.set_limit(
+                        snuba_query.limit.limit * len(snuba_query.select)
+                    )
                     snuba_query = snuba_query.set_offset(0)
 
                     snuba_query_res = raw_snql_query(

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -263,7 +263,7 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
     intervals = list(get_intervals(query))
     results = {}
 
-    if query.orderby is not None and len(query.fields) > 1:
+    if query.orderby is not None:
         # ToDo(ahmed): Re-examine the known limitation that since we make two queries,
         #  where we use the results of the first query to filter down the results of the second
         #  query, so if the field used to order by has no values for certain transactions for
@@ -343,13 +343,13 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
                     # condition project_id cause it might be more relaxed than the project_id
                     # condition in the second query
                     where = []
-                    if "project_id" in groupby_tags:
-                        for condition in snuba_query.where:
-                            if not (
-                                isinstance(condition.lhs, Column)
-                                and condition.lhs.name == "project_id"
-                            ):
-                                where += [condition]
+                    for condition in snuba_query.where:
+                        if not (
+                            isinstance(condition.lhs, Column)
+                            and condition.lhs.name == "project_id"
+                            and "project_id" in groupby_tags
+                        ):
+                            where += [condition]
 
                     # Adds the conditions obtained from the previous query
                     for condition_key, condition_value in ordered_tag_conditions.items():

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -261,6 +261,7 @@ def get_tag_values(
 def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
     """Get time series for the given query"""
     intervals = list(get_intervals(query))
+    results = {}
 
     if query.orderby is not None and len(query.fields) > 1:
         # ToDo(ahmed): Re-examine the known limitation that since we make two queries,
@@ -306,8 +307,6 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
 
         snuba_queries = SnubaQueryBuilder(projects, query).get_snuba_queries()
 
-        results = {entity: {"totals": {"data": []}} for entity in snuba_queries.keys()}
-
         # If we do not get any results from the first query, then there is no point in making
         # the second query
         if len(initial_query_results["data"]) > 0:
@@ -334,75 +333,84 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
             ]
 
             for entity, queries in snuba_queries.items():
+                results.setdefault(entity, {})
                 # This loop has constant time complexity as it will always have a maximum of
                 # three queries corresponding to the three available entities
                 # ["metrics_sets", "metrics_distributions", "metrics_counters"]
-                snuba_query = queries["totals"]
+                for key, snuba_query in queries.items():
+                    results[entity].setdefault(key, {"data": []})
+                    # If query is grouped by project_id, then we should remove the original
+                    # condition project_id cause it might be more relaxed than the project_id
+                    # condition in the second query
+                    where = []
+                    if "project_id" in groupby_tags:
+                        for condition in snuba_query.where:
+                            if not (
+                                isinstance(condition.lhs, Column)
+                                and condition.lhs.name == "project_id"
+                            ):
+                                where += [condition]
 
-                # If query is grouped by project_id, then we should remove the original
-                # condition project_id cause it might be more relaxed than the project_id
-                # condition in the second query
-                where = []
-                if "project_id" in groupby_tags:
-                    for condition in snuba_query.where:
-                        if not (
-                            isinstance(condition.lhs, Column) and condition.lhs.name == "project_id"
-                        ):
-                            where += [condition]
+                    # Adds the conditions obtained from the previous query
+                    for condition_key, condition_value in ordered_tag_conditions.items():
+                        lhs_condition = (
+                            Function("tuple", [Column(col) for col in condition_key])
+                            if isinstance(condition_key, tuple)
+                            else Column(condition_key)
+                        )
+                        where += [
+                            Condition(lhs_condition, Op.IN, Function("tuple", condition_value))
+                        ]
+                    snuba_query = snuba_query.set_where(where)
 
-                # Adds the conditions obtained from the previous query
-                for condition_key, condition_value in ordered_tag_conditions.items():
-                    lhs_condition = (
-                        Function("tuple", [Column(col) for col in condition_key])
-                        if isinstance(condition_key, tuple)
-                        else Column(condition_key)
+                    # Set the limit of the second query to be the provided limits multiplied by
+                    # the number of the metrics requested in the query in this specific entity
+                    secondary_query_limit = query.limit * len(snuba_query.select)
+                    # In a series query, we also need to factor in the len of the intervals array
+                    if key == "series":
+                        secondary_query_limit *= len(intervals)
+
+                    snuba_query = snuba_query.set_limit(secondary_query_limit)
+                    snuba_query = snuba_query.set_offset(0)
+
+                    snuba_query_res = raw_snql_query(
+                        snuba_query, use_cache=False, referrer=f"api.metrics.{key}.second_query"
                     )
-                    where += [Condition(lhs_condition, Op.IN, Function("tuple", condition_value))]
-                snuba_query = snuba_query.set_where(where)
-                # Set the limit of the second query to be the provided limits multiplied by
-                # the number of the metrics requested in the query in this specific entity
-                snuba_query = snuba_query.set_limit(query.limit * len(snuba_query.select))
-                snuba_query = snuba_query.set_offset(0)
+                    # Create a dictionary that has keys representing the ordered by tuples from the
+                    # initial query, so that we are able to order it easily in the next code block
+                    # If for example, we are grouping by (project_id, transaction) -> then this
+                    # logic will output a dictionary that looks something like, where `tags[1]`
+                    # represents transaction
+                    # {
+                    #     (3, 2): [{"metric_id": 4, "project_id": 3, "tags[1]": 2, "p50": [11.0]}],
+                    #     (3, 3): [{"metric_id": 4, "project_id": 3, "tags[1]": 3, "p50": [5.0]}],
+                    # }
+                    snuba_query_data_dict = {}
+                    for data_elem in snuba_query_res["data"]:
+                        snuba_query_data_dict.setdefault(
+                            tuple(data_elem[col] for col in groupby_tags), []
+                        ).append(data_elem)
 
-                snuba_query_res = raw_snql_query(
-                    snuba_query, use_cache=False, referrer="api.metrics.totals.second_query"
-                )
-                # Create a dictionary that has keys representing the ordered by tuples from the
-                # initial query, so that we are able to order it easily in the next code block
-                # If for example, we are grouping by (project_id, transaction) -> then this
-                # logic will output a dictionary that looks something like, where `tags[1]`
-                # represents transaction
-                # {
-                #     (3, 2): [{"metric_id": 4, "project_id": 3, "tags[1]": 2, "p50": [11.0]}],
-                #     (3, 3): [{"metric_id": 4, "project_id": 3, "tags[1]": 3, "p50": [5.0]}],
-                # }
-                snuba_query_data_dict = {}
-                for data_elem in snuba_query_res["data"]:
-                    snuba_query_data_dict.setdefault(
-                        tuple(data_elem[col] for col in groupby_tags), []
-                    ).append(data_elem)
-
-                # Order the results according to the results of the initial query, so that when
-                # the results dict is passed on to `SnubaResultsConverter`, it comes out ordered
-                # Ordered conditions might for example look something like this
-                # {..., ('project_id', 'tags[1]'): [(3, 3), (3, 2)]}, then we end up with
-                # {
-                #     "totals": {
-                #         "data": [
-                #             {
-                #               "metric_id": 5, "project_id": 3, "tags[1]": 3, "count_unique": 5
-                #             },
-                #             {
-                #               "metric_id": 5, "project_id": 3, "tags[1]": 2, "count_unique": 1
-                #             },
-                #         ]
-                #     }
-                # }
-                for group_tuple in ordered_tag_conditions[groupby_tags]:
-                    results[entity]["totals"]["data"] += snuba_query_data_dict.get(group_tuple, [])
+                    # Order the results according to the results of the initial query, so that when
+                    # the results dict is passed on to `SnubaResultsConverter`, it comes out ordered
+                    # Ordered conditions might for example look something like this
+                    # {..., ('project_id', 'tags[1]'): [(3, 3), (3, 2)]}, then we end up with
+                    # {
+                    #     "totals": {
+                    #         "data": [
+                    #             {
+                    #               "metric_id": 5, "project_id": 3, "tags[1]": 3, "count_unique": 5
+                    #             },
+                    #             {
+                    #               "metric_id": 5, "project_id": 3, "tags[1]": 2, "count_unique": 1
+                    #             },
+                    #         ]
+                    #     }
+                    # }
+                    for group_tuple in ordered_tag_conditions[groupby_tags]:
+                        results[entity][key]["data"] += snuba_query_data_dict.get(group_tuple, [])
     else:
         snuba_queries = SnubaQueryBuilder(projects, query).get_snuba_queries()
-        results = {}
         for entity, queries in snuba_queries.items():
             results.setdefault(entity, {})
             for key, snuba_query in queries.items():

--- a/src/sentry/snuba/metrics/helpers.py
+++ b/src/sentry/snuba/metrics/helpers.py
@@ -464,6 +464,12 @@ class SnubaQueryBuilder:
             (totals_query.groupby or []) + [Column(TS_COL_GROUP)]
         )
 
+        # In a series query, we also need to factor in the len of the intervals array
+        series_limit = MAX_POINTS
+        if query_definition.limit:
+            series_limit = query_definition.limit * len(list(get_intervals(query_definition)))
+        series_query = series_query.set_limit(series_limit)
+
         return {
             "totals": totals_query,
             "series": series_query,

--- a/src/sentry/snuba/metrics/helpers.py
+++ b/src/sentry/snuba/metrics/helpers.py
@@ -460,12 +460,9 @@ class SnubaQueryBuilder:
             orderby=self._build_orderby(query_definition, entity),
         )
 
-        if totals_query.orderby is None:
-            series_query = totals_query.set_groupby(
-                (totals_query.groupby or []) + [Column(TS_COL_GROUP)]
-            )
-        else:
-            series_query = None
+        series_query = totals_query.set_groupby(
+            (totals_query.groupby or []) + [Column(TS_COL_GROUP)]
+        )
 
         return {
             "totals": totals_query,

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -694,6 +694,35 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         }
 
     @with_feature(FEATURE_FLAG)
+    def test_series_are_limited_to_total_order_in_case_with_one_field_orderby(self):
+        # Create time series [1, 2, 3, 4] for every release:
+        for minute in range(4):
+            for _ in range(minute + 1):
+                # One for each release
+                for release in ("foo", "bar", "baz"):
+                    self.store_session(
+                        self.build_session(
+                            project_id=self.project.id,
+                            started=(time.time() // 60 - 3 + minute) * 60,
+                            release=release,
+                        )
+                    )
+        response = self.get_success_response(
+            self.organization.slug,
+            field="sum(sentry.sessions.session)",
+            statsPeriod="4m",
+            interval="1m",
+            groupBy="release",
+            orderBy="-sum(sentry.sessions.session)",
+            per_page=1,  # limit to a single page
+        )
+
+        for group in response.data["groups"]:
+            assert group["series"]["sum(sentry.sessions.session)"] == [1, 2, 3, 4]
+
+        assert len(response.data["groups"]) == 1
+
+    @with_feature(FEATURE_FLAG)
     def test_orderby_percentile_with_many_fields_multiple_entities_with_missing_data(self):
         """
         Test that ensures when transactions table has null values for some fields (i.e. fields

--- a/tests/sentry/snuba/test_metrics.py
+++ b/tests/sentry/snuba/test_metrics.py
@@ -275,7 +275,7 @@ def test_build_snuba_query_orderby(mock_now, mock_now2, monkeypatch):
             Condition(Column("tags[6]", entity=None), Op.IN, [10]),
         ],
         orderby=[OrderBy(Column("sum"), Direction.DESC)],
-        limit=Limit(3),
+        limit=Limit(6480),
         offset=Offset(0),
         granularity=Granularity(query_definition.rollup),
     )

--- a/tests/sentry/snuba/test_metrics.py
+++ b/tests/sentry/snuba/test_metrics.py
@@ -256,7 +256,29 @@ def test_build_snuba_query_orderby(mock_now, mock_now2, monkeypatch):
 
     counter_queries = snuba_queries.pop("metrics_counters")
     assert not snuba_queries
-    assert counter_queries["series"] is None  # No series because of orderBy
+    assert counter_queries["series"] == Query(
+        dataset="metrics",
+        match=Entity("metrics_counters"),
+        select=[Function("sum", [Column("value")], "sum")],
+        groupby=[
+            Column("metric_id"),
+            Column("tags[8]"),
+            Column("tags[2]"),
+            Column("bucketed_time"),
+        ],
+        where=[
+            Condition(Column("org_id"), Op.EQ, 1),
+            Condition(Column("project_id"), Op.IN, [1]),
+            Condition(Column("metric_id"), Op.IN, [9]),
+            Condition(Column("timestamp"), Op.GTE, datetime(2021, 5, 28, 0, tzinfo=pytz.utc)),
+            Condition(Column("timestamp"), Op.LT, datetime(2021, 8, 26, 0, tzinfo=pytz.utc)),
+            Condition(Column("tags[6]", entity=None), Op.IN, [10]),
+        ],
+        orderby=[OrderBy(Column("sum"), Direction.DESC)],
+        limit=Limit(3),
+        offset=Offset(0),
+        granularity=Granularity(query_definition.rollup),
+    )
 
     assert counter_queries["totals"] == Query(
         dataset="metrics",


### PR DESCRIPTION
This PR:
- Adds logic that enables you to get series back when a request is sent with an orderBy clause
- Fixes bug that adds conditions only if there is a `project_id` in the `GroupBy` when performing `orderBy` queries
- Fixes bug that sends empty condition tuple in query when there is no `GroupBy` columns when performing `orderBy` queries