### PR TITLE
fix(slack): Handle missing organization in analytics

### DIFF
--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -221,12 +221,13 @@ def unfurl_discover(
         ).build()
 
     org_model = integration.organizations.first()
-    analytics.record(
-        "integrations.slack.chart_unfurl",
-        organization_id=org_model.id if org_model is not None else None,
-        user_id=user.id if user else None,
-        unfurls_count=len(unfurls),
-    )
+    if org_model is not None and hasattr(org_model, "id"):
+        analytics.record(
+            "integrations.slack.chart_unfurl",
+            organization_id=org_model.id,
+            user_id=user.id if user else None,
+            unfurls_count=len(unfurls),
+        )
 
     return unfurls
 

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -220,9 +220,10 @@ def unfurl_discover(
             chart_url=url,
         ).build()
 
+    org_model = integration.organizations.first()
     analytics.record(
         "integrations.slack.chart_unfurl",
-        organization_id=integration.organizations.all()[0].id,
+        organization_id=org_model.id if org_model is not None else None,
         user_id=user.id if user else None,
         unfurls_count=len(unfurls),
     )


### PR DESCRIPTION
Queryset used .all()[0] which would fail if there were no organizations. Switched to using .first() which returns None

Fixes SENTRY-SZY