### PR TITLE
ref(ui): Fix require so ndb works

### DIFF
--- a/tests/js/test-balancer/index.js
+++ b/tests/js/test-balancer/index.js
@@ -1,6 +1,6 @@
 /* eslint-env node */
 /* eslint import/no-nodejs-modules:0 */
-const fs = require('fs/promises');
+const fs = require('fs').promises;
 
 class TestBalancer {
   constructor(globalConfig, options) {


### PR DESCRIPTION
### Summary
This require doesn't work for ndb, splitting it into require('fs') which should hopefully work on both sides