### PR TITLE
fix(new-widget-builder-experience): Table headers overlap footer [DD-663]

### DIFF
--- a/static/app/components/panels/panelTable.tsx
+++ b/static/app/components/panels/panelTable.tsx
@@ -181,7 +181,7 @@ export const PanelTableHeader = styled('div')<{sticky: boolean}>`
     `
     position: sticky;
     top: 0;
-    z-index: 1;
+    z-index: ${p.theme.zIndex.initial};
   `}
 `;
 

--- a/static/app/views/dashboardsV2/widgetBuilder/footer.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/footer.tsx
@@ -59,4 +59,5 @@ const FooterWrapper = styled('div')`
   position: sticky;
   bottom: 0;
   padding: ${space(4)};
+  z-index: ${p => p.theme.zIndex.initial};
 `;


### PR DESCRIPTION
We added z-index to the table headers so they would be sticky and display over the Assignee avatars for issue widgets, this is causing the header cells to display over the footer, so I set z-index on the footer as well. I changed them both to use our value for initial z-index (1) which is fine because the footer appears after the table headers in the stacking context.

Before:
![Screen Shot 2022-03-07 at 6 03 20 PM](https://user-images.githubusercontent.com/22846452/157133427-33223a64-7b4c-4623-85c6-a49a0a60a08f.png)

After:
![Screen Shot 2022-03-07 at 6 03 41 PM](https://user-images.githubusercontent.com/22846452/157133447-32b24c77-f1f5-4678-83bb-5f9c341509fb.png)

