### PR TITLE
fix(widget-builder-new-experience): Fix fields not getting update when displayType changes in a widget coming from discover - [DD-536]

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -92,7 +92,8 @@ export function normalizeQueries(
   }
 
   if ([DisplayType.TABLE, DisplayType.TOP_N].includes(displayType)) {
-    return queries;
+    // Reset orderby
+    return queries.map(query => ({...query, orderby: ''}));
   }
 
   // Filter out non-aggregate fields


### PR DESCRIPTION
This PR fixes the following issue by updating the `defaultFields` logic. The function `defaultFields()` was not being called for widgets with origins other than dashboards.

https://user-images.githubusercontent.com/29228205/156364322-9bb499da-9f82-434e-b372-8c6891b11649.mov






