### PR TITLE
ref(ui): Try and fix flakey visual regression on breadcrumbs

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/type/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/type/index.tsx
@@ -14,7 +14,12 @@ type Props = Required<Pick<React.ComponentProps<typeof SvgIcon>, 'color'>> &
 function Type({type, color, description, error}: Props) {
   return (
     <Wrapper error={error}>
-      <Tooltip title={description} disabled={!description}>
+      <Tooltip
+        title={description}
+        disabled={!description}
+        skipWrapper
+        disableForVisualTest
+      >
         <IconWrapper color={color}>
           <Icon type={type} />
         </IconWrapper>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/158478608-fffe067e-c4a0-4dbc-a034-b1902ffafbeb.png)

My theory is that the tooltip shadow is wacky