### PR TITLE
fix(workflow): User Misery tooltip copy

### DIFF
--- a/static/app/components/userMisery.tsx
+++ b/static/app/components/userMisery.tsx
@@ -38,7 +38,7 @@ function UserMisery(props: Props) {
     );
   } else if (defined(miseryLimit)) {
     title = tct(
-      'User Misery score is [userMisery], representing users who waited more than more than [duration]ms (4x the response time threshold)',
+      'User Misery score is [userMisery], representing users who waited more than [duration]ms (4x the response time threshold)',
       {
         duration: 4 * miseryLimit,
         userMisery: userMisery.toFixed(3),


### PR DESCRIPTION
Fix User Misery tooltip copy. Previously had 'more than' twice.

[FIXES WOR-1678](https://getsentry.atlassian.net/browse/WOR-1678)

Before

<img width="233" alt="Screen Shot 2022-03-07 at 12 26 59 PM" src="https://user-images.githubusercontent.com/20312973/157113108-ed197582-88ea-42d2-b518-16e958a82dd2.png">

After
<img width="234" alt="Screen Shot 2022-03-07 at 12 27 43 PM" src="https://user-images.githubusercontent.com/20312973/157113147-f9e816d6-7408-42da-a077-bc3253db2bfc.png">


