### PR TITLE
ref(profiling): make a reusable useTraces hook

### DIFF
--- a/static/app/utils/profiling/hooks/useProfiles.tsx
+++ b/static/app/utils/profiling/hooks/useProfiles.tsx
@@ -27,15 +27,15 @@ function fetchTraces(
   });
 }
 
-interface UseTraceOptions {
+interface UseProfilesOptions {
   cursor: string | undefined;
   selection: PageFilters | undefined;
 }
 
-function useTraces({
+function useProfiles({
   cursor,
   selection,
-}: UseTraceOptions): [RequestState, Trace[], string | null] {
+}: UseProfilesOptions): [RequestState, Trace[], string | null] {
   const api = useApi();
   const organization = useOrganization();
 
@@ -63,4 +63,4 @@ function useTraces({
   return [requestState, traces, pageLinks];
 }
 
-export {useTraces};
+export {useProfiles};

--- a/static/app/utils/profiling/hooks/useTraces.tsx
+++ b/static/app/utils/profiling/hooks/useTraces.tsx
@@ -1,0 +1,66 @@
+import {useEffect, useState} from 'react';
+
+import {Client, ResponseMeta} from 'sentry/api';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {Organization, PageFilters} from 'sentry/types';
+import {Trace} from 'sentry/types/profiling/core';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type RequestState = 'initial' | 'loading' | 'resolved' | 'errored';
+
+function fetchTraces(
+  api: Client,
+  cursor: string | undefined,
+  organization: Organization,
+  selection: PageFilters
+): Promise<[Trace[], string | undefined, ResponseMeta | undefined]> {
+  return api.requestPromise(`/organizations/${organization.slug}/profiling/profiles/`, {
+    method: 'GET',
+    includeAllArgs: true,
+    query: {
+      cursor,
+      project: selection.projects,
+      environment: selection.environments,
+      ...normalizeDateTimeParams(selection.datetime),
+    },
+  });
+}
+
+interface UseTraceOptions {
+  cursor: string | undefined;
+  selection: PageFilters | undefined;
+}
+
+function useTraces({
+  cursor,
+  selection,
+}: UseTraceOptions): [RequestState, Trace[], string | null] {
+  const api = useApi();
+  const organization = useOrganization();
+
+  const [requestState, setRequestState] = useState<RequestState>('initial');
+  const [traces, setTraces] = useState<Trace[]>([]);
+  const [pageLinks, setPageLinks] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (selection === undefined) {
+      return;
+    }
+
+    api.clear();
+    setRequestState('loading');
+
+    fetchTraces(api, cursor, organization, selection)
+      .then(([_traces, , response]) => {
+        setTraces(_traces);
+        setPageLinks(response?.getResponseHeader('Link') ?? null);
+        setRequestState('resolved');
+      })
+      .catch(() => setRequestState('errored'));
+  }, [api, cursor, organization, selection]);
+
+  return [requestState, traces, pageLinks];
+}
+
+export {useTraces};

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -1,49 +1,24 @@
-import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import {Client, ResponseMeta} from 'sentry/api';
 import Alert from 'sentry/components/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import PageHeading from 'sentry/components/pageHeading';
 import Pagination from 'sentry/components/pagination';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconFlag} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
-import {Organization, PageFilters} from 'sentry/types';
-import {Trace} from 'sentry/types/profiling/core';
-import {defined} from 'sentry/utils';
+import {PageFilters} from 'sentry/types';
+import {useTraces} from 'sentry/utils/profiling/hooks/useTraces';
 import {decodeScalar} from 'sentry/utils/queryString';
-import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 
 import {ProfilingScatterChart} from './landing/profilingScatterChart';
 import {ProfilingTable} from './landing/profilingTable';
-
-type RequestState = 'initial' | 'loading' | 'resolved' | 'errored';
-
-function fetchProfiles(
-  api: Client,
-  cursor: string | undefined,
-  organization: Organization,
-  selection: PageFilters
-): Promise<[Trace[], string | undefined, ResponseMeta | undefined]> {
-  return api.requestPromise(`/organizations/${organization.slug}/profiling/profiles/`, {
-    method: 'GET',
-    includeAllArgs: true,
-    query: {
-      cursor,
-      project: selection.projects,
-      environment: selection.environments,
-      ...normalizeDateTimeParams(selection.datetime),
-    },
-  });
-}
 
 interface ProfilingContentProps {
   location: Location;
@@ -51,30 +26,9 @@ interface ProfilingContentProps {
 }
 
 function ProfilingContent({location, selection}: ProfilingContentProps) {
-  const [requestState, setRequestState] = useState<RequestState>('initial');
-  const [traces, setTraces] = useState<Trace[]>([]);
-  const [pageLinks, setPageLinks] = useState<string | null>(null);
   const organization = useOrganization();
   const cursor = decodeScalar(location.query.cursor);
-
-  const api = useApi();
-
-  useEffect(() => {
-    if (!defined(selection)) {
-      return;
-    }
-
-    api.clear();
-    setRequestState('loading');
-
-    fetchProfiles(api, cursor, organization, selection)
-      .then(([_traces, , response]) => {
-        setTraces(_traces);
-        setPageLinks(response?.getResponseHeader('Link') ?? null);
-        setRequestState('resolved');
-      })
-      .catch(() => setRequestState('errored'));
-  }, [api, cursor, organization, selection]);
+  const [requestState, traces, pageLinks] = useTraces({cursor, selection});
 
   return (
     <SentryDocumentTitle title={t('Profiling')} orgSlug={organization.slug}>

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -12,7 +12,7 @@ import {IconFlag} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import {PageFilters} from 'sentry/types';
-import {useTraces} from 'sentry/utils/profiling/hooks/useTraces';
+import {useProfiles} from 'sentry/utils/profiling/hooks/useProfiles';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useOrganization from 'sentry/utils/useOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
@@ -28,7 +28,7 @@ interface ProfilingContentProps {
 function ProfilingContent({location, selection}: ProfilingContentProps) {
   const organization = useOrganization();
   const cursor = decodeScalar(location.query.cursor);
-  const [requestState, traces, pageLinks] = useTraces({cursor, selection});
+  const [requestState, traces, pageLinks] = useProfiles({cursor, selection});
 
   return (
     <SentryDocumentTitle title={t('Profiling')} orgSlug={organization.slug}>


### PR DESCRIPTION
@Zylphrex we'll need to reuse the data fetching functionality for differential flamegraphs (users can select to compare traces from a list)