### PR TITLE
ref(sdk): Bump idleTimeout to 5000ms for testing

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -31,7 +31,7 @@ function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
             ),
           }
         : {}),
-      idleTimeout: 1000,
+      idleTimeout: 5000,
       _metricOptions: {
         _reportAllChanges: false,
       },


### PR DESCRIPTION
### Summary
This bumps the idleTimeout to 5000ms to test if more LCP final candidates are captured without reportAllChanges being set to true.

#### Screenshots
Example of the same element rate being captured for a single page, dips correlate to the previous release where we modified idleTimeout and the reportAllChanges flag.
![Screen Shot 2022-03-01 at 12 45 52 PM](https://user-images.githubusercontent.com/6111995/156221704-365e85ae-3cad-4d6b-bf3e-de850be087f6.png)


