### PR TITLE
fix(sdk): Do not error if a project is using an unknown version

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -31,6 +31,7 @@ lxml==4.6.5
 maxminddb==2.0.3
 mistune==0.8.4
 mmh3==3.0.0
+packaging==21.3
 parsimonious==0.8.0
 petname==2.6
 phonenumberslite==8.12.0

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -1,9 +1,9 @@
 from datetime import timedelta
-from distutils.version import LooseVersion
 from itertools import chain, groupby
 
 import sentry_sdk
 from django.utils import timezone
+from packaging import version
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -30,7 +30,7 @@ def serialize(data, projects):
             {
                 "projectId": str(project_id),
                 "sdkName": sdk_name,
-                "sdkVersion": max((s["sdk.version"] for s in sdks), key=LooseVersion),
+                "sdkVersion": max((s["sdk.version"] for s in sdks), key=version.parse),
             }
             for sdk_name, sdks in groupby(sorted(sdks_used, key=by_sdk_name), key=by_sdk_name)
         ]

--- a/tests/sentry/api/endpoints/test_organization_sdk_updates.py
+++ b/tests/sentry/api/endpoints/test_organization_sdk_updates.py
@@ -128,6 +128,41 @@ class OrganizationSdkUpdates(APITestCase, SnubaTestCase):
         update_suggestions = response.data
         assert len(update_suggestions) == 0
 
+    @mock.patch(
+        "sentry.api.endpoints.organization_sdk_updates.SdkIndexState",
+        return_value=SdkIndexState(sdk_versions={"example.sdk": "2.0.0"}),
+    )
+    def test_unknown_version(self, mock_index_state):
+        min_ago = iso_format(before_now(minutes=1))
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "oh no",
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+                "sdk": {"name": "example.sdk", "version": "dev-master@32e5415"},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "b",
+                "timestamp": min_ago,
+                "fingerprint": ["group-2"],
+                "sdk": {"name": "example.sdk", "version": "2.0.0"},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+
+        with self.feature(self.features):
+            response = self.client.get(self.url)
+
+        update_suggestions = response.data
+        assert len(update_suggestions) == 0
+
 
 class OrganizationSdkUpdatesWithSnql(OrganizationSdkUpdates):
     def setUp(self):


### PR DESCRIPTION
There are instances where an SDK, such as `sentry-php`, is using a version string, such as `dev-master@32e5415`, that cannot be readily compared to known formats such as semver. 

Comparisons such as `LooseVersion('dev-master@32e5415') > LooseVersion('2.0')` will result in an exception.

I've opted to use `from packaging import version` https://packaging.pypa.io/en/latest/version.html in favour of `LooseVersion` so that `version.parse(x)` will not create an exception.

`version.parse('dev-master@32e5415')` will result in an instance of `LegacyVersion` that always sorts before `Version`. 

References:
- https://www.python.org/dev/peps/pep-0440/
- https://www.python.org/dev/peps/pep-0386/


------


Fixes SENTRY-SGW