### PR TITLE
ref(rules): Explicit Rule IDs

### DIFF
--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -15,6 +15,7 @@ logger = logging.getLogger("sentry.rules")
 
 
 class JiraCreateTicketAction(TicketEventAction):
+    id = "sentry.integrations.jira.notify_action.JiraCreateTicketAction"
     label = "Create a Jira issue in {integration} with these "
     ticket_type = "a Jira issue"
     link = "https://docs.sentry.io/product/integrations/project-mgmt/jira/#issue-sync"

--- a/src/sentry/integrations/msteams/notify_action.py
+++ b/src/sentry/integrations/msteams/notify_action.py
@@ -56,6 +56,7 @@ class MsTeamsNotifyServiceForm(forms.Form):
 
 
 class MsTeamsNotifyServiceAction(IntegrationEventAction):
+    id = "sentry.integrations.msteams.MsTeamsNotifyServiceAction"
     form_cls = MsTeamsNotifyServiceForm
     label = "Send a notification to the {team} Team to {channel}"
     prompt = "Send a Microsoft Teams notification"

--- a/src/sentry/integrations/msteams/notify_action.py
+++ b/src/sentry/integrations/msteams/notify_action.py
@@ -56,7 +56,7 @@ class MsTeamsNotifyServiceForm(forms.Form):
 
 
 class MsTeamsNotifyServiceAction(IntegrationEventAction):
-    id = "sentry.integrations.msteams.MsTeamsNotifyServiceAction"
+    id = "sentry.integrations.msteams.notify_action.MsTeamsNotifyServiceAction"
     form_cls = MsTeamsNotifyServiceForm
     label = "Send a notification to the {team} Team to {channel}"
     prompt = "Send a Microsoft Teams notification"

--- a/src/sentry/integrations/pagerduty/notify_action.py
+++ b/src/sentry/integrations/pagerduty/notify_action.py
@@ -86,6 +86,7 @@ class PagerDutyNotifyServiceForm(forms.Form):
 
 
 class PagerDutyNotifyServiceAction(IntegrationEventAction):
+    id = "sentry.integrations.pagerduty.PagerDutyNotifyServiceAction"
     form_cls = PagerDutyNotifyServiceForm
     label = "Send a notification to PagerDuty account {account} and service {service}"
     prompt = "Send a PagerDuty notification"

--- a/src/sentry/integrations/pagerduty/notify_action.py
+++ b/src/sentry/integrations/pagerduty/notify_action.py
@@ -86,7 +86,7 @@ class PagerDutyNotifyServiceForm(forms.Form):
 
 
 class PagerDutyNotifyServiceAction(IntegrationEventAction):
-    id = "sentry.integrations.pagerduty.PagerDutyNotifyServiceAction"
+    id = "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction"
     form_cls = PagerDutyNotifyServiceForm
     label = "Send a notification to PagerDuty account {account} and service {service}"
     prompt = "Send a PagerDuty notification"

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -162,7 +162,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
 
 
 class SlackNotifyServiceAction(IntegrationEventAction):  # type: ignore
-    id = "sentry.integrations.slack.SlackNotifyServiceAction"
+    id = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
     form_cls = SlackNotifyServiceForm
     label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
     prompt = "Send a Slack notification"

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -162,6 +162,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
 
 
 class SlackNotifyServiceAction(IntegrationEventAction):  # type: ignore
+    id = "sentry.integrations.slack.SlackNotifyServiceAction"
     form_cls = SlackNotifyServiceForm
     label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
     prompt = "Send a Slack notification"

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -10,6 +10,7 @@ logger = logging.getLogger("sentry.rules")
 
 
 class AzureDevopsCreateTicketAction(TicketEventAction):  # type: ignore
+    id = "sentry.integrations.vsts.notify_action.AzureDevopsCreateTicketAction"
     label = "Create an Azure DevOps work item in {integration} with these "
     ticket_type = "an Azure DevOps work item"
     link = "https://docs.sentry.io/product/integrations/source-code-mgmt/azure-devops/#issue-sync"

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -7,6 +7,7 @@ from sentry.utils import metrics
 
 
 class NotifyEmailAction(EventAction):
+    id = "sentry.mail.actions.NotifyEmailAction"
     form_cls = NotifyEmailForm
     label = "Send a notification to {targetType}"
     prompt = "Send a notification"

--- a/src/sentry/rules/__init__.py
+++ b/src/sentry/rules/__init__.py
@@ -1,4 +1,4 @@
-from .base import EventState, RuleBase, RuleDescriptor
+from .base import EventState, RuleBase
 from .match import LEVEL_MATCH_CHOICES, MATCH_CHOICES, MatchType
 from .registry import RuleRegistry
 
@@ -9,7 +9,6 @@ __all__ = (
     "MATCH_CHOICES",
     "MatchType",
     "RuleBase",
-    "RuleDescriptor",
     "rules",
 )
 

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -1,3 +1,4 @@
+import abc
 import logging
 
 from django import forms
@@ -24,7 +25,7 @@ class IntegrationNotifyServiceForm(forms.Form):
         self.fields[INTEGRATION_KEY].widget.choices = self.fields[INTEGRATION_KEY].choices
 
 
-class EventAction(RuleBase):
+class EventAction(RuleBase, abc.ABC):
     rule_type = "action/event"
 
     def after(self, event, state):
@@ -50,7 +51,7 @@ class EventAction(RuleBase):
         raise NotImplementedError
 
 
-class IntegrationEventAction(EventAction):
+class IntegrationEventAction(EventAction, abc.ABC):
     """
     Intermediate abstract class to help DRY some event actions code.
     """
@@ -179,7 +180,7 @@ def create_issue(event, futures):
         create_link(integration, installation, event, response)
 
 
-class TicketEventAction(IntegrationEventAction):
+class TicketEventAction(IntegrationEventAction, abc.ABC):
     """Shared ticket actions"""
 
     form_cls = IntegrationNotifyServiceForm

--- a/src/sentry/rules/actions/notify_event.py
+++ b/src/sentry/rules/actions/notify_event.py
@@ -10,6 +10,7 @@ from sentry.utils.safe import safe_execute
 
 
 class NotifyEventAction(EventAction):
+    id = "sentry.rules.actions.notify_event.NotifyEventAction"
     label = "Send a notification (for all legacy integrations)"
     prompt = "Send a notification to all legacy integrations"
 

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -29,6 +29,7 @@ def validate_field(value: Optional[str], field: Mapping[str, Any], app_name: str
 
 
 class NotifyEventSentryAppAction(EventAction):  # type: ignore
+    id = "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
     actionType = "sentryapp"
     # Required field for EventAction, value is ignored
     label = ""

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -134,6 +134,7 @@ class NotifyEventServiceForm(forms.Form):
 
 
 class NotifyEventServiceAction(EventAction):
+    id = "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
     form_cls = NotifyEventServiceForm
     label = "Send a notification via {service}"
     prompt = "Send a notification via an integration"

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -27,7 +27,7 @@ by the rule's logic. Each rule condition may be associated with a form.
 - [ACTION:I want to get notified when] [RULE:an event is first seen]
 - [ACTION:I want to group events when] [RULE:an event matches [FORM]]
 """
-
+import abc
 import logging
 from collections import namedtuple
 
@@ -37,14 +37,7 @@ from collections import namedtuple
 CallbackFuture = namedtuple("CallbackFuture", ["callback", "kwargs", "key"])
 
 
-class RuleDescriptor(type):
-    def __new__(cls, *args, **kwargs):
-        new_cls = super().__new__(cls, *args, **kwargs)
-        new_cls.id = f"{new_cls.__module__}.{new_cls.__name__}"
-        return new_cls
-
-
-class RuleBase(metaclass=RuleDescriptor):
+class RuleBase(abc.ABC):
     label = None
     form_cls = None
 

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -52,7 +52,7 @@ class RuleBase(abc.ABC):
     @property
     @abc.abstractmethod
     def id(self) -> str:
-        raise NotImplementedError
+        pass
 
     def is_enabled(self):
         return True

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -49,6 +49,11 @@ class RuleBase(abc.ABC):
         self.had_data = data is not None
         self.rule = rule
 
+    @property
+    @abc.abstractmethod
+    def id(self) -> str:
+        raise NotImplementedError
+
     def is_enabled(self):
         return True
 

--- a/src/sentry/rules/conditions/base.py
+++ b/src/sentry/rules/conditions/base.py
@@ -1,8 +1,9 @@
+import abc
 from sentry.eventstore.models import Event
 from sentry.rules.base import EventState, RuleBase
 
 
-class EventCondition(RuleBase):  # type: ignore
+class EventCondition(RuleBase, abc.ABC):
     rule_type = "condition/event"
 
     def passes(self, event: Event, state: EventState) -> bool:

--- a/src/sentry/rules/conditions/base.py
+++ b/src/sentry/rules/conditions/base.py
@@ -1,9 +1,10 @@
 import abc
+
 from sentry.eventstore.models import Event
 from sentry.rules.base import EventState, RuleBase
 
 
-class EventCondition(RuleBase, abc.ABC):
+class EventCondition(RuleBase, abc.ABC):  # type: ignore
     rule_type = "condition/event"
 
     def passes(self, event: Event, state: EventState) -> bool:

--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -49,8 +49,6 @@ class EventAttributeCondition(EventCondition):
     - extra.{FIELD}
     """
 
-    # TODO(dcramer): add support for stacktrace.vars.[name]
-
     id = "sentry.rules.conditions.event_attribute.EventAttributeCondition"
     form_cls = EventAttributeForm
     label = "The event's {attribute} value {match} {value}"

--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -51,6 +51,7 @@ class EventAttributeCondition(EventCondition):
 
     # TODO(dcramer): add support for stacktrace.vars.[name]
 
+    id = "sentry.rules.conditions.event_attribute.EventAttributeCondition"
     form_cls = EventAttributeForm
     label = "The event's {attribute} value {match} {value}"
 

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -174,6 +174,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
 
 
 class EventFrequencyCondition(BaseEventFrequencyCondition):
+    id = "sentry.rules.conditions.event_frequency.EventFrequencyCondition"
     label = "The issue is seen more than {value} times in {interval}"
 
     def query_hook(self, event: Event, start: datetime, end: datetime, environment_id: str) -> int:
@@ -189,6 +190,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
 
 
 class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
+    id = "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition"
     label = "The issue is seen by more than {value} users in {interval}"
 
     def query_hook(self, event: Event, start: datetime, end: datetime, environment_id: str) -> int:
@@ -249,6 +251,7 @@ class EventFrequencyPercentForm(EventFrequencyForm):
 
 
 class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
+    id = "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition"
     label = "The issue affects more than {value} percent of sessions in {interval}"
     logger = logging.getLogger("rules.event_frequency")
 

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import abc
 import logging
 import re
 from datetime import datetime, timedelta
@@ -80,7 +81,7 @@ class EventFrequencyForm(forms.Form):  # type: ignore
         return cleaned_data
 
 
-class BaseEventFrequencyCondition(EventCondition):
+class BaseEventFrequencyCondition(EventCondition, abc.ABC):
     intervals = standard_intervals
     form_cls = EventFrequencyForm
     label: str

--- a/src/sentry/rules/conditions/every_event.py
+++ b/src/sentry/rules/conditions/every_event.py
@@ -4,6 +4,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class EveryEventCondition(EventCondition):
+    id = "sentry.rules.conditions.every_event.EveryEventCondition"
     label = "The event occurs"
 
     def passes(self, event: Event, state: EventState) -> bool:

--- a/src/sentry/rules/conditions/first_seen_event.py
+++ b/src/sentry/rules/conditions/first_seen_event.py
@@ -4,6 +4,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class FirstSeenEventCondition(EventCondition):
+    id = "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
     label = "A new issue is created"
 
     def passes(self, event: Event, state: EventState) -> bool:

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -23,6 +23,7 @@ class LevelEventForm(forms.Form):  # type: ignore
 
 
 class LevelCondition(EventCondition):
+    id = "sentry.rules.conditions.level.LevelCondition"
     form_cls = LevelEventForm
     label = "The event's level is {match} {level}"
     form_fields = {

--- a/src/sentry/rules/conditions/reappeared_event.py
+++ b/src/sentry/rules/conditions/reappeared_event.py
@@ -4,6 +4,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class ReappearedEventCondition(EventCondition):
+    id = "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"
     label = "The issue changes state from ignored to unresolved"
 
     def passes(self, event: Event, state: EventState) -> bool:

--- a/src/sentry/rules/conditions/regression_event.py
+++ b/src/sentry/rules/conditions/regression_event.py
@@ -4,6 +4,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class RegressionEventCondition(EventCondition):
+    id = "sentry.rules.conditions.regression_event.RegressionEventCondition"
     label = "The issue changes state from resolved to unresolved"
 
     def passes(self, event: Event, state: EventState) -> bool:

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -28,6 +28,7 @@ class TaggedEventForm(forms.Form):  # type: ignore
 
 
 class TaggedEventCondition(EventCondition):
+    id = "sentry.rules.conditions.tagged_event.TaggedEventCondition"
     form_cls = TaggedEventForm
     label = "The event's tags match {key} {match} {value}"
 

--- a/src/sentry/rules/filters/age_comparison.py
+++ b/src/sentry/rules/filters/age_comparison.py
@@ -43,6 +43,7 @@ class AgeComparisonForm(forms.Form):  # type: ignore
 
 
 class AgeComparisonFilter(EventFilter):
+    id = "sentry.rules.filters.age_comparison.AgeComparisonFilter"
     form_cls = AgeComparisonForm
     form_fields = {
         "comparison_type": {"type": "choice", "choices": age_comparison_choices},

--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 
 class AssignedToFilter(EventFilter):
+    id = "sentry.rules.filters.assigned_to.AssignedToFilter"
     form_cls = AssignedToForm
     label = "The issue is assigned to {targetType}"
     prompt = "The issue is assigned to {no one/team/member}"

--- a/src/sentry/rules/filters/base.py
+++ b/src/sentry/rules/filters/base.py
@@ -1,8 +1,9 @@
+import abc
 from sentry.eventstore.models import Event
 from sentry.rules.base import EventState, RuleBase
 
 
-class EventFilter(RuleBase):  # type: ignore
+class EventFilter(RuleBase, abc.ABC):
     rule_type = "filter/event"
 
     def passes(self, event: Event, state: EventState) -> bool:

--- a/src/sentry/rules/filters/base.py
+++ b/src/sentry/rules/filters/base.py
@@ -1,9 +1,10 @@
 import abc
+
 from sentry.eventstore.models import Event
 from sentry.rules.base import EventState, RuleBase
 
 
-class EventFilter(RuleBase, abc.ABC):
+class EventFilter(RuleBase, abc.ABC):  # type: ignore
     rule_type = "filter/event"
 
     def passes(self, event: Event, state: EventState) -> bool:

--- a/src/sentry/rules/filters/event_attribute.py
+++ b/src/sentry/rules/filters/event_attribute.py
@@ -2,4 +2,5 @@ from sentry.rules.conditions.event_attribute import EventAttributeCondition
 
 
 class EventAttributeFilter(EventAttributeCondition):
+    id = "sentry.rules.filters.event_attribute.EventAttributeFilter"
     rule_type = "filter/event"

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -10,6 +10,7 @@ class IssueOccurrencesForm(forms.Form):  # type: ignore
 
 
 class IssueOccurrencesFilter(EventFilter):
+    id = "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter"
     form_cls = IssueOccurrencesForm
     form_fields = {
         "value": {"type": "number", "placeholder": 10},

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -12,10 +12,7 @@ class IssueOccurrencesForm(forms.Form):  # type: ignore
 class IssueOccurrencesFilter(EventFilter):
     id = "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter"
     form_cls = IssueOccurrencesForm
-    form_fields = {
-        "value": {"type": "number", "placeholder": 10},
-    }
-
+    form_fields = {"value": {"type": "number", "placeholder": 10}}
     label = "The issue has happened at least {value} times"
     prompt = "The issue has happened at least {x} times (Note: this is approximate)"
 

--- a/src/sentry/rules/filters/latest_release.py
+++ b/src/sentry/rules/filters/latest_release.py
@@ -42,6 +42,7 @@ def clear_release_project_cache(instance: ReleaseProject, **kwargs: Any) -> None
 
 
 class LatestReleaseFilter(EventFilter):
+    id = "sentry.rules.filters.latest_release.LatestReleaseFilter"
     label = "The event is from the latest release"
 
     def get_latest_release(self, event: Event) -> Release | None:

--- a/src/sentry/rules/filters/level.py
+++ b/src/sentry/rules/filters/level.py
@@ -2,4 +2,5 @@ from sentry.rules.conditions.level import LevelCondition
 
 
 class LevelFilter(LevelCondition):
+    id = "sentry.rules.filters.level.LevelFilter"
     rule_type = "filter/event"

--- a/src/sentry/rules/filters/tagged_event.py
+++ b/src/sentry/rules/filters/tagged_event.py
@@ -2,4 +2,5 @@ from sentry.rules.conditions.tagged_event import TaggedEventCondition
 
 
 class TaggedEventFilter(TaggedEventCondition):
+    id = "sentry.rules.filters.tagged_event.TaggedEventFilter"
     rule_type = "filter/event"

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -25,6 +25,8 @@ EVERY_EVENT_COND_DATA = {"id": "sentry.rules.conditions.every_event.EveryEventCo
 
 
 class MockConditionTrue(EventCondition):
+    id = "tests.sentry.rules.test_processor.MockConditionTrue"
+
     def passes(self, event, state):
         return True
 
@@ -202,14 +204,20 @@ class RuleProcessorTest(TestCase):
         assert passes.call_count == 0
 
 
-# mock filter which always passes
 class MockFilterTrue(EventFilter):
+    """Mock filter which always passes."""
+
+    id = "tests.sentry.rules.test_processor.MockFilterTrue"
+
     def passes(self, event, state):
         return True
 
 
-# mock filter which never passes
 class MockFilterFalse(EventFilter):
+    """Mock filter which never passes."""
+
+    id = "tests.sentry.rules.test_processor.MockFilterFalse"
+
     def passes(self, event, state):
         return False
 


### PR DESCRIPTION
We noticed a potentially catastrophic vulnerability in the way we define Rules. Rules are either "filters", "conditions", or "actions" and are implemented as classes in the Rules hierarchy. The are accessible through the `RuleRegistry`:
```py
class RuleRegistry:
    ...
    def add(self, rule):
        self._map[rule.id] = rule

    def get(self, rule_id, type=None):
        return self._map.get(rule_id)
```
The are accessed in a similarly obvious way:
```py
_SENTRY_RULES = (
    "sentry.mail.actions.NotifyEmailAction",
    ...
    "sentry.rules.filters.level.LevelFilter",
)

def init_registry() -> RuleRegistry:
    registry = RuleRegistry()
    for rule in _SENTRY_RULES:
        cls = import_string(rule)
        registry.add(cls)
    return registry
rules = init_registry()
```
The problem arises because of how the rule classes are assigned IDs:
```py
class RuleDescriptor(type):
    def __new__(cls, *args, **kwargs):
        new_cls = super().__new__(cls, *args, **kwargs)
        new_cls.id = f"{new_cls.__module__}.{new_cls.__name__}"
        return new_cls

class RuleBase(metaclass=RuleDescriptor):
    ...
```
This means that moving Rules between files or changing their names will change their IDs. 

Rules are are stored in the in the DB as a JSON blob:
```py
class Rule(Model):
    ...
    data = GzippedDictField()
```
The looks something like:
```json
{
  "actions": [...],
  "conditions": [{
    "id":  "sentry.rules.conditions.event_attribute.EventAttributeCondition",
    ...
  }],
  "filters": [],
}
```   
If the IDs of the rules ever change, then all the DB rules that reference them by ID will break.

For an example of how a name change could go undetected, see https://github.com/getsentry/sentry/pull/32512. We are somewhat confident that this hasn't already happened because we'd expect to see `warning` logs like:
```
Unregistered condition sentry.rules.conditions.event_attribute.EventAttributeCondition
```
This PR solves this problem by hardcoding the IDs as class variables on _every_ rule.