### PR TITLE
chore(api): Remove update teams code from project details

### DIFF
--- a/api-docs/paths/projects/details.json
+++ b/api-docs/paths/projects/details.json
@@ -227,10 +227,6 @@
                 "type": "string",
                 "description": "The new slug for the project."
               },
-              "team": {
-                "type": "string",
-                "description": "The slug of new team for the project. Note, will be deprecated soon when multiple teams can have access to a project."
-              },
               "platform": {
                 "type": "string",
                 "description": "The new platform for the project."
@@ -268,10 +264,7 @@
               "$ref": "../../components/schemas/project.json#/DetailedProject"
             },
             "example": {
-              "allowedDomains": [
-                "http://example.com",
-                "http://example.invalid"
-              ],
+              "allowedDomains": ["http://example.com", "http://example.invalid"],
               "avatar": {
                 "avatarType": "letter_avatar",
                 "avatarUuid": null

--- a/api-docs/paths/projects/details.json
+++ b/api-docs/paths/projects/details.json
@@ -248,8 +248,7 @@
           "example": {
             "name": "Plane Proxy",
             "platform": "javascript",
-            "slug": "plane-proxy",
-            "team": "the-inflated-philosophers"
+            "slug": "plane-proxy"
           }
         }
       },

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -398,8 +398,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         :pparam string project_slug: the slug of the project to update.
         :param string name: the new name for the project.
         :param string slug: the new slug for the project.
-        :param string team: the slug of new team for the project. Note, will be deprecated
-                            soon when multiple teams can have access to a project.
         :param string platform: the new platform for the project.
         :param boolean isBookmarked: in case this API call is invoked with a
                                      user context this allows changing of

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -39,7 +39,6 @@ from sentry.models import (
     ProjectBookmark,
     ProjectRedirect,
     ProjectStatus,
-    ProjectTeam,
     ScheduledDeletion,
 )
 from sentry.notifications.types import NotificationSettingTypes
@@ -469,24 +468,12 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             changed = True
             changed_proj_settings["new_project"] = project.name
 
-        old_team_id = None
-        new_team = None
-        if result.get("team"):
-            return Response(
-                {"detail": ["Editing a team via this endpoint has been deprecated."]}, status=400
-            )
-
         if result.get("platform"):
             project.platform = result["platform"]
             changed = True
 
         if changed:
             project.save()
-            if old_team_id is not None:
-                ProjectTeam.objects.filter(project=project, team_id=old_team_id).update(
-                    team=new_team
-                )
-
             if old_slug:
                 ProjectRedirect.record(project, old_slug)
 

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -208,19 +208,6 @@ class ProjectUpdateTest(APITestCase):
         self.get_valid_response(self.org_slug, self.proj_slug, options=options)
         assert project.get_option("mail:subject_prefix") == ""
 
-    def test_team_changes_deprecated(self):
-        project = self.create_project()
-        team = self.create_team(members=[self.user])
-        self.login_as(user=self.user)
-
-        resp = self.get_valid_response(
-            self.org_slug, self.proj_slug, team=team.slug, status_code=400
-        )
-        assert resp.data["detail"][0] == "Editing a team via this endpoint has been deprecated."
-
-        project = Project.objects.get(id=project.id)
-        assert project.teams.first() != team
-
     def test_simple_member_restriction(self):
         project = self.create_project()
         user = self.create_user("bar@example.com")


### PR DESCRIPTION
See https://github.com/getsentry/sentry-docs/issues/4813

This was already mostly done but the messaging that it's deprecated has lived on the endpoint for around four years now. I've opted to just remove the deprecated code all together, but just the docs change is important. I can remove the actual changes to the endpoint if we want to preserve that messaging.