### PR TITLE
feat(dev): Do not write CPATH and LDFLAGS in .zshrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -153,6 +153,20 @@ else
     export SENTRY_DEVSERVICES_DSN=https://23670f54c6254bfd9b7de106637808e9@o1.ingest.sentry.io/1492057
 fi
 
+# We can remove these lines in few months
+if [ "$SHELL" == "/bin/zsh" ]; then
+    zshrc_path="${HOME}/.zshrc"
+    header="# Apple M1 environment variables"
+    if grep -qF "${header}" "${zshrc_path}"; then
+        echo -e "\n${red}Please delete from ${zshrc_path}, the following three lines:${reset}"
+        echo -e "${header}
+export CPATH=/opt/homebrew/Cellar/librdkafka/1.8.2/include
+export LDFLAGS=-L/opt/homebrew/Cellar/gettext/0.21/lib"
+        echo -e "\nWe have moved exporting of these variables to the right place."
+        return 1
+    fi
+fi
+
 ### System ###
 
 for pkg in \

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -113,11 +113,10 @@ install-py-dev() {
         # This saves having to install postgresql on the Developer's machine + using flags
         # https://github.com/psycopg/psycopg2/issues/1286
         pip install https://storage.googleapis.com/python-arm64-wheels/psycopg2_binary-2.8.6-cp38-cp38-macosx_11_0_arm64.whl
-        BREW_PATH="$(brew --prefix)/opt"
         # The CPATH is needed for confluent-kakfa --> https://github.com/confluentinc/confluent-kafka-python/issues/1190
-        export CPATH="${BREW_PATH}/librdkafka/include"
+        export CPATH="$(brew --prefix librdkafka)/include"
         # The LDFLAGS is needed for uWSGI --> https://github.com/unbit/uwsgi/issues/2361
-        export LDFLAGS="-L${BREW_PATH}/gettext/lib"
+        export LDFLAGS="-L$(brew --prefix gettext)/lib"
     fi
 
     # SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -113,6 +113,11 @@ install-py-dev() {
         # This saves having to install postgresql on the Developer's machine + using flags
         # https://github.com/psycopg/psycopg2/issues/1286
         pip install https://storage.googleapis.com/python-arm64-wheels/psycopg2_binary-2.8.6-cp38-cp38-macosx_11_0_arm64.whl
+        BREW_PATH="$(brew --prefix)/opt"
+        # The CPATH is needed for confluent-kakfa --> https://github.com/confluentinc/confluent-kafka-python/issues/1190
+        export CPATH="${BREW_PATH}/librdkafka/include"
+        # The LDFLAGS is needed for uWSGI --> https://github.com/unbit/uwsgi/issues/2361
+        export LDFLAGS="-L${BREW_PATH}/gettext/lib"
     fi
 
     # SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
@@ -130,30 +135,6 @@ patch-selenium() {
     if grep -q "or setting is" "${fx_profile}"; then
         echo "We are patching ${fx_profile}. You will see this message only once."
         patch -p0 <scripts/patches/firefox_profile.diff
-    fi
-}
-
-setup-apple-m1() {
-    ! query-apple-m1 && return
-
-    zshrc_path="${HOME}/.zshrc"
-    header="# Apple M1 environment variables"
-    # The CPATH is needed for confluent-kakfa --> https://github.com/confluentinc/confluent-kafka-python/issues/1190
-    # The LDFLAGS is needed for uWSGI --> https://github.com/unbit/uwsgi/issues/2361
-    body="
-$header
-export CPATH=/opt/homebrew/Cellar/librdkafka/1.8.2/include
-export LDFLAGS=-L/opt/homebrew/Cellar/gettext/0.21/lib"
-    if [ "$SHELL" == "/bin/zsh" ]; then
-        if ! grep -qF "${header}" "${zshrc_path}"; then
-            echo "Added the following to ${zshrc_path}"
-            cp "${zshrc_path}" "${zshrc_path}.bak"
-            echo -e "$body" >> "${zshrc_path}"
-            echo -e "$body"
-        fi
-    else
-        echo "You are not using a supported shell. Please add these variables where appropiate."
-        echo -e "$body"
     fi
 }
 
@@ -236,7 +217,6 @@ build-platform-assets() {
 }
 
 bootstrap() {
-    setup-apple-m1
     develop
     init-config
     run-dependent-services


### PR DESCRIPTION
First of all, updating it to correct values in the future is complicated.

Second, it had hard coded versions of the libraries. This means that future brew installations
could make it useless.

Exporting it as variables within the `make install-py-dev` target seems sufficient.

The negative of this approach means that `pip install` of these packages without using the make target would fail.