### PR TITLE
fix: Improve setup/recovery instructions for incorrect node version

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -162,6 +162,8 @@ node-version-check() {
     node -pe "process.exit(Number(!(process.version == 'v' + require('./package.json').volta.node )))" ||
         (
             echo 'Unexpected node version. Recommended to use https://github.com/volta-cli/volta'
+            echo 'Run `volta install node` and `volta install yarn` to update your toolchain.'
+            echo 'If you do not have volta installed run `curl https://get.volta.sh | bash` or visit https://volta.sh'
             exit 1
         )
 }


### PR DESCRIPTION
Don't assume that the reader knows how to operate volta.