### PR TITLE
fix(vercel): Set ENV variables for preview builds 

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -256,7 +256,7 @@ class VercelIntegration(IntegrationInstallation):
         data = {
             "key": key,
             "value": value,
-            "target": ["production"],
+            "target": ["production", "preview"],
             "type": type,
         }
         try:


### PR DESCRIPTION
See: https://github.com/getsentry/sentry/issues/32449

We were only setting the environment variables for production builds, not preview builds. This would cause preview builds to fail since Sentry CLI would be missing environment variables. That said, adding the preview environment variables won't do anything crazy like create a release because of this check:

https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/vercel/generic_webhook.py#L276

I tested and verified that Vercel deploys worked for previews:

Before:

![image](https://user-images.githubusercontent.com/35509934/158704205-acac721e-47b7-400d-af57-49a03eefd44e.png)

![image](https://user-images.githubusercontent.com/35509934/158704183-561cc189-a08b-4073-85e3-01f8e823a261.png)


After:

![image](https://user-images.githubusercontent.com/35509934/158704089-0d1c44f9-6b69-437e-9b91-398523f10e36.png)

![image](https://user-images.githubusercontent.com/35509934/158704116-7bbd0be1-2f52-4d61-b888-59d6bdea1ff6.png)
