### PR TITLE
ref(rules): Fix abstract classes

### DIFF
--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import logging
 
@@ -52,9 +54,19 @@ class EventAction(RuleBase, abc.ABC):
 
 
 class IntegrationEventAction(EventAction, abc.ABC):
-    """
-    Intermediate abstract class to help DRY some event actions code.
-    """
+    """Intermediate abstract class to help DRY some event actions code."""
+
+    @property
+    def prompt(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def provider(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def integration_key(self) -> str:
+        raise NotImplementedError
 
     def is_enabled(self):
         return self.get_integrations().exists()
@@ -211,6 +223,14 @@ class TicketEventAction(IntegrationEventAction, abc.ABC):
     def render_label(self):
         return self.label.format(integration=self.get_integration_name())
 
+    @property
+    def ticket_type(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def prompt(self) -> str:
+        return f"Create {self.ticket_type}"
+
     def get_dynamic_form_fields(self):
         """
         Either get the dynamic form fields cached on the DB return `None`.
@@ -232,10 +252,6 @@ class TicketEventAction(IntegrationEventAction, abc.ABC):
 
     def translate_integration(self, integration):
         return integration.name
-
-    @property
-    def prompt(self):
-        return f"Create {self.ticket_type}"
 
     def generate_footer(self, rule_url):
         raise NotImplementedError

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -30,6 +30,7 @@ class IntegrationNotifyServiceForm(forms.Form):
 class EventAction(RuleBase, abc.ABC):
     rule_type = "action/event"
 
+    @abc.abstractmethod
     def after(self, event, state):
         """
         Executed after a Rule matches.
@@ -50,23 +51,26 @@ class EventAction(RuleBase, abc.ABC):
         >>>     for future in futures:
         >>>         print(future)
         """
-        raise NotImplementedError
+        pass
 
 
 class IntegrationEventAction(EventAction, abc.ABC):
     """Intermediate abstract class to help DRY some event actions code."""
 
     @property
+    @abc.abstractmethod
     def prompt(self) -> str:
-        raise NotImplementedError
+        pass
 
     @property
+    @abc.abstractmethod
     def provider(self) -> str:
-        raise NotImplementedError
+        pass
 
     @property
+    @abc.abstractmethod
     def integration_key(self) -> str:
-        raise NotImplementedError
+        pass
 
     def is_enabled(self):
         return self.get_integrations().exists()
@@ -224,8 +228,9 @@ class TicketEventAction(IntegrationEventAction, abc.ABC):
         return self.label.format(integration=self.get_integration_name())
 
     @property
+    @abc.abstractmethod
     def ticket_type(self) -> str:
-        raise NotImplementedError
+        pass
 
     @property
     def prompt(self) -> str:
@@ -253,8 +258,9 @@ class TicketEventAction(IntegrationEventAction, abc.ABC):
     def translate_integration(self, integration):
         return integration.name
 
+    @abc.abstractmethod
     def generate_footer(self, rule_url):
-        raise NotImplementedError
+        pass
 
     def after(self, event, state):
         integration_id = self.get_integration_id()

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -38,7 +38,6 @@ CallbackFuture = namedtuple("CallbackFuture", ["callback", "kwargs", "key"])
 
 
 class RuleBase(abc.ABC):
-    label = None
     form_cls = None
 
     logger = logging.getLogger("sentry.rules")
@@ -53,6 +52,9 @@ class RuleBase(abc.ABC):
     @abc.abstractmethod
     def id(self) -> str:
         pass
+
+    def label(self) -> str:
+        raise NotImplementedError
 
     def is_enabled(self):
         return True


### PR DESCRIPTION
The abstract classes `TicketEventAction` and `IntegrationEventAction` aren't defining their properties in the right places. This PR fixes up the properties and marks the classes as abstract.

I was getting this error:
```
typeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
```
because `RuleBase` cant use both `ABC` and the custom metaclass so I moved the code to the Rules registry.