### PR TITLE
feat(metrics): Re-structure metrics queries

### DIFF
--- a/src/sentry/snuba/metrics/helpers.py
+++ b/src/sentry/snuba/metrics/helpers.py
@@ -10,6 +10,7 @@ __all__ = (
     "MetricType",
     "MetricUnit",
     "OPERATIONS",
+    "OP_TO_SNUBA_FUNCTION",
     "QueryDefinition",
     "SnubaQueryBuilder",
     "SnubaResultConverter",
@@ -345,7 +346,7 @@ class MetricMetaWithTagKeys(MetricMeta):
 
 
 # Map requested op name to the corresponding Snuba function
-_OP_TO_SNUBA_FUNCTION = {
+OP_TO_SNUBA_FUNCTION = {
     "metrics_counters": {"sum": "sumIf"},
     "metrics_distributions": {
         "avg": "avgIf",
@@ -363,7 +364,7 @@ _OP_TO_SNUBA_FUNCTION = {
 }
 
 AVAILABLE_OPERATIONS = {
-    type_: sorted(mapping.keys()) for type_, mapping in _OP_TO_SNUBA_FUNCTION.items()
+    type_: sorted(mapping.keys()) for type_, mapping in OP_TO_SNUBA_FUNCTION.items()
 }
 OPERATIONS_TO_ENTITY = {
     op: entity for entity, operations in AVAILABLE_OPERATIONS.items() for op in operations
@@ -457,7 +458,7 @@ class SnubaQueryBuilder:
 
     @staticmethod
     def _build_conditional_aggregate_for_metric(entity, op, name):
-        snuba_function = _OP_TO_SNUBA_FUNCTION[entity][op]
+        snuba_function = OP_TO_SNUBA_FUNCTION[entity][op]
         return Function(
             snuba_function,
             [Column("value"), Function("equals", [Column("metric_id"), resolve_weak(name)])],

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -915,7 +915,9 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         )
 
         groups = response.data["groups"]
-        assert len(groups) == 0
+        assert len(groups) == 1
+        assert groups[0]["totals"]["sum(sentry.sessions.session)"] == 0
+        assert groups[0]["series"]["sum(sentry.sessions.session)"] == [0]
 
 
 class OrganizationMetricMetaIntegrationTest(SessionMetricsTestCase, APITestCase):


### PR DESCRIPTION
This PR:
- Re-structures select statements as conditional aggregates and so removes the groupBy metric_id applied on all metrics queries
- Fixes bug where previous aliasing based on op only might lead to unexpected results. See -> https://github.com/getsentry/sentry/pull/32348/files#diff-c12479cc2192867aeb089c61f8f33c3dd727cad20b01039147b6620385244ad7L486