### PR TITLE
fix(issue_alert_status): Fix off by one bug when fetching issue alert firing history.

### DIFF
--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -74,8 +74,8 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         existing_data = {row["bucket"]: TimeSeriesValue(row["bucket"], row["count"]) for row in qs}
 
         results = []
-        current = start.replace(minute=0, second=0, microsecond=0)
-        while current < end.replace(minute=0, second=0, microsecond=0):
+        current = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+        while current <= end.replace(minute=0, second=0, microsecond=0):
             results.append(existing_data.get(current, TimeSeriesValue(current, 0)))
             current += timedelta(hours=1)
         return results

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -169,8 +169,8 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
 
         results = self.backend.fetch_rule_hourly_stats(rule, before_now(hours=24), before_now())
         assert len(results) == 24
-        assert [r.count for r in results[-5:]] == [0, 0, 3, 2, 1]
+        assert [r.count for r in results[-5:]] == [0, 3, 2, 1, 0]
 
         results = self.backend.fetch_rule_hourly_stats(rule_2, before_now(hours=24), before_now())
         assert len(results) == 24
-        assert [r.count for r in results[-5:]] == [0, 0, 0, 1, 1]
+        assert [r.count for r in results[-5:]] == [0, 0, 1, 1, 0]

--- a/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
@@ -64,8 +64,9 @@ class ProjectRuleStatsIndexEndpointTest(APITestCase):
         )
         assert len(resp.data) == 144
         now = timezone.now().replace(minute=0, second=0, microsecond=0)
-        assert [r for r in resp.data[-3:]] == [
+        assert [r for r in resp.data[-4:]] == [
             {"date": now - timedelta(hours=3), "count": 3},
             {"date": now - timedelta(hours=2), "count": 2},
             {"date": now - timedelta(hours=1), "count": 1},
+            {"date": now, "count": 0},
         ]


### PR DESCRIPTION
We were cutting off the most recent bucket when fetching this data.