### PR TITLE
fix(metrics): Fix 500 error with specific interval and statsPeriod combination [INGEST-1048]

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -858,6 +858,21 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         assert groups[0]["totals"]["sum(sentry.sessions.session)"] == 0
         assert groups[0]["series"]["sum(sentry.sessions.session)"] == [0]
 
+    def test_request_too_granular(self):
+        response = self.get_response(
+            self.organization.slug,
+            field="sum(sentry.sessions.session)",
+            statsPeriod="24h",
+            interval="5m",
+            orderBy="-sum(sentry.sessions.session)",
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "Requested interval of 5m with statsPeriod of 24h is too granular for a per_page of "
+            "51 elements. Increase your interval, decrease your statsPeriod, or decrease your "
+            "per_page parameter."
+        )
+
 
 class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
     endpoint = "sentry-api-0-organization-metrics-data"


### PR DESCRIPTION
Fixes a bug that was throwing a 500 error
for specific statsPeriod and interval combinations
because the paginator sets a default limit
of 51, and then if the interval is too
low compared to the statsPeriod, we might be
exceeding the snuba 10,000 query limit
as an example, if we request statsPeriod of 24h
and interval of 5 min, we end up with 288 intervals
for time series query, which when we multiply by 51
we end up with 14,688