### PR TITLE
fix(ui): Form field label required mark isnt on the same row

### DIFF
--- a/static/app/views/alerts/incidentRules/triggers/form.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/form.tsx
@@ -369,13 +369,9 @@ const StyledIconDiamond = styled(IconDiamond)`
 `;
 
 const StyledField = styled(Field)<{hasAlertWizardV3: boolean}>`
-  & > label > div > span {
-    ${p =>
-      p.hasAlertWizardV3 &&
-      `
-      display: flex;
-      flex-direction: row;
-    `}
+  & > label > div:first-child > span {
+    display: flex;
+    flex-direction: row;
   }
 `;
 


### PR DESCRIPTION
Before:
<img width="307" alt="old" src="https://user-images.githubusercontent.com/15015880/156692356-a75a3727-4832-4c3a-a5dc-4e28f4e3af01.png">

After:
<img width="307" alt="new" src="https://user-images.githubusercontent.com/15015880/156692345-a62a9e0a-e25d-42a8-8dd4-c231d9e60f15.png">

