### PR TITLE
fix(ui): Remove route re-mount when orgId is undefined

### DIFF
--- a/static/app/views/organizationDetails/index.tsx
+++ b/static/app/views/organizationDetails/index.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import {switchOrganization} from 'sentry/actionCreators/organizations';
@@ -11,7 +11,19 @@ type Props = RouteComponentProps<{orgId: string}, {}> &
 
 function OrganizationDetails({children, ...props}: Props) {
   // Switch organizations when the orgId changes
-  useEffect(() => void switchOrganization(), [props.params.orgId]);
+  const orgId = useRef(props.params.orgId);
+  useEffect(() => {
+    if (props.params.orgId && orgId.current !== props.params.orgId) {
+      // Only switch on: org1 -> org2
+      // Not on: undefined -> org1
+      // Also avoid: org1 -> undefined -> org1
+      if (orgId.current) {
+        switchOrganization();
+      }
+
+      orgId.current = props.params.orgId;
+    }
+  }, [props.params.orgId]);
 
   return (
     <OrganizationContextContainer includeSidebar useLastOrganization {...props}>

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -1,6 +1,8 @@
-import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {pinFilter} from 'sentry/actionCreators/pageFilters';
 import OrganizationStore from 'sentry/stores/organizationStore';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import OrganizationDetails from 'sentry/views/organizationDetails';
 
@@ -13,6 +15,7 @@ describe('OrganizationDetails', function () {
   beforeEach(function () {
     OrganizationStore.reset();
     act(() => ProjectsStore.reset());
+    PageFiltersStore.reset();
 
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
@@ -139,5 +142,42 @@ describe('OrganizationDetails', function () {
 
     expect(inProgress).toBeInTheDocument();
     expect(screen.queryByLabelText('Restore Organization')).not.toBeInTheDocument();
+  });
+
+  it('should switch organization', async function () {
+    const body = TestStubs.Organization({slug: 'org-slug'});
+    MockApiClient.addMockResponse({url: '/organizations/org-slug/', body});
+    MockApiClient.addMockResponse({url: '/organizations/other-org/', body});
+    MockApiClient.addMockResponse({url: '/organizations/other-org/teams/', body: []});
+    MockApiClient.addMockResponse({url: '/organizations/other-org/projects/', body: []});
+
+    const {rerender} = render(
+      <OrganizationDetails params={{orgId: undefined}} location={{}} routes={[]}>
+        <div />
+      </OrganizationDetails>
+    );
+
+    pinFilter('projects', true);
+    await waitFor(() =>
+      expect(PageFiltersStore.getState().pinnedFilters).toEqual(new Set(['projects']))
+    );
+
+    rerender(
+      <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]}>
+        <div />
+      </OrganizationDetails>
+    );
+
+    expect(PageFiltersStore.getState().pinnedFilters).toEqual(new Set(['projects']));
+
+    rerender(
+      <OrganizationDetails params={{orgId: 'other-org'}} location={{}} routes={[]}>
+        <div />
+      </OrganizationDetails>
+    );
+
+    await waitFor(() =>
+      expect(PageFiltersStore.getState().pinnedFilters).toEqual(new Set())
+    );
   });
 });


### PR DESCRIPTION
Fixes an issue when going from user settings to issues stream `/settings/account/details/` -> `/organizations/{orgSlug}/issues/` that makes the issues stream unmount. fixes https://getsentry.atlassian.net/browse/WOR-1690

