### PR TITLE
chore(ratelimit): enable rate limit on ProjectReleaseFilesEndpoint 

### DIFF
--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -209,8 +209,6 @@ def pseudo_releasefile(url, info, dist):
 class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
     permission_classes = (ProjectReleasePermission,)
 
-    enforce_rate_limit = False
-
     def get(self, request: Request, project, version) -> Response:
         """
         List a Project Release's Files


### PR DESCRIPTION
Reverts getsentry/sentry#31775

Removes the user-requested exemption made 3 weeks ago.