### PR TITLE
fix(ui): Fix disabled link styles

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -226,7 +226,7 @@ const getColors = ({
     color: ${color};
     background-color: ${background};
 
-    border: 1px solid ${borderless ? 'transparent' : border};
+    border: 1px solid ${borderless || priority === 'link' ? 'transparent' : border};
 
     ${translucentBorder && `border-width: 0;`}
 
@@ -241,7 +241,7 @@ const getColors = ({
     &:active {
       color: ${colorActive || color};
       background: ${backgroundActive};
-      border-color: ${borderless ? 'transparent' : borderActive};
+      border-color: ${borderless || priority === 'link' ? 'transparent' : borderActive};
     }`}
 
     &.focus-visible {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8980455/157752362-c5cbae68-f4da-4eec-8929-30f1fdbbca85.png)
Right now when you create a disabled button with `priority` set to `link`, the button would still render its border which shouldn't be there.

This PR makes it so that disabled link buttons no longer render their borders.