### PR TITLE
feat(perf): Add error bar for landing instead of just toast

### DIFF
--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -137,7 +137,7 @@ type EventsRequestPartialProps = {
    */
   generatePathname?: (org: OrganizationSummary) => string;
   /**
-   * Hide error toast (used for pages which also query eventsV2)
+   * Hide error toast (used for pages which also query eventsV2). Stops error appearing as a toast.
    */
   hideError?: boolean;
   /**
@@ -148,6 +148,10 @@ type EventsRequestPartialProps = {
    * Query name used for displaying error toast if it is out of retention
    */
   name?: string;
+  /**
+   * A way to control error if error handling is not owned by the toast.
+   */
+  onError?: (error: string) => void;
   /**
    * How to order results when getting top events.
    */
@@ -258,7 +262,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
   private unmounting: boolean = false;
 
   fetchData = async () => {
-    const {api, confirmedQuery, expired, name, hideError, ...props} = this.props;
+    const {api, confirmedQuery, onError, expired, name, hideError, ...props} = this.props;
     let timeseriesData: EventsStats | MultiSeriesEventsStats | null = null;
 
     if (confirmedQuery === false) {
@@ -295,6 +299,9 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
         }
         if (!hideError) {
           addErrorMessage(errorMessage);
+        }
+        if (onError) {
+          onError(errorMessage);
         }
         this.setState({
           errored: true,

--- a/static/app/utils/performance/contexts/pageError.tsx
+++ b/static/app/utils/performance/contexts/pageError.tsx
@@ -32,7 +32,7 @@ export const PageErrorAlert = () => {
   }
 
   return (
-    <Alert type="error" icon={<IconFlag size="md" />}>
+    <Alert type="error" data-test-id="page-error-alert" icon={<IconFlag size="md" />}>
       {pageError}
     </Alert>
   );

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -19,6 +19,10 @@ import {Organization, PageFilters, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {generateAggregateFields} from 'sentry/utils/discover/fields';
 import {GenericQueryBatcher} from 'sentry/utils/performance/contexts/genericQueryBatcher';
+import {
+  PageErrorAlert,
+  PageErrorProvider,
+} from 'sentry/utils/performance/contexts/pageError';
 import useTeams from 'sentry/utils/useTeams';
 
 import MetricsSearchBar from '../metricsSearchBar';
@@ -105,109 +109,112 @@ export function PerformanceLanding(props: Props) {
 
   return (
     <StyledPageContent data-test-id="performance-landing-v3">
-      <Layout.Header>
-        <Layout.HeaderContent>
-          <StyledHeading>{t('Performance')}</StyledHeading>
-        </Layout.HeaderContent>
-        <Layout.HeaderActions>
-          {!showOnboarding && (
-            <ButtonBar gap={3}>
-              <MetricsSwitch onSwitch={() => handleSearch('')} />
-              <Button
-                priority="primary"
-                data-test-id="landing-header-trends"
-                onClick={() => handleTrendsClick()}
-              >
-                {t('View Trends')}
-              </Button>
-            </ButtonBar>
-          )}
-        </Layout.HeaderActions>
-
-        <Layout.HeaderNavTabs>
-          {LANDING_DISPLAYS.map(({label, field}) => (
-            <li key={label} className={landingDisplay.field === field ? 'active' : ''}>
-              <a
-                href="#"
-                data-test-id={`landing-tab-${field}`}
-                onClick={() =>
-                  handleLandingDisplayChange(
-                    field,
-                    location,
-                    projects,
-                    organization,
-                    eventView
-                  )
-                }
-              >
-                {t(label)}
-              </a>
-            </li>
-          ))}
-        </Layout.HeaderNavTabs>
-      </Layout.Header>
-      <Layout.Body>
-        <Layout.Main fullWidth>
-          <GlobalSdkUpdateAlert />
-          {showOnboarding ? (
-            <Onboarding
-              organization={organization}
-              project={
-                props.selection.projects.length > 0
-                  ? // If some projects selected, use the first selection
-                    projects.find(
-                      project => props.selection.projects[0].toString() === project.id
-                    ) || projects[0]
-                  : // Otherwise, use the first project in the org
-                    projects[0]
-              }
-            />
-          ) : (
-            <Fragment>
-              <SearchContainerWithFilter>
-                {isMetricsData ? (
-                  <MetricsSearchBar
-                    searchSource="performance_landing_metrics"
-                    orgSlug={organization.slug}
-                    query={filterString}
-                    onSearch={handleSearch}
-                    maxQueryLength={MAX_QUERY_LENGTH}
-                    projectIds={eventView.project}
-                  />
-                ) : (
-                  <SearchBar
-                    searchSource="performance_landing"
-                    organization={organization}
-                    projectIds={eventView.project}
-                    query={filterString}
-                    fields={generateAggregateFields(
-                      organization,
-                      [...eventView.fields, {field: 'tps()'}],
-                      ['epm()', 'eps()']
-                    )}
-                    onSearch={handleSearch}
-                    maxQueryLength={MAX_QUERY_LENGTH}
-                  />
-                )}
-              </SearchContainerWithFilter>
-              {initiallyLoaded ? (
-                <TeamKeyTransactionManager.Provider
-                  organization={organization}
-                  teams={teams}
-                  selectedTeams={['myteams']}
-                  selectedProjects={eventView.project.map(String)}
+      <PageErrorProvider>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <StyledHeading>{t('Performance')}</StyledHeading>
+          </Layout.HeaderContent>
+          <Layout.HeaderActions>
+            {!showOnboarding && (
+              <ButtonBar gap={3}>
+                <MetricsSwitch onSwitch={() => handleSearch('')} />
+                <Button
+                  priority="primary"
+                  data-test-id="landing-header-trends"
+                  onClick={() => handleTrendsClick()}
                 >
-                  <GenericQueryBatcher>
-                    <ViewComponent {...props} />
-                  </GenericQueryBatcher>
-                </TeamKeyTransactionManager.Provider>
-              ) : (
-                <LoadingIndicator />
-              )}
-            </Fragment>
-          )}
-        </Layout.Main>
-      </Layout.Body>
+                  {t('View Trends')}
+                </Button>
+              </ButtonBar>
+            )}
+          </Layout.HeaderActions>
+
+          <Layout.HeaderNavTabs>
+            {LANDING_DISPLAYS.map(({label, field}) => (
+              <li key={label} className={landingDisplay.field === field ? 'active' : ''}>
+                <a
+                  href="#"
+                  data-test-id={`landing-tab-${field}`}
+                  onClick={() =>
+                    handleLandingDisplayChange(
+                      field,
+                      location,
+                      projects,
+                      organization,
+                      eventView
+                    )
+                  }
+                >
+                  {t(label)}
+                </a>
+              </li>
+            ))}
+          </Layout.HeaderNavTabs>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <GlobalSdkUpdateAlert />
+            <PageErrorAlert />
+            {showOnboarding ? (
+              <Onboarding
+                organization={organization}
+                project={
+                  props.selection.projects.length > 0
+                    ? // If some projects selected, use the first selection
+                      projects.find(
+                        project => props.selection.projects[0].toString() === project.id
+                      ) || projects[0]
+                    : // Otherwise, use the first project in the org
+                      projects[0]
+                }
+              />
+            ) : (
+              <Fragment>
+                <SearchContainerWithFilter>
+                  {isMetricsData ? (
+                    <MetricsSearchBar
+                      searchSource="performance_landing_metrics"
+                      orgSlug={organization.slug}
+                      query={filterString}
+                      onSearch={handleSearch}
+                      maxQueryLength={MAX_QUERY_LENGTH}
+                      projectIds={eventView.project}
+                    />
+                  ) : (
+                    <SearchBar
+                      searchSource="performance_landing"
+                      organization={organization}
+                      projectIds={eventView.project}
+                      query={filterString}
+                      fields={generateAggregateFields(
+                        organization,
+                        [...eventView.fields, {field: 'tps()'}],
+                        ['epm()', 'eps()']
+                      )}
+                      onSearch={handleSearch}
+                      maxQueryLength={MAX_QUERY_LENGTH}
+                    />
+                  )}
+                </SearchContainerWithFilter>
+                {initiallyLoaded ? (
+                  <TeamKeyTransactionManager.Provider
+                    organization={organization}
+                    teams={teams}
+                    selectedTeams={['myteams']}
+                    selectedProjects={eventView.project.map(String)}
+                  >
+                    <GenericQueryBatcher>
+                      <ViewComponent {...props} />
+                    </GenericQueryBatcher>
+                  </TeamKeyTransactionManager.Provider>
+                ) : (
+                  <LoadingIndicator />
+                )}
+              </Fragment>
+            )}
+          </Layout.Main>
+        </Layout.Body>
+      </PageErrorProvider>
     </StyledPageContent>
   );
 }

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -11,6 +11,7 @@ import Truncate from 'sentry/components/truncate';
 import {t, tct} from 'sentry/locale';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
+import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withApi from 'sentry/utils/withApi';
 import _DurationChart from 'sentry/views/performance/charts/chart';
@@ -53,6 +54,7 @@ const framesList = [
 export function LineChartListWidget(props: PerformanceWidgetProps) {
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
   const {ContainerActions} = props;
+  const pageError = usePageError();
 
   const field = props.fields[0];
 
@@ -171,6 +173,8 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
               },
               'medium'
             )}
+            hideError
+            onError={pageError.setPageError}
           />
         );
       },

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -7,6 +7,7 @@ import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {getInterval, getPreviousSeriesName} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
 import {QueryBatchNode} from 'sentry/utils/performance/contexts/genericQueryBatcher';
+import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import withApi from 'sentry/utils/withApi';
 import _DurationChart from 'sentry/views/performance/charts/chart';
 
@@ -22,6 +23,7 @@ type DataType = {
 export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
   const {ContainerActions} = props;
   const globalSelection = props.eventView.getPageFilters();
+  const pageError = usePageError();
 
   if (props.fields.length !== 1) {
     throw new Error(`Single field area can only accept a single field (${props.fields})`);
@@ -52,6 +54,8 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
                 },
                 'medium'
               )}
+              hideError
+              onError={pageError.setPageError}
             />
           )}
         </QueryBatchNode>

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -11,6 +11,7 @@ import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import DiscoverQuery, {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {WebVital} from 'sentry/utils/discover/fields';
+import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {VitalData} from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
 import {decodeList} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -88,6 +89,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
   const {ContainerActions, eventView, organization, location} = props;
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
   const field = props.fields[0];
+  const pageError = usePageError();
 
   const {fieldsList, vitalFields, sortField} = transformFieldsWithStops({
     field,
@@ -161,6 +163,8 @@ export function VitalWidget(props: PerformanceWidgetProps) {
                 },
                 'medium'
               )}
+              hideError
+              onError={pageError.setPageError}
             />
           );
         },

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
@@ -221,7 +221,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
   });
 
-  it('Errors in widgets call PageError Provider', async function () {
+  it('should call PageError Provider when errors are present', async function () {
     const data = initializeData();
 
     eventStatsMock = MockApiClient.addMockResponse({


### PR DESCRIPTION
### Summary
This will add the error bar back for the landing page. Uses the new PageError context, the toast should not show up at least for any of the landing widgets, they all hide the toast in lieu of the Alert bar.

Reopen of https://github.com/getsentry/sentry/pull/30421 with all the eventsRequest widgets covered + test.

#### Screenshot
![Screen Shot 2021-12-03 at 4 48 25 PM](https://user-images.githubusercontent.com/6111995/144677980-bf5ab0e9-c8c2-4fbd-9e71-bd72f59d7eb7.png)
