### PR TITLE
fix(mep): Handle invalid metric in parameters

### DIFF
--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -40,8 +40,7 @@ class MetricsDatasetConfig(DatasetConfig):
     def resolve_metric(self, value: str) -> int:
         metric_id = indexer.resolve(constants.METRICS_MAP.get(value, value))
         if metric_id is None:
-            # TODO: unsure if this should be incompatible or invalid
-            raise InvalidSearchQuery(f"Metric: {value} could not be resolved")
+            raise IncompatibleMetricsQuery(f"Metric: {value} could not be resolved")
 
         self.builder.metric_ids.append(metric_id)
         return metric_id

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -849,6 +849,14 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
                 selected_columns=["transaction", "project", "p95(transaction.duration)"],
             )
 
+    def test_incorrect_parameter_for_metrics(self):
+        with self.assertRaises(IncompatibleMetricsQuery):
+            MetricsQueryBuilder(
+                self.params,
+                f"project:{self.project.slug}",
+                selected_columns=["transaction", "count_unique(test)"],
+            )
+
     def test_project_filter(self):
         query = MetricsQueryBuilder(
             self.params,


### PR DESCRIPTION
- This handles the case where the parameter to a function isn't valid in
  metrics, eg. count_unique on a tag
  - This was raising an Invalidsearch error which meant we weren't
    trying the query again in Discover