### PR TITLE
fix(alerts): Adjust alert details overflow on mobile (WOR-1595)

### DIFF
--- a/static/app/views/alerts/details/issuesList.tsx
+++ b/static/app/views/alerts/details/issuesList.tsx
@@ -168,6 +168,7 @@ const TitleWrapper = styled('div')`
   ${overflowEllipsis};
   display: flex;
   gap: ${space(0.5)};
+  min-width: 200px;
 `;
 
 const MessageWrapper = styled('span')`

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -312,7 +312,7 @@ class MetricChart extends React.PureComponent<Props, State> {
     return (
       <ChartActions>
         <ChartSummary>
-          <SummaryText>{t('SUMMARY')}</SummaryText>
+          <SummaryText>{t('Summary')}</SummaryText>
           <SummaryStats>
             <StatItem>
               <IconCheckmark color="green300" isCircled />
@@ -865,14 +865,17 @@ const Filters = styled('span')`
 
 const ChartActions = styled(PanelFooter)`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
   padding: ${space(1)} 20px;
+  gap: ${space(1)};
 `;
 
 const ChartSummary = styled('div')`
   display: flex;
   margin-right: auto;
+  gap: ${space(2)};
 `;
 
 const SummaryText = styled(SectionHeading)`
@@ -882,19 +885,20 @@ const SummaryText = styled(SectionHeading)`
   margin: 0;
   font-weight: bold;
   font-size: ${p => p.theme.fontSizeSmall};
+  text-transform: uppercase;
   line-height: 1;
 `;
 
 const SummaryStats = styled('div')`
   display: flex;
   align-items: center;
-  margin: 0 ${space(2)};
+  gap: ${space(2)};
 `;
 
 const StatItem = styled('div')`
   display: flex;
   align-items: center;
-  margin: 0 ${space(2)} 0 0;
+  font-variant-numeric: tabular-nums;
 `;
 
 /* Override padding to make chart appear centered */

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -312,7 +312,7 @@ class MetricChart extends React.PureComponent<Props, State> {
     return (
       <ChartActions>
         <ChartSummary>
-          <SummaryText>{t('Summary')}</SummaryText>
+          <SummaryText>{t('SUMMARY')}</SummaryText>
           <SummaryStats>
             <StatItem>
               <IconCheckmark color="green300" isCircled />
@@ -865,17 +865,14 @@ const Filters = styled('span')`
 
 const ChartActions = styled(PanelFooter)`
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
-  flex-wrap: wrap;
   padding: ${space(1)} 20px;
-  gap: ${space(1)};
 `;
 
 const ChartSummary = styled('div')`
   display: flex;
   margin-right: auto;
-  gap: ${space(2)};
 `;
 
 const SummaryText = styled(SectionHeading)`
@@ -885,20 +882,19 @@ const SummaryText = styled(SectionHeading)`
   margin: 0;
   font-weight: bold;
   font-size: ${p => p.theme.fontSizeSmall};
-  text-transform: uppercase;
   line-height: 1;
 `;
 
 const SummaryStats = styled('div')`
   display: flex;
   align-items: center;
-  gap: ${space(2)};
+  margin: 0 ${space(2)};
 `;
 
 const StatItem = styled('div')`
   display: flex;
   align-items: center;
-  font-variant-numeric: tabular-nums;
+  margin: 0 ${space(2)} 0 0;
 `;
 
 /* Override padding to make chart appear centered */


### PR DESCRIPTION
before
<img width="409" alt="image" src="https://user-images.githubusercontent.com/1400464/157561267-afcd787e-8325-4acf-9a61-ec0562c61e79.png">



after - Shows more of the issue title
<img width="401" alt="image" src="https://user-images.githubusercontent.com/1400464/157561225-b3c20c90-679a-46a7-902f-03845252d38c.png">

