### PR TITLE
chore(acceptance-tests): Increase global jest timeout

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -62,7 +62,7 @@ jobs:
           CI_NODE_TOTAL: 4
           CI_NODE_INDEX: ${{ matrix.instance }}
         run: |
-          JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit
+          JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit --testTimeout=10000
 
       - name: Save HTML artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
A lot of our jest tests are timing out with tests exceeding
5000ms. Increasing the timeout to prevent CI flakes.