### PR TITLE
ref(ui): Do not use outline for widgetCard

### DIFF
--- a/static/app/views/dashboardsV2/widgetLibrary/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetLibrary/widgetCard.tsx
@@ -103,9 +103,9 @@ type PanelProps = {
 };
 
 const StyledPanel = styled(Panel)<PanelProps>`
-  margin-bottom: 0;
-  border: ${p => '1px solid ' + p.theme.border};
-  outline: ${p => (p.selected ? '2px solid' + p.theme.purple400 : undefined)};
+  border: ${p =>
+    p.selected ? `2px solid ${p.theme.active}` : `1px solid ${p.theme.border}`};
+  margin: ${p => (p.selected ? '-1px' : 0)};
   box-sizing: border-box;
   box-shadow: 0px 2px 1px rgba(0, 0, 0, 0.08);
   cursor: pointer;


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1421724/156666566-fe966800-6449-4e58-873b-a0956edf413e.png)

After
![image](https://user-images.githubusercontent.com/1421724/156666588-fff1498e-ddc6-4810-9fda-03b9e10f417f.png)

Less muddy bc the border is now fully active