### PR TITLE
chore(deps): Bump prettier 2.5.1 -> 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "jest-sentry-environment": "1.3.0",
     "postcss-jsx": "0.36.4",
     "postcss-syntax": "0.36.2",
-    "prettier": "2.5.1",
+    "prettier": "2.6.0",
     "react-refresh": "0.11.0",
     "react-select-event": "5.3.0",
     "react-test-renderer": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12712,10 +12712,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
-  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+prettier@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
+  integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
 
 prettier@~2.2.1:
   version "2.2.1"


### PR DESCRIPTION
I know we just bumped this, but they released 2.6 today so :shrug: