### PR TITLE
feat(issue_alert_details): Add `lastTriggered` expansion to `Rule` serializer

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -5,7 +5,8 @@ from rest_framework.response import Response
 from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.endpoints.project_rules import trigger_alert_rule_action_creators
 from sentry.api.serializers import serialize
-from sentry.api.serializers.rest_framework.rule import RuleSerializer
+from sentry.api.serializers.models.rule import RuleSerializer
+from sentry.api.serializers.rest_framework.rule import RuleSerializer as DrfRuleSerializer
 from sentry.integrations.slack import tasks
 from sentry.mediators import project_rules
 from sentry.models import (
@@ -35,8 +36,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
 
         # Serialize Rule object
         serialized_rule = serialize(
-            rule,
-            request.user,
+            rule, request.user, RuleSerializer(request.GET.getlist("expand", []))
         )
 
         errors = []
@@ -85,7 +85,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             }}
 
         """
-        serializer = RuleSerializer(
+        serializer = DrfRuleSerializer(
             context={"project": project, "organization": project.organization},
             data=request.data,
             partial=True,

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.api.serializers.models.rule import RuleSerializer
 from sentry.incidents.endpoints.utils import translate_threshold
 from sentry.incidents.logic import translate_aggregate_field
 from sentry.incidents.models import (
@@ -194,7 +195,11 @@ class CombinedRuleSerializer(Serializer):
                 incident_map[incident.id] = serialize(incident, user=user)
 
         serialized_alert_rules = serialize(alert_rules, user=user)
-        rules = serialize([x for x in item_list if isinstance(x, Rule)], user=user)
+        rules = serialize(
+            [x for x in item_list if isinstance(x, Rule)],
+            user=user,
+            serializer=RuleSerializer(expand=self.expand),
+        )
 
         for item in item_list:
             if isinstance(item, AlertRule):

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+from django.db.models import Max
+
 from sentry.api.serializers import Serializer, register
 from sentry.models import (
     ACTOR_TYPES,
@@ -7,6 +9,7 @@ from sentry.models import (
     Rule,
     RuleActivity,
     RuleActivityType,
+    RuleFireHistory,
     SentryAppInstallation,
     actor_type_to_class,
     actor_type_to_string,
@@ -34,6 +37,10 @@ def _is_filter(data):
 
 @register(Rule)
 class RuleSerializer(Serializer):
+    def __init__(self, expand=None):
+        super().__init__()
+        self.expand = expand or []
+
     def get_attrs(self, item_list, user, **kwargs):
         environments = Environment.objects.in_bulk(
             [_f for _f in [i.environment_id for i in item_list] if _f]
@@ -102,6 +109,16 @@ class RuleSerializer(Serializer):
                     action["_sentry_app_component"] = install.get("sentry_app_component")
                     action["_sentry_app_installation"] = install.get("sentry_app_installation")
 
+        if "lastTriggered" in self.expand:
+            last_triggered_lookup = {
+                rfh["rule_id"]: rfh["date_added"]
+                for rfh in RuleFireHistory.objects.filter(rule__in=item_list)
+                .values("rule_id")
+                .annotate(date_added=Max("date_added"))
+            }
+            for rule in item_list:
+                result[rule]["last_triggered"] = last_triggered_lookup.get(rule.id, None)
+
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
@@ -133,4 +150,6 @@ class RuleSerializer(Serializer):
             "environment": environment.name if environment is not None else None,
             "projects": [obj.project.slug],
         }
+        if "last_triggered" in attrs:
+            d["lastTriggered"] = attrs["last_triggered"]
         return d

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -135,8 +135,8 @@ class Fixtures:
             project = self.project
         return Factories.create_project_rule(
             project=project,
-            action_match=action_match,
-            condition_match=condition_match,
+            action_data=action_match,
+            condition_data=condition_match,
             *args,
             **kwargs,
         )

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from datetime import datetime
 
 import pytz
 import requests
@@ -12,6 +13,7 @@ from sentry.incidents.models import (
     IncidentTrigger,
     TriggerStatus,
 )
+from sentry.models import Rule, RuleFireHistory
 from sentry.models.organizationmember import OrganizationMember
 from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
 from sentry.testutils import APITestCase
@@ -1107,3 +1109,13 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         assert response.status_code == 200
         assert response.data[0]["id"] == str(alert_rule.id)
         assert response.data[0]["owner"] is None
+
+    @freeze_time()
+    def test_last_triggered(self):
+        self.login_as(user=self.user)
+        rule = Rule.objects.filter(project=self.project).first()
+        resp = self.get_success_response(self.organization.slug, expand=["lastTriggered"])
+        assert resp.data[0]["lastTriggered"] is None
+        RuleFireHistory.objects.create(project=self.project, rule=rule, group=self.group)
+        resp = self.get_success_response(self.organization.slug, expand=["lastTriggered"])
+        assert resp.data[0]["lastTriggered"] == datetime.now().replace(tzinfo=pytz.UTC)


### PR DESCRIPTION
This adds `lastTriggered` an an expand parameter to rule details and the combined rule endpoint.
This will return the last time the rule was triggered or None if no triggers have happened, and will
be returned as a datetime value in the `lastTriggered` key.