### PR TITLE
fix(metric_alerts): Fix case where resolving an alert with critical and warning triggers with duplicate actions send warning instead of resolve

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -952,8 +952,8 @@ def sort_by_priority_list(incident_triggers):
     priority_dict = {
         (CRITICAL_TRIGGER_LABEL, TriggerStatus.ACTIVE.value): 0,
         (WARNING_TRIGGER_LABEL, TriggerStatus.ACTIVE.value): 1,
-        (CRITICAL_TRIGGER_LABEL, TriggerStatus.RESOLVED.value): 2,
-        (WARNING_TRIGGER_LABEL, TriggerStatus.RESOLVED.value): 3,
+        (WARNING_TRIGGER_LABEL, TriggerStatus.RESOLVED.value): 2,
+        (CRITICAL_TRIGGER_LABEL, TriggerStatus.RESOLVED.value): 3,
     }
     return sorted(
         incident_triggers,

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1208,7 +1208,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             ],
         )
 
-    def test_multiple_identical_triggers_at_same_time(self):
+    def test_multiple_triggers_with_identical_actions_at_same_time(self):
         # Check that both triggers fire if an update comes through that exceeds both of
         # their thresholds
         rule = self.rule

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -643,10 +643,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.RESOLVED)
         self.assert_actions_resolved_for_incident(
             incident,
-            [self.action, other_action],
+            [other_action, self.action],
             [
-                (other_trigger.alert_threshold - 1, IncidentStatus.WARNING),
                 (other_trigger.alert_threshold - 1, IncidentStatus.CLOSED),
+                (other_trigger.alert_threshold - 1, IncidentStatus.WARNING),
             ],
         )
 
@@ -996,10 +996,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.RESOLVED)
         self.assert_actions_resolved_for_incident(
             incident,
-            [self.action, other_action],
+            [other_action, self.action],
             [
-                (rule.resolve_threshold - 1, IncidentStatus.WARNING),
                 (rule.resolve_threshold - 1, IncidentStatus.CLOSED),
+                (rule.resolve_threshold - 1, IncidentStatus.WARNING),
             ],
         )
 
@@ -1201,9 +1201,58 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.RESOLVED)
         self.assert_actions_resolved_for_incident(
             incident,
-            [self.action, other_action],
+            [other_action, self.action],
             [
+                (rule.resolve_threshold - 1, IncidentStatus.CLOSED),
                 (rule.resolve_threshold - 1, IncidentStatus.WARNING),
+            ],
+        )
+
+    def test_multiple_identical_triggers_at_same_time(self):
+        # Check that both triggers fire if an update comes through that exceeds both of
+        # their thresholds
+        rule = self.rule
+        trigger = self.trigger
+        other_trigger = create_alert_rule_trigger(
+            self.rule, WARNING_TRIGGER_LABEL, trigger.alert_threshold - 20
+        )
+        other_action = create_alert_rule_trigger_action(
+            other_trigger,
+            AlertRuleTriggerAction.Type.EMAIL,
+            AlertRuleTriggerAction.TargetType.USER,
+            str(self.user.id),
+        )
+
+        processor = self.send_update(
+            rule, trigger.alert_threshold + 1, timedelta(minutes=-10), subscription=self.sub
+        )
+        self.assert_trigger_counts(processor, trigger, 0, 0)
+        self.assert_trigger_counts(processor, other_trigger, 0, 0)
+        incident = self.assert_active_incident(rule, self.sub)
+        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
+        self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.ACTIVE)
+        self.assert_actions_fired_for_incident(
+            incident,
+            [
+                self.action,
+            ],
+            [
+                (trigger.alert_threshold + 1, IncidentStatus.CRITICAL),
+            ],
+        )
+
+        processor = self.send_update(
+            rule, rule.resolve_threshold - 1, timedelta(minutes=-9), subscription=self.sub
+        )
+        self.assert_trigger_counts(processor, trigger, 0, 0)
+        self.assert_trigger_counts(processor, other_trigger, 0, 0)
+        self.assert_no_active_incident(rule, self.sub)
+        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.RESOLVED)
+        self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.RESOLVED)
+        self.assert_actions_resolved_for_incident(
+            incident,
+            [other_action],
+            [
                 (rule.resolve_threshold - 1, IncidentStatus.CLOSED),
             ],
         )


### PR DESCRIPTION
This continues the work done in https://github.com/getsentry/sentry/pull/31883. Most of the issues
we were having with alerts was resolved in that PR, although we didn't have a test to cover cases
where we have an alert with a critical and warning threshold, and identical actions on both.

It looked like we did in the tests, but the warning action had no id, and so was not de-duped.

The bug here was that if we had an alert like this, and it went from critical -> resolved in one
update, then we'd send a warning notification rather than resolved. I've added a test to cover this.
The fix was to prioritize warning resolutions over critical resolutions. This makes sense, since a
warning resolution represents the largest change to status.