### PR TITLE
ref(new-widget-builder-library): Align footer actions with form fields and alignments tweaks - [DD-681] and [DD-631]

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -126,6 +126,7 @@ export const Main = styled('section')<{fullWidth?: boolean}>`
   grid-column: ${p => (p.fullWidth ? '1/3' : '1/2')};
   max-width: 100%;
 `;
+
 export const Side = styled('aside')`
   grid-column: 2/3;
 `;

--- a/static/app/views/dashboardsV2/widgetBuilder/buildStep.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildStep.tsx
@@ -14,13 +14,11 @@ interface Props {
 function BuildStep({title, description, required = false, children}: Props) {
   return (
     <Wrapper>
-      <Header>
-        <Heading>
-          {title}
-          {required && <RequiredBadge />}
-        </Heading>
-        <SubHeading>{description}</SubHeading>
-      </Header>
+      <Heading>
+        {title}
+        {required && <RequiredBadge />}
+      </Heading>
+      <SubHeading>{description}</SubHeading>
       <Content>{children}</Content>
     </Wrapper>
   );
@@ -30,12 +28,6 @@ export default BuildStep;
 
 const Wrapper = styled(ListItem)`
   display: grid;
-  gap: ${space(2)};
-`;
-
-const Header = styled('div')`
-  display: grid;
-  gap: ${space(0.25)};
 `;
 
 const Heading = styled('h5')`
@@ -45,10 +37,19 @@ const Heading = styled('h5')`
 
 const SubHeading = styled('small')`
   color: ${p => p.theme.gray300};
+  padding: ${space(0.25)} ${space(2)} ${space(2)} 0;
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    padding-top: ${space(1)};
+    margin-left: -${space(4)};
+  }
 `;
 
 const Content = styled('div')`
   display: grid;
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    margin-left: -${space(4)};
+  }
 `;
 
 const RequiredBadge = styled('div')`

--- a/static/app/views/dashboardsV2/widgetBuilder/footer.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/footer.tsx
@@ -24,7 +24,7 @@ export function Footer({
   isEditing,
 }: Props) {
   return (
-    <FooterWrapper>
+    <Wrapper>
       <Actions gap={1}>
         <Button to={goBackLocation}>{t('Cancel')}</Button>
         {isEditing && onDelete && (
@@ -45,19 +45,30 @@ export function Footer({
           {isEditing ? t('Update Widget') : t('Add Widget')}
         </Button>
       </Actions>
-    </FooterWrapper>
+    </Wrapper>
   );
 }
 
 const Actions = styled(ButtonBar)`
   justify-content: flex-end;
+  max-width: 1000px;
+  padding: ${space(4)} ${space(2)};
+
+  /* to match Layout.Main padding + Field padding-right */
+  padding-right: calc(${space(2)} + ${space(2)});
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    padding: ${space(4)};
+
+    /* to match Layout.Main padding + Field padding-right */
+    padding-right: calc(${space(4)} + ${space(2)});
+  }
 `;
 
-const FooterWrapper = styled('div')`
+const Wrapper = styled('div')`
   background: ${p => p.theme.background};
   border-top: 1px solid ${p => p.theme.gray200};
   position: sticky;
   bottom: 0;
-  padding: ${space(4)};
   z-index: ${p => p.theme.zIndex.initial};
 `;

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -1191,12 +1191,27 @@ const Body = styled(Layout.Body)`
   @media (max-width: ${p => p.theme.breakpoints[3]}) {
     grid-template-columns: 1fr;
   }
+
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    /* 325px + 16px + 16px to match Side component width, padding-left and padding-right */
+    grid-template-columns: minmax(100px, auto) calc(325px + ${space(2) + space(2)});
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints[3]}) {
+    /* 325px + 16px + 30px to match Side component width, padding-left and padding-right */
+    grid-template-columns: minmax(100px, auto) calc(325px + ${space(2) + space(4)});
+  }
 `;
 
 const Main = styled(Layout.Main)`
   max-width: 1000px;
-  padding: ${space(4)};
   flex: 1;
+
+  padding: ${space(4)} ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    padding: ${space(4)};
+  }
 `;
 
 const Side = styled(Layout.Side)`
@@ -1204,6 +1219,9 @@ const Side = styled(Layout.Side)`
 
   @media (min-width: ${p => p.theme.breakpoints[3]}) {
     border-left: 1px solid ${p => p.theme.gray200};
+
+    /* to be consistent with Layout.Body in other verticals */
+    padding-right: ${space(4)};
   }
 
   @media (max-width: ${p => p.theme.breakpoints[3]}) {

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetLibrary/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetLibrary/index.tsx
@@ -67,11 +67,13 @@ const WidgetLibraryWrapper = styled('div')`
 `;
 
 const Header = styled('h5')`
-  margin-left: ${space(2)};
+  /* to be aligned with the 30px of Layout.main padding */
+  padding-left: calc(${space(2)} - ${space(0.25)});
 `;
 
 const CardHoverWrapper = styled('div')`
-  padding: calc(${space(2)} - 1px);
+  /* to be aligned with the 30px of Layout.main padding - 1px of the widget item border */
+  padding: calc(${space(2)} - 3px);
   border: 1px solid transparent;
   border-radius: ${p => p.theme.borderRadius};
   transition: border-color 0.3s ease;


### PR DESCRIPTION
According to our last discussion with the design team, it was decided that we would like to have the action buttons of the footer aligned with the widget builder form fields.

This PR:

- [x] Align the footer action buttons with the form fields

**Before:**
![image](https://user-images.githubusercontent.com/29228205/157439792-94d63a5d-4a13-4dc8-97b2-f913f35e11b3.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/157439578-3caf2e92-0c07-4a87-bb2e-26f06dd778af.png)

- [x] Fix spacing issues on smaller devices (some design updates where needed)

**Before:**

![image](https://user-images.githubusercontent.com/29228205/157439906-ef75019c-ab96-468c-a80e-1cd175150f37.png)

**After:**

![image](https://user-images.githubusercontent.com/29228205/157439986-cc8c3c9d-3199-4ff5-b484-ac5c7d594601.png)

- [x] Updated the right spacing on the side layout to be consistent with other verticals

**Project Details example:**

![image](https://user-images.githubusercontent.com/29228205/157440207-9c5615ec-af9d-4689-9c11-93bf0a5e37cb.png)


**Before:**

![image](https://user-images.githubusercontent.com/29228205/157440305-2c1d4b0c-c790-465f-abed-04b3f02afeb5.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/157440506-64dc5e2f-6578-4a89-b750-fb507bc51366.png)
