### PR TITLE
fix(new-widget-builder-experience): Fix weird widget library width in breakpoint

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -1100,12 +1100,17 @@ const Main = styled(Layout.Main)`
 const Side = styled(Layout.Side)`
   padding: ${space(4)} ${space(2)};
 
-  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+  @media (min-width: ${p => p.theme.breakpoints[3]}) {
     border-left: 1px solid ${p => p.theme.gray200};
   }
 
-  @media (max-width: ${p => p.theme.breakpoints[2]}) {
+  @media (max-width: ${p => p.theme.breakpoints[3]}) {
     border-top: 1px solid ${p => p.theme.gray200};
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints[3]}) {
+    grid-row: 2/2;
+    grid-column: 1/1;
   }
 `;
 


### PR DESCRIPTION
Unfortunately, our breakpoints are not always good and in some cases, we have to offer a mobile experience due to some issues (like this one) even if there is still quite a good amount of space.

**Before:**
![image](https://user-images.githubusercontent.com/29228205/157040271-d82ccea3-c14f-4243-85bc-560c36f342de.png)


**After:**
![image](https://user-images.githubusercontent.com/29228205/157040421-92b35e34-a6e8-4a98-ba4b-3c1f1a9c7a7e.png)
