### PR TITLE
fix(perf): Measurement markers in dark mode

### DIFF
--- a/static/app/components/events/interfaces/spans/styles.tsx
+++ b/static/app/components/events/interfaces/spans/styles.tsx
@@ -11,7 +11,7 @@ export const MeasurementMarker = styled('div')<{failedThreshold: boolean}>`
   background: repeating-linear-gradient(
       to bottom,
       transparent 0 4px,
-      ${p => (p.failedThreshold ? p.theme.red300 : 'black')} 4px 8px
+      ${p => (p.failedThreshold ? p.theme.red300 : p.theme.textColor)} 4px 8px
     )
     80%/2px 100% no-repeat;
   z-index: ${p => p.theme.zIndex.traceView.dividerLine};


### PR DESCRIPTION
Add dark mode support for measurement markers on the span view.


https://user-images.githubusercontent.com/139499/156428501-28f76b5f-2e1b-4a37-afeb-f0193664380e.mp4

