### PR TITLE
feat(metrics): Return crash_free_rate as a ratio [INGEST-1085]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -362,7 +362,7 @@ DERIVED_METRICS = {
             metrics=["session.crashed", "session.init"],
             unit="percentage",
             snql=lambda *args, metric_ids, alias=None: percentage(
-                *args, metric_ids, alias="session.crash_free_rate"
+                *args, alias="session.crash_free_rate"
             ),
         ),
         SingularEntityDerivedMetric(

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -3,7 +3,7 @@ from snuba_sdk import Column, Function
 from sentry.sentry_metrics.utils import resolve_weak
 
 
-def __counter_sum_aggregation_on_session_status_factory(session_status, metric_ids, alias=None):
+def _counter_sum_aggregation_on_session_status_factory(session_status, metric_ids, alias=None):
     return Function(
         "sumIf",
         [
@@ -27,19 +27,19 @@ def __counter_sum_aggregation_on_session_status_factory(session_status, metric_i
 
 
 def init_sessions(metric_ids, alias=None):
-    return __counter_sum_aggregation_on_session_status_factory(
+    return _counter_sum_aggregation_on_session_status_factory(
         session_status="init", metric_ids=metric_ids, alias=alias
     )
 
 
 def crashed_sessions(metric_ids, alias=None):
-    return __counter_sum_aggregation_on_session_status_factory(
+    return _counter_sum_aggregation_on_session_status_factory(
         session_status="crashed", metric_ids=metric_ids, alias=alias
     )
 
 
 def errored_preaggr_sessions(metric_ids, alias=None):
-    return __counter_sum_aggregation_on_session_status_factory(
+    return _counter_sum_aggregation_on_session_status_factory(
         session_status="errored_preaggr", metric_ids=metric_ids, alias=alias
     )
 
@@ -61,12 +61,5 @@ def sessions_errored_set(metric_ids, alias=None):
     )
 
 
-def percentage(arg1_snql, arg2_snql, metric_ids, alias=None):
-    return Function(
-        "multiply",
-        [
-            100,
-            Function("minus", [1, Function("divide", [arg1_snql, arg2_snql])]),
-        ],
-        alias,
-    )
+def percentage(arg1_snql, arg2_snql, alias=None):
+    return Function("minus", [1, Function("divide", [arg1_snql, arg2_snql])], alias)

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -907,10 +907,10 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             interval="1m",
         )
         group = response.data["groups"][0]
-        assert group["totals"]["session.crash_free_rate"] == 50
+        assert group["totals"]["session.crash_free_rate"] == 0.5
         assert group["totals"]["session.init"] == 8
         assert group["totals"]["session.crashed"] == 4
-        assert group["series"]["session.crash_free_rate"] == [None, None, 50, 50, 50, 50]
+        assert group["series"]["session.crash_free_rate"] == [None, None, 0.5, 0.5, 0.5, 0.5]
 
     @freeze_time((timezone.now() - timedelta(days=2)).replace(hour=3, minute=26, second=31))
     def test_crash_free_percentage_with_orderby(self):
@@ -943,13 +943,13 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         )
         group = response.data["groups"][0]
         assert group["by"]["release"] == "foobar@2.0"
-        assert group["totals"]["session.crash_free_rate"] == 100
-        assert group["series"]["session.crash_free_rate"] == [None, None, 100, 100, 100, 100]
+        assert group["totals"]["session.crash_free_rate"] == 1
+        assert group["series"]["session.crash_free_rate"] == [None, None, 1, 1, 1, 1]
 
         group = response.data["groups"][1]
         assert group["by"]["release"] == "foobar@1.0"
-        assert group["totals"]["session.crash_free_rate"] == 50
-        assert group["series"]["session.crash_free_rate"] == [None, None, 50, 50, 50, 50]
+        assert group["totals"]["session.crash_free_rate"] == 0.5
+        assert group["series"]["session.crash_free_rate"] == [None, None, 0.5, 0.5, 0.5, 0.5]
 
     def test_crash_free_rate_when_no_session_metrics_data_exist(self):
         response = self.get_success_response(

--- a/tests/sentry/snuba/metrics/test_fields.py
+++ b/tests/sentry/snuba/metrics/test_fields.py
@@ -98,7 +98,6 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             percentage(
                 crashed_sessions(metric_ids=session_ids, alias="session.crashed"),
                 init_sessions(metric_ids=session_ids, alias="session.init"),
-                metric_ids=session_ids,
                 alias="session.crash_free_rate",
             )
         ]

--- a/tests/sentry/snuba/metrics/test_snql.py
+++ b/tests/sentry/snuba/metrics/test_snql.py
@@ -64,15 +64,6 @@ class DerivedMetricSnQLTestCase(TestCase):
         init_session_snql = init_sessions(self.metric_ids, "init_sessions")
         crashed_session_snql = crashed_sessions(self.metric_ids, "crashed_sessions")
 
-        assert percentage(
-            crashed_session_snql, init_session_snql, self.metric_ids, alias=alias
-        ) == Function(
-            "multiply",
-            [
-                100,
-                Function(
-                    "minus", [1, Function("divide", [crashed_session_snql, init_session_snql])]
-                ),
-            ],
-            alias,
+        assert percentage(crashed_session_snql, init_session_snql, alias=alias) == Function(
+            "minus", [1, Function("divide", [crashed_session_snql, init_session_snql])], alias
         )


### PR DESCRIPTION
Modifies the SnQL for crash_free_rate to return
the value as a ratio rather than a percentage