### PR TITLE
ref(tsc): fix large type union on breadcrumbs

### DIFF
--- a/static/app/components/breadcrumbs.tsx
+++ b/static/app/components/breadcrumbs.tsx
@@ -8,7 +8,9 @@ import {IconChevron} from 'sentry/icons';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
 import {Theme} from 'sentry/utils/theme';
-import BreadcrumbDropdown from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
+import BreadcrumbDropdown, {
+  BreadcrumbDropdownProps,
+} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
 
 const BreadcrumbList = styled('div')`
   display: flex;
@@ -44,7 +46,7 @@ export type CrumbDropdown = {
   /**
    * Items of the crumb dropdown
    */
-  items: React.ComponentProps<typeof BreadcrumbDropdown>['items'];
+  items: BreadcrumbDropdownProps['items'];
 
   /**
    * Name of the crumb
@@ -54,10 +56,10 @@ export type CrumbDropdown = {
   /**
    * Callback function for when an item is selected
    */
-  onSelect: React.ComponentProps<typeof BreadcrumbDropdown>['onSelect'];
+  onSelect: BreadcrumbDropdownProps['onSelect'];
 };
 
-type Props = React.ComponentPropsWithoutRef<typeof BreadcrumbList> & {
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Array of crumbs that will be rendered
    */
@@ -70,7 +72,7 @@ type Props = React.ComponentPropsWithoutRef<typeof BreadcrumbList> & {
    * assign `to: null/undefined` when passing props to this component.
    */
   linkLastItem?: boolean;
-};
+}
 
 function isCrumbDropdown(crumb: Crumb | CrumbDropdown): crumb is CrumbDropdown {
   return (crumb as CrumbDropdown).items !== undefined;

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
@@ -9,12 +9,13 @@ import {RouteWithName} from './types';
 
 const EXIT_DELAY = 0;
 
-type AdditionalDropdownProps = Pick<
-  React.ComponentProps<typeof DropdownAutoCompleteMenu>,
-  'onChange' | 'busyItemsStillVisible'
->;
+interface AdditionalDropdownProps
+  extends Pick<
+    React.ComponentProps<typeof DropdownAutoCompleteMenu>,
+    'onChange' | 'busyItemsStillVisible'
+  > {}
 
-type Props = {
+export interface BreadcrumbDropdownProps extends AdditionalDropdownProps {
   items: Item[];
   name: React.ReactNode;
   onSelect: (item: Item) => void;
@@ -22,13 +23,13 @@ type Props = {
   enterDelay?: number;
   hasMenu?: boolean;
   isLast?: boolean;
-} & AdditionalDropdownProps;
+}
 
 type State = {
   isOpen: boolean;
 };
 
-class BreadcrumbDropdown extends React.Component<Props, State> {
+class BreadcrumbDropdown extends React.Component<BreadcrumbDropdownProps, State> {
   state: State = {
     isOpen: false,
   };


### PR DESCRIPTION
Before:
<img width="993" alt="CleanShot 2022-03-01 at 11 00 58@2x" src="https://user-images.githubusercontent.com/9317857/156148484-dd2b3af4-c248-40b0-a67c-d1b47f80c073.png">
After
<img width="986" alt="CleanShot 2022-03-01 at 11 02 53@2x" src="https://user-images.githubusercontent.com/9317857/156148462-9e71e67d-8def-4247-b427-e3d6e9807969.png">


