### PR TITLE
feat(auditlog): Add quota volumes

### DIFF
--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -394,8 +394,14 @@ class AuditLogEntry(Model):
             return f"changed on-demand budget to {next_ondemand_budget}"
         elif self.event == AuditLogEntryEvent.TRIAL_STARTED:
             return "started trial"
+
         elif self.event == AuditLogEntryEvent.PLAN_CHANGED:
-            return "changed plan to {}".format(self.data["plan_name"])
+            plan_name = self.data["plan_name"]
+            if "quotas" in self.data:
+                quotas = self.data["quotas"]
+                return f"changed plan to {plan_name} with {quotas}"
+            return f"changed plan to {plan_name}"
+
         elif self.event == AuditLogEntryEvent.PLAN_CANCELLED:
             return "cancelled plan"
 

--- a/tests/sentry/models/test_auditlogentry.py
+++ b/tests/sentry/models/test_auditlogentry.py
@@ -1,0 +1,34 @@
+from django.utils import timezone
+
+from sentry.models import AuditLogEntry, AuditLogEntryEvent
+from sentry.testutils import TestCase
+
+
+class AuditLogEntryTest(TestCase):
+    def test_plan_changed(self):
+        entry = AuditLogEntry.objects.create(
+            organization=self.organization,
+            event=AuditLogEntryEvent.PLAN_CHANGED,
+            actor=self.user,
+            datetime=timezone.now(),
+            data={"plan_name": "Team"},
+        )
+
+        assert entry.get_note() == "changed plan to Team"
+
+    def test_plan_changed_with_quotas(self):
+        entry = AuditLogEntry.objects.create(
+            organization=self.organization,
+            event=AuditLogEntryEvent.PLAN_CHANGED,
+            actor=self.user,
+            datetime=timezone.now(),
+            data={
+                "plan_name": "Team",
+                "quotas": "50K errors, 100K transactions, and 1 GB of attachments",
+            },
+        )
+
+        assert (
+            entry.get_note()
+            == "changed plan to Team with 50K errors, 100K transactions, and 1 GB of attachments"
+        )


### PR DESCRIPTION
Currently `AuditLogEntryEvent.PLAN_CHANGED` only displays the plan name in the audit log entry. Adding the selected volumes for errors, transactions, and quotas to the log entries for subscription changes to am_1 plans.