### PR TITLE
fix(page-filters): Correct bug in environment quick-select

### DIFF
--- a/static/app/components/organizations/multipleEnvironmentSelector.tsx
+++ b/static/app/components/organizations/multipleEnvironmentSelector.tsx
@@ -71,21 +71,26 @@ function MultipleEnvironmentSelector({
   router,
 }: Props) {
   const [selectedEnvs, setSelectedEnvs] = useState(value);
+  const hasChanges = !isEqual(selectedEnvs, value);
 
   // Update selected envs value on change
-  useEffect(() => setSelectedEnvs(value), [value]);
+  useEffect(() => {
+    setSelectedEnvs(value);
+    lastSelectedEnvs.current = selectedEnvs;
+  }, [value]);
 
   // We keep a separate list of selected environments to use for sorting. This
   // allows us to only update it after the list is closed, to avoid the list
   // jumping around while selecting projects.
   const lastSelectedEnvs = useRef(value);
 
-  const hasChanges = !isEqual(selectedEnvs, value);
+  // Ref to help avoid updating stale selected values
+  const didQuickSelect = useRef(false);
 
   /**
    * Toggle selected state of an environment
    */
-  const toggleSelected = (environment: string) => {
+  const toggleCheckbox = (environment: string) => {
     const willRemove = selectedEnvs.includes(environment);
 
     const updatedSelectedEnvs = willRemove
@@ -106,11 +111,10 @@ function MultipleEnvironmentSelector({
     onUpdate(selectedEnvs);
   };
 
-  const handleClose = () => {
-    lastSelectedEnvs.current = selectedEnvs;
-
+  const handleMenuClose = () => {
     // Only update if there are changes
-    if (!hasChanges) {
+    if (!hasChanges || didQuickSelect.current) {
+      didQuickSelect.current = false;
       return;
     }
 
@@ -136,7 +140,7 @@ function MultipleEnvironmentSelector({
     onUpdate([]);
   };
 
-  const handleSelect = (item: Item) => {
+  const handleQuickSelect = (item: Item) => {
     analytics('environmentselector.direct_selection', {
       path: getRouteStringFromRoutes(router.routes),
       org_id: parseInt(organization.id, 10),
@@ -146,6 +150,10 @@ function MultipleEnvironmentSelector({
 
     setSelectedEnvs(selectedEnvironments);
     onUpdate(selectedEnvironments);
+
+    // Track that we just did a click select so we don't trigger an update in
+    // the close handler.
+    didQuickSelect.current = true;
   };
 
   const config = ConfigStore.getConfig();
@@ -228,8 +236,8 @@ function MultipleEnvironmentSelector({
           blendCorner={false}
           detached={detached}
           searchPlaceholder={t('Filter environments')}
-          onSelect={handleSelect}
-          onClose={handleClose}
+          onSelect={handleQuickSelect}
+          onClose={handleMenuClose}
           maxHeight={500}
           rootClassName={css`
             position: relative;
@@ -259,7 +267,7 @@ function MultipleEnvironmentSelector({
                 checked={selectedEnvs.includes(env)}
                 onCheckClick={e => {
                   e.stopPropagation();
-                  toggleSelected(env);
+                  toggleCheckbox(env);
                 }}
               >
                 <Highlight text={inputValue}>{env}</Highlight>

--- a/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.tsx
+++ b/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.tsx
@@ -277,4 +277,19 @@ describe('MultipleEnvironmentSelector', function () {
     expect(screen.getByLabelText('staging')).toBeInTheDocument();
     expect(screen.getByLabelText('dev')).toBeInTheDocument();
   });
+
+  it('can quick select an environment', async function () {
+    renderSelector();
+    await clickMenu();
+
+    // Select something first, we want to make sure that having a changed
+    // selection doesn't effect the quick select
+    userEvent.click(screen.getByRole('checkbox', {name: 'dev'}));
+
+    // Now 'quick select' the production environment
+    userEvent.click(screen.getByText('production'));
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith(['production']);
+  });
 });


### PR DESCRIPTION
When quick selecting, if you had mutated the selected environments list
before performing the quick select, it would cause the close handler to
update the state with a stale selection