### PR TITLE
fix(dashboards): Fix slight overflow with template cards

### DIFF
--- a/static/app/views/dashboardsV2/manage/templateCard.tsx
+++ b/static/app/views/dashboardsV2/manage/templateCard.tsx
@@ -60,15 +60,8 @@ const Detail = styled(Title)`
 
 const ButtonContainer = styled('div')`
   display: flex;
+  flex-wrap: wrap;
   gap: ${space(1)};
-
-  @media (min-width: ${p => p.theme.breakpoints[2]}) {
-    flex-direction: column;
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints[3]}) {
-    flex-direction: row;
-  }
 `;
 
 const StyledButton = styled(Button)`


### PR DESCRIPTION
Previously the button row wrapped according to breakpoints which left a window where there would be a small amount of overflow for the preview button until it wrapped to the next line.

Before:
<img width="590" alt="image" src="https://user-images.githubusercontent.com/9372512/157953989-c18b9ff5-956d-42ff-8e85-447dcb9c6358.png">

After:
<img width="593" alt="image" src="https://user-images.githubusercontent.com/9372512/157954029-70d4d607-c6f0-4f49-8521-8dc03cda1f92.png">
