### PR TITLE
ref(sentry apps): Add ignored to list of issue webhooks

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/constants.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/constants.tsx
@@ -1,7 +1,7 @@
 export const EVENT_CHOICES = ['issue', 'error', 'comment'] as const;
 
 export const DESCRIPTIONS = {
-  issue: 'created, resolved, assigned',
+  issue: 'created, resolved, assigned, ignored',
   error: 'created',
   comment: 'created, edited, deleted',
 } as const;


### PR DESCRIPTION
When a user selects the "issue" webhooks checkbox, they are actually subscribed to created, resolved, assigned, ignored webhooks, but we don't mention the ignored one. This PR adds that to the list so users know what to expect. This is already in the documentation. 


**Before**
<img width="340" alt="Screen Shot 2022-03-07 at 9 58 31 AM" src="https://user-images.githubusercontent.com/29959063/157091141-7348c5b1-014a-4457-a611-3746ae4415e0.png">

**After**
<img width="325" alt="Screen Shot 2022-03-07 at 9 58 05 AM" src="https://user-images.githubusercontent.com/29959063/157091376-928ea079-eb34-4cae-b488-8b2102d4eb9c.png">

