### PR TITLE
fix(profiling): Show project and version name

### DIFF
--- a/static/app/types/profiling/core.tsx
+++ b/static/app/types/profiling/core.tsx
@@ -6,6 +6,7 @@ type Annotation = {
 export type Trace = {
   app_id: string;
   app_version: string;
+  app_version_name: string;
   device_class: string;
   device_locale: string;
   device_manufacturer: string;

--- a/static/app/views/profiling/landing/profilingTable.tsx
+++ b/static/app/views/profiling/landing/profilingTable.tsx
@@ -45,9 +45,10 @@ function renderProfilingTableCell(
 }
 
 const COLUMN_ORDER: TableColumnKey[] = [
-  'id',
   'failed',
-  'app_version',
+  'id',
+  'app_id',
+  'app_version_name',
   'interaction_name',
   'start_time_unix',
   'trace_duration_ms',
@@ -58,16 +59,21 @@ const COLUMN_ORDER: TableColumnKey[] = [
 const COLUMNS: TableColumnOrders = {
   id: {
     key: 'id',
-    name: t('Flamegraph'),
+    name: t('Profile ID'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  app_id: {
+    key: 'app_id',
+    name: t('Project'),
     width: COL_WIDTH_UNDEFINED,
   },
   failed: {
     key: 'failed',
     name: t('Status'),
-    width: COL_WIDTH_UNDEFINED,
+    width: 14, // make this as small as possible
   },
-  app_version: {
-    key: 'app_version',
+  app_version_name: {
+    key: 'app_version_name',
     name: t('Version'),
     width: COL_WIDTH_UNDEFINED,
   },

--- a/static/app/views/profiling/landing/profilingTableCell.tsx
+++ b/static/app/views/profiling/landing/profilingTableCell.tsx
@@ -1,4 +1,5 @@
 import DateTime from 'sentry/components/dateTime';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import {IconCheckmark, IconClose} from 'sentry/icons';
@@ -24,11 +25,15 @@ function ProfilingTableCell({column, dataRow}: ProfilingTableCellProps) {
   const organization = useOrganization();
   const {projects} = useProjects();
 
+  const project =
+    column.key === 'id' || column.key === 'app_id'
+      ? projects.find(proj => proj.id === dataRow.app_id)
+      : undefined;
+
   const value = dataRow[column.key];
 
   switch (column.key) {
     case 'id':
-      const project = projects.find(proj => proj.id === dataRow.app_id);
       if (!defined(project)) {
         // should never happen but just in case
         return <Container>{t('n/a')}</Container>;
@@ -43,6 +48,23 @@ function ProfilingTableCell({column, dataRow}: ProfilingTableCellProps) {
       return (
         <Container>
           <Link to={target}>{getShortEventId(dataRow.id)}</Link>
+        </Container>
+      );
+    case 'app_id':
+      if (!defined(project)) {
+        // should never happen but just in case
+        return <Container>{t('n/a')}</Container>;
+      }
+
+      return (
+        <Container>
+          <ProjectBadge project={project} avatarSize={16} />
+        </Container>
+      );
+    case 'app_version_name':
+      return (
+        <Container>
+          {dataRow.app_version ? t('%s (build %s)', value, dataRow.app_version) : value}
         </Container>
       );
     case 'failed':

--- a/static/app/views/profiling/landing/types.tsx
+++ b/static/app/views/profiling/landing/types.tsx
@@ -4,7 +4,7 @@ import {Trace} from 'sentry/types/profiling/core';
 export type TableColumnKey = keyof Trace;
 
 type NonTableColumnKey =
-  | 'app_id'
+  | 'app_version'
   | 'device_locale'
   | 'device_manufacturer'
   | 'backtrace_available'


### PR DESCRIPTION
This change adds a new column to show the project of the profile and renders the
version name in addition to the build. It includes some minor clean up of the
table as well.