### PR TITLE
ref(new-widget-builder-experience): Update 'Remove this y-axis' logic

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/yAxisSelector/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/yAxisSelector/index.tsx
@@ -193,9 +193,10 @@ export function YAxisSelector({
             filterAggregateParameters={filterAggregateParameters(fieldValue)}
             otherColumns={fields}
           />
-          {i !== 0 && (canDelete || fieldValue.kind === FieldValueKind.EQUATION) && (
-            <DeleteButton onDelete={event => handleRemoveQueryField(event, i)} />
-          )}
+          {fields.length > 1 &&
+            (canDelete || fieldValue.kind === FieldValueKind.EQUATION) && (
+              <DeleteButton onDelete={event => handleRemoveQueryField(event, i)} />
+            )}
         </QueryFieldWrapper>
       ))}
       {!hideAddYAxisButtons && (


### PR DESCRIPTION
With the current logic, the fields look unaligned, so  I'm updating the logic to not allow the removal of the last remaining field

**Before:**

![image](https://user-images.githubusercontent.com/29228205/157286891-37efa649-22b7-478a-9b4c-f7a851221c6a.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/157287038-cc950b3b-1ad9-4f7f-9a8c-5255330606ff.png)

![image](https://user-images.githubusercontent.com/29228205/157287073-82a28033-807f-43a3-9dc7-387821076d8b.png)
