### PR TITLE
fix(design): Separate background colours for code and pre

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -34,8 +34,15 @@ const styles = (theme: Theme, isDark: boolean) => css`
 
   pre,
   code {
-    background-color: ${theme.backgroundSecondary};
     color: ${theme.textColor};
+  }
+
+  pre {
+    background-color: ${theme.backgroundSecondary};
+  }
+
+  code {
+    background-color: transparent;
   }
 
   /**


### PR DESCRIPTION
Fix regression introduced in https://github.com/getsentry/sentry/pull/32589

`code` and `pre` should have separately defined `background-color` definitions. 

This fixes regression for code content: 

![Screen Shot 2022-03-15 at 3 02 00 PM](https://user-images.githubusercontent.com/139499/158463636-7c11a2b8-2ae3-4b14-b76c-90524948eab4.png)
