### PR TITLE
feat(metric_alerts): Add logs for session and metric subscriptions for comparison.

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -381,6 +381,22 @@ class SubscriptionProcessor:
                 },
             )
 
+        if self.subscription.snuba_query.dataset == QueryDatasets.SESSIONS.value:
+            try:
+                # Temporarily logging results from session updates for comparison with data from metric
+                # updates
+                logger.info(
+                    "subscription_processor.message",
+                    extra={
+                        "subscription_id": self.subscription.id,
+                        "dataset": self.subscription.snuba_query.dataset,
+                        "snuba_subscription_id": self.subscription.subscription_id,
+                        "result": subscription_update,
+                    },
+                )
+            except Exception:
+                logger.exception("Failed to log subscription results for session subscription")
+
         aggregation_value = self.get_aggregation_value(subscription_update)
         if aggregation_value is None:
             metrics.incr("incidents.alert_rules.skipping_update_invalid_aggregation_value")


### PR DESCRIPTION
We want to switch over from using sessions to power crash rate alerts to metrics. Before we do this,
we want to validate the metrics are producing the same or similar values to sessions.

We'll log this to GCP and then download the log files and compare locally. When creating test
subscriptions for metrics based on existing session subscriptions I'll log a mapping that can be
used locally for comparison.

For logging metric subscriptions I'm just reusing an old handler that we used before. I'll make
sure the old test subscriptions are removed first before we merge this.