### PR TITLE
feat(issue_alert_details): Include `lastTriggered` in response for ProjectRuleGroupHistoryIndexEndpoint

### DIFF
--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Mapping, Sequence
+from typing import TYPE_CHECKING, Sequence, TypedDict
 
 import pytz
 from django.db.models import Count, Max
@@ -16,7 +16,13 @@ if TYPE_CHECKING:
     from sentry.utils.cursors import Cursor, CursorResult
 
 
-def convert_results(results: Sequence[Mapping[str, int]]) -> Sequence[RuleGroupHistory]:
+class _Result(TypedDict):
+    group: int
+    count: int
+    last_triggered: datetime
+
+
+def convert_results(results: Sequence[_Result]) -> Sequence[RuleGroupHistory]:
     group_lookup = {g.id: g for g in Group.objects.filter(id__in=[r["group"] for r in results])}
     return [
         RuleGroupHistory(group_lookup[r["group"]], r["count"], r["last_triggered"]) for r in results

--- a/src/sentry/rules/history/base.py
+++ b/src/sentry/rules/history/base.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 class RuleGroupHistory:
     group: Group
     count: int
+    last_triggered: datetime
 
 
 @dataclass(frozen=True)

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Mapping, MutableMapping, Sequence, TypedDict
 
 from drf_spectacular.utils import OpenApiExample, extend_schema
@@ -17,9 +18,10 @@ from sentry.rules.history import fetch_rule_groups_paginated
 from sentry.rules.history.base import RuleGroupHistory
 
 
-class OrganizationMemberResponse(TypedDict):
+class RuleGroupHistoryResponse(TypedDict):
     group: BaseGroupSerializerResponse
     count: int
+    lastTriggered: datetime
 
 
 class RuleGroupHistorySerializer(Serializer):  # type: ignore
@@ -35,10 +37,11 @@ class RuleGroupHistorySerializer(Serializer):  # type: ignore
 
     def serialize(
         self, obj: RuleGroupHistory, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
-    ) -> OrganizationMemberResponse:
+    ) -> RuleGroupHistoryResponse:
         return {
             "group": attrs["group"],
             "count": obj.count,
+            "lastTriggered": obj.last_triggered,
         }
 
 

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -1,3 +1,6 @@
+from datetime import timedelta
+
+import pytz
 from freezegun import freeze_time
 
 from sentry.models import Rule, RuleFireHistory
@@ -69,14 +72,16 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         )
         RuleFireHistory.objects.bulk_create(history)
 
+        base_triggered_date = before_now(days=1).replace(tzinfo=pytz.UTC)
+
         self.run_test(
             rule,
             before_now(days=6),
             before_now(days=0),
             [
-                RuleGroupHistory(self.group, count=3),
-                RuleGroupHistory(group_3, count=2),
-                RuleGroupHistory(group_2, count=1),
+                RuleGroupHistory(self.group, count=3, last_triggered=base_triggered_date),
+                RuleGroupHistory(group_3, count=2, last_triggered=base_triggered_date),
+                RuleGroupHistory(group_2, count=1, last_triggered=base_triggered_date),
             ],
         )
         result = self.run_test(
@@ -84,7 +89,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             before_now(days=6),
             before_now(days=0),
             [
-                RuleGroupHistory(self.group, count=3),
+                RuleGroupHistory(self.group, count=3, last_triggered=base_triggered_date),
             ],
             per_page=1,
         )
@@ -93,7 +98,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             before_now(days=6),
             before_now(days=0),
             [
-                RuleGroupHistory(group_3, count=2),
+                RuleGroupHistory(group_3, count=2, last_triggered=base_triggered_date),
             ],
             cursor=result.next,
             per_page=1,
@@ -103,7 +108,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             before_now(days=6),
             before_now(days=0),
             [
-                RuleGroupHistory(group_2, count=1),
+                RuleGroupHistory(group_2, count=1, last_triggered=base_triggered_date),
             ],
             cursor=result.next,
             per_page=1,
@@ -114,9 +119,9 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             before_now(days=1),
             before_now(days=0),
             [
-                RuleGroupHistory(self.group, count=1),
-                RuleGroupHistory(group_2, count=1),
-                RuleGroupHistory(group_3, count=1),
+                RuleGroupHistory(self.group, count=1, last_triggered=base_triggered_date),
+                RuleGroupHistory(group_2, count=1, last_triggered=base_triggered_date),
+                RuleGroupHistory(group_3, count=1, last_triggered=base_triggered_date),
             ],
         )
 
@@ -125,7 +130,9 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             before_now(days=3),
             before_now(days=2),
             [
-                RuleGroupHistory(self.group, count=1),
+                RuleGroupHistory(
+                    self.group, count=1, last_triggered=base_triggered_date - timedelta(days=2)
+                ),
             ],
         )
 


### PR DESCRIPTION
Include the last time that the group triggered the given rule in the selected time period in the
result. Also changes the sorting to sort by lastTriggered as a secondary sort.