### PR TITLE
feat(sentryapp): Stringify dependantData json queryparam

### DIFF
--- a/src/sentry/mediators/sentry_app_components/preparer.py
+++ b/src/sentry/mediators/sentry_app_components/preparer.py
@@ -4,6 +4,7 @@ from django.utils.encoding import force_str
 
 from sentry.mediators import Mediator, Param
 from sentry.mediators.external_requests import SelectRequester
+from sentry.utils import json
 
 
 class Preparer(Mediator):
@@ -71,7 +72,7 @@ class Preparer(Mediator):
             if len(dependant_data_list) != len(field.get("depends_on")):
                 return field.update({"choices": []})
 
-            dependant_data = {x["name"]: x["value"] for x in dependant_data_list}
+            dependant_data = json.dumps({x["name"]: x["value"] for x in dependant_data_list})
 
             return self._get_select_choices(field, dependant_data)
 

--- a/tests/sentry/mediators/sentry_app_components/test_preparer.py
+++ b/tests/sentry/mediators/sentry_app_components/test_preparer.py
@@ -2,6 +2,7 @@ from unittest.mock import call, patch
 
 from sentry.mediators.sentry_app_components import Preparer
 from sentry.testutils import TestCase
+from sentry.utils import json
 
 
 class TestPreparerIssueLink(TestCase):
@@ -98,4 +99,102 @@ class TestPreparerStacktraceLink(TestCase):
         assert (
             self.component.schema["url"]
             == f"https://example.com/redirection?installationId={self.install.uuid}&projectSlug={self.project.slug}"
+        )
+
+
+class TestPreparerAlertRuleAction(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.sentry_app = self.create_sentry_app(
+            name="Pied Piper",
+            organization=self.project.organization,
+            schema={
+                "elements": [
+                    {
+                        "type": "alert-rule-action",
+                        "title": "Create a Issue",
+                        "settings": {
+                            "type": "alert-rule-settings",
+                            "uri": "/hooks/sentry/alert-rule-action",
+                            "description": "When the alert fires automatically create an issue with the following properties.",
+                            "required_fields": [
+                                {
+                                    "name": "teamId",
+                                    "label": "Team",
+                                    "type": "select",
+                                    "uri": "/hooks/sentry/issues/teams",
+                                }
+                            ],
+                            "optional_fields": [
+                                {
+                                    "name": "assigneeId",
+                                    "label": "Assignee",
+                                    "type": "select",
+                                    "uri": "/hooks/sentry/issues/assignees",
+                                    "depends_on": ["teamId"],
+                                },
+                                {
+                                    "name": "labelId",
+                                    "label": "Label",
+                                    "type": "select",
+                                    "uri": "/hooks/sentry/issues/labels",
+                                    "depends_on": ["teamId"],
+                                },
+                            ],
+                        },
+                    }
+                ]
+            },
+        )
+        self.install = self.create_sentry_app_installation(
+            slug="pied-piper", organization=self.project.organization
+        )
+
+        self.component = self.sentry_app.components.first()
+        self.project = self.install.organization.project_set.first()
+
+    @patch("sentry.mediators.external_requests.SelectRequester.run")
+    def test_prepares_components_requiring_requests(self, run):
+        self.preparer = Preparer(
+            component=self.component,
+            install=self.install,
+            project=self.project,
+            values=[
+                {"name": "teamId", "value": "Ecosystem"},
+                {"name": "assigneeId", "value": "3"},
+                {"name": "labelId", "value": "Priority"},
+            ],
+        )
+
+        self.preparer.call()
+
+        assert (
+            call(
+                install=self.install,
+                project=self.project,
+                uri="/hooks/sentry/issues/teams",
+                dependent_data=None,
+            )
+            in run.mock_calls
+        )
+
+        assert (
+            call(
+                install=self.install,
+                project=self.project,
+                uri="/hooks/sentry/issues/assignees",
+                dependent_data=json.dumps({"teamId": "Ecosystem"}),
+            )
+            in run.mock_calls
+        )
+
+        assert (
+            call(
+                install=self.install,
+                project=self.project,
+                uri="/hooks/sentry/issues/labels",
+                dependent_data=json.dumps({"teamId": "Ecosystem"}),
+            )
+            in run.mock_calls
         )


### PR DESCRIPTION
## Objective:
Seeing failed requests to partners for SelectRequester requests with dependentData queryparam. We to stringify the json payload for urlencode to encode the queryparam properly.