### PR TITLE
ref(sentry apps): Use issue_id instead of group_id

### DIFF
--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -260,9 +260,9 @@ def build_comment_webhook(installation_id, issue_id, type, user_id, *args, **kwa
     project_slug = data.get("project_slug")
     comment_id = data.get("comment_id")
     payload = {
-        "comment_id": comment_id,
-        "group_id": issue_id,
-        "project_slug": project_slug,
+        "comment_id": data.get("comment_id"),
+        "issue_id": issue_id,
+        "project_slug": data.get("project_slug"),
         "timestamp": data.get("timestamp"),
         "comment": data.get("comment"),
     }

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -469,7 +469,7 @@ class TestCommentWebhook(TestCase):
         assert faux(safe_urlopen).kwarg_equals("url", self.sentry_app.webhook_url)
         assert faux(safe_urlopen).kwarg_equals("data.action", "created", format="json")
         assert faux(safe_urlopen).kwarg_equals("headers.Sentry-Hook-Resource", "comment")
-        assert faux(safe_urlopen).kwarg_equals("data.data.group_id", self.issue.id, format="json")
+        assert faux(safe_urlopen).kwarg_equals("data.data.issue_id", self.issue.id, format="json")
 
     def test_sends_comment_updated_webhook(self, safe_urlopen):
         self.data.update(data={"text": "goodbye world"})
@@ -480,7 +480,7 @@ class TestCommentWebhook(TestCase):
         assert faux(safe_urlopen).kwarg_equals("url", self.sentry_app.webhook_url)
         assert faux(safe_urlopen).kwarg_equals("data.action", "updated", format="json")
         assert faux(safe_urlopen).kwarg_equals("headers.Sentry-Hook-Resource", "comment")
-        assert faux(safe_urlopen).kwarg_equals("data.data.group_id", self.issue.id, format="json")
+        assert faux(safe_urlopen).kwarg_equals("data.data.issue_id", self.issue.id, format="json")
 
     def test_sends_comment_deleted_webhook(self, safe_urlopen):
         self.note.delete()
@@ -491,7 +491,7 @@ class TestCommentWebhook(TestCase):
         assert faux(safe_urlopen).kwarg_equals("url", self.sentry_app.webhook_url)
         assert faux(safe_urlopen).kwarg_equals("data.action", "deleted", format="json")
         assert faux(safe_urlopen).kwarg_equals("headers.Sentry-Hook-Resource", "comment")
-        assert faux(safe_urlopen).kwarg_equals("data.data.group_id", self.issue.id, format="json")
+        assert faux(safe_urlopen).kwarg_equals("data.data.issue_id", self.issue.id, format="json")
 
 
 @patch("sentry.tasks.sentry_apps.safe_urlopen", return_value=MockResponseInstance)


### PR DESCRIPTION
Update a user facing payload to use "issue" instead of "group". 