### PR TITLE
fix(page-filters): Add prop to force alignment on date page filter

### DIFF
--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -17,13 +17,13 @@ import useOrganization from 'sentry/utils/useOrganization';
 type Props = Omit<
   React.ComponentProps<typeof TimeRangeSelector>,
   'organization' | 'start' | 'end' | 'utc' | 'relative' | 'onUpdate'
-> & {
-  router: WithRouterProps['router'];
-  /**
-   * Reset these URL params when we fire actions (custom routing only)
-   */
-  resetParamsOnChange?: string[];
-};
+> &
+  WithRouterProps & {
+    /**
+     * Reset these URL params when we fire actions (custom routing only)
+     */
+    resetParamsOnChange?: string[];
+  };
 
 function DatePageFilter({router, resetParamsOnChange, ...props}: Props) {
   const {selection, desyncedFilters} = useLegacyStore(PageFiltersStore);

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -101,6 +101,11 @@ type Props = WithRouterProps & {
   utc: boolean | null;
 
   /**
+   * Aligns dropdown menu to left or right of button
+   */
+  alignDropdown?: 'left' | 'right';
+
+  /**
    * Optionally render a custom dropdown button, instead of the default
    * <HeaderItem />
    */
@@ -118,11 +123,6 @@ type Props = WithRouterProps & {
    * Whether the menu should be detached from the actor
    */
   detached?: boolean;
-
-  /**
-   * Aligns dropdown menu to left or right of button
-   */
-  forceAlignment?: 'left' | 'right';
 
   /**
    * Small info icon with tooltip hint text
@@ -374,7 +374,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
       maxPickableDays,
       customDropdownButton,
       detached,
-      forceAlignment,
+      alignDropdown,
     } = this.props;
     const {start, end, relative} = this.state;
 
@@ -436,7 +436,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
                   {...getMenuProps()}
                   isAbsoluteSelected={isAbsoluteSelected}
                   detached={detached}
-                  forceAlignment={forceAlignment}
+                  alignDropdown={alignDropdown}
                 >
                   <SelectorList isAbsoluteSelected={isAbsoluteSelected}>
                     <SelectorItemsHook
@@ -491,16 +491,16 @@ const StyledHeaderItem = styled(HeaderItem)`
 
 type MenuProps = {
   isAbsoluteSelected: boolean;
+  alignDropdown?: Props['alignDropdown'];
   detached?: Props['detached'];
-  forceAlignment?: Props['forceAlignment'];
 };
 
 const Menu = styled('div')<MenuProps>`
   ${p =>
-    p.forceAlignment
+    p.alignDropdown
       ? `
-    ${p.forceAlignment === 'left' && 'left: -1px'};
-    ${p.forceAlignment === 'right' && 'right: -1px'};
+    ${p.alignDropdown === 'left' && 'left: -1px'};
+    ${p.alignDropdown === 'right' && 'right: -1px'};
   `
       : `
     ${!p.isAbsoluteSelected && 'left: -1px'};

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -120,6 +120,11 @@ type Props = WithRouterProps & {
   detached?: boolean;
 
   /**
+   * Aligns dropdown menu to left or right of button
+   */
+  forceAlignment?: 'left' | 'right';
+
+  /**
    * Small info icon with tooltip hint text
    */
   hint?: string;
@@ -369,6 +374,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
       maxPickableDays,
       customDropdownButton,
       detached,
+      forceAlignment,
     } = this.props;
     const {start, end, relative} = this.state;
 
@@ -430,6 +436,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
                   {...getMenuProps()}
                   isAbsoluteSelected={isAbsoluteSelected}
                   detached={detached}
+                  forceAlignment={forceAlignment}
                 >
                   <SelectorList isAbsoluteSelected={isAbsoluteSelected}>
                     <SelectorItemsHook
@@ -484,12 +491,21 @@ const StyledHeaderItem = styled(HeaderItem)`
 
 type MenuProps = {
   isAbsoluteSelected: boolean;
-  detached?: boolean;
+  detached?: Props['detached'];
+  forceAlignment?: Props['forceAlignment'];
 };
 
 const Menu = styled('div')<MenuProps>`
-  ${p => !p.isAbsoluteSelected && 'left: -1px'};
-  ${p => p.isAbsoluteSelected && 'right: -1px'};
+  ${p =>
+    p.forceAlignment
+      ? `
+    ${p.forceAlignment === 'left' && 'left: -1px'};
+    ${p.forceAlignment === 'right' && 'right: -1px'};
+  `
+      : `
+    ${!p.isAbsoluteSelected && 'left: -1px'};
+    ${p.isAbsoluteSelected && 'right: -1px'};
+  `}
 
   display: flex;
   background: ${p => p.theme.background};

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -111,7 +111,7 @@ function IssueListFilters({
       </SearchContainer>
       {hasPageFilters && (
         <IssueListDropdownsWrapper>
-          <DatePageFilter forceAlignment="left" />
+          <DatePageFilter alignDropdown="left" />
           {hasIssuePercentDisplay && (
             <IssueListDisplayOptions
               onDisplayChange={onDisplayChange}

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -111,7 +111,7 @@ function IssueListFilters({
       </SearchContainer>
       {hasPageFilters && (
         <IssueListDropdownsWrapper>
-          <DatePageFilter />
+          <DatePageFilter forceAlignment="left" />
           {hasIssuePercentDisplay && (
             <IssueListDisplayOptions
               onDisplayChange={onDisplayChange}

--- a/static/app/views/userFeedback/index.tsx
+++ b/static/app/views/userFeedback/index.tsx
@@ -149,7 +149,7 @@ class OrganizationUserFeedback extends AsyncView<Props, State> {
                 <PageFilters>
                   <ProjectPageFilter />
                   <EnvironmentPageFilter />
-                  <DatePageFilter />
+                  <DatePageFilter forceAlignment="right" />
                 </PageFilters>
               </Feature>
               {this.renderStreamBody()}

--- a/static/app/views/userFeedback/index.tsx
+++ b/static/app/views/userFeedback/index.tsx
@@ -149,7 +149,7 @@ class OrganizationUserFeedback extends AsyncView<Props, State> {
                 <PageFilters>
                   <ProjectPageFilter />
                   <EnvironmentPageFilter />
-                  <DatePageFilter forceAlignment="right" />
+                  <DatePageFilter alignDropdown="right" />
                 </PageFilters>
               </Feature>
               {this.renderStreamBody()}


### PR DESCRIPTION
Before:
<img width="266" alt="image" src="https://user-images.githubusercontent.com/9372512/156474734-4dd49b21-ed03-43d1-bba4-be945b1d393d.png">

After:
<img width="303" alt="image" src="https://user-images.githubusercontent.com/9372512/156474747-3222c65e-7271-43e6-b313-07aef77be5c3.png">
