### PR TITLE
fix(discover): Fix flakey test on span view in Discover

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -923,6 +923,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
   }
 
   render() {
+    const {spanNumber} = this.props;
     const bounds = this.getBounds();
     const {isSpanVisibleInView} = bounds;
 
@@ -932,7 +933,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           ref={this.spanRowDOMRef}
           visible={isSpanVisibleInView}
           showBorder={this.state.showDetail}
-          data-test-id="span-row"
+          data-test-id={`span-row-${spanNumber}`}
         >
           <QuickTraceContext.Consumer>
             {quickTrace => {

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -329,7 +329,11 @@ class SpanGroupBar extends React.Component<Props> {
               const durationString = getHumanDuration(duration);
 
               return (
-                <Row visible={isSpanVisible} showBorder={false} data-test-id="span-row">
+                <Row
+                  visible={isSpanVisible}
+                  showBorder={false}
+                  data-test-id={`span-row-${spanNumber}`}
+                >
                   <RowCellContainer>
                     <RowCell
                       data-type="span-row-cell"

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -409,6 +409,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.elements('[data-test-id="span-row"]')[4].click()
 
             span_rows = self.browser.elements('[data-test-id="span-row"]')
+            span_rows_len = len(span_rows)
 
             # Open a span detail so we can check the search by trace link.
             # Click on the 6th one as a missing instrumentation span is inserted.

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -406,14 +406,11 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.snapshot("events-v2 - transactions event with auto-grouped spans")
 
             # Expand auto-grouped spans
-            self.browser.elements('[data-test-id="span-row"]')[4].click()
-
-            span_rows = self.browser.elements('[data-test-id="span-row"]')
-            span_rows_len = len(span_rows)
+            self.browser.elements('[data-test-id="span-row-5"]')[0].click()
 
             # Open a span detail so we can check the search by trace link.
             # Click on the 6th one as a missing instrumentation span is inserted.
-            span_rows[6].click()
+            self.browser.elements('[data-test-id="span-row-7"]')[0].click()
 
             # Wait until the child event loads.
             child_button = '[data-test-id="view-child-transaction"]'

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -410,7 +410,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
             # Open a span detail so we can check the search by trace link.
             # Click on the 6th one as a missing instrumentation span is inserted.
-            self.browser.elements('[data-test-id="span-row-7"]')[0].click()
+            self.browser.element('[data-test-id="span-row-7"]').click()
 
             # Wait until the child event loads.
             child_button = '[data-test-id="view-child-transaction"]'

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -408,9 +408,11 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             # Expand auto-grouped spans
             self.browser.elements('[data-test-id="span-row"]')[4].click()
 
+            span_rows = self.browser.elements('[data-test-id="span-row"]')
+
             # Open a span detail so we can check the search by trace link.
             # Click on the 6th one as a missing instrumentation span is inserted.
-            self.browser.elements('[data-test-id="span-row"]')[6].click()
+            span_rows[6].click()
 
             # Wait until the child event loads.
             child_button = '[data-test-id="view-child-transaction"]'

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -406,7 +406,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.snapshot("events-v2 - transactions event with auto-grouped spans")
 
             # Expand auto-grouped spans
-            self.browser.elements('[data-test-id="span-row-5"]')[0].click()
+            self.browser.element('[data-test-id="span-row-5"]').click()
 
             # Open a span detail so we can check the search by trace link.
             # Click on the 6th one as a missing instrumentation span is inserted.


### PR DESCRIPTION
The [`test_event_detail_view_from_transactions_query`](https://github.com/getsentry/sentry/blob/52ddd432cfca3081f45821d0502a7f6e9af01539/tests/acceptance/test_organization_events_v2.py#L376-L422) test fails on a majority of github CI jobs, and therefore relies on re-runs for it to eventually pass: https://sentry.io/organizations/sentry/issues/3111002615/
and https://sentry.io/organizations/sentry/issues/2521757654

I've attempted to try to fix this by ensuring the `data-test-ids` are unique.

Fixes SENTRY-TESTS-3AQ
Fixes SENTRY-TESTS-30S