### PR TITLE
fix(js): Mark FormModel.resetForm as a mobx action

### DIFF
--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -104,6 +104,7 @@ class FormModel {
     this.resetForm();
   }
 
+  @action
   resetForm() {
     this.fields.clear();
     this.errors.clear();


### PR DESCRIPTION
This will fix the following warning we get:

> observable values without using an action is not allowed

Any time you mutate a mobx observable, it should be done within an @action. Read more as to why mutations should be wrapped in actions [0]

[0]: https://mobx.js.org/actions.html#wrapping-functions-using-action