### PR TITLE
fix(dashboards): Widget Viewer path name match to only check digits

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -114,7 +114,7 @@ class DashboardDetail extends Component<Props, State> {
       location,
       router,
     } = this.props;
-    if (location.pathname.match(/\/widget\/\w*\/$/) && !this.isWidgetBuilderRouter) {
+    if (location.pathname.match(/\/widget\/[0-9]+\/$/) && !this.isWidgetBuilderRouter) {
       const widget =
         defined(widgetId) && dashboard.widgets.find(({id}) => id === String(widgetId));
       if (widget) {

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -114,7 +114,7 @@ class DashboardDetail extends Component<Props, State> {
       location,
       router,
     } = this.props;
-    if (location.pathname.match(/\/widget\/[0-9]+\/$/) && !this.isWidgetBuilderRouter) {
+    if (location.pathname.match(/\/widget\/[0-9]+\/$/)) {
       const widget =
         defined(widgetId) && dashboard.widgets.find(({id}) => id === String(widgetId));
       if (widget) {


### PR DESCRIPTION
Updates `checkIfShouldMountWidgetViewerModal` to more accurately match widget ids in the pathname:
`/\/widget\/[0-9]+\/$/`

This should only match pathnames that end with something like `/widget/123/`.
This fixes the case where it was matching `/widget/new/` since `new` is not a number
This should not be matching `/widget/0/edit/` due to the `$` token