### PR TITLE
fix(profiling): Fix group by app version in chart

### DIFF
--- a/static/app/views/profiling/landing/profilingScatterChart.tsx
+++ b/static/app/views/profiling/landing/profilingScatterChart.tsx
@@ -55,7 +55,10 @@ function ProfilingScatterChart({
   const data: Record<string, Trace[]> = useMemo(() => {
     const dataMap = {};
     for (const row of traces) {
-      const seriesName = row[colorEncoding];
+      const seriesName =
+        colorEncoding === 'version'
+          ? `${row.app_version_name} (build ${row.app_version})`
+          : row[colorEncoding];
       if (!dataMap[seriesName]) {
         dataMap[seriesName] = [];
       }

--- a/static/app/views/profiling/utils.tsx
+++ b/static/app/views/profiling/utils.tsx
@@ -6,20 +6,18 @@ import {defined} from 'sentry/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
 
 type ColorEncoding =
-  | 'app_version'
+  | 'version' // this will use a concatenation of `app_version_name` and `app_version`
   | 'device_manufacturer'
   | 'device_model'
   | 'device_os_version'
-  | 'interaction_name'
-  | 'android_api_level';
+  | 'interaction_name';
 
 const COLOR_ENCODING_LABELS: Record<ColorEncoding, string> = {
-  app_version: t('App Version'),
+  version: t('App Version'),
   device_manufacturer: t('Device Manufacturer'),
   device_model: t('Device Model'),
   device_os_version: t('Device Os Version'),
   interaction_name: t('Interaction Name'),
-  android_api_level: t('Android Api Level'),
 };
 
 export const COLOR_ENCODINGS: SelectValue<ColorEncoding>[] = Object.entries(


### PR DESCRIPTION
The app version of a profile should be the concatenation of app_version_name and
app_version. This fixes the group by app version in the scatter chart to respect
that.