### PR TITLE
ref(sdk): Bump idleTimeout to 10s temporarily

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -31,7 +31,7 @@ function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
             ),
           }
         : {}),
-      idleTimeout: 5000,
+      idleTimeout: 10000,
       _metricOptions: {
         _reportAllChanges: false,
       },


### PR DESCRIPTION
### Summary
This will help show us if there is any higher LCP capture rate available.