### PR TITLE
feat(issue_alert_status): Add issue alert status page links to email alerts

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Mapping, Optional, Sequence
 
 from sentry import digests
+from sentry.digests import Digest
 from sentry.digests import get_option_key as get_digest_option_key
 from sentry.digests.notifications import event_to_record, unsplit_key
 from sentry.models import NotificationSetting, Project, ProjectOption
@@ -103,7 +104,7 @@ class MailAdapter:
     @staticmethod
     def notify_digest(
         project: Project,
-        digest: Any,
+        digest: Digest,
         target_type: ActionTargetType,
         target_identifier: Optional[int] = None,
     ) -> None:

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable, Mapping, MutableMapping
 
 import pytz
 
+from sentry import features
 from sentry.models import Team, User, UserOption
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.types import ActionTargetType, NotificationSettingTypes
@@ -86,6 +87,9 @@ class AlertRuleNotification(ProjectNotification):
     def get_context(self) -> MutableMapping[str, Any]:
         environment = self.event.get_tag("environment")
         enhanced_privacy = self.organization.flags.enhanced_privacy
+        alert_status_page_enabled = features.has(
+            "organizations:alert-rule-status-page", self.project.organization
+        )
         context = {
             "project_label": self.project.get_full_name(),
             "group": self.group,
@@ -98,6 +102,7 @@ class AlertRuleNotification(ProjectNotification):
             "environment": environment,
             "slack_link": get_integration_link(self.organization, "slack"),
             "has_alert_integration": has_alert_integration(self.project),
+            "alert_status_page_enabled": alert_status_page_enabled,
         }
 
         # if the organization has enabled enhanced privacy controls we don't send

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Sequence, cast
 
 from django.db.models import Count
@@ -141,11 +142,24 @@ def get_integration_link(organization: Organization, integration_slug: str) -> s
     return integration_link
 
 
+@dataclass
+class NotificationRuleDetails:
+    id: int
+    label: str
+    url: str
+    status_url: str
+
+
 def get_rules(
     rules: Sequence[Rule], organization: Organization, project: Project
-) -> Sequence[tuple[str, str]]:
+) -> Sequence[NotificationRuleDetails]:
     return [
-        (rule.label, f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule.id}/")
+        NotificationRuleDetails(
+            rule.id,
+            rule.label,
+            f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule.id}/",
+            f"/organizations/{organization.slug}/alerts/rules/{project.slug}/{rule.id}/details/",
+        )
         for rule in rules
     ]
 

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -32,7 +32,13 @@
 
     <div class="rule">
       <div class="container">
-        {{ rule.label }}
+        {% if alert_status_page_enabled %}
+            {% with rule_details=rules_details|get_item:rule.id %}
+                You’re receiving this email because you’re subscribed to notifications for <a href="{% absolute_uri rule_details.status_url %}">{{ rule_details.label }}</a>
+            {% endwith %}
+        {% else %}
+            {{ rule.label }}
+        {% endif %}
       </div>
     </div>
 

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -68,6 +68,16 @@
         {% if environment %} in {{ environment }}{% endif %}
     </h2>
 
+    {% if rules and alert_status_page_enabled %}
+        <p class="via">
+            You’re receiving this email because you’re subscribed to notifications for:
+            {% for rule in rules %}
+                <a href="{% absolute_uri rule.status_url %}">{{ rule.label }}</a>{% if not forloop.last %}, {% endif %}
+            {% endfor %}
+        </p>
+    {% endif %}
+
+
     {% if enhanced_privacy %}
       <div class="event">
         <div class="event-id">ID: {{ event.event_id }}</div>
@@ -195,11 +205,11 @@
       {% endif %}
     {% endif %}
 
-    {% if rules %}
+    {% if rules and not alert_status_page_enabled %}
         <p class="via">
             You are receiving this email due to matching rules:
-            {% for rule_label, rule_link in rules %}
-                <a href="{% absolute_uri rule_link %}">{{ rule_label }}</a>{% if not forloop.last %}, {% endif %}
+            {% for rule in rules %}
+                <a href="{% absolute_uri rule.url %}">{{ rule.label }}</a>{% if not forloop.last %}, {% endif %}
             {% endfor %}
         </p>
     {% endif %}

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -285,3 +285,8 @@ def random_int(a, b=None):
     if b is None:
         a, b = 0, a
     return randint(a, b)
+
+
+@register.filter
+def get_item(dictionary, key):
+    return dictionary.get(key, "")

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -84,3 +84,17 @@ def test_date_handle_date_and_datetime():
     )
 
     assert result == "\n".join(["2021-04-16", "2021-04-17"])
+
+
+@pytest.mark.parametrize(
+    "a_dict,key,expected",
+    (
+        ({}, "", ""),
+        ({}, "hi", ""),
+        ({"hello": 1}, "hello", "1"),
+    ),
+)
+def test_get_item(a_dict, key, expected):
+    prefix = '{% load sentry_helpers %} {{ something|get_item:"' + key + '" }}'
+    result = engines["django"].from_string(prefix).render(context={"something": a_dict}).strip()
+    assert result == expected


### PR DESCRIPTION
This adds links to the new issue alert status pages to both the digest and individual alert emails.
Example digest
![Screen Shot 2022-03-03 at 4 21 39 PM](https://user-images.githubusercontent.com/6288560/156678571-6b48b642-1ff3-4105-9e07-6035a0f33016.png)

Example individual
![Screen Shot 2022-03-03 at 4 21 32 PM](https://user-images.githubusercontent.com/6288560/156678577-be3e09d0-002e-4710-ba70-05a6a22700bb.png)

