### PR TITLE
feat(discover): Enable auto add for equations for eventsv2

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -77,6 +77,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
                 use_snql=features.has(
                     "organizations:discover-use-snql", organization, actor=request.user
                 ),
+                equation_config={"auto_add": True},
             )
 
         with self.handle_query_errors():

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -214,6 +214,7 @@ def query(
     extra_snql_condition=None,
     functions_acl=None,
     use_snql=False,
+    equation_config=None,
 ):
     """
     High-level API for doing arbitrary user queries against events.
@@ -263,6 +264,7 @@ def query(
             functions_acl=functions_acl,
             limit=limit,
             offset=offset,
+            equation_config=equation_config,
         )
         if extra_snql_condition is not None:
             builder.add_conditions(extra_snql_condition)

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -48,6 +48,7 @@ def query(
     extra_snql_condition=None,
     functions_acl=None,
     use_snql=False,
+    equation_config=None,
 ):
     """ """
     metrics_compatible = not equations
@@ -101,6 +102,7 @@ def query(
             extra_snql_condition=extra_snql_condition,
             functions_acl=functions_acl,
             use_snql=use_snql,
+            equation_config=equation_config,
         )
         results["meta"]["isMetricsData"] = False
 


### PR DESCRIPTION
Turns on equation auto_add for eventsv2 so equation terms don't have to be explicitly queried

The use case here is to avoid having to add all the individual terms in an equation as a column in the Widget Viewer, so we can reduce clutter.
![image](https://user-images.githubusercontent.com/83961295/159292093-1fce2714-8d21-49a4-bfe5-db7ee093b451.png)
