### PR TITLE
feat: Expose role permissions in the UI

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from sentry.api.authentication import QuietBasicAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import SsoRequired
-from sentry.api.serializers import DetailedUserSerializer, serialize
+from sentry.api.serializers import DetailedSelfUserSerializer, serialize
 from sentry.api.validators import AuthVerifyValidator
 from sentry.auth.superuser import Superuser, is_active_superuser
 from sentry.models import Authenticator, Organization
@@ -40,7 +40,7 @@ class AuthIndexEndpoint(Endpoint):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         user = extract_lazy_object(request._request.user)
-        return Response(serialize(user, user, DetailedUserSerializer()))
+        return Response(serialize(user, user, DetailedSelfUserSerializer()))
 
     def post(self, request: Request) -> Response:
         """

--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
 from sentry.api.serializers.base import serialize
-from sentry.api.serializers.models.user import DetailedUserSerializer
+from sentry.api.serializers.models.user import DetailedSelfUserSerializer
 from sentry.app import ratelimiter
 from sentry.utils import auth, metrics
 from sentry.utils.hashlib import md5_text
@@ -52,7 +52,7 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
             return Response(
                 {
                     "nextUri": "/auth/reactivate/",
-                    "user": serialize(user, user, DetailedUserSerializer()),
+                    "user": serialize(user, user, DetailedSelfUserSerializer()),
                 }
             )
 
@@ -62,7 +62,7 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
         return Response(
             {
                 "nextUri": auth.get_login_redirect(request, redirect_url),
-                "user": serialize(user, user, DetailedUserSerializer()),
+                "user": serialize(user, user, DetailedSelfUserSerializer()),
             }
         )
 

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -15,7 +15,7 @@ from sentry.api import client
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.user import DetailedUserSerializer
+from sentry.api.serializers.models.user import DetailedSelfUserSerializer
 from sentry.api.serializers.rest_framework import ListField
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import LANGUAGES
@@ -132,7 +132,7 @@ class UserDetailsEndpoint(UserEndpoint):
 
         :auth: required
         """
-        return Response(serialize(user, request.user, DetailedUserSerializer()))
+        return Response(serialize(user, request.user, DetailedSelfUserSerializer()))
 
     def put(self, request: Request, user) -> Response:
         """
@@ -196,7 +196,7 @@ class UserDetailsEndpoint(UserEndpoint):
                     },
                 )
 
-        return Response(serialize(user, request.user, DetailedUserSerializer()))
+        return Response(serialize(user, request.user, DetailedSelfUserSerializer()))
 
     @sudo_required
     def delete(self, request: Request, user) -> Response:

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -1,3 +1,5 @@
+import itertools
+import warnings
 from collections import defaultdict
 from datetime import datetime
 from typing import Any, Callable, Dict, List, MutableMapping, Optional, Sequence, Union, cast
@@ -21,6 +23,7 @@ from sentry.models import (
     UserEmail,
     UserOption,
     UserPermission,
+    UserRoleUser,
 )
 from sentry.utils.avatar import get_gravatar_url
 
@@ -209,12 +212,15 @@ class UserSerializer(Serializer):  # type: ignore
 
 
 class DetailedUserSerializerResponse(UserSerializerResponse):
-    permissions: Any
     authenticators: List[Any]  # TODO
     canReset2fa: bool
 
 
 class DetailedUserSerializer(UserSerializer):
+    """
+    Used in situations like when a member admin (on behalf of an organization) looks up memberships.
+    """
+
     def get_attrs(self, item_list: Sequence[User], user: User) -> MutableMapping[User, Any]:
         attrs = super().get_attrs(item_list, user)
 
@@ -223,10 +229,6 @@ class DetailedUserSerializer(UserSerializer):
             Authenticator.objects.filter(user__in=item_list),
             "user_id",
             lambda x: not x.interface.is_backup_interface,
-        )
-
-        permissions = manytoone_to_dict(
-            UserPermission.objects.filter(user__in=item_list), "user_id"
         )
 
         memberships = manytoone_to_dict(
@@ -238,8 +240,6 @@ class DetailedUserSerializer(UserSerializer):
 
         for item in item_list:
             attrs[item]["authenticators"] = authenticators[item.id]
-            attrs[item]["permissions"] = permissions[item.id]
-
             # org can reset 2FA if the user is only in one org
             attrs[item]["canReset2fa"] = len(memberships[item.id]) == 1
 
@@ -255,8 +255,6 @@ class DetailedUserSerializer(UserSerializer):
         # for requests that require an *active* session, they should prompt
         # on-demand. This ensures things like links to the Sentry admin can
         # still easily be rendered.
-        d["isSuperuser"] = obj.is_superuser
-        d["permissions"] = [up.permission for up in attrs["permissions"]]
         d["authenticators"] = [
             {
                 "id": str(a.id),
@@ -268,4 +266,74 @@ class DetailedUserSerializer(UserSerializer):
             for a in attrs["authenticators"]
         ]
         d["canReset2fa"] = attrs["canReset2fa"]
+        return d
+
+
+class DetailedSelfUserSerializerResponse(UserSerializerResponse):
+    permissions: Any
+    authenticators: List[Any]  # TODO
+
+
+class DetailedSelfUserSerializer(UserSerializer):
+    """
+    Return additional information for operating on behalf of a user, like their permissions.
+
+    Should only be returned when acting on behalf of the user, or acting on behalf of a Sentry `users.admin`.
+    """
+
+    def get_attrs(self, item_list: Sequence[User], user: User) -> MutableMapping[User, Any]:
+        attrs = super().get_attrs(item_list, user)
+
+        # ignore things that aren't user controlled (like recovery codes)
+        authenticators = manytoone_to_dict(
+            Authenticator.objects.filter(user__in=item_list),
+            "user_id",
+            lambda x: not x.interface.is_backup_interface,
+        )
+
+        permissions = manytoone_to_dict(
+            UserPermission.objects.filter(user__in=item_list), "user_id"
+        )
+        # XXX(dcramer): theres def a way to write this query using djangos awkward orm magic to cache it using `UserRole`
+        # but at least someone can understand this direction of access/optimization
+        roles = {
+            ur.user_id: ur.role.permissions
+            for ur in UserRoleUser.objects.filter(user__in=item_list).select_related("role")
+        }
+
+        for item in item_list:
+            attrs[item]["authenticators"] = authenticators[item.id]
+            attrs[item]["permissions"] = {p.permission for p in permissions[item.id]} | set(
+                itertools.chain(roles.get(item.id, []))
+            )
+
+        return attrs
+
+    def serialize(
+        self, obj: User, attrs: MutableMapping[User, Any], user: User
+    ) -> DetailedSelfUserSerializerResponse:
+        d = cast(DetailedSelfUserSerializerResponse, super().serialize(obj, attrs, user))
+
+        # safety check to never return this information if the acting user is not 1) this user, 2) an admin
+        if user.id == obj.id or user.is_superuser:
+            # XXX(dcramer): we don't use is_active_superuser here as we simply
+            # want to tell the UI that we're an authenticated superuser, and
+            # for requests that require an *active* session, they should prompt
+            # on-demand. This ensures things like links to the Sentry admin can
+            # still easily be rendered.
+            d["permissions"] = sorted(attrs["permissions"])
+            d["authenticators"] = [
+                {
+                    "id": str(a.id),
+                    "type": a.interface.interface_id,
+                    "name": str(a.interface.name),
+                    "dateCreated": a.created_at,
+                    "dateUsed": a.last_used_at,
+                }
+                for a in attrs["authenticators"]
+            ]
+        else:
+            warnings.warn(
+                "Incorrectly calling `DetailedSelfUserSerializer`. See docstring for details."
+            )
         return d

--- a/src/sentry/apidocs/constants.py
+++ b/src/sentry/apidocs/constants.py
@@ -7,3 +7,5 @@ RESPONSE_FORBIDDEN = OpenApiResponse(description="Forbidden")
 RESPONSE_NOTFOUND = OpenApiResponse(description="Not Found")
 
 RESPONSE_SUCCESS = OpenApiResponse(description="Success")
+
+RESPONSE_NO_CONTENT = OpenApiResponse(description="No Content")

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -232,7 +232,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         return Response(context)
 
     @extend_schema(
-        operation_id="Delete an Organization Member",
+        operation_id="Delete an Organization Member via SCIM",
         parameters=[GLOBAL_PARAMS.ORG_SLUG, SCIM_PARAMS.MEMBER_ID],
         request=None,
         responses={

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -8,7 +8,7 @@ from pkg_resources import parse_version
 import sentry
 from sentry import features, options
 from sentry.api.serializers.base import serialize
-from sentry.api.serializers.models.user import DetailedUserSerializer
+from sentry.api.serializers.models.user import DetailedSelfUserSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import ProjectKey
 from sentry.utils import auth
@@ -183,7 +183,7 @@ def get_client_config(request=None):
     }
     if user and user.is_authenticated:
         context.update(
-            {"isAuthenticated": True, "user": serialize(user, user, DetailedUserSerializer())}
+            {"isAuthenticated": True, "user": serialize(user, user, DetailedSelfUserSerializer())}
         )
 
         if request.user.is_superuser:

--- a/tests/sentry/api/serializers/test_user.py
+++ b/tests/sentry/api/serializers/test_user.py
@@ -1,5 +1,5 @@
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.user import DetailedUserSerializer
+from sentry.api.serializers.models.user import DetailedSelfUserSerializer, DetailedUserSerializer
 from sentry.models import Authenticator, AuthIdentity, AuthProvider, UserEmail, UserPermission
 from sentry.models.authenticator import available_authenticators
 from sentry.testutils import TestCase
@@ -71,9 +71,39 @@ class DetailedUserSerializerTest(TestCase):
         assert "authenticators" in result
         assert len(result["authenticators"]) == 1
         assert result["authenticators"][0]["id"] == str(auth.id)
-        assert result["permissions"] == ["foo"]
         assert result["canReset2fa"] is True
 
         self.create_organization(owner=user)
         result = serialize(user, user, DetailedUserSerializer())
         assert result["canReset2fa"] is False
+
+
+class DetailedSelfUserSerializerTest(TestCase):
+    def test_simple(self):
+        user = self.create_user()
+        UserPermission.objects.create(user=user, permission="foo")
+
+        org = self.create_organization(owner=user)
+
+        auth_provider = AuthProvider.objects.create(organization=org, provider="dummy")
+        auth_identity = AuthIdentity.objects.create(
+            auth_provider=auth_provider, ident=user.email, user=user
+        )
+        auth = Authenticator.objects.create(
+            type=available_authenticators(ignore_backup=True)[0].type, user=user
+        )
+
+        result = serialize(user, user, DetailedSelfUserSerializer())
+        assert result["id"] == str(user.id)
+        assert result["has2fa"] is True
+        assert len(result["emails"]) == 1
+        assert result["emails"][0]["email"] == user.email
+        assert result["emails"][0]["is_verified"]
+        assert "identities" in result
+        assert len(result["identities"]) == 1
+        assert result["identities"][0]["id"] == str(auth_identity.id)
+        assert result["identities"][0]["name"] == auth_identity.ident
+        assert "authenticators" in result
+        assert len(result["authenticators"]) == 1
+        assert result["authenticators"][0]["id"] == str(auth.id)
+        assert result["permissions"] == ["foo"]


### PR DESCRIPTION
Correct UI behavior around checking permissions by also pulling in `UserRole`.

This additionally splits the user serialization into two serializers with more clear use cases:

- DetailedUserSerializer (future renaming project?) which contains additional user information for member admins
- DetailedSelfUserSerializer which is primarily aimed at user administration (whether as superuser or self).