### PR TITLE
perf(db): Make group inbox queries run on the replica

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -103,7 +103,7 @@ def inbox_search(
         date_added__gte=start,
         date_added__lte=end,
         project__in=projects,
-    )
+    ).using_replica()
 
     if environments is not None:
         environment_ids: List[int] = [environment.id for environment in environments]


### PR DESCRIPTION
These queries can be expensive, moving them over to replicas as well.