### PR TITLE
ref(metrics-indexer): Add custom manager for new StringIndexer table

### DIFF
--- a/src/sentry/sentry_metrics/indexer/models.py
+++ b/src/sentry/sentry_metrics/indexer/models.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 from django.conf import settings
@@ -5,7 +6,11 @@ from django.db import connections, models, router
 from django.utils import timezone
 
 from sentry.db.models import Model
+from sentry.db.models.manager import make_key
 from sentry.db.models.manager.base import BaseManager
+from sentry.utils.cache import cache
+
+logger = logging.getLogger(__name__)
 
 
 class MetricsKeyIndexer(Model):  # type: ignore
@@ -32,3 +37,125 @@ class MetricsKeyIndexer(Model):  # type: ignore
             "SELECT nextval('sentry_metricskeyindexer_id_seq') from generate_series(1,%s)", [num]
         )
         return connection.fetchall()
+
+
+class StringIndexerManager(BaseManager):
+    def __get_lookup_cache_key(self, **kwargs: Any) -> str:
+        return make_key(self.model, "modelcache", kwargs)
+
+    def get_items_from_cache(self, values, composite_key: str):
+        # composite_key => project_id:string, project_id:id, etc
+        # values => ["1:hello", "2:goodbye", "4:3"]
+        fields = composite_key.split(":")
+        fields_set = {*fields}
+
+        if not fields_set.issubset({*self.cache_fields}):
+            raise Exception("incorrect field names")
+
+        final_results = []
+        cache_lookup_cache_keys = []
+        cache_lookup_values = []
+        local_cache = self._get_local_cache()
+
+        # Step 1. Check the local cache
+        for value in values:
+            cache_key = self.__get_lookup_cache_key(**{composite_key: value})
+
+            result = local_cache and local_cache.get(cache_key)
+            if result is not None:
+                final_results.append(result)
+            else:
+                cache_lookup_cache_keys.append(cache_key)
+                cache_lookup_values.append(value)
+
+        if not cache_lookup_cache_keys:
+            return final_results
+
+        # Step 2. Check model cache (if we still need results)
+        cache_results = cache.get_many(cache_lookup_cache_keys, version=self.cache_version)
+
+        db_lookup_cache_keys_values = {}
+        for field in fields:
+            db_lookup_cache_keys_values[field] = []
+
+        db_lookup_cache_keys = []
+        db_lookup_cache_values = []
+
+        for cache_key, value in zip(cache_lookup_cache_keys, cache_lookup_values):
+            cache_result = cache_results.get(cache_key)
+            if cache_result is None:
+                db_lookup_cache_keys.append(cache_key)
+                db_lookup_cache_values.append(value)
+                values = value.split(":")
+                for i, v in enumerate(values):
+                    field = fields[i]
+                    # todo check the field type instead
+                    if field == ["project_id", "id"]:
+                        v = int(v)
+                    db_lookup_cache_keys_values[field].append(v)
+                continue
+
+            if not isinstance(cache_result, self.model):
+                if settings.DEBUG:
+                    raise ValueError("Unexpected value type returned from cache")
+                logger.error("Cache response returned invalid value %r", cache_result)
+
+                db_lookup_cache_keys.append(cache_key)
+                values = value.split(":")
+                for i, v in enumerate(values):
+                    field = fields[i]
+                    db_lookup_cache_keys_values[field].append(v)
+                continue
+
+            final_results.append(cache_result)
+
+        if not db_lookup_cache_keys:
+            return final_results
+
+        # Step 3. Check the database (if we STILL need results)
+        cache_writes = []
+        db_filter_kwargs = {}
+        for key_field, value_options in db_lookup_cache_keys_values.items():
+            db_filter_kwargs[key_field + "__in"] = value_options
+
+        # our results might contain more results than we actually want
+        # so make sure we reconstruct the value pair
+        db_results_dict = {}
+        values_set = set(db_lookup_cache_values)
+        for result in self.filter(**db_filter_kwargs):
+            # if the composite key was "project_id:string"
+            # this gets those fields from the instance and
+            # turns it into composite_key form => "1:release"
+            composite_key_value = ":".join([str(getattr(result, field)) for field in fields])
+            # only add results if the instance can reconstruct
+            # the value pair we passed in to begin with
+            if composite_key_value in values_set:
+                db_results_dict[composite_key_value] = result
+
+        # Step 4. Write db look up into local cache and compile final_results
+        for cache_key, value in zip(db_lookup_cache_keys, db_lookup_cache_values):
+            db_result = db_results_dict.get(value)
+            if db_result is None:
+                continue
+
+            cache_writes.append((value, db_result))
+            if local_cache is not None:
+                local_cache[cache_key] = db_result
+
+            final_results.append(db_result)
+
+        # Step 4. Write db look up into model cache
+        for cw in cache_writes:
+            value, instance = cw
+            try:
+                # todo use set many
+                cache.set(
+                    key=self.__get_lookup_cache_key(**{composite_key: value}),
+                    value=instance,
+                    timeout=self.cache_ttl,
+                    version=self.cache_version,
+                )
+            except Exception as e:
+                logger.error(e, exc_info=True)
+
+        return final_results

--- a/tests/sentry/utils/models/tests.py
+++ b/tests/sentry/utils/models/tests.py
@@ -6,7 +6,10 @@ from sentry.db.models import (
     BoundedPositiveIntegerField,
     Model,
 )
+from sentry.db.models.manager import make_key
+from sentry.sentry_metrics.indexer.models import StringIndexerManager
 from sentry.testutils import TestCase
+from sentry.utils.cache import cache
 
 
 # There's a good chance this model wont get created in the db, so avoid
@@ -30,3 +33,53 @@ class ModelTest(TestCase):
 
         with self.assertRaises(AssertionError):
             DummyModel.objects.create(posint=int(9223372036854775808), foo="bar")
+
+
+class DummyIndexer(Model):
+    __include_in_export__ = False
+
+    string = models.CharField(max_length=200)
+    project_id = BoundedBigIntegerField()
+
+    objects = StringIndexerManager(cache_fields=("project_id", "string"), cache_version=1)
+
+    class Meta:
+        db_table = "sentry_test2"
+        app_label = "sentry"
+        constraints = [
+            models.UniqueConstraint(fields=["string", "project_id"], name="unique_project_string"),
+        ]
+
+
+class StringIndexerManagerTesting(TestCase):
+    def _make_key(self, **kwargs):
+        return make_key(DummyIndexer, "modelcache", kwargs)
+
+    def test_caching(self):
+        composite_key = "project_id:string"
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        obj1 = DummyIndexer.objects.create(string="hello", project_id=1)
+        obj2 = DummyIndexer.objects.create(string="goodbye", project_id=2)
+        obj3 = DummyIndexer.objects.create(string="sup", project_id=2)
+
+        values = ["1:hello", "2:goodbye", "2:sup"]
+        cache_keys = [self._make_key(**{composite_key: v}) for v in values]
+        assert cache.get_many(cache_keys, version=1) == {}
+
+        with CaptureQueriesContext(connection) as ctx:
+            objs = DummyIndexer.objects.get_items_from_cache(
+                values=values, composite_key="project_id:string"
+            )
+            assert [o.id for o in objs] == [obj1.id, obj2.id, obj3.id]
+            assert len(cache.get_many(cache_keys, version=1)) == 3
+            assert len(ctx.captured_queries) == 1
+
+            objs_2 = DummyIndexer.objects.get_items_from_cache(
+                values=values, composite_key="project_id:string"
+            )
+            assert [o.id for o in objs_2] == [obj1.id, obj2.id, obj3.id]
+            # should only be one query since the second time should have
+            # just used the cache
+            assert len(ctx.captured_queries) == 1


### PR DESCRIPTION
**context**
We are going to be changing the indexer schema in https://github.com/getsentry/sentry/pull/32540. Still tbd about the final schema but regardless of what it is, we need to be able to cache by a composite key since strings will no longer be global. 

I don't know if this is a good way to go about solving this problem but here is the idea:

* instead of `key` as the column, use a composite key of whichever columns you want to cache by. values passed in are in the format of the composite key. So if composite key is `project_id:string` then values look like a list of `1:somestring`. 
* looks up the local cache and model cache in the same way as `get_many_for_cache` (uses the same way of formatting the cache_key) 
* instead of doing a single filter on a column, we have to break down the composite keys into their fields, so that we have a list of all the values for each columns. Then when we query we'd have two (or more) filter `__in`'s.
    * the problem here is that we'll probs get more records than we actually need. For the scenario of projects and strings, if there are `n` number for values passed in, there are `n^n` max records we could get if each project actually had a record for every single string. This seems v bad. 