### PR TITLE
ref(alerts): Refactor alert rule trigger type from string to enum

### DIFF
--- a/static/app/views/alerts/changeAlerts/comparisonMarklines.tsx
+++ b/static/app/views/alerts/changeAlerts/comparisonMarklines.tsx
@@ -4,15 +4,23 @@ import {t} from 'sentry/locale';
 import {Series} from 'sentry/types/echarts';
 import {MINUTE} from 'sentry/utils/formatters';
 import theme from 'sentry/utils/theme';
-import {AlertRuleThresholdType, Trigger} from 'sentry/views/alerts/incidentRules/types';
+import {
+  AlertRuleThresholdType,
+  AlertRuleTriggerType,
+  Trigger,
+} from 'sentry/views/alerts/incidentRules/types';
 
 export const checkChangeStatus = (
   value: number,
   thresholdType: AlertRuleThresholdType,
   triggers: Trigger[]
 ): string => {
-  const criticalTrigger = triggers?.find(trig => trig.label === 'critical');
-  const warningTrigger = triggers?.find(trig => trig.label === 'warning');
+  const criticalTrigger = triggers?.find(
+    trig => trig.label === AlertRuleTriggerType.CRITICAL
+  );
+  const warningTrigger = triggers?.find(
+    trig => trig.label === AlertRuleTriggerType.WARNING
+  );
   const criticalTriggerAlertThreshold =
     typeof criticalTrigger?.alertThreshold === 'number'
       ? criticalTrigger.alertThreshold
@@ -28,14 +36,14 @@ export const checkChangeStatus = (
     criticalTriggerAlertThreshold &&
     value >= criticalTriggerAlertThreshold
   ) {
-    return 'critical';
+    return AlertRuleTriggerType.CRITICAL;
   }
   if (
     thresholdType === AlertRuleThresholdType.ABOVE &&
     warningTriggerAlertThreshold &&
     value >= warningTriggerAlertThreshold
   ) {
-    return 'warning';
+    return AlertRuleTriggerType.WARNING;
   }
   // When threshold is below(lower than in comparison alerts) the % diff value is negative
   // It crosses the threshold if its abs value is greater than threshold
@@ -45,14 +53,14 @@ export const checkChangeStatus = (
     criticalTriggerAlertThreshold &&
     -1 * value >= criticalTriggerAlertThreshold
   ) {
-    return 'critical';
+    return AlertRuleTriggerType.CRITICAL;
   }
   if (
     thresholdType === AlertRuleThresholdType.BELOW &&
     warningTriggerAlertThreshold &&
     -1 * value >= warningTriggerAlertThreshold
   ) {
-    return 'warning';
+    return AlertRuleTriggerType.WARNING;
   }
 
   return '';
@@ -104,9 +112,9 @@ export const getComparisonMarkLines = (
           silent: true,
           lineStyle: {
             color:
-              status === 'critical'
+              status === AlertRuleTriggerType.CRITICAL
                 ? theme.red300
-                : status === 'warning'
+                : status === AlertRuleTriggerType.WARNING
                 ? theme.yellow300
                 : theme.green300,
             type: 'solid',

--- a/static/app/views/alerts/incidentRules/constants.tsx
+++ b/static/app/views/alerts/incidentRules/constants.tsx
@@ -4,6 +4,7 @@ import {AggregationKey, LooseFieldKey} from 'sentry/utils/discover/fields';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {
   AlertRuleThresholdType,
+  AlertRuleTriggerType,
   Dataset,
   Datasource,
   EventTypes,
@@ -114,7 +115,7 @@ export const transactionFieldConfig: OptionConfig = {
   measurementKeys: Object.keys(WEB_VITAL_DETAILS),
 };
 
-export function createDefaultTrigger(label: 'critical' | 'warning'): Trigger {
+export function createDefaultTrigger(label: AlertRuleTriggerType): Trigger {
   return {
     label,
     alertThreshold: '',
@@ -132,7 +133,10 @@ export function createDefaultRule(
     query: '',
     timeWindow: 60,
     thresholdPeriod: 1,
-    triggers: [createDefaultTrigger('critical'), createDefaultTrigger('warning')],
+    triggers: [
+      createDefaultTrigger(AlertRuleTriggerType.CRITICAL),
+      createDefaultTrigger(AlertRuleTriggerType.WARNING),
+    ],
     projects: [],
     environment: null,
     resolveThreshold: '',

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -45,6 +45,7 @@ import RuleConditionsForm from '../ruleConditionsForm';
 import {
   AlertRuleComparisonType,
   AlertRuleThresholdType,
+  AlertRuleTriggerType,
   Dataset,
   EventTypes,
   IncidentRule,
@@ -111,7 +112,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
     // Warning trigger is removed if it is blank when saving
     if (triggersClone.length !== 2) {
-      triggersClone.push(createDefaultTrigger('warning'));
+      triggersClone.push(createDefaultTrigger(AlertRuleTriggerType.WARNING));
     }
 
     return {
@@ -337,7 +338,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
           errors: triggerErrors,
           triggerIndex,
           isValid: (): boolean => {
-            if (trigger.label === 'critical') {
+            if (trigger.label === AlertRuleTriggerType.CRITICAL) {
               return !isEmpty(trigger[field]);
             }
 
@@ -360,7 +361,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
     // If we have 2 triggers, we need to make sure that the critical and warning
     // alert thresholds are valid (e.g. if critical is above x, warning must be less than x)
-    const criticalTriggerIndex = triggers.findIndex(({label}) => label === 'critical');
+    const criticalTriggerIndex = triggers.findIndex(
+      ({label}) => label === AlertRuleTriggerType.CRITICAL
+    );
     const warningTriggerIndex = criticalTriggerIndex ^ 1;
     const criticalTrigger = triggers[criticalTriggerIndex];
     const warningTrigger = triggers[warningTriggerIndex];
@@ -463,7 +466,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     } = this.state;
     // Remove empty warning trigger
     const sanitizedTriggers = triggers.filter(
-      trigger => trigger.label !== 'warning' || !isEmpty(trigger.alertThreshold)
+      trigger =>
+        trigger.label !== AlertRuleTriggerType.WARNING || !isEmpty(trigger.alertThreshold)
     );
 
     // form model has all form state data, however we use local state to keep

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -28,10 +28,10 @@ const ThresholdTypeForm = ({
   disabled,
   comparisonType,
   onComparisonDeltaChange,
-      onComparisonTypeChange,
-      hasAlertWizardV3,
-      comparisonDelta,
-    } : Props) =>
+  onComparisonTypeChange,
+  hasAlertWizardV3,
+  comparisonDelta,
+}: Props) =>
   dataset === Dataset.SESSIONS ? null : (
     <Feature features={['organizations:change-alerts']} organization={organization}>
       {!hasAlertWizardV3 && <StyledListItem>{t('Select threshold type')}</StyledListItem>}
@@ -49,9 +49,8 @@ const ThresholdTypeForm = ({
               hasAlertWizardV3 ? (
                 comparisonType === AlertRuleComparisonType.COUNT ? (
                   t('Percent Change: {x%} higher or lower compared to previous period')
-                ) : (
-                  // Prevent default to avoid dropdown menu closing on click
-                  <ComparisonContainer onClick={e => e.preventDefault()}>
+                ) : (// Prevent default to avoid dropdown menu closing on click
+                  <ComparisonContaineronClick={e => e.preventDefault()}>
                     {t('Percent Change: {x%} higher or lower compared to')}
                     <SelectControl
                       name="comparisonDelta"
@@ -83,6 +82,7 @@ const ThresholdTypeForm = ({
                         }),
                       }}
                       value={comparisonDelta}
+
                       onChange={({value}) => onComparisonDeltaChange(value)}
                       options={COMPARISON_DELTA_OPTIONS}
                       required={comparisonType === AlertRuleComparisonType.CHANGE}

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -49,7 +49,7 @@ const ThresholdTypeForm = ({
               hasAlertWizardV3 ? (
                 comparisonType === AlertRuleComparisonType.COUNT ? (
                   t('Percent Change: {x%} higher or lower compared to previous period')
-                ) : (// Prevent default to avoid dropdown menu closing on click
+                ) : (
                   // Prevent default to avoid dropdown menu closing on click
                   <ComparisonContainer onClick={e => e.preventDefault()}>
                     {t('Percent Change: {x%} higher or lower compared to')}

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -28,10 +28,10 @@ const ThresholdTypeForm = ({
   disabled,
   comparisonType,
   onComparisonDeltaChange,
-  onComparisonTypeChange,
-  hasAlertWizardV3,
-  comparisonDelta,
-}: Props) =>
+      onComparisonTypeChange,
+      hasAlertWizardV3,
+      comparisonDelta,
+    } : Props) =>
   dataset === Dataset.SESSIONS ? null : (
     <Feature features={['organizations:change-alerts']} organization={organization}>
       {!hasAlertWizardV3 && <StyledListItem>{t('Select threshold type')}</StyledListItem>}

--- a/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/incidentRules/thresholdTypeForm.tsx
@@ -50,7 +50,8 @@ const ThresholdTypeForm = ({
                 comparisonType === AlertRuleComparisonType.COUNT ? (
                   t('Percent Change: {x%} higher or lower compared to previous period')
                 ) : (// Prevent default to avoid dropdown menu closing on click
-                  <ComparisonContaineronClick={e => e.preventDefault()}>
+                  // Prevent default to avoid dropdown menu closing on click
+                  <ComparisonContainer onClick={e => e.preventDefault()}>
                     {t('Percent Change: {x%} higher or lower compared to')}
                     <SelectControl
                       name="comparisonDelta"
@@ -82,7 +83,6 @@ const ThresholdTypeForm = ({
                         }),
                       }}
                       value={comparisonDelta}
-
                       onChange={({value}) => onComparisonDeltaChange(value)}
                       options={COMPARISON_DELTA_OPTIONS}
                       required={comparisonType === AlertRuleComparisonType.CHANGE}

--- a/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -24,7 +24,12 @@ import {
   shouldScaleAlertChart,
 } from 'sentry/views/alerts/utils';
 
-import {AlertRuleThresholdType, IncidentRule, Trigger} from '../../types';
+import {
+  AlertRuleThresholdType,
+  AlertRuleTriggerType,
+  IncidentRule,
+  Trigger,
+} from '../../types';
 
 type DefaultProps = {
   comparisonData: Series[];
@@ -224,7 +229,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
     // Shave off the left margin
     const graphAreaMargin = 7;
 
-    const isCritical = trigger.label === 'critical';
+    const isCritical = trigger.label === AlertRuleTriggerType.CRITICAL;
     const LINE_STYLE = {
       stroke: isResolution ? theme.green300 : isCritical ? theme.red300 : theme.yellow300,
       lineDash: [2],
@@ -387,9 +392,9 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
           );
 
           const changeStatusColor =
-            changeStatus === 'critical'
+            changeStatus === AlertRuleTriggerType.CRITICAL
               ? theme.red300
-              : changeStatus === 'warning'
+              : changeStatus === AlertRuleTriggerType.WARNING
               ? theme.yellow300
               : theme.green300;
 

--- a/static/app/views/alerts/incidentRules/triggers/form.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/form.tsx
@@ -190,7 +190,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
     return '300';
   }
 
-  getIndicator(type?: AlertRuleTriggerType) {
+  getIndicator(type: AlertRuleTriggerType) {
     const {hasAlertWizardV3} = this.props;
 
     if (type === AlertRuleTriggerType.CRITICAL) {
@@ -236,7 +236,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
     } = this.props;
 
     const resolveTrigger: UnsavedTrigger = {
-      label: 'resolve',
+      label: AlertRuleTriggerType.RESOLVE,
       alertThreshold: resolveThreshold,
       actions: [],
     };
@@ -329,7 +329,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
           }
           triggerLabel={
             <TriggerLabel>
-              {this.getIndicator()}
+              {this.getIndicator(AlertRuleTriggerType.RESOLVE)}
               {t('Resolved')}
             </TriggerLabel>
           }

--- a/static/app/views/alerts/incidentRules/triggers/form.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/form.tsx
@@ -17,6 +17,7 @@ import {isSessionAggregate} from '../../utils';
 import {
   AlertRuleComparisonType,
   AlertRuleThresholdType,
+  AlertRuleTriggerType,
   ThresholdControlValue,
   Trigger,
   UnsavedIncidentRule,
@@ -189,10 +190,10 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
     return '300';
   }
 
-  getIndicator(type: string) {
+  getIndicator(type?: AlertRuleTriggerType) {
     const {hasAlertWizardV3} = this.props;
 
-    if (type === 'critical') {
+    if (type === AlertRuleTriggerType.CRITICAL) {
       return hasAlertWizardV3 ? (
         <StyledIconDiamond color="red300" size="sm" />
       ) : (
@@ -200,7 +201,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
       );
     }
 
-    if (type === 'warning') {
+    if (type === AlertRuleTriggerType.WARNING) {
       return hasAlertWizardV3 ? (
         <StyledIconDiamond color="yellow300" size="sm" />
       ) : (
@@ -278,7 +279,11 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
               }
               triggerLabel={
                 <TriggerLabel>
-                  {this.getIndicator(isCritical ? 'critical' : 'warning')}
+                  {this.getIndicator(
+                    isCritical
+                      ? AlertRuleTriggerType.CRITICAL
+                      : AlertRuleTriggerType.WARNING
+                  )}
                   {isCritical ? t('Critical') : t('Warning')}
                 </TriggerLabel>
               }
@@ -324,7 +329,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
           }
           triggerLabel={
             <TriggerLabel>
-              {this.getIndicator('resolved')}
+              {this.getIndicator()}
               {t('Resolved')}
             </TriggerLabel>
           }

--- a/static/app/views/alerts/incidentRules/types.tsx
+++ b/static/app/views/alerts/incidentRules/types.tsx
@@ -9,6 +9,7 @@ export enum AlertRuleThresholdType {
 export enum AlertRuleTriggerType {
   CRITICAL = 'critical',
   WARNING = 'warning',
+  RESOLVE = 'resolve',
 }
 
 export enum AlertRuleComparisonType {

--- a/static/app/views/alerts/incidentRules/types.tsx
+++ b/static/app/views/alerts/incidentRules/types.tsx
@@ -6,6 +6,11 @@ export enum AlertRuleThresholdType {
   BELOW,
 }
 
+export enum AlertRuleTriggerType {
+  CRITICAL = 'critical',
+  WARNING = 'warning',
+}
+
 export enum AlertRuleComparisonType {
   COUNT = 'count',
   CHANGE = 'change',
@@ -45,7 +50,7 @@ export enum SessionsAggregate {
 export type UnsavedTrigger = {
   actions: Action[];
   alertThreshold: number | '' | null;
-  label: string;
+  label: AlertRuleTriggerType;
   // UnsavedTrigger can be apart of an Unsaved Alert Rule that does not have an
   // id yet
   alertRuleId?: string;

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -30,6 +30,7 @@ import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/incidentRules/consta
 import {
   Action,
   AlertRuleThresholdType,
+  AlertRuleTriggerType,
   Dataset,
   IncidentRule,
 } from 'sentry/views/alerts/incidentRules/types';
@@ -125,15 +126,15 @@ export default class DetailsBody extends React.Component<Props> {
     }
 
     const status =
-      label === 'critical'
+      label === AlertRuleTriggerType.CRITICAL
         ? t('Critical')
-        : label === 'warning'
+        : label === AlertRuleTriggerType.WARNING
         ? t('Warning')
         : t('Resolved');
     const statusIcon =
-      label === 'critical' ? (
+      label === AlertRuleTriggerType.CRITICAL ? (
         <StyledIconDiamond color="red300" size="md" />
-      ) : label === 'warning' ? (
+      ) : label === AlertRuleTriggerType.WARNING ? (
         <StyledIconDiamond color="yellow300" size="md" />
       ) : (
         <StyledIconDiamond color="green300" size="md" />
@@ -192,8 +193,12 @@ export default class DetailsBody extends React.Component<Props> {
       return <Placeholder height="200px" />;
     }
 
-    const criticalTrigger = rule?.triggers.find(({label}) => label === 'critical');
-    const warningTrigger = rule?.triggers.find(({label}) => label === 'warning');
+    const criticalTrigger = rule?.triggers.find(
+      ({label}) => label === AlertRuleTriggerType.CRITICAL
+    );
+    const warningTrigger = rule?.triggers.find(
+      ({label}) => label === AlertRuleTriggerType.WARNING
+    );
 
     const ownerId = rule.owner?.split(':')[1];
     const teamActor = ownerId && {type: 'team' as Actor['type'], id: ownerId, name: ''};

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -43,7 +43,11 @@ import theme from 'sentry/utils/theme';
 import {checkChangeStatus} from 'sentry/views/alerts/changeAlerts/comparisonMarklines';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/incidentRules/constants';
 import {makeDefaultCta} from 'sentry/views/alerts/incidentRules/incidentRulePresets';
-import {Dataset, IncidentRule} from 'sentry/views/alerts/incidentRules/types';
+import {
+  AlertRuleTriggerType,
+  Dataset,
+  IncidentRule,
+} from 'sentry/views/alerts/incidentRules/types';
 import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 
@@ -348,8 +352,12 @@ class MetricChart extends React.PureComponent<Props, State> {
       return this.renderEmpty();
     }
 
-    const criticalTrigger = rule.triggers.find(({label}) => label === 'critical');
-    const warningTrigger = rule.triggers.find(({label}) => label === 'warning');
+    const criticalTrigger = rule.triggers.find(
+      ({label}) => label === AlertRuleTriggerType.CRITICAL
+    );
+    const warningTrigger = rule.triggers.find(
+      ({label}) => label === AlertRuleTriggerType.WARNING
+    );
 
     const series: AreaChartSeries[] = [...timeseriesData];
     const areaSeries: any[] = [];
@@ -680,9 +688,9 @@ class MetricChart extends React.PureComponent<Props, State> {
                         );
 
                         const changeStatusColor =
-                          changeStatus === 'critical'
+                          changeStatus === AlertRuleTriggerType.CRITICAL
                             ? theme.red300
-                            : changeStatus === 'warning'
+                            : changeStatus === AlertRuleTriggerType.WARNING
                             ? theme.yellow300
                             : theme.green300;
 

--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -21,7 +21,10 @@ import space from 'sentry/styles/space';
 import {Actor, Organization, Project} from 'sentry/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import type {Color} from 'sentry/utils/theme';
-import {AlertRuleThresholdType} from 'sentry/views/alerts/incidentRules/types';
+import {
+  AlertRuleThresholdType,
+  AlertRuleTriggerType,
+} from 'sentry/views/alerts/incidentRules/types';
 
 import {CombinedMetricIssueAlerts, IncidentStatus} from '../types';
 import {isIssueAlert} from '../utils';
@@ -90,8 +93,12 @@ function RuleListRow({
       return null;
     }
 
-    const criticalTrigger = rule.triggers.find(({label}) => label === 'critical');
-    const warningTrigger = rule.triggers.find(({label}) => label === 'warning');
+    const criticalTrigger = rule.triggers.find(
+      ({label}) => label === AlertRuleTriggerType.CRITICAL
+    );
+    const warningTrigger = rule.triggers.find(
+      ({label}) => label === AlertRuleTriggerType.WARNING
+    );
     const resolvedTrigger = rule.resolveThreshold;
     const trigger =
       activeIncident && rule.latestIncident?.status === IncidentStatus.CRITICAL
@@ -107,9 +114,9 @@ function RuleListRow({
 
     if (activeIncident) {
       iconColor =
-        trigger?.label === 'critical'
+        trigger?.label === AlertRuleTriggerType.CRITICAL
           ? 'red300'
-          : trigger?.label === 'warning'
+          : trigger?.label === AlertRuleTriggerType.WARNING
           ? 'yellow300'
           : 'green300';
       iconDirection = rule.thresholdType === AlertRuleThresholdType.ABOVE ? 'up' : 'down';

--- a/tests/js/spec/views/alerts/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/details.spec.jsx
@@ -11,6 +11,7 @@ import {
 import GlobalModal from 'sentry/components/globalModal';
 import {metric} from 'sentry/utils/analytics';
 import IncidentRulesDetails from 'sentry/views/alerts/incidentRules/details';
+import {AlertRuleTriggerType} from 'sentry/views/alerts/incidentRules/types';
 
 jest.mock('sentry/utils/analytics', () => ({
   metric: {
@@ -164,7 +165,11 @@ describe('Incident Rules Details', function () {
   it('clears trigger', async function () {
     const {organization, project} = initializeOrg();
     const rule = TestStubs.IncidentRule();
-    rule.triggers.push({label: 'warning', alertThreshold: 13, actions: []});
+    rule.triggers.push({
+      label: AlertRuleTriggerType.WARNING,
+      alertThreshold: 13,
+      actions: [],
+    });
     rule.resolveThreshold = 12;
 
     const onChangeTitleMock = jest.fn();


### PR DESCRIPTION
This creates a new enum for Critical/Warning alert triggers. It is used for labels, conditional rendering for trigger related things, trigger colors, etc.