### PR TITLE
fix(profiling): Empty profile minFrameDuration is not inf

### DIFF
--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -44,7 +44,7 @@ export class Profile {
   }
 
   static Empty() {
-    return new Profile(100000, 0, 100000, '', 'milliseconds');
+    return new Profile(100000, 0, 100000, '', 'milliseconds').build();
   }
 
   forEach(

--- a/tests/js/spec/utils/profiling/profile/profile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/profile.spec.tsx
@@ -61,6 +61,12 @@ stack top -> stack bottom`;
 };
 
 describe('Profile', () => {
+  it('Empty profile duration is not infinity', () => {
+    const profile = Profile.Empty();
+    expect(profile.duration).toEqual(100_000);
+    expect(profile.minFrameDuration).toEqual(100_000);
+  });
+
   it('forEach - iterates over a single sample', () => {
     const profile = new Profile(1000, 0, 1000, 'profile', 'ms');
 


### PR DESCRIPTION
An empty profile currently has a minFrameDuration of infinity and results in an
non invertible matrix when rendering. Make sure to call `build` on the empty
profile to ensure its not infinity.