### PR TITLE
fix(release-health): Basic type check for fixed list comparison [INGEST-784 INGEST-1023]

### DIFF
--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -500,7 +500,10 @@ def compare_fixed_list(
     path: str,
     schema: FixedList,
 ) -> List[ComparisonError]:
-    errors = []
+    done, errors = _compare_basic_sequence(sessions, metrics, path)
+    if done:
+        return errors
+
     expected_length = len(schema.child_schemas)
     if len(sessions) != expected_length:
         errors.append(

--- a/tests/sentry/release_health/test_duplex.py
+++ b/tests/sentry/release_health/test_duplex.py
@@ -229,6 +229,9 @@ def test_compare_list_set(sessions, metrics, schema, are_equal):
 @pytest.mark.parametrize(
     "sessions,metrics,schema, are_equal",
     [
+        (None, None, FixedList([Ct.Exact]), True),
+        (None, [1], FixedList([Ct.Exact]), False),
+        ([1], None, FixedList([Ct.Exact]), False),
         ([1, 2], [1], FixedList([Ct.Exact, Ct.Exact]), False),
         ([1, 2], [1, 2], FixedList([Ct.Exact, Ct.Exact]), True),
         ([1, 2, 3], [1, 2, 4], FixedList([Ct.Exact, Ct.Exact, Ct.Ignore]), True),


### PR DESCRIPTION
Cleanup after https://github.com/getsentry/sentry/pull/32211, which crashed when the input data are not sequences.