### PR TITLE
ref(tsc): remove large union on searchbar

### DIFF
--- a/static/app/components/activity/item/bubble.tsx
+++ b/static/app/components/activity/item/bubble.tsx
@@ -1,15 +1,15 @@
 import styled from '@emotion/styled';
 
-type Props = {
+export interface ActivityBubbleProps extends React.HTMLAttributes<HTMLDivElement> {
   backgroundColor?: string;
   borderColor?: string;
-};
+}
 
 /**
  * This creates a bordered box that has a left pointing arrow
  * on the left-side at the top.
  */
-const ActivityBubble = styled('div')<Props>`
+const ActivityBubble = styled('div')<ActivityBubbleProps>`
   flex: 1;
   background-color: ${p => p.backgroundColor || p.theme.background};
   border: 1px solid ${p => p.borderColor || p.theme.border};

--- a/static/app/components/activity/item/index.tsx
+++ b/static/app/components/activity/item/index.tsx
@@ -10,13 +10,13 @@ import {AvatarUser} from 'sentry/types';
 import {isRenderFunc} from 'sentry/utils/isRenderFunc';
 
 import ActivityAvatar from './avatar';
-import ActivityBubble from './bubble';
+import ActivityBubble, {ActivityBubbleProps} from './bubble';
 
 export type ActivityAuthorType = 'user' | 'system';
 
 type ChildFunction = () => React.ReactNode;
 
-type Props = {
+interface ActivityItemProps {
   /**
    * Used to render an avatar for the author. Currently can be a user, otherwise
    * defaults as a "system" avatar (i.e. sentry)
@@ -29,7 +29,7 @@ type Props = {
   };
   // Size of the avatar.
   avatarSize?: number;
-  bubbleProps?: React.ComponentProps<typeof ActivityBubble>;
+  bubbleProps?: ActivityBubbleProps;
 
   children?: React.ReactChild | ChildFunction;
 
@@ -65,7 +65,7 @@ type Props = {
 
   // Instead of showing a relative time/date, show the time
   showTime?: boolean;
-};
+}
 
 function ActivityItem({
   author,
@@ -80,7 +80,7 @@ function ActivityItem({
   header,
   hideDate = false,
   showTime = false,
-}: Props) {
+}: ActivityItemProps) {
   const showDate = !hideDate && date && !interval;
   const showRange = !hideDate && date && interval;
   const dateEnded = showRange

--- a/static/app/components/searchBar.tsx
+++ b/static/app/components/searchBar.tsx
@@ -3,30 +3,27 @@ import styled from '@emotion/styled';
 import classNames from 'classnames';
 
 import Button from 'sentry/components/button';
-import Input from 'sentry/components/forms/controls/input';
+import Input, {InputProps} from 'sentry/components/forms/controls/input';
 import {IconSearch} from 'sentry/icons';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import {callIfFunction} from 'sentry/utils/callIfFunction';
 
-type DefaultProps = {
+interface SearchBarProps extends Omit<InputProps, 'onChange'> {
   defaultQuery: string;
   onSearch: (query: string) => void;
   query: string;
-};
-
-type Props = DefaultProps & {
   onChange?: (query: string) => void;
   width?: string;
-} & Omit<React.ComponentProps<typeof Input>, 'onChange'>;
+}
 
 type State = {
   dropdownVisible: boolean;
   query: string;
 };
 
-class SearchBar extends React.PureComponent<Props, State> {
-  static defaultProps: DefaultProps = {
+class SearchBar extends React.PureComponent<SearchBarProps, State> {
+  static defaultProps: Pick<SearchBarProps, 'query' | 'defaultQuery' | 'onSearch'> = {
     query: '',
     defaultQuery: '',
     onSearch: function () {},
@@ -37,7 +34,7 @@ class SearchBar extends React.PureComponent<Props, State> {
     dropdownVisible: false,
   };
 
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: SearchBarProps) {
     if (nextProps.query !== this.props.query) {
       this.setState({
         query: nextProps.query,


### PR DESCRIPTION
Before
<img width="861" alt="CleanShot 2022-03-02 at 12 06 23@2x" src="https://user-images.githubusercontent.com/9317857/156350385-59645155-a4ef-4adf-8135-ecabd57d7d56.png">
After
<img width="872" alt="CleanShot 2022-03-02 at 12 06 57@2x" src="https://user-images.githubusercontent.com/9317857/156350382-2ce1874b-f317-4cac-b641-a9535088cf66.png">


