### PR TITLE
fix(new-widget-builder-experience): Use regex to split fields string [DD-649]

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -178,7 +178,7 @@ export function getParsedDefaultWidgetQuery(query = ''): WidgetQuery | undefined
     return undefined;
   }
 
-  const fields = parseFields(parsedQuery.fields);
+  const fields = parsedQuery.fields ? getFields(parsedQuery.fields) : [];
   const {columns, aggregates} = getColumnsAndAggregates(fields);
 
   return {
@@ -189,24 +189,7 @@ export function getParsedDefaultWidgetQuery(query = ''): WidgetQuery | undefined
   } as WidgetQuery;
 }
 
-/**
- * Retrieves the array of fields from a string.
- *
- * Since fields themselves can contain commas, we need to build
- * up each field to ensure we don't accidentally split a field.
- */
-function parseFields(fieldsString: string): string[] {
-  const exploded = fieldsString.split(',');
-  const completedFields: string[] = [];
-
-  let currentField: string[] = [];
-  exploded.forEach(term => {
-    currentField.push(term);
-    if (term.includes(')')) {
-      completedFields.push(currentField.join(','));
-      currentField = [];
-    }
-  });
-
-  return completedFields;
+export function getFields(fieldsString: string): string[] {
+  // Use a negative lookahead to avoid splitting on commas inside equation fields
+  return fieldsString.split(/,(?![^(]*\))/g) ?? [];
 }

--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -191,5 +191,5 @@ export function getParsedDefaultWidgetQuery(query = ''): WidgetQuery | undefined
 
 export function getFields(fieldsString: string): string[] {
   // Use a negative lookahead to avoid splitting on commas inside equation fields
-  return fieldsString.split(/,(?![^(]*\))/g) ?? [];
+  return fieldsString.split(/,(?![^(]*\))/g);
 }

--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -177,7 +177,8 @@ export function getParsedDefaultWidgetQuery(query = ''): WidgetQuery | undefined
   if (!Object.keys(parsedQuery).length) {
     return undefined;
   }
-  const fields = parsedQuery.fields?.split(',') ?? [];
+
+  const fields = parseFields(parsedQuery.fields);
   const {columns, aggregates} = getColumnsAndAggregates(fields);
 
   return {
@@ -186,4 +187,26 @@ export function getParsedDefaultWidgetQuery(query = ''): WidgetQuery | undefined
     columns,
     aggregates,
   } as WidgetQuery;
+}
+
+/**
+ * Retrieves the array of fields from a string.
+ *
+ * Since fields themselves can contain commas, we need to build
+ * up each field to ensure we don't accidentally split a field.
+ */
+function parseFields(fieldsString: string): string[] {
+  const exploded = fieldsString.split(',');
+  const completedFields: string[] = [];
+
+  let currentField: string[] = [];
+  exploded.forEach(term => {
+    currentField.push(term);
+    if (term.includes(')')) {
+      completedFields.push(currentField.join(','));
+      currentField = [];
+    }
+  });
+
+  return completedFields;
 }

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/utils.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/utils.spec.tsx
@@ -1,4 +1,4 @@
-import {mapErrors} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
+import {getFields, mapErrors} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
 
 describe('WidgetBuilder utils', function () {
   describe('mapErrors', function () {
@@ -14,6 +14,30 @@ describe('WidgetBuilder utils', function () {
         queries: [{fields: 'just a string'}],
         another: [{fields: 'another string'}],
       });
+    });
+  });
+
+  describe('getFields', function () {
+    it('splits simple fields by comma', function () {
+      const testFieldsString = 'title,transaction';
+      const actual = getFields(testFieldsString);
+      expect(actual).toEqual(['title', 'transaction']);
+    });
+
+    it('splits aggregate fields by comma', function () {
+      const testFieldsString = 'p75(),p95()';
+      const actual = getFields(testFieldsString);
+      expect(actual).toEqual(['p75()', 'p95()']);
+    });
+
+    it('does not split aggregates with inner commas', function () {
+      const testFieldsString = 'p75(),count_if(transaction.duration,equal,200),p95()';
+      const actual = getFields(testFieldsString);
+      expect(actual).toEqual([
+        'p75()',
+        'count_if(transaction.duration,equal,200)',
+        'p95()',
+      ]);
     });
   });
 });

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -876,6 +876,8 @@ describe('WidgetBuilder', function () {
       },
     });
 
+    await screen.findByText('Add Widget');
+
     expect(
       await screen.findByText('count_if(transaction.duration,equals,300)*2')
     ).toBeInTheDocument();

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -856,6 +856,31 @@ describe('WidgetBuilder', function () {
     });
   });
 
+  it('renders fields with commas properly', async () => {
+    const defaultWidgetQuery = {
+      conditions: '',
+      fields: ['equation|count_if(transaction.duration,equals,300)*2'],
+      orderby: '',
+      name: '',
+    };
+    const defaultTableColumns = [
+      'count_if(transaction.duration,equals,300)',
+      'equation|count_if(transaction.duration,equals,300)*2',
+    ];
+    renderTestComponent({
+      query: {
+        source: DashboardWidgetSource.DISCOVERV2,
+        defaultWidgetQuery: urlEncode(defaultWidgetQuery),
+        defaultTableColumns,
+        yAxis: ['equation|count_if(transaction.duration,equals,300)*2'],
+      },
+    });
+
+    expect(
+      await screen.findByText('count_if(transaction.duration,equals,300)*2')
+    ).toBeInTheDocument();
+  });
+
   describe('Widget creation coming from other verticals', function () {
     it('redirects correctly when creating a new dashboard', async function () {
       const {router} = renderTestComponent({


### PR DESCRIPTION
Setting the y-axis to a column that included a comma was rendering over multiple fields.

![Screen Shot 2022-03-07 at 3 35 01 PM](https://user-images.githubusercontent.com/22846452/157113651-0df4aca8-d727-4a7b-b5c0-82df61b838f4.png)

The problem was that we were splitting by just `,` when some fields can contain commas. This split captures commas not followed by open and closed parentheses