### PR TITLE
fix(design): Fix code css definition

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -35,14 +35,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
   pre,
   code {
     background-color: ${theme.backgroundSecondary};
-  }
-
-  pre {
     color: ${theme.textColor};
-  }
-
-  code {
-    background-color: transparent;
   }
 
   /**


### PR DESCRIPTION
Fix regression introduced in https://github.com/getsentry/sentry/pull/32238

This pull request simplifies `code` css definition by merging it with `pre` definition.

### Before

<img width="1283" alt="Screen Shot 2022-03-14 at 4 52 07 PM" src="https://user-images.githubusercontent.com/139499/158259285-a9ff786b-5d88-4ace-9f8f-a8c496a5ba32.png">

### After

<img width="1305" alt="Screen Shot 2022-03-14 at 4 52 03 PM" src="https://user-images.githubusercontent.com/139499/158259283-5eec585d-8bb4-4934-be9b-e6b361300e26.png">