### PR TITLE
fix(profiling): Set start/end time range on scatter chart

### DIFF
--- a/static/app/views/profiling/landing/profilingScatterChart.tsx
+++ b/static/app/views/profiling/landing/profilingScatterChart.tsx
@@ -3,6 +3,7 @@ import {browserHistory, withRouter, WithRouterProps} from 'react-router';
 import {useTheme} from '@emotion/react';
 import type {TooltipComponentFormatterCallback} from 'echarts';
 import {Location} from 'history';
+import moment from 'moment';
 import momentTimezone from 'moment-timezone';
 
 import ChartZoom from 'sentry/components/charts/chartZoom';
@@ -79,12 +80,13 @@ function ProfilingScatterChart({
     () =>
       makeScatterChartOptions({
         data,
+        datetime,
         location,
         organization,
         projects,
         theme,
       }),
-    [location, theme, data]
+    [location, datetime, theme, data]
   );
 
   const handleColorEncodingChange = useCallback(
@@ -136,6 +138,7 @@ function ProfilingScatterChart({
 
 function makeScatterChartOptions({
   data,
+  datetime,
   location,
   organization,
   projects,
@@ -146,6 +149,7 @@ function makeScatterChartOptions({
    * the order of the traces must match the order of the data in the series in the scatter plot.
    */
   data: Record<string, Trace[]>;
+  datetime: PageFilters['datetime'];
   location: Location;
   organization: Organization;
   projects: Project[];
@@ -193,6 +197,17 @@ function makeScatterChartOptions({
     ].join('');
   };
 
+  const now = moment.utc();
+  const end = (defined(datetime.end) ? moment.utc(datetime.end) : now).valueOf();
+  const start = (
+    defined(datetime.start)
+      ? moment.utc(datetime.start)
+      : now.subtract(
+          parseInt(datetime.period ?? '14', 10),
+          datetime.period?.charAt(datetime.period.length - 1) === 'h' ? 'hours' : 'days'
+        )
+  ).valueOf();
+
   return {
     grid: {
       left: '10px',
@@ -203,6 +218,12 @@ function makeScatterChartOptions({
     tooltip: {
       trigger: 'item' as const,
       formatter: _tooltipFormatter,
+    },
+    xAxis: {
+      // need to specify a min/max on the date range here
+      // or echarts will use the min/max from the series
+      min: start,
+      max: end,
     },
     yAxis: {
       axisLabel: {


### PR DESCRIPTION
By default, echarts uses the min/max x values from the series to determine the
bounds of the chart. Because the scatter plot only contains data points, this
means the min/max timestamps will be used. This change enforces the min/max
value for the chart based on the page filters.