### PR TITLE
ref(settings): Update org avatar placeholder

### DIFF
--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -127,16 +127,12 @@ class SettingsIndex extends React.Component<SettingsIndexProps> {
               {!organization && <LoadingIndicator overlay hideSpinner />}
               <HomePanelHeader>
                 <HomeLinkIcon to={organizationSettingsUrl}>
-                  {organization ? (
-                    <AvatarContainer>
-                      <OrganizationAvatar
-                        organization={organization}
-                        size={HOME_ICON_SIZE}
-                      />
-                    </AvatarContainer>
-                  ) : (
-                    <OrgAvatarPlaceholder />
-                  )}
+                  <AvatarContainer>
+                    <OrganizationAvatar
+                      organization={organization}
+                      size={HOME_ICON_SIZE}
+                    />
+                  </AvatarContainer>
                   <OrganizationName>
                     {organization ? organization.slug : t('No Organization')}
                   </OrganizationName>
@@ -310,12 +306,6 @@ const HomeIcon = styled('div')<{color?: string}>`
   margin-bottom: 20px;
 `;
 
-const OrgAvatarPlaceholder = styled(HomeIcon)`
-  background: ${p => p.theme.backgroundSecondary};
-  border-radius: ${p => p.theme.borderRadius};
-  border: solid 1px ${p => p.theme.innerBorder};
-`;
-
 const HomeLink = styled(Link)<LinkProps>`
   color: ${p => p.theme.purple300};
 
@@ -368,8 +358,10 @@ function SupportLinkComponent(
   return <HomeLink {...props} />;
 }
 
-const AvatarContainer = styled('div')`
-  margin-bottom: 20px;
+const AvatarContainer = styled(HomeIcon)`
+  background: ${p => p.theme.backgroundSecondary};
+  border-radius: ${p => p.theme.borderRadius};
+  border: solid 1px ${p => p.theme.innerBorder};
 `;
 
 const OrganizationName = styled('div')`

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -12,7 +12,7 @@ import Link, {LinkProps} from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {IconDocs, IconLock, IconStack, IconSupport} from 'sentry/icons';
+import {IconDocs, IconLock, IconSupport} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -135,9 +135,7 @@ class SettingsIndex extends React.Component<SettingsIndexProps> {
                       />
                     </AvatarContainer>
                   ) : (
-                    <HomeIcon color="green300">
-                      <IconStack size="lg" />
-                    </HomeIcon>
+                    <OrgAvatarPlaceholder />
                   )}
                   <OrganizationName>
                     {organization ? organization.slug : t('No Organization')}
@@ -310,6 +308,12 @@ const HomeIcon = styled('div')<{color?: string}>`
   justify-content: center;
   align-items: center;
   margin-bottom: 20px;
+`;
+
+const OrgAvatarPlaceholder = styled(HomeIcon)`
+  background: ${p => p.theme.backgroundSecondary};
+  border-radius: ${p => p.theme.borderRadius};
+  border: solid 1px ${p => p.theme.innerBorder};
 `;
 
 const HomeLink = styled(Link)<LinkProps>`


### PR DESCRIPTION
For some reason we use `IconStack` as a placeholder while waiting for the org avatar to load. This leads to some jumpy UI during load time:

https://user-images.githubusercontent.com/44172267/157130911-9e0e0473-21e2-4a59-adb8-b80661f4beee.mov

We can use a simple persistent placeholder rectangle to minimize the visual jitter:

https://user-images.githubusercontent.com/44172267/157131043-2e3fdc31-b727-4229-8fad-1715721451c5.mov
