### PR TITLE
ref(ui): Enforce max-width on dropdown labels

### DIFF
--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -165,6 +165,7 @@ const TitleContainer = styled('div')`
 `;
 
 const DropdownTitle = styled('div')`
+  width: max-content;
   display: flex;
   overflow: hidden;
   align-items: center;


### PR DESCRIPTION
Should force dropdown labels to expand to the text content, unless the parent container is explicitly making them smaller.