### PR TITLE
ref(ratelimits): surface concurrent requests to access logs

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -38,6 +38,22 @@ def _get_token_name(auth: RequestAuth) -> str | None:
     return token_class.__name__ if token_class else None
 
 
+def _get_rate_limit_stats_dict(request: Request) -> dict[str, str]:
+    default = {
+        "rate_limit_type": "ERROR",
+        "concurrent_limit": str(None),
+        "concurrent_requests": str(None),
+    }
+
+    rate_limit_metadata = getattr(request, "rate_limit_metadata", None)
+    if not rate_limit_metadata:
+        return default
+    res = {}
+    for field in default:
+        res[field] = str(getattr(rate_limit_metadata, field, None))
+    return res
+
+
 def _create_api_access_log(
     request: Request, response: Response | None, access_log_metadata: _AccessLogMetaData
 ) -> None:
@@ -74,6 +90,7 @@ def _create_api_access_log(
             rate_limited=str(getattr(request, "will_be_rate_limited", False)),
             rate_limit_category=str(getattr(request, "rate_limit_category", None)),
             request_duration_seconds=access_log_metadata.get_request_duration(),
+            **_get_rate_limit_stats_dict(request),
         )
         api_access_logger.info("api.access", extra=log_metrics)
     except Exception:

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -39,6 +39,7 @@ def _get_token_name(auth: RequestAuth) -> str | None:
 
 
 def _get_rate_limit_stats_dict(request: Request) -> dict[str, str]:
+    # TODO:: plumb the rate limit group up here as well for better future analysis
     default = {
         "rate_limit_type": "ERROR",
         "concurrent_limit": str(None),

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -41,7 +41,7 @@ def _get_token_name(auth: RequestAuth) -> str | None:
 def _get_rate_limit_stats_dict(request: Request) -> dict[str, str]:
     # TODO:: plumb the rate limit group up here as well for better future analysis
     default = {
-        "rate_limit_type": "ERROR",
+        "rate_limit_type": "DNE",
         "concurrent_limit": str(None),
         "concurrent_requests": str(None),
     }

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from django.http.response import HttpResponse
 from django.utils.deprecation import MiddlewareMixin
 from rest_framework.request import Request
@@ -19,38 +21,41 @@ class RatelimitMiddleware(MiddlewareMixin):
 
     def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response | None:
         """Check if the endpoint call will violate."""
-        request.will_be_rate_limited = False
-        request.rate_limit_category = None
+        try:
+            request.will_be_rate_limited = False
+            request.rate_limit_category = None
 
-        key = get_rate_limit_key(view_func, request)
-        if key is None:
-            return
-        category_str = key.split(":", 1)[0]
-        request.rate_limit_category = category_str
+            key = get_rate_limit_key(view_func, request)
+            if key is None:
+                return
+            category_str = key.split(":", 1)[0]
+            request.rate_limit_category = category_str
 
-        rate_limit = get_rate_limit_value(
-            http_method=request.method,
-            endpoint=view_func.view_class,
-            category=RateLimitCategory(category_str),
-        )
-        if rate_limit is None:
-            return
+            rate_limit = get_rate_limit_value(
+                http_method=request.method,
+                endpoint=view_func.view_class,
+                category=RateLimitCategory(category_str),
+            )
+            if rate_limit is None:
+                return
 
-        request.rate_limit_metadata = above_rate_limit_check(key, rate_limit)
+            request.rate_limit_metadata = above_rate_limit_check(key, rate_limit)
 
-        if request.rate_limit_metadata.is_limited:
-            request.will_be_rate_limited = True
-            enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
-            if enforce_rate_limit:
-                return HttpResponse(
-                    {
-                        "detail": DEFAULT_ERROR_MESSAGE.format(
-                            limit=request.rate_limit_metadata.limit,
-                            window=request.rate_limit_metadata.window,
-                        )
-                    },
-                    status=429,
-                )
+            if request.rate_limit_metadata.is_limited:
+                request.will_be_rate_limited = True
+                enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
+                if enforce_rate_limit:
+                    return HttpResponse(
+                        {
+                            "detail": DEFAULT_ERROR_MESSAGE.format(
+                                limit=request.rate_limit_metadata.limit,
+                                window=request.rate_limit_metadata.window,
+                            )
+                        },
+                        status=429,
+                    )
+        except Exception:
+            logging.exception("Error during rate limiting, failing open. THIS SHOULD NOT HAPPEN")
 
     def process_response(self, request: Request, response: Response) -> Response:
         if hasattr(request, "rate_limit_metadata"):

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -8,7 +8,12 @@ from django.utils.deprecation import MiddlewareMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.ratelimits import above_rate_limit_check, get_rate_limit_key, get_rate_limit_value
+from sentry.ratelimits import (
+    above_rate_limit_check,
+    finish_request,
+    get_rate_limit_key,
+    get_rate_limit_value,
+)
 from sentry.types.ratelimit import RateLimitCategory, RateLimitType
 
 DEFAULT_ERROR_MESSAGE = (
@@ -27,11 +32,10 @@ class RatelimitMiddleware(MiddlewareMixin):
             request.will_be_rate_limited = False
             request.rate_limit_category = None
             request.rate_limit_uid = uuid.uuid4().hex
-
-            key = get_rate_limit_key(view_func, request)
-            if key is None:
+            request.rate_limit_key = get_rate_limit_key(view_func, request)
+            if request.rate_limit_key is None:
                 return
-            category_str = key.split(":", 1)[0]
+            category_str = request.rate_limit_key.split(":", 1)[0]
             request.rate_limit_category = category_str
 
             rate_limit = get_rate_limit_value(
@@ -43,7 +47,7 @@ class RatelimitMiddleware(MiddlewareMixin):
                 return
 
             request.rate_limit_metadata = above_rate_limit_check(
-                key, rate_limit, request.rate_limit_uid
+                request.rate_limit_key, rate_limit, request.rate_limit_uid
             )
 
             # TODO: also limit by concurrent window once we have the data
@@ -68,4 +72,5 @@ class RatelimitMiddleware(MiddlewareMixin):
             response["X-Sentry-Rate-Limit-Remaining"] = request.rate_limit_metadata.remaining
             response["X-Sentry-Rate-Limit-Limit"] = request.rate_limit_metadata.limit
             response["X-Sentry-Rate-Limit-Reset"] = request.rate_limit_metadata.reset_time
+        finish_request(request.rate_limit_key, request.rate_limit_uid)
         return response

--- a/src/sentry/ratelimits/__init__.py
+++ b/src/sentry/ratelimits/__init__.py
@@ -7,6 +7,7 @@ __all__ = (
     "above_rate_limit_check",
     "get_rate_limit_key",
     "get_rate_limit_value",
+    "finish_request",
     "RateLimiter",
 )
 
@@ -19,6 +20,7 @@ backend.expose(locals())
 
 from .utils import (
     above_rate_limit_check,
+    finish_request,
     for_organization_member_invite,
     get_rate_limit_key,
     get_rate_limit_value,

--- a/src/sentry/ratelimits/concurrent.py
+++ b/src/sentry/ratelimits/concurrent.py
@@ -28,7 +28,7 @@ def _bucket_start_time(bucket_number: int, window: int) -> int:
     return bucket_number * window
 
 
-class RedisRateLimiter(RateLimiter):
+class RedisRateLimiter:
     def __init__(self, **options: Any) -> None:
         cluster_key = getattr(settings, "SENTRY_RATE_LIMIT_REDIS_CLUSTER", "default")
         self.client = redis.redis_clusters.get(cluster_key)
@@ -97,8 +97,6 @@ class RedisRateLimiter(RateLimiter):
         rate limit window will start
         """
         request_time = time()
-        if window is None or window == 0:
-            window = self.window
         redis_key = self._construct_redis_key(key, project=project, window=window)
 
         expiration = window - int(request_time % window)

--- a/src/sentry/ratelimits/concurrent.py
+++ b/src/sentry/ratelimits/concurrent.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import logging
+from time import time
+from typing import TYPE_CHECKING, Any
+
+from django.conf import settings
+from redis.exceptions import RedisError
+
+from sentry.exceptions import InvalidConfiguration
+from sentry.ratelimits.base import RateLimiter
+from sentry.utils import redis
+from sentry.utils.hashlib import md5_text
+
+if TYPE_CHECKING:
+    from sentry.models.project import Project
+
+logger = logging.getLogger(__name__)
+
+
+def _time_bucket(request_time: float, window: int) -> int:
+    """Bucket number lookup for given UTC time since epoch"""
+    return int(request_time / window)
+
+
+def _bucket_start_time(bucket_number: int, window: int) -> int:
+    """Determine bucket start time in seconds from epoch in UTC"""
+    return bucket_number * window
+
+
+class RedisRateLimiter(RateLimiter):
+    def __init__(self, **options: Any) -> None:
+        cluster_key = getattr(settings, "SENTRY_RATE_LIMIT_REDIS_CLUSTER", "default")
+        self.client = redis.redis_clusters.get(cluster_key)
+
+    def _construct_redis_key(
+        self,
+        key: str,
+        project: Project | None = None,
+        window: int | None = None,
+        request_time: float | None = None,
+    ) -> str:
+        """
+        Construct a rate limit key using the args given. Key will have a format of:
+        "rl:<key_hex>:[project?<project_id>:]<time_bucket>"
+        where the time bucket is calculated by integer dividing the current time by the window
+        """
+
+        if window is None or window == 0:
+            window = self.window
+
+        if request_time is None:
+            request_time = time()
+
+        key_hex = md5_text(key).hexdigest()
+        bucket = _time_bucket(request_time, window)
+
+        redis_key = f"rl:{key_hex}"
+        if project is not None:
+            redis_key += f":{project.id}"
+        redis_key += f":{bucket}"
+
+        return redis_key
+
+    def validate(self) -> None:
+        try:
+            self.client.ping()
+        except Exception as e:
+            raise InvalidConfiguration(str(e))
+
+    def current_value(
+        self, key: str, project: Project | None = None, window: int | None = None
+    ) -> int:
+        """
+        Get the current value stored in redis for the rate limit with key "key" and said window
+        """
+        redis_key = self._construct_redis_key(key, project=project, window=window)
+
+        try:
+            current_count = self.client.get(redis_key)
+        except RedisError:
+            # Don't report any existing hits when there is a redis error.
+            # Log what happened and move on
+            logger.exception("Failed to retrieve current value from redis")
+            return 0
+
+        if current_count is None:
+            # Key hasn't been created yet, therefore no hits done so far
+            return 0
+        return int(current_count)
+
+    def is_limited_with_value(
+        self, key: str, limit: int, project: Project | None = None, window: int | None = None
+    ) -> tuple[bool, int, int]:
+        """
+        Does a rate limit check as well as returning the new rate limit value and when the next
+        rate limit window will start
+        """
+        request_time = time()
+        if window is None or window == 0:
+            window = self.window
+        redis_key = self._construct_redis_key(key, project=project, window=window)
+
+        expiration = window - int(request_time % window)
+        # Reset Time = next time bucket's start time
+        reset_time = _bucket_start_time(_time_bucket(request_time, window) + 1, window)
+        try:
+            result = self.client.incr(redis_key)
+            self.client.expire(redis_key, expiration)
+        except RedisError:
+            # We don't want rate limited endpoints to fail when ratelimits
+            # can't be updated. We do want to know when that happens.
+            logger.exception("Failed to retrieve current value from redis")
+            return False, 0, reset_time
+
+        return result > limit, result, reset_time

--- a/src/sentry/ratelimits/concurrent.py
+++ b/src/sentry/ratelimits/concurrent.py
@@ -12,10 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 ErrorLimit = float("inf")
+DEFAULT_MAX_TTL_SECONDS = 30
 
 
 class ConcurrentRateLimiter:
-    def __init__(self, max_tll_seconds: int = 30) -> None:
+    def __init__(self, max_tll_seconds: int = DEFAULT_MAX_TTL_SECONDS) -> None:
         cluster_key = getattr(settings, "SENTRY_RATE_LIMIT_REDIS_CLUSTER", "default")
         self.client = redis.redis_clusters.get(cluster_key)
         self.max_ttl_seconds = max_tll_seconds
@@ -26,27 +27,38 @@ class ConcurrentRateLimiter:
         except Exception as e:
             raise InvalidConfiguration(str(e))
 
-    # TODO: maybe pass in the request object? But maybe we don't want to tie this to requests
+    # TODO: returning the amoutn of concurrent requests is not that nice of an interface, should
+    #   use a struct of some sort instead
     def start_request(self, key: str, limit: int, request_uid: str) -> int:
         # TODO: This should fail open
-        cur_time = time()
-        p = self.client.pipeline()
-        p.zremrangebyscore(key, "-inf", cur_time - self.max_ttl_seconds)
-
-        # TODO: do this using a redis lua script to keep things atomic
-        p.zcard(key)
-        currently_executing_calls = p.execute()[1]
-
-        if currently_executing_calls >= limit:
-            return limit
-        else:
+        try:
+            cur_time = time()
             p = self.client.pipeline()
-            p.zadd(key, {request_uid: cur_time})
+            p.zremrangebyscore(key, "-inf", cur_time - self.max_ttl_seconds)
+
+            # TODO: do this using a redis lua script to keep things atomic
             p.zcard(key)
-            return p.execute()[1]
+            currently_executing_calls = p.execute()[1]
+
+            if currently_executing_calls >= limit:
+                return limit
+            else:
+                p = self.client.pipeline()
+                p.zadd(key, {request_uid: cur_time})
+                p.zcard(key)
+                return p.execute()[1]
+        except Exception:
+            logger.exception(
+                "Could not start request", dict(key=key, limit=limit, request_uid=request_uid)
+            )
+            return 20000
 
     def get_concurrent_requests(self, key: str):
+        # this can fail loudly as it is only meant for observability
         return self.client.zcard(key)
 
     def finish_request(self, key: str, request_uid: str) -> None:
-        self.client.zrem(key, request_uid)
+        try:
+            self.client.zrem(key, request_uid)
+        except Exception:
+            logger.exception("Could not finish request", dict(key=key, request_uid=request_uid))

--- a/src/sentry/ratelimits/concurrent.py
+++ b/src/sentry/ratelimits/concurrent.py
@@ -43,10 +43,9 @@ class ConcurrentRateLimiter:
     def start_request(self, key: str, limit: int, request_uid: str) -> ConcurrentLimitInfo:
         redis_key = self.namespaced_key(key)
         try:
-            res = rate_limit_info(
+            current_executions, request_allowed = rate_limit_info(
                 self.client, [redis_key], [limit, request_uid, time(), self.max_ttl_seconds]
             )
-            current_executions, request_allowed = res
             return ConcurrentLimitInfo(limit, int(current_executions), not bool(request_allowed))
         except Exception:
             logger.exception(

--- a/src/sentry/ratelimits/concurrent.py
+++ b/src/sentry/ratelimits/concurrent.py
@@ -35,39 +35,41 @@ class ConcurrentRateLimiter:
         except Exception as e:
             raise InvalidConfiguration(str(e))
 
-    # TODO: returning the amoutn of concurrent requests is not that nice of an interface, should
-    #   use a struct of some sort instead
+    def namespaced_key(self, key: str) -> str:
+        return f"concurrent_limit:{key}"
+
     def start_request(self, key: str, limit: int, request_uid: str) -> ConcurrentLimitInfo:
-        # TODO: This should fail open
+        redis_key = self.namespaced_key(key)
         try:
             cur_time = time()
             p = self.client.pipeline()
-            p.zremrangebyscore(key, "-inf", cur_time - self.max_ttl_seconds)
+            p.zremrangebyscore(redis_key, "-inf", cur_time - self.max_ttl_seconds)
 
             # TODO: do this using a redis lua script to keep things atomic
-            p.zcard(key)
+            p.zcard(redis_key)
             currently_executing_calls = p.execute()[1]
 
             if currently_executing_calls >= limit:
                 return ConcurrentLimitInfo(limit, currently_executing_calls, True)
             else:
                 p = self.client.pipeline()
-                p.zadd(key, {request_uid: cur_time})
-                p.zcard(key)
+                p.zadd(redis_key, {request_uid: cur_time})
+                p.zcard(redis_key)
                 current_executions = p.execute()[1]
                 return ConcurrentLimitInfo(limit, current_executions, False)
         except Exception:
             logger.exception(
-                "Could not start request", dict(key=key, limit=limit, request_uid=request_uid)
+                "Could not start request", dict(key=redis_key, limit=limit, request_uid=request_uid)
             )
             return ConcurrentLimitInfo(limit, -1, False)
 
     def get_concurrent_requests(self, key: str) -> int:
+        redis_key = self.namespaced_key(key)
         # this can fail loudly as it is only meant for observability
-        return self.client.zcard(key)
+        return self.client.zcard(redis_key)
 
     def finish_request(self, key: str, request_uid: str) -> None:
         try:
-            self.client.zrem(key, request_uid)
+            self.client.zrem(self.namespaced_key(key), request_uid)
         except Exception:
             logger.exception("Could not finish request", dict(key=key, request_uid=request_uid))

--- a/src/sentry/ratelimits/concurrent.py
+++ b/src/sentry/ratelimits/concurrent.py
@@ -46,8 +46,8 @@ class ConcurrentRateLimiter:
             res = rate_limit_info(
                 self.client, [redis_key], [limit, request_uid, time(), self.max_ttl_seconds]
             )
-            current_executions, limit_exceeded = res
-            return ConcurrentLimitInfo(limit, int(current_executions), bool(limit_exceeded))
+            current_executions, request_allowed = res
+            return ConcurrentLimitInfo(limit, int(current_executions), not bool(request_allowed))
         except Exception:
             logger.exception(
                 "Could not start request", dict(key=redis_key, limit=limit, request_uid=request_uid)

--- a/src/sentry/ratelimits/config.py
+++ b/src/sentry/ratelimits/config.py
@@ -23,10 +23,16 @@ RateLimitOverrideDict = Mapping[HttpMethodName, Mapping[RateLimitCategory, RateL
 # This default value is going to shrink over time
 _SENTRY_RATELIMITER_DEFAULT = 520
 
+# The concurrent rate limiter stores a sorted set of requests, don't make this number
+# too large (e.g > 100)
+_SENTRY_CONCURRENT_RATE_LIMIT_DEFAULT = 40
+ENFORCE_CONCURRENT_RATE_LIMITS = False
+
 
 _SENTRY_RATELIMITER_GROUP_DEFAULTS: Mapping[GroupName, Mapping[RateLimitCategory, RateLimit]] = {
     "default": {
-        category: RateLimit(_SENTRY_RATELIMITER_DEFAULT, 1) for category in RateLimitCategory
+        category: RateLimit(_SENTRY_RATELIMITER_DEFAULT, 1, _SENTRY_CONCURRENT_RATE_LIMIT_DEFAULT)
+        for category in RateLimitCategory
     }
 }
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -164,6 +164,10 @@ def above_rate_limit_check(key: str, rate_limit: RateLimit, request_uid: str) ->
     )
 
 
+def finish_request(key: str, request_uid: str) -> None:
+    concurrent_limiter().finish_request(key, request_uid)
+
+
 def for_organization_member_invite(
     organization: Organization,
     email: str,

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -131,6 +131,10 @@ def get_rate_limit_value(
 
 
 def above_rate_limit_check(key: str, rate_limit: RateLimit, request_uid: str) -> RateLimitMeta:
+    # TODO: This is not as performant as it could be. The roundtrip betwwen the server and redis
+    # is doubled because the fixd window limit and concurrent limit are two separate things with different
+    # paths. Ideally there is just one lua script that does both and just says what kind of limit was hit
+    # (if any)
     rate_limit_type = RateLimitType.NOT_LIMITED
     window_limited, current, reset_time = ratelimiter.is_limited_with_value(
         key, limit=rate_limit.limit, window=rate_limit.window

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -148,9 +148,6 @@ def above_rate_limit_check(key: str, rate_limit: RateLimit, request_uid: str) ->
         concurrent_limit_info = concurrent_limiter().start_request(
             key, rate_limit.concurrent_limit, request_uid
         )
-        # TODO: This is a little clunky. I do this comparison here and in
-        # the rate limit class. Maybe make the rate limit class return a
-        # a payload with metadata?
         if concurrent_limit_info.limit_exceeded:
             rate_limit_type = RateLimitType.CONCURRENT
         concurrent_requests = concurrent_limit_info.current_executions

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -139,7 +139,6 @@ def above_rate_limit_check(key: str, rate_limit: RateLimit, request_uid: str) ->
     window_limited, current, reset_time = ratelimiter.is_limited_with_value(
         key, limit=rate_limit.limit, window=rate_limit.window
     )
-    remaining = 0
     remaining = rate_limit.limit - current if not window_limited else 0
     if window_limited:
         rate_limit_type = RateLimitType.FIXED_WINDOW

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -145,14 +145,15 @@ def above_rate_limit_check(key: str, rate_limit: RateLimit, request_uid: str) ->
         rate_limit_type = RateLimitType.FIXED_WINDOW
     concurrent_requests = None
     if rate_limit.concurrent_limit is not None:
-        concurrent_requests = concurrent_limiter().start_request(
+        concurrent_limit_info = concurrent_limiter().start_request(
             key, rate_limit.concurrent_limit, request_uid
         )
         # TODO: This is a little clunky. I do this comparison here and in
         # the rate limit class. Maybe make the rate limit class return a
         # a payload with metadata?
-        if concurrent_requests >= rate_limit.concurrent_limit:
+        if concurrent_limit_info.limit_exceeded:
             rate_limit_type = RateLimitType.CONCURRENT
+        concurrent_requests = concurrent_limit_info.current_executions
 
     return RateLimitMeta(
         rate_limit_type=rate_limit_type,

--- a/src/sentry/scripts/ratelimits/api_limiter.lua
+++ b/src/sentry/scripts/ratelimits/api_limiter.lua
@@ -8,7 +8,7 @@
 --  concurrent_limit, request_uid, current_time, max_tll_seconds
 --
 -- Output:
--- current_executions (including the one that was just added), is_limit_exceeded?
+-- current_executions (including the one that was just added), request_allowed?
 local key = KEYS[1]
 
 local concurrent_limit = tonumber(ARGV[1])

--- a/src/sentry/scripts/ratelimits/api_limiter.lua
+++ b/src/sentry/scripts/ratelimits/api_limiter.lua
@@ -1,0 +1,27 @@
+-- TODO: This is currently just the concurrent rate limiter however this should subsume the fixed
+-- window rate limiter (at least for the API level) as well to reduce the redis roundtrips
+--
+-- Input:
+-- keys:
+--  redis_key,
+-- args:
+--  concurrent_limit, request_uid, current_time, max_tll_seconds
+--
+-- Output:
+-- current_executions (including the one that was just added), is_limit_exceeded?
+local key = KEYS[1]
+
+local concurrent_limit = tonumber(ARGV[1])
+local request_uid = ARGV[2]
+local cur_time = tonumber(ARGV[3])
+local max_tll_seconds = tonumber(ARGV[4])
+redis.call("zremrangebyscore", key, "-inf", cur_time - max_tll_seconds)
+local current_executions = redis.call("zcard", key)
+local allowed = current_executions < concurrent_limit
+
+if allowed then
+  redis.call("zadd", key, cur_time, request_uid)
+  current_executions = current_executions + 1
+end
+
+return { current_executions, allowed}

--- a/src/sentry/scripts/ratelimits/api_limiter.lua
+++ b/src/sentry/scripts/ratelimits/api_limiter.lua
@@ -1,6 +1,12 @@
 -- TODO: This is currently just the concurrent rate limiter however this should subsume the fixed
 -- window rate limiter (at least for the API level) as well to reduce the redis roundtrips
 --
+-- The concurrent rate limiter stores all currently executing requests in a redis
+-- sorted set. It can be thought of in the following way:
+--
+-- at any point in time there are <concurrent_limit> amount of slots for a specific key.
+-- every executing is stored with a string uid (for id lookups) and the timestamp as the score (for sorting)
+--
 -- Input:
 -- keys:
 --  redis_key,
@@ -11,16 +17,33 @@
 -- current_executions (including the one that was just added), request_allowed?
 local key = KEYS[1]
 
+-- The maximum amount of concurrent requests for the given key
 local concurrent_limit = tonumber(ARGV[1])
+-- a unique id associated with the request. We need this to be able to remove a specific request
+-- from the currently executing requests once it finishes (finishing the request is not done
+-- by this script)
 local request_uid = ARGV[2]
+-- current time according to the application server. To understand why we pass this,
+-- read https://github.blog/2021-04-05-how-we-scaled-github-api-sharded-replicated-rate-limiter-redis/
 local cur_time = tonumber(ARGV[3])
+-- the maximum time a request can be alive on the backend server. If the timestamp of a request is
+-- at least this old that means either something went wrong with the request and it never finished
+-- or the server timed it out
 local max_tll_seconds = tonumber(ARGV[4])
+
+-- first we remove all the requests whose scores (i.e. their timestamps) are older than the now - max ttl
+-- this prevents us from overcounting concurrent requests
 redis.call("zremrangebyscore", key, "-inf", cur_time - max_tll_seconds)
+-- get the size of the set, which tells us how many requests are currently executing
 local current_executions = redis.call("zcard", key)
 local allowed = current_executions < concurrent_limit
 
 if allowed then
+  -- if below the limit, add to the set
   redis.call("zadd", key, cur_time, request_uid)
+  -- a lua script executes atomically and only one element was added to the set
+  -- hence we can safely say that the amount of current executions is one higher
+  -- than it was before
   current_executions = current_executions + 1
 end
 

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
@@ -26,6 +28,12 @@ class RateLimit:
     concurrent_limit: Optional[int] = field(default=None)
 
 
+class RateLimitType(Enum):
+    NOT_LIMITED = "not_limited"
+    CONCURRENT = "concurrent"
+    FIXED_WINDOW = "fixed_window"
+
+
 @dataclass
 class RateLimitMeta:
     """
@@ -40,9 +48,11 @@ class RateLimitMeta:
         reset_time (int): UTC Epoch time in seconds when the current window expires
     """
 
-    is_limited: bool
+    rate_limit_type: RateLimitType
     current: int
     remaining: int
     limit: int
     window: int
     reset_time: int
+    concurrent_limit: int | None
+    concurrent_requests: int | None

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -56,3 +56,9 @@ class RateLimitMeta:
     reset_time: int
     concurrent_limit: int | None
     concurrent_requests: int | None
+
+    @property
+    def concurrent_remaining(self) -> int | None:
+        if self.concurrent_limit is not None and self.concurrent_requests is not None:
+            return self.concurrent_limit - self.concurrent_requests
+        return None

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -141,7 +141,8 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
 
     endpoint = "concurrent-ratelimit-endpoint"
 
-    def test_access_log_rate_limited(self):
+    def test_concurrent_request_finishes(self):
+        # TODO: This should be moved into test_access_log_middleware
         self._caplog.set_level(logging.INFO, logger="api.access")
         self.get_success_response()
         self.assert_access_log_recorded()
@@ -149,7 +150,15 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
         assert self.captured_logs[0].token_type == "None"
         assert self.captured_logs[0].concurrent_requests == "1"
         assert self.captured_logs[0].concurrent_limit == "1"
-        assert self.captured_logs[0].rate_limit_type == "RateLimitType.CONCURRENT"
+        assert self.captured_logs[0].rate_limit_type == "RateLimitType.NOT_LIMITED"
+        self.get_success_response()
+        assert self.captured_logs[1].token_type == "None"
+        assert self.captured_logs[1].concurrent_requests == "1"
+        assert self.captured_logs[1].concurrent_limit == "1"
+        assert self.captured_logs[1].rate_limit_type == "RateLimitType.NOT_LIMITED"
+
+    def test_concurrent_requests_rate_limited(self):
+        assert False
 
 
 class TestAccessLogSuccess(LogCaptureAPITestCase):

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -145,8 +145,9 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
         # TODO: This should be moved into test_access_log_middleware
         self._caplog.set_level(logging.INFO, logger="api.access")
         self.get_success_response()
+        # these requests were done in succession, so we should not have any
+        # rate limiting
         self.assert_access_log_recorded()
-        # no token because the endpoint was not hit
         assert self.captured_logs[0].token_type == "None"
         assert self.captured_logs[0].concurrent_requests == "1"
         assert self.captured_logs[0].concurrent_limit == "1"
@@ -156,9 +157,6 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
         assert self.captured_logs[1].concurrent_requests == "1"
         assert self.captured_logs[1].concurrent_limit == "1"
         assert self.captured_logs[1].rate_limit_type == "RateLimitType.NOT_LIMITED"
-
-    def test_concurrent_requests_rate_limited(self):
-        assert False
 
 
 class TestAccessLogSuccess(LogCaptureAPITestCase):

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -142,7 +142,6 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
     endpoint = "concurrent-ratelimit-endpoint"
 
     def test_concurrent_request_finishes(self):
-        # TODO: This should be moved into test_access_log_middleware
         self._caplog.set_level(logging.INFO, logger="api.access")
         self.get_success_response()
         # these requests were done in succession, so we should not have any

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -46,6 +46,24 @@ class RateLimitedEndpoint(Endpoint):
         return Response({"ok": True})
 
 
+class ConcurrentRateLimitedEndpoint(Endpoint):
+    permission_classes = (AllowAny,)
+    enforce_rate_limit = True
+    rate_limits = RateLimitConfig(
+        group="foo",
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(20, 1, 1),
+                RateLimitCategory.USER: RateLimit(20, 1, 1),
+                RateLimitCategory.ORGANIZATION: RateLimit(20, 1, 1),
+            },
+        },
+    )
+
+    def get(self, request):
+        return Response({"ok": True})
+
+
 access_log_fields = (
     "method",
     "view",
@@ -61,6 +79,9 @@ access_log_fields = (
     "rate_limited",
     "rate_limit_category",
     "request_duration_seconds",
+    "rate_limit_type",
+    "concurrent_limit",
+    "concurrent_requests",
 )
 
 
@@ -73,6 +94,11 @@ urlpatterns = [
     url(r"^/dummy$", DummyEndpoint.as_view(), name="dummy-endpoint"),
     url(r"^/dummyfail$", DummyFailEndpoint.as_view(), name="dummy-fail-endpoint"),
     url(r"^/dummyratelimit$", RateLimitedEndpoint.as_view(), name="ratelimit-endpoint"),
+    url(
+        r"^/dummyratelimitconcurrent$",
+        ConcurrentRateLimitedEndpoint.as_view(),
+        name="concurrent-ratelimit-endpoint",
+    ),
     url(
         r"^(?P<organization_slug>[^\/]+)/stats_v2/$",
         MyOrganizationEndpoint.as_view(),
@@ -109,6 +135,21 @@ class TestAccessLogRateLimited(LogCaptureAPITestCase):
         self.assert_access_log_recorded()
         # no token because the endpoint was not hit
         assert self.captured_logs[0].token_type == "None"
+
+
+class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
+
+    endpoint = "concurrent-ratelimit-endpoint"
+
+    def test_access_log_rate_limited(self):
+        self._caplog.set_level(logging.INFO, logger="api.access")
+        self.get_success_response()
+        self.assert_access_log_recorded()
+        # no token because the endpoint was not hit
+        assert self.captured_logs[0].token_type == "None"
+        assert self.captured_logs[0].concurrent_requests == "1"
+        assert self.captured_logs[0].concurrent_limit == "1"
+        assert self.captured_logs[0].rate_limit_type == "RateLimitType.CONCURRENT"
 
 
 class TestAccessLogSuccess(LogCaptureAPITestCase):

--- a/tests/sentry/ratelimits/test_redis_concurrent.py
+++ b/tests/sentry/ratelimits/test_redis_concurrent.py
@@ -1,0 +1,68 @@
+from time import time
+
+from freezegun import freeze_time
+
+from sentry.ratelimits.redis import RedisRateLimiter
+from sentry.ratelimits.concurrent import ConcurrentRateLimiter
+from sentry.testutils import TestCase
+
+
+class RedisRateLimiterTest(TestCase):
+    def setUp(self):
+        self.backend = ConcurrentRateLimiter()
+
+    def test_project_key(self):
+        with freeze_time("2000-01-01"):
+            assert not self.backend.is_limited("foo", 1, self.project)
+            assert self.backend.is_limited("foo", 1, self.project)
+
+    def test_simple_key(self):
+        with freeze_time("2000-01-01"):
+            assert not self.backend.is_limited("foo", 1)
+            assert self.backend.is_limited("foo", 1)
+
+    def test_correct_current_value(self):
+        """Ensure that current_value get the correct value after the counter in incremented"""
+
+        with freeze_time("2000-01-01"):
+            for _ in range(10):
+                self.backend.is_limited("foo", 100)
+
+            assert self.backend.current_value("foo") == 10
+            self.backend.is_limited("foo", 100)
+            assert self.backend.current_value("foo") == 11
+
+    def test_current_value_new_key(self):
+        """current_value should return 0 for a new key"""
+
+        assert self.backend.current_value("new") == 0
+
+    def test_current_value_expire(self):
+        """Ensure that the count resets when the window expires"""
+        with freeze_time("2000-01-01") as frozen_time:
+            for _ in range(10):
+                self.backend.is_limited("foo", 1, window=10)
+            assert self.backend.current_value("foo", window=10) == 10
+
+            frozen_time.tick(10)
+            assert self.backend.current_value("foo", window=10) == 0
+
+    def test_is_limited_with_value(self):
+        with freeze_time("2000-01-01") as frozen_time:
+            expected_reset_time = int(time() + 5)
+
+            limited, value, reset_time = self.backend.is_limited_with_value("foo", 1, window=5)
+            assert not limited
+            assert value == 1
+            assert reset_time == expected_reset_time
+
+            limited, value, reset_time = self.backend.is_limited_with_value("foo", 1, window=5)
+            assert limited
+            assert value == 2
+            assert reset_time == expected_reset_time
+
+            frozen_time.tick(5)
+            limited, value, reset_time = self.backend.is_limited_with_value("foo", 1, window=5)
+            assert not limited
+            assert value == 1
+            assert reset_time == expected_reset_time + 5

--- a/tests/sentry/ratelimits/test_redis_concurrent.py
+++ b/tests/sentry/ratelimits/test_redis_concurrent.py
@@ -1,68 +1,22 @@
-from time import time
-
 from freezegun import freeze_time
 
-from sentry.ratelimits.redis import RedisRateLimiter
 from sentry.ratelimits.concurrent import ConcurrentRateLimiter
 from sentry.testutils import TestCase
 
 
-class RedisRateLimiterTest(TestCase):
+class ConcurrentLimiterTest(TestCase):
     def setUp(self):
         self.backend = ConcurrentRateLimiter()
 
-    def test_project_key(self):
+    def test_add_and_remove(self):
+        limit = 8
         with freeze_time("2000-01-01"):
-            assert not self.backend.is_limited("foo", 1, self.project)
-            assert self.backend.is_limited("foo", 1, self.project)
+            for i in range(1, limit + 1):
+                assert self.backend.start_request("foo", limit, f"request_id{i}") == i
+            assert self.backend.start_request("foo", limit, "request_id_12") == limit
 
-    def test_simple_key(self):
-        with freeze_time("2000-01-01"):
-            assert not self.backend.is_limited("foo", 1)
-            assert self.backend.is_limited("foo", 1)
-
-    def test_correct_current_value(self):
-        """Ensure that current_value get the correct value after the counter in incremented"""
-
-        with freeze_time("2000-01-01"):
-            for _ in range(10):
-                self.backend.is_limited("foo", 100)
-
-            assert self.backend.current_value("foo") == 10
-            self.backend.is_limited("foo", 100)
-            assert self.backend.current_value("foo") == 11
-
-    def test_current_value_new_key(self):
-        """current_value should return 0 for a new key"""
-
-        assert self.backend.current_value("new") == 0
-
-    def test_current_value_expire(self):
-        """Ensure that the count resets when the window expires"""
-        with freeze_time("2000-01-01") as frozen_time:
-            for _ in range(10):
-                self.backend.is_limited("foo", 1, window=10)
-            assert self.backend.current_value("foo", window=10) == 10
-
-            frozen_time.tick(10)
-            assert self.backend.current_value("foo", window=10) == 0
-
-    def test_is_limited_with_value(self):
-        with freeze_time("2000-01-01") as frozen_time:
-            expected_reset_time = int(time() + 5)
-
-            limited, value, reset_time = self.backend.is_limited_with_value("foo", 1, window=5)
-            assert not limited
-            assert value == 1
-            assert reset_time == expected_reset_time
-
-            limited, value, reset_time = self.backend.is_limited_with_value("foo", 1, window=5)
-            assert limited
-            assert value == 2
-            assert reset_time == expected_reset_time
-
-            frozen_time.tick(5)
-            limited, value, reset_time = self.backend.is_limited_with_value("foo", 1, window=5)
-            assert not limited
-            assert value == 1
-            assert reset_time == expected_reset_time + 5
+            for i in range(10):
+                # limit exceeded
+                assert self.backend.get_concurrent_requests("foo") == 8
+            self.backend.finish_request("foo", "request_id1")
+            assert self.backend.get_concurrent_requests("foo") == 7

--- a/tests/sentry/ratelimits/test_redis_concurrent.py
+++ b/tests/sentry/ratelimits/test_redis_concurrent.py
@@ -13,6 +13,9 @@ class ConcurrentLimiterTest(TestCase):
     def setUp(self):
         self.backend = ConcurrentRateLimiter()
 
+    def validate(self):
+        assert self.backend.validate()
+
     def test_add_and_remove(self):
         """Test the basic adding and removal of requests to the concurrent
         rate limiter, no concurrency testing done here"""
@@ -51,7 +54,7 @@ class ConcurrentLimiterTest(TestCase):
         failed_request = limiter.start_request("key", 100, "some_uid")
         assert failed_request.current_executions == -1
         assert failed_request.limit_exceeded is False
-        limiter.finish_request("key", "some_uid")
+        assert limiter.finish_request("key", "some_uid") is None
 
     def test_cleanup_stale(self):
         limit = 10

--- a/tests/sentry/ratelimits/test_redis_concurrent.py
+++ b/tests/sentry/ratelimits/test_redis_concurrent.py
@@ -1,6 +1,8 @@
+from datetime import datetime, timedelta
+
 from freezegun import freeze_time
 
-from sentry.ratelimits.concurrent import ConcurrentRateLimiter
+from sentry.ratelimits.concurrent import DEFAULT_MAX_TTL_SECONDS, ConcurrentRateLimiter
 from sentry.testutils import TestCase
 
 
@@ -20,3 +22,37 @@ class ConcurrentLimiterTest(TestCase):
                 assert self.backend.get_concurrent_requests("foo") == 8
             self.backend.finish_request("foo", "request_id1")
             assert self.backend.get_concurrent_requests("foo") == 7
+
+    def test_fails_open(self):
+        class FakeClient:
+            def __init__(self, real_client):
+                self._client = real_client
+
+            def __getattr__(self, name):
+                return getattr(self._client, name)
+
+            def pipeline(self):
+                return self
+
+            def execute(self):
+                # TODO: When the script changes to lua,
+                # make this fail differently
+                raise Exception("OH NO")
+
+        limiter = ConcurrentRateLimiter()
+        limiter.client = FakeClient(limiter.client)
+        limiter.start_request("key", 100, "some_uid")
+        limiter.finish_request("key", "some_uid")
+
+    def test_cleanup_stale(self):
+        limit = 10
+        num_stale = 5
+        request_date = datetime(2000, 1, 1)
+        with freeze_time(request_date):
+            for i in range(1, num_stale + 1):
+                assert self.backend.start_request("foo", limit, f"request_id{i}") == i
+            assert self.backend.get_concurrent_requests("foo") == num_stale
+        with freeze_time(request_date + timedelta(seconds=DEFAULT_MAX_TTL_SECONDS + 1)):
+            # the old requests did not finish however they are past their TTL and therefore
+            # are irrelevant
+            assert self.backend.start_request("foo", limit, "updated_request") == 1

--- a/tests/sentry/ratelimits/test_redis_concurrent.py
+++ b/tests/sentry/ratelimits/test_redis_concurrent.py
@@ -18,16 +18,15 @@ class ConcurrentLimiterTest(TestCase):
                     self.backend.start_request("foo", limit, f"request_id{i}").current_executions
                     == i
                 )
-            assert (
-                self.backend.start_request("foo", limit, "request_id_12").current_executions
-                == limit
-            )
 
-            for i in range(10):
-                # limit exceeded
-                assert self.backend.get_concurrent_requests("foo") == 8
+            info = self.backend.start_request("foo", limit, "request_id_12")
+            assert info.current_executions == limit
+            assert info.limit_exceeded
+
+            # limit exceeded
+            assert self.backend.get_concurrent_requests("foo") == limit
             self.backend.finish_request("foo", "request_id1")
-            assert self.backend.get_concurrent_requests("foo") == 7
+            assert self.backend.get_concurrent_requests("foo") == limit - 1
 
     def test_fails_open(self):
         class FakeClient:

--- a/tests/sentry/ratelimits/test_redis_concurrent.py
+++ b/tests/sentry/ratelimits/test_redis_concurrent.py
@@ -66,3 +66,6 @@ class ConcurrentLimiterTest(TestCase):
             assert (
                 self.backend.start_request("foo", limit, "updated_request").current_executions == 1
             )
+
+    def test_finish_non_existent(self):
+        self.backend.finish_request("fasdlfkdsalfkjlasdkjlasdkjflsakj", "fsdlkajflsdakjsda")

--- a/tests/sentry/ratelimits/test_redis_concurrent.py
+++ b/tests/sentry/ratelimits/test_redis_concurrent.py
@@ -89,7 +89,6 @@ class ConcurrentLimiterTest(TestCase):
             results = []
             for f in futures:
                 results.append(f.result())
-            print(results)
             assert len([r for r in results if r.limit_exceeded]) == 1
             time.sleep(0.3)
             assert not do_request().limit_exceeded

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -4,29 +4,33 @@ from unittest import TestCase
 from freezegun import freeze_time
 
 from sentry.ratelimits import above_rate_limit_check
-from sentry.types.ratelimit import RateLimit, RateLimitMeta
+from sentry.types.ratelimit import RateLimit, RateLimitMeta, RateLimitType
 
 
 class RatelimitMiddlewareTest(TestCase):
     def test_above_rate_limit_check(self):
         with freeze_time("2000-01-01"):
             expected_reset_time = int(time() + 100)
-            return_val = above_rate_limit_check("foo", RateLimit(10, 100))
+            return_val = above_rate_limit_check("foo", RateLimit(10, 100), "request_uid")
             assert return_val == RateLimitMeta(
-                is_limited=False,
+                rate_limit_type=RateLimitType.NOT_LIMITED,
                 current=1,
                 limit=10,
                 window=100,
                 reset_time=expected_reset_time,
                 remaining=9,
+                concurrent_limit=None,
+                concurrent_requests=None,
             )
-            for _ in range(10):
-                return_val = above_rate_limit_check("foo", RateLimit(10, 100))
+            for i in range(10):
+                return_val = above_rate_limit_check("foo", RateLimit(10, 100), f"request_uid{i}")
             assert return_val == RateLimitMeta(
-                is_limited=True,
+                rate_limit_type=RateLimitType.FIXED_WINDOW,
                 current=11,
                 limit=10,
                 window=100,
                 reset_time=expected_reset_time,
                 remaining=0,
+                concurrent_limit=None,
+                concurrent_requests=None,
             )

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -34,3 +34,18 @@ class RatelimitMiddlewareTest(TestCase):
                 concurrent_limit=None,
                 concurrent_requests=None,
             )
+
+            for i in range(10):
+                return_val = above_rate_limit_check(
+                    "bar", RateLimit(120, 100, 9), f"request_uid{i}"
+                )
+            assert return_val == RateLimitMeta(
+                rate_limit_type=RateLimitType.CONCURRENT,
+                current=10,
+                limit=120,
+                window=100,
+                reset_time=expected_reset_time,
+                remaining=110,
+                concurrent_limit=9,
+                concurrent_requests=9,
+            )


### PR DESCRIPTION
### Context
All context on this project and reasoning for the implementation can be found [here](https://www.notion.so/sentry/Concurrent-Rate-Limiter-ebd5b7562aed4d01b102d83774a06b11)

This is the first step of concurrent rate limits in sentry. In order to understand what to rate limit by, we fist need to understand what the concurrent usage of our API is. 

### This PR does the following:

* Implements the concurrent rate limiting mechanism which will be used in sentry
* Surfaces the data to the access logs
* Does NOT enforce any concurrent rate limits

Some unrelated but otherwise important things:
* Makes the rate limit middleware fail open. As it is, an exception in that middleware would shut down the request

### What is needed from reviewers

* Are there any test cases that I missed?
* Is it clear what I'm testing and why?
* Would you know how to enable concurrent rate limiting if you had to?
* Does the implementation of the concurrent rate limiter make sense?


