### PR TITLE
feat(perf): Fix anomaly chart yAxis

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
@@ -53,8 +53,8 @@ const _AnomalyChart = (props: Props) => {
     xAxis: undefined,
     yAxis: {
       axisLabel: {
-        // p50() coerces the axis to be time based
-        formatter: (value: number) => axisLabelFormatter(value, 'p50()'),
+        // Coerces the axis to be count based
+        formatter: (value: number) => axisLabelFormatter(value, 'tpm()'),
       },
     },
   };


### PR DESCRIPTION
### Summary
Was using p50 to coerce yAxis labels to duration by accident, switched to tpm so it's count on the yAxis. Can change this in the future if we do dynamic fields.

#### Screenshots
![Screen Shot 2022-03-01 at 1 07 51 PM](https://user-images.githubusercontent.com/6111995/156224526-81879ffc-953b-461f-aaf5-be48a0d9b952.png)


