### PR TITLE
ref(sdk): Fix observer breaking on Safari

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -66,9 +66,13 @@ export const VisuallyCompleteWithData = ({
         });
       });
     });
-    observer.observe({entryTypes: ['longtask']});
+    if (observer && observer.observe) {
+      observer.observe({entryTypes: ['longtask']});
+    }
     return () => {
-      observer.disconnect();
+      if (observer && observer.disconnect) {
+        observer.disconnect();
+      }
     };
   }, []);
 


### PR DESCRIPTION
### Summary
Slipped past the check again on Safari, this will check observer exists and the functions exist