### PR TITLE
fix(profiling): Use the empty profile duration on grid renderer when …

### DIFF
--- a/static/app/components/profiling/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph.tsx
@@ -67,8 +67,8 @@ function Flamegraph(props: FlamegraphProps): React.ReactElement {
   useEffect(() => {
     setFlamegraph(
       new FlamegraphModel(
-        props.profiles.profiles[flamegraph.profileIndex],
-        flamegraph.profileIndex,
+        props.profiles.profiles[props.profiles.activeProfileIndex],
+        props.profiles.activeProfileIndex,
         {
           inverted: view === 'bottom up',
           leftHeavy: sorting === 'left heavy',

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -49,21 +49,7 @@ export class Flamegraph {
 
     this.formatter = makeFormatter(profile.unit);
 
-    if (this.frames.length) {
-      this.configSpace = new Rect(this.startedAt, 0, this.duration, this.depth);
-    } else {
-      // If we have no frames, set the trace duration to 1 second so that we can render a placeholder grid
-      this.configSpace = new Rect(
-        this.startedAt,
-        0,
-        this.profile.unit === 'microseconds'
-          ? 1e6
-          : this.profile.unit === 'milliseconds'
-          ? 1e3
-          : 1,
-        0
-      );
-    }
+    this.configSpace = new Rect(this.startedAt, 0, this.duration, this.depth);
   }
 
   static Empty(): Flamegraph {

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -49,11 +49,26 @@ export class Flamegraph {
 
     this.formatter = makeFormatter(profile.unit);
 
-    this.configSpace = new Rect(this.startedAt, 0, this.duration, this.depth);
+    if (this.duration) {
+      this.configSpace = new Rect(this.startedAt, 0, this.duration, this.depth);
+    } else {
+      // If the profile duration is 0, set the flamegraph duration
+      // to 1 second so we can render a placeholder grid
+      this.configSpace = new Rect(
+        this.startedAt,
+        0,
+        this.profile.unit === 'microseconds'
+          ? 1e6
+          : this.profile.unit === 'milliseconds'
+          ? 1e3
+          : 1,
+        this.depth
+      );
+    }
   }
 
   static Empty(): Flamegraph {
-    return new Flamegraph(new Profile(0, 0, 1_000_000, 'Profile', 'microseconds'), 0, {
+    return new Flamegraph(Profile.Empty(), 0, {
       inverted: false,
       leftHeavy: false,
     });

--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -44,7 +44,7 @@ export class Profile {
   }
 
   static Empty() {
-    return new Profile(100000, 0, 100000, '', 'milliseconds').build();
+    return new Profile(1000, 0, 1000, '', 'milliseconds').build();
   }
 
   forEach(

--- a/tests/js/spec/utils/profiling/flamegraph.spec.tsx
+++ b/tests/js/spec/utils/profiling/flamegraph.spec.tsx
@@ -318,9 +318,7 @@ describe('flamegraph', () => {
   });
 
   it('Empty', () => {
-    expect(Flamegraph.Empty().configSpace.equals(new Rect(0, 0, 1_000_000, 0))).toBe(
-      true
-    );
+    expect(Flamegraph.Empty().configSpace.equals(new Rect(0, 0, 1_000, 0))).toBe(true);
   });
 
   it('withOffset', () => {

--- a/tests/js/spec/utils/profiling/profile/profile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/profile.spec.tsx
@@ -63,8 +63,8 @@ stack top -> stack bottom`;
 describe('Profile', () => {
   it('Empty profile duration is not infinity', () => {
     const profile = Profile.Empty();
-    expect(profile.duration).toEqual(100_000);
-    expect(profile.minFrameDuration).toEqual(100_000);
+    expect(profile.duration).toEqual(1000);
+    expect(profile.minFrameDuration).toEqual(1000);
   });
 
   it('forEach - iterates over a single sample', () => {


### PR DESCRIPTION
…loading

While loading, we should use the duration of the empty profile on the grid
renderer. Using a fixed 1s duration results in unexpected behaviour when the
width of the empty profile is longer.