### PR TITLE
feat(alertStatus): Remove alert status badge, clean up slack

### DIFF
--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -27,6 +27,7 @@ export type IssueAlertRuleActionTemplate = {
   enabled: boolean;
   id: string;
   label: string;
+  name: string;
   prompt: string;
   actionType?: 'ticket' | 'sentryapp';
   formFields?:

--- a/static/app/views/alerts/details/sidebar.tsx
+++ b/static/app/views/alerts/details/sidebar.tsx
@@ -1,7 +1,6 @@
 import {Fragment, PureComponent} from 'react';
 import styled from '@emotion/styled';
 
-import AlertBadge from 'sentry/components/alertBadge';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
@@ -34,9 +33,20 @@ class Sidebar extends PureComponent<Props> {
         ))
       : '';
     const actions = rule.actions.length
-      ? rule.actions.map(action => (
-          <ConditionsBadge key={action.id}>{action.name}</ConditionsBadge>
-        ))
+      ? rule.actions.map(action => {
+          let name = action.name;
+          if (
+            action.id ===
+            'sentry.integrations.slack.notify_action.SlackNotifyServiceAction'
+          ) {
+            // Remove (optionally, an ID: XXX) from slack action
+            name = name.replace(/\(optionally.*\)/, '');
+            // Remove tags if they aren't used
+            name = name.replace(' and show tags [] in notification', '');
+          }
+
+          return <ConditionsBadge key={action.id}>{name}</ConditionsBadge>;
+        })
       : '';
 
     return (
@@ -98,7 +108,6 @@ class Sidebar extends PureComponent<Props> {
   render() {
     const {rule} = this.props;
     const dateTriggered = new Date(0);
-    const dateModified = new Date(0);
 
     const ownerId = rule.owner?.split(':')[1];
     const teamActor = ownerId && {type: 'team' as Actor['type'], id: ownerId, name: ''};
@@ -106,12 +115,6 @@ class Sidebar extends PureComponent<Props> {
     return (
       <Fragment>
         <StatusContainer>
-          <HeaderItem>
-            <Heading noMargin>{t('Alert Status')}</Heading>
-            <Status>
-              <AlertBadge status={undefined} />
-            </Status>
-          </HeaderItem>
           <HeaderItem>
             <Heading noMargin>{t('Last Triggered')}</Heading>
             <Status>
@@ -140,12 +143,6 @@ class Sidebar extends PureComponent<Props> {
               <KeyValueTableRow
                 keyName={t('Created By')}
                 value={<CreatedBy>{rule.createdBy.name ?? '-'}</CreatedBy>}
-              />
-            )}
-            {dateModified && (
-              <KeyValueTableRow
-                keyName={t('Last Modified')}
-                value={<TimeSince date={dateModified} suffix={t('ago')} />}
               />
             )}
             <KeyValueTableRow


### PR DESCRIPTION
- removes the alert status badge until we have a solution for it
- removes the modified date, it doesn't exist yet

changes slack action from 
<img width="351" alt="Screen Shot 2022-03-04 at 5 00 14 PM" src="https://user-images.githubusercontent.com/1400464/156861133-75a69bf7-b383-4ac8-aeb0-7ef7b830eab0.png">



to 
<img width="344" alt="Screen Shot 2022-03-04 at 5 00 24 PM" src="https://user-images.githubusercontent.com/1400464/156861110-f4ed5ef4-4ab6-466d-bad6-8cff5e2395e9.png">

