### PR TITLE
fix(alerts): Pass correct project to metric alert details

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -45,9 +45,9 @@ type Props = {
   api: Client;
   location: Location;
   organization: Organization;
-  project: Project;
   timePeriod: TimePeriodType;
   incidents?: Incident[];
+  project?: Project;
   rule?: IncidentRule;
   selectedIncident?: Incident | null;
 } & RouteComponentProps<{orgId: string}, {}>;

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -186,31 +186,36 @@ class AlertRuleDetails extends Component<Props, State> {
 
     return (
       <Projects orgId={organization.slug} slugs={rule?.projects}>
-        {({projects}) => (
-          <PageFiltersContainer
-            shouldForceProject
-            forceProject={projects[0] as Project}
-            forceEnvironment={rule?.environment ?? ''}
-            lockedMessageSubject={t('alert rule')}
-            showDateSelector={false}
-          >
-            <SentryDocumentTitle title={rule?.name ?? ''} />
+        {({projects}) => {
+          const project = projects.find(({slug}) => slug === rule?.projects[0]) as
+            | Project
+            | undefined;
+          return (
+            <PageFiltersContainer
+              shouldForceProject
+              forceProject={project}
+              forceEnvironment={rule?.environment ?? ''}
+              lockedMessageSubject={t('alert rule')}
+              showDateSelector={false}
+            >
+              <SentryDocumentTitle title={rule?.name ?? ''} />
 
-            <DetailsHeader
-              hasIncidentRuleDetailsError={hasError}
-              params={params}
-              rule={rule}
-            />
-            <DetailsBody
-              {...this.props}
-              rule={rule}
-              project={projects[0] as Project}
-              incidents={incidents}
-              timePeriod={timePeriod}
-              selectedIncident={selectedIncident}
-            />
-          </PageFiltersContainer>
-        )}
+              <DetailsHeader
+                hasIncidentRuleDetailsError={hasError}
+                params={params}
+                rule={rule}
+              />
+              <DetailsBody
+                {...this.props}
+                rule={rule}
+                project={project}
+                incidents={incidents}
+                timePeriod={timePeriod}
+                selectedIncident={selectedIncident}
+              />
+            </PageFiltersContainer>
+          );
+        }}
       </Projects>
     );
   }

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -190,12 +190,12 @@ class AlertRuleDetails extends Component<Props, State> {
           const project = projects.find(({slug}) => slug === rule?.projects[0]) as
             | Project
             | undefined;
-          const globalSelectionReady = project !== undefined && !fetching;
+          const isGlobalSelectionReady = project !== undefined && !fetching;
 
           return (
             <PageFiltersContainer
-              isGlobalSelectionReady={globalSelectionReady}
-              shouldForceProject={globalSelectionReady}
+              isGlobalSelectionReady={isGlobalSelectionReady}
+              shouldForceProject={isGlobalSelectionReady}
               forceProject={project}
               forceEnvironment={rule?.environment ?? ''}
               lockedMessageSubject={t('alert rule')}

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -186,13 +186,16 @@ class AlertRuleDetails extends Component<Props, State> {
 
     return (
       <Projects orgId={organization.slug} slugs={rule?.projects}>
-        {({projects}) => {
+        {({projects, fetching}) => {
           const project = projects.find(({slug}) => slug === rule?.projects[0]) as
             | Project
             | undefined;
+          const globalSelectionReady = project !== undefined && !fetching;
+
           return (
             <PageFiltersContainer
-              shouldForceProject
+              isGlobalSelectionReady={globalSelectionReady}
+              shouldForceProject={globalSelectionReady}
               forceProject={project}
               forceEnvironment={rule?.environment ?? ''}
               lockedMessageSubject={t('alert rule')}

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -197,6 +197,7 @@ class AlertRuleDetails extends Component<Props, State> {
               forceEnvironment={rule?.environment ?? ''}
               lockedMessageSubject={t('alert rule')}
               showDateSelector={false}
+              skipLoadLastUsed
             >
               <SentryDocumentTitle title={rule?.name ?? ''} />
 


### PR DESCRIPTION
Fixes a bug with #32188 where the first project returned is passed, but is the wrong project.