### PR TITLE
[NO MERGE] Moving Rules Experiment

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -230,7 +230,7 @@ _SENTRY_RULES = (
     "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
     "sentry.rules.conditions.event_attribute.EventAttributeCondition",
     "sentry.rules.conditions.level.LevelCondition",
-    "sentry.rules.filters.age_comparison.AgeComparisonFilter",
+    "sentry.rules.filters.age_comparison.CompareAgeFilter",
     "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
     "sentry.rules.filters.assigned_to.AssignedToFilter",
     "sentry.rules.filters.latest_release.LatestReleaseFilter",

--- a/src/sentry/rules/filters/age_comparison.py
+++ b/src/sentry/rules/filters/age_comparison.py
@@ -39,7 +39,7 @@ class AgeComparisonForm(forms.Form):
     time = forms.ChoiceField(choices=get_timerange_choices)
 
 
-class AgeComparisonFilter(EventFilter):
+class CompareAgeFilter(EventFilter):
     form_cls = AgeComparisonForm
     form_fields = {
         "comparison_type": {"type": "choice", "choices": age_comparison_choices},

--- a/tests/sentry/rules/filters/test_age_comparison.py
+++ b/tests/sentry/rules/filters/test_age_comparison.py
@@ -4,12 +4,12 @@ from unittest import mock
 import pytz
 from django.utils import timezone
 
-from sentry.rules.filters.age_comparison import AgeComparisonFilter
+from sentry.rules.filters.age_comparison import CompareAgeFilter
 from sentry.testutils.cases import RuleTestCase
 
 
 class AgeComparisonFilterTest(RuleTestCase):
-    rule_cls = AgeComparisonFilter
+    rule_cls = CompareAgeFilter
 
     @mock.patch("django.utils.timezone.now")
     def test_older_applies_correctly(self, now):


### PR DESCRIPTION
My hypothesis is that we do not have any tests to catch moved rules (e.g. filters, conditions, actions). This would break Sentry because `rules.data` references rules by path.