### PR TITLE
ref(metrics): Clean up tests

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1587,6 +1587,7 @@ class MetricsAPIBaseTestCase(SessionMetricsTestCase, APITestCase):
 
 class OrganizationMetricMetaIntegrationTestCase(MetricsAPIBaseTestCase):
     def setUp(self):
+        super().setUp()
         self.login_as(user=self.user)
         now = int(time.time())
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -17,6 +17,7 @@ __all__ = (
     "AcceptanceTestCase",
     "IntegrationTestCase",
     "SnubaTestCase",
+    "SessionMetricsTestCase",
     "BaseIncidentsTest",
     "IntegrationRepositoryTestCase",
     "ReleaseCommitPatchTest",
@@ -25,6 +26,8 @@ __all__ = (
     "SCIMTestCase",
     "SCIMAzureTestCase",
     "MetricsEnhancedPerformanceTestCase",
+    "MetricsAPIBaseTestCase",
+    "OrganizationMetricMetaIntegrationTestCase",
 )
 
 import hashlib
@@ -118,7 +121,14 @@ from sentry.utils.snuba import _snuba_pool
 from . import assert_status_code
 from .factories import Factories
 from .fixtures import Fixtures
-from .helpers import AuthProvider, Feature, TaskRunner, override_options, parse_queries
+from .helpers import (
+    AuthProvider,
+    Feature,
+    TaskRunner,
+    apply_feature_flag_on_cls,
+    override_options,
+    parse_queries,
+)
 from .skips import requires_snuba
 
 DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
@@ -1567,3 +1577,76 @@ class SlackActivityNotificationTest(ActivityTestCase):
         )
         self.name = self.user.get_display_name()
         self.short_id = self.group.qualified_short_id
+
+
+@apply_feature_flag_on_cls("organizations:metrics")
+@pytest.mark.usefixtures("reset_snuba")
+class MetricsAPIBaseTestCase(SessionMetricsTestCase, APITestCase):
+    ...
+
+
+class OrganizationMetricMetaIntegrationTestCase(MetricsAPIBaseTestCase):
+    def setUp(self):
+        self.login_as(user=self.user)
+        now = int(time.time())
+
+        # TODO: move _send to SnubaMetricsTestCase
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": indexer.record("metric1"),
+                    "timestamp": now,
+                    "tags": {
+                        indexer.record("tag1"): indexer.record("value1"),
+                        indexer.record("tag2"): indexer.record("value2"),
+                    },
+                    "type": "c",
+                    "value": 1,
+                    "retention_days": 90,
+                },
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": indexer.record("metric1"),
+                    "timestamp": now,
+                    "tags": {
+                        indexer.record("tag3"): indexer.record("value3"),
+                    },
+                    "type": "c",
+                    "value": 1,
+                    "retention_days": 90,
+                },
+            ],
+            entity="metrics_counters",
+        )
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": indexer.record("metric2"),
+                    "timestamp": now,
+                    "tags": {
+                        indexer.record("tag4"): indexer.record("value3"),
+                        indexer.record("tag1"): indexer.record("value2"),
+                        indexer.record("tag2"): indexer.record("value1"),
+                    },
+                    "type": "s",
+                    "value": [123],
+                    "retention_days": 90,
+                },
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": indexer.record("metric3"),
+                    "timestamp": now,
+                    "tags": {},
+                    "type": "s",
+                    "value": [123],
+                    "retention_days": 90,
+                },
+            ],
+            entity="metrics_sets",
+        )

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -1,5 +1,6 @@
-__all__ = ["Feature", "with_feature"]
+__all__ = ["Feature", "with_feature", "apply_feature_flag_on_cls"]
 
+import inspect
 import logging
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -79,3 +80,12 @@ def with_feature(feature):
         return wrapped
 
     return decorator
+
+
+def apply_feature_flag_on_cls(feature_flag):
+    def decorate(cls):
+        for name, fn in inspect.getmembers(cls, inspect.isfunction):
+            setattr(cls, name, with_feature(feature_flag)(fn))
+        return cls
+
+    return decorate

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -1,7 +1,9 @@
+import copy
 import time
 from operator import itemgetter
 from typing import Optional
 from unittest import mock
+from unittest.mock import patch
 
 from django.urls import reverse
 from freezegun import freeze_time
@@ -12,11 +14,22 @@ from sentry.sentry_metrics.sessions import SessionMetricKey
 from sentry.snuba.metrics.fields import DERIVED_METRICS, SingularEntityDerivedMetric
 from sentry.snuba.metrics.fields.snql import percentage
 from sentry.testutils import APITestCase
-from sentry.testutils.cases import SessionMetricsTestCase
-from sentry.testutils.helpers import with_feature
+from sentry.testutils.cases import MetricsAPIBaseTestCase, OrganizationMetricMetaIntegrationTestCase
 from sentry.utils.cursors import Cursor
 
-FEATURE_FLAG = "organizations:metrics"
+MOCKED_DERIVED_METRICS = copy.deepcopy(DERIVED_METRICS)
+MOCKED_DERIVED_METRICS.update(
+    {
+        "crash_free_fake": SingularEntityDerivedMetric(
+            metric_name="crash_free_fake",
+            metrics=["session.crashed", "session.errored_set"],
+            unit="percentage",
+            snql=lambda *args, entity, metric_ids, alias=None: percentage(
+                *args, entity, metric_ids, alias="crash_free_fake"
+            ),
+        )
+    }
+)
 
 
 class OrganizationMetricsPermissionTest(APITestCase):
@@ -33,7 +46,6 @@ class OrganizationMetricsPermissionTest(APITestCase):
         url = reverse(endpoint, args=(self.project.organization.slug,) + args)
         return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json")
 
-    @with_feature(FEATURE_FLAG)
     def test_permissions(self):
 
         token = ApiToken.objects.create(user=self.user, scope_list=[])
@@ -56,76 +68,7 @@ class OrganizationMetricsPermissionTest(APITestCase):
             assert response.status_code == 404
 
 
-class OrganizationMetricMetaIntegrationTest(SessionMetricsTestCase, APITestCase):
-    def setUp(self):
-        super().setUp()
-        self.login_as(user=self.user)
-
-        now = int(time.time())
-
-        # TODO: move _send to SnubaMetricsTestCase
-        self._send_buckets(
-            [
-                {
-                    "org_id": self.organization.id,
-                    "project_id": self.project.id,
-                    "metric_id": indexer.record("metric1"),
-                    "timestamp": now,
-                    "tags": {
-                        indexer.record("tag1"): indexer.record("value1"),
-                        indexer.record("tag2"): indexer.record("value2"),
-                    },
-                    "type": "c",
-                    "value": 1,
-                    "retention_days": 90,
-                },
-                {
-                    "org_id": self.organization.id,
-                    "project_id": self.project.id,
-                    "metric_id": indexer.record("metric1"),
-                    "timestamp": now,
-                    "tags": {
-                        indexer.record("tag3"): indexer.record("value3"),
-                    },
-                    "type": "c",
-                    "value": 1,
-                    "retention_days": 90,
-                },
-            ],
-            entity="metrics_counters",
-        )
-        self._send_buckets(
-            [
-                {
-                    "org_id": self.organization.id,
-                    "project_id": self.project.id,
-                    "metric_id": indexer.record("metric2"),
-                    "timestamp": now,
-                    "tags": {
-                        indexer.record("tag4"): indexer.record("value3"),
-                        indexer.record("tag1"): indexer.record("value2"),
-                        indexer.record("tag2"): indexer.record("value1"),
-                    },
-                    "type": "s",
-                    "value": [123],
-                    "retention_days": 90,
-                },
-                {
-                    "org_id": self.organization.id,
-                    "project_id": self.project.id,
-                    "metric_id": indexer.record("metric3"),
-                    "timestamp": now,
-                    "tags": {},
-                    "type": "s",
-                    "value": [123],
-                    "retention_days": 90,
-                },
-            ],
-            entity="metrics_sets",
-        )
-
-
-class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationTest):
+class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationTestCase):
 
     endpoint = "sentry-api-0-organization-metrics-index"
 
@@ -161,7 +104,6 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
             {"name": "session.init", "type": "numeric", "operations": [], "unit": "sessions"},
         ]
 
-    @with_feature(FEATURE_FLAG)
     def test_metrics_index(self):
         """
 
@@ -188,7 +130,7 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
         response = self.get_success_response(self.organization.slug, project=[self.proj2.id])
         assert response.data == self.session_metrics_meta
 
-    @with_feature(FEATURE_FLAG)
+    @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
     def test_metrics_index_invalid_derived_metric(self):
         for errors, minute in [(0, 0), (2, 1)]:
             self.store_session(
@@ -201,18 +143,6 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
                 )
             )
 
-        DERIVED_METRICS.update(
-            {
-                "crash_free_fake": SingularEntityDerivedMetric(
-                    metric_name="crash_free_fake",
-                    metrics=["session.crashed", "session.errored_set"],
-                    unit="percentage",
-                    snql=lambda *args, entity, metric_ids, alias=None: percentage(
-                        *args, entity, metric_ids, alias="crash_free_fake"
-                    ),
-                )
-            }
-        )
         response = self.get_success_response(self.organization.slug, project=[self.proj2.id])
         assert response.data == sorted(
             self.session_metrics_meta
@@ -234,11 +164,10 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
         )
 
 
-class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegrationTest):
+class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegrationTestCase):
 
     endpoint = "sentry-api-0-organization-metric-details"
 
-    @with_feature(FEATURE_FLAG)
     def test_metric_details(self):
         # metric1:
         response = self.get_success_response(
@@ -288,11 +217,10 @@ class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegration
         }
 
 
-class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTest):
+class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTestCase):
 
     endpoint = "sentry-api-0-organization-metrics-tags"
 
-    @with_feature(FEATURE_FLAG)
     def test_metric_tags(self):
         response = self.get_success_response(
             self.organization.slug,
@@ -320,7 +248,8 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
         )
         assert response.data == []
 
-    @with_feature(FEATURE_FLAG)
+    @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
+    @patch("sentry.snuba.metrics.datasource.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
     def test_derived_metric_tags(self):
         for minute in range(4):
             self.store_session(
@@ -351,18 +280,6 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
             {"key": "session.status"},
         ]
 
-        DERIVED_METRICS.update(
-            {
-                "crash_free_fake": SingularEntityDerivedMetric(
-                    metric_name="crash_free_fake",
-                    metrics=["session.crashed", "session.errored_set"],
-                    unit="percentage",
-                    snql=lambda *args, entity, metric_ids, alias=None: percentage(
-                        *args, entity, metric_ids, alias="crash_free_fake"
-                    ),
-                )
-            }
-        )
         self.store_session(
             self.build_session(
                 project_id=self.project.id,
@@ -391,29 +308,25 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
         )
 
 
-class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegrationTest):
+class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegrationTestCase):
 
     endpoint = "sentry-api-0-organization-metrics-tag-details"
 
-    @with_feature(FEATURE_FLAG)
     def test_unknown_tag(self):
         indexer.record("bar")
         response = self.get_success_response(self.project.organization.slug, "bar")
         assert response.data == []
 
-    @with_feature(FEATURE_FLAG)
     def test_non_existing_tag(self):
         response = self.get_response(self.project.organization.slug, "bar")
         assert response.status_code == 400
 
-    @with_feature(FEATURE_FLAG)
     def test_non_existing_filter(self):
         indexer.record("bar")
         response = self.get_response(self.project.organization.slug, "bar", metric="bad")
         assert response.status_code == 200
         assert response.data == []
 
-    @with_feature(FEATURE_FLAG)
     def test_metric_tag_details(self):
         response = self.get_success_response(
             self.organization.slug,
@@ -452,7 +365,8 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
         )
         assert response.data == []
 
-    @with_feature(FEATURE_FLAG)
+    @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
+    @patch("sentry.snuba.metrics.datasource.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
     def test_tag_values_for_derived_metrics(self):
         self.store_session(
             self.build_session(
@@ -470,18 +384,6 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
         )
         assert response.data == [{"key": "release", "value": "foobar"}]
 
-        DERIVED_METRICS.update(
-            {
-                "crash_free_fake": SingularEntityDerivedMetric(
-                    metric_name="crash_free_fake",
-                    metrics=["session.crashed", "session.errored_set"],
-                    unit="percentage",
-                    snql=lambda *args, entity, metric_ids, alias=None: percentage(
-                        *args, entity, metric_ids, alias="crash_free_fake"
-                    ),
-                )
-            }
-        )
         response = self.get_response(
             self.organization.slug,
             "release",
@@ -494,7 +396,7 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
         )
 
 
-class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
+class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
     endpoint = "sentry-api-0-organization-metrics-data"
 
     def setUp(self):
@@ -502,19 +404,16 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         self.project2 = self.create_project()
         self.login_as(user=self.user)
 
-    @with_feature(FEATURE_FLAG)
     def test_missing_field(self):
         response = self.get_response(self.project.organization.slug)
         assert response.status_code == 400
         assert response.json()["detail"] == 'Request is missing a "field"'
 
-    @with_feature(FEATURE_FLAG)
     def test_invalid_field(self):
         for field in ["", "(*&%", "foo(session", "foo(session)"]:
             response = self.get_response(self.project.organization.slug, field=field)
             assert response.status_code == 400
 
-    @with_feature(FEATURE_FLAG)
     def test_groupby_single(self):
         indexer.record("environment")
         response = self.get_response(
@@ -525,7 +424,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
 
         assert response.status_code == 200
 
-    @with_feature(FEATURE_FLAG)
     def test_invalid_filter(self):
         query = "release:foo or "
         response = self.get_response(
@@ -536,7 +434,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         )
         assert response.status_code == 400, query
 
-    @with_feature(FEATURE_FLAG)
     def test_valid_filter(self):
         for tag in ("release", "environment"):
             indexer.record(tag)
@@ -549,14 +446,12 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         )
         assert response.data.keys() == {"start", "end", "query", "intervals", "groups"}
 
-    @with_feature(FEATURE_FLAG)
     def test_orderby_unknown(self):
         response = self.get_response(
             self.project.organization.slug, field="sum(sentry.sessions.session)", orderBy="foo"
         )
         assert response.status_code == 400
 
-    @with_feature(FEATURE_FLAG)
     def test_orderby_tag(self):
         """Order by tag is not supported (yet)"""
         response = self.get_response(
@@ -567,7 +462,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         )
         assert response.status_code == 400
 
-    @with_feature(FEATURE_FLAG)
     def test_pagination_limit_without_orderby(self):
         """
         Test that ensures an exception is raised when pagination `per_page` parameter is sent
@@ -584,7 +478,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
             "'per_page' is only supported in combination with 'orderBy'"
         )
 
-    @with_feature(FEATURE_FLAG)
     def test_pagination_offset_without_orderby(self):
         """
         Test that ensures an exception is raised when pagination `per_page` parameter is sent
@@ -601,7 +494,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
             "'cursor' is only supported in combination with 'orderBy'"
         )
 
-    @with_feature(FEATURE_FLAG)
     def test_statsperiod_invalid(self):
         response = self.get_response(
             self.project.organization.slug,
@@ -610,7 +502,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         )
         assert response.status_code == 400
 
-    @with_feature(FEATURE_FLAG)
     def test_separate_projects(self):
         # Insert session metrics:
         self.store_session(self.build_session(project_id=self.project.id))
@@ -637,7 +528,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         # Request for single project gives a counter of one:
         assert count_sessions(project_id=self.project2.id) == 1
 
-    @with_feature(FEATURE_FLAG)
     def test_orderby(self):
         # Record some strings
         metric_id = indexer.record("sentry.transactions.measurements.lcp")
@@ -699,7 +589,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
                 "count(sentry.transactions.measurements.lcp)": expected_count
             }
 
-    @with_feature(FEATURE_FLAG)
     def test_orderby_percentile(self):
         # Record some strings
         metric_id = indexer.record("sentry.transactions.measurements.lcp")
@@ -750,7 +639,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
                 "p50(sentry.transactions.measurements.lcp)": [expected_count]
             }
 
-    @with_feature(FEATURE_FLAG)
     def test_orderby_percentile_with_pagination(self):
         metric_id = indexer.record("sentry.transactions.measurements.lcp")
         tag1 = indexer.record("tag1")
@@ -806,7 +694,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         assert groups[0]["by"] == {"tag1": "value1"}
         assert groups[0]["totals"] == {"p50(sentry.transactions.measurements.lcp)": 5}
 
-    @with_feature(FEATURE_FLAG)
     def test_limit_with_orderby_is_overridden_by_paginator_limit(self):
         """
         Test that ensures when an `orderBy` clause is set, then the paginator limit overrides the
@@ -849,7 +736,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         groups = response.data["groups"]
         assert len(groups) == 1
 
-    @with_feature(FEATURE_FLAG)
     def test_orderby_percentile_with_many_fields_one_entity_no_data(self):
         """
         Test that ensures that when metrics data is available then an empty response is returned
@@ -876,7 +762,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         groups = response.data["groups"]
         assert len(groups) == 0
 
-    @with_feature(FEATURE_FLAG)
     def test_orderby_percentile_with_many_fields_one_entity(self):
         """
         Test that ensures when transactions are ordered correctly when all the fields requested
@@ -959,7 +844,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
                 "p50(sentry.transactions.measurements.fcp)": [expected_fcp_count],
             }
 
-    @with_feature(FEATURE_FLAG)
     def test_orderby_percentile_with_many_fields_multiple_entities(self):
         """
         Test that ensures when transactions are ordered correctly when all the fields requested
@@ -1039,7 +923,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
             }
 
     @freeze_time("2018-12-11 03:21:34")
-    @with_feature(FEATURE_FLAG)
     def test_orderby_percentile_with_many_fields_multiple_entities_with_paginator(self):
         """
         Test that ensures when transactions are ordered correctly when all the fields requested
@@ -1135,7 +1018,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
             "count_unique(sentry.transactions.user)": [0, 0, 0, 3, 0, 1],
         }
 
-    @with_feature(FEATURE_FLAG)
     def test_series_are_limited_to_total_order_in_case_with_one_field_orderby(self):
         # Create time series [1, 2, 3, 4] for every release:
         for minute in range(4):
@@ -1164,7 +1046,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
 
         assert len(response.data["groups"]) == 1
 
-    @with_feature(FEATURE_FLAG)
     def test_one_field_orderby_with_no_groupby_returns_one_row(self):
         # Create time series [1, 2, 3, 4] for every release:
         for minute in range(4):
@@ -1192,7 +1073,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
 
         assert len(response.data["groups"]) == 1
 
-    @with_feature(FEATURE_FLAG)
     def test_orderby_percentile_with_many_fields_multiple_entities_with_missing_data(self):
         """
         Test that ensures when transactions table has null values for some fields (i.e. fields
@@ -1252,7 +1132,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
                 "p50(sentry.transactions.measurements.lcp)": [expected_lcp_count],
             }
 
-    @with_feature(FEATURE_FLAG)
     def test_groupby_project(self):
         self.store_session(self.build_session(project_id=self.project2.id))
         for _ in range(2):
@@ -1282,7 +1161,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
             totals = group["totals"]
             assert totals == {"sum(sentry.sessions.session)": expected_count}
 
-    @with_feature(FEATURE_FLAG)
     def test_unknown_groupby(self):
         """Use a tag name in groupby that does not exist in the indexer"""
         # Insert session metrics:
@@ -1312,7 +1190,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         )
         assert response.status_code == 400
 
-    @with_feature(FEATURE_FLAG)
     @mock.patch(
         "sentry.api.endpoints.organization_metrics.OrganizationMetricsDataEndpoint.default_per_page",
         1,
@@ -1336,7 +1213,6 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         assert group["totals"]["sum(sentry.sessions.session)"] == 4
         assert group["series"]["sum(sentry.sessions.session)"] == [1, 1, 1, 1]
 
-    @with_feature(FEATURE_FLAG)
     def test_unknown_filter(self):
         """Use a tag key/value in filter that does not exist in the indexer"""
         # Insert session metrics:
@@ -1364,27 +1240,16 @@ class OrganizationMetricDataTest(SessionMetricsTestCase, APITestCase):
         assert groups[0]["series"]["sum(sentry.sessions.session)"] == [0]
 
 
-class DerivedMetricsDataTest(SessionMetricsTestCase, APITestCase):
+class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
     endpoint = "sentry-api-0-organization-metrics-data"
 
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
 
-    @with_feature(FEATURE_FLAG)
+    @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
+    @patch("sentry.snuba.metrics.query_builder.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
     def test_derived_metric_incorrectly_defined_as_singular_entity(self):
-        DERIVED_METRICS.update(
-            {
-                "crash_free_fake": SingularEntityDerivedMetric(
-                    metric_name="crash_free_fake",
-                    metrics=["session.crashed", "session.errored_set"],
-                    unit="percentage",
-                    snql=lambda *args, entity, metric_ids, alias=None: percentage(
-                        *args, entity, metric_ids, alias="crash_free_fake"
-                    ),
-                )
-            }
-        )
         for status in ["ok", "crashed"]:
             for minute in range(4):
                 self.store_session(
@@ -1405,7 +1270,6 @@ class DerivedMetricsDataTest(SessionMetricsTestCase, APITestCase):
             "Derived Metric crash_free_fake cannot be calculated from a single entity"
         )
 
-    @with_feature(FEATURE_FLAG)
     def test_crash_free_percentage(self):
         for status in ["ok", "crashed"]:
             for minute in range(4):
@@ -1428,7 +1292,6 @@ class DerivedMetricsDataTest(SessionMetricsTestCase, APITestCase):
         assert group["totals"]["session.crashed"] == 4
         assert group["series"]["session.crash_free_rate"] == [None, None, 50, 50, 50, 50]
 
-    @with_feature(FEATURE_FLAG)
     def test_crash_free_percentage_with_orderby(self):
         for status in ["ok", "crashed"]:
             for minute in range(4):
@@ -1467,7 +1330,6 @@ class DerivedMetricsDataTest(SessionMetricsTestCase, APITestCase):
         assert group["totals"]["session.crash_free_rate"] == 50
         assert group["series"]["session.crash_free_rate"] == [None, None, 50, 50, 50, 50]
 
-    @with_feature(FEATURE_FLAG)
     def test_crash_free_rate_when_no_session_metrics_data_exist(self):
         response = self.get_success_response(
             self.organization.slug,
@@ -1483,7 +1345,6 @@ class DerivedMetricsDataTest(SessionMetricsTestCase, APITestCase):
         assert group["series"]["sum(sentry.sessions.session)"] == [0]
         assert group["series"]["session.crash_free_rate"] == [None]
 
-    @with_feature(FEATURE_FLAG)
     def test_crash_free_rate_when_no_session_metrics_data_with_orderby_and_groupby(self):
         indexer.record("release")
         response = self.get_success_response(
@@ -1497,7 +1358,6 @@ class DerivedMetricsDataTest(SessionMetricsTestCase, APITestCase):
         )
         assert response.data["groups"] == []
 
-    @with_feature(FEATURE_FLAG)
     def test_incorrect_crash_free_rate(self):
         response = self.get_response(
             self.organization.slug,
@@ -1510,7 +1370,6 @@ class DerivedMetricsDataTest(SessionMetricsTestCase, APITestCase):
             "field as it is already a derived metric with an aggregation applied to it."
         )
 
-    @with_feature(FEATURE_FLAG)
     def test_errored_sessions(self):
         session_metric = indexer.record(SessionMetricKey.SESSION.value)
         indexer.record("sentry.sessions.session.duration")

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -1194,6 +1194,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         "sentry.api.endpoints.organization_metrics.OrganizationMetricsDataEndpoint.default_per_page",
         1,
     )
+    @freeze_time("2021-12-11 03:21:30")
     def test_no_limit_with_series(self):
         """Pagination args do not apply to series"""
         indexer.record("session.status")
@@ -1292,6 +1293,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["totals"]["session.crashed"] == 4
         assert group["series"]["session.crash_free_rate"] == [None, None, 50, 50, 50, 50]
 
+    @freeze_time("2021-12-11 03:21:30")
     def test_crash_free_percentage_with_orderby(self):
         for status in ["ok", "crashed"]:
             for minute in range(4):


### PR DESCRIPTION
This PR:
- Mocks `DERIVED_METRICS` object that was incorrectly mutated in the test
- Adds decorator `apply_feature_flag_on_cls` that allows for defining a feature flag on an entire cls rather than just a test
- Resets snuba after every test to prevent clickhouse state from leaking across tests by using `reset_snuba` fixture
- Refactors base test class `OrganizationMetricMetaIntegrationTestCase` to `testutils/cases.py`