### PR TITLE
fix(workflow): Handle zoom on metric alert details chart

### DIFF
--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -597,6 +597,11 @@ class MetricChart extends React.PureComponent<Props, State> {
                 start={start}
                 end={end}
                 onZoom={zoomArgs => this.handleZoom(zoomArgs.start, zoomArgs.end)}
+                onFinished={() => {
+                  // We want to do this whenever the chart finishes re-rendering so that we can update the dimensions of
+                  // any graphics related to the triggers (e.g. the threshold areas + boundaries)
+                  this.updateDimensions();
+                }}
               >
                 {zoomRenderProps => (
                   <AreaChart
@@ -734,11 +739,6 @@ class MetricChart extends React.PureComponent<Props, State> {
                           .filter(e => e)
                           .join('');
                       },
-                    }}
-                    onFinished={() => {
-                      // We want to do this whenever the chart finishes re-rendering so that we can update the dimensions of
-                      // any graphics related to the triggers (e.g. the threshold areas + boundaries)
-                      this.updateDimensions();
                     }}
                   />
                 )}


### PR DESCRIPTION
This fixes an issue where zoom wasn't working on the metric alert details chart. With onFinished on AreaChart, this blocked ChartZoom from being accessed/updated.

![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/20312973/158759039-fa035bcb-33a6-435c-9a36-24dfc7066a8b.gif)

[FIXES WOR-1596](https://getsentry.atlassian.net/browse/WOR-1596)