### PR TITLE
fix(workflow): Remove seen by column from alert history table

### DIFF
--- a/static/app/views/alerts/rules/details/metricHistory.tsx
+++ b/static/app/views/alerts/rules/details/metricHistory.tsx
@@ -162,7 +162,7 @@ function MetricHistory({organization, incidents}: Props) {
 export default MetricHistory;
 
 const StyledPanelTable = styled(PanelTable)<{expanded: boolean; isEmpty: boolean}>`
-  grid-template-columns: max-content 1fr 0.2fr 0.5fr;
+  grid-template-columns: max-content 1fr repeat(2, max-content);
 
   & > div {
     padding: ${space(1)} ${space(2)};

--- a/static/app/views/alerts/rules/details/metricHistory.tsx
+++ b/static/app/views/alerts/rules/details/metricHistory.tsx
@@ -10,8 +10,6 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import Link from 'sentry/components/links/link';
 import PanelTable from 'sentry/components/panels/panelTable';
 import StatusIndicator from 'sentry/components/statusIndicator';
-import Tooltip from 'sentry/components/tooltip';
-import {IconShow} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
@@ -107,14 +105,6 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
         })}
       </Cell>
       <Cell>{threshold}</Cell>
-      <SeenByCell>
-        <IconWrapper>
-          <Tooltip title={t('People who have viewed this')} skipWrapper>
-            <StyledIconShow size="xs" color="gray200" />
-          </Tooltip>
-          {incident.seenBy.length}
-        </IconWrapper>
-      </SeenByCell>
       <StyledDateTime
         date={getDynamicText({
           value: incident.dateCreated,
@@ -143,13 +133,7 @@ function MetricHistory({organization, incidents}: Props) {
       {({isExpanded, showMoreButton}) => (
         <div>
           <StyledPanelTable
-            headers={[
-              t('Alert'),
-              t('Reason'),
-              t('Duration'),
-              t('Seen By'),
-              t('Date Triggered'),
-            ]}
+            headers={[t('Alert'), t('Reason'), t('Duration'), t('Date Triggered')]}
             isEmpty={!numOfIncidents}
             emptyMessage={t('No alerts triggered during this time.')}
             expanded={numOfIncidents <= COLLAPSE_COUNT || isExpanded}
@@ -178,7 +162,7 @@ function MetricHistory({organization, incidents}: Props) {
 export default MetricHistory;
 
 const StyledPanelTable = styled(PanelTable)<{expanded: boolean; isEmpty: boolean}>`
-  grid-template-columns: max-content 3fr repeat(3, max-content);
+  grid-template-columns: max-content 1fr 0.2fr 0.5fr;
 
   & > div {
     padding: ${space(1)} ${space(2)};
@@ -223,18 +207,4 @@ const Cell = styled('div')`
   white-space: nowrap;
   font-size: ${p => p.theme.fontSizeMedium};
   padding: ${space(1)};
-`;
-
-const SeenByCell = styled(Cell)`
-  justify-content: flex-end;
-`;
-
-const IconWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: end;
-`;
-
-const StyledIconShow = styled(IconShow)`
-  margin-right: ${space(0.5)};
 `;


### PR DESCRIPTION
Remove seen by column.

# Before
<img width="833" alt="Screen Shot 2022-03-04 at 3 28 12 PM" src="https://user-images.githubusercontent.com/20312973/156856070-fef37841-9797-4b75-9fa0-11d5a542de18.png">

# After
<img width="851" alt="Screen Shot 2022-03-04 at 3 24 20 PM" src="https://user-images.githubusercontent.com/20312973/156856079-1dd00bac-2eda-47df-a573-d76081c0791e.png">


