### PR TITLE
ref(test): throw if a fixture ever gets overriden

### DIFF
--- a/tests/js/sentry-test/loadFixtures.ts
+++ b/tests/js/sentry-test/loadFixtures.ts
@@ -45,9 +45,7 @@ export function loadFixtures(dir: string, opts: Options = {}): Record<string, an
   if (opts.flatten) {
     const flattenedFixtures: Record<string, any> = {};
 
-    // Iterate over all fixture files
     for (const moduleKey in fixtures) {
-      // Iterate over all exports of a file
       for (const moduleExport in fixtures[moduleKey]) {
         // Check if our flattenedFixtures already contains a key with the same export.
         // If it does, we want to throw and make sure that we dont silently override the fixtures.

--- a/tests/js/sentry-test/loadFixtures.ts
+++ b/tests/js/sentry-test/loadFixtures.ts
@@ -4,6 +4,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import TestStubFixtures from '../../fixtures/js-stubs/types';
+
 const FIXTURES_ROOT = path.join(__dirname, '../../fixtures');
 
 type Options = {
@@ -16,10 +18,12 @@ type Options = {
 /**
  * Loads a directory of fixtures. Supports js and json fixtures.
  */
-export function loadFixtures(dir: string, opts: Options = {}): Record<string, any> {
+export function loadFixtures(dir: string, opts: Options = {}): TestStubFixtures {
   const from = path.join(FIXTURES_ROOT, dir);
   const files = fs.readdirSync(from);
-  const fixtures: Record<string, any> = {};
+
+  // @ts-ignore, this is a partial definition
+  const fixtures: TestStubFixtures = {};
 
   for (const file of files) {
     const filePath = path.join(from, file);
@@ -43,7 +47,8 @@ export function loadFixtures(dir: string, opts: Options = {}): Record<string, an
   }
 
   if (opts.flatten) {
-    const flattenedFixtures: Record<string, any> = {};
+    // @ts-ignore, this is a partial definition
+    const flattenedFixtures: TestStubFixtures = {};
 
     for (const moduleKey in fixtures) {
       for (const moduleExport in fixtures[moduleKey]) {

--- a/tests/js/spec/components/searchSyntax/parser.spec.tsx
+++ b/tests/js/spec/components/searchSyntax/parser.spec.tsx
@@ -55,7 +55,7 @@ const normalizeResult = (tokens: TokenResult<Token>[]) =>
   });
 
 describe('searchSyntax/parser', function () {
-  const testData: Record<string, TestCase[]> = loadFixtures('search-syntax');
+  const testData = loadFixtures('search-syntax') as unknown as Record<string, TestCase[]>;
 
   const registerTestCase = (testCase: TestCase) =>
     it(`handles ${testCase.query}`, () => {


### PR DESCRIPTION
There was a chance that in case of same named exports, a fixture could have been silently overwritten by the next fixture with the same export. In case that ever happens, we want to throw early and warn the developer adding the fixture.