### PR TITLE
fix(span): Fix end timestamp of nested grouped spans

### DIFF
--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -79,7 +79,7 @@ class SpanGroupBar extends React.Component<Props> {
           newStartTimestamp = start_timestamp;
         }
 
-        if (newEndTimestamp > timestamp) {
+        if (newEndTimestamp < timestamp) {
           newEndTimestamp = timestamp;
         }
 


### PR DESCRIPTION
End timestamp of nested grouped spans should be the latest end timestamp of the spans they contain.

### Before


https://user-images.githubusercontent.com/139499/158682268-044d4f31-bbc3-40d6-b3f8-49c7324dcbfc.mp4



### After


https://user-images.githubusercontent.com/139499/158682296-22673c3c-25a8-4242-a53f-1b552db77272.mp4

