### PR TITLE
fix(dashboard): Fixes widget context menu overlapping content

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -46,7 +46,7 @@ function WidgetCardContextMenu({
   if (isPreview) {
     return (
       <ContextWrapper>
-        <DropdownMenuControlV2
+        <StyledDropdownMenuControlV2
           items={[
             {
               key: 'preview',
@@ -141,7 +141,7 @@ function WidgetCardContextMenu({
 
   return (
     <ContextWrapper>
-      <DropdownMenuControlV2
+      <StyledDropdownMenuControlV2
         items={menuOptions}
         triggerProps={{
           'aria-label': t('Widget actions'),
@@ -164,4 +164,10 @@ const ContextWrapper = styled('div')`
   align-items: center;
   height: ${space(3)};
   margin-left: ${space(1)};
+`;
+
+const StyledDropdownMenuControlV2 = styled(DropdownMenuControlV2)`
+  & > button {
+    z-index: auto;
+  }
 `;


### PR DESCRIPTION
Fixes z-index for context menu button overlapping widget content
Before
![image](https://user-images.githubusercontent.com/83961295/156458866-773597ec-6650-4089-a383-ae71191500ec.png)
After
![image](https://user-images.githubusercontent.com/83961295/156458581-f34681b2-7832-4e83-a6e7-c24268ccfa51.png)
