### PR TITLE
chore(reports): Turn on weekly email tasks instrumentation

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -98,6 +98,8 @@ SAMPLED_TASKS = {
     "sentry.tasks.reprocessing2.reprocess_group": settings.SENTRY_REPROCESSING_APM_SAMPLING,
     "sentry.tasks.reprocessing2.finish_reprocessing": settings.SENTRY_REPROCESSING_APM_SAMPLING,
     "sentry.tasks.relay.update_config_cache": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
+    "sentry.tasks.reports.prepare_organization_report": 0.1,
+    "sentry.tasks.reports.deliver_organization_user_report": 0.01,
 }
 
 


### PR DESCRIPTION
We'd like to turn on instrumentation for weekly report tasks so that we could cross reference numbers from SendGrid.