### PR TITLE
ref(ratelimits): make rate limit middleware fail open on process_response

### DIFF
--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -67,6 +67,11 @@ class RatelimitMiddlewareTest(TestCase):
             default_rate_limit_mock.return_value = RateLimit(0, 100)
             self.middleware.process_view(request, self._test_endpoint, [], {})
 
+    def test_process_response_fails_open(self):
+        request = self.factory.get("/")
+        bad_response = object()
+        assert self.middleware.process_response(request, bad_response) is bad_response
+
     @patch("sentry.middleware.ratelimit.get_rate_limit_value")
     def test_positive_rate_limit_check(self, default_rate_limit_mock):
         request = self.factory.get("/")

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -72,6 +72,13 @@ class RatelimitMiddlewareTest(TestCase):
         bad_response = object()
         assert self.middleware.process_response(request, bad_response) is bad_response
 
+        class BadRequest:
+            def __getattr__(self, attr):
+                raise Exception("nope")
+
+        bad_request = BadRequest()
+        assert self.middleware.process_response(bad_request, bad_response) is bad_response
+
     @patch("sentry.middleware.ratelimit.get_rate_limit_value")
     def test_positive_rate_limit_check(self, default_rate_limit_mock):
         request = self.factory.get("/")


### PR DESCRIPTION
Fixes the following sentry issue:

https://sentry.io/organizations/sentry/issues/3111654899/events/2070652e08f846a581792fa4642cfb4a/?project=1