### PR TITLE
fix(ui): Link to Alert Rules list from command pallet

### DIFF
--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -75,6 +75,14 @@ async function createProjectResults(
           resultType: 'settings',
           to: `/settings/${orgId}/projects/${project.slug}/`,
         },
+        {
+          title: t('%s Alerts', project.slug),
+          description: t('List of project alert rules'),
+          model: project,
+          sourceType: 'project',
+          resultType: 'route',
+          to: `/organizations/${orgId}/alerts/rules/?project=${project.id}`,
+        },
       ];
 
       projectResults.unshift({

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -32,7 +32,7 @@ export default function getConfiguration({
           description: t('Manage team access for a project'),
         },
         {
-          path: `${pathPrefix}/alerts/`,
+          path: `/organizations/:orgId/alerts/rules/`,
           title: t('Alerts'),
           description: t('Manage alert rules for a project'),
         },

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -33,8 +33,8 @@ export default function getConfiguration({
         },
         {
           path: `${pathPrefix}/alerts/`,
-          title: t('Alerts'),
-          description: t('Manage alert rules for a project'),
+          title: t('Alert Settings'),
+          description: t('Alert Settings'),
         },
         {
           path: `${pathPrefix}/tags/`,

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -32,7 +32,7 @@ export default function getConfiguration({
           description: t('Manage team access for a project'),
         },
         {
-          path: `/organizations/:orgId/alerts/rules/`,
+          path: `${pathPrefix}/alerts/`,
           title: t('Alerts'),
           description: t('Manage alert rules for a project'),
         },

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -34,7 +34,7 @@ export default function getConfiguration({
         {
           path: `${pathPrefix}/alerts/`,
           title: t('Alert Settings'),
-          description: t('Alert Settings'),
+          description: t('Project alert settings'),
         },
         {
           path: `${pathPrefix}/tags/`,

--- a/tests/js/spec/components/search/sources/apiSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/apiSource.spec.jsx
@@ -255,6 +255,18 @@ describe('ApiSource', function () {
               slug: 'foo-project',
             }),
             sourceType: 'project',
+            resultType: 'route',
+            to: '/organizations/org-slug/alerts/rules/?project=2',
+          }),
+          matches: expect.anything(),
+          score: expect.anything(),
+        }),
+        expect.objectContaining({
+          item: expect.objectContaining({
+            model: expect.objectContaining({
+              slug: 'foo-project',
+            }),
+            sourceType: 'project',
             resultType: 'settings',
             to: '/settings/org-slug/projects/foo-project/',
           }),
@@ -278,7 +290,7 @@ describe('ApiSource', function () {
 
     // The return values here are because of fuzzy search matching.
     // There are no members that match
-    expect(mock.mock.calls[1][0].results).toHaveLength(5);
+    expect(mock.mock.calls[1][0].results).toHaveLength(6);
   });
 
   it('render function is called with correct results when API requests partially succeed', async function () {
@@ -342,7 +354,7 @@ describe('ApiSource', function () {
 
     // The return values here are because of fuzzy search matching.
     // There are no members that match
-    expect(mock.mock.calls[1][0].results).toHaveLength(5);
+    expect(mock.mock.calls[1][0].results).toHaveLength(6);
     expect(mock.mock.calls[1][0].results[0].item.model.slug).toBe('foo-org');
 
     mock.mockClear();
@@ -351,7 +363,7 @@ describe('ApiSource', function () {
     wrapper.update();
 
     // Still have 4 results, but is re-ordered
-    expect(mock.mock.calls[0][0].results).toHaveLength(5);
+    expect(mock.mock.calls[0][0].results).toHaveLength(6);
     expect(mock.mock.calls[0][0].results[0].item.model.slug).toBe('foo-team');
   });
 


### PR DESCRIPTION
Previously, the Alerts link on the command pallet (CMD + K) would go to the Alerts page for Project Settings. This PR adds a link for the Alert Rules list page and also makes it clearer that the "Alerts" link goes to the Alerts

# Before
<img width="634" alt="Screen Shot 2022-03-10 at 1 17 53 PM" src="https://user-images.githubusercontent.com/20312973/157757049-1cfa805c-9496-40e1-8b72-21b858207842.png">

# After
<img width="626" alt="Screen Shot 2022-03-10 at 2 54 39 PM" src="https://user-images.githubusercontent.com/20312973/157768801-05530346-53a1-4a36-b6ce-fdcc3b0790cf.png">

[FIXES WOR-1594](https://getsentry.atlassian.net/browse/WOR-1594)