### PR TITLE
fix(perf): Remove temporary duration clause from search

### DIFF
--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -424,11 +424,6 @@ function generateGenericPerformanceEventView(
   const searchQuery = decodeScalar(query.query, '');
   const conditions = new MutableSearch(searchQuery);
 
-  // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (!conditions.hasFilter('transaction.duration') && !isMetricsData) {
-    conditions.setFilterValues('transaction.duration', ['<15m']);
-  }
-
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.freeText.length > 0) {
@@ -504,11 +499,6 @@ function generateBackendPerformanceEventView(
 
   const searchQuery = decodeScalar(query.query, '');
   const conditions = new MutableSearch(searchQuery);
-
-  // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (!conditions.hasFilter('transaction.duration') && !isMetricsData) {
-    conditions.setFilterValues('transaction.duration', ['<15m']);
-  }
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
@@ -596,11 +586,6 @@ function generateMobilePerformanceEventView(
   const searchQuery = decodeScalar(query.query, '');
   const conditions = new MutableSearch(searchQuery);
 
-  // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (!conditions.hasFilter('transaction.duration') && !isMetricsData) {
-    conditions.setFilterValues('transaction.duration', ['<15m']);
-  }
-
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.freeText.length > 0) {
@@ -666,11 +651,6 @@ function generateFrontendPageloadPerformanceEventView(
 
   const searchQuery = decodeScalar(query.query, '');
   const conditions = new MutableSearch(searchQuery);
-
-  // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (!conditions.hasFilter('transaction.duration') && !isMetricsData) {
-    conditions.setFilterValues('transaction.duration', ['<15m']);
-  }
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
@@ -738,11 +718,6 @@ function generateFrontendOtherPerformanceEventView(
 
   const searchQuery = decodeScalar(query.query, '');
   const conditions = new MutableSearch(searchQuery);
-
-  // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (!conditions.hasFilter('transaction.duration') && !isMetricsData) {
-    conditions.setFilterValues('transaction.duration', ['<15m']);
-  }
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.

--- a/tests/js/spec/views/performance/content.spec.jsx
+++ b/tests/js/spec/views/performance/content.spec.jsx
@@ -371,7 +371,7 @@ describe('Performance > Content', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           transaction: '/apple/cart',
-          query: 'sentry:yes transaction.duration:<15m',
+          query: 'sentry:yes',
         }),
       })
     );

--- a/tests/js/spec/views/performance/data.spec.jsx
+++ b/tests/js/spec/views/performance/data.spec.jsx
@@ -9,10 +9,8 @@ describe('generatePerformanceEventView()', function () {
     expect(result.id).toBeUndefined();
     expect(result.name).toEqual('Performance');
     expect(result.fields.length).toBeGreaterThanOrEqual(7);
-    expect(result.query).toEqual('transaction.duration:<15m');
-    expect(result.getQueryWithAdditionalConditions()).toEqual(
-      'transaction.duration:<15m event.type:transaction'
-    );
+    expect(result.query).toEqual('');
+    expect(result.getQueryWithAdditionalConditions()).toEqual('event.type:transaction');
     expect(result.sorts).toEqual([{kind: 'desc', field: 'tpm'}]);
     expect(result.statsPeriod).toEqual('24h');
   });

--- a/tests/js/spec/views/performance/transactionSummary.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.tsx
@@ -345,7 +345,7 @@ describe('Performance > TransactionSummary', function () {
       project: TestStubs.Project({teams, platform: 'javascript'}),
       query: {
         query:
-          'transaction.duration:<15m transaction.op:pageload event.type:transaction transaction:/organizations/:orgId/issues/',
+          'transaction.op:pageload event.type:transaction transaction:/organizations/:orgId/issues/',
       },
     });
 

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -50,7 +50,7 @@ describe('Performance Transaction Events Content', function () {
   let eventView;
   let initialData;
   const query =
-    'transaction.duration:<15m event.type:transaction transaction:/api/0/organizations/{organization_slug}/eventsv2/';
+    'event.type:transaction transaction:/api/0/organizations/{organization_slug}/eventsv2/';
   beforeEach(function () {
     transactionName = 'transactionName';
     fields = [

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -46,7 +46,7 @@ describe('Performance GridEditable Table', function () {
   let data;
   let transactionName;
   const query =
-    'transaction.duration:<15m event.type:transaction transaction:/api/0/organizations/{organization_slug}/eventsv2/';
+    'event.type:transaction transaction:/api/0/organizations/{organization_slug}/eventsv2/';
   beforeEach(function () {
     transactionName = 'transactionName';
     transactionsListTitles = [


### PR DESCRIPTION
### Summary
We initially added the transaction duration condition to our search pages to make sure visualizations wouldn't have outlier data skewing their results. The primary source of that outlier data was frontend browser timing differences causing a rare transaction duration that would essentially wreck any perf visualization. Since the primary cause of that has now been fixed, we can simply remove the default transaction duration filter instead.
