### PR TITLE
feat(devenv): set sentry SDK default off if dsn not provided and relay off

### DIFF
--- a/src/sentry/utils/pytest/relay.py
+++ b/src/sentry/utils/pytest/relay.py
@@ -163,7 +163,6 @@ def adjust_settings_for_relay_tests(settings):
         }
     }
     settings.SENTRY_RELAY_WHITELIST_PK = ["SMSesqan65THCV6M4qs4kBzPai60LzuDn-xNsvYpuP8"]
-    settings.SENTRY_USE_RELAY = True
 
 
 @pytest.fixture

--- a/src/sentry/utils/pytest/relay.py
+++ b/src/sentry/utils/pytest/relay.py
@@ -163,6 +163,7 @@ def adjust_settings_for_relay_tests(settings):
         }
     }
     settings.SENTRY_RELAY_WHITELIST_PK = ["SMSesqan65THCV6M4qs4kBzPai60LzuDn-xNsvYpuP8"]
+    settings.SENTRY_USE_RELAY = True
 
 
 @pytest.fixture

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -257,7 +257,9 @@ def configure_sdk():
     if relay_dsn:
         transport = make_transport(get_options(dsn=relay_dsn, **sdk_options))
         relay_transport = patch_transport_for_instrumentation(transport, "relay")
-    elif internal_project_key and internal_project_key.dsn_private and settings.SENTRY_USE_RELAY:
+    elif settings.IS_DEV and not settings.SENTRY_USE_RELAY:
+        relay_transport = None
+    elif internal_project_key and internal_project_key.dsn_private:
         transport = make_transport(get_options(dsn=internal_project_key.dsn_private, **sdk_options))
         relay_transport = patch_transport_for_instrumentation(transport, "relay")
     else:

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -257,7 +257,7 @@ def configure_sdk():
     if relay_dsn:
         transport = make_transport(get_options(dsn=relay_dsn, **sdk_options))
         relay_transport = patch_transport_for_instrumentation(transport, "relay")
-    elif internal_project_key and internal_project_key.dsn_private:
+    elif internal_project_key and internal_project_key.dsn_private and settings.SENTRY_USE_RELAY:
         transport = make_transport(get_options(dsn=internal_project_key.dsn_private, **sdk_options))
         relay_transport = patch_transport_for_instrumentation(transport, "relay")
     else:

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -81,7 +81,7 @@ def _get_public_dsn():
     if settings.SENTRY_FRONTEND_DSN:
         return settings.SENTRY_FRONTEND_DSN
 
-    if not settings.SENTRY_USE_RELAY:
+    if settings.IS_DEV and not settings.SENTRY_USE_RELAY:
         return ""
 
     project_id = settings.SENTRY_FRONTEND_PROJECT or settings.SENTRY_PROJECT

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -77,8 +77,12 @@ def _get_project_key(project_id):
 
 
 def _get_public_dsn():
+
     if settings.SENTRY_FRONTEND_DSN:
         return settings.SENTRY_FRONTEND_DSN
+
+    if not settings.SENTRY_USE_RELAY:
+        return False
 
     project_id = settings.SENTRY_FRONTEND_PROJECT or settings.SENTRY_PROJECT
     cache_key = f"dsn:{project_id}"

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -82,7 +82,7 @@ def _get_public_dsn():
         return settings.SENTRY_FRONTEND_DSN
 
     if not settings.SENTRY_USE_RELAY:
-        return False
+        return ""
 
     project_id = settings.SENTRY_FRONTEND_PROJECT or settings.SENTRY_PROJECT
     cache_key = f"dsn:{project_id}"


### PR DESCRIPTION
since relay is off by default now, we'll receive lots of 504 errors from webpack trying to proxy sentry SDK requests to it locally. The intention of this change is in the default scenario dev env, we set the DSN to empty if relay is off. If a DSN is provided, it should still use it.