### PR TITLE
ref(sdk): Change reportAllChanges back to true temporarily

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -33,7 +33,7 @@ function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
         : {}),
       idleTimeout: 10000,
       _metricOptions: {
-        _reportAllChanges: false,
+        _reportAllChanges: true,
       },
     }),
   ];


### PR DESCRIPTION
This will change reportAllChanges features back to true to compare with the last few days of high idleTimeout data directly. Specifically checking that desired lcp element candidates haven't changed since that is what we want to collect against.