### PR TITLE
fix(issues-index): Offset sort options dropdown by 1px

### DIFF
--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -202,6 +202,25 @@ const QueryCount = styled('p')`
 
 const DisplayOptionsBar = styled(PageFilterBar)`
   height: auto;
+  position: relative;
+
+  /* box-shadow trick to get an inset border, so the dropdown's border 
+  aligns with the one on the table below */
+  border: none;
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    pointer-events: none;
+    box-shadow: inset 0 0 0 1px ${p => p.theme.border};
+    border-radius: ${p => p.theme.borderRadius};
+    /* make sure that the border is on top of the trigger buttons */
+    z-index: ${p => p.theme.zIndex.issuesList.displayOptions + 1};
+  }
+
   button[aria-haspopup='listbox'] {
     font-weight: 600;
   }


### PR DESCRIPTION
Before:
<img width="302" alt="Screen Shot 2022-03-14 at 6 42 07 PM" src="https://user-images.githubusercontent.com/44172267/158289183-41e3f78e-f60c-482a-a6f3-a65a631a11d2.png">

After:
<img width="302" alt="Screen Shot 2022-03-14 at 6 42 20 PM" src="https://user-images.githubusercontent.com/44172267/158289202-311dc125-ca0b-4cce-aa01-b0816587bf4c.png">

