### PR TITLE
feat(access): Introduce team roles to RoleManager

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1678,7 +1678,7 @@ SENTRY_TEAM_ROLES = (
             "alerts:read",
             "alerts:write",
         },
-        "mapped_to": "admin",
+        "is_entry_role_for": "admin",
     },
 )
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1543,9 +1543,16 @@ SENTRY_ROLES = (
     {
         "id": "admin",
         "name": "Admin",
-        "desc": "Admin privileges on any teams of which they're a member. They can create new teams and projects, "
-        "as well as remove teams and projects on which they already hold membership (or all teams, if open membership is enabled). "
-        "Additionally, they can manage memberships of teams that they are members of. They cannot invite members to the organization.",
+        "desc": (
+            """
+            Admin privileges on any teams of which they're a member. They can
+            create new teams and projects, as well as remove teams and projects
+            on which they already hold membership (or all teams, if open
+            membership is enabled). Additionally, they can manage memberships of
+            teams that they are members of. They cannot invite members to the
+            organization.
+            """
+        ),
         "scopes": {
             "event:read",
             "event:write",
@@ -1593,8 +1600,13 @@ SENTRY_ROLES = (
     {
         "id": "owner",
         "name": "Owner",
-        "desc": "Unrestricted access to the organization, its data, and its settings. Can add, modify, and delete "
-        "projects and members, as well as make billing and plan changes.",
+        "desc": (
+            """
+            Unrestricted access to the organization, its data, and its settings.
+            Can add, modify, and delete projects and members, as well as make
+            billing and plan changes.
+            """
+        ),
         "is_global": True,
         "scopes": {
             "org:read",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1543,9 +1543,16 @@ SENTRY_ROLES = (
     {
         "id": "admin",
         "name": "Admin",
-        "desc": "Admin privileges on any teams of which they're a member. They can create new teams and projects, "
-        "as well as remove teams and projects on which they already hold membership (or all teams, if open membership is enabled). "
-        "Additionally, they can manage memberships of teams that they are members of. They cannot invite members to the organization.",
+        "desc": (
+            """
+            Admin privileges on any teams of which they're a member. They can
+            create new teams and projects, as well as remove teams and projects
+            on which they already hold membership (or all teams, if open
+            membership is enabled). Additionally, they can manage memberships of
+            teams that they are members of. They cannot invite members to the
+            organization.
+            """
+        ),
         "scopes": {
             "event:read",
             "event:write",
@@ -1593,8 +1600,13 @@ SENTRY_ROLES = (
     {
         "id": "owner",
         "name": "Owner",
-        "desc": "Unrestricted access to the organization, its data, and its settings. Can add, modify, and delete "
-        "projects and members, as well as make billing and plan changes.",
+        "desc": (
+            """
+            Unrestricted access to the organization, its data, and its settings.
+            Can add, modify, and delete projects and members, as well as make
+            billing and plan changes.
+            """
+        ),
         "is_global": True,
         "scopes": {
             "org:read",
@@ -1617,6 +1629,56 @@ SENTRY_ROLES = (
             "alerts:read",
             "alerts:write",
         },
+    },
+)
+
+SENTRY_TEAM_ROLES = (
+    {
+        "id": "contributor",
+        "name": "Contributor",
+        "desc": "Contributors can view and act on events, as well as view most other data within the team's projects.",
+        "scopes": {
+            "event:read",
+            "event:write",
+            "event:admin",
+            "project:releases",
+            "project:read",
+            "org:read",
+            "member:read",
+            "team:read",
+            "alerts:read",
+            "alerts:write",
+        },
+    },
+    {
+        "id": "admin",
+        "name": "Team Admin",
+        "desc": (
+            # TODO: Editing pass
+            """
+            Admin privileges on the team. They can create and remove projects,
+            and can manage the team's memberships. They cannot invite members to
+            the organization.
+            """
+        ),
+        "scopes": {
+            "event:read",
+            "event:write",
+            "event:admin",
+            "org:read",
+            "member:read",
+            "project:read",
+            "project:write",
+            "project:admin",
+            "project:releases",
+            "team:read",
+            "team:write",
+            "team:admin",
+            "org:integrations",
+            "alerts:read",
+            "alerts:write",
+        },
+        "mapped_to": "admin",
     },
 )
 

--- a/src/sentry/roles/__init__.py
+++ b/src/sentry/roles/__init__.py
@@ -6,6 +6,11 @@ default_manager = RoleManager(
     settings.SENTRY_ROLES, settings.SENTRY_TEAM_ROLES, settings.SENTRY_DEFAULT_ROLE
 )
 
+get_organization_roles = default_manager.get_organization_roles
+get_team_roles = default_manager.get_team_roles
+get_entry_role = default_manager.get_entry_role
+
+# Deprecated: Prefer calling get_organization_roles, then RoleSet methods
 can_manage = default_manager.can_manage
 get = default_manager.get
 get_all = default_manager.get_all
@@ -14,5 +19,3 @@ get_default = default_manager.get_default
 get_top_dog = default_manager.get_top_dog
 with_scope = default_manager.with_scope
 with_any_scope = default_manager.with_any_scope
-get_team_role = default_manager.get_team_role
-get_entry_role = default_manager.get_entry_role

--- a/src/sentry/roles/__init__.py
+++ b/src/sentry/roles/__init__.py
@@ -14,3 +14,5 @@ get_default = default_manager.get_default
 get_top_dog = default_manager.get_top_dog
 with_scope = default_manager.with_scope
 with_any_scope = default_manager.with_any_scope
+get_team_role = default_manager.get_team_role
+get_entry_role = default_manager.get_entry_role

--- a/src/sentry/roles/__init__.py
+++ b/src/sentry/roles/__init__.py
@@ -2,7 +2,9 @@ from django.conf import settings
 
 from .manager import RoleManager
 
-default_manager = RoleManager(settings.SENTRY_ROLES, settings.SENTRY_DEFAULT_ROLE)
+default_manager = RoleManager(
+    settings.SENTRY_ROLES, settings.SENTRY_TEAM_ROLES, settings.SENTRY_DEFAULT_ROLE
+)
 
 can_manage = default_manager.can_manage
 get = default_manager.get

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -9,7 +9,7 @@ def _normalize_whitespace(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class Role(abc.ABC):
     priority: int
     id: str

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -47,7 +47,7 @@ class OrganizationRole(Role):
 
 @dataclass(frozen=True, eq=True)
 class TeamRole(Role):
-    mapped_to: Optional[str] = None
+    is_entry_role_for: Optional[str] = None
 
 
 class RoleManager:
@@ -76,19 +76,19 @@ class RoleManager:
             team_role = TeamRole.from_config(idx, **role_cfg)
             self._team_roles[team_role.id] = team_role
 
-        self._org_to_team_map = self._make_org_to_team_map()
+        self._entry_role_map = self._make_entry_role_map()
 
-    def _make_org_to_team_map(self) -> Dict[str, str]:
+    def _make_entry_role_map(self) -> Dict[str, str]:
         team_default = next(iter(self._team_roles.values()))
         team_top_dog = next(iter(reversed(self._team_roles.values())))
 
         def get_mapped_org_role(team_role: TeamRole) -> Optional[OrganizationRole]:
-            if team_role.mapped_to is None:
+            if team_role.is_entry_role_for is None:
                 return None
-            org_role = self._org_roles.get(team_role.mapped_to)
+            org_role = self._org_roles.get(team_role.is_entry_role_for)
             if org_role is None:
                 warnings.warn(
-                    f"Broken role mapping: {team_role.id}.mapped_to = {team_role.mapped_to}"
+                    f"Broken role mapping: {team_role.id}.is_entry_role_for = {team_role.is_entry_role_for}"
                 )
             return org_role
 
@@ -140,5 +140,5 @@ class RoleManager:
     def get_team_role(self, role: str) -> TeamRole:
         return self._team_roles[role]
 
-    def get_base_team_role(self, org_role: str) -> TeamRole:
-        return self.get_team_role(self._org_to_team_map[org_role])
+    def get_entry_role(self, org_role: str) -> TeamRole:
+        return self.get_team_role(self._entry_role_map[org_role])

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -1,25 +1,29 @@
+import abc
+import re
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Dict, Iterable, Mapping, Optional, Tuple
 
+from sentry.utils import warnings
 
-class Role:
-    def __init__(
-        self,
-        priority: int,
-        id: str,
-        name: str,
-        desc: str = "",
-        scopes: Iterable[str] = (),
-        is_global: bool = False,
-    ) -> None:
-        assert len(id) <= 32, "Role id must be no more than 32 characters"
 
-        self.priority = priority
-        self.id = id
-        self.name = name
-        self.desc = desc
-        self.scopes = frozenset(scopes)
-        self.is_global = bool(is_global)
+def _normalize_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip())
+
+
+@dataclass
+class Role(abc.ABC):
+    priority: int
+    id: str
+    name: str
+    desc: str = ""
+    scopes: Iterable[str] = ()
+
+    def __post_init__(self):
+        assert len(self.id) <= 32, "Role id must be no more than 32 characters"
+
+        self.desc = _normalize_whitespace(self.desc)
+        self.scopes = frozenset(self.scopes)
 
     def __str__(self) -> str:
         return str(self.name)
@@ -31,55 +35,109 @@ class Role:
         return scope in self.scopes
 
 
+@dataclass
+class OrganizationRole(Role):
+    is_global: bool = False
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.is_global = bool(self.is_global)
+
+
+@dataclass
+class TeamRole(Role):
+    mapped_to: Optional[str] = None
+
+
 class RoleManager:
     def __init__(
         self,
-        config: Iterable[Mapping[str, str]],
-        default: Optional[str] = None,
+        org_config: Iterable[Mapping[str, str]],
+        team_config: Iterable[Mapping[str, str]],
+        default_org_role: Optional[str] = None,
     ) -> None:
-        role_list = []
-        self._roles: Dict[str, Role] = OrderedDict()
-        for idx, role_cfg in enumerate(config):
-            role = Role(idx, **role_cfg)
-            role_list.append(role)
-            self._roles[role.id] = role
+        self._org_roles: Dict[str, OrganizationRole] = OrderedDict()
+        for idx, role_cfg in enumerate(org_config):
+            role = OrganizationRole(idx, **role_cfg)
+            self._org_roles[role.id] = role
 
-        self._choices = tuple((r.id, r.name) for r in role_list)
+        self._choices = tuple((r.id, r.name) for r in self._org_roles.values())
 
-        if default:
-            self._default = self._roles[default]
+        if default_org_role:
+            self._default = self._org_roles[default_org_role]
         else:
-            self._default = role_list[0]
+            self._default = next(iter(self._org_roles.values()))
 
-        self._top_dog = role_list[-1]
+        self._top_dog = next(iter(reversed(self._org_roles.values())))
 
-    def __iter__(self) -> Iterable[Role]:
-        yield from self._roles.values()
+        self._team_roles: Dict[str, TeamRole] = OrderedDict()
+        for idx, role_cfg in enumerate(team_config):
+            role = TeamRole(idx, **role_cfg)
+            self._team_roles[role.id] = role
+
+        self._org_to_team_map = self._make_org_to_team_map()
+
+    def _make_org_to_team_map(self) -> Dict[str, str]:
+        team_default = next(iter(self._team_roles.values()))
+        team_top_dog = next(iter(reversed(self._team_roles.values())))
+
+        def get_mapped_org_role(team_role: TeamRole) -> Optional[OrganizationRole]:
+            if team_role.mapped_to is None:
+                return None
+            org_role = self._org_roles.get(team_role.mapped_to)
+            if org_role is None:
+                warnings.warn(
+                    f"Broken role mapping: {team_role.id}.mapped_to = {team_role.mapped_to}"
+                )
+            return org_role
+
+        def get_highest_available_team_role(org_role: OrganizationRole) -> TeamRole:
+            if org_role is self._top_dog:
+                return team_top_dog
+            for team_role in reversed(self._team_roles.values()):
+                mapped_org_role = get_mapped_org_role(team_role)
+                if mapped_org_role and mapped_org_role.priority <= org_role.priority:
+                    return team_role
+            return team_default
+
+        return OrderedDict(
+            (org_role.id, get_highest_available_team_role(org_role).id)
+            for org_role in self._org_roles.values()
+        )
+
+    def __iter__(self) -> Iterable[OrganizationRole]:
+        yield from self._org_roles.values()
 
     def can_manage(self, role: str, other: str) -> bool:
         return self.get(role).priority >= self.get(other).priority
 
-    def get(self, id: str) -> Role:
-        return self._roles[id]
+    def get(self, id: str) -> OrganizationRole:
+        return self._org_roles[id]
 
-    def get_all(self) -> Iterable[Role]:
-        return list(self._roles.values())
+    def get_all(self) -> Iterable[OrganizationRole]:
+        return list(self._org_roles.values())
 
     def get_choices(self) -> Iterable[Tuple[str, str]]:
         return self._choices
 
-    def get_default(self) -> Role:
+    def get_default(self) -> OrganizationRole:
         return self._default
 
-    def get_top_dog(self) -> Role:
+    def get_top_dog(self) -> OrganizationRole:
         return self._top_dog
 
-    def with_scope(self, scope: str) -> Iterable[Role]:
+    def with_scope(self, scope: str) -> Iterable[OrganizationRole]:
         for role in self.get_all():
             if role.has_scope(scope):
                 yield role
 
-    def with_any_scope(self, scopes: Iterable[str]) -> Iterable[Role]:
+    def with_any_scope(self, scopes: Iterable[str]) -> Iterable[OrganizationRole]:
         for role in self.get_all():
             if any(role.has_scope(scope) for scope in scopes):
                 yield role
+
+    def get_team_role(self, role: str) -> TeamRole:
+        return self._team_roles[role]
+
+    def get_base_team_role(self, org_role: str) -> TeamRole:
+        return self.get_team_role(self._org_to_team_map[org_role])

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -2,7 +2,7 @@ import abc
 import re
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Dict, FrozenSet, Iterable, Mapping, Optional, Sequence, Tuple
+from typing import Dict, FrozenSet, Generic, Iterable, Mapping, Optional, Sequence, Tuple, TypeVar
 
 from sentry.utils import warnings
 
@@ -50,6 +50,53 @@ class TeamRole(Role):
     is_entry_role_for: Optional[str] = None
 
 
+R = TypeVar("R", bound=Role)
+
+
+class RoleSet(Generic[R]):
+    def __init__(self, roles: Iterable[R], default_id: Optional[str] = None) -> None:
+        self._priority_seq = tuple(sorted(roles, key=lambda r: r.priority))
+        self._id_map = OrderedDict((r.id, r) for r in self._priority_seq)
+
+        self._choices = tuple((r.id, r.name) for r in self._priority_seq)
+        self._default = self._id_map[default_id] if default_id else self._priority_seq[0]
+        self._top_dog = self._priority_seq[-1]
+
+    def __iter__(self) -> Iterable[R]:
+        yield from self._priority_seq
+
+    def can_manage(self, role: str, other: str) -> bool:
+        return self.get(role).priority >= self.get(other).priority
+
+    def get(self, id: str) -> R:
+        return self._id_map[id]
+
+    def get_if_exists(self, id: str) -> Optional[R]:
+        return self._id_map.get(id)
+
+    def get_all(self) -> Sequence[R]:
+        return self._priority_seq
+
+    def get_choices(self) -> Sequence[Tuple[str, str]]:
+        return self._choices
+
+    def get_default(self) -> R:
+        return self._default
+
+    def get_top_dog(self) -> R:
+        return self._top_dog
+
+    def with_scope(self, scope: str) -> Iterable[R]:
+        for role in self.get_all():
+            if role.has_scope(scope):
+                yield role
+
+    def with_any_scope(self, scopes: Iterable[str]) -> Iterable[R]:
+        for role in self.get_all():
+            if any(role.has_scope(scope) for scope in scopes):
+                yield role
+
+
 class RoleManager:
     def __init__(
         self,
@@ -57,35 +104,25 @@ class RoleManager:
         team_config: Iterable[Mapping[str, str]],
         default_org_role: Optional[str] = None,
     ) -> None:
-        self._org_roles: Dict[str, OrganizationRole] = OrderedDict()
-        for idx, role_cfg in enumerate(org_config):
-            org_role = OrganizationRole.from_config(idx, **role_cfg)
-            self._org_roles[org_role.id] = org_role
+        self._org_roles: RoleSet[OrganizationRole] = RoleSet(
+            (
+                OrganizationRole.from_config(idx, **role_cfg)
+                for idx, role_cfg in enumerate(org_config)
+            ),
+            default_org_role,
+        )
 
-        self._choices = tuple((r.id, r.name) for r in self._org_roles.values())
-
-        if default_org_role:
-            self._default = self._org_roles[default_org_role]
-        else:
-            self._default = next(iter(self._org_roles.values()))
-
-        self._top_dog = next(iter(reversed(self._org_roles.values())))
-
-        self._team_roles: Dict[str, TeamRole] = OrderedDict()
-        for idx, role_cfg in enumerate(team_config):
-            team_role = TeamRole.from_config(idx, **role_cfg)
-            self._team_roles[team_role.id] = team_role
+        self._team_roles: RoleSet[TeamRole] = RoleSet(
+            TeamRole.from_config(idx, **role_cfg) for idx, role_cfg in enumerate(team_config)
+        )
 
         self._entry_role_map = self._make_entry_role_map()
 
     def _make_entry_role_map(self) -> Dict[str, str]:
-        team_default = next(iter(self._team_roles.values()))
-        team_top_dog = next(iter(reversed(self._team_roles.values())))
-
         def get_mapped_org_role(team_role: TeamRole) -> Optional[OrganizationRole]:
             if team_role.is_entry_role_for is None:
                 return None
-            org_role = self._org_roles.get(team_role.is_entry_role_for)
+            org_role = self._org_roles.get_if_exists(team_role.is_entry_role_for)
             if org_role is None:
                 warnings.warn(
                     f"Broken role mapping: {team_role.id}.is_entry_role_for = {team_role.is_entry_role_for}"
@@ -93,52 +130,51 @@ class RoleManager:
             return org_role
 
         def get_highest_available_team_role(org_role: OrganizationRole) -> TeamRole:
-            if org_role is self._top_dog:
-                return team_top_dog
-            for team_role in reversed(self._team_roles.values()):
+            if org_role is self._org_roles.get_top_dog():
+                return self._team_roles.get_top_dog()
+            for team_role in reversed(self._team_roles.get_all()):
                 mapped_org_role = get_mapped_org_role(team_role)
                 if mapped_org_role and mapped_org_role.priority <= org_role.priority:
                     return team_role
-            return team_default
+            return self._team_roles.get_default()
 
         return OrderedDict(
             (org_role.id, get_highest_available_team_role(org_role).id)
-            for org_role in self._org_roles.values()
+            for org_role in self._org_roles.get_all()
         )
 
     def __iter__(self) -> Iterable[OrganizationRole]:
-        yield from self._org_roles.values()
+        yield from self._org_roles
 
     def can_manage(self, role: str, other: str) -> bool:
-        return self.get(role).priority >= self.get(other).priority
+        return self._org_roles.can_manage(role, other)
 
     def get(self, id: str) -> OrganizationRole:
-        return self._org_roles[id]
+        return self._org_roles.get(id)
 
     def get_all(self) -> Sequence[OrganizationRole]:
-        return list(self._org_roles.values())
+        return self._org_roles.get_all()
 
     def get_choices(self) -> Sequence[Tuple[str, str]]:
-        return self._choices
+        return self._org_roles.get_choices()
 
     def get_default(self) -> OrganizationRole:
-        return self._default
+        return self._org_roles.get_default()
 
     def get_top_dog(self) -> OrganizationRole:
-        return self._top_dog
+        return self._org_roles.get_top_dog()
 
     def with_scope(self, scope: str) -> Iterable[OrganizationRole]:
-        for role in self.get_all():
-            if role.has_scope(scope):
-                yield role
+        return self._org_roles.with_scope(scope)
 
     def with_any_scope(self, scopes: Iterable[str]) -> Iterable[OrganizationRole]:
-        for role in self.get_all():
-            if any(role.has_scope(scope) for scope in scopes):
-                yield role
+        return self._org_roles.with_any_scope(scopes)
 
-    def get_team_role(self, role: str) -> TeamRole:
-        return self._team_roles[role]
+    def get_organization_roles(self) -> RoleSet[OrganizationRole]:
+        return self._org_roles
+
+    def get_team_roles(self) -> RoleSet[TeamRole]:
+        return self._team_roles
 
     def get_entry_role(self, org_role: str) -> TeamRole:
-        return self.get_team_role(self._entry_role_map[org_role])
+        return self._team_roles.get(self._entry_role_map[org_role])

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -2,7 +2,7 @@ import abc
 import re
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Dict, FrozenSet, Iterable, Mapping, Optional, Tuple
+from typing import Dict, FrozenSet, Iterable, Mapping, Optional, Sequence, Tuple
 
 
 def _normalize_whitespace(text: str) -> str:
@@ -68,10 +68,10 @@ class RoleManager:
     def get(self, id: str) -> Role:
         return self._roles[id]
 
-    def get_all(self) -> Iterable[Role]:
+    def get_all(self) -> Sequence[Role]:
         return list(self._roles.values())
 
-    def get_choices(self) -> Iterable[Tuple[str, str]]:
+    def get_choices(self) -> Sequence[Tuple[str, str]]:
         return self._choices
 
     def get_default(self) -> Role:

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -44,9 +44,6 @@ class Role(abc.ABC):
 class OrganizationRole(Role):
     is_global: bool = False
 
-    def __post_init__(self) -> None:
-        super().__post_init__()
-
 
 @dataclass(frozen=True, eq=True)
 class TeamRole(Role):

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -19,7 +19,7 @@ class Role(abc.ABC):
     desc: str = ""
     scopes: Iterable[str] = ()
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         assert len(self.id) <= 32, "Role id must be no more than 32 characters"
 
         self.desc = _normalize_whitespace(self.desc)
@@ -39,7 +39,7 @@ class Role(abc.ABC):
 class OrganizationRole(Role):
     is_global: bool = False
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__post_init__()
         self.is_global = bool(self.is_global)
 
@@ -58,8 +58,8 @@ class RoleManager:
     ) -> None:
         self._org_roles: Dict[str, OrganizationRole] = OrderedDict()
         for idx, role_cfg in enumerate(org_config):
-            role = OrganizationRole(idx, **role_cfg)
-            self._org_roles[role.id] = role
+            org_role = OrganizationRole(idx, **role_cfg)
+            self._org_roles[org_role.id] = org_role
 
         self._choices = tuple((r.id, r.name) for r in self._org_roles.values())
 
@@ -72,8 +72,8 @@ class RoleManager:
 
         self._team_roles: Dict[str, TeamRole] = OrderedDict()
         for idx, role_cfg in enumerate(team_config):
-            role = TeamRole(idx, **role_cfg)
-            self._team_roles[role.id] = role
+            team_role = TeamRole(idx, **role_cfg)
+            self._team_roles[team_role.id] = team_role
 
         self._org_to_team_map = self._make_org_to_team_map()
 

--- a/tests/sentry/roles/test_manager.py
+++ b/tests/sentry/roles/test_manager.py
@@ -1,0 +1,28 @@
+from sentry.roles import RoleManager, default_manager
+from sentry.testutils import TestCase
+
+
+class RoleManagerTest(TestCase):
+    def test_default_manager(self):
+        assert default_manager.get_all()
+        assert len(default_manager.get_choices()) == len(default_manager.get_all())
+        assert default_manager.get_top_dog().id == "owner"
+
+        assert default_manager.can_manage("owner", "manager")
+        assert default_manager.can_manage("owner", "member")
+        assert default_manager.can_manage("manager", "member")
+
+    TEST_ORG_ROLES = [
+        {"id": "peasant", "name": "Peasant"},
+        {"id": "baron", "name": "Baron"},
+        {"id": "earl", "name": "Earl"},
+        {"id": "duke", "name": "Duke"},
+        {"id": "monarch", "name": "Monarch"},
+    ]
+
+    def test_priority(self):
+        manager = RoleManager(self.TEST_ORG_ROLES)
+        assert len(manager.get_all()) == len(self.TEST_ORG_ROLES)
+        assert manager.can_manage("duke", "baron")
+        assert manager.get_default().id == "peasant"
+        assert manager.get_top_dog().id == "monarch"

--- a/tests/sentry/roles/test_manager.py
+++ b/tests/sentry/roles/test_manager.py
@@ -1,0 +1,136 @@
+from unittest import mock
+
+from sentry.roles import RoleManager, default_manager
+from sentry.testutils import TestCase
+
+
+class RoleManagerTest(TestCase):
+    @staticmethod
+    def _assert_mapping(manager: RoleManager, org_role: str, team_role: str) -> None:
+        assert manager.get_base_team_role(org_role).id == team_role
+
+    def test_default_manager(self):
+        assert default_manager.get_all()
+        assert len(default_manager.get_choices()) == len(default_manager.get_all())
+        assert default_manager.get_top_dog().id == "owner"
+
+        self._assert_mapping(default_manager, "member", "contributor")
+        self._assert_mapping(default_manager, "admin", "admin")
+        self._assert_mapping(default_manager, "manager", "admin")
+        self._assert_mapping(default_manager, "owner", "admin")
+
+    TEST_ORG_ROLES = [
+        {"id": "peasant", "name": "Peasant"},
+        {"id": "baron", "name": "Baron"},
+        {"id": "earl", "name": "Earl"},
+        {"id": "duke", "name": "Duke"},
+        {"id": "monarch", "name": "Monarch"},
+    ]
+
+    TEST_TEAM_ROLES = [
+        {"id": "private", "name": "Private", "mapped_to": "peasant"},
+        {"id": "sergeant", "name": "Sergeant", "mapped_to": "earl"},
+        {"id": "lieutenant", "name": "Lieutenant"},
+        {"id": "captain", "name": "Captain", "mapped_to": "monarch"},
+    ]
+
+    def test_priority(self):
+        manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)
+        assert len(manager.get_all()) == 5
+        assert manager.can_manage("duke", "baron")
+        assert manager.get_default().id == "peasant"
+        assert manager.get_top_dog().id == "monarch"
+
+    def test_mapping(self):
+        manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)
+
+        self._assert_mapping(manager, "monarch", "captain")
+        self._assert_mapping(manager, "duke", "sergeant")
+        self._assert_mapping(manager, "earl", "sergeant")
+        self._assert_mapping(manager, "baron", "private")
+        self._assert_mapping(manager, "peasant", "private")
+
+    def test_team_default_mapping(self):
+        # Check that RoleManager provides sensible defaults in case the team roles
+        # don't specify any mappings
+
+        team_roles = [
+            {k: v for (k, v) in role.items() if k != "mapped_to"} for role in self.TEST_TEAM_ROLES
+        ]
+        manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
+
+        self._assert_mapping(manager, "monarch", "captain")
+        self._assert_mapping(manager, "duke", "private")
+        self._assert_mapping(manager, "earl", "private")
+        self._assert_mapping(manager, "baron", "private")
+        self._assert_mapping(manager, "peasant", "private")
+
+    def test_top_dog_accesses_all_team_roles(self):
+        # Check that the org's top dog role has access to the top team role even if
+        # it's explicitly mapped to a lower role
+
+        team_roles = [
+            {"id": "private", "name": "Private", "mapped_to": "peasant"},
+            {"id": "sergeant", "name": "Sergeant", "mapped_to": "earl"},
+            {"id": "lieutenant", "name": "Lieutenant", "mapped_to": "monarch"},
+            {"id": "captain", "name": "Captain"},
+        ]
+        manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
+
+        self._assert_mapping(manager, "monarch", "captain")
+        self._assert_mapping(manager, "duke", "sergeant")
+        self._assert_mapping(manager, "earl", "sergeant")
+        self._assert_mapping(manager, "baron", "private")
+        self._assert_mapping(manager, "peasant", "private")
+
+    def test_if_team_top_dog_is_not_org_top_dog(self):
+        team_roles = [
+            {"id": "private", "name": "Private", "mapped_to": "peasant"},
+            {"id": "sergeant", "name": "Sergeant", "mapped_to": "earl"},
+            {"id": "lieutenant", "name": "Lieutenant"},
+            {"id": "captain", "name": "Captain", "mapped_to": "duke"},
+        ]
+        manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
+
+        self._assert_mapping(manager, "monarch", "captain")
+        self._assert_mapping(manager, "duke", "captain")
+        self._assert_mapping(manager, "earl", "sergeant")
+        self._assert_mapping(manager, "baron", "private")
+        self._assert_mapping(manager, "peasant", "private")
+
+    def test_handles_non_injective_mapping(self):
+        # Check that RoleManager tolerates multiple team roles pointing at the same
+        # org role and maps to the highest one
+
+        team_roles = [
+            {"id": "private", "name": "Private", "mapped_to": "peasant"},
+            {"id": "sergeant", "name": "Sergeant", "mapped_to": "earl"},
+            {"id": "lieutenant", "name": "Lieutenant", "mapped_to": "earl"},
+            {"id": "captain", "name": "Captain", "mapped_to": "monarch"},
+        ]
+        manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
+
+        self._assert_mapping(manager, "monarch", "captain")
+        self._assert_mapping(manager, "duke", "lieutenant")
+        self._assert_mapping(manager, "earl", "lieutenant")
+        self._assert_mapping(manager, "baron", "private")
+        self._assert_mapping(manager, "peasant", "private")
+
+    @mock.patch("sentry.roles.manager.warnings")
+    def test_team_mapping_to_legacy_roles(self, mock_warnings):
+        # Check that RoleManager provides sensible defaults in case the default org
+        # roles have been overridden by unfamiliar values, leaving behind default
+        # team roles that with mapping keys that point to nothing
+
+        legacy_roles = [
+            {"id": "legionary", "name": "Legionary"},
+            {"id": "centurion", "name": "Centurion"},
+            {"id": "legate", "name": "Legate"},
+        ]
+        manager = RoleManager(legacy_roles, self.TEST_TEAM_ROLES)
+
+        assert mock_warnings.warn.called
+
+        self._assert_mapping(manager, "legate", "captain")
+        self._assert_mapping(manager, "centurion", "private")
+        self._assert_mapping(manager, "legionary", "private")


### PR DESCRIPTION
Early preview of changes to support team-level roles.

The overall objective is to introduce a structure of team-level roles alongside the existing structure of org-level roles, and to expose it through the `RoleManager` class. We need some kind of "mapping" between the two hierarchies: we must know what is the minimum org role required to promote yourself or another to each team role.

The list of existing org roles is exposed as a customizable setting, so it's a bonus if we can fail gracefully in case someone had decided to override it. The new unit test describes several failure cases and their fallback behavior.

The other major pieces of the puzzle to deliver the complete feature will be to represent each user's team role on the `OrganizationMemberTeam` model, to expose it in the API, and to expose it in the `Access` model.