### PR TITLE
fix(ui) Fix overflow numbers in key stats

### DIFF
--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -6,6 +6,7 @@ import {useTheme} from '@emotion/react';
 import set from 'lodash/set';
 
 import {getFormattedDate} from 'sentry/utils/dates';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 
 import BarChart, {BarChartSeries} from './barChart';
 import BaseChart from './baseChart';
@@ -173,6 +174,14 @@ function MiniBarChart({
         showMinLabel: true,
         showMaxLabel: true,
         interval: Infinity,
+        axisLabel: {
+          formatter(value: number) {
+            if (tooltipFormatter) {
+              return tooltipFormatter(value);
+            }
+            return formatAbbreviatedNumber(value);
+          },
+        },
       }
     : {
         axisLabel: {


### PR DESCRIPTION
As well as other minibarcharts with y-axis labels. This aligns the y-axis formatting with organization stats and smaller charts in performance.

### Before

![Screen Shot 2022-03-01 at 11 58 36 AM](https://user-images.githubusercontent.com/24086/156213723-e040df82-6c4f-4316-a5b5-e239c9d93026.png)

### After

![Screen Shot 2022-03-01 at 11 58 22 AM](https://user-images.githubusercontent.com/24086/156213755-cd9d87b8-2a82-40ff-b83c-eb6da3e8b075.png)
