### PR TITLE
ref(models): `update_or_create()`

### DIFF
--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -94,9 +94,9 @@ def update_or_create(
     if affected:
         return affected, False
 
-    create_kwargs = kwargs.copy()
     instance = objects.model()
 
+    create_kwargs = kwargs.copy()
     create_kwargs.update(
         {_handle_key(model, k, v): _handle_value(instance, v) for k, v in defaults.items()}
     )
@@ -107,7 +107,8 @@ def update_or_create(
     except IntegrityError:
         pass
 
-    return affected, False
+    # Retrying the update() here to preserve behavior in a race condition with a concurrent create().
+    return objects.filter(**kwargs).update(**defaults), False
 
 
 def create_or_update(


### PR DESCRIPTION
Introduce a replacement for the deprecated `create_or_update()`. Separating this from https://github.com/getsentry/sentry/pull/32335 so that https://github.com/getsentry/getsentry/pull/7134 can access the function.