### PR TITLE
feat(dam): Remove metrics allow list [DD-627]

### DIFF
--- a/static/app/actionCreators/metrics.tsx
+++ b/static/app/actionCreators/metrics.tsx
@@ -5,7 +5,6 @@ import {Client} from 'sentry/api';
 import {getInterval} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
-import MetricsMetaStore from 'sentry/stores/metricsMetaStore';
 import MetricsTagStore from 'sentry/stores/metricsTagStore';
 import {
   DateString,
@@ -120,8 +119,6 @@ export function fetchMetricsFields(
   orgSlug: Organization['slug'],
   projects?: number[]
 ): Promise<MetricMeta[]> {
-  MetricsMetaStore.reset();
-
   const promise: Promise<MetricMeta[]> = api.requestPromise(
     `/organizations/${orgSlug}/metrics/meta/`,
     {

--- a/static/app/actionCreators/metrics.tsx
+++ b/static/app/actionCreators/metrics.tsx
@@ -5,6 +5,7 @@ import {Client} from 'sentry/api';
 import {getInterval} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
+import MetricsMetaStore from 'sentry/stores/metricsMetaStore';
 import MetricsTagStore from 'sentry/stores/metricsTagStore';
 import {
   DateString,
@@ -119,6 +120,8 @@ export function fetchMetricsFields(
   orgSlug: Organization['slug'],
   projects?: number[]
 ): Promise<MetricMeta[]> {
+  MetricsMetaStore.reset();
+
   const promise: Promise<MetricMeta[]> = api.requestPromise(
     `/organizations/${orgSlug}/metrics/meta/`,
     {

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -54,11 +54,7 @@ import {
   WidgetType,
 } from 'sentry/views/dashboardsV2/types';
 import {generateIssueWidgetFieldOptions} from 'sentry/views/dashboardsV2/widgetBuilder/issueWidget/utils';
-import {
-  DEFAULT_METRICS_FIELDS,
-  generateMetricsWidgetFieldOptions,
-  METRICS_FIELDS_ALLOW_LIST,
-} from 'sentry/views/dashboardsV2/widgetBuilder/metricWidget/fields';
+import {generateMetricsWidgetFieldOptions} from 'sentry/views/dashboardsV2/widgetBuilder/metricWidget/fields';
 import {mapErrors, normalizeQueries} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
 import WidgetCard from 'sentry/views/dashboardsV2/widgetCard';
 import {WidgetTemplate} from 'sentry/views/dashboardsV2/widgetLibrary/data';
@@ -599,12 +595,9 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       ? {...selection, datetime: {start, end, period: null, utc: null}}
       : selection;
 
-    const filteredMeta = Object.values(metricsMeta).filter(field =>
-      METRICS_FIELDS_ALLOW_LIST.includes(field.name)
-    );
     const issueWidgetFieldOptions = generateIssueWidgetFieldOptions();
     const metricsWidgetFieldOptions = generateMetricsWidgetFieldOptions(
-      filteredMeta.length ? filteredMeta : DEFAULT_METRICS_FIELDS,
+      Object.values(metricsMeta),
       Object.values(metricsTags).map(({key}) => key)
     );
     const fieldOptions = (measurementKeys: string[]) =>

--- a/static/app/views/dashboardsV2/widgetBuilder/metricWidget/fields.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/metricWidget/fields.tsx
@@ -3,12 +3,6 @@ import {defined} from 'sentry/utils';
 import {SessionMetric} from 'sentry/utils/metrics/fields';
 import {FieldValue, FieldValueKind} from 'sentry/views/eventsV2/table/types';
 
-export const METRICS_FIELDS_ALLOW_LIST: string[] = [
-  SessionMetric.SENTRY_SESSIONS_SESSION,
-  SessionMetric.SENTRY_SESSIONS_SESSION_DURATION,
-  SessionMetric.SENTRY_SESSIONS_USER,
-];
-
 export const DEFAULT_METRICS_FIELDS: MetricMeta[] = [
   {
     name: SessionMetric.SENTRY_SESSIONS_SESSION,

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -138,12 +138,6 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       operations: ['count_unique'],
       unit: null,
     },
-    {
-      name: 'not.on.allow.list',
-      type: 'set',
-      operations: ['count_unique'],
-      unit: null,
-    },
   ];
   const dashboard = TestStubs.Dashboard([], {
     id: '1',
@@ -1357,10 +1351,6 @@ describe('Modals -> AddDashboardWidgetModal', function () {
 
       userEvent.click(screen.getByText('count_unique(…)'));
       expect(screen.getByText('sentry.sessions.user')).toBeInTheDocument();
-
-      userEvent.click(screen.getByText('sentry.sessions.user'));
-      // Ensure METRICS_FIELDS_ALLOW_LIST is honoured
-      expect(screen.queryByText('not.on.allow.list')).not.toBeInTheDocument();
 
       wrapper.unmount();
     });


### PR DESCRIPTION
In preparation for custom measurements, we want to display all the metrics returned from the `/metrics/meta` endpoint, not just the ones that are on allow list.

This is just a first step.
`METRICS_AGGREGATIONS` right now contains only `count_unique` and `sum`, we will address that in a follow-up PRs.