### PR TITLE
fix(discover): Fix drag and drop on Edit Column modal

### DIFF
--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -174,7 +174,7 @@ type Rect = {
 };
 
 // get position of element relative to top/left of document
-const getOffsetOfElement = (element: Element) => {
+export const getOffsetOfElement = (element: Element) => {
   // left and top are relative to viewport
   const {left, top} = element.getBoundingClientRect();
 

--- a/static/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/static/app/views/eventsV2/table/columnEditCollection.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {parseArithmetic} from 'sentry/components/arithmeticInput/parser';
 import Button from 'sentry/components/button';
 import {SectionHeading} from 'sentry/components/charts/styles';
+import {getOffsetOfElement} from 'sentry/components/performance/waterfall/utils';
 import {IconAdd, IconDelete, IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -231,9 +232,10 @@ class ColumnEditCollection extends React.Component<Props, State> {
 
     // Compute where the user clicked on the drag handle. Avoids the element
     // jumping from the cursor on mousedown.
-    const {x, y} = Array.from(document.querySelectorAll(`.${DRAG_CLASS}`))
-      .find(n => n.contains(event.currentTarget))!
-      .getBoundingClientRect();
+    const draggingElement = Array.from(document.querySelectorAll(`.${DRAG_CLASS}`)).find(
+      n => n.contains(event.currentTarget)
+    )!;
+    const {x, y} = getOffsetOfElement(draggingElement);
 
     const draggingGrabbedOffset = {
       x: left - x + GHOST_PADDING,


### PR DESCRIPTION
Fix a regression introduced in https://github.com/getsentry/sentry/issues/23127 whereby the scroll offsets was not accounted for the ghost React component.

I may follow up with a larger refactor to outsource the drag and drop mechanism to the `dnd-kit` library.

### Before

https://user-images.githubusercontent.com/139499/156261659-52ef0570-5268-4d37-b696-54eef1a9ab86.mp4

### After

https://user-images.githubusercontent.com/139499/156261662-7e81f1ac-e30a-46a1-b8fb-fbcfc8358eb2.mp4

