### PR TITLE
chore(less): Move background and font colour of pre and code css definitions

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -35,7 +35,14 @@ const styles = (theme: Theme, isDark: boolean) => css`
   pre,
   code {
     background-color: ${theme.backgroundSecondary};
+  }
+
+  pre {
     color: ${theme.textColor};
+  }
+
+  code {
+    background-color: transparent;
   }
 
   /**

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -32,6 +32,12 @@ const styles = (theme: Theme, isDark: boolean) => css`
     border-top-color: ${theme.border};
   }
 
+  pre,
+  code {
+    background-color: ${theme.backgroundSecondary};
+    color: ${theme.textColor};
+  }
+
   /**
    * See https://web.dev/prefers-reduced-motion/
    */
@@ -162,11 +168,6 @@ const styles = (theme: Theme, isDark: boolean) => css`
         .nav-header a.help-link,
         .nav-header span.help-link a {
           color: ${theme.subText};
-        }
-        pre,
-        code {
-          background-color: ${theme.backgroundSecondary};
-          color: ${theme.textColor};
         }
         .search .search-input {
           background: ${theme.background};

--- a/static/less/base.less
+++ b/static/less/base.less
@@ -404,7 +404,6 @@ pre {
   word-break: break-all;
   white-space: pre-wrap;
   word-wrap: break-word;
-  background-color: @pre-bg;
   border-radius: @border-radius-base;
   overflow: auto;
 
@@ -414,7 +413,6 @@ pre {
     font-size: inherit;
     color: inherit;
     white-space: pre-wrap;
-    background-color: transparent;
     border-radius: 0;
   }
 }

--- a/static/less/base.less
+++ b/static/less/base.less
@@ -400,7 +400,6 @@ pre {
   padding: ((@line-height-computed - 1) / 2);
   font-size: (@font-size-base - 1); // 14px to 13px
   line-height: @line-height-base;
-  color: @pre-color;
   word-break: break-all;
   white-space: pre-wrap;
   word-wrap: break-word;
@@ -411,7 +410,6 @@ pre {
   code {
     padding: 0;
     font-size: inherit;
-    color: inherit;
     white-space: pre-wrap;
     border-radius: 0;
   }

--- a/static/less/includes/bootstrap/variables.less
+++ b/static/less/includes/bootstrap/variables.less
@@ -686,7 +686,7 @@
 @kbd-color: #fff;
 @kbd-bg: #333;
 
-@pre-bg: #f7f8f9;
+@pre-bg: #faf9fb;
 @pre-color: #1d1127;
 @pre-border-color: #ccc;
 

--- a/static/less/includes/bootstrap/variables.less
+++ b/static/less/includes/bootstrap/variables.less
@@ -686,8 +686,6 @@
 @kbd-color: #fff;
 @kbd-bg: #333;
 
-@pre-border-color: #ccc;
-
 //== Type
 //
 //##

--- a/static/less/includes/bootstrap/variables.less
+++ b/static/less/includes/bootstrap/variables.less
@@ -686,7 +686,6 @@
 @kbd-color: #fff;
 @kbd-bg: #333;
 
-@pre-bg: #faf9fb;
 @pre-color: #1d1127;
 @pre-border-color: #ccc;
 

--- a/static/less/includes/bootstrap/variables.less
+++ b/static/less/includes/bootstrap/variables.less
@@ -686,7 +686,6 @@
 @kbd-color: #fff;
 @kbd-bg: #333;
 
-@pre-color: #1d1127;
 @pre-border-color: #ccc;
 
 //== Type


### PR DESCRIPTION
Changing this to match `surface100` or `backgroundSecondary`.

For dark mode, `<pre />` is defined here https://github.com/getsentry/sentry/blob/9aaee20b909521378d71a1b3ed01b85187d0f98f/static/app/styles/global.tsx#L166-L170