### PR TITLE
fix(profiling): Clear selected node on flame graph change

### DIFF
--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -124,6 +124,19 @@ function FlamegraphZoomView({
     return flamegraphRenderer.getHoveredNode(configSpaceCursor);
   }, [configSpaceCursor, flamegraphRenderer]);
 
+  /**
+   * Whenever the flamegraph changes, the reference to the selected node
+   * may no longer be valid/correct. So clear it when that happens.
+   *
+   * The flamegraph may for reasons like
+   * - inverted/leftHeavy changed
+   * - thread changed
+   * - import happened
+   */
+  useEffect(() => {
+    setSelectedNode(null);
+  }, [flamegraph]);
+
   useEffect(() => {
     if (!flamegraphRenderer) {
       return undefined;
@@ -225,6 +238,7 @@ function FlamegraphZoomView({
     };
   }, [
     scheduler,
+    flamegraph,
     flamegraphRenderer,
     textRenderer,
     gridRenderer,


### PR DESCRIPTION
Whenever the flame graph changes, the current reference to the selected node may
no longer be valid as it points to a location relative the old flame graph. This
change clears the selected node whenever the flame graph changes to avoid this.