### PR TITLE
ref(tsc): use HTMLAttributes in sidebarSection

### DIFF
--- a/static/app/components/group/sidebarSection.tsx
+++ b/static/app/components/group/sidebarSection.tsx
@@ -27,16 +27,17 @@ const Subheading = styled('h6')`
   margin-bottom: ${space(1)};
 `;
 
-type Props = {
+interface SidebarSectionProps
+  extends Omit<React.HTMLAttributes<HTMLHeadingElement>, 'title'> {
   children: React.ReactNode;
   title: React.ReactNode;
   secondary?: boolean;
-} & Omit<React.ComponentProps<typeof Heading>, 'title'>;
+}
 
 /**
  * Used to add a new section in Issue Details' sidebar.
  */
-function SidebarSection({title, children, secondary, ...props}: Props) {
+function SidebarSection({title, children, secondary, ...props}: SidebarSectionProps) {
   const HeaderComponent = secondary ? Subheading : Heading;
 
   return (


### PR DESCRIPTION
Before:
<img width="908" alt="CleanShot 2022-03-02 at 14 18 14@2x" src="https://user-images.githubusercontent.com/9317857/156369138-97b52361-971f-43d9-ac82-e9eed7cc2a84.png">
After:
<img width="909" alt="CleanShot 2022-03-02 at 14 21 37@2x" src="https://user-images.githubusercontent.com/9317857/156369698-fa8054bb-442a-4b36-a621-0572dc2225ee.png">

🚀 Huzzah this seems to have been the last big union in our project
<img width="1512" alt="CleanShot 2022-03-02 at 14 24 34@2x" src="https://user-images.githubusercontent.com/9317857/156370234-a1fc6510-77a3-4e04-b565-d25525a31b44.png">

