### PR TITLE
chore(perf): Rename "Span Details" to "Span Summary"

### DIFF
--- a/static/app/views/performance/breadcrumb.tsx
+++ b/static/app/views/performance/breadcrumb.tsx
@@ -131,7 +131,7 @@ class Breadcrumb extends Component<Props> {
     if (transaction && spanSlug) {
       crumbs.push({
         to: '',
-        label: t('Span Details'),
+        label: t('Span Summary'),
       });
     } else if (transaction && eventSlug) {
       crumbs.push({

--- a/tests/js/spec/views/performance/transactionSpans/spanDetails.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/spanDetails.spec.tsx
@@ -14,7 +14,7 @@ function initializeData(settings) {
   return data;
 }
 
-describe('Performance > Transaction Spans > Span Details', function () {
+describe('Performance > Transaction Spans > Span Summary', function () {
   beforeEach(function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
@@ -245,6 +245,8 @@ describe('Performance > Transaction Spans > Span Details', function () {
         context: data.routerContext,
         organization: data.organization,
       });
+
+      expect(await screen.findByText('Span Summary')).toBeInTheDocument();
 
       const operationNameHeader = await screen.findByTestId('header-operation-name');
       expect(


### PR DESCRIPTION
This pull request renames "Span Details" to "Span Summary" to reduce confusion that this page refers to displaying details of any specific span akin to the "Event Details" page.

"Span Summary" is also consistent with the "Transaction Summary" page we already have in the product. 