### PR TITLE
fix(devserver): Honor the SENTRY_USE_RELAY setting

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1671,7 +1671,7 @@ SENTRY_WATCHERS = (
 
 # Controls whether devserver spins up Relay, Kafka, and several ingest worker jobs to direct store traffic
 # through the Relay ingestion pipeline. Without, ingestion is completely disabled. Use `bin/load-mocks` to
-# generate fake data for local testing. You can also manually enable relay with the `--relay` flag to `devserver`.
+# generate fake data for local testing. You can also manually enable relay with the `--ingest` flag to `devserver`.
 # XXX: This is disabled by default as typical development workflows do not require end-to-end services running
 # and disabling optional services reduces resource consumption and complexity
 SENTRY_USE_RELAY = False

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -57,7 +57,7 @@ def _get_daemon(name, *args, **kwargs):
     "--watchers/--no-watchers", default=True, help="Watch static files and recompile on changes."
 )
 @click.option("--workers/--no-workers", default=False, help="Run asynchronous workers.")
-@click.option("--ingest/--no-ingest", help="Run ingest services (including Relay).")
+@click.option("--ingest/--no-ingest", default=None, help="Run ingest services (including Relay).")
 @click.option(
     "--prefix/--no-prefix", default=True, help="Show the service name prefix and timestamp"
 )
@@ -210,6 +210,9 @@ def devserver(
             }
         )
 
+    if ingest in (True, False):
+        settings.SENTRY_USE_RELAY = ingest
+
     if workers:
         if settings.CELERY_ALWAYS_EAGER:
             raise click.ClickException(
@@ -245,10 +248,8 @@ def devserver(
                 )
             daemons += [_get_daemon("metrics")]
 
-    if ingest is True or (settings.SENTRY_USE_RELAY and ingest is not False):
+    if settings.SENTRY_USE_RELAY:
         daemons += [_get_daemon("ingest")]
-    else:
-        settings.SENTRY_USE_RELAY = False
 
     if needs_https and has_https:
         https_port = str(parsed_url.port)


### PR DESCRIPTION
Fixes `sentry devserver` behavior to honor `SENTRY_USE_RELAY` unless either
`--ingest` or `--no-ingest` are explicitly specified. Also ensures that the CLI
flag is propagated to worker initialization.

