### PR TITLE
fix(page-filters): Show pin only with new page filters

### DIFF
--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -75,6 +75,7 @@ function DatePageFilter({router, resetParamsOnChange, ...props}: Props) {
       onUpdate={handleUpdate}
       label={<IconCalendar color="textColor" />}
       customDropdownButton={customDropdownButton}
+      showPin
       {...props}
     />
   );

--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -71,6 +71,7 @@ function EnvironmentPageFilter({router, resetParamsOnChange = [], alignDropdown}
       customLoadingIndicator={customLoadingIndicator}
       alignDropdown={alignDropdown}
       detached
+      showPin
     />
   );
 }

--- a/static/app/components/organizations/multipleEnvironmentSelector.tsx
+++ b/static/app/components/organizations/multipleEnvironmentSelector.tsx
@@ -49,6 +49,10 @@ type Props = WithRouterProps & {
   customLoadingIndicator?: React.ReactNode;
   detached?: boolean;
   forceEnvironment?: string;
+  /**
+   * Show the pin button in the dropdown's header actions
+   */
+  showPin?: boolean;
 };
 
 /**
@@ -69,6 +73,7 @@ function MultipleEnvironmentSelector({
   detached,
   forceEnvironment,
   router,
+  showPin,
 }: Props) {
   const [selectedEnvs, setSelectedEnvs] = useState(value);
   const hasChanges = !isEqual(selectedEnvs, value);
@@ -186,8 +191,6 @@ function MultipleEnvironmentSelector({
     env,
   ]);
 
-  const hasNewPageFilters = organization.features.includes('selection-filters-v2');
-
   const validatedValue = value.filter(env => environments.includes(env));
   const summary = validatedValue.length
     ? `${validatedValue.join(', ')}`
@@ -249,9 +252,7 @@ function MultipleEnvironmentSelector({
           virtualizedHeight={theme.headerSelectorRowHeight}
           emptyHidesInput
           inputActions={
-            hasNewPageFilters ? (
-              <StyledPinButton size="xsmall" filter="environments" />
-            ) : undefined
+            showPin ? <StyledPinButton size="xsmall" filter="environments" /> : undefined
           }
           menuFooter={({actions}) =>
             hasChanges ? (

--- a/static/app/components/organizations/multipleProjectSelector.tsx
+++ b/static/app/components/organizations/multipleProjectSelector.tsx
@@ -42,6 +42,7 @@ type Props = WithRouterProps & {
   lockedMessageSubject?: React.ReactNode;
   shouldForceProject?: boolean;
   showIssueStreamLink?: boolean;
+  showPin?: boolean;
   showProjectSettingsLink?: boolean;
 };
 

--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -64,6 +64,10 @@ type Props = {
    * Represents if a search is taking place
    */
   searching?: boolean;
+  /**
+   * Show the pin button in the dropdown's header actions
+   */
+  showPin?: boolean;
 } & Pick<
   DropdownAutoCompleteProps,
   'menuFooter' | 'onScroll' | 'onClose' | 'rootClassName' | 'className'
@@ -86,6 +90,7 @@ const ProjectSelector = ({
   onMultiSelect,
   multi = false,
   selectedProjects = [],
+  showPin,
   ...props
 }: Props) => {
   // We'll only update the selected project list every time we open the menu,
@@ -175,7 +180,6 @@ const ProjectSelector = ({
   const hasProjects = !!projects?.length || !!nonMemberProjects?.length;
   const newProjectUrl = `/organizations/${organization.slug}/projects/new/`;
   const hasProjectWrite = organization.access.includes('project:write');
-  const hasPageFilters = organization.features.includes('selection-filters-v2');
 
   return (
     <DropdownAutoComplete
@@ -210,9 +214,9 @@ const ProjectSelector = ({
                 : undefined
             }
           >
-            {hasPageFilters ? '' : t('Project')}
+            {showPin ? '' : t('Project')}
           </AddButton>
-          {hasPageFilters && <PageFilterPinButton size="xsmall" filter="projects" />}
+          {showPin && <PageFilterPinButton size="xsmall" filter="projects" />}
         </InputActions>
       }
       menuFooter={renderProps => {

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -154,6 +154,11 @@ type Props = WithRouterProps & {
    * Override defaults from DEFAULT_RELATIVE_PERIODS
    */
   relativeOptions?: Record<string, React.ReactNode>;
+
+  /**
+   * Show the pin button in the dropdown's header actions
+   */
+  showPin?: boolean;
 } & Partial<typeof defaultProps>;
 
 type State = {
@@ -389,10 +394,9 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
       customDropdownButton,
       detached,
       alignDropdown,
+      showPin,
     } = this.props;
     const {start, end, relative} = this.state;
-
-    const hasNewPageFilters = organization.features.includes('selection-filters-v2');
 
     const shouldShowAbsolute = showAbsolute;
     const shouldShowRelative = showRelative;
@@ -437,7 +441,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
                   height: 100%;
                 `}
                 inputActions={
-                  hasNewPageFilters ? (
+                  showPin ? (
                     <StyledPinButton size="xsmall" filter="datetime" />
                   ) : undefined
                 }

--- a/static/app/components/pageTimeRangeSelector.tsx
+++ b/static/app/components/pageTimeRangeSelector.tsx
@@ -10,6 +10,7 @@ import {defined} from 'sentry/utils';
 
 type Props = React.ComponentProps<typeof TimeRangeSelector> & {
   className?: string;
+  showPin?: boolean;
 };
 
 function PageTimeRangeSelector({className, customDropdownButton, ...props}: Props) {

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -152,6 +152,7 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
       customDropdownButton={customProjectDropdown}
       customLoadingIndicator={customLoadingIndicator}
       detached
+      showPin
       {...otherProps}
     />
   );


### PR DESCRIPTION
Realized that I feature flagged the pin button, which meant it showed on global selection header dropdowns even when they weren't new page filters. Added a prop which is sent from page filter components to the dropdowns.

Before:
<img width="421" alt="image" src="https://user-images.githubusercontent.com/9372512/157513809-774df74d-8605-472e-a5cc-9e7a4467c4e8.png">

After:
<img width="418" alt="image" src="https://user-images.githubusercontent.com/9372512/157513846-4ca1f1f5-a291-40f3-9d15-cebee65a931f.png">
