### PR TITLE
fix(metrics): Restructure tags and meta endpoint for derived metrics [INGEST-924]

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -69,7 +69,7 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
         projects = self.get_projects(request, organization)
         try:
             tags = get_tags(projects, metric_names)
-        except InvalidParams as exc:
+        except (InvalidParams, DerivedMetricParseException) as exc:
             raise (ParseError(detail=str(exc)))
 
         return Response(tags, status=200)

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -15,9 +15,8 @@ __all__ = (
 
 from collections import defaultdict
 from copy import copy
-from itertools import chain
 from operator import itemgetter
-from typing import Any, List, Mapping, Optional, Sequence, Set
+from typing import Any, Dict, Mapping, Optional, Sequence, Set
 
 from snuba_sdk import Column, Condition, Function, Op
 
@@ -26,7 +25,7 @@ from sentry.models import Project
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.utils import resolve_tag_key, reverse_resolve
 from sentry.snuba.dataset import EntityKey
-from sentry.snuba.metrics.fields import DERIVED_METRICS, DerivedMetric, run_metrics_query
+from sentry.snuba.metrics.fields import DERIVED_METRICS, run_metrics_query
 from sentry.snuba.metrics.query_builder import (
     ALLOWED_GROUPBY_COLUMNS,
     QueryDefinition,
@@ -38,8 +37,10 @@ from sentry.snuba.metrics.query_builder import (
 from sentry.snuba.metrics.utils import (
     AVAILABLE_OPERATIONS,
     METRIC_TYPE_TO_ENTITY,
-    MetricDoesNotExistException,
+    DerivedMetricParseException,
+    MetricDoesNotExistInIndexer,
     MetricMeta,
+    MetricType,
     Tag,
     TagValue,
 )
@@ -58,108 +59,121 @@ def _get_metrics_for_entity(entity_key: EntityKey, projects, org_id) -> Mapping[
     )
 
 
-def get_derived_metrics_in_projects(
-    projects: Sequence[Project], derived_metric_names: Optional[Set[str]] = None
-) -> Sequence[DerivedMetric]:
+def get_available_derived_metrics(
+    supported_metric_ids_in_entities: Dict[MetricType, Sequence[int]],
+    derived_metric_names: Optional[Set[str]] = None,
+) -> Set[str]:
     """
-    Function that generates meta information for all derived metrics respecting the projects filter
+    Function that takes as input a dictionary of the available ids in each entity,
+    and an optional derived metric names set, and in turn goes through each derived metric (or
+    each derived metric from the input set of provided), and returns back a set of the derived
+    metrics that have data in the dataset.
     """
-    derived_metrics = (
-        [DERIVED_METRICS[derived_metric_name] for derived_metric_name in derived_metric_names]
+    requested_derived_metrics = (
+        {
+            derived_metric_name: DERIVED_METRICS[derived_metric_name]
+            for derived_metric_name in derived_metric_names
+        }
         if derived_metric_names
-        else DERIVED_METRICS.values()
+        else DERIVED_METRICS
     )
 
-    for metric_obj in derived_metrics:
-        try:
-            # The call to `get_entity` will validate that the derived metric constituents
-            # actually exist before adding them to the response
-            metric_obj.get_entity(projects)
-            yield metric_obj
-        except MetricDoesNotExistException:
-            continue
+    found_derived_metrics = set()
+    for derived_metric_name, derived_metric_obj in requested_derived_metrics.items():
+        derived_metric_obj_ids = derived_metric_obj.generate_metric_ids()
+
+        for ids_per_entity in supported_metric_ids_in_entities.values():
+            if derived_metric_obj_ids.intersection(ids_per_entity) == derived_metric_obj_ids:
+                found_derived_metrics.add(derived_metric_name)
+                # If we find a match in ids in one entity, then skip checks across entities
+                break
+    return found_derived_metrics
 
 
 def get_metrics(projects: Sequence[Project]) -> Sequence[MetricMeta]:
     assert projects
 
-    # Generate meta information for all available raw metrics respecting the projects filter
-    metric_names = (
-        (metric_type, row)
-        for metric_type in ("counter", "set", "distribution")
+    metrics_meta = []
+    metric_ids_in_entities = {}
+
+    for metric_type in ("counter", "set", "distribution"):
+        metric_ids_in_entities.setdefault(metric_type, set())
         for row in _get_metrics_for_entity(
             entity_key=METRIC_TYPE_TO_ENTITY[metric_type],
             projects=projects,
             org_id=projects[0].organization_id,
-        )
-    )
-    metric_names_meta_gen = (
-        MetricMeta(
-            name=reverse_resolve(row["metric_id"]),
-            type=metric_type,
-            operations=AVAILABLE_OPERATIONS[METRIC_TYPE_TO_ENTITY[metric_type].value],
-            unit=None,  # snuba does not know the unit
-        )
-        for metric_type, row in metric_names
-    )
+        ):
+            metrics_meta.append(
+                MetricMeta(
+                    name=reverse_resolve(row["metric_id"]),
+                    type=metric_type,
+                    operations=AVAILABLE_OPERATIONS[METRIC_TYPE_TO_ENTITY[metric_type].value],
+                    unit=None,  # snuba does not know the unit
+                )
+            )
+            metric_ids_in_entities[metric_type].add(row["metric_id"])
 
-    # Generate meta information for all available derived metrics respecting the projects filter
-    derived_metrics = get_derived_metrics_in_projects(projects)
-    derived_metrics_meta_gen = (
-        MetricMeta(
-            name=metric_obj.metric_name,
-            type=metric_obj.result_type,
-            operations=metric_obj.generate_available_operations(),
-            unit=metric_obj.unit,
-        )
-        for metric_obj in derived_metrics
-    )
+    # In the previous loop, we find all available metric ids per entity with respect to the
+    # projects filter, and so to figure out which derived metrics are supported for these
+    # projects, we need to iterate over the list of derived metrics and generate the ids of
+    # their constituent metrics. A derived metric should be added to the response list if its
+    # metric ids are a subset of the metric ids in one of the entities i.e. Its an instance of
+    # SingularEntityDerivedMetric.
+    # ToDo(ahmed): When CompositeEntityDerivedMetrics are introduced we need to do these checks
+    #  not on the instance of the CompositeEntityDerivedMetric but rather on its
+    #  SingularEntityDerivedMetric constituents
+    found_derived_metrics = get_available_derived_metrics(metric_ids_in_entities)
+    for derived_metric_name in found_derived_metrics:
+        derived_metric_obj = DERIVED_METRICS[derived_metric_name]
+        metrics_meta += [
+            MetricMeta(
+                name=derived_metric_obj.metric_name,
+                type=derived_metric_obj.result_type,
+                operations=derived_metric_obj.generate_available_operations(),
+                unit=derived_metric_obj.unit,
+            )
+        ]
+    return sorted(metrics_meta, key=itemgetter("name"))
 
-    return sorted(
-        chain(metric_names_meta_gen, derived_metrics_meta_gen),
-        key=itemgetter("name"),
-    )
 
-
-def _get_metrics_filter(
-    projects: Sequence[Project], metric_names: Optional[Sequence[str]]
-) -> Optional[List[Condition]]:
+def _get_metrics_filter_ids(metric_names: Sequence[str]) -> Set[int]:
     """Add a condition to filter by metrics. Return None if a name cannot be resolved."""
-    where = []
-    if metric_names is not None:
-        metric_ids = set()
-        derived_metric_names = set()
-        for name in metric_names:
-            if name in DERIVED_METRICS:
-                derived_metric_names.add(name)
-            else:
-                resolved = indexer.resolve(name)
-                metric_ids.add(resolved)
-
-        derived_metrics = get_derived_metrics_in_projects(projects, derived_metric_names)
-        for metric_obj in derived_metrics:
-            metric_ids |= metric_obj.generate_metric_ids()
-
+    metric_ids = set()
+    for name in metric_names:
+        if name not in DERIVED_METRICS:
+            metric_ids.add(indexer.resolve(name))
+        else:
+            metric_ids |= DERIVED_METRICS[name].generate_metric_ids()
+    if None in metric_ids:
         # We are looking for tags that appear in all given metrics.
         # A tag cannot appear in a metric if the metric is not even indexed.
-        if None in metric_ids:
-            return None
-        where.append(Condition(Column("metric_id"), Op.IN, list(metric_ids)))
-    return where
+        raise MetricDoesNotExistInIndexer()
+    return metric_ids
 
 
 def get_tags(projects: Sequence[Project], metric_names: Optional[Sequence[str]]) -> Sequence[Tag]:
     """Get all metric tags for the given projects and metric_names"""
     assert projects
 
-    where = _get_metrics_filter(projects, metric_names)
-    if where is None:
-        return []
+    metric_ids = set()
+    if metric_names:
+        try:
+            metric_ids = _get_metrics_filter_ids(metric_names)
+        except MetricDoesNotExistInIndexer:
+            return []
+        where = [Condition(Column("metric_id"), Op.IN, list(metric_ids))]
+    else:
+        where = []
 
     tag_ids_per_metric_id = defaultdict(list)
+    # This dictionary is required as a mapping from an entity to the ids available in it to
+    # validate that constituent metrics of a SingleEntityDerivedMetric actually span a single
+    # entity by validating that the ids of the constituent metrics all lie in the same entity
+    supported_metric_ids_in_entities = {}
 
     for metric_type in ("counter", "set", "distribution"):
-        # TODO: What if metric_id exists for multiple types / units?
+        supported_metric_ids_in_entities.setdefault(metric_type, [])
+
         entity_key = METRIC_TYPE_TO_ENTITY[metric_type]
         rows = run_metrics_query(
             entity_key=entity_key,
@@ -170,11 +184,41 @@ def get_tags(projects: Sequence[Project], metric_names: Optional[Sequence[str]])
             projects=projects,
             org_id=projects[0].organization_id,
         )
+
         for row in rows:
             tag_ids_per_metric_id[row["metric_id"]].extend(row["tags.key"])
+            supported_metric_ids_in_entities[metric_type].append(row["metric_id"])
+
+        # If we are trying to find the tags for only one metric name, then no need to query other
+        # entities once we find data for that metric_name in one of the entity
+        if metric_names and len(metric_names) == 1 and rows:
+            break
+
+    # If we get not results back from snuba, then just return an empty set
+    if not tag_ids_per_metric_id:
+        return []
 
     tag_id_lists = tag_ids_per_metric_id.values()
-    if metric_names is not None:
+    if metric_names:
+        # If there are metric_ids that were not found in the dataset, then just return an []
+        if set(tag_ids_per_metric_id.keys()) != metric_ids:
+            # This can occur for metric names that don't have an equivalent in the dataset.
+            return []
+
+        requested_derived_metrics = {
+            metric_name for metric_name in metric_names if metric_name in DERIVED_METRICS
+        }
+        found_derived_metrics = get_available_derived_metrics(
+            supported_metric_ids_in_entities, requested_derived_metrics
+        )
+
+        if requested_derived_metrics != found_derived_metrics:
+            raise DerivedMetricParseException(
+                f"The following metrics {requested_derived_metrics - found_derived_metrics} "
+                f"cannot be computed from single entities. Please revise the definition of these "
+                f"singular entity derived metrics"
+            )
+
         # Only return tags that occur in all metrics
         tag_ids = set.intersection(*map(set, tag_id_lists))
     else:
@@ -196,9 +240,14 @@ def get_tag_values(
     if tag_id is None:
         raise InvalidParams
 
-    where = _get_metrics_filter(projects=projects, metric_names=metric_names)
-    if where is None:
-        return []
+    if metric_names:
+        try:
+            metric_ids = _get_metrics_filter_ids(metric_names)
+        except MetricDoesNotExistInIndexer:
+            return []
+        where = [Condition(Column("metric_id"), Op.IN, list(metric_ids))]
+    else:
+        where = []
 
     tags = defaultdict(list)
 
@@ -246,12 +295,15 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
         query.orderby = None
 
     if query.orderby is not None:
-        # ToDo(ahmed): Re-examine the known limitation that since we make two queries,
-        #  where we use the results of the first query to filter down the results of the second
-        #  query, so if the field used to order by has no values for certain transactions for
-        #  example in the case of the performance table, we might end up showing less
-        #  transactions than there actually are if we choose to order by it. We are limited by
-        #  the rows available for the field used in the orderBy.
+        # ToDo(ahmed): Now that we have conditional aggregates as select statements, we might be
+        #  able to shave off a query here. we only need the other queries for fields spanning other
+        #  entities otherwise if all the fields belong to one entity then there is no need
+        # There is a known limitation that since we make two queries, where we use the results of
+        # the first query to filter down the results of the second query, so if the field used to
+        # order by has no values for certain transactions for example in the case of the
+        # performance table, we might end up showing less transactions than there actually are if
+        # we choose to order by it. We are limited by the rows available for the field used in
+        # the orderBy.
 
         # Multi-field select with order by functionality. Currently only supports the
         # performance table.

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -125,14 +125,14 @@ def get_metrics(projects: Sequence[Project]) -> Sequence[MetricMeta]:
     found_derived_metrics = get_available_derived_metrics(metric_ids_in_entities)
     for derived_metric_name in found_derived_metrics:
         derived_metric_obj = DERIVED_METRICS[derived_metric_name]
-        metrics_meta += [
+        metrics_meta.append(
             MetricMeta(
                 name=derived_metric_obj.metric_name,
                 type=derived_metric_obj.result_type,
                 operations=derived_metric_obj.generate_available_operations(),
                 unit=derived_metric_obj.unit,
             )
-        ]
+        )
     return sorted(metrics_meta, key=itemgetter("name"))
 
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -145,6 +145,10 @@ class MetricDoesNotExistException(Exception):
     ...
 
 
+class MetricDoesNotExistInIndexer(Exception):
+    ...
+
+
 class TimeRange(Protocol):
     start: datetime
     end: datetime


### PR DESCRIPTION
This PR:-
- Changes the behavior of how tags and meta info are retrieved for derived metrics. Previous approach
involved running an extra query to fetch the derived metrics that respect the projects filter. However this
is not necessary as the derived metrics checks can be done post the query that returns all the available metric ids to check for their existence. In addition an extra check needs to be made to ensure that each derived metric constituent ids span a single entity ensuring that it was defined correctly as a `SingleEntityDerivedMetric`
- Also fixes bug that if the metric_id has a translation in the indexer but no values in the database, it is ignored when determining the intersection (i.e. its not included, and so the intersection will be over other metric ids) rather than returning [] in case where a metric_name has no data