### PR TITLE
feat(native): Increase max crash reports to 100 per issue [INGEST-1034]

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -20,7 +20,11 @@ from sentry.api.serializers.models.organization import TrustedRelaySerializer
 from sentry.api.serializers.rest_framework import ListField
 from sentry.constants import LEGACY_RATE_LIMIT_OPTIONS, RESERVED_ORGANIZATION_SLUGS
 from sentry.datascrubbing import validate_pii_config_update
-from sentry.lang.native.utils import STORE_CRASH_REPORTS_DEFAULT, convert_crashreport_count
+from sentry.lang.native.utils import (
+    STORE_CRASH_REPORTS_DEFAULT,
+    STORE_CRASH_REPORTS_MAX,
+    convert_crashreport_count,
+)
 from sentry.models import (
     AuditLogEntryEvent,
     Authenticator,
@@ -141,7 +145,9 @@ class OrganizationSerializer(serializers.Serializer):
     dataScrubberDefaults = serializers.BooleanField(required=False)
     sensitiveFields = ListField(child=serializers.CharField(), required=False)
     safeFields = ListField(child=serializers.CharField(), required=False)
-    storeCrashReports = serializers.IntegerField(min_value=-1, max_value=20, required=False)
+    storeCrashReports = serializers.IntegerField(
+        min_value=-1, max_value=STORE_CRASH_REPORTS_MAX, required=False
+    )
     attachmentsRole = serializers.CharField(required=True)
     debugFilesRole = serializers.CharField(required=True)
     eventsMemberAdmin = serializers.BooleanField(required=False)

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -29,7 +29,7 @@ from sentry.lang.native.symbolicator import (
     parse_sources,
     redact_source_secrets,
 )
-from sentry.lang.native.utils import convert_crashreport_count
+from sentry.lang.native.utils import STORE_CRASH_REPORTS_MAX, convert_crashreport_count
 from sentry.models import (
     AuditLogEntryEvent,
     Group,
@@ -141,7 +141,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
     sensitiveFields = ListField(child=serializers.CharField(), required=False)
     safeFields = ListField(child=serializers.CharField(), required=False)
     storeCrashReports = serializers.IntegerField(
-        min_value=-1, max_value=20, required=False, allow_null=True
+        min_value=-1, max_value=STORE_CRASH_REPORTS_MAX, required=False, allow_null=True
     )
     relayPiiConfig = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     builtinSymbolSources = ListField(child=serializers.CharField(), required=False)

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -26,8 +26,10 @@ NATIVE_IMAGE_TYPES = (
 
 # Default disables storing crash reports.
 STORE_CRASH_REPORTS_DEFAULT = 0
-# Do not limit crash report attachments per group.
+# Do not limit crash report attachments per issue.
 STORE_CRASH_REPORTS_ALL = -1
+# The maximum number of crash report attachments per issue if not unlimited.
+STORE_CRASH_REPORTS_MAX = 100
 
 
 def is_native_platform(platform):

--- a/static/app/utils/crashReports.tsx
+++ b/static/app/utils/crashReports.tsx
@@ -31,10 +31,12 @@ export enum SettingScope {
 export function getStoreCrashReportsValues(settingScope: SettingScope) {
   const values: Array<number | null> = [
     0, // disabled
-    1,
+    1, // limited per issue
     5,
     10,
-    20, // limited per issue
+    20,
+    50,
+    100,
     -1, // unlimited
   ];
 

--- a/tests/js/spec/utils/crashReports.spec.jsx
+++ b/tests/js/spec/utils/crashReports.spec.jsx
@@ -7,10 +7,10 @@ import {
 
 describe('crashReportsUtils', () => {
   it('returns correct values for organization scope', () => {
-    expect(getStoreCrashReportsValues(0)).toEqual([0, 1, 5, 10, 20, -1]);
+    expect(getStoreCrashReportsValues(0)).toEqual([0, 1, 5, 10, 20, 50, 100, -1]);
   });
   it('returns correct values for project scope', () => {
-    expect(getStoreCrashReportsValues(1)).toEqual([null, 0, 1, 5, 10, 20, -1]);
+    expect(getStoreCrashReportsValues(1)).toEqual([null, 0, 1, 5, 10, 20, 50, 100, -1]);
   });
   it('formats basic values', () => {
     expect(formatStoreCrashReports(-1)).toBe('Unlimited');

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -611,6 +611,18 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert self.organization.get_option("sentry:relay_pii_config") == value
         assert response.data["relayPiiConfig"] == value
 
+    def test_store_crash_reports_exceeded(self):
+        # Uses a hard-coded number of MAX + 1 for regression testing.
+        #
+        # DO NOT INCREASE this number without checking the logic in event
+        # manager's ``get_stored_crashreports`` function. Increasing this number
+        # causes more load on postgres during ingestion.
+        data = {"storeCrashReports": 101}
+
+        resp = self.get_error_response(self.organization.slug, status_code=400, **data)
+        assert self.organization.get_option("sentry:store_crash_reports") is None
+        assert b"storeCrashReports" in resp.content
+
 
 class OrganizationDeleteTest(OrganizationDetailsTestBase):
     method = "delete"

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -534,6 +534,14 @@ class ProjectUpdateTest(APITestCase):
         assert self.project.get_option("sentry:store_crash_reports") == 10
         assert resp.data["storeCrashReports"] == 10
 
+    def test_store_crash_reports_exceeded(self):
+        # NB: Align with test_organization_details.py
+        data = {"storeCrashReports": 101}
+
+        resp = self.get_error_response(self.org_slug, self.proj_slug, status_code=400, **data)
+        assert self.project.get_option("sentry:store_crash_reports") is None
+        assert b"storeCrashReports" in resp.content
+
     def test_relay_pii_config(self):
         value = '{"applications": {"freeform": []}}'
         resp = self.get_valid_response(self.org_slug, self.proj_slug, relayPiiConfig=value)


### PR DESCRIPTION
Increases the maximum allowed value for "Store Native Crash Reports" from 20 to
100 per issue. In organization and project settings, users can now choose from
50 and 100 in addition to the previously available values.

The default is still not to store native crash reports, and there is an
"unlimited" setting.

Until the limit is reached, the `save_event` task performs a database query to
determine the actual number of crash reports for the current issue. Once the
limit is exceeded, the numer is cached in memcache. Increasing the maximum limit
to 100 will cause slightly increased database load during event ingestion.

