### PR TITLE
fix(dashboards): Revert the change that causes sort to be wiped

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -92,8 +92,7 @@ export function normalizeQueries(
   }
 
   if ([DisplayType.TABLE, DisplayType.TOP_N].includes(displayType)) {
-    // Reset orderby
-    return queries.map(query => ({...query, orderby: ''}));
+    return queries;
   }
 
   // Filter out non-aggregate fields

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -642,7 +642,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
           name: 'errors',
           conditions: 'event.type:error',
           fields: ['sdk.name', 'count()'],
-          orderby: '',
+          orderby: 'count',
         },
       ],
     };
@@ -670,6 +670,12 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     expect(wrapper.find('WidgetQueriesForm SelectControl[name="orderby"]')).toHaveLength(
       1
     );
+
+    expect(
+      wrapper
+        .find('WidgetQueriesForm SelectControl[name="orderby"] SingleValue div')
+        .text()
+    ).toEqual('count() asc');
 
     // Add a column, and choose a value,
     wrapper.find('button[aria-label="Add a Column"]').simulate('click');


### PR DESCRIPTION
The sort field on table and ton-n widgets were being reset
due to a change introduced in #32208

Will add tests in a follow up so this can be promoted
to prod ASAP