### PR TITLE
ref(js): Remove domId mock

### DIFF
--- a/static/app/utils/__mocks__/domId.tsx
+++ b/static/app/utils/__mocks__/domId.tsx
@@ -1,5 +1,0 @@
-function domId(prefix: string): string {
-  return prefix + '123456';
-}
-
-export {domId};

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -72,7 +72,6 @@ ConfigStore.loadInitialData(fixtures.Config());
 jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 jest.mock('sentry/utils/recreateRoute');
 jest.mock('sentry/api');
-jest.mock('sentry/utils/domId');
 jest.mock('sentry/utils/withOrganization');
 jest.mock('scroll-to-element', () => jest.fn());
 jest.mock('react-router', () => {


### PR DESCRIPTION
domId can be valuable for tests in places where we use it to generate
IDs for things like aria-labeledby