### PR TITLE
feat: Add brotli support for http fetches [ISSUE-1413]

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,6 +67,7 @@ typing-extensions==3.10.0.2
 ua-parser==0.10.0
 unidiff==0.6.0
 urllib3[brotli]==1.25.11
+brotlipy==0.7.0
 # See if we can remove LDFLAGS from lib.sh
 # https://github.com/getsentry/sentry/pull/30094
 uWSGI==2.0.19.1

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ toronado==0.1.0
 typing-extensions==3.10.0.2
 ua-parser==0.10.0
 unidiff==0.6.0
-urllib3==1.24.2
+urllib3[brotli]==1.25.11
 # See if we can remove LDFLAGS from lib.sh
 # https://github.com/getsentry/sentry/pull/30094
 uWSGI==2.0.19.1


### PR DESCRIPTION
This upgrades urllib3 and enables the brotli feature. With this change the http fetcher is now able to handle brotli compressed resources. This primarily will help with situations where code needs to fetch a brotli compressed resource. It does not add support for brotli compressed source artifacts in the release files.

Fixes ISSUE-1413