### PR TITLE
feat: Disable relay by default in devservices

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1667,11 +1667,12 @@ SENTRY_WATCHERS = (
     ),
 )
 
-# Controls whether DEVSERVICES will spin up a Relay and direct store traffic through Relay or not.
-# If Relay is used a reverse proxy server will be run at the 8000 (the port formally used by Sentry) that
-# will split the requests between Relay and Sentry (all store requests will be passed to Relay, and the
-# rest will be forwarded to Sentry)
-SENTRY_USE_RELAY = True
+# Controls whether devserver spins up Relay, Kafka, and several ingest worker jobs to direct store traffic
+# through the Relay ingestion pipeline. Without, ingestion is completely disabled. Use `bin/load-mocks` to
+# generate fake data for local testing. You can also manually enable relay with the `--relay` flag to `devserver`.
+# XXX: This is disabled by default as typical development workflows do not require end-to-end services running
+# and disabling optional services reduces resource consumption and complexity
+SENTRY_USE_RELAY = False
 SENTRY_RELAY_PORT = 7899
 
 # Controls whether we'll run the snuba subscription processor. If enabled, we'll run

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -57,6 +57,7 @@ def _get_daemon(name, *args, **kwargs):
     "--watchers/--no-watchers", default=True, help="Watch static files and recompile on changes."
 )
 @click.option("--workers/--no-workers", default=False, help="Run asynchronous workers.")
+@click.option("--ingest/--no-ingest", help="Run ingest services (including Relay).")
 @click.option(
     "--prefix/--no-prefix", default=True, help="Show the service name prefix and timestamp"
 )
@@ -89,6 +90,7 @@ def devserver(
     reload,
     watchers,
     workers,
+    ingest,
     experimental_spa,
     styleguide,
     prefix,
@@ -243,8 +245,10 @@ def devserver(
                 )
             daemons += [_get_daemon("metrics")]
 
-    if settings.SENTRY_USE_RELAY:
+    if ingest is True or (settings.SENTRY_USE_RELAY and ingest is not False):
         daemons += [_get_daemon("ingest")]
+    else:
+        settings.SENTRY_USE_RELAY = False
 
     if needs_https and has_https:
         https_port = str(parsed_url.port)


### PR DESCRIPTION
The motivation around this is driven by the principal of keeping development an MVP and lightweight. While Relay itself may not be a large resource consumer, the more exceptions we make, the more they stack up. Even when things aren't utilizing huge amounts of resources, they are still creating complexity in workflows. For example, I was developing an entirely UI-driven feature (debugging TS compile errors), and Relay kept filling up my terminal with its logs.

See also getsentry/getsentry#7136