### PR TITLE
ref(github plugin): Demote logger.error to logger.info

### DIFF
--- a/src/sentry_plugins/github/endpoints/webhook.py
+++ b/src/sentry_plugins/github/endpoints/webhook.py
@@ -393,7 +393,7 @@ class GithubWebhookBase(View):
         try:
             method, signature = request.META["HTTP_X_HUB_SIGNATURE"].split("=", 1)
         except (KeyError, IndexError):
-            logger.error(
+            logger.info(
                 "github.webhook.missing-signature", extra=self.get_logging_data(organization)
             )
             return HttpResponse(status=400)


### PR DESCRIPTION
We have 1m unactionable events on this issue for the GitHub plugin, this PR changes it to an info level so we don't get notified of it in Sentry.

Fixes [SENTRY-6D6](https://sentry.io/organizations/sentry/issues/528070766/)