### PR TITLE
feat(perf): Add "View Similar Spans" button to span details panel

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -39,6 +39,7 @@ import {generateEventSlug} from 'sentry/utils/discover/urls';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {QuickTraceEvent, TraceError} from 'sentry/utils/performance/quickTrace/types';
 import withApi from 'sentry/utils/withApi';
+import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 
 import * as SpanEntryContext from './context';
 import InlineDocs from './inlineDocs';
@@ -203,6 +204,30 @@ class SpanDetail extends React.Component<Props, State> {
     );
   }
 
+  renderSpanSummaryButton() {
+    const {span, organization, location, event} = this.props;
+
+    if (isGapSpan(span) || !span.op || !span.hash) {
+      return null;
+    }
+
+    const transactionName = event.title;
+
+    const target = spanDetailsRouteWithQuery({
+      orgSlug: organization.slug,
+      transaction: transactionName,
+      query: location.query,
+      spanSlug: {op: span.op, group: span.hash},
+      projectID: event.projectID,
+    });
+
+    return (
+      <StyledButton size="xsmall" to={target}>
+        {t('View Span Summary')}
+      </StyledButton>
+    );
+  }
+
   renderOrphanSpanMessage() {
     const {span} = this.props;
 
@@ -343,7 +368,9 @@ class SpanDetail extends React.Component<Props, State> {
               <Row title="Trace ID" extra={this.renderTraceButton()}>
                 {span.trace_id}
               </Row>
-              <Row title="Description">{span?.description ?? ''}</Row>
+              <Row title="Description" extra={this.renderSpanSummaryButton()}>
+                {span?.description ?? ''}
+              </Row>
               <Row title="Status">{span.status || ''}</Row>
               <Row title="Start Date">
                 {getDynamicText({

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -204,7 +204,7 @@ class SpanDetail extends React.Component<Props, State> {
     );
   }
 
-  renderSpanSummaryButton() {
+  renderViewSimilarSpansButton() {
     const {span, organization, location, event} = this.props;
 
     if (isGapSpan(span) || !span.op || !span.hash) {
@@ -223,7 +223,7 @@ class SpanDetail extends React.Component<Props, State> {
 
     return (
       <StyledButton size="xsmall" to={target}>
-        {t('View Span Summary')}
+        {t('View Similar Spans')}
       </StyledButton>
     );
   }
@@ -368,7 +368,7 @@ class SpanDetail extends React.Component<Props, State> {
               <Row title="Trace ID" extra={this.renderTraceButton()}>
                 {span.trace_id}
               </Row>
-              <Row title="Description" extra={this.renderSpanSummaryButton()}>
+              <Row title="Description" extra={this.renderViewSimilarSpansButton()}>
                 {span?.description ?? ''}
               </Row>
               <Row title="Status">{span.status || ''}</Row>


### PR DESCRIPTION
This pull request adds a convenience button that links to the span summary page (to be renamed in another pull request) from the span view:

https://user-images.githubusercontent.com/139499/156456873-11dfaabd-82de-4602-9a6b-a1780311c749.mp4

