### PR TITLE
chore(design): Remove redundant pre, code definitions from base.less

### DIFF
--- a/static/less/base.less
+++ b/static/less/base.less
@@ -387,14 +387,6 @@ kbd {
   }
 }
 
-pre,
-code {
-  border: 0;
-  background-color: @white-darker;
-  color: @gray-darker;
-  border-radius: 3px;
-}
-
 pre {
   display: block;
   padding: ((@line-height-computed - 1) / 2);
@@ -403,6 +395,7 @@ pre {
   word-break: break-all;
   white-space: pre-wrap;
   word-wrap: break-word;
+  border: 0;
   border-radius: @border-radius-base;
   overflow: auto;
 


### PR DESCRIPTION
Continuation of https://github.com/getsentry/sentry/pull/32238

This pull request removes redundant `pre, code` definitions from `base.less`. 

I've retained the `border` property.