### PR TITLE
fix(perf): Redirect to performance homepage from span details page when required query strings are missing

### DIFF
--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -75,13 +75,7 @@ function PageLayout(props: Props) {
   const transactionName = getTransactionName(location);
 
   if (!defined(projectId) || !defined(transactionName)) {
-    // If there is no transaction name, redirect to the Performance landing page
-    browserHistory.replace({
-      pathname: `/organizations/${organization.slug}/performance/`,
-      query: {
-        ...location.query,
-      },
-    });
+    redirectToPerformanceHomepage(organization, location);
     return null;
   }
 
@@ -202,5 +196,18 @@ const StyledAlert = styled(Alert)`
   grid-column: 1/3;
   margin: 0;
 `;
+
+export function redirectToPerformanceHomepage(
+  organization: Organization,
+  location: Location
+) {
+  // If there is no transaction name, redirect to the Performance landing page
+  browserHistory.replace({
+    pathname: `/organizations/${organization.slug}/performance/`,
+    query: {
+      ...location.query,
+    },
+  });
+}
 
 export default PageLayout;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
@@ -13,7 +13,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
 import {getTransactionName} from '../../../utils';
-import {NoAccess} from '../../pageLayout';
+import {NoAccess, redirectToPerformanceHomepage} from '../../pageLayout';
 import {
   generateSpansEventView,
   parseSpanSlug,
@@ -30,12 +30,14 @@ export default function SpanDetails(props: Props) {
   const transactionName = getTransactionName(location);
   const spanSlug = parseSpanSlug(params.spanSlug);
 
+  const organization = useOrganization();
+
   const projectId = decodeScalar(location.query.project);
   if (!defined(projectId) || !defined(transactionName) || !defined(spanSlug)) {
+    redirectToPerformanceHomepage(organization, location);
     return null;
   }
 
-  const organization = useOrganization();
   const {projects} = useProjects();
 
   const project = projects.find(p => p.id === projectId);


### PR DESCRIPTION
When required query strings are missing on the span details page, we just render an empty page.

This pull request adds a redirect to the performance homepage in this scenario.

![Screen Shot 2022-03-01 at 6 24 47 PM](https://user-images.githubusercontent.com/139499/156266105-10a3dd19-fd6d-43e6-991e-5043dc000620.png)
