### PR TITLE
ref(models): `create_or_update()` -> `update_or_create()`

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -533,7 +533,7 @@ def main(num_events=1, extra_events=False, load_trends=False, slow=False):
                 authors=[str(a.id) for a in authors],
             )
 
-            ReleaseProjectEnvironment.objects.create_or_update(
+            ReleaseProjectEnvironment.objects.update_or_create(
                 project=project,
                 environment=environment,
                 release=release,
@@ -705,7 +705,7 @@ def main(num_events=1, extra_events=False, load_trends=False, slow=False):
 
             mocks_loaded.send(project=project, sender=__name__)
 
-        OrganizationAccessRequest.objects.create_or_update(member=dummy_member, team=team)
+        OrganizationAccessRequest.objects.update_or_create(member=dummy_member, team=team)
 
     create_mock_transactions(project_map, load_trends, slow)
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -6,6 +6,8 @@ from django.db import models, transaction
 from django.db.models.query_utils import DeferredAttribute
 from pytz import UTC
 from rest_framework import serializers, status
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from bitfield.types import BitHandler
 from sentry import roles
@@ -445,10 +447,6 @@ class OwnerOrganizationSerializer(OrganizationSerializer):
         return super().save(*args, **kwargs)
 
 
-from rest_framework.request import Request
-from rest_framework.response import Response
-
-
 class OrganizationDetailsEndpoint(OrganizationEndpoint):
     def get(self, request: Request, organization) -> Response:
         """
@@ -586,12 +584,12 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
 
 
 def flag_has_changed(org, flag_name):
-    "Returns ``True`` if ``flag`` has changed since initialization."
+    """Returns ``True`` if ``flag`` has changed since initialization."""
     return getattr(old_value(org, "flags"), flag_name, None) != getattr(org.flags, flag_name)
 
 
 def update_tracked_data(model):
-    "Updates a local copy of attributes values"
+    """Updates a local copy of attributes values"""
     if model.id:
         data = {}
         for f in model._meta.fields:
@@ -621,7 +619,7 @@ def get_field_value(model, field):
 
 
 def has_changed(model, field_name):
-    "Returns ``True`` if ``field`` has changed since initialization."
+    """Returns ``True`` if ``field`` has changed since initialization."""
     if model.__data is UNSAVED:
         return False
     field = model._meta.get_field(field_name)
@@ -632,7 +630,7 @@ def has_changed(model, field_name):
 
 
 def old_value(model, field_name):
-    "Returns the previous value of ``field``"
+    """Returns the previous value of ``field``"""
     if model.__data is UNSAVED:
         return None
     value = model.__data.get(field_name)

--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -38,19 +38,20 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
         ):
             return Response(status=422)
 
-        values = {}
-
+        values = {"user": request.user}
         if status:
             values["status"] = status
             values["date_completed"] = timezone.now()
         if completion_seen:
             values["completion_seen"] = timezone.now()
 
-        rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
-            organization=organization, task=task_id, values=values, defaults={"user": request.user}
+        task, created = OrganizationOnboardingTask.objects.update_or_create(
+            organization=organization,
+            task=task_id,
+            defaults=values,
         )
 
-        if rows_affected or created:
+        if task or created:
             try_mark_onboarding_complete(organization.id)
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -34,12 +34,12 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
 
         if serializer.is_valid():
             result = serializer.validated_data
-            SavedSearch.objects.create_or_update(
+            SavedSearch.objects.update_or_create(
                 organization=organization,
                 name=PINNED_SEARCH_NAME,
                 owner=request.user,
                 type=result["type"],
-                values={"query": result["query"], "sort": result["sort"]},
+                defaults={"query": result["query"], "sort": result["sort"]},
             )
             pinned_search = SavedSearch.objects.get(
                 organization=organization, owner=request.user, type=result["type"]

--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -60,13 +60,13 @@ class OrganizationRecentSearchesEndpoint(OrganizationEndpoint):
         if serializer.is_valid():
             result = serializer.validated_data
 
-            created = RecentSearch.objects.create_or_update(
+            _, created = RecentSearch.objects.update_or_create(
                 organization=organization,
                 user=request.user,
                 type=result["type"],
                 query=result["query"],
-                values={"last_seen": timezone.now()},
-            )[1]
+                defaults={"last_seen": timezone.now()},
+            )
             if created:
                 remove_excess_recent_searches(organization, request.user, result["type"])
             status = 201 if created else 204

--- a/src/sentry/api/endpoints/project_search_details.py
+++ b/src/sentry/api/endpoints/project_search_details.py
@@ -87,8 +87,8 @@ class ProjectSearchDetailsEndpoint(ProjectEndpoint):
             )
 
         if result.get("isUserDefault"):
-            SavedSearchUserDefault.objects.create_or_update(
-                user=request.user, project=project, values={"savedsearch": search}
+            SavedSearchUserDefault.objects.update_or_create(
+                user=request.user, project=project, defaults={"savedsearch": search}
             )
 
         return Response(serialize(search, request.user))

--- a/src/sentry/api/endpoints/project_searches.py
+++ b/src/sentry/api/endpoints/project_searches.py
@@ -81,7 +81,7 @@ class ProjectSearchesEndpoint(ProjectEndpoint):
                         )
 
                 if result.get("isUserDefault"):
-                    SavedSearchUserDefault.objects.create_or_update(
+                    SavedSearchUserDefault.objects.update_or_create(
                         savedsearch=search, user=request.user, project=project
                     )
 

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -100,8 +100,10 @@ class PromptsActivityEndpoint(Endpoint):
 
         try:
             with transaction.atomic():
-                PromptsActivity.objects.create_or_update(
-                    feature=feature, user=request.user, values={"data": data}, **fields
+                PromptsActivity.objects.update_or_create(
+                    feature=feature,
+                    user=request.user,
+                    defaults={"data": data, **fields},
                 )
         except IntegrityError:
             pass

--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -110,11 +110,11 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
             )
 
             for project in projects:
-                ReleaseProjectEnvironment.objects.create_or_update(
+                ReleaseProjectEnvironment.objects.update_or_create(
                     release=release,
                     environment=env,
                     project=project,
-                    values={"last_deploy_id": deploy.id},
+                    defaults={"last_deploy_id": deploy.id},
                 )
 
             Deploy.notify_if_ready(deploy.id)

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -1,6 +1,9 @@
-import logging
+from __future__ import annotations
 
-from django.db.models import F
+import logging
+from typing import Any, Mapping
+
+from django.db.models import F, Model
 
 from sentry.signals import buffer_incr_complete
 from sentry.tasks.process_buffer import process_incr
@@ -57,7 +60,14 @@ class Buffer(Service, metaclass=BufferMount):
     def process_pending(self, partition=None):
         return []
 
-    def process(self, model, columns, filters, extra=None, signal_only=None):
+    def process(
+        self,
+        model: Model,
+        columns: Mapping[str, Any],
+        filters: Mapping[str, Any],
+        extra: Mapping[str, Any] | None = None,
+        signal_only: bool | None = None,
+    ) -> None:
         from sentry.event_manager import ScoreClause
         from sentry.models import Group
 

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -78,7 +78,7 @@ class Buffer(Service, metaclass=BufferMount):
                     last_seen=update_kwargs["last_seen"],
                 )
 
-            _, created = model.objects.create_or_update(values=update_kwargs, **filters)
+            _, created = model.objects.update_or_create(defaults=update_kwargs, **filters)
 
         buffer_incr_complete.send_robust(
             model=model,

--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -2,7 +2,7 @@ import logging
 import threading
 import weakref
 from contextlib import contextmanager
-from typing import Any, Generator, Generic, Mapping, MutableMapping, Optional, Sequence, Tuple
+from typing import Any, Generator, Generic, Mapping, MutableMapping, Optional, Sequence
 
 from django.conf import settings
 from django.db import router
@@ -12,7 +12,6 @@ from django.db.models.signals import class_prepared, post_delete, post_init, pos
 
 from sentry.db.models.manager import M, make_key
 from sentry.db.models.manager.base_query_set import BaseQuerySet
-from sentry.db.models.query import create_or_update
 from sentry.utils.cache import cache
 from sentry.utils.compat import zip
 from sentry.utils.hashlib import md5_text
@@ -409,9 +408,6 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
             self.__post_save(instance=instance)
 
         return final_results
-
-    def create_or_update(self, **kwargs: Any) -> Tuple[Any, bool]:
-        return create_or_update(self.model, **kwargs)
 
     def uncache_object(self, instance_id: int) -> None:
         pk_name = self.model._meta.pk.name

--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -221,7 +221,7 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
         class_prepared.connect(self.__class_prepared, sender=model)
 
     def get(self, *args: Any, **kwargs: Any) -> M:
-        # Explicitly typing to satisfy mypy.
+        # TODO(mgaeta): Remove this method once we add django types.
         model: M = super().get(*args, **kwargs)
         return model
 
@@ -264,14 +264,12 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
                     local_cache[cache_key] = result
                 return result
 
-            # If we didn't look up by pk we need to hit the reffed
-            # key
+            # If we didn't look up by pk we need to hit the reffed key.
             if key != pk_name:
                 result = self.get_from_cache(**{pk_name: retval})
                 if local_cache is not None:
                     local_cache[cache_key] = result
                 return result
-
             if not isinstance(retval, self.model):
                 if settings.DEBUG:
                     raise ValueError("Unexpected value type returned from cache")
@@ -415,14 +413,12 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
         cache.delete(cache_key, version=self.cache_version)
 
     def post_save(self, instance: M, **kwargs: Any) -> None:
-        """
-        Triggered when a model bound to this manager is saved.
-        """
+        """Triggered when a model bound to this manager is saved."""
+        pass
 
     def post_delete(self, instance: M, **kwargs: Any) -> None:
-        """
-        Triggered when a model bound to this manager is deleted.
-        """
+        """Triggered when a model bound to this manager is deleted."""
+        pass
 
     def get_queryset(self) -> BaseQuerySet:
         """

--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import itertools
 from functools import reduce
-from typing import Any, Tuple, Type, cast
+from typing import Any, Type, cast
 
 from django.db import IntegrityError, router, transaction
 from django.db.models import Model, Q
@@ -12,7 +11,6 @@ from django.db.models.signals import post_save
 from .utils import resolve_combined_expression
 
 __all__ = (
-    "create_or_update",
     "update",
     "update_or_create",
 )
@@ -34,9 +32,8 @@ def _handle_key(model: Type[Model], key: str, value: Any) -> str:
 
 
 def update(instance: Model, using: str | None = None, **kwargs: Any) -> int:
-    """
-    Updates specified attributes on the current instance.
-    """
+    """Updates specified attributes on the current instance."""
+
     assert instance.pk, "Cannot update an instance that has not yet been created."
 
     using = using or router.db_for_write(instance.__class__, instance=instance)
@@ -106,59 +103,6 @@ def update_or_create(
             return objects.create(**create_kwargs), True
     except IntegrityError:
         pass
-
-    return affected, False
-
-
-def create_or_update(
-    model: Type[Model], using: str | None = None, **kwargs: Any
-) -> Tuple[int, bool]:
-    """
-    Similar to get_or_create, either updates a row or creates it.
-
-    In order to determine if the row exists, this searches on all of the kwargs
-    besides `values` and `default`.
-
-    If the row exists, it is updated with the data in `values`. If it
-    doesn't, it is created with the data in `values`, `defaults`, and the remaining
-    kwargs.
-
-    The result will be (rows affected, False) if the row was not created,
-    or (instance, True) if the object is new.
-
-    >>> create_or_update(MyModel, key='value', values={
-    >>>     'col_name': F('col_name') + 1,
-    >>> }, defaults={'created_at': timezone.now()})
-    """
-    values = kwargs.pop("values", {})
-    defaults = kwargs.pop("defaults", {})
-
-    if not using:
-        using = router.db_for_write(model)
-
-    objects = model.objects.using(using)
-
-    affected = objects.filter(**kwargs).update(**values)
-    if affected:
-        return affected, False
-
-    create_kwargs = kwargs.copy()
-    inst = objects.model()
-    for k, v in itertools.chain(values.items(), defaults.items()):
-        # XXX(dcramer): we want to support column shortcut on create so
-        # we can do create_or_update(..., {'project': 1})
-        if not isinstance(v, Model):
-            k = model._meta.get_field(k).attname
-        if isinstance(v, CombinedExpression):
-            create_kwargs[k] = resolve_combined_expression(inst, v)
-        else:
-            create_kwargs[k] = v
-
-    try:
-        with transaction.atomic(using=using):
-            return objects.create(**create_kwargs), True
-    except IntegrityError:
-        affected = objects.filter(**kwargs).update(**values)
 
     return affected, False
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -190,7 +190,7 @@ class ScoreClause(Func):
 
     def __int__(self):
         # Calculate the score manually when coercing to an int.
-        # This is used within create_or_update and friends
+        # This is used within update_or_create and friends
         return self.group.get_score() if self.group else 0
 
     def as_sql(self, compiler, connection, function=None, template=None):

--- a/src/sentry/incidents/endpoints/organization_incident_seen.py
+++ b/src/sentry/incidents/endpoints/organization_incident_seen.py
@@ -3,12 +3,14 @@ from rest_framework.response import Response
 
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.incidents.logic import set_incident_seen
+from sentry.incidents.models import Incident
+from sentry.models import Organization
 
 
 class OrganizationIncidentSeenEndpoint(IncidentEndpoint):
     permission_classes = (IncidentPermission,)
 
-    def post(self, request: Request, organization, incident) -> Response:
+    def post(self, request: Request, organization: Organization, incident: Incident) -> Response:
         """
         Mark an incident as seen by the user
         ````````````````````````````````````

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -198,8 +198,8 @@ def set_incident_seen(incident, user=None):
                 break
 
         if is_project_member:
-            incident_seen, created = IncidentSeen.objects.create_or_update(
-                incident=incident, user=user, values={"last_seen": timezone.now()}
+            incident_seen, created = IncidentSeen.objects.update_or_create(
+                incident=incident, user=user, defaults={"last_seen": timezone.now()}
             )
             return incident_seen
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -32,7 +34,7 @@ from sentry.incidents.models import (
     IncidentTrigger,
     TriggerStatus,
 )
-from sentry.models import Integration, PagerDutyService, Project, SentryApp
+from sentry.models import Integration, PagerDutyService, Project, SentryApp, User
 from sentry.search.events.fields import resolve_field
 from sentry.search.events.filter import get_filter
 from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
@@ -181,10 +183,8 @@ def update_incident_status(
         return incident
 
 
-def set_incident_seen(incident, user=None):
-    """
-    Updates the incident to be seen
-    """
+def set_incident_seen(incident: Incident, user: User | None = None) -> IncidentSeen | None:
+    """Updates the incident to be seen."""
 
     is_org_member = incident.organization.has_access(user)
 
@@ -203,7 +203,7 @@ def set_incident_seen(incident, user=None):
             )
             return incident_seen
 
-    return False
+    return None
 
 
 @transaction.atomic

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -405,11 +405,11 @@ class PullRequestEventWebhook(Webhook):
             )
 
         try:
-            PullRequest.create_or_save(
+            PullRequest.objects.update_or_create(
                 organization_id=organization.id,
                 repository_id=repo.id,
                 key=number,
-                values={
+                defaults={
                     "organization_id": organization.id,
                     "title": title,
                     "author": author,

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -124,11 +124,11 @@ class MergeEventWebhook(Webhook):
         )[0]
 
         try:
-            PullRequest.create_or_save(
+            PullRequest.objects.update_or_create(
                 organization_id=organization.id,
                 repository_id=repo.id,
                 key=number,
-                values={
+                defaults={
                     "title": title,
                     "author": author,
                     "message": body,

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -150,7 +150,7 @@ class PagerDutyIntegrationProvider(IntegrationProvider):
 
         with transaction.atomic():
             for service in services:
-                PagerDutyService.objects.create_or_update(
+                PagerDutyService.objects.update_or_create(
                     organization_integration=org_integration,
                     integration_key=service["integration_key"],
                     service_name=service["name"],

--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -147,7 +147,7 @@ class FeatureAdoptionManager(BaseManager):
             return False
 
         if not self.in_cache(organization_id, feature_id):
-            row, created = self.create_or_update(
+            row, created = self.update_or_create(
                 organization_id=organization_id, feature_id=feature_id, complete=True
             )
             self.set_cache(organization_id, feature_id)

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from enum import Enum
 from functools import reduce
 from operator import or_
-from typing import TYPE_CHECKING, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 from django.db import models
 from django.db.models import Q, QuerySet
@@ -29,6 +29,7 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
+from sentry.db.models.query import update_or_create
 from sentry.eventstore.models import Event
 from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.types.activity import ActivityType
@@ -204,6 +205,9 @@ def get_oldest_or_latest_event_for_environments(
 
 class GroupManager(BaseManager):
     use_for_related_fields = True
+
+    def update_or_create(self, **kwargs: Any) -> tuple[Model, bool]:
+        return update_or_create(self.model, **kwargs)
 
     def by_qualified_short_id(self, organization_id: int, short_id: str):
         return self.by_qualified_short_id_bulk(organization_id, [short_id])[0]

--- a/src/sentry/models/groupmeta.py
+++ b/src/sentry/models/groupmeta.py
@@ -77,7 +77,7 @@ class GroupMetaManager(BaseManager):
             pass
 
     def set_value(self, instance, key, value):
-        self.create_or_update(group=instance, key=key, values={"value": value})
+        self.update_or_create(group=instance, key=key, defaults={"value": value})
         self.__cache.setdefault(instance.id, {})
         self.__cache[instance.id][key] = value
 

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -40,7 +40,7 @@ class OrganizationOptionManager(OptionManager["Organization"]):
         self.reload_cache(organization.id, "organizationoption.unset_value")
 
     def set_value(self, organization: Organization, key: str, value: Value) -> None:
-        self.create_or_update(organization=organization, key=key, values={"value": value})
+        self.update_or_create(organization=organization, key=key, defaults={"value": value})
         self.reload_cache(organization.id, "organizationoption.set_value")
 
     def get_all_values(self, organization: Organization) -> Mapping[str, Value]:

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -282,7 +282,7 @@ class Organization(Model):
                     organizationmember=from_member, is_active=True
                 ).select_related()
                 for omt in qs:
-                    OrganizationMemberTeam.objects.create_or_update(
+                    OrganizationMemberTeam.objects.update_or_create(
                         organizationmember=to_member, team=omt.team, defaults={"is_active": True}
                     )
             logger.info(

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from django.conf import settings
 from django.core.cache import cache
 from django.db import IntegrityError, models, transaction
@@ -52,6 +56,13 @@ class OnboardingTaskStatus:
 
 
 class OrganizationOnboardingTaskManager(BaseManager):
+    def update_or_create(self, **kwargs: Any) -> tuple[Model | None, bool]:
+        defaults = kwargs.pop("defaults", {})
+        try:
+            return super().update_or_create(defaults=defaults, **kwargs)
+        except IntegrityError:
+            return None, False
+
     def record(self, organization_id, task, **kwargs):
         cache_key = f"organizationonboardingtask:{organization_id}:{task}"
         if cache.get(cache_key) is None:

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -793,11 +793,11 @@ class Release(Model):
                     organization_id=self.organization_id, repository_id=repo.id, key=ref["commit"]
                 )[0]
                 # update head commit for repo/release if exists
-                ReleaseHeadCommit.objects.create_or_update(
+                ReleaseHeadCommit.objects.update_or_create(
                     organization_id=self.organization_id,
                     repository_id=repo.id,
                     release=self,
-                    values={"commit": commit},
+                    defaults={"commit": commit},
                 )
             if fetch:
                 fetch_commits.apply_async(
@@ -1062,9 +1062,9 @@ class Release(Model):
                     router.db_for_write(Activity),
                 )
             ):
-                GroupResolution.objects.create_or_update(
+                GroupResolution.objects.update_or_create(
                     group_id=group_id,
-                    values={
+                    defaults={
                         "release": self,
                         "type": GroupResolution.Type.in_release,
                         "status": GroupResolution.Status.resolved,

--- a/src/sentry/models/scheduledeletion.py
+++ b/src/sentry/models/scheduledeletion.py
@@ -40,11 +40,11 @@ class ScheduledDeletion(Model):
     @classmethod
     def schedule(cls, instance, days=30, hours=0, data=None, actor=None):
         model_name = type(instance).__name__
-        record, created = cls.objects.create_or_update(
+        record, created = cls.objects.update_or_create(
             app_label=instance._meta.app_label,
             model_name=model_name,
             object_id=instance.pk,
-            values={
+            defaults={
                 "date_scheduled": timezone.now() + timedelta(days=days, hours=hours),
                 "data": data or {},
                 "actor_id": actor.id if actor else None,

--- a/src/sentry/models/userip.py
+++ b/src/sentry/models/userip.py
@@ -41,5 +41,5 @@ class UserIP(Model):
         if geo:
             values.update({"country_code": geo["country_code"], "region_code": geo["region"]})
 
-        UserIP.objects.create_or_update(user=user, ip_address=ip_address, values=values)
+        UserIP.objects.update_or_create(user=user, ip_address=ip_address, defaults=values)
         cache.set(cache_key, 1, 300)

--- a/src/sentry/nodestore/django/backend.py
+++ b/src/sentry/nodestore/django/backend.py
@@ -4,7 +4,6 @@ import pickle
 
 from django.utils import timezone
 
-from sentry.db.models import create_or_update
 from sentry.nodestore.base import NodeStorage
 from sentry.utils.strings import compress, decompress
 
@@ -49,7 +48,9 @@ class DjangoNodeStorage(NodeStorage):
         self._delete_cache_items(id_list)
 
     def _set_bytes(self, id, data, ttl=None):
-        create_or_update(Node, id=id, values={"data": compress(data), "timestamp": timezone.now()})
+        Node.objects.update_or_create(
+            id=id, defaults={"data": compress(data), "timestamp": timezone.now()}
+        )
 
     def cleanup(self, cutoff_timestamp):
         from sentry.db.deletion import BulkDeleteQuery

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -185,10 +185,8 @@ class OptionsStore:
         return self.set_cache(key, value)
 
     def set_store(self, key, value):
-        from sentry.db.models.query import create_or_update
-
-        create_or_update(
-            model=self.model, key=key.name, values={"value": value, "last_updated": timezone.now()}
+        self.model.objects.update_or_create(
+            key=key.name, defaults={"value": value, "last_updated": timezone.now()}
         )
 
     def set_cache(self, key, value):

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -119,11 +119,11 @@ def record_first_event(project, event, **kwargs):
     # If complete, pass (creation fails due to organization, task unique constraint)
     # If pending, update.
     # If does not exist, create.
-    rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
+    task, created = OrganizationOnboardingTask.objects.update_or_create(
         organization_id=project.organization_id,
         task=OnboardingTask.FIRST_EVENT,
         status=OnboardingTaskStatus.PENDING,
-        values={
+        defaults={
             "status": OnboardingTaskStatus.COMPLETE,
             "project_id": project.id,
             "date_completed": project.first_event,
@@ -140,7 +140,7 @@ def record_first_event(project, event, **kwargs):
         )
         return
 
-    if rows_affected or created:
+    if task or created:
         analytics.record(
             "first_event.sent",
             user_id=user.id,
@@ -159,18 +159,18 @@ def record_first_event(project, event, **kwargs):
 
     # Only counts if it's a new project
     if oot.project_id != project.id:
-        rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
+        task, created = OrganizationOnboardingTask.objects.update_or_create(
             organization_id=project.organization_id,
             task=OnboardingTask.SECOND_PLATFORM,
             status=OnboardingTaskStatus.PENDING,
-            values={
+            defaults={
                 "status": OnboardingTaskStatus.COMPLETE,
                 "project_id": project.id,
                 "date_completed": project.first_event,
                 "data": {"platform": event.platform},
             },
         )
-        if rows_affected or created:
+        if task or created:
             analytics.record(
                 "second_platform.added",
                 user_id=user.id,
@@ -225,17 +225,17 @@ def record_member_invited(member, user, **kwargs):
 
 @member_joined.connect(weak=False)
 def record_member_joined(member, organization, **kwargs):
-    rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
+    task, created = OrganizationOnboardingTask.objects.update_or_create(
         organization_id=member.organization_id,
         task=OnboardingTask.INVITE_MEMBER,
         status=OnboardingTaskStatus.PENDING,
-        values={
+        defaults={
             "status": OnboardingTaskStatus.COMPLETE,
             "date_completed": timezone.now(),
             "data": {"invited_member_id": member.id},
         },
     )
-    if created or rows_affected:
+    if task or created:
         try_mark_onboarding_complete(member.organization_id)
 
 
@@ -371,10 +371,10 @@ def record_plugin_enabled(plugin, project, user, **kwargs):
 
 @alert_rule_created.connect(weak=False)
 def record_alert_rule_created(user, project, rule, **kwargs):
-    rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
+    task, created = OrganizationOnboardingTask.objects.update_or_create(
         organization_id=project.organization_id,
         task=OnboardingTask.ALERT_RULE,
-        values={
+        defaults={
             "status": OnboardingTaskStatus.COMPLETE,
             "user": user,
             "project_id": project.id,
@@ -382,17 +382,17 @@ def record_alert_rule_created(user, project, rule, **kwargs):
         },
     )
 
-    if rows_affected or created:
+    if task or created:
         try_mark_onboarding_complete(project.organization_id)
 
 
 @issue_tracker_used.connect(weak=False)
 def record_issue_tracker_used(plugin, project, user, **kwargs):
-    rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
+    task, created = OrganizationOnboardingTask.objects.update_or_create(
         organization_id=project.organization_id,
         task=OnboardingTask.ISSUE_TRACKER,
         status=OnboardingTaskStatus.PENDING,
-        values={
+        defaults={
             "status": OnboardingTaskStatus.COMPLETE,
             "user": user,
             "project_id": project.id,
@@ -401,7 +401,7 @@ def record_issue_tracker_used(plugin, project, user, **kwargs):
         },
     )
 
-    if rows_affected or created:
+    if task or created:
         try_mark_onboarding_complete(project.organization_id)
 
     if user and user.is_authenticated:

--- a/src/sentry/tasks/app_store_connect.py
+++ b/src/sentry/tasks/app_store_connect.py
@@ -167,8 +167,10 @@ def process_builds(
             if not build_state.fetched:
                 pending_builds.append((build, build_state))
 
-    LatestAppConnectBuildsCheck.objects.create_or_update(
-        project=project, source_id=config.id, values={"last_checked": timezone.now()}
+    LatestAppConnectBuildsCheck.objects.update_or_create(
+        project=project,
+        source_id=config.id,
+        defaults={"last_checked": timezone.now()},
     )
 
     return pending_builds

--- a/src/sentry/tasks/collect_project_platforms.py
+++ b/src/sentry/tasks/collect_project_platforms.py
@@ -32,8 +32,10 @@ def collect_project_platforms(**kwargs):
             platform = platform.lower()
             if platform not in VALID_PLATFORMS:
                 continue
-            ProjectPlatform.objects.create_or_update(
-                project_id=project_id, platform=platform, values={"last_seen": now}
+            ProjectPlatform.objects.update_or_create(
+                project_id=project_id,
+                platform=platform,
+                defaults={"last_seen": now},
             )
         min_project_id += step
 

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -217,10 +217,10 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
                     ).values("deploy_id"),
                     date_finished__gt=date_finished,
                 ).exists():
-                    LatestRepoReleaseEnvironment.objects.create_or_update(
+                    LatestRepoReleaseEnvironment.objects.update_or_create(
                         repository_id=repository_id,
                         environment_id=environment_id,
-                        values={
+                        defaults={
                             "release_id": release.id,
                             "deploy_id": deploy_id,
                             "commit_id": commit_id,

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -65,7 +65,7 @@ def _process_suspect_commits(
                     :PREFERRED_GROUP_OWNERS
                 ]:
                     try:
-                        go, created = GroupOwner.objects.update_or_create(
+                        _, created = GroupOwner.objects.update_or_create(
                             group_id=group_id,
                             type=GroupOwnerType.SUSPECT_COMMIT.value,
                             user_id=owner_id,

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -291,11 +291,10 @@ def repair_group_environment_data(caches, project, events):
         if first_release:
             fields["first_release"] = caches["Release"](project.organization_id, first_release)
 
-        GroupEnvironment.objects.create_or_update(
+        GroupEnvironment.objects.update_or_create(
             environment_id=caches["Environment"](project.organization_id, env_name).id,
             group_id=group_id,
             defaults=fields,
-            values=fields,
         )
 
 

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -275,7 +275,7 @@ def truncate_denormalizations(project, group):
 
 
 def collect_group_environment_data(events):
-    """\
+    """
     Find the first release for a each group and environment pair from a
     date-descending sorted list of events.
     """

--- a/src/sentry/web/frontend/unsubscribe_issue_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_issue_notifications.py
@@ -18,6 +18,9 @@ class UnsubscribeIssueNotificationsView(UnsubscribeBaseView):
         return instance.get_absolute_url()
 
     def unsubscribe(self, instance, user):
-        GroupSubscription.objects.create_or_update(
-            group=instance, project=instance.project, user=user, values={"is_active": False}
+        GroupSubscription.objects.update_or_create(
+            group=instance,
+            project=instance.project,
+            user=user,
+            defaults={"is_active": False},
         )

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -482,12 +482,12 @@ class GitHubAppsRepositoryProvider(GitHubRepositoryProvider):
 
         for repo in self.get_repositories(integration):
             # TODO(jess): figure out way to migrate from github --> github apps
-            Repository.objects.create_or_update(
+            Repository.objects.update_or_create(
                 organization_id=organization.id,
                 name=repo["name"],
                 external_id=repo["external_id"],
                 provider="github_apps",
-                values={
+                defaults={
                     "integration_id": integration.id,
                     "url": repo["url"],
                     "config": repo["config"],

--- a/src/sentry_plugins/github/webhooks/events/pull_request.py
+++ b/src/sentry_plugins/github/webhooks/events/pull_request.py
@@ -82,10 +82,11 @@ class PullRequestEventWebhook(Webhook):
                 )
 
         try:
-            PullRequest.objects.create_or_update(
+            PullRequest.objects.update_or_create(
+                organization_id=organization.id,
                 repository_id=repo.id,
                 key=number,
-                values={
+                defaults={
                     "organization_id": organization.id,
                     "title": title,
                     "author": author,

--- a/tests/acceptance/test_dashboard.py
+++ b/tests/acceptance/test_dashboard.py
@@ -56,7 +56,7 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
             last_seen=datetime(2018, 1, 13, 3, 8, 25, tzinfo=timezone.utc),
         )
         GroupAssignee.objects.create(user=self.user, group=event.group, project=self.project)
-        OrganizationOnboardingTask.objects.create_or_update(
+        OrganizationOnboardingTask.objects.update_or_create(
             organization_id=self.project.organization_id,
             task=OnboardingTask.FIRST_EVENT,
             status=OnboardingTaskStatus.COMPLETE,

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -88,7 +88,10 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         )
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 35
+        expected_queries = 28
+
+        # UserIP.objects.update_or_create()
+        expected_queries += 9
 
         # TODO(mgaeta): Extra query while we're "dual reading" from UserOptions and NotificationSettings.
         expected_queries += 1

--- a/tests/sentry/buffer/base/tests.py
+++ b/tests/sentry/buffer/base/tests.py
@@ -63,8 +63,8 @@ class BufferTest(TestCase):
         release_project_ = ReleaseProject.objects.get(id=release_project.id)
         assert release_project_.new_groups == 1
 
-    @mock.patch("sentry.models.Group.objects.create_or_update")
-    def test_signal_only(self, create_or_update):
+    @mock.patch("sentry.models.Group.objects.update_or_create")
+    def test_signal_only(self, update_or_create):
         group = Group.objects.create(project=Project(id=1))
         columns = {"times_seen": 1}
         filters = {"id": group.id, "project_id": 1}

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -673,9 +673,9 @@ class EventManagerTest(TestCase):
             }
         )
 
-        external_issue = ExternalIssue.objects.get_or_create(
+        external_issue, _ = ExternalIssue.objects.get_or_create(
             organization_id=org.id, integration_id=integration.id, key="APP-%s" % group.id
-        )[0]
+        )
 
         GroupLink.objects.get_or_create(
             group_id=group.id,

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -157,7 +157,8 @@ class EventManagerTest(TestCase):
         with self.tasks():
             event2 = manager.save(project.id)
 
-        # make sure that events did get into same group because of fallback grouping, not because of hashes which come from primary grouping only
+        # Make sure that events did get into same group because of fallback
+        # grouping, not because of hashes which come from primary grouping only.
         assert not set(event.get_hashes().hashes) & set(event2.get_hashes().hashes)
         assert event.group_id == event2.group_id
 
@@ -226,7 +227,8 @@ class EventManagerTest(TestCase):
         # Switching to newstyle grouping changes hashes as 123 will be removed
         event2 = save_event(2)
 
-        # make sure that events did get into same group because of fallback grouping, not because of hashes which come from primary grouping only
+        # Make sure that events did get into same group because of fallback
+        # grouping, not because of hashes which come from primary grouping only.
         assert not set(event.get_hashes().hashes) & set(event2.get_hashes().hashes)
         assert event.group_id == event2.group_id
 
@@ -683,7 +685,7 @@ class EventManagerTest(TestCase):
             linked_type=GroupLink.LinkedType.issue,
             linked_id=external_issue.id,
             relationship=GroupLink.Relationship.references,
-        )[0]
+        )
 
         group.update(status=GroupStatus.RESOLVED)
 

--- a/tests/sentry/event_manager/test_save_aggregate.py
+++ b/tests/sentry/event_manager/test_save_aggregate.py
@@ -38,7 +38,7 @@ def test_group_creation_race(monkeypatch, default_project, is_race_free):
                 yield
 
         # Disable transaction isolation just within event manager, but not in
-        # GroupHash.objects.create_or_update
+        # GroupHash.objects.update_or_create
         monkeypatch.setattr("sentry.event_manager.transaction", FakeTransactionModule)
 
         # select_for_update cannot be used outside of transactions

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -40,12 +40,12 @@ class UserDetailsTest(TestCase):
 class UserMergeToTest(TestCase):
     def test_simple(self):
         from_user = self.create_user("foo@example.com")
-        UserEmail.objects.create_or_update(
-            user=from_user, email=from_user.email, values={"is_verified": True}
+        UserEmail.objects.update_or_create(
+            user=from_user, email=from_user.email, defaults={"is_verified": True}
         )
         to_user = self.create_user("bar@example.com")
-        UserEmail.objects.create_or_update(
-            user=to_user, email=to_user.email, values={"is_verified": True}
+        UserEmail.objects.update_or_create(
+            user=to_user, email=to_user.email, defaults={"is_verified": True}
         )
         auth1 = Authenticator.objects.create(user=from_user, type=1)
         auth2 = Authenticator.objects.create(user=to_user, type=1)

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -14,7 +14,7 @@ class QuotaTest(TestCase):
         org = self.create_organization()
         project = self.create_project(organization=org)
 
-        with self.assertNumQueries(7), self.settings(SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE=0):
+        with self.assertNumQueries(9), self.settings(SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE=0):
             with self.options({"system.rate-limit": 0}):
                 assert self.backend.get_project_quota(project) == (None, 60)
 


### PR DESCRIPTION
This PR drops in [`update_or_create()` from django 2+](https://docs.djangoproject.com/en/4.0/ref/models/querysets/#update-or-create) as a replacement for `create_or_update()` and fixes up some behavior. My theory is that we created `create_or_update()` when we were [still on django 1](https://github.com/getsentry/sentry/commit/af97d0fb99948f6e08e8d3ac874cb9ae1b7916b8).

The old helper was doing three things that we'd lose and have to do manually:
- swallowing `IntegrityError`s that would be thrown if the created object would conflict
- separating "update kwargs" from "create kwargs"
- resolving expression values like `col_name=F("col_name") + 1`

I think these tradeoffs are worth the consistency of the standard django query API.

See https://github.com/getsentry/getsentry/pull/7134.