### PR TITLE
ref(models): `create_or_save()` -> `update_or_create()`

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -405,11 +405,11 @@ class PullRequestEventWebhook(Webhook):
             )
 
         try:
-            PullRequest.create_or_save(
+            PullRequest.objects.update_or_create(
                 organization_id=organization.id,
                 repository_id=repo.id,
                 key=number,
-                values={
+                defaults={
                     "organization_id": organization.id,
                     "title": title,
                     "author": author,

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -124,11 +124,11 @@ class MergeEventWebhook(Webhook):
         )[0]
 
         try:
-            PullRequest.create_or_save(
+            PullRequest.objects.update_or_create(
                 organization_id=organization.id,
                 repository_id=repo.id,
                 key=number,
-                values={
+                defaults={
                     "title": title,
                     "author": author,
                     "message": body,

--- a/src/sentry_plugins/github/webhooks/events/pull_request.py
+++ b/src/sentry_plugins/github/webhooks/events/pull_request.py
@@ -82,10 +82,11 @@ class PullRequestEventWebhook(Webhook):
                 )
 
         try:
-            PullRequest.objects.create_or_update(
+            PullRequest.objects.update_or_create(
+                organization_id=organization.id,
                 repository_id=repo.id,
                 key=number,
-                values={
+                defaults={
                     "organization_id": organization.id,
                     "title": title,
                     "author": author,


### PR DESCRIPTION
This PR refactors the `PullRequest` model to use the built in django `update_or_create()` instead of `create_or_update()`.