### PR TITLE
feat(dashboard): Widget Viewer persistent pagination

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -77,10 +77,8 @@ function WidgetViewerModal(props: Props) {
   const [modalSelection, setModalSelection] = React.useState<PageFilters>(selection);
   const selectedQueryIndex =
     decodeInteger(location.query[WidgetViewerQueryField.QUERY]) ?? 0;
-  const [pagination, setPagination] = React.useState<{page: number; cursor?: string}>({
-    cursor: undefined,
-    page: 0,
-  });
+  const page = decodeInteger(location.query[WidgetViewerQueryField.PAGE]) ?? 0;
+  const cursor = decodeScalar(location.query[WidgetViewerQueryField.CURSOR]);
 
   // Use sort if provided by location query to sort table
   const sort = decodeScalar(location.query[WidgetViewerQueryField.SORT]);
@@ -209,7 +207,7 @@ function WidgetViewerModal(props: Props) {
                   ? FULL_TABLE_ITEM_LIMIT
                   : HALF_TABLE_ITEM_LIMIT
               }
-              cursor={pagination.cursor}
+              cursor={cursor}
             >
               {({transformedResults, loading, pageLinks}) => {
                 return (
@@ -237,9 +235,7 @@ function WidgetViewerModal(props: Props) {
                     <StyledPagination
                       pageLinks={pageLinks}
                       onCursor={(nextCursor, _path, _query, delta) => {
-                        let nextPage = isNaN(pagination.page)
-                          ? delta
-                          : pagination.page + delta;
+                        let nextPage = isNaN(page) ? delta : page + delta;
                         let newCursor = nextCursor;
                         // unset cursor and page when we navigate back to the first page
                         // also reset cursor if somehow the previous button is enabled on
@@ -248,7 +244,14 @@ function WidgetViewerModal(props: Props) {
                           newCursor = undefined;
                           nextPage = 0;
                         }
-                        setPagination({cursor: newCursor, page: nextPage});
+                        router.replace({
+                          pathname: location.pathname,
+                          query: {
+                            ...location.query,
+                            [WidgetViewerQueryField.CURSOR]: newCursor,
+                            [WidgetViewerQueryField.PAGE]: nextPage,
+                          },
+                        });
                       }}
                     />
                   </React.Fragment>
@@ -267,7 +270,7 @@ function WidgetViewerModal(props: Props) {
                   : HALF_TABLE_ITEM_LIMIT
               }
               pagination
-              cursor={pagination.cursor}
+              cursor={cursor}
             >
               {({tableResults, loading, pageLinks}) => {
                 const isFirstPage = pageLinks
@@ -308,7 +311,13 @@ function WidgetViewerModal(props: Props) {
                     <StyledPagination
                       pageLinks={pageLinks}
                       onCursor={newCursor => {
-                        setPagination({cursor: newCursor, page: 0});
+                        router.replace({
+                          pathname: location.pathname,
+                          query: {
+                            ...location.query,
+                            [WidgetViewerQueryField.CURSOR]: newCursor,
+                          },
+                        });
                       }}
                     />
                   </React.Fragment>

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -190,7 +190,12 @@ function WidgetViewerModal(props: Props) {
             onChange={(option: SelectValue<number>) =>
               router.replace({
                 pathname: location.pathname,
-                query: {...location.query, [WidgetViewerQueryField.QUERY]: option.value},
+                query: {
+                  ...location.query,
+                  [WidgetViewerQueryField.QUERY]: option.value,
+                  [WidgetViewerQueryField.PAGE]: undefined,
+                  [WidgetViewerQueryField.CURSOR]: undefined,
+                },
               })
             }
           />

--- a/static/app/components/modals/widgetViewerModal/utils.tsx
+++ b/static/app/components/modals/widgetViewerModal/utils.tsx
@@ -1,7 +1,9 @@
 // Widget Viewer specific query params so we don't interfere with other params like GSH
 export enum WidgetViewerQueryField {
-  SORT = 'modalSort',
+  SORT = 'sort',
   QUERY = 'query',
+  PAGE = 'page',
+  CURSOR = 'cursor',
 }
 
 export function isWidgetViewerPath(pathname: string) {

--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -60,7 +60,12 @@ export const renderIssueGridHeaderCell =
         canSort={!!sortField}
         generateSortLink={() => ({
           ...location,
-          query: {...location.query, [WidgetViewerQueryField.SORT]: sortField},
+          query: {
+            ...location.query,
+            [WidgetViewerQueryField.SORT]: sortField,
+            [WidgetViewerQueryField.PAGE]: undefined,
+            [WidgetViewerQueryField.CURSOR]: undefined,
+          },
         })}
       />
     );
@@ -88,7 +93,12 @@ export const renderDiscoverGridHeaderCell =
 
       return {
         ...location,
-        query: {...location.query, [WidgetViewerQueryField.SORT]: queryStringObject.sort},
+        query: {
+          ...location.query,
+          [WidgetViewerQueryField.SORT]: queryStringObject.sort,
+          [WidgetViewerQueryField.PAGE]: undefined,
+          [WidgetViewerQueryField.CURSOR]: undefined,
+        },
       };
     }
 

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -397,6 +397,29 @@ describe('Modals -> WidgetViewerModal', function () {
     it('paginates to the next page', async function () {
       expect(screen.getByText('Test Error 1c')).toBeInTheDocument();
       userEvent.click(await screen.findByRole('button', {name: 'Next'}));
+      expect(initialData.router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {cursor: '0:10:0'},
+        })
+      );
+      // Need to manually set the new router location and rerender to simulate the next page click
+      initialData.router.location.query = {cursor: ['0:10:0']};
+      rerender(
+        <WidgetViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widget={mockWidget}
+          onEdit={() => undefined}
+        />,
+        {
+          context: initialData.routerContext,
+          organization: initialData.organization,
+        }
+      );
       expect(await screen.findByText('Next Page Test Error')).toBeInTheDocument();
     });
   });
@@ -626,6 +649,29 @@ describe('Modals -> WidgetViewerModal', function () {
       expect(screen.getByText('Error: Failed')).toBeInTheDocument();
       userEvent.click(await screen.findByRole('button', {name: 'Next'}));
       expect(issuesMock).toHaveBeenCalledTimes(1);
+      expect(initialData.router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {cursor: '0:10:0', page: 1},
+        })
+      );
+      // Need to manually set the new router location and rerender to simulate the next page click
+      initialData.router.location.query = {cursor: ['0:10:0']};
+      rerender(
+        <WidgetViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widget={mockWidget}
+          onEdit={() => undefined}
+        />,
+        {
+          context: initialData.routerContext,
+          organization: initialData.organization,
+        }
+      );
       expect(await screen.findByText('Another Error: Failed')).toBeInTheDocument();
     });
   });

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -355,10 +355,10 @@ describe('Modals -> WidgetViewerModal', function () {
     it('sorts table when a sortable column header is clicked', function () {
       userEvent.click(screen.getByText('count()'));
       expect(initialData.router.push).toHaveBeenCalledWith({
-        query: {modalSort: ['-count']},
+        query: {sort: ['-count']},
       });
       // Need to manually set the new router location and rerender to simulate the sortable column click
-      initialData.router.location.query = {modalSort: ['-count']};
+      initialData.router.location.query = {sort: ['-count']};
       rerender(
         <WidgetViewerModal
           Header={stubEl}
@@ -579,10 +579,10 @@ describe('Modals -> WidgetViewerModal', function () {
     it('sorts table when a sortable column header is clicked', function () {
       userEvent.click(screen.getByText('events'));
       expect(initialData.router.push).toHaveBeenCalledWith({
-        query: {modalSort: 'freq'},
+        query: {sort: 'freq'},
       });
       // Need to manually set the new router location and rerender to simulate the sortable column click
-      initialData.router.location.query = {modalSort: ['freq']};
+      initialData.router.location.query = {sort: ['freq']};
       rerender(
         <WidgetViewerModal
           Header={stubEl}


### PR DESCRIPTION
Moves pagination values outside of state and onto router location so that it can be shared via url.
Also forces pagination to reset when changing query or sorting