### PR TITLE
ref(dam): Refactor metricsWidgetQuery columns and aggregates [DD-633]

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/metricsWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/metricsWidgetQueries.tsx
@@ -164,7 +164,7 @@ class MetricsWidgetQueries extends React.Component<Props, State> {
         groupBy: columns.length ? columns : undefined,
         interval,
         limit: this.limit,
-        orderBy: query.orderby || this.limit ? query.fields[0] : undefined,
+        orderBy: query.orderby || (this.limit ? aggregates[0] : undefined),
         project: projects,
         query: query.conditions,
         start,

--- a/static/app/views/dashboardsV2/widgetCard/metricsWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/metricsWidgetQueries.tsx
@@ -10,7 +10,7 @@ import {t} from 'sentry/locale';
 import {MetricsApiResponse, OrganizationSummary, PageFilters} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
-import {getAggregateFields} from 'sentry/utils/discover/fields';
+import {getColumnsAndAggregates} from 'sentry/utils/discover/fields';
 import {TOP_N} from 'sentry/utils/discover/types';
 import {transformMetricsResponseToSeries} from 'sentry/utils/metrics/transformMetricsResponseToSeries';
 import {transformMetricsResponseToTable} from 'sentry/utils/metrics/transformMetricsResponseToTable';
@@ -152,17 +152,16 @@ class MetricsWidgetQueries extends React.Component<Props, State> {
     const {environments, projects, datetime} = selection;
     const {start, end, period} = datetime;
     const interval = getWidgetInterval(widget, {start, end, period});
-    const widgetQuery = widget.queries[0];
-    const fields = getAggregateFields(widgetQuery.fields);
-    const groupingColumns = widgetQuery.fields.filter(field => !!!fields.includes(field));
+
+    const {aggregates, columns} = getColumnsAndAggregates(widget.queries[0].fields); // all queries have the same fields, filters differ
 
     const promises = widget.queries.map(query => {
       const requestData = {
-        field: fields,
+        field: aggregates,
         orgSlug: organization.slug,
         end,
         environment: environments,
-        groupBy: groupingColumns.length ? groupingColumns : undefined, // TODO(dam): add backend groupBy support
+        groupBy: columns.length ? columns : undefined,
         interval,
         limit: this.limit,
         orderBy: query.orderby || this.limit ? query.fields[0] : undefined,


### PR DESCRIPTION
Refactoring to use `getColumnsAndAggregates` helper function. 
It's got the same functionality, but the temporary manual distinction between columns and aggregates will be now localized to one function.

This PR also makes sure that orderBy never gets a tag (it happened when the first row in table visualization was a tag).