### PR TITLE
feat(dev/ci): Test loading mocks and bootstrap code

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
 
+      # Trick for unattended Docker installations
+      # https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
       - name: Install prerequisites
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask docker

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -37,6 +37,9 @@ jobs:
 
       - name: Install prerequisites
         run: |
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask docker
+          sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
+          open -a /Applications/Docker.app --args --unattended --accept-license
           make prerequisites
 
       - name: Setup Python
@@ -66,7 +69,7 @@ jobs:
           [[ $(python -V) == "Python $(cat .python-version)" ]]
           python -m venv .venv
           source .venv/bin/activate
-          make develop init-config
+          make bootstrap
           pre-commit
 
   bootstrap-script:

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -203,7 +203,7 @@ apply-migrations() {
 
 create-user() {
     if [[ -n "${GITHUB_ACTIONS+x}" ]]; then
-        sentry createuser --superuser --email foo@tbd.com --no-password
+        sentry createuser --superuser --email foo@tbd.com --no-password  --no-input
     else
         sentry createuser --superuser
     fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -221,6 +221,8 @@ bootstrap() {
     create-db
     apply-migrations
     create-user
+    # Load mocks requires a super user to exist, thus, we execute after create-user
+    bin/load-mocks
     build-platform-assets
 }
 
@@ -245,6 +247,8 @@ reset-db() {
     drop-db
     create-db
     apply-migrations
+    # This ensures that your set up as some data inside of it
+    bin/load-mocks
 }
 
 prerequisites() {

--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -127,7 +127,7 @@ def createuser(email, password, superuser, no_password, no_input, force_update):
         user.save()
 
     # for self hosted to give superusers admin permissions
-    if superuser is True and settings.SENTRY_SELF_HOSTED:
+    if superuser is True and settings.SENTRY_SELF_HOSTED and not no_input:
         _set_user_permissions(user)
 
     click.echo(f"User {verb}: {email}")


### PR DESCRIPTION
We want to run loading mocks automatically as part of the bootstrapping process and when recreating the DB.
This will ensure that all developers have this data in their local development set up and won't have to discover
documentation talking about loading mocks or to forget to load them the last time they reset their set up.

In order to test loading mocks on CI, we need to run the dependent services and in order to do
that we need to use Docker, thus, need to install it on the Apple runners.

Now that we can install Docker on the Apple runners we can also test the bootstrap target.