### PR TITLE
ref(ui): Enforce max-width for buttons

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -343,6 +343,7 @@ const ButtonLabel = styled('span', {
   align-items: center;
   justify-content: ${p => p.align};
   white-space: nowrap;
+  width: max-content;
 `;
 
 type IconProps = {


### PR DESCRIPTION
Going to look at the snapshots for this.

But this basically stops buttons from collapsing when the containers push them to be smaller and instead prioritizes the container to be bigger.