### PR TITLE
ref(ui): Enforce max-width on dropdown labels

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -343,6 +343,7 @@ const ButtonLabel = styled('span', {
   align-items: center;
   justify-content: ${p => p.align};
   white-space: nowrap;
+  width: max-content;
 `;
 
 type IconProps = {


### PR DESCRIPTION
Should help with dropdown buttons that are within parent containers that
collapse them to be too small