### PR TITLE
fix(page-filters): Remove independent state from environmentPageFilter

### DIFF
--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -26,14 +25,8 @@ function EnvironmentPageFilter({router, resetParamsOnChange = []}: Props) {
   const organization = useOrganization();
   const {selection, isReady, desyncedFilters} = useLegacyStore(PageFiltersStore);
 
-  const [selectedEnvironments, setSelectedEnvironments] = useState<string[] | null>(null);
-
-  const handleChangeEnvironments = (environments: string[] | null) => {
-    setSelectedEnvironments(environments);
-  };
-
-  const handleUpdateEnvironments = (quickSelectedEnvs?: string[]) => {
-    updateEnvironments(quickSelectedEnvs ?? selectedEnvironments, router, {
+  const handleUpdateEnvironments = (selectedEnvironments: string[]) => {
+    updateEnvironments(selectedEnvironments, router, {
       save: true,
       resetParams: resetParamsOnChange,
     });
@@ -70,7 +63,7 @@ function EnvironmentPageFilter({router, resetParamsOnChange = []}: Props) {
       loadingProjects={!projectsLoaded || !isReady}
       selectedProjects={selection.projects}
       value={selection.environments}
-      onChange={handleChangeEnvironments}
+      onChange={() => {}}
       onUpdate={handleUpdateEnvironments}
       customDropdownButton={customDropdownButton}
       customLoadingIndicator={customLoadingIndicator}

--- a/static/app/components/organizations/multipleEnvironmentSelector.tsx
+++ b/static/app/components/organizations/multipleEnvironmentSelector.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
-import uniq from 'lodash/uniq';
+import isEqual from 'lodash/isEqual';
+import sortBy from 'lodash/sortBy';
 
-import {Client} from 'sentry/api';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
 import {MenuFooterChildProps} from 'sentry/components/dropdownAutoComplete/menu';
 import {Item} from 'sentry/components/dropdownAutoComplete/types';
@@ -23,17 +23,8 @@ import {Organization, Project} from 'sentry/types';
 import {analytics} from 'sentry/utils/analytics';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import theme from 'sentry/utils/theme';
-import withApi from 'sentry/utils/withApi';
-
-type DefaultProps = {
-  /**
-   * This component must be controlled using a value array
-   */
-  value: string[];
-};
 
 type Props = WithRouterProps & {
-  api: Client;
   loadingProjects: boolean;
   /**
    * Handler whenever selector values are changed
@@ -46,6 +37,10 @@ type Props = WithRouterProps & {
   organization: Organization;
   projects: Project[];
   selectedProjects: number[];
+  /**
+   * This component must be controlled using a value array
+   */
+  value: string[];
   customDropdownButton?: (config: {
     getActorProps: GetActorPropsFn;
     isOpen: boolean;
@@ -54,11 +49,6 @@ type Props = WithRouterProps & {
   customLoadingIndicator?: React.ReactNode;
   detached?: boolean;
   forceEnvironment?: string;
-} & DefaultProps;
-
-type State = {
-  hasChanges: boolean;
-  selectedEnvs: Set<string>;
 };
 
 /**
@@ -66,192 +56,147 @@ type State = {
  *
  * Note we only fetch environments when this component is mounted
  */
-class MultipleEnvironmentSelector extends React.PureComponent<Props, State> {
-  static defaultProps: DefaultProps = {
-    value: [],
-  };
+function MultipleEnvironmentSelector({
+  loadingProjects,
+  onChange,
+  onUpdate,
+  organization,
+  projects,
+  selectedProjects,
+  value,
+  customDropdownButton,
+  customLoadingIndicator,
+  detached,
+  forceEnvironment,
+  router,
+}: Props) {
+  const [selectedEnvs, setSelectedEnvs] = useState(value);
 
-  state: State = {
-    selectedEnvs: new Set(this.props.value),
-    hasChanges: false,
-  };
+  // Update selected envs value on change
+  useEffect(() => setSelectedEnvs(value), [value]);
 
-  componentDidUpdate(prevProps: Props) {
-    // Need to sync state
-    if (this.props.value !== prevProps.value) {
-      this.syncSelectedStateFromProps();
-    }
-  }
+  // We keep a separate list of selected environments to use for sorting. This
+  // allows us to only update it after the list is closed, to avoid the list
+  // jumping around while selecting projects.
+  const lastSelectedEnvs = useRef(value);
 
-  syncSelectedStateFromProps = () =>
-    this.setState({selectedEnvs: new Set(this.props.value)});
-
-  /**
-   * If value in state is different than value from props, propagate changes
-   */
-  doChange = (environments: string[]) => {
-    this.props.onChange(environments);
-  };
-
-  /**
-   * Checks if "onUpdate" is callable. Only calls if there are changes
-   * @param selectedEnvs optional parameter passed to onUpdate representing
-   * an array containing a directly selected environment (not multi-selected)
-   */
-  doUpdate = (selectedEnvs?: string[]) => {
-    this.setState({hasChanges: false}, () => this.props.onUpdate(selectedEnvs));
-  };
+  const hasChanges = !isEqual(selectedEnvs, value);
 
   /**
    * Toggle selected state of an environment
    */
-  toggleSelected = (environment: string) => {
-    this.setState(state => {
-      const selectedEnvs = new Set(state.selectedEnvs);
+  const toggleSelected = (environment: string) => {
+    const willRemove = selectedEnvs.includes(environment);
 
-      if (selectedEnvs.has(environment)) {
-        selectedEnvs.delete(environment);
-      } else {
-        selectedEnvs.add(environment);
-      }
+    const updatedSelectedEnvs = willRemove
+      ? selectedEnvs.filter(env => env !== environment)
+      : [...selectedEnvs, environment];
 
-      analytics('environmentselector.toggle', {
-        action: selectedEnvs.has(environment) ? 'added' : 'removed',
-        path: getRouteStringFromRoutes(this.props.router.routes),
-        org_id: parseInt(this.props.organization.id, 10),
-      });
-
-      this.doChange(Array.from(selectedEnvs.values()));
-
-      return {
-        selectedEnvs,
-        hasChanges: true,
-      };
+    analytics('environmentselector.toggle', {
+      action: willRemove ? 'removed' : 'added',
+      path: getRouteStringFromRoutes(router.routes),
+      org_id: parseInt(organization.id, 10),
     });
+
+    onChange(updatedSelectedEnvs);
+    setSelectedEnvs(updatedSelectedEnvs);
   };
 
   /**
    * Calls "onUpdate" callback and closes the dropdown menu
    */
-  handleUpdate = (actions: MenuFooterChildProps['actions']) => {
+  const handleUpdate = (actions: MenuFooterChildProps['actions']) => {
     actions.close();
-    this.doUpdate();
+    onUpdate();
   };
 
-  handleClose = () => {
+  const handleClose = () => {
+    lastSelectedEnvs.current = selectedEnvs;
+
     // Only update if there are changes
-    if (!this.state.hasChanges) {
+    if (hasChanges) {
       return;
     }
 
     analytics('environmentselector.update', {
-      count: this.state.selectedEnvs.size,
-      path: getRouteStringFromRoutes(this.props.router.routes),
-      org_id: parseInt(this.props.organization.id, 10),
+      count: selectedEnvs.length,
+      path: getRouteStringFromRoutes(router.routes),
+      org_id: parseInt(organization.id, 10),
     });
 
-    this.doUpdate();
+    onUpdate();
   };
 
   /**
    * Clears all selected environments and updates
    */
-  handleClear = () => {
+  const handleClear = () => {
     analytics('environmentselector.clear', {
-      path: getRouteStringFromRoutes(this.props.router.routes),
-      org_id: parseInt(this.props.organization.id, 10),
+      path: getRouteStringFromRoutes(router.routes),
+      org_id: parseInt(organization.id, 10),
     });
 
-    this.setState(
-      {
-        hasChanges: false,
-        selectedEnvs: new Set(),
-      },
-      () => {
-        this.doChange([]);
-        this.doUpdate();
-      }
-    );
+    setSelectedEnvs([]);
+    onChange([]);
+    onUpdate();
   };
 
   /**
    * Selects an environment, should close menu and initiate an update
    */
-  handleSelect = (item: Item) => {
+  const handleSelect = (item: Item) => {
     const {value: environment} = item;
     analytics('environmentselector.direct_selection', {
-      path: getRouteStringFromRoutes(this.props.router.routes),
-      org_id: parseInt(this.props.organization.id, 10),
+      path: getRouteStringFromRoutes(router.routes),
+      org_id: parseInt(organization.id, 10),
     });
 
-    const envSelection = [environment];
+    const selectedEnvironments = [environment];
 
-    this.setState(
-      () => {
-        this.doChange(envSelection);
-
-        return {
-          selectedEnvs: new Set(envSelection),
-        };
-      },
-      () => this.doUpdate(envSelection)
-    );
+    setSelectedEnvs(selectedEnvironments);
+    onChange(selectedEnvironments);
+    onUpdate(selectedEnvironments);
   };
 
-  /**
-   * Handler for when an environment is selected by the multiple select component
-   * Does not initiate an "update"
-   */
-  handleMultiSelect = (environment: string) => {
-    this.toggleSelected(environment);
-  };
+  const config = ConfigStore.getConfig();
 
-  getEnvironments() {
-    const {projects, selectedProjects} = this.props;
-    const config = ConfigStore.getConfig();
-    let environments: Project['environments'] = [];
-    projects.forEach(function (project) {
-      const projectId = parseInt(project.id, 10);
-      // Include environments from:
-      // - all projects if the user is a superuser
-      // - the requested projects
-      // - all member projects if 'my projects' (empty list) is selected.
-      // - all projects if -1 is the only selected project.
-      if (
-        (selectedProjects.length === 1 &&
-          selectedProjects[0] === ALL_ACCESS_PROJECTS &&
-          project.hasAccess) ||
-        (selectedProjects.length === 0 &&
-          (project.isMember || config.user.isSuperuser)) ||
-        selectedProjects.includes(projectId)
-      ) {
-        environments = environments.concat(project.environments);
-      }
-    });
+  const unsortedEnvironments = projects.flatMap(project => {
+    const projectId = parseInt(project.id, 10);
+    // Include environments from:
+    // - all projects if the user is a superuser
+    // - the requested projects
+    // - all member projects if 'my projects' (empty list) is selected.
+    // - all projects if -1 is the only selected project.
+    if (
+      (selectedProjects.length === 1 &&
+        selectedProjects[0] === ALL_ACCESS_PROJECTS &&
+        project.hasAccess) ||
+      (selectedProjects.length === 0 && (project.isMember || config.user.isSuperuser)) ||
+      selectedProjects.includes(projectId)
+    ) {
+      return project.environments;
+    }
 
-    return uniq(environments);
-  }
+    return [];
+  });
 
-  render() {
-    const {
-      value,
-      loadingProjects,
-      customDropdownButton,
-      customLoadingIndicator,
-      forceEnvironment,
-      detached,
-    } = this.props;
-    const environments = this.getEnvironments();
+  const uniqueEnvironments = Array.from(new Set(unsortedEnvironments));
 
-    const hasNewPageFilters =
-      this.props.organization.features.includes('selection-filters-v2');
+  // Sort with the last selected environments at the top
+  const environments = sortBy(uniqueEnvironments, env => [
+    !lastSelectedEnvs.current.find(e => e === env),
+    env,
+  ]);
 
-    const validatedValue = value.filter(env => environments.includes(env));
-    const summary = validatedValue.length
-      ? `${validatedValue.join(', ')}`
-      : t('All Environments');
+  const hasNewPageFilters = organization.features.includes('selection-filters-v2');
 
-    return forceEnvironment !== undefined ? (
+  const validatedValue = value.filter(env => environments.includes(env));
+  const summary = validatedValue.length
+    ? `${validatedValue.join(', ')}`
+    : t('All Environments');
+
+  if (forceEnvironment !== undefined) {
+    return (
       <StyledHeaderItem
         data-test-id="global-header-environment-selector"
         icon={<IconWindow />}
@@ -260,92 +205,104 @@ class MultipleEnvironmentSelector extends React.PureComponent<Props, State> {
       >
         {forceEnvironment ? forceEnvironment : t('All Environments')}
       </StyledHeaderItem>
-    ) : loadingProjects ? (
-      customLoadingIndicator ?? (
-        <StyledHeaderItem
-          data-test-id="global-header-environment-selector"
-          icon={<IconWindow />}
-          loading={loadingProjects}
-          hasChanges={false}
-          hasSelected={false}
-          isOpen={false}
-          locked={false}
-        >
-          {t('Loading\u2026')}
-        </StyledHeaderItem>
-      )
-    ) : (
-      <ClassNames>
-        {({css}) => (
-          <StyledDropdownAutoComplete
-            alignMenu="left"
-            allowActorToggle
-            closeOnSelect
-            blendCorner={false}
-            detached={detached}
-            searchPlaceholder={t('Filter environments')}
-            onSelect={this.handleSelect}
-            onClose={this.handleClose}
-            maxHeight={500}
-            rootClassName={css`
-              position: relative;
-              display: flex;
-            `}
-            inputProps={{style: {padding: 8, paddingLeft: 14}}}
-            emptyMessage={t('You have no environments')}
-            noResultsMessage={t('No environments found')}
-            virtualizedHeight={theme.headerSelectorRowHeight}
-            emptyHidesInput
-            inputActions={
-              hasNewPageFilters ? (
-                <StyledPinButton size="xsmall" filter="environments" />
-              ) : undefined
-            }
-            menuFooter={({actions}) =>
-              this.state.hasChanges ? (
-                <MultipleSelectorSubmitRow onSubmit={() => this.handleUpdate(actions)} />
-              ) : null
-            }
-            items={environments.map(env => ({
-              value: env,
-              searchKey: env,
-              label: ({inputValue}) => (
-                <EnvironmentSelectorItem
-                  environment={env}
-                  inputValue={inputValue}
-                  isChecked={this.state.selectedEnvs.has(env)}
-                  onMultiSelect={this.handleMultiSelect}
-                />
-              ),
-            }))}
-          >
-            {({isOpen, getActorProps}) =>
-              customDropdownButton ? (
-                customDropdownButton({isOpen, getActorProps, summary})
-              ) : (
-                <StyledHeaderItem
-                  data-test-id="global-header-environment-selector"
-                  icon={<IconWindow />}
-                  isOpen={isOpen}
-                  hasSelected={value && !!value.length}
-                  onClear={this.handleClear}
-                  hasChanges={false}
-                  locked={false}
-                  loading={false}
-                  {...getActorProps()}
-                >
-                  {summary}
-                </StyledHeaderItem>
-              )
-            }
-          </StyledDropdownAutoComplete>
-        )}
-      </ClassNames>
     );
   }
+
+  if (loadingProjects && customLoadingIndicator) {
+    return <Fragment>{customLoadingIndicator}</Fragment>;
+  }
+
+  if (loadingProjects) {
+    return (
+      <StyledHeaderItem
+        data-test-id="global-header-environment-selector"
+        icon={<IconWindow />}
+        loading={loadingProjects}
+        hasChanges={false}
+        hasSelected={false}
+        isOpen={false}
+        locked={false}
+      >
+        {t('Loading\u2026')}
+      </StyledHeaderItem>
+    );
+  }
+
+  return (
+    <ClassNames>
+      {({css}) => (
+        <StyledDropdownAutoComplete
+          alignMenu="left"
+          allowActorToggle
+          closeOnSelect
+          blendCorner={false}
+          detached={detached}
+          searchPlaceholder={t('Filter environments')}
+          onSelect={handleSelect}
+          onClose={handleClose}
+          maxHeight={500}
+          rootClassName={css`
+            position: relative;
+            display: flex;
+          `}
+          inputProps={{style: {padding: 8, paddingLeft: 14}}}
+          emptyMessage={t('You have no environments')}
+          noResultsMessage={t('No environments found')}
+          virtualizedHeight={theme.headerSelectorRowHeight}
+          emptyHidesInput
+          inputActions={
+            hasNewPageFilters ? (
+              <StyledPinButton size="xsmall" filter="environments" />
+            ) : undefined
+          }
+          menuFooter={({actions}) =>
+            hasChanges ? (
+              <MultipleSelectorSubmitRow onSubmit={() => handleUpdate(actions)} />
+            ) : null
+          }
+          items={environments.map(env => ({
+            value: env,
+            searchKey: env,
+            label: ({inputValue}) => (
+              <PageFilterRow
+                data-test-id={`environment-${env}`}
+                checked={selectedEnvs.includes(env)}
+                onCheckClick={e => {
+                  e.stopPropagation();
+                  toggleSelected(env);
+                }}
+              >
+                <Highlight text={inputValue}>{env}</Highlight>
+              </PageFilterRow>
+            ),
+          }))}
+        >
+          {({isOpen, getActorProps}) =>
+            customDropdownButton ? (
+              customDropdownButton({isOpen, getActorProps, summary})
+            ) : (
+              <StyledHeaderItem
+                data-test-id="global-header-environment-selector"
+                icon={<IconWindow />}
+                isOpen={isOpen}
+                hasSelected={value && !!value.length}
+                onClear={handleClear}
+                hasChanges={false}
+                locked={false}
+                loading={false}
+                {...getActorProps()}
+              >
+                {summary}
+              </StyledHeaderItem>
+            )
+          }
+        </StyledDropdownAutoComplete>
+      )}
+    </ClassNames>
+  );
 }
 
-export default withApi(withRouter(MultipleEnvironmentSelector));
+export default withRouter(MultipleEnvironmentSelector);
 
 const StyledHeaderItem = styled(HeaderItem)`
   height: 100%;
@@ -369,35 +326,3 @@ const StyledDropdownAutoComplete = styled(DropdownAutoComplete)`
 const StyledPinButton = styled(PageFilterPinButton)`
   margin: 0 ${space(1)};
 `;
-
-type EnvironmentSelectorItemProps = {
-  environment: string;
-  inputValue: string;
-  isChecked: boolean;
-  onMultiSelect: (environment: string) => void;
-};
-
-class EnvironmentSelectorItem extends React.PureComponent<EnvironmentSelectorItemProps> {
-  handleMultiSelect = () => {
-    const {environment, onMultiSelect} = this.props;
-    onMultiSelect(environment);
-  };
-
-  handleClick = (e: React.MouseEvent<Element, MouseEvent>) => {
-    e.stopPropagation();
-    this.handleMultiSelect();
-  };
-
-  render() {
-    const {environment, inputValue, isChecked} = this.props;
-    return (
-      <PageFilterRow
-        data-test-id={`environment-${environment}`}
-        checked={isChecked}
-        onCheckClick={this.handleClick}
-      >
-        <Highlight text={inputValue}>{environment}</Highlight>
-      </PageFilterRow>
-    );
-  }
-}

--- a/static/app/components/organizations/multipleEnvironmentSelector.tsx
+++ b/static/app/components/organizations/multipleEnvironmentSelector.tsx
@@ -33,7 +33,7 @@ type Props = WithRouterProps & {
   /**
    * When menu is closed
    */
-  onUpdate: (selectedEnvs?: string[]) => void;
+  onUpdate: (selectedEnvs: string[]) => void;
   organization: Organization;
   projects: Project[];
   selectedProjects: number[];
@@ -107,14 +107,14 @@ function MultipleEnvironmentSelector({
    */
   const handleUpdate = (actions: MenuFooterChildProps['actions']) => {
     actions.close();
-    onUpdate();
+    onUpdate(selectedEnvs);
   };
 
   const handleClose = () => {
     lastSelectedEnvs.current = selectedEnvs;
 
     // Only update if there are changes
-    if (hasChanges) {
+    if (!hasChanges) {
       return;
     }
 
@@ -124,7 +124,7 @@ function MultipleEnvironmentSelector({
       org_id: parseInt(organization.id, 10),
     });
 
-    onUpdate();
+    onUpdate(selectedEnvs);
   };
 
   /**
@@ -138,7 +138,7 @@ function MultipleEnvironmentSelector({
 
     setSelectedEnvs([]);
     onChange([]);
-    onUpdate();
+    onUpdate([]);
   };
 
   /**


### PR DESCRIPTION
Change so that onUpdate always sends the currently selected environment. This allows us to remove the state in `environmentPageFilter`