### PR TITLE
ref(ui): Update Alert Details sidebar triggers to look more like Alert Status sidebar conditions

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -6,41 +6,28 @@ import moment from 'moment';
 
 import {Client} from 'sentry/api';
 import Alert from 'sentry/components/alert';
-import AlertBadge from 'sentry/components/alertBadge';
-import ActorAvatar from 'sentry/components/avatar/actorAvatar';
-import {SectionHeading} from 'sentry/components/charts/styles';
 import {getInterval} from 'sentry/components/charts/utils';
-import DateTime from 'sentry/components/dateTime';
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
 import Duration from 'sentry/components/duration';
-import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {Panel, PanelBody} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
-import TimeSince from 'sentry/components/timeSince';
-import {IconDiamond, IconInfo} from 'sentry/icons';
+import {IconInfo} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
-import {Actor, Organization, Project} from 'sentry/types';
+import {Organization, Project} from 'sentry/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/incidentRules/constants';
-import {
-  Action,
-  AlertRuleThresholdType,
-  AlertRuleTriggerType,
-  Dataset,
-  IncidentRule,
-} from 'sentry/views/alerts/incidentRules/types';
+import {Dataset, IncidentRule} from 'sentry/views/alerts/incidentRules/types';
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/incidentRules/utils/getEventTypeFilter';
 import MetricHistory from 'sentry/views/alerts/rules/details/metricHistory';
 
-import {AlertRuleStatus, Incident, IncidentStatus} from '../../types';
+import {AlertRuleStatus, Incident} from '../../types';
 
 import {API_INTERVAL_POINTS_LIMIT, TIME_OPTIONS, TimePeriodType} from './constants';
 import MetricChart from './metricChart';
 import RelatedIssues from './relatedIssues';
 import RelatedTransactions from './relatedTransactions';
+import Sidebar from './sidebar';
 
 type Props = {
   api: Client;
@@ -109,186 +96,6 @@ export default class DetailsBody extends React.Component<Props> {
       },
     });
   };
-
-  renderTrigger(label: string, threshold: number, actions: Action[]): React.ReactNode {
-    const {rule} = this.props;
-
-    if (!rule) {
-      return null;
-    }
-
-    const status =
-      label === AlertRuleTriggerType.CRITICAL
-        ? t('Critical')
-        : label === AlertRuleTriggerType.WARNING
-        ? t('Warning')
-        : t('Resolved');
-    const statusIcon =
-      label === AlertRuleTriggerType.CRITICAL ? (
-        <StyledIconDiamond color="red300" size="md" />
-      ) : label === AlertRuleTriggerType.WARNING ? (
-        <StyledIconDiamond color="yellow300" size="md" />
-      ) : (
-        <StyledIconDiamond color="green300" size="md" />
-      );
-
-    const thresholdTypeText = (
-      label === 'resolved'
-        ? rule.thresholdType === AlertRuleThresholdType.BELOW
-        : rule.thresholdType === AlertRuleThresholdType.ABOVE
-    )
-      ? rule.comparisonDelta
-        ? t('higher')
-        : t('above')
-      : rule.comparisonDelta
-      ? t('lower')
-      : t('below');
-
-    const thresholdText = rule.comparisonDelta
-      ? tct(
-          'When [threshold]% [comparisonType] in [timeWindow] compared to [comparisonDelta]',
-          {
-            threshold,
-            comparisonType: thresholdTypeText,
-            timeWindow: this.getTimeWindow(),
-            comparisonDelta: (
-              COMPARISON_DELTA_OPTIONS.find(
-                ({value}) => value === rule.comparisonDelta
-              ) ?? COMPARISON_DELTA_OPTIONS[0]
-            ).label,
-          }
-        )
-      : tct('If  [condition] in [timeWindow]', {
-          condition: `${thresholdTypeText} ${threshold}`,
-          timeWindow: this.getTimeWindow(),
-        });
-
-    return (
-      <TriggerConditionContainer>
-        {statusIcon}
-        <TriggerCondition>
-          {status}
-          <TriggerText>{thresholdText}</TriggerText>
-          {actions.map(
-            action =>
-              action.desc && <TriggerText key={action.id}>{action.desc}</TriggerText>
-          )}
-        </TriggerCondition>
-      </TriggerConditionContainer>
-    );
-  }
-
-  renderRuleDetails() {
-    const {rule} = this.props;
-
-    if (rule === undefined) {
-      return <Placeholder height="200px" />;
-    }
-
-    const criticalTrigger = rule?.triggers.find(
-      ({label}) => label === AlertRuleTriggerType.CRITICAL
-    );
-    const warningTrigger = rule?.triggers.find(
-      ({label}) => label === AlertRuleTriggerType.WARNING
-    );
-
-    const ownerId = rule.owner?.split(':')[1];
-    const teamActor = ownerId && {type: 'team' as Actor['type'], id: ownerId, name: ''};
-
-    return (
-      <React.Fragment>
-        <SidebarGroup>
-          <Heading>{t('Thresholds')}</Heading>
-          {typeof criticalTrigger?.alertThreshold === 'number' &&
-            this.renderTrigger(
-              criticalTrigger.label,
-              criticalTrigger.alertThreshold,
-              criticalTrigger.actions
-            )}
-          {typeof warningTrigger?.alertThreshold === 'number' &&
-            this.renderTrigger(
-              warningTrigger.label,
-              warningTrigger.alertThreshold,
-              warningTrigger.actions
-            )}
-          {typeof rule.resolveThreshold === 'number' &&
-            this.renderTrigger('resolved', rule.resolveThreshold, [])}
-        </SidebarGroup>
-
-        <SidebarGroup>
-          <Heading>{t('Alert Rule Details')}</Heading>
-          <KeyValueTable>
-            <KeyValueTableRow
-              keyName={t('Date created')}
-              value={
-                <DateTime
-                  date={getDynamicText({
-                    value: rule.dateCreated,
-                    fixed: new Date('2021-04-20'),
-                  })}
-                  format="ll"
-                />
-              }
-            />
-
-            {rule.createdBy && (
-              <KeyValueTableRow
-                keyName={t('Created By')}
-                value={<CreatedBy>{rule.createdBy.name ?? '-'}</CreatedBy>}
-              />
-            )}
-
-            {rule.dateModified && (
-              <KeyValueTableRow
-                keyName={t('Last Modified')}
-                value={<TimeSince date={rule.dateModified} suffix={t('ago')} />}
-              />
-            )}
-
-            <KeyValueTableRow
-              keyName={t('Team')}
-              value={
-                teamActor ? <ActorAvatar actor={teamActor} size={24} /> : t('Unassigned')
-              }
-            />
-          </KeyValueTable>
-        </SidebarGroup>
-      </React.Fragment>
-    );
-  }
-
-  renderMetricStatus() {
-    const {incidents} = this.props;
-
-    // get current status
-    const activeIncident = incidents?.find(({dateClosed}) => !dateClosed);
-    const status = activeIncident ? activeIncident.status : IncidentStatus.CLOSED;
-
-    const latestIncident = incidents?.length ? incidents[0] : null;
-    // The date at which the alert was triggered or resolved
-    const activityDate = activeIncident
-      ? activeIncident.dateStarted
-      : latestIncident
-      ? latestIncident.dateClosed
-      : null;
-
-    return (
-      <StatusContainer>
-        <HeaderItem>
-          <Heading noMargin>{t('Alert Status')}</Heading>
-          <Status>
-            <AlertBadge status={status} />
-          </Status>
-        </HeaderItem>
-        <HeaderItem>
-          <Heading noMargin>{t('Last Triggered')}</Heading>
-          <Status>
-            {activityDate ? <TimeSince date={activityDate} /> : t('No alerts triggered')}
-          </Status>
-        </HeaderItem>
-      </StatusContainer>
-    );
-  }
 
   renderLoading() {
     return (
@@ -419,18 +226,13 @@ export default class DetailsBody extends React.Component<Props> {
             </DetailWrapper>
           </Layout.Main>
           <Layout.Side>
-            {this.renderMetricStatus()}
-            {this.renderRuleDetails()}
+            <Sidebar incidents={incidents} rule={rule} />
           </Layout.Side>
         </StyledLayoutBodyWrapper>
       </React.Fragment>
     );
   }
 }
-
-const SidebarGroup = styled('div')`
-  margin-bottom: ${space(4)};
-`;
 
 const DetailWrapper = styled('div')`
   display: flex;
@@ -460,18 +262,6 @@ const StyledDropdownControl = styled(DropdownControl)`
   }
 `;
 
-const HeaderItem = styled('div')`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-
-  > *:nth-child(2) {
-    flex: 1;
-    display: flex;
-    align-items: center;
-  }
-`;
-
 const StyledLayoutBody = styled(Layout.Body)`
   flex-grow: 0;
   padding-bottom: 0 !important;
@@ -495,57 +285,6 @@ const ActivityWrapper = styled('div')`
   width: 100%;
 `;
 
-const Status = styled('div')`
-  position: relative;
-  display: grid;
-  grid-template-columns: auto auto auto;
-  gap: ${space(0.5)};
-  font-size: ${p => p.theme.fontSizeLarge};
-`;
-
-const StatusContainer = styled('div')`
-  height: 60px;
-  display: flex;
-  margin-bottom: ${space(1.5)};
-`;
-
-const Heading = styled(SectionHeading)<{noMargin?: boolean}>`
-  display: grid;
-  grid-template-columns: auto auto;
-  justify-content: flex-start;
-  margin-top: ${p => (p.noMargin ? 0 : space(2))};
-  margin-bottom: ${space(0.5)};
-  line-height: 1;
-  gap: ${space(1)};
-`;
-
 const ChartPanel = styled(Panel)`
   margin-top: ${space(2)};
-`;
-
-const TriggerConditionContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-`;
-
-const TriggerCondition = styled('div')`
-  display: flex;
-  flex-direction: column;
-  margin-left: ${space(0.75)};
-  line-height: 1.4;
-  position: relative;
-  top: 2px;
-`;
-
-const TriggerText = styled('div')`
-  color: ${p => p.theme.subText};
-  font-size: ${p => p.theme.fontSizeMedium};
-`;
-
-const CreatedBy = styled('div')`
-  ${overflowEllipsis}
-`;
-
-const StyledIconDiamond = styled(IconDiamond)`
-  margin-top: ${space(0.5)};
 `;

--- a/static/app/views/alerts/rules/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/details/sidebar.tsx
@@ -1,0 +1,292 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+
+import AlertBadge from 'sentry/components/alertBadge';
+import ActorAvatar from 'sentry/components/avatar/actorAvatar';
+import {SectionHeading} from 'sentry/components/charts/styles';
+import DateTime from 'sentry/components/dateTime';
+import Duration from 'sentry/components/duration';
+import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
+import TimeSince from 'sentry/components/timeSince';
+import {IconDiamond} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import overflowEllipsis from 'sentry/styles/overflowEllipsis';
+import space from 'sentry/styles/space';
+import {Actor} from 'sentry/types';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/incidentRules/constants';
+import {
+  Action,
+  AlertRuleThresholdType,
+  AlertRuleTriggerType,
+  IncidentRule,
+} from 'sentry/views/alerts/incidentRules/types';
+
+import {Incident, IncidentStatus} from '../../types';
+
+type Props = {
+  rule: IncidentRule;
+  incidents?: Incident[];
+};
+
+export default class Sidebar extends React.Component<Props> {
+  getTimeWindow(): React.ReactNode {
+    const {rule} = this.props;
+
+    if (!rule) {
+      return '';
+    }
+
+    const {timeWindow} = rule;
+
+    return tct('[window]', {
+      window: <Duration seconds={timeWindow * 60} />,
+    });
+  }
+
+  renderTrigger(label: string, threshold: number, actions: Action[]): React.ReactNode {
+    const {rule} = this.props;
+
+    if (!rule) {
+      return null;
+    }
+
+    const status =
+      label === AlertRuleTriggerType.CRITICAL
+        ? t('Critical')
+        : label === AlertRuleTriggerType.WARNING
+        ? t('Warning')
+        : t('Resolved');
+    const statusIcon =
+      label === AlertRuleTriggerType.CRITICAL ? (
+        <StyledIconDiamond color="red300" size="md" />
+      ) : label === AlertRuleTriggerType.WARNING ? (
+        <StyledIconDiamond color="yellow300" size="md" />
+      ) : (
+        <StyledIconDiamond color="green300" size="md" />
+      );
+
+    const thresholdTypeText = (
+      label === 'resolved'
+        ? rule.thresholdType === AlertRuleThresholdType.BELOW
+        : rule.thresholdType === AlertRuleThresholdType.ABOVE
+    )
+      ? rule.comparisonDelta
+        ? t('higher')
+        : t('above')
+      : rule.comparisonDelta
+      ? t('lower')
+      : t('below');
+
+    const thresholdText = rule.comparisonDelta
+      ? tct(
+          'When [threshold]% [comparisonType] in [timeWindow] compared to [comparisonDelta]',
+          {
+            threshold,
+            comparisonType: thresholdTypeText,
+            timeWindow: this.getTimeWindow(),
+            comparisonDelta: (
+              COMPARISON_DELTA_OPTIONS.find(
+                ({value}) => value === rule.comparisonDelta
+              ) ?? COMPARISON_DELTA_OPTIONS[0]
+            ).label,
+          }
+        )
+      : tct('If  [condition] in [timeWindow]', {
+          condition: `${thresholdTypeText} ${threshold}`,
+          timeWindow: this.getTimeWindow(),
+        });
+
+    return (
+      <TriggerConditionContainer>
+        {statusIcon}
+        <TriggerCondition>
+          {status}
+          <TriggerText>{thresholdText}</TriggerText>
+          {actions.map(
+            action =>
+              action.desc && <TriggerText key={action.id}>{action.desc}</TriggerText>
+          )}
+        </TriggerCondition>
+      </TriggerConditionContainer>
+    );
+  }
+
+  render() {
+    const {incidents, rule} = this.props;
+
+    // get current status
+    const activeIncident = incidents?.find(({dateClosed}) => !dateClosed);
+    const status = activeIncident ? activeIncident.status : IncidentStatus.CLOSED;
+
+    const latestIncident = incidents?.length ? incidents[0] : null;
+    // The date at which the alert was triggered or resolved
+    const activityDate = activeIncident
+      ? activeIncident.dateStarted
+      : latestIncident
+      ? latestIncident.dateClosed
+      : null;
+
+    const criticalTrigger = rule?.triggers.find(
+      ({label}) => label === AlertRuleTriggerType.CRITICAL
+    );
+    const warningTrigger = rule?.triggers.find(
+      ({label}) => label === AlertRuleTriggerType.WARNING
+    );
+
+    const ownerId = rule.owner?.split(':')[1];
+    const teamActor = ownerId && {type: 'team' as Actor['type'], id: ownerId, name: ''};
+
+    return (
+      <React.Fragment>
+        <StatusContainer>
+          <HeaderItem>
+            <Heading noMargin>{t('Alert Status')}</Heading>
+            <Status>
+              <AlertBadge status={status} />
+            </Status>
+          </HeaderItem>
+          <HeaderItem>
+            <Heading noMargin>{t('Last Triggered')}</Heading>
+            <Status>
+              {activityDate ? (
+                <TimeSince date={activityDate} />
+              ) : (
+                t('No alerts triggered')
+              )}
+            </Status>
+          </HeaderItem>
+        </StatusContainer>
+        <React.Fragment>
+          <SidebarGroup>
+            <Heading>{t('Thresholds')}</Heading>
+            {typeof criticalTrigger?.alertThreshold === 'number' &&
+              this.renderTrigger(
+                criticalTrigger.label,
+                criticalTrigger.alertThreshold,
+                criticalTrigger.actions
+              )}
+            {typeof warningTrigger?.alertThreshold === 'number' &&
+              this.renderTrigger(
+                warningTrigger.label,
+                warningTrigger.alertThreshold,
+                warningTrigger.actions
+              )}
+            {typeof rule.resolveThreshold === 'number' &&
+              this.renderTrigger('resolved', rule.resolveThreshold, [])}
+          </SidebarGroup>
+
+          <SidebarGroup>
+            <Heading>{t('Alert Rule Details')}</Heading>
+            <KeyValueTable>
+              <KeyValueTableRow
+                keyName={t('Date created')}
+                value={
+                  <DateTime
+                    date={getDynamicText({
+                      value: rule.dateCreated,
+                      fixed: new Date('2021-04-20'),
+                    })}
+                    format="ll"
+                  />
+                }
+              />
+
+              {rule.createdBy && (
+                <KeyValueTableRow
+                  keyName={t('Created By')}
+                  value={<CreatedBy>{rule.createdBy.name ?? '-'}</CreatedBy>}
+                />
+              )}
+
+              {rule.dateModified && (
+                <KeyValueTableRow
+                  keyName={t('Last Modified')}
+                  value={<TimeSince date={rule.dateModified} suffix={t('ago')} />}
+                />
+              )}
+
+              <KeyValueTableRow
+                keyName={t('Team')}
+                value={
+                  teamActor ? (
+                    <ActorAvatar actor={teamActor} size={24} />
+                  ) : (
+                    t('Unassigned')
+                  )
+                }
+              />
+            </KeyValueTable>
+          </SidebarGroup>
+        </React.Fragment>
+      </React.Fragment>
+    );
+  }
+}
+
+const SidebarGroup = styled('div')`
+  margin-bottom: ${space(4)};
+`;
+
+const HeaderItem = styled('div')`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+
+  > *:nth-child(2) {
+    flex: 1;
+    display: flex;
+    align-items: center;
+  }
+`;
+
+const Status = styled('div')`
+  position: relative;
+  display: grid;
+  grid-template-columns: auto auto auto;
+  gap: ${space(0.5)};
+  font-size: ${p => p.theme.fontSizeLarge};
+`;
+
+const StatusContainer = styled('div')`
+  height: 60px;
+  display: flex;
+  margin-bottom: ${space(1.5)};
+`;
+
+const Heading = styled(SectionHeading)<{noMargin?: boolean}>`
+  display: grid;
+  grid-template-columns: auto auto;
+  justify-content: flex-start;
+  margin-top: ${p => (p.noMargin ? 0 : space(2))};
+  margin-bottom: ${space(0.5)};
+  line-height: 1;
+  gap: ${space(1)};
+`;
+
+const TriggerConditionContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+`;
+
+const TriggerCondition = styled('div')`
+  display: flex;
+  flex-direction: column;
+  margin-left: ${space(0.75)};
+  line-height: 1.4;
+  position: relative;
+  top: 2px;
+`;
+
+const TriggerText = styled('div')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const CreatedBy = styled('div')`
+  ${overflowEllipsis}
+`;
+
+const StyledIconDiamond = styled(IconDiamond)`
+  margin-top: ${space(0.5)};
+`;

--- a/static/app/views/alerts/rules/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/details/sidebar.tsx
@@ -65,11 +65,12 @@ export default class Sidebar extends PureComponent<Props> {
 
     const defaultAction = t('Change alert status to %s', status);
 
-    const thresholdTypeText = (
+    const aboveThreshold =
       label === AlertRuleTriggerType.RESOLVE
         ? rule.thresholdType === AlertRuleThresholdType.BELOW
-        : rule.thresholdType === AlertRuleThresholdType.ABOVE
-    )
+        : rule.thresholdType === AlertRuleThresholdType.ABOVE;
+
+    const thresholdTypeText = aboveThreshold
       ? rule.comparisonDelta
         ? t('higher')
         : t('above')

--- a/static/app/views/alerts/rules/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/details/sidebar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Fragment, PureComponent, ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import AlertBadge from 'sentry/components/alertBadge';
@@ -21,6 +21,8 @@ import {
   AlertRuleTriggerType,
   IncidentRule,
 } from 'sentry/views/alerts/incidentRules/types';
+import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
+import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 
 import {Incident, IncidentStatus} from '../../types';
 
@@ -29,8 +31,8 @@ type Props = {
   incidents?: Incident[];
 };
 
-export default class Sidebar extends React.Component<Props> {
-  getTimeWindow(): React.ReactNode {
+export default class Sidebar extends PureComponent<Props> {
+  getTimeWindow(): ReactNode {
     const {rule} = this.props;
 
     if (!rule) {
@@ -44,12 +46,8 @@ export default class Sidebar extends React.Component<Props> {
     });
   }
 
-  renderTrigger(label: string, threshold: number, actions: Action[]): React.ReactNode {
+  renderTrigger(label: string, threshold: number, actions: Action[]): ReactNode {
     const {rule} = this.props;
-
-    if (!rule) {
-      return null;
-    }
 
     const status =
       label === AlertRuleTriggerType.CRITICAL
@@ -57,17 +55,18 @@ export default class Sidebar extends React.Component<Props> {
         : label === AlertRuleTriggerType.WARNING
         ? t('Warning')
         : t('Resolved');
-    const statusIcon =
-      label === AlertRuleTriggerType.CRITICAL ? (
-        <StyledIconDiamond color="red300" size="md" />
-      ) : label === AlertRuleTriggerType.WARNING ? (
-        <StyledIconDiamond color="yellow300" size="md" />
-      ) : (
-        <StyledIconDiamond color="green300" size="md" />
-      );
+
+    const statusIconColor =
+      label === AlertRuleTriggerType.CRITICAL
+        ? 'red300'
+        : label === AlertRuleTriggerType.WARNING
+        ? 'yellow300'
+        : 'green300';
+
+    const defaultAction = t('Change alert status to %s', status);
 
     const thresholdTypeText = (
-      label === 'resolved'
+      label === AlertRuleTriggerType.RESOLVE
         ? rule.thresholdType === AlertRuleThresholdType.BELOW
         : rule.thresholdType === AlertRuleThresholdType.ABOVE
     )
@@ -80,8 +79,9 @@ export default class Sidebar extends React.Component<Props> {
 
     const thresholdText = rule.comparisonDelta
       ? tct(
-          'When [threshold]% [comparisonType] in [timeWindow] compared to [comparisonDelta]',
+          '[metric] is [threshold]% [comparisonType] in [timeWindow] compared to [comparisonDelta]',
           {
+            metric: AlertWizardAlertNames[getAlertTypeFromAggregateDataset(rule)],
             threshold,
             comparisonType: thresholdTypeText,
             timeWindow: this.getTimeWindow(),
@@ -92,23 +92,34 @@ export default class Sidebar extends React.Component<Props> {
             ).label,
           }
         )
-      : tct('If  [condition] in [timeWindow]', {
+      : tct('[metric] is [condition] in [timeWindow]', {
+          metric: AlertWizardAlertNames[getAlertTypeFromAggregateDataset(rule)],
           condition: `${thresholdTypeText} ${threshold}`,
           timeWindow: this.getTimeWindow(),
         });
 
     return (
-      <TriggerConditionContainer>
-        {statusIcon}
-        <TriggerCondition>
-          {status}
-          <TriggerText>{thresholdText}</TriggerText>
-          {actions.map(
-            action =>
-              action.desc && <TriggerText key={action.id}>{action.desc}</TriggerText>
-          )}
-        </TriggerCondition>
-      </TriggerConditionContainer>
+      <TriggerContainer>
+        <TriggerTitle>
+          <IconDiamond color={statusIconColor} size="xs" />
+          <TriggerTitleText>{t('%s Conditions', status)}</TriggerTitleText>
+        </TriggerTitle>
+        <TriggerStep>
+          <TriggerTitleText>When</TriggerTitleText>
+          <TriggerActions>
+            <TriggerText>{thresholdText}</TriggerText>
+          </TriggerActions>
+        </TriggerStep>
+        <TriggerStep>
+          <TriggerTitleText>Then</TriggerTitleText>
+          <TriggerActions>
+            {actions.map(action => (
+              <TriggerText key={action.id}>{action.desc}</TriggerText>
+            ))}
+            <TriggerText>{defaultAction}</TriggerText>
+          </TriggerActions>
+        </TriggerStep>
+      </TriggerContainer>
     );
   }
 
@@ -138,7 +149,7 @@ export default class Sidebar extends React.Component<Props> {
     const teamActor = ownerId && {type: 'team' as Actor['type'], id: ownerId, name: ''};
 
     return (
-      <React.Fragment>
+      <Fragment>
         <StatusContainer>
           <HeaderItem>
             <Heading noMargin>{t('Alert Status')}</Heading>
@@ -157,75 +168,68 @@ export default class Sidebar extends React.Component<Props> {
             </Status>
           </HeaderItem>
         </StatusContainer>
-        <React.Fragment>
-          <SidebarGroup>
-            <Heading>{t('Thresholds')}</Heading>
-            {typeof criticalTrigger?.alertThreshold === 'number' &&
-              this.renderTrigger(
-                criticalTrigger.label,
-                criticalTrigger.alertThreshold,
-                criticalTrigger.actions
-              )}
-            {typeof warningTrigger?.alertThreshold === 'number' &&
-              this.renderTrigger(
-                warningTrigger.label,
-                warningTrigger.alertThreshold,
-                warningTrigger.actions
-              )}
-            {typeof rule.resolveThreshold === 'number' &&
-              this.renderTrigger('resolved', rule.resolveThreshold, [])}
-          </SidebarGroup>
+        <SidebarGroup>
+          {typeof criticalTrigger?.alertThreshold === 'number' &&
+            this.renderTrigger(
+              criticalTrigger.label,
+              criticalTrigger.alertThreshold,
+              criticalTrigger.actions
+            )}
+          {typeof warningTrigger?.alertThreshold === 'number' &&
+            this.renderTrigger(
+              warningTrigger.label,
+              warningTrigger.alertThreshold,
+              warningTrigger.actions
+            )}
+          {typeof rule.resolveThreshold === 'number' &&
+            this.renderTrigger(AlertRuleTriggerType.RESOLVE, rule.resolveThreshold, [])}
+        </SidebarGroup>
 
-          <SidebarGroup>
-            <Heading>{t('Alert Rule Details')}</Heading>
-            <KeyValueTable>
-              <KeyValueTableRow
-                keyName={t('Date created')}
-                value={
-                  <DateTime
-                    date={getDynamicText({
-                      value: rule.dateCreated,
-                      fixed: new Date('2021-04-20'),
-                    })}
-                    format="ll"
-                  />
-                }
-              />
-
-              {rule.createdBy && (
-                <KeyValueTableRow
-                  keyName={t('Created By')}
-                  value={<CreatedBy>{rule.createdBy.name ?? '-'}</CreatedBy>}
+        <SidebarGroup>
+          <Heading>{t('Alert Rule Details')}</Heading>
+          <KeyValueTable>
+            <KeyValueTableRow
+              keyName={t('Date created')}
+              value={
+                <DateTime
+                  date={getDynamicText({
+                    value: rule.dateCreated,
+                    fixed: new Date('2021-04-20'),
+                  })}
+                  format="ll"
                 />
-              )}
+              }
+            />
 
-              {rule.dateModified && (
-                <KeyValueTableRow
-                  keyName={t('Last Modified')}
-                  value={<TimeSince date={rule.dateModified} suffix={t('ago')} />}
-                />
-              )}
-
+            {rule.createdBy && (
               <KeyValueTableRow
-                keyName={t('Team')}
-                value={
-                  teamActor ? (
-                    <ActorAvatar actor={teamActor} size={24} />
-                  ) : (
-                    t('Unassigned')
-                  )
-                }
+                keyName={t('Created By')}
+                value={<CreatedBy>{rule.createdBy.name ?? '-'}</CreatedBy>}
               />
-            </KeyValueTable>
-          </SidebarGroup>
-        </React.Fragment>
-      </React.Fragment>
+            )}
+
+            {rule.dateModified && (
+              <KeyValueTableRow
+                keyName={t('Last Modified')}
+                value={<TimeSince date={rule.dateModified} suffix={t('ago')} />}
+              />
+            )}
+
+            <KeyValueTableRow
+              keyName={t('Team')}
+              value={
+                teamActor ? <ActorAvatar actor={teamActor} size={24} /> : t('Unassigned')
+              }
+            />
+          </KeyValueTable>
+        </SidebarGroup>
+      </Fragment>
     );
   }
 }
 
 const SidebarGroup = styled('div')`
-  margin-bottom: ${space(4)};
+  margin-bottom: ${space(3)};
 `;
 
 const HeaderItem = styled('div')`
@@ -251,42 +255,58 @@ const Status = styled('div')`
 const StatusContainer = styled('div')`
   height: 60px;
   display: flex;
-  margin-bottom: ${space(1.5)};
+  margin-bottom: ${space(1)};
 `;
 
 const Heading = styled(SectionHeading)<{noMargin?: boolean}>`
-  display: grid;
-  grid-template-columns: auto auto;
-  justify-content: flex-start;
   margin-top: ${p => (p.noMargin ? 0 : space(2))};
-  margin-bottom: ${space(0.5)};
-  line-height: 1;
-  gap: ${space(1)};
-`;
-
-const TriggerConditionContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-`;
-
-const TriggerCondition = styled('div')`
-  display: flex;
-  flex-direction: column;
-  margin-left: ${space(0.75)};
-  line-height: 1.4;
-  position: relative;
-  top: 2px;
-`;
-
-const TriggerText = styled('div')`
-  color: ${p => p.theme.subText};
-  font-size: ${p => p.theme.fontSizeMedium};
+  margin-bottom: ${p => (p.noMargin ? 0 : space(1))};
 `;
 
 const CreatedBy = styled('div')`
   ${overflowEllipsis}
 `;
 
-const StyledIconDiamond = styled(IconDiamond)`
-  margin-top: ${space(0.5)};
+const TriggerContainer = styled('div')`
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: ${space(1)};
+  margin-top: ${space(4)};
+`;
+
+const TriggerTitle = styled('div')`
+  display: grid;
+  grid-template-columns: 20px 1fr;
+  align-items: center;
+`;
+
+const TriggerTitleText = styled('h4')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin: 0;
+  line-height: 24px;
+  min-width: 40px;
+`;
+
+const TriggerStep = styled('div')`
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  align-items: flex-start;
+`;
+
+const TriggerActions = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(1fr);
+  gap: ${space(0.25)};
+`;
+
+const TriggerText = styled('span')`
+  display: block;
+  background-color: ${p => p.theme.surface100};
+  padding: 0 ${space(0.75)};
+  border-radius: ${p => p.theme.borderRadius};
+  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSizeSmall};
+  width: 100%;
+  font-weight: 400;
 `;


### PR DESCRIPTION
This updates the Alert Details (metric alert)  sidebar to look more like Alert Status (issue alert) sidebar. Moved the sidebar to a separate component and updated the triggers to look more like conditions.

Before:
![Screen Shot 2022-03-08 at 5 13 05 PM](https://user-images.githubusercontent.com/15015880/157353090-1f031d61-8933-42a1-8b20-dc860c70c442.png)

After:
![Screen Shot 2022-03-08 at 5 12 34 PM](https://user-images.githubusercontent.com/15015880/157353109-43ea57b6-bcab-4510-8d86-fec20d12d58b.png)

