### PR TITLE
ref(monitors): Simplify monitors layout

### DIFF
--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -71,20 +71,19 @@ class Monitors extends AsyncView<Props, State> {
             <div>
               {t('Monitors')} <FeatureBadge type="beta" />
             </div>
-            <NewMonitorButton
+            <Button
               to={`/organizations/${organization.slug}/monitors/create/`}
               priority="primary"
-              size="xsmall"
             >
               {t('New Monitor')}
-            </NewMonitorButton>
+            </Button>
           </HeaderTitle>
-          <StyledSearchBar
-            query={decodeScalar(qs.parse(location.search)?.query, '')}
-            placeholder={t('Search for monitors.')}
-            onSearch={this.handleSearch}
-          />
         </PageHeader>
+        <StyledSearchBar
+          query={decodeScalar(qs.parse(location.search)?.query, '')}
+          placeholder={t('Search for monitors.')}
+          onSearch={this.handleSearch}
+        />
         <Panel>
           <PanelBody>
             {monitorList?.map(monitor => (
@@ -120,11 +119,7 @@ const HeaderTitle = styled(PageHeading)`
 `;
 
 const StyledSearchBar = styled(SearchBar)`
-  flex: 1;
-`;
-
-const NewMonitorButton = styled(Button)`
-  margin-right: ${space(2)};
+  margin-bottom: ${space(2)};
 `;
 
 const PanelItemCentered = styled(PanelItem)`


### PR DESCRIPTION
Simplify monitors layout. Looks more similar to pages like Releases or Alerts

- Pulled search bar into its own row
- Made the `New Monitor` button bigger to match other header action buttons in the app

Before:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9372512/157328059-3221b2e7-aafb-4a1b-ada9-7ece889b6f63.png">


After:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9372512/157328017-b2614869-e3fe-4a4e-bc21-7d0f73082f0d.png">
