### PR TITLE
fix(perf): Switch MEP sampled condition 

### DIFF
--- a/static/app/utils/performance/contexts/metricsEnhancedPerformanceContext.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedPerformanceContext.tsx
@@ -42,7 +42,7 @@ export const MEPTag = () => {
     return null;
   }
 
-  if (isMetricsData !== true) {
+  if (isMetricsData !== false) {
     return <span data-test-id="no-metrics-data-tag" />;
   }
 

--- a/static/app/utils/performance/contexts/metricsEnhancedPerformanceContext.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedPerformanceContext.tsx
@@ -38,11 +38,11 @@ export const MEPTag = () => {
     return null;
   }
 
-  if (!isMEPEnabled) {
-    return null;
-  }
-
-  if (isMetricsData !== false) {
+  // - If MEP is not enabled but they have the flag, always show sampled (corresponds to 'always show sampled')
+  // - If isMetricsData is false it means a result was returned (not undefined) and is sampled
+  // - If isMetricsData is true it means a result was returned and is metrics (unsampled)
+  // - If isMetricsData is undefined it means a result was not been returned so we don't want to show sampled.
+  if (isMEPEnabled && isMetricsData !== false) {
     return <span data-test-id="no-metrics-data-tag" />;
   }
 

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.tsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.tsx
@@ -346,12 +346,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
         }),
       })
     );
-    expect(await screen.findByTestId('has-metrics-data-tag')).toHaveTextContent(
-      'Sampled'
-    );
-    expect(await screen.findByTestId('performance-widget-title')).toHaveTextContent(
-      'Failure RateSampled'
-    );
+    expect(await screen.findByTestId('no-metrics-data-tag')).toBeInTheDocument();
   });
 
   it('Widget with MEP enabled and metric meta set to undefined', async function () {
@@ -417,7 +412,6 @@ describe('Performance > Widgets > WidgetContainer', function () {
       />
     );
 
-    expect(await screen.findByTestId('no-metrics-data-tag')).toBeInTheDocument();
     expect(eventStatsMock).toHaveBeenCalledTimes(1);
     expect(eventStatsMock).toHaveBeenNthCalledWith(
       1,
@@ -427,6 +421,9 @@ describe('Performance > Widgets > WidgetContainer', function () {
           metricsEnhanced: '1',
         }),
       })
+    );
+    expect(await screen.findByTestId('has-metrics-data-tag')).toHaveTextContent(
+      'Sampled'
     );
   });
 


### PR DESCRIPTION
### Summary
Switch sampled tag so it appears on isMetricsData false. Added comment since the words with `un-` etc. can be confusing.

- Also fixed a setting to show sampled if you have the feature and selected 'always sampled' in the modal.