### PR TITLE
perf(db): Count hits on a replica instead of the primary postgres

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -190,7 +190,7 @@ class BasePaginator:
             h_sql, h_params = hits_query.sql_with_params()
         except EmptyResultSet:
             return 0
-        cursor = connections[self.queryset.db].cursor()
+        cursor = connections[self.queryset.using_replica().db].cursor()
         cursor.execute(f"SELECT COUNT(*) FROM ({h_sql}) as t", h_params)
         return cursor.fetchone()[0]
 


### PR DESCRIPTION
This can be an expensive query, and it doesn't need to be 100% accurate, so we can safely use a
replica here. Replag is typically low anyway, so this shouldn't have any noticeable customer impact.