### PR TITLE
ref(tsc): fix large type union on transparentloadingmask

### DIFF
--- a/static/app/components/breadcrumbs.tsx
+++ b/static/app/components/breadcrumbs.tsx
@@ -8,7 +8,9 @@ import {IconChevron} from 'sentry/icons';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
 import {Theme} from 'sentry/utils/theme';
-import BreadcrumbDropdown from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
+import BreadcrumbDropdown, {
+  BreadcrumbDropdownProps,
+} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
 
 const BreadcrumbList = styled('div')`
   display: flex;
@@ -44,7 +46,7 @@ export type CrumbDropdown = {
   /**
    * Items of the crumb dropdown
    */
-  items: React.ComponentProps<typeof BreadcrumbDropdown>['items'];
+  items: BreadcrumbDropdownProps['items'];
 
   /**
    * Name of the crumb
@@ -54,10 +56,10 @@ export type CrumbDropdown = {
   /**
    * Callback function for when an item is selected
    */
-  onSelect: React.ComponentProps<typeof BreadcrumbDropdown>['onSelect'];
+  onSelect: BreadcrumbDropdownProps['onSelect'];
 };
 
-type Props = React.ComponentPropsWithoutRef<typeof BreadcrumbList> & {
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Array of crumbs that will be rendered
    */
@@ -70,7 +72,7 @@ type Props = React.ComponentPropsWithoutRef<typeof BreadcrumbList> & {
    * assign `to: null/undefined` when passing props to this component.
    */
   linkLastItem?: boolean;
-};
+}
 
 function isCrumbDropdown(crumb: Crumb | CrumbDropdown): crumb is CrumbDropdown {
   return (crumb as CrumbDropdown).items !== undefined;

--- a/static/app/components/charts/transparentLoadingMask.tsx
+++ b/static/app/components/charts/transparentLoadingMask.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 
-import LoadingMask from 'sentry/components/loadingMask';
+import LoadingMask, {LoadingMaskProps} from 'sentry/components/loadingMask';
 
-type Props = {
+interface TransparentLoadingMaskProps extends LoadingMaskProps {
   visible: boolean;
   children?: React.ReactNode;
   className?: string;
-} & React.ComponentProps<typeof LoadingMask>;
+}
 
 const TransparentLoadingMask = styled(
-  ({className, visible, children, ...props}: Props) => {
+  ({className, visible, children, ...props}: TransparentLoadingMaskProps) => {
     const other = visible ? {...props, 'data-test-id': 'loading-placeholder'} : props;
     return (
       <LoadingMask className={className} {...other}>
@@ -18,7 +18,7 @@ const TransparentLoadingMask = styled(
       </LoadingMask>
     );
   }
-)<Props>`
+)<TransparentLoadingMaskProps>`
   ${p => !p.visible && 'display: none;'};
   opacity: 0.4;
   z-index: 1;

--- a/static/app/components/loadingMask.tsx
+++ b/static/app/components/loadingMask.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 
-const LoadingMask = styled('div')`
+export interface LoadingMaskProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const LoadingMask = styled('div')<LoadingMaskProps>`
   background-color: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
   position: absolute;

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
@@ -9,12 +9,13 @@ import {RouteWithName} from './types';
 
 const EXIT_DELAY = 0;
 
-type AdditionalDropdownProps = Pick<
-  React.ComponentProps<typeof DropdownAutoCompleteMenu>,
-  'onChange' | 'busyItemsStillVisible'
->;
+interface AdditionalDropdownProps
+  extends Pick<
+    React.ComponentProps<typeof DropdownAutoCompleteMenu>,
+    'onChange' | 'busyItemsStillVisible'
+  > {}
 
-type Props = {
+export interface BreadcrumbDropdownProps extends AdditionalDropdownProps {
   items: Item[];
   name: React.ReactNode;
   onSelect: (item: Item) => void;
@@ -22,13 +23,13 @@ type Props = {
   enterDelay?: number;
   hasMenu?: boolean;
   isLast?: boolean;
-} & AdditionalDropdownProps;
+}
 
 type State = {
   isOpen: boolean;
 };
 
-class BreadcrumbDropdown extends React.Component<Props, State> {
+class BreadcrumbDropdown extends React.Component<BreadcrumbDropdownProps, State> {
   state: State = {
     isOpen: false,
   };


### PR DESCRIPTION
Before:
<img width="975" alt="CleanShot 2022-03-01 at 11 12 33@2x" src="https://user-images.githubusercontent.com/9317857/156150065-0c4c08e4-fefe-41bb-b343-206ca1ee5141.png">
After:
<img width="1058" alt="CleanShot 2022-03-01 at 11 11 22@2x" src="https://user-images.githubusercontent.com/9317857/156150009-9599f7ba-15c8-42a3-a027-cbe9450ce804.png">

