### PR TITLE
fix(alerts): Send the correct default threshold

### DIFF
--- a/static/app/views/alerts/rules/details/relatedTransactions.tsx
+++ b/static/app/views/alerts/rules/details/relatedTransactions.tsx
@@ -18,7 +18,7 @@ import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {fieldAlignment, getAggregateAlias} from 'sentry/utils/discover/fields';
 import {IncidentRule} from 'sentry/views/alerts/incidentRules/types';
 import {TableColumn} from 'sentry/views/eventsV2/table/types';
-import {DEFAULT_PROJECT_THRESHOLD_METRIC} from 'sentry/views/performance/data';
+import {DEFAULT_PROJECT_THRESHOLD} from 'sentry/views/performance/data';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 function getProjectID(eventData: EventData, projects: Project[]): string | undefined {
@@ -194,7 +194,7 @@ class RelatedTransactions extends React.Component<Props> {
         'project',
         `${rule.aggregate}`,
         'count_unique(user)',
-        `user_misery(${DEFAULT_PROJECT_THRESHOLD_METRIC})`,
+        `user_misery(${DEFAULT_PROJECT_THRESHOLD})`,
       ],
       orderby: `-${aggregateAlias}`,
 


### PR DESCRIPTION
Previously made the api request with the metric instead
of the threshold which resulted in a 400.