### PR TITLE
fix(projects): Use subText for project issues table's heading

### DIFF
--- a/static/app/components/issues/groupListHeader.tsx
+++ b/static/app/components/issues/groupListHeader.tsx
@@ -31,6 +31,7 @@ const Heading = styled('div')`
   display: flex;
   align-self: center;
   margin: 0 ${space(2)};
+  color: ${p => p.theme.subText};
 `;
 
 const IssueWrapper = styled(Heading)`


### PR DESCRIPTION
Before:
<img width="994" alt="Screen Shot 2022-03-14 at 3 29 17 PM" src="https://user-images.githubusercontent.com/44172267/158271459-2edf1741-44ac-4925-a91b-154d84f84e3f.png">

After:
<img width="994" alt="Screen Shot 2022-03-14 at 3 28 35 PM" src="https://user-images.githubusercontent.com/44172267/158271371-e2421bac-2f4a-4968-b827-a87f95015df8.png">

