### PR TITLE
feat(devenv): turn access logs off by default in dev

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2511,3 +2511,6 @@ SENTRY_PROFILING_SERVICE_URL = "http://localhost:8085"
 
 SENTRY_ISSUE_ALERT_HISTORY = "sentry.rules.history.backends.postgres.PostgresRuleHistoryBackend"
 SENTRY_ISSUE_ALERT_HISTORY_OPTIONS = {}
+
+
+LOG_API_ACCESS = not IS_DEV or os.environ.get("SENTRY_LOG_API_ACCESS")

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -88,6 +88,10 @@ def access_log_middleware(
         # they make DB calls. For static urls that should not happen. Hence
         # this middleware is skipped for them. We don't care about its access
         # that much anyways
+
+        if not settings.LOG_API_ACCESS:
+            return get_response(request)
+
         if request.path_info.startswith(settings.ANONYMOUS_STATIC_PREFIXES):
             return get_response(request)
         access_log_metadata = _AccessLogMetaData(request_start_time=time.time())

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -82,6 +82,7 @@ urlpatterns = [
 
 
 @override_settings(ROOT_URLCONF="tests.sentry.middleware.test_access_log_middleware")
+@override_settings(LOG_API_ACCESS=True)
 class LogCaptureAPITestCase(APITestCase):
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, caplog):

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -123,6 +123,18 @@ class TestAccessLogSuccess(LogCaptureAPITestCase):
         assert self.captured_logs[0].token_type == "ApiToken"
 
 
+@override_settings(LOG_API_ACCESS=False)
+class TestAccessLogSuccessNotLoggedInDev(LogCaptureAPITestCase):
+
+    endpoint = "dummy-endpoint"
+
+    def test_access_log_success(self):
+        token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
+        self.login_as(user=self.create_user())
+        self.get_success_response(extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token.token}"})
+        assert len(self.captured_logs) == 0
+
+
 class TestAccessLogFail(LogCaptureAPITestCase):
     endpoint = "dummy-fail-endpoint"
 


### PR DESCRIPTION
leave access logs off as it can make looking through local server logs harder. (Still enabled for prod by default).