### PR TITLE
perf(test): Move organization context to its own file

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -19,7 +19,7 @@ import App from 'sentry/views/app';
 import AuthLayout from 'sentry/views/auth/layout';
 import IssueListContainer from 'sentry/views/issueList/container';
 import IssueListOverview from 'sentry/views/issueList/overview';
-import OrganizationContextContainer from 'sentry/views/organizationContext';
+import OrganizationContextContainer from 'sentry/views/organizationContextContainer';
 import OrganizationDetails from 'sentry/views/organizationDetails';
 import {Tab} from 'sentry/views/organizationGroupDetails/types';
 import OrganizationRoot from 'sentry/views/organizationRoot';

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -1,0 +1,5 @@
+import {createContext} from 'react';
+
+import {Organization} from 'sentry/types';
+
+export const OrganizationContext = createContext<Organization | null>(null);

--- a/static/app/views/organizationContextContainer.tsx
+++ b/static/app/views/organizationContextContainer.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {createContext} from 'react';
 import {PlainRoute, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -28,6 +27,8 @@ import RequestError from 'sentry/utils/requestError/requestError';
 import withApi from 'sentry/utils/withApi';
 import withOrganizations from 'sentry/utils/withOrganizations';
 
+import {OrganizationContext} from './organizationContext';
+
 type Props = RouteComponentProps<{orgId: string}, {}> & {
   api: Client;
   includeSidebar: boolean;
@@ -50,8 +51,6 @@ type State = {
   errorType?: string | null;
   hooks?: React.ReactNode[];
 };
-
-const OrganizationContext = createContext<Organization | null>(null);
 
 class OrganizationContextContainer extends React.Component<Props, State> {
   static getDerivedStateFromProps(props: Readonly<Props>, prevState: State): State {

--- a/static/app/views/organizationDetails/index.tsx
+++ b/static/app/views/organizationDetails/index.tsx
@@ -2,7 +2,7 @@ import {useEffect} from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import {switchOrganization} from 'sentry/actionCreators/organizations';
-import OrganizationContextContainer from 'sentry/views/organizationContext';
+import OrganizationContextContainer from 'sentry/views/organizationContextContainer';
 
 import Body from './body';
 

--- a/tests/js/spec/views/organizationContextContainer.spec.jsx
+++ b/tests/js/spec/views/organizationContextContainer.spec.jsx
@@ -6,7 +6,7 @@ import ProjectActions from 'sentry/actions/projectActions';
 import TeamActions from 'sentry/actions/teamActions';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
-import {OrganizationLegacyContext} from 'sentry/views/organizationContext';
+import {OrganizationLegacyContext} from 'sentry/views/organizationContextContainer';
 
 jest.mock('sentry/stores/configStore', () => ({
   get: jest.fn(),
@@ -15,7 +15,7 @@ jest.mock('sentry/actionCreators/modal', () => ({
   openSudo: jest.fn(),
 }));
 
-describe('OrganizationContext', function () {
+describe('OrganizationContextContainer', function () {
   let wrapper;
   const org = TestStubs.Organization();
   const teams = [TestStubs.Team()];


### PR DESCRIPTION
Just focusing on jest startup time, with the following super minimal test:

test.spec.ts
```ts
import {mountWithTheme} from 'sentry-test/reactTestingLibrary';

import {Organization} from 'sentry/types';

type Props = {
  organization?: Organization;
};

function Test(props: Props) {
  return <div>{props.organization?.slug}</div>;
}

it('should do whatever', () => {
  mountWithTheme(<Test />);
});
```

command used
```
node --inspect-brk node_modules/.bin/jest --runInBand --no-cache tests/js/spec/test.spec.tsx
```

3.19 seconds of jest startup time was spent loading the dependency tree from `organizationContext.tsx` after loading `sentry-test/reactTestingLibrary` (3.75 seconds on that entire tree).
<img width="698" alt="image" src="https://user-images.githubusercontent.com/1400464/156486306-ba8723ae-4c02-45d2-928c-6be591b91fec.png">

After rearranging organizationContext to not drag in as many components.

<img width="396" alt="image" src="https://user-images.githubusercontent.com/1400464/156486874-056ccf9d-f2fd-4b40-854f-06e954a0da88.png">


running the single test before/after (--watch is disabled and --no-cache is enabled)

<img width="474" alt="image" src="https://user-images.githubusercontent.com/1400464/156488008-8dce7385-6e5b-4af8-a65c-340013f01385.png">


If run against a regular test like alerts/create.spec.jsx it saves like 2 seconds.