### PR TITLE
fix(onboarding): Onboarding illustration style changes

### DIFF
--- a/static/app/views/onboarding/components/pageCorners.tsx
+++ b/static/app/views/onboarding/components/pageCorners.tsx
@@ -1,3 +1,4 @@
+import {HTMLAttributes} from 'react';
 import styled from '@emotion/styled';
 import {AnimationControls, motion} from 'framer-motion';
 
@@ -5,10 +6,10 @@ import testableTransition from 'sentry/utils/testableTransition';
 
 type Props = {
   animateVariant: AnimationControls;
-};
+} & HTMLAttributes<HTMLDivElement>;
 
-const PageCorners = ({animateVariant}: Props) => (
-  <Container>
+const PageCorners = ({animateVariant, ...rest}: Props) => (
+  <Container {...rest}>
     <TopRight
       key="tr"
       width="874"
@@ -88,7 +89,7 @@ const TopLeft = styled(motion.svg)`
 `;
 
 TopLeft.defaultProps = {
-  initial: {x: '-40px', opacity: 0},
+  initial: {x: '-40px', opacity: 0, originX: 0, originY: 0, scale: 'var(--corner-scale)'},
   variants: {
     'top-right': {x: '-40px', opacity: 0},
     'top-left': {x: 0, opacity: 1},
@@ -103,7 +104,13 @@ const TopRight = styled(motion.svg)`
 `;
 
 TopRight.defaultProps = {
-  initial: {x: '40px', opacity: 0},
+  initial: {
+    x: '40px',
+    opacity: 0,
+    originX: '100%',
+    originY: 0,
+    scale: 'var(--corner-scale)',
+  },
   variants: {
     'top-left': {x: '40px', opacity: 0},
     'top-right': {x: 0, opacity: 1},
@@ -118,7 +125,13 @@ const BottomLeft = styled(motion.svg)`
 `;
 
 BottomLeft.defaultProps = {
-  initial: {x: '-40px', opacity: 0},
+  initial: {
+    x: '-40px',
+    opacity: 0,
+    originX: 0,
+    originY: '100%',
+    scale: 'var(--corner-scale)',
+  },
   variants: {
     'top-left': {x: '-40px', opacity: 0},
     'top-right': {x: 0, opacity: 1},
@@ -133,7 +146,13 @@ const BottomRight = styled(motion.svg)`
 `;
 
 BottomRight.defaultProps = {
-  initial: {x: '40px', opacity: 0},
+  initial: {
+    x: '40px',
+    opacity: 0,
+    originX: '100%',
+    originY: '100%',
+    scale: 'var(--corner-scale)',
+  },
   variants: {
     'top-right': {x: '40px', opacity: 0},
     'top-left': {x: 0, opacity: 1},

--- a/static/app/views/onboarding/targetedOnboarding/components/welcomeBackground.tsx
+++ b/static/app/views/onboarding/targetedOnboarding/components/welcomeBackground.tsx
@@ -247,8 +247,8 @@ const Illustration = styled(motion.svg)`
 `;
 
 const Compass = styled(Illustration)`
-  left: -15px;
-  top: 107px;
+  left: 24px;
+  top: 32px;
 `;
 
 Compass.defaultProps = {
@@ -297,7 +297,7 @@ const Container = styled(motion.div)`
   width: 100vw;
   height: 80vh;
   min-width: 200px;
-  max-width: 1000px;
+  max-width: 1200px;
   min-height: 800px;
   max-height: 900px;
 

--- a/static/app/views/onboarding/targetedOnboarding/onboarding.tsx
+++ b/static/app/views/onboarding/targetedOnboarding/onboarding.tsx
@@ -33,7 +33,7 @@ export default function Onboarding() {
         <AnimatePresence exitBeforeEnter onExitComplete={updateCornerVariant}>
           <TargetedOnboardingWelcome />
         </AnimatePresence>
-        <PageCorners animateVariant={cornerVariantControl} />
+        <AdaptivePageCorners animateVariant={cornerVariantControl} />
       </Container>
     </OnboardingWrapper>
   );
@@ -73,4 +73,11 @@ const LogoSvg = styled(LogoSentry)`
   width: 130px;
   height: 30px;
   color: ${p => p.theme.textColor};
+`;
+
+const AdaptivePageCorners = styled(PageCorners)`
+  --corner-scale: 1;
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    --corner-scale: 0.5;
+  }
 `;

--- a/static/app/views/onboarding/targetedOnboarding/onboarding.tsx
+++ b/static/app/views/onboarding/targetedOnboarding/onboarding.tsx
@@ -52,7 +52,6 @@ const Container = styled('div')`
   position: relative;
   background: ${p => p.theme.background};
   padding: 120px ${space(3)};
-  padding-top: 12vh;
   width: 100%;
   margin: 0 auto;
   flex-grow: 1;

--- a/static/app/views/onboarding/targetedOnboarding/welcome.tsx
+++ b/static/app/views/onboarding/targetedOnboarding/welcome.tsx
@@ -184,6 +184,7 @@ const Wrapper = styled(motion.div)`
   display: flex;
   flex-direction: column;
   align-items: center;
+  align-self: center;
   text-align: center;
 
   h1 {


### PR DESCRIPTION
A few changes to optimize the placement of various illustrations on the onboarding welcome page.

Before:
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/8980455/158857390-bef13387-68bd-46a2-b4d9-5ead53fac7aa.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/8980455/158857327-cec3ccbd-9d91-43d2-b087-7af436ca50b6.png">


After: 
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/8980455/158857042-7176fa76-967e-4142-9e33-804aee48aa40.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/8980455/158857193-e7052f1b-17fc-41ac-abe4-bc681e8fd387.png">
