### PR TITLE
fix(projects): Use subText for project card's score title

### DIFF
--- a/static/app/components/scoreCard.tsx
+++ b/static/app/components/scoreCard.tsx
@@ -65,7 +65,7 @@ export const HeaderTitle = styled('div')`
   width: fit-content;
 `;
 
-const Title = styled('div')`
+export const Title = styled('div')`
   color: ${p => p.theme.headingColor};
   ${overflowEllipsis};
   font-weight: 600;

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -10,10 +10,10 @@ import Placeholder from 'sentry/components/placeholder';
 import BookmarkStar from 'sentry/components/projects/bookmarkStar';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import ScoreCard, {
-  Title,
   Score,
   ScorePanel,
   ScoreWrapper,
+  Title,
   Trend,
 } from 'sentry/components/scoreCard';
 import {releaseHealth} from 'sentry/data/platformCategories';

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -10,7 +10,7 @@ import Placeholder from 'sentry/components/placeholder';
 import BookmarkStar from 'sentry/components/projects/bookmarkStar';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import ScoreCard, {
-  HeaderTitle,
+  Title,
   Score,
   ScorePanel,
   ScoreWrapper,
@@ -338,9 +338,8 @@ const ScoreCardWrapper = styled('div')`
   ${ScorePanel} {
     min-height: auto;
   }
-  ${HeaderTitle} {
+  ${Title} {
     color: ${p => p.theme.gray300};
-    font-weight: 600;
   }
   ${ScoreWrapper} {
     flex-direction: column;


### PR DESCRIPTION
The score card titles ("Crash Free Sessions") should be in `gray300`.

Before:
<img width="463" alt="Screen Shot 2022-03-14 at 3 10 38 PM" src="https://user-images.githubusercontent.com/44172267/158269438-e1b31d0b-b4f7-4652-91ce-2053e31ed009.png">

After:
<img width="463" alt="Screen Shot 2022-03-14 at 3 10 47 PM" src="https://user-images.githubusercontent.com/44172267/158269455-e2ded08a-b8ea-423d-be98-5a94c47c66a0.png">

