### PR TITLE
ref(new-widget-builder-experience): Update the edit logic

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -347,9 +347,10 @@ class Dashboard extends Component<Props, State> {
       paramDashboardId,
       onSetWidgetToBeUpdated,
       handleAddCustomWidget,
+      isEditing,
     } = this.props;
 
-    if (organization.features.includes('new-widget-builder-experience')) {
+    if (organization.features.includes('new-widget-builder-experience') && isEditing) {
       onSetWidgetToBeUpdated(widget);
 
       trackAdvancedAnalyticsEvent('dashboards_views.edit_widget_in_builder.opened', {


### PR DESCRIPTION
Users will be able to see the new experience when editing, only while in editing mode