### PR TITLE
feat(alertStatus): Use ruleFireHistory to show last triggered in alert status page

### DIFF
--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -85,6 +85,7 @@ export type IssueAlertRule = UnsavedIssueAlertRule & {
   id: string;
   projects: string[];
   errors?: {detail: string}[];
+  lastTriggered?: string;
 };
 
 // Project's alert rule stats

--- a/static/app/views/alerts/details/issuesList.tsx
+++ b/static/app/views/alerts/details/issuesList.tsx
@@ -19,6 +19,7 @@ import {getMessage, getTitle} from 'sentry/utils/events';
 type GroupHistory = {
   count: number;
   group: Group;
+  lastTriggered: string;
 };
 
 type Props = AsyncComponent['props'] &
@@ -100,7 +101,7 @@ class AlertRuleIssuesList extends AsyncComponent<Props, State> {
             t('Last Triggered'),
           ]}
         >
-          {groupHistory?.map(({group: issue, count}) => {
+          {groupHistory?.map(({group: issue, count, lastTriggered}) => {
             const message = getMessage(issue);
             const {title} = getTitle(issue);
 
@@ -124,7 +125,7 @@ class AlertRuleIssuesList extends AsyncComponent<Props, State> {
                   <Count value={issue.count} />
                 </AlignRight>
                 <div>
-                  <StyledDateTime date={issue.lastSeen} />
+                  <StyledDateTime date={lastTriggered} />
                 </div>
               </Fragment>
             );

--- a/static/app/views/alerts/details/ruleDetails.tsx
+++ b/static/app/views/alerts/details/ruleDetails.tsx
@@ -78,7 +78,13 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {orgId, ruleId, projectId} = this.props.params;
-    return [['rule', `/projects/${orgId}/${projectId}/rules/${ruleId}/`]];
+    return [
+      [
+        'rule',
+        `/projects/${orgId}/${projectId}/rules/${ruleId}/`,
+        {query: {expand: 'lastTriggered'}},
+      ],
+    ];
   }
 
   getDataDatetime(): DateTimeObject {

--- a/static/app/views/alerts/details/sidebar.tsx
+++ b/static/app/views/alerts/details/sidebar.tsx
@@ -108,8 +108,6 @@ class Sidebar extends PureComponent<Props> {
 
   render() {
     const {rule} = this.props;
-    // TODO: update this with rule's dateTriggered and dateModified when api updates
-    const dateTriggered = new Date(0);
 
     const ownerId = rule.owner?.split(':')[1];
     const teamActor = ownerId && {type: 'team' as Actor['type'], id: ownerId, name: ''};
@@ -120,8 +118,8 @@ class Sidebar extends PureComponent<Props> {
           <HeaderItem>
             <Heading noMargin>{t('Last Triggered')}</Heading>
             <Status>
-              {dateTriggered ? (
-                <TimeSince date={dateTriggered} />
+              {rule.lastTriggered ? (
+                <TimeSince date={rule.lastTriggered} />
               ) : (
                 t('No alerts triggered')
               )}

--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -116,7 +116,7 @@ describe('AlertRuleDetails', () => {
     });
   });
 
-  it('should show the time since last triggered', async () => {
+  it('should show the time since last triggered in sidebar', async () => {
     createWrapper();
 
     expect(await screen.findAllByText('Last Triggered')).toHaveLength(2);

--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -16,7 +16,9 @@ describe('AlertRuleDetails', () => {
   });
   const organization = context.organization;
   const project = TestStubs.Project();
-  const rule = TestStubs.ProjectAlertRule();
+  const rule = TestStubs.ProjectAlertRule({
+    lastTriggered: moment().subtract(2, 'day').format(),
+  });
 
   const createWrapper = (props = {}) => {
     const params = {
@@ -46,15 +48,11 @@ describe('AlertRuleDetails', () => {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/rules/${rule.id}/`,
       body: rule,
+      match: [MockApiClient.matchQuery({expand: 'lastTriggered'})],
     });
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/rules/${rule.id}/stats/`,
-      body: [
-        {date: moment().subtract(3, 'day').unix(), count: 4},
-        {date: moment().subtract(2, 'day').unix(), count: 0},
-        {date: moment().subtract(1, 'day').unix(), count: 5},
-        {date: moment().unix(), count: 0},
-      ],
+      body: [],
     });
 
     MockApiClient.addMockResponse({
@@ -118,10 +116,10 @@ describe('AlertRuleDetails', () => {
     });
   });
 
-  it('should show most recent stat date with positive alert count', async () => {
+  it('should show the time since last triggered', async () => {
     createWrapper();
 
-    expect(await screen.findByText('Last Triggered')).toBeInTheDocument();
-    expect(screen.getByText('a day ago')).toBeInTheDocument();
+    expect(await screen.findAllByText('Last Triggered')).toHaveLength(2);
+    expect(screen.getByText('2 days ago')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import moment from 'moment';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -48,7 +49,12 @@ describe('AlertRuleDetails', () => {
     });
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/rules/${rule.id}/stats/`,
-      body: [],
+      body: [
+        {date: moment().subtract(3, 'day').unix(), count: 4},
+        {date: moment().subtract(2, 'day').unix(), count: 0},
+        {date: moment().subtract(1, 'day').unix(), count: 5},
+        {date: moment().unix(), count: 0},
+      ],
     });
 
     MockApiClient.addMockResponse({
@@ -110,5 +116,12 @@ describe('AlertRuleDetails', () => {
         pageUtc: undefined,
       },
     });
+  });
+
+  it('should show most recent stat date with positive alert count', async () => {
+    createWrapper();
+
+    expect(await screen.findByText('Last Triggered')).toBeInTheDocument();
+    expect(screen.getByText('a day ago')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -57,7 +57,13 @@ describe('AlertRuleDetails', () => {
 
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/rules/${rule.id}/group-history/`,
-      body: [{count: 1, group: TestStubs.Group()}],
+      body: [
+        {
+          count: 1,
+          group: TestStubs.Group(),
+          lastTriggered: moment('Apr 11, 2019 1:08:59 AM UTC').format(),
+        },
+      ],
       headers: {
         Link:
           '<https://sentry.io/api/0/projects/org-slug/project-slug/rules/1/group-history/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +


### PR DESCRIPTION
This updates the alert status page sidebar to show the last triggered date from rule and the issue list to show last triggered from rule history's last triggered.

Before (placeholder):
<img width="298" alt="Screen Shot 2022-03-07 at 3 22 18 PM" src="https://user-images.githubusercontent.com/15015880/157135489-65cb3755-8b37-4f05-9f1f-69fbb6747245.png">


After:
<img width="298" alt="Screen Shot 2022-03-07 at 3 21 40 PM" src="https://user-images.githubusercontent.com/15015880/157135526-837c0626-af0b-4060-a29a-0f945195b89a.png">

