### PR TITLE
fix(alertStatus): Update font size and weight for alert conditions

### DIFF
--- a/static/app/views/alerts/details/sidebar.tsx
+++ b/static/app/views/alerts/details/sidebar.tsx
@@ -218,7 +218,7 @@ const StepContent = styled('div')`
     position: absolute;
     height: 100%;
     top: 28px;
-    left: 19px;
+    left: ${space(1)};
     border-right: 1px ${p => p.theme.gray200} dashed;
   }
 `;
@@ -226,13 +226,13 @@ const StepContent = styled('div')`
 const StepLead = styled('div')`
   margin-bottom: ${space(0.5)};
   font-size: ${p => p.theme.fontSizeMedium};
-  font-weight: 600;
+  font-weight: 400;
 `;
 
 const ChevronContainer = styled('div')`
   display: flex;
   align-items: center;
-  padding: ${space(0.5)} ${space(1.5)};
+  padding: ${space(0.5)} ${space(1)} ${space(0.5)} 0;
 `;
 
 const Badge = styled('span')`
@@ -244,7 +244,7 @@ const Badge = styled('span')`
   text-transform: uppercase;
   text-align: center;
   font-size: ${p => p.theme.fontSizeSmall};
-  font-weight: 600;
+  font-weight: 400;
   line-height: 1.5;
 `;
 
@@ -254,9 +254,10 @@ const ConditionsBadge = styled('span')`
   padding: 0 ${space(0.75)};
   border-radius: ${p => p.theme.borderRadius};
   color: ${p => p.theme.textColor};
-  font-size: ${p => p.theme.fontSizeMedium};
+  font-size: ${p => p.theme.fontSizeSmall};
   margin-bottom: ${space(1)};
   width: fit-content;
+  font-weight: 400;
 `;
 
 const Heading = styled(SectionHeading)<{noMargin?: boolean}>`


### PR DESCRIPTION
Update the font size and weight for alert conditions side bar

[FIXES WOR-1662
](https://getsentry.atlassian.net/browse/WOR-1662)
# Before
<img width="356" alt="Screen Shot 2022-03-01 at 5 53 06 AM" src="https://user-images.githubusercontent.com/20312973/156182355-7751b26e-145e-4ed7-8800-1e4654bba514.png">

# After
<img width="277" alt="Screen Shot 2022-03-01 at 5 50 47 AM" src="https://user-images.githubusercontent.com/20312973/156182381-764a74c9-e8c5-47c2-8369-4ee76c0c2f23.png">


