### PR TITLE
fix(dashboards): Widget Viewer edit button regression fix

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -47,7 +47,17 @@ const HALF_TABLE_ITEM_LIMIT = 10;
 const GEO_COUNTRY_CODE = 'geo.country_code';
 
 function WidgetViewerModal(props: Props) {
-  const {organization, widget, selection, location, Footer, Body, Header, onEdit} = props;
+  const {
+    organization,
+    widget,
+    selection,
+    location,
+    Footer,
+    Body,
+    Header,
+    closeModal,
+    onEdit,
+  } = props;
   const isTableWidget = widget.displayType === DisplayType.TABLE;
   const renderWidgetViewer = () => {
     const api = useApi();
@@ -199,9 +209,17 @@ function WidgetViewerModal(props: Props) {
       <Body>{renderWidgetViewer()}</Body>
       <StyledFooter>
         <ButtonBar gap={1}>
-          <Button type="button" onClick={onEdit}>
-            {t('Edit Widget')}
-          </Button>
+          {onEdit && (
+            <Button
+              type="button"
+              onClick={() => {
+                closeModal();
+                onEdit();
+              }}
+            >
+              {t('Edit Widget')}
+            </Button>
+          )}
           <Button to={path} priority="primary" type="button">
             {openLabel}
           </Button>

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -1,6 +1,7 @@
 import {cloneElement, Component, isValidElement} from 'react';
 import {browserHistory, PlainRoute, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
+import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 
@@ -123,6 +124,19 @@ class DashboardDetail extends Component<Props, State> {
             router.push({
               pathname: `/organizations/${organization.slug}/dashboard/${dashboard.id}/`,
               query: location.query,
+            });
+          },
+          onEdit: () => {
+            openAddDashboardWidgetModal({
+              organization,
+              widget,
+              onUpdateWidget: (nextWidget: Widget) => {
+                const updateIndex = dashboard.widgets.indexOf(widget);
+                const nextWidgetsList = cloneDeep(dashboard.widgets);
+                nextWidgetsList[updateIndex] = nextWidget;
+                this.handleUpdateWidgetList(nextWidgetsList);
+              },
+              source: DashboardWidgetSource.DASHBOARDS,
             });
           },
         });

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -145,6 +145,7 @@ class WidgetCard extends React.Component<Props> {
       showWidgetViewerButton,
       router,
       isEditing,
+      onEdit,
     } = this.props;
     return (
       <ErrorBoundary
@@ -168,6 +169,7 @@ class WidgetCard extends React.Component<Props> {
                     openWidgetViewerModal({
                       organization,
                       widget,
+                      onEdit,
                     });
                   }
                 }}

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -35,6 +35,7 @@ function mountModal({initialData: {organization, routerContext}, widget}) {
         closeModal={() => undefined}
         organization={organization}
         widget={widget}
+        onEdit={() => undefined}
       />
     </div>,
     {


### PR DESCRIPTION
Edit button in the Widget Viewer stopped working since we added shareable links. 
This fixes by adding an onEdit handler to `detail.tsx`