### PR TITLE
fix(ui): Use active hover background for menu item

### DIFF
--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -124,13 +124,7 @@ const StyledTruncate = styled(Truncate)<{
   isActive: boolean;
 }>`
   & span {
-    ${p =>
-      p.isActive &&
-      `
-      color: ${p.theme.white};
-      background: ${p.theme.active};
-      border: none;
-    `}
+    ${p => p.isActive && 'border: none;'}
   }
 `;
 

--- a/static/app/components/menuItem.tsx
+++ b/static/app/components/menuItem.tsx
@@ -202,7 +202,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
       background: ${props.theme.active};
 
       &:hover {
-        color: ${props.theme.black};
+        background: ${props.theme.activeHover};
       }
     `;
   }


### PR DESCRIPTION
Previously, menu items would change the text color of the active item to black
on hover. This looked unnatural. Instead, this change opts to use the
activeHover color for the background for a more consistent experience.