### PR TITLE
feat(alerts): Redirect wizard to details page after alert creation

### DIFF
--- a/static/app/views/alerts/incidentRules/create.tsx
+++ b/static/app/views/alerts/incidentRules/create.tsx
@@ -32,15 +32,22 @@ type Props = {
  * Show metric rules form with an empty rule. Redirects to alerts list after creation.
  */
 function IncidentRulesCreate(props: Props) {
-  function handleSubmitSuccess() {
+  function handleSubmitSuccess(data: any) {
     const {router, project} = props;
     const {orgId} = props.params;
+    const alertRuleId: string | undefined = data
+      ? (data.id as string | undefined)
+      : undefined;
 
     metric.endTransaction({name: 'saveAlertRule'});
-    router.push({
-      pathname: `/organizations/${orgId}/alerts/rules/`,
-      query: {project: project.id},
-    });
+    router.push(
+      alertRuleId
+        ? {pathname: `/organizations/${orgId}/alerts/rules/details/${alertRuleId}/`}
+        : {
+            pathname: `/organizations/${orgId}/alerts/rules/`,
+            query: {project: project.id},
+          }
+    );
   }
 
   const {project, eventView, wizardTemplate, sessionId, userTeamIds, ...otherProps} =

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -251,8 +251,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     metric.endTransaction({name: 'saveAlertRule'});
 
     router.push({
-      pathname: `/organizations/${organization.slug}/alerts/rules/`,
-      query: {project: project.id},
+      pathname: `/organizations/sentry/alerts/rules/${project.slug}/${rule.id}/details/`,
     });
     addSuccessMessage(isNew ? t('Created alert rule') : t('Updated alert rule'));
   };

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -250,9 +250,16 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
     metric.endTransaction({name: 'saveAlertRule'});
 
-    router.push({
-      pathname: `/organizations/sentry/alerts/rules/${project.slug}/${rule.id}/details/`,
-    });
+    router.push(
+      organization.features.includes('alert-rule-status-page')
+        ? {
+            pathname: `/organizations/sentry/alerts/rules/${project.slug}/${rule.id}/details/`,
+          }
+        : {
+            pathname: `/organizations/${organization.slug}/alerts/rules/`,
+            query: {project: project.id},
+          }
+    );
     addSuccessMessage(isNew ? t('Created alert rule') : t('Updated alert rule'));
   };
 


### PR DESCRIPTION
This redirects the app to the alert details page after successfully creating an alert rule. Redirects to the appropriately different links for metric and issue alert rules.

Jira: [WOR-1653](https://getsentry.atlassian.net/browse/WOR-1653)