### PR TITLE
fix(metrics): Force derived metrics to respect projects filter [INGEST-924]

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -281,6 +281,8 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
                 initial_snuba_query, use_cache=False, referrer="api.metrics.totals.initial_query"
             ).get("data")
         except StopIteration:
+            # This can occur when requesting a list of derived metrics that are not have no data
+            # for the passed projects
             initial_query_results = {}
 
         # If we do not get any results from the first query, then there is no point in making

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -279,15 +279,15 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
 
             initial_query_results = raw_snql_query(
                 initial_snuba_query, use_cache=False, referrer="api.metrics.totals.initial_query"
-            ).get("data")
+            )["data"]
         except StopIteration:
             # This can occur when requesting a list of derived metrics that are not have no data
             # for the passed projects
-            initial_query_results = {}
+            initial_query_results = []
 
         # If we do not get any results from the first query, then there is no point in making
         # the second query
-        if initial_query_results and len(initial_query_results) > 0:
+        if initial_query_results:
             # We no longer want the order by in the 2nd query because we already have the order of
             # the group by tags from the first query so we basically remove the order by columns,
             # and reset the query fields to the original fields because in the second query,

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -229,7 +229,7 @@ class SingularEntityDerivedMetric(DerivedMetric):
     def __raise_entity_validation_exception(self, func_name: str):
         raise DerivedMetricParseException(
             f"Method `{func_name}` can only be called on instance of "
-            f"SingularEntityDerivedMetric {self.metric_name} with a `projects attribute."
+            f"SingularEntityDerivedMetric {self.metric_name} with a `projects` attribute."
         )
 
     @classmethod

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -1344,7 +1344,7 @@ class DerivedMetricsDataTest(SessionMetricsTestCase, APITestCase):
         assert group["series"]["session.crash_free_rate"] == [None]
 
     @with_feature(FEATURE_FLAG)
-    def test_crash_free_rate_when_no_session_metrics_data_with_orderBy_and_groupBy(self):
+    def test_crash_free_rate_when_no_session_metrics_data_with_orderby_and_groupby(self):
         indexer.record("release")
         response = self.get_success_response(
             self.organization.slug,

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -1344,6 +1344,20 @@ class DerivedMetricsDataTest(SessionMetricsTestCase, APITestCase):
         assert group["series"]["session.crash_free_rate"] == [None]
 
     @with_feature(FEATURE_FLAG)
+    def test_crash_free_rate_when_no_session_metrics_data_with_orderBy_and_groupBy(self):
+        indexer.record("release")
+        response = self.get_success_response(
+            self.organization.slug,
+            project=[self.project.id],
+            field=["session.crash_free_rate", "sum(sentry.sessions.session)"],
+            statsPeriod="6m",
+            interval="6m",
+            groupBy=["release"],
+            orderBy="-session.crash_free_rate",
+        )
+        assert response.data["groups"] == []
+
+    @with_feature(FEATURE_FLAG)
     def test_incorrect_crash_free_rate(self):
         response = self.get_response(
             self.organization.slug,

--- a/tests/sentry/snuba/metrics/test_fields.py
+++ b/tests/sentry/snuba/metrics/test_fields.py
@@ -28,12 +28,6 @@ def get_single_metric_info_mocked(_, metric_name):
     }
 
 
-def clear_derived_metrics_entity_state():
-    """Clears Derived Metrics state"""
-    for _, derived_metric_obj in DERIVED_METRICS.items():
-        derived_metric_obj._entity = None
-
-
 class SingleEntityDerivedMetricTestCase(TestCase):
     def setUp(self):
         self.crash_free_fake = SingularEntityDerivedMetric(
@@ -45,15 +39,6 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             ),
         )
         DERIVED_METRICS.update({"crash_free_fake": self.crash_free_fake})
-
-    def tearDown(self):
-        clear_derived_metrics_entity_state()
-
-    def __call_get_entity_on_supported_derived_metrics(self):
-        for derived_metric_name in DERIVED_METRICS.keys():
-            if derived_metric_name == self.crash_free_fake.metric_name:
-                continue
-            DERIVED_METRICS[derived_metric_name].get_entity(projects=[self.project])
 
     @mock.patch(
         "sentry.snuba.metrics.fields.base.get_single_metric_info", get_single_metric_info_mocked
@@ -93,8 +78,6 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             indexer.record(status)
         session_ids = [indexer.record("sentry.sessions.session")]
 
-        self.__call_get_entity_on_supported_derived_metrics()
-
         derived_name_snql = {
             "session.init": (init_sessions, session_ids),
             "session.crashed": (crashed_sessions, session_ids),
@@ -105,11 +88,13 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             ),
         }
         for metric_name, (func, metric_ids_list) in derived_name_snql.items():
-            assert DERIVED_METRICS[metric_name].generate_select_statements() == [
+            assert DERIVED_METRICS[metric_name].generate_select_statements([self.project]) == [
                 func(metric_ids=metric_ids_list, alias=metric_name),
             ]
 
-        assert DERIVED_METRICS["session.crash_free_rate"].generate_select_statements() == [
+        assert DERIVED_METRICS["session.crash_free_rate"].generate_select_statements(
+            [self.project]
+        ) == [
             percentage(
                 crashed_sessions(metric_ids=session_ids, alias="session.crashed"),
                 init_sessions(metric_ids=session_ids, alias="session.init"),
@@ -121,7 +106,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         # Test that ensures that even if `generate_select_statements` is called before
         # `get_entity` is called, and thereby the entity validation logic, we throw an exception
         with pytest.raises(DerivedMetricParseException):
-            self.crash_free_fake.generate_select_statements()
+            self.crash_free_fake.generate_select_statements([self.project])
 
     @mock.patch(
         "sentry.snuba.metrics.fields.base.get_single_metric_info", get_single_metric_info_mocked
@@ -129,16 +114,6 @@ class SingleEntityDerivedMetricTestCase(TestCase):
     def test_generate_metric_ids(self):
         session_metric_id = indexer.record("sentry.sessions.session")
         session_error_metric_id = indexer.record("sentry.sessions.session.error")
-
-        # Test that ensures that if `generate_select_statements` is called before
-        # `get_entity` is called, and thereby bypassing the entity validation and setting logic
-        # for both correctly and incorrectly defined derived metrics, we throw an exception
-        with pytest.raises(DerivedMetricParseException):
-            self.crash_free_fake.generate_select_statements()
-        with pytest.raises(DerivedMetricParseException):
-            DERIVED_METRICS["session.errored_set"].generate_metric_ids()
-
-        self.__call_get_entity_on_supported_derived_metrics()
 
         for derived_metric_name in [
             "session.init",
@@ -150,20 +125,22 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         assert DERIVED_METRICS["session.errored_set"].generate_metric_ids() == {
             session_error_metric_id
         }
-        clear_derived_metrics_entity_state()
 
     @mock.patch(
         "sentry.snuba.metrics.fields.base.get_single_metric_info", get_single_metric_info_mocked
     )
     def test_generate_order_by_clause(self):
-        self.__call_get_entity_on_supported_derived_metrics()
         for derived_metric_name in DERIVED_METRICS.keys():
             if derived_metric_name == self.crash_free_fake.metric_name:
                 continue
             derived_metric_obj = DERIVED_METRICS[derived_metric_name]
             assert derived_metric_obj.generate_orderby_clause(
                 projects=[self.project], direction=Direction.ASC
-            ) == [OrderBy(derived_metric_obj.generate_select_statements()[0], Direction.ASC)]
+            ) == [
+                OrderBy(
+                    derived_metric_obj.generate_select_statements([self.project])[0], Direction.ASC
+                )
+            ]
 
         with pytest.raises(DerivedMetricParseException):
             self.crash_free_fake.generate_orderby_clause(


### PR DESCRIPTION
This PR:-
- Adds a fix where entity is not set on the instance of derived metric as the definition of a derived metric
and thereby its entity might change from one project to the next, and so the entity of a derived metric should
be computed on the fly. 
- Also handles a bug when we groupby and orderby a derived metric that does not exist in dataset resulting in a 500 response error