### PR TITLE
feat(alertStatus): Use group-history endpoint to fetch issues in alert status page

### DIFF
--- a/static/app/views/alerts/details/issuesList.tsx
+++ b/static/app/views/alerts/details/issuesList.tsx
@@ -15,6 +15,11 @@ import {Group, Organization, Project} from 'sentry/types';
 import {IssueAlertRule} from 'sentry/types/alerts';
 import {getMessage, getTitle} from 'sentry/utils/events';
 
+type GroupHistory = {
+  count: number;
+  group: Group;
+};
+
 type Props = AsyncComponent['props'] &
   DateTimeObject & {
     organization: Organization;
@@ -24,12 +29,7 @@ type Props = AsyncComponent['props'] &
   };
 
 type State = AsyncComponent['state'] & {
-  groupHistory:
-    | {
-        count: number;
-        group: Group;
-      }[]
-    | null;
+  groupHistory: GroupHistory[] | null;
 };
 
 class AlertRuleIssuesList extends AsyncComponent<Props, State> {

--- a/static/app/views/alerts/details/issuesList.tsx
+++ b/static/app/views/alerts/details/issuesList.tsx
@@ -84,7 +84,7 @@ class AlertRuleIssuesList extends AsyncComponent<Props, State> {
 
   renderBody() {
     const {organization} = this.props;
-    const {loading, groupHistory, issuesPageLinks} = this.state;
+    const {loading, groupHistory, groupHistoryPageLinks} = this.state;
 
     return (
       <Fragment>
@@ -123,7 +123,7 @@ class AlertRuleIssuesList extends AsyncComponent<Props, State> {
           })}
         </StyledPanelTable>
         <PaginationWrapper>
-          <StyledPagination pageLinks={issuesPageLinks} size="xsmall" />
+          <StyledPagination pageLinks={groupHistoryPageLinks} size="xsmall" />
         </PaginationWrapper>
       </Fragment>
     );

--- a/static/app/views/alerts/details/ruleDetails.tsx
+++ b/static/app/views/alerts/details/ruleDetails.tsx
@@ -231,6 +231,7 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
             <AlertRuleIssuesList
               organization={organization}
               project={project}
+              rule={rule}
               period={period ?? ''}
               start={start ?? null}
               end={end ?? null}

--- a/static/app/views/alerts/details/sidebar.tsx
+++ b/static/app/views/alerts/details/sidebar.tsx
@@ -97,6 +97,7 @@ class Sidebar extends PureComponent<Props> {
 
   render() {
     const {rule} = this.props;
+    // TODO: update this with rule's dateTriggered and dateModified when api updates
     const dateTriggered = new Date(0);
     const dateModified = new Date(0);
 

--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -52,8 +52,8 @@ describe('AlertRuleDetails', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/`,
-      body: [TestStubs.Group()],
+      url: `/projects/${organization.slug}/${project.slug}/rules/${rule.id}/group-history/`,
+      body: [{count: 1, group: TestStubs.Group()}],
       headers: {
         Link:
           '<https://sentry.io/api/0/organizations/org-slug/issues/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
@@ -78,20 +78,6 @@ describe('AlertRuleDetails', () => {
     expect(await screen.findByText('My alert rule')).toBeInTheDocument();
     expect(screen.getByText('RequestError:')).toBeInTheDocument();
     expect(screen.getByText('Apr 11, 2019 1:08:59 AM UTC')).toBeInTheDocument();
-  });
-
-  it('should allow paginating results', async () => {
-    createWrapper();
-
-    expect(await screen.findByLabelText('Next')).toBeEnabled();
-    userEvent.click(screen.getByLabelText('Next'));
-
-    expect(browserHistory.push).toHaveBeenCalledWith({
-      pathname: '/mock-pathname/',
-      query: {
-        cursor: '0:100:0',
-      },
-    });
   });
 
   it('should reset pagination cursor on date change', async () => {

--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -56,8 +56,8 @@ describe('AlertRuleDetails', () => {
       body: [{count: 1, group: TestStubs.Group()}],
       headers: {
         Link:
-          '<https://sentry.io/api/0/organizations/org-slug/issues/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
-          '<https://sentry.io/api/0/organizations/org-slug/issues/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"',
+          '<https://sentry.io/api/0/projects/org-slug/project-slug/rules/1/group-history/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
+          '<https://sentry.io/api/0/projects/org-slug/project-slug/rules/1/group-history/?cursor=0:0:1>; rel="next"; results="true"; cursor="0:100:0"',
       },
     });
     MockApiClient.addMockResponse({
@@ -78,6 +78,20 @@ describe('AlertRuleDetails', () => {
     expect(await screen.findByText('My alert rule')).toBeInTheDocument();
     expect(screen.getByText('RequestError:')).toBeInTheDocument();
     expect(screen.getByText('Apr 11, 2019 1:08:59 AM UTC')).toBeInTheDocument();
+  });
+
+  it('should allow paginating results', async () => {
+    createWrapper();
+
+    expect(await screen.findByLabelText('Next')).toBeEnabled();
+    userEvent.click(screen.getByLabelText('Next'));
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: '/mock-pathname/',
+      query: {
+        cursor: '0:100:0',
+      },
+    });
   });
 
   it('should reset pagination cursor on date change', async () => {

--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -57,7 +57,7 @@ describe('AlertRuleDetails', () => {
       headers: {
         Link:
           '<https://sentry.io/api/0/projects/org-slug/project-slug/rules/1/group-history/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
-          '<https://sentry.io/api/0/projects/org-slug/project-slug/rules/1/group-history/?cursor=0:0:1>; rel="next"; results="true"; cursor="0:100:0"',
+          '<https://sentry.io/api/0/projects/org-slug/project-slug/rules/1/group-history/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"',
       },
     });
     MockApiClient.addMockResponse({


### PR DESCRIPTION
This replaces the place holder organization issues request with the new group-history request, also changed the alerts and events columns values with correct values.

Jira: [WOR-1676](https://getsentry.atlassian.net/browse/WOR-1676)