### PR TITLE
fix(page-filters): Fix date comparison for desynced values

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -463,13 +463,13 @@ async function updateDesyncedUrlState(router?: Router) {
     currentQuery.utc !== null ||
     currentQuery.period !== null;
 
-  // Is the datetime filter differning?
+  // Is the datetime filter different?
   if (
     pinnedFilters.has('datetime') &&
     dateTimeInQuery &&
     (currentQuery.period !== storedState.period ||
-      currentQuery.start !== storedState.start ||
-      currentQuery.end !== storedState.end ||
+      currentQuery.start?.getTime() !== storedState.start?.getTime() ||
+      currentQuery.end?.getTime() !== storedState.end?.getTime() ||
       currentQuery.utc !== storedState.utc)
   ) {
     differingFilters.add('datetime');


### PR DESCRIPTION
Due to the way we compare dates any time there was an absolute date time the previous logic would think there was a desynced value between the query params and stored state. 

Use `.getTime()` to do a comparison on value rather than identity.