### PR TITLE
ref(page-filters): Improve checking for new paths with page filters

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -17,8 +17,8 @@ import {
 } from 'sentry/components/organizations/pageFilters/persistence';
 import {PageFiltersStringified} from 'sentry/components/organizations/pageFilters/types';
 import {
+  doesPathHaveNewFilters,
   getDefaultSelection,
-  getPathsWithNewFilters,
 } from 'sentry/components/organizations/pageFilters/utils';
 import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/constants/pageFilters';
 import OrganizationStore from 'sentry/stores/organizationStore';
@@ -189,7 +189,7 @@ export function initializeUrlState({
   if (storedPageFilters) {
     const {state: storedState, pinnedFilters} = storedPageFilters;
 
-    const pageHasPinning = getPathsWithNewFilters(organization).includes(pathname);
+    const pageHasPinning = doesPathHaveNewFilters(pathname, organization);
 
     const filtersToRestore = pageHasPinning
       ? pinnedFilters
@@ -422,7 +422,7 @@ async function updateDesyncedUrlState(router?: Router) {
   }
 
   const storedPageFilters = getPageFilterStorage(organization.slug);
-  const pageHasPinning = getPathsWithNewFilters(organization).includes(pathname);
+  const pageHasPinning = doesPathHaveNewFilters(pathname, organization);
 
   // If we don't have any stored page filters OR pinning is not enabled for
   // this page, then we do not check desynced state

--- a/static/app/components/organizations/pageFilters/utils.tsx
+++ b/static/app/components/organizations/pageFilters/utils.tsx
@@ -72,14 +72,16 @@ export function isSelectionEqual(selection: PageFilters, other: PageFilters): bo
 
 /**
  * TODO(davidenwang): Temporarily used for when pages with the GSH live alongside new page filters
+ * @param pathname
  * @param organization
- * @returns list of paths that have the new page filters, these pages
- * should only load the pinned filters, not the whole global selection
+ * @returns true if the pathname has new page filters
  */
-export function getPathsWithNewFilters(organization: Organization): string[] {
-  return (
+export function doesPathHaveNewFilters(pathname: string, organization: Organization) {
+  const newFilterPaths = (
     organization.features.includes('selection-filters-v2')
       ? ['issues', 'user-feedback', 'alerts', 'monitors']
       : []
   ).map(route => `/organizations/${organization.slug}/${route}/`);
+
+  return newFilterPaths.some(pageFilterPath => pathname.includes(pageFilterPath));
 }

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -11,8 +11,8 @@ import Feature from 'sentry/components/acl/feature';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import {
+  doesPathHaveNewFilters,
   extractSelectionParameters,
-  getPathsWithNewFilters,
 } from 'sentry/components/organizations/pageFilters/utils';
 import {
   IconChevron,
@@ -116,7 +116,7 @@ function Sidebar({location, organization}: Props) {
     // of new page filter selection. You must pin your filters in which case
     // they will persist anyway.
     if (organization) {
-      if (getPathsWithNewFilters(organization).includes(pathname)) {
+      if (doesPathHaveNewFilters(pathname, organization)) {
         return;
       }
     }

--- a/tests/js/spec/components/environmentPageFilter.spec.tsx
+++ b/tests/js/spec/components/environmentPageFilter.spec.tsx
@@ -18,7 +18,10 @@ describe('EnvironmentPageFilter', function () {
       },
     ],
     router: {
-      location: {query: {}},
+      location: {
+        pathname: '/organizations/org-slug/issues/',
+        query: {},
+      },
       params: {orgId: 'org-slug'},
     },
   });

--- a/tests/js/spec/components/projectPageFilter.spec.tsx
+++ b/tests/js/spec/components/projectPageFilter.spec.tsx
@@ -17,7 +17,10 @@ describe('ProjectPageFilter', function () {
       },
     ],
     router: {
-      location: {query: {}},
+      location: {
+        pathname: '/organizations/org-slug/issues/',
+        query: {},
+      },
       params: {orgId: 'org-slug'},
     },
   });


### PR DESCRIPTION
Use `includes` for the pathname to avoid having to hardcode each subpage ex: `alerts/rules` and `alerts/`