### PR TITLE
feat(issue_alert_status): Add endpoint to return issue alert stats

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -62,13 +62,11 @@ from sentry.incidents.endpoints.project_alert_rule_task_details import (
 from sentry.rules.history.endpoints.project_rule_group_history import (
     ProjectRuleGroupHistoryIndexEndpoint,
 )
+from sentry.rules.history.endpoints.project_rule_stats import ProjectRuleStatsIndexEndpoint
 from sentry.scim.endpoints.members import OrganizationSCIMMemberDetails, OrganizationSCIMMemberIndex
 from sentry.scim.endpoints.schemas import OrganizationSCIMSchemaIndex
 from sentry.scim.endpoints.teams import OrganizationSCIMTeamDetails, OrganizationSCIMTeamIndex
 
-# issues endpoints are available both top level (by numerical ID) as well as coupled
-# to the organization (and queryable via short ID)
-from ..rules.history.endpoints.project_rule_stats import ProjectRuleStatsIndexEndpoint
 from .endpoints.accept_organization_invite import AcceptOrganizationInvite
 from .endpoints.accept_project_transfer import AcceptProjectTransferEndpoint
 from .endpoints.api_application_details import ApiApplicationDetailsEndpoint
@@ -465,6 +463,8 @@ from .endpoints.user_subscriptions import UserSubscriptionsEndpoint
 from .endpoints.userroles_details import UserRoleDetailsEndpoint
 from .endpoints.userroles_index import UserRolesEndpoint
 
+# issues endpoints are available both top level (by numerical ID) as well as coupled
+# to the organization (and queryable via short ID)
 GROUP_URLS = [
     url(r"^(?P<issue_id>[^\/]+)/$", GroupDetailsEndpoint.as_view()),
     url(r"^(?P<issue_id>[^\/]+)/activities/$", GroupActivitiesEndpoint.as_view()),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -66,6 +66,9 @@ from sentry.scim.endpoints.members import OrganizationSCIMMemberDetails, Organiz
 from sentry.scim.endpoints.schemas import OrganizationSCIMSchemaIndex
 from sentry.scim.endpoints.teams import OrganizationSCIMTeamDetails, OrganizationSCIMTeamIndex
 
+# issues endpoints are available both top level (by numerical ID) as well as coupled
+# to the organization (and queryable via short ID)
+from ..rules.history.endpoints.project_rule_stats import ProjectRuleStatsIndexEndpoint
 from .endpoints.accept_organization_invite import AcceptOrganizationInvite
 from .endpoints.accept_project_transfer import AcceptProjectTransferEndpoint
 from .endpoints.api_application_details import ApiApplicationDetailsEndpoint
@@ -462,8 +465,6 @@ from .endpoints.user_subscriptions import UserSubscriptionsEndpoint
 from .endpoints.userroles_details import UserRoleDetailsEndpoint
 from .endpoints.userroles_index import UserRolesEndpoint
 
-# issues endpoints are available both top level (by numerical ID) as well as coupled
-# to the organization (and queryable via short ID)
 GROUP_URLS = [
     url(r"^(?P<issue_id>[^\/]+)/$", GroupDetailsEndpoint.as_view()),
     url(r"^(?P<issue_id>[^\/]+)/activities/$", GroupActivitiesEndpoint.as_view()),
@@ -1946,6 +1947,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/group-history/$",
                     ProjectRuleGroupHistoryIndexEndpoint.as_view(),
                     name="sentry-api-0-project-rule-group-history-index",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/stats/$",
+                    ProjectRuleStatsIndexEndpoint.as_view(),
+                    name="sentry-api-0-project-rule-stats-index",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rule-task/(?P<task_uuid>[^\/]+)/$",

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -62,7 +62,6 @@ class ProjectRuleGroupHistoryIndexEndpoint(RuleEndpoint):
         ],
     )
     def get(self, request: Request, project: Project, rule: Rule) -> Response:
-        """ """
         per_page = self.get_per_page(request)
         cursor = self.get_cursor_from_request(request)
         start, end = get_date_range_from_params(request.GET)

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Mapping, TypedDict
+
+from drf_spectacular.utils import OpenApiExample, extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.bases.rule import RuleEndpoint
+from sentry.api.serializers import Serializer, serialize
+from sentry.api.utils import get_date_range_from_params
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOTFOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GLOBAL_PARAMS, ISSUE_ALERT_PARAMS
+from sentry.models import Project, Rule
+from sentry.rules.history import fetch_rule_hourly_stats
+from sentry.rules.history.base import TimeSeriesValue
+
+
+class TimeSeriesValueResponse(TypedDict):
+    date: datetime
+    count: int
+
+
+class TimeSeriesValueSerializer(Serializer):  # type: ignore
+    def serialize(
+        self, obj: TimeSeriesValue, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
+    ) -> TimeSeriesValueResponse:
+        return {
+            "date": obj.bucket,
+            "count": obj.count,
+        }
+
+
+@extend_schema(tags=["issue_alerts"])
+class ProjectRuleStatsIndexEndpoint(RuleEndpoint):
+    @extend_schema(
+        operation_id="Retrieve firing starts for an issue alert rule for a given time range. Results are returned in hourly buckets.",
+        parameters=[GLOBAL_PARAMS.ORG_SLUG, GLOBAL_PARAMS.PROJECT_SLUG, ISSUE_ALERT_PARAMS],
+        responses={
+            200: TimeSeriesValueSerializer,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOTFOUND,
+        },
+        examples=[
+            OpenApiExample(
+                "Successful response",
+                value={},
+                status_codes=["200"],
+            )
+        ],
+    )
+    def get(self, request: Request, project: Project, rule: Rule) -> Response:
+        start, end = get_date_range_from_params(request.GET)
+        results = fetch_rule_hourly_stats(rule, start, end)
+        return Response(serialize(results, request.user, TimeSeriesValueSerializer()))

--- a/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta
+
+from django.utils import timezone
+from freezegun import freeze_time
+
+from sentry.api.serializers import serialize
+from sentry.models import Rule, RuleFireHistory
+from sentry.rules.history.base import TimeSeriesValue
+from sentry.rules.history.endpoints.project_rule_stats import TimeSeriesValueSerializer
+from sentry.testutils import APITestCase, TestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
+
+
+class TimeSeriesValueSerializerTest(TestCase):
+    def test(self):
+        time_series_value = TimeSeriesValue(datetime.now(), 30)
+        result = serialize([time_series_value], self.user, TimeSeriesValueSerializer())
+        assert result == [
+            {
+                "date": time_series_value.bucket,
+                "count": time_series_value.count,
+            }
+        ]
+
+
+@freeze_time()
+class ProjectRuleStatsIndexEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-project-rule-stats-index"
+
+    def test(self):
+        rule = Rule.objects.create(project=self.event.project)
+        rule_2 = Rule.objects.create(project=self.event.project)
+        history = []
+
+        for i in range(3):
+            for _ in range(i + 1):
+                history.append(
+                    RuleFireHistory(
+                        project=rule.project,
+                        rule=rule,
+                        group=self.group,
+                        date_added=before_now(hours=i + 1),
+                    )
+                )
+
+        for i in range(2):
+            history.append(
+                RuleFireHistory(
+                    project=rule_2.project,
+                    rule=rule_2,
+                    group=self.group,
+                    date_added=before_now(hours=i + 1),
+                )
+            )
+
+        RuleFireHistory.objects.bulk_create(history)
+        self.login_as(self.user)
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            rule.id,
+            start=iso_format(before_now(days=6)),
+            end=iso_format(before_now(days=0)),
+        )
+        assert len(resp.data) == 144
+        now = timezone.now().replace(minute=0, second=0, microsecond=0)
+        assert [r for r in resp.data[-3:]] == [
+            {"date": now - timedelta(hours=3), "count": 3},
+            {"date": now - timedelta(hours=2), "count": 2},
+            {"date": now - timedelta(hours=1), "count": 1},
+        ]


### PR DESCRIPTION
This adds an endpoint that returns values from `fetch_rule_hourly_stats` in our history backend.
This gives us time series values, in the format
```
[
 {'date': '2022-03-02 12:24', count: 1},
 ...
]
```

I moved away from returning results as a dictionary keyed by the date since that feels wrong for
time series data. If that's going to cause us problems I can switch back to that format.