### PR TITLE
fix(ui): copy of alert details chart

### DIFF
--- a/static/app/views/alerts/details/alertChart.tsx
+++ b/static/app/views/alerts/details/alertChart.tsx
@@ -139,7 +139,7 @@ class AlertChart extends AsyncComponent<Props, State> {
       <Panel>
         <StyledPanelBody withPadding>
           <ChartHeader>
-            <HeaderTitleLegend>{t('Total Alerts')}</HeaderTitleLegend>
+            <HeaderTitleLegend>{t('Alerts Triggered')}</HeaderTitleLegend>
           </ChartHeader>
           {getDynamicText({
             value: this.renderChart(),
@@ -147,7 +147,7 @@ class AlertChart extends AsyncComponent<Props, State> {
           })}
         </StyledPanelBody>
         <ChartFooter>
-          <FooterHeader>{t('Alerts Triggered')}</FooterHeader>
+          <FooterHeader>{t('Total Alerts')}</FooterHeader>
           <FooterValue>{totalAlertsTriggered}</FooterValue>
         </ChartFooter>
       </Panel>


### PR DESCRIPTION
Fixed description of the alert details page so it makes a bit more sense.

## Before

![CleanShot 2022-03-14 at 13 53 23](https://user-images.githubusercontent.com/1900676/158259499-db52f99b-8f8a-4c09-bb86-c24a9a67ff3b.png)


## After
![CleanShot 2022-03-14 at 13 53 58](https://user-images.githubusercontent.com/1900676/158259545-cc8f26e0-2c70-464a-84b2-14d11cce65cb.png)

