### PR TITLE
test(acceptance): Fix flaky big number in dashboard tests

### DIFF
--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -703,21 +703,21 @@ class OrganizationDashboardLayoutAcceptanceTest(AcceptanceTestCase):
         self,
     ):
         layouts = [
-            {"x": 0, "y": 0, "w": 2, "h": 1, "minH": 1},
-            {"x": 0, "y": 1, "w": 2, "h": 1, "minH": 1},
+            (DashboardWidgetDisplayTypes.BIG_NUMBER, {"x": 0, "y": 0, "w": 2, "h": 1, "minH": 1}),
+            (DashboardWidgetDisplayTypes.LINE_CHART, {"x": 0, "y": 1, "w": 2, "h": 2, "minH": 2}),
         ]
         existing_widgets = DashboardWidget.objects.bulk_create(
             [
                 DashboardWidget(
                     dashboard=self.dashboard,
                     order=i,
-                    title=f"Big Number {i}",
-                    display_type=DashboardWidgetDisplayTypes.BIG_NUMBER,
+                    title=f"Widget {i}",
+                    display_type=display_type,
                     widget_type=DashboardWidgetTypes.DISCOVER,
                     interval="1d",
                     detail={"layout": layout},
                 )
-                for i, layout in enumerate(layouts)
+                for i, (display_type, layout) in enumerate(layouts)
             ]
         )
         DashboardWidgetQuery.objects.bulk_create(


### PR DESCRIPTION
It isn't important that a big number is the second widget, so we can
swap it out for a different chart that's rendered with getDynamicText

Fixes: 
![image](https://user-images.githubusercontent.com/22846452/158600185-96493d6b-505b-4c95-a1f9-1496a237a638.png)
