### PR TITLE
 feat(metrics): Support for DM in Details Endpoint [INGEST-924 INGEST-1084]

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -42,8 +42,10 @@ class OrganizationMetricDetailsEndpoint(OrganizationEndpoint):
         projects = self.get_projects(request, organization)
         try:
             metric = get_single_metric_info(projects, metric_name)
-        except InvalidParams:
-            raise ResourceDoesNotExist(detail=f"metric '{metric_name}'")
+        except InvalidParams as e:
+            raise ResourceDoesNotExist(e)
+        except DerivedMetricParseException as exc:
+            raise ParseError(detail=str(exc))
 
         return Response(metric, status=200)
 

--- a/tests/sentry/api/endpoints/test_organization_metric_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_details.py
@@ -1,4 +1,25 @@
+import copy
+import time
+from unittest.mock import patch
+
+from sentry.sentry_metrics import indexer
+from sentry.snuba.metrics import SingularEntityDerivedMetric, percentage, resolve_weak
 from sentry.testutils.cases import OrganizationMetricMetaIntegrationTestCase
+from tests.sentry.api.endpoints.test_organization_metrics import MOCKED_DERIVED_METRICS
+
+MOCKED_DERIVED_METRICS_2 = copy.deepcopy(MOCKED_DERIVED_METRICS)
+MOCKED_DERIVED_METRICS_2.update(
+    {
+        "derived_metric.multiple_metrics": SingularEntityDerivedMetric(
+            metric_name="derived_metric.multiple_metrics",
+            metrics=["metric1", "session.init"],
+            unit="percentage",
+            snql=lambda *args, metric_ids, alias=None: percentage(
+                *args, alias="session.crash_free_rate"
+            ),
+        )
+    }
+)
 
 
 class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegrationTestCase):
@@ -51,4 +72,120 @@ class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegration
             "operations": ["count_unique"],
             "unit": None,
             "tags": [],
+        }
+
+    def test_metric_details_metric_does_not_exist_in_indexer(self):
+        response = self.get_response(
+            self.organization.slug,
+            "foo.bar",
+        )
+        assert response.status_code == 404
+
+    def test_metric_details_metric_does_not_have_data(self):
+        indexer.record("foo.bar")
+        response = self.get_response(
+            self.organization.slug,
+            "foo.bar",
+        )
+        assert response.status_code == 404
+
+        indexer.record("sentry.sessions.session")
+        response = self.get_response(
+            self.organization.slug,
+            "session.crash_free_rate",
+        )
+        assert response.status_code == 404
+        assert (
+            response.data["detail"]
+            == "metric name session.crash_free_rate does not exist in the dataset"
+        )
+
+    def test_derived_metric_details(self):
+        # 3rd Test: Test for derived metrics when indexer and dataset have data
+        self.store_session(
+            self.build_session(
+                project_id=self.project.id,
+                started=(time.time() // 60) * 60,
+                status="ok",
+                release="foobar@2.0",
+            )
+        )
+        response = self.get_success_response(
+            self.organization.slug,
+            "session.crash_free_rate",
+        )
+        assert response.data == {
+            "name": "session.crash_free_rate",
+            "type": "numeric",
+            "operations": [],
+            "unit": "percentage",
+            "tags": [{"key": "environment"}, {"key": "release"}, {"key": "session.status"}],
+        }
+
+    @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS_2)
+    @patch("sentry.snuba.metrics.datasource.DERIVED_METRICS", MOCKED_DERIVED_METRICS_2)
+    def test_incorrectly_setup_derived_metric(self):
+        self.store_session(
+            self.build_session(
+                project_id=self.project.id,
+                started=(time.time() // 60) * 60,
+                status="ok",
+                release="foobar@2.0",
+                errors=2,
+            )
+        )
+        response = self.get_response(
+            self.organization.slug,
+            "crash_free_fake",
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "The following metrics {'crash_free_fake'} cannot be computed from single entities. "
+            "Please revise the definition of these singular entity derived metrics"
+        )
+
+    @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS_2)
+    @patch("sentry.snuba.metrics.datasource.DERIVED_METRICS", MOCKED_DERIVED_METRICS_2)
+    def test_same_entity_multiple_metric_ids(self):
+        """
+        Test that ensures that if a derived metric is defined with constituent metrics that
+        belong to the same entity but have different ids, then we are able to correctly return
+        its detail info
+        """
+        self.store_session(
+            self.build_session(
+                project_id=self.project.id,
+                started=(time.time() // 60) * 60,
+                status="ok",
+                release="foobar@2.0",
+                errors=2,
+            )
+        )
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": resolve_weak("metric1"),
+                    "timestamp": time.time(),
+                    "tags": {
+                        indexer.record("release"): indexer.record("foo"),
+                    },
+                    "type": "c",
+                    "value": 1,
+                    "retention_days": 90,
+                },
+            ],
+            entity="metrics_counters",
+        )
+        response = self.get_success_response(
+            self.organization.slug,
+            "derived_metric.multiple_metrics",
+        )
+        assert response.data == {
+            "name": "derived_metric.multiple_metrics",
+            "type": "numeric",
+            "operations": [],
+            "unit": "percentage",
+            "tags": [{"key": "release"}],
         }

--- a/tests/sentry/api/endpoints/test_organization_metric_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tags.py
@@ -37,7 +37,7 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
         )
         assert response.data == []
 
-    def test_metric_details_metric_does_not_exist_in_indexer(self):
+    def test_metric_tags_metric_does_not_exist_in_indexer(self):
         assert (
             self.get_response(
                 self.organization.slug,
@@ -46,7 +46,7 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
             == []
         )
 
-    def test_metric_details_metric_does_not_have_data(self):
+    def test_metric_tags_metric_does_not_have_data(self):
         indexer.record("foo.bar")
         assert (
             self.get_response(

--- a/tests/sentry/snuba/metrics/test_fields.py
+++ b/tests/sentry/snuba/metrics/test_fields.py
@@ -4,6 +4,7 @@ import pytest
 from snuba_sdk import Direction, OrderBy
 
 from sentry.sentry_metrics import indexer
+from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics import (
     DERIVED_METRICS,
     DerivedMetricParseException,
@@ -19,13 +20,11 @@ from sentry.snuba.metrics.fields.snql import (
 from sentry.testutils import TestCase
 
 
-def get_single_metric_info_mocked(_, metric_name):
+def get_entity_of_metric_mocked(_, metric_name):
     return {
-        "type": {
-            "sentry.sessions.session": "counter",
-            "sentry.sessions.session.error": "set",
-        }[metric_name]
-    }
+        "sentry.sessions.session": EntityKey.MetricsCounters,
+        "sentry.sessions.session.error": EntityKey.MetricsSets,
+    }[metric_name]
 
 
 class SingleEntityDerivedMetricTestCase(TestCase):
@@ -41,7 +40,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         DERIVED_METRICS.update({"crash_free_fake": self.crash_free_fake})
 
     @mock.patch(
-        "sentry.snuba.metrics.fields.base.get_single_metric_info", get_single_metric_info_mocked
+        "sentry.snuba.metrics.fields.base._get_entity_of_metric_name", get_entity_of_metric_mocked
     )
     def test_get_entity_and_validate_dependency_tree_of_a_single_entity_derived_metric(self):
         """
@@ -67,7 +66,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             self.crash_free_fake.get_entity(projects=[self.project])
 
     @mock.patch(
-        "sentry.snuba.metrics.fields.base.get_single_metric_info", get_single_metric_info_mocked
+        "sentry.snuba.metrics.fields.base._get_entity_of_metric_name", get_entity_of_metric_mocked
     )
     def test_generate_select_snql_of_derived_metric(self):
         """
@@ -108,7 +107,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             self.crash_free_fake.generate_select_statements([self.project])
 
     @mock.patch(
-        "sentry.snuba.metrics.fields.base.get_single_metric_info", get_single_metric_info_mocked
+        "sentry.snuba.metrics.fields.base._get_entity_of_metric_name", get_entity_of_metric_mocked
     )
     def test_generate_metric_ids(self):
         session_metric_id = indexer.record("sentry.sessions.session")
@@ -126,7 +125,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         }
 
     @mock.patch(
-        "sentry.snuba.metrics.fields.base.get_single_metric_info", get_single_metric_info_mocked
+        "sentry.snuba.metrics.fields.base._get_entity_of_metric_name", get_entity_of_metric_mocked
     )
     def test_generate_order_by_clause(self):
         for derived_metric_name in DERIVED_METRICS.keys():


### PR DESCRIPTION
This PR: 
- Adds support for derived metrics in metrics detail endpoint by checking that the metric_ids involved in derived metric are available in the indexer, have data in the dataset, and map to a single entity
- Moves `get_single_metric_info` to `datasource.py`
- Added private func `_get_entity_of_metric_name` to fetch the entity of a raw metric from dataset so that `get_entity` on `SingularEntityDerivedMetric` uses rather than using `get_single_metric_info` for that

P.S. In upcoming PR, will refactor alot of the code in the `datasource.py` module as the code in `get_tags`, `get_tag_values`, and `get_single_metric_info` is almost identical 