### PR TITLE
ref(rate limits): Use new style Django middleware

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -88,8 +88,10 @@ def _create_api_access_log(
             path=str(request.path),
             caller_ip=str(request.META.get("REMOTE_ADDR")),
             user_agent=str(request.META.get("HTTP_USER_AGENT")),
-            rate_limited=str(getattr(request, "will_be_rate_limited", False)),
-            rate_limit_category=str(getattr(request, "rate_limit_category", None)),
+            rate_limited=str(getattr(request, "will_be_rate_limited", False)),  # XXX
+            # ^ str(True if response.status_code == 429 else False)
+            rate_limit_category=str(getattr(request, "rate_limit_category", None)),  # XXX?
+            # ^ still not sure how to pass this through if it's not on the request
             request_duration_seconds=access_log_metadata.get_request_duration(),
             **_get_rate_limit_stats_dict(request),
         )

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -75,6 +75,7 @@ def _create_api_access_log(
         request_auth = _get_request_auth(request)
         auth_id = getattr(request_auth, "id", None)
         status_code = response.status_code if response else 500
+        rate_limited = True if status_code == 429 else False
         log_metrics = dict(
             method=str(request.method),
             view=view,
@@ -88,8 +89,7 @@ def _create_api_access_log(
             path=str(request.path),
             caller_ip=str(request.META.get("REMOTE_ADDR")),
             user_agent=str(request.META.get("HTTP_USER_AGENT")),
-            rate_limited=str(getattr(request, "will_be_rate_limited", False)),  # XXX
-            # ^ str(True if response.status_code == 429 else False)
+            rate_limited=rate_limited,
             rate_limit_category=str(getattr(request, "rate_limit_category", None)),  # XXX?
             # ^ still not sure how to pass this through if it's not on the request
             request_duration_seconds=access_log_metadata.get_request_duration(),

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -90,8 +90,7 @@ def _create_api_access_log(
             caller_ip=str(request.META.get("REMOTE_ADDR")),
             user_agent=str(request.META.get("HTTP_USER_AGENT")),
             rate_limited=rate_limited,
-            rate_limit_category=str(getattr(request, "rate_limit_category", None)),  # XXX?
-            # ^ still not sure how to pass this through if it's not on the request
+            rate_limit_category=str(getattr(response, "rate_limit_category", None)),
             request_duration_seconds=access_log_metadata.get_request_duration(),
             **_get_rate_limit_stats_dict(request),
         )

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -6,11 +6,8 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 from django.conf import settings
-from django.urls import resolve
 from rest_framework.request import Request
 from rest_framework.response import Response
-
-from sentry.ratelimits import get_category_str, get_rate_limit_key
 
 from . import is_frontend_request
 
@@ -47,6 +44,7 @@ def _get_rate_limit_stats_dict(request: Request) -> dict[str, str]:
         "rate_limit_type": "DNE",
         "concurrent_limit": str(None),
         "concurrent_requests": str(None),
+        "rate_limit_category": str(None),
     }
 
     rate_limit_metadata = getattr(request, "rate_limit_metadata", None)
@@ -74,8 +72,6 @@ def _create_api_access_log(
         user_id = getattr(request_user, "id", None)
         is_app = getattr(request_user, "is_sentry_app", None)
         org_id = getattr(getattr(request, "organization", None), "id", None)
-        view_func = resolve(request.path).func
-        rate_limit_key = get_rate_limit_key(view_func, request)
         request_auth = _get_request_auth(request)
         auth_id = getattr(request_auth, "id", None)
         status_code = response.status_code if response else 500
@@ -94,7 +90,6 @@ def _create_api_access_log(
             caller_ip=str(request.META.get("REMOTE_ADDR")),
             user_agent=str(request.META.get("HTTP_USER_AGENT")),
             rate_limited=rate_limited,
-            rate_limit_category=get_category_str(rate_limit_key),
             request_duration_seconds=access_log_metadata.get_request_duration(),
             **_get_rate_limit_stats_dict(request),
         )

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -23,7 +23,9 @@ DEFAULT_ERROR_MESSAGE = (
 
 
 class RatelimitMiddleware:
-    """Middleware that applies a rate limit to every endpoint. See: https://docs.djangoproject.com/en/4.0/topics/http/middleware/#writing-your-own-middleware"""
+    """Middleware that applies a rate limit to every endpoint.
+    See: https://docs.djangoproject.com/en/4.0/topics/http/middleware/#writing-your-own-middleware
+    """
 
     def __init__(self, get_response):
         self.get_response = get_response

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -4,7 +4,6 @@ import logging
 import uuid
 
 from django.http.response import HttpResponse
-from django.utils.deprecation import MiddlewareMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -23,8 +22,16 @@ DEFAULT_ERROR_MESSAGE = (
 )
 
 
-class RatelimitMiddleware(MiddlewareMixin):
-    """Middleware that applies a rate limit to every endpoint."""
+class RatelimitMiddleware:
+    """Middleware that applies a rate limit to every endpoint. See: https://docs.djangoproject.com/en/4.0/topics/http/middleware/#writing-your-own-middleware"""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        self.process_response(request, response)
+        return response
 
     def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response | None:
         """Check if the endpoint call will violate."""

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -30,7 +30,7 @@ class RatelimitMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
-    def __call__(self, request):
+    def __call__(self, request: Request) -> Response:
         response = self.get_response(request)
         self.process_response(request, response)
         return response

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -46,7 +46,7 @@ class RatelimitMiddleware:
         return response
 
     def process_request(self, request: Request) -> Tuple[HttpResponse | None, RateLimitData]:
-        rate_limit_data: RateLimitData = {}
+        rate_limit_data: RateLimitData = object()
         response = None
 
         # First, check if the endpoint call will violate.

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -42,7 +42,7 @@ class RatelimitMiddleware:
             view_func = resolve(request.path).func
             rate_limit_key = get_rate_limit_key(view_func, request)
             if rate_limit_key is None:
-                pass
+                return self.get_response(request)
 
             category_str = rate_limit_key.split(":", 1)[0]
             rate_limit = get_rate_limit_value(
@@ -51,7 +51,7 @@ class RatelimitMiddleware:
                 category=RateLimitCategory(category_str),
             )
             if rate_limit is None:
-                return
+                return self.get_response(request)
 
             rate_limit_metadata = above_rate_limit_check(
                 rate_limit_key, rate_limit, rate_limit_uid, category_str

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -15,7 +15,7 @@ from sentry.ratelimits import (
     get_rate_limit_value,
 )
 from sentry.ratelimits.config import ENFORCE_CONCURRENT_RATE_LIMITS
-from sentry.types.ratelimit import RateLimitCategory, RateLimitMeta, RateLimitType
+from sentry.types.ratelimit import RateLimitCategory, RateLimitType
 
 DEFAULT_ERROR_MESSAGE = (
     "You are attempting to use this endpoint too frequently. Limit is "
@@ -33,8 +33,6 @@ class RatelimitMiddleware:
 
     def __call__(self, request: Request) -> Response:
         # First, check if the endpoint call will violate.
-        data = {}
-
         try:
             request.rate_limit_category = None
             rate_limit_uid = uuid.uuid4().hex
@@ -42,10 +40,8 @@ class RatelimitMiddleware:
             rate_limit_key = get_rate_limit_key(view_func, request)
             if rate_limit_key is None:
                 return
-            data["will_be_rate_limited"] = False
-            data["rate_limit_uid"] = rate_limit_uid
-            data["rate_limit_key"] = rate_limit_key
-            category_str = data["rate_limit_key"].split(":", 1)[0]
+            will_be_rate_limited = False
+            category_str = rate_limit_key.split(":", 1)[0]
             request.rate_limit_category = category_str
 
             rate_limit = get_rate_limit_value(
@@ -56,24 +52,22 @@ class RatelimitMiddleware:
             if rate_limit is None:
                 return
 
-            request.rate_limit_metadata = above_rate_limit_check(
-                data["rate_limit_key"], rate_limit, data["rate_limit_uid"]
-            )
+            rate_limit_metadata = above_rate_limit_check(rate_limit_key, rate_limit, rate_limit_uid)
             # TODO: also limit by concurrent window once we have the data
             rate_limit_cond = (
-                request.rate_limit_metadata.rate_limit_type != RateLimitType.NOT_LIMITED
+                rate_limit_metadata.rate_limit_type != RateLimitType.NOT_LIMITED
                 if ENFORCE_CONCURRENT_RATE_LIMITS
-                else request.rate_limit_metadata.rate_limit_type == RateLimitType.FIXED_WINDOW
+                else rate_limit_metadata.rate_limit_type == RateLimitType.FIXED_WINDOW
             )
             if rate_limit_cond:
-                data["will_be_rate_limited"] = True
+                will_be_rate_limited = True
                 enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
                 if enforce_rate_limit:
                     return HttpResponse(
                         {
                             "detail": DEFAULT_ERROR_MESSAGE.format(
-                                limit=request.rate_limit_metadata.limit,
-                                window=request.rate_limit_metadata.window,
+                                limit=rate_limit_metadata.limit,
+                                window=rate_limit_metadata.window,
                             )
                         },
                         status=429,
@@ -86,9 +80,6 @@ class RatelimitMiddleware:
 
         # Process the response
         try:
-            rate_limit_metadata: RateLimitMeta | None = getattr(
-                request, "rate_limit_metadata", None
-            )
             if rate_limit_metadata:
                 response["X-Sentry-Rate-Limit-Remaining"] = rate_limit_metadata.remaining
                 response["X-Sentry-Rate-Limit-Limit"] = rate_limit_metadata.limit
@@ -99,7 +90,7 @@ class RatelimitMiddleware:
                 response[
                     "X-Sentry-Rate-Limit-ConcurrentLimit"
                 ] = rate_limit_metadata.concurrent_limit
-            finish_request(data["rate_limit_key"], data["rate_limit_uid"])
+            finish_request(rate_limit_key, rate_limit_uid)
         except Exception:
             logging.exception("COULD NOT POPULATE RATE LIMIT HEADERS")
         return response

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -32,38 +32,53 @@ class RatelimitMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: Request) -> Response:
-        rate_limit_metadata = None
-        rate_limit_key = None
-        rate_limit_uid = None
+        response, rate_limit_data = self.process_request(request)
+        # Hit the endpoint
+        request.rate_limit_metadata = rate_limit_data.get("rate_limit_metadata")
+        if not response:
+            response = self.get_response(request)
+
+        # Process the response
+        self.add_headers(response, request.rate_limit_metadata)
+        if rate_limit_data.get("rate_limit_key") and rate_limit_data.get("rate_limit_uid"):
+            finish_request(rate_limit_data["rate_limit_key"], rate_limit_data["rate_limit_uid"])
+        return response
+
+    def process_request(self, request: Request):
+        rate_limit_data = {}
         response = None
 
         # First, check if the endpoint call will violate.
         try:
-            rate_limit_uid = uuid.uuid4().hex
+            rate_limit_data["rate_limit_uid"] = uuid.uuid4().hex
             # in deprecated django middleware the view function is passed in to process_view
             # but we can still access it this way through the request
             view_func = resolve(request.path).func
-            rate_limit_key = get_rate_limit_key(view_func, request)
-            if rate_limit_key is None:
-                return self.get_response(request)
+            rate_limit_data["rate_limit_key"] = get_rate_limit_key(view_func, request)
+            if rate_limit_data["rate_limit_key"] is None:
+                return response, rate_limit_data
 
-            category_str = rate_limit_key.split(":", 1)[0]
+            category_str = rate_limit_data["rate_limit_key"].split(":", 1)[0]
             rate_limit = get_rate_limit_value(
                 http_method=request.method,
                 endpoint=view_func.view_class,
                 category=RateLimitCategory(category_str),
             )
             if rate_limit is None:
-                return self.get_response(request)
+                return response, rate_limit_data
 
-            rate_limit_metadata = above_rate_limit_check(
-                rate_limit_key, rate_limit, rate_limit_uid, category_str
+            rate_limit_data["rate_limit_metadata"] = above_rate_limit_check(
+                rate_limit_data["rate_limit_key"],
+                rate_limit,
+                rate_limit_data["rate_limit_uid"],
+                category_str,
             )
             # TODO: also limit by concurrent window once we have the data
             rate_limit_cond = (
-                rate_limit_metadata.rate_limit_type != RateLimitType.NOT_LIMITED
+                rate_limit_data["rate_limit_metadata"].rate_limit_type != RateLimitType.NOT_LIMITED
                 if ENFORCE_CONCURRENT_RATE_LIMITS
-                else rate_limit_metadata.rate_limit_type == RateLimitType.FIXED_WINDOW
+                else rate_limit_data["rate_limit_metadata"].rate_limit_type
+                == RateLimitType.FIXED_WINDOW
             )
             if rate_limit_cond:
                 enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
@@ -71,8 +86,8 @@ class RatelimitMiddleware:
                     response = HttpResponse(
                         {
                             "detail": DEFAULT_ERROR_MESSAGE.format(
-                                limit=rate_limit_metadata.limit,
-                                window=rate_limit_metadata.window,
+                                limit=rate_limit_data["rate_limit_metadata"].limit,
+                                window=rate_limit_data["rate_limit_metadata"].window,
                             )
                         },
                         status=429,
@@ -81,15 +96,7 @@ class RatelimitMiddleware:
         except Exception:
             logging.exception("Error during rate limiting, failing open. THIS SHOULD NOT HAPPEN")
 
-        # Hit the endpoint
-        request.rate_limit_metadata = rate_limit_metadata
-        if not response:
-            response = self.get_response(request)
-
-        # Process the response
-        self.add_headers(response, request.rate_limit_metadata)
-        finish_request(rate_limit_key, rate_limit_uid)
-        return response
+        return response, rate_limit_data
 
     def add_headers(self, response, rate_limit_metadata):
         if not rate_limit_metadata or type(response) not in (Response, HttpResponse):

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -40,7 +40,6 @@ class RatelimitMiddleware:
             rate_limit_key = get_rate_limit_key(view_func, request)
             if rate_limit_key is None:
                 return
-            will_be_rate_limited = False
             category_str = rate_limit_key.split(":", 1)[0]
             request.rate_limit_category = category_str
 
@@ -60,8 +59,8 @@ class RatelimitMiddleware:
                 else rate_limit_metadata.rate_limit_type == RateLimitType.FIXED_WINDOW
             )
             if rate_limit_cond:
-                will_be_rate_limited = True
                 enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
+                # view_func.view_class is sentry.web.frontend.home.HomeView
                 if enforce_rate_limit:
                     return HttpResponse(
                         {

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -42,7 +42,7 @@ class RatelimitMiddleware:
             view_func = resolve(request.path).func
             rate_limit_key = get_rate_limit_key(view_func, request)
             if rate_limit_key is None:
-                return
+                pass
 
             category_str = rate_limit_key.split(":", 1)[0]
             rate_limit = get_rate_limit_value(

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -40,6 +40,8 @@ class RatelimitMiddleware:
         try:
             rate_limit_uid = uuid.uuid4().hex
             view_func = resolve(request.path).func
+            # in deprecated django middleware the view function is passed in to process_view
+            # but we can still access it this way through the request
             rate_limit_key = get_rate_limit_key(view_func, request)
             if rate_limit_key is None:
                 return self.get_response(request)

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -35,6 +35,8 @@ class RatelimitMiddleware:
         # First, check if the endpoint call will violate.
         try:
             request.rate_limit_category = None
+            # CEO: idk how to not put this on the request object
+            # and still have it in the access logs and test for it
             rate_limit_uid = uuid.uuid4().hex
             view_func = resolve(request.path).func
             rate_limit_key = get_rate_limit_key(view_func, request)
@@ -60,7 +62,6 @@ class RatelimitMiddleware:
             )
             if rate_limit_cond:
                 enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
-                # view_func.view_class is sentry.web.frontend.home.HomeView
                 if enforce_rate_limit:
                     return HttpResponse(
                         {
@@ -92,4 +93,5 @@ class RatelimitMiddleware:
             finish_request(rate_limit_key, rate_limit_uid)
         except Exception:
             logging.exception("COULD NOT POPULATE RATE LIMIT HEADERS")
+        # CEO: the headers are on the response here and then not in the test
         return response

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -88,7 +88,7 @@ class RatelimitMiddleware:
         return response
 
     def add_headers(self, response, rate_limit_metadata):
-        if not rate_limit_metadata or type(response) != Response:
+        if not rate_limit_metadata or type(response) not in (Response, HttpResponse):
             logging.exception("COULD NOT POPULATE RATE LIMIT HEADERS")
             return response
 

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -46,7 +46,7 @@ class RatelimitMiddleware:
         return response
 
     def process_request(self, request: Request) -> Tuple[HttpResponse | None, RateLimitData]:
-        rate_limit_data: RateLimitData = object()
+        rate_limit_data: RateLimitData = {}
         response = None
 
         # First, check if the endpoint call will violate.

--- a/src/sentry/ratelimits/__init__.py
+++ b/src/sentry/ratelimits/__init__.py
@@ -5,7 +5,6 @@ from sentry.utils.services import LazyServiceWrapper
 __all__ = (
     "for_organization_member_invite",
     "above_rate_limit_check",
-    "get_category_str",
     "get_rate_limit_key",
     "get_rate_limit_value",
     "finish_request",
@@ -23,7 +22,6 @@ from .utils import (
     above_rate_limit_check,
     finish_request,
     for_organization_member_invite,
-    get_category_str,
     get_rate_limit_key,
     get_rate_limit_value,
 )

--- a/src/sentry/ratelimits/__init__.py
+++ b/src/sentry/ratelimits/__init__.py
@@ -5,6 +5,7 @@ from sentry.utils.services import LazyServiceWrapper
 __all__ = (
     "for_organization_member_invite",
     "above_rate_limit_check",
+    "get_category_str",
     "get_rate_limit_key",
     "get_rate_limit_value",
     "finish_request",
@@ -22,6 +23,7 @@ from .utils import (
     above_rate_limit_check,
     finish_request,
     for_organization_member_invite,
+    get_category_str,
     get_rate_limit_key,
     get_rate_limit_value,
 )

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -38,6 +38,13 @@ def concurrent_limiter() -> ConcurrentRateLimiter:
     return _CONCURRENT_RATE_LIMITER
 
 
+def get_category_str(rate_limit_key=None):
+    if not rate_limit_key:
+        return None
+
+    return rate_limit_key.split(":", 1)[0]
+
+
 def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | None:
     """Construct a consistent global rate limit key using the arguments provided"""
     if not hasattr(view_func, "view_class") or request.path_info.startswith(

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -38,7 +38,7 @@ def concurrent_limiter() -> ConcurrentRateLimiter:
     return _CONCURRENT_RATE_LIMITER
 
 
-def get_category_str(rate_limit_key=None):
+def get_category_str(rate_limit_key: str | None = None):
     if not rate_limit_key:
         return None
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -38,7 +38,7 @@ def concurrent_limiter() -> ConcurrentRateLimiter:
     return _CONCURRENT_RATE_LIMITER
 
 
-def get_category_str(rate_limit_key: str | None = None):
+def get_category_str(rate_limit_key: str | None = None) -> str | None:
     if not rate_limit_key:
         return None
 

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -34,7 +34,7 @@ class RateLimitType(Enum):
     FIXED_WINDOW = "fixed_window"
 
 
-@dataclass
+@dataclass(frozen=True)
 class RateLimitMeta:
     """
     Rate Limit response metadata
@@ -56,6 +56,7 @@ class RateLimitMeta:
     reset_time: int
     concurrent_limit: int | None
     concurrent_requests: int | None
+    rate_limit_category: RateLimitCategory
 
     @property
     def concurrent_remaining(self) -> int | None:

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -34,6 +34,13 @@ class RateLimitType(Enum):
     FIXED_WINDOW = "fixed_window"
 
 
+@dataclass
+class RateLimitData:
+    rate_limit_uid: str | None
+    rate_limit_key: str | None
+    rate_limit_metadata: RateLimitMeta | None
+
+
 @dataclass(frozen=True)
 class RateLimitMeta:
     """

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -26,7 +26,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class RatelimitMiddlewareTest(TestCase):
-    middleware = fixture(RatelimitMiddleware)
+    middleware = RatelimitMiddleware(None)
     factory = fixture(RequestFactory)
 
     class TestEndpoint(Endpoint):

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -298,6 +298,16 @@ class TestRatelimitHeader(APITestCase):
             assert int(response["X-Sentry-Rate-Limit-Limit"]) == 2
             assert int(response["X-Sentry-Rate-Limit-Reset"]) == expected_reset_time
 
+            response = self.get_error_response()
+            assert int(response["X-Sentry-Rate-Limit-Remaining"]) == 0
+            assert int(response["X-Sentry-Rate-Limit-Limit"]) == 2
+            assert int(response["X-Sentry-Rate-Limit-Reset"]) == expected_reset_time
+
+            response = self.get_error_response()
+            assert int(response["X-Sentry-Rate-Limit-Remaining"]) == 0
+            assert int(response["X-Sentry-Rate-Limit-Limit"]) == 2
+            assert int(response["X-Sentry-Rate-Limit-Reset"]) == expected_reset_time
+
     @patch("sentry.ratelimits.utils.get_rate_limit_key")
     def test_omit_header(self, can_be_ratelimited_patch):
         """

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -130,7 +130,7 @@ class RatelimitMiddlewareTest(TestCase):
         request = self.factory.get("/middleware/")
         request.META["REMOTE_ADDR"] = None
         resp = self.middleware(request)
-        assert resp is None
+        assert resp.status_code == 200
 
         request = self.factory.get("/middleware/")
         resp = self.middleware(request)

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -75,15 +75,9 @@ class RatelimitMiddlewareTest(TestCase):
             self.middleware(request)
 
     def test_bad_request_bad_response_fails_open(self):
-        # TODO rewrite this since we no longer call process_response
-        # and __call__ doesn't take a response
-
         # Ensure it doesn't blow up if it returns a bad response
-        # confused how it would return a bad response, we know it either returns None or the response
-        # struggling to patch __call__
         bad_response = object()
-        middleware = self.middleware
-        middleware.get_response = Mock()
+        middleware = RatelimitMiddleware(Mock())
         middleware.get_response.return_value = bad_response
         request = self.factory.get("/middleware/")
         assert middleware(request) is bad_response
@@ -94,8 +88,7 @@ class RatelimitMiddlewareTest(TestCase):
                 raise Exception("nope")
 
         bad_request = BadRequest()
-        # can we assert that log statements were hit?
-        assert self.middleware(bad_request).status_code == 200
+        assert middleware(bad_request) == bad_response
 
     @patch("sentry.middleware.ratelimit.get_rate_limit_value")
     def test_positive_rate_limit_check(self, default_rate_limit_mock):

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -13,7 +13,7 @@ class RatelimitMiddlewareTest(TestCase):
     def test_above_rate_limit_check(self):
         with freeze_time("2000-01-01"):
             expected_reset_time = int(time() + 100)
-            return_val = above_rate_limit_check("foo", RateLimit(10, 100), "request_uid")
+            return_val = above_rate_limit_check("foo", RateLimit(10, 100), "request_uid", "foo")
             assert return_val == RateLimitMeta(
                 rate_limit_type=RateLimitType.NOT_LIMITED,
                 current=1,
@@ -23,9 +23,12 @@ class RatelimitMiddlewareTest(TestCase):
                 remaining=9,
                 concurrent_limit=None,
                 concurrent_requests=None,
+                rate_limit_category="foo",
             )
             for i in range(10):
-                return_val = above_rate_limit_check("foo", RateLimit(10, 100), f"request_uid{i}")
+                return_val = above_rate_limit_check(
+                    "foo", RateLimit(10, 100), f"request_uid{i}", "foo"
+                )
             assert return_val == RateLimitMeta(
                 rate_limit_type=RateLimitType.FIXED_WINDOW,
                 current=11,
@@ -35,11 +38,12 @@ class RatelimitMiddlewareTest(TestCase):
                 remaining=0,
                 concurrent_limit=None,
                 concurrent_requests=None,
+                rate_limit_category="foo",
             )
 
             for i in range(10):
                 return_val = above_rate_limit_check(
-                    "bar", RateLimit(120, 100, 9), f"request_uid{i}"
+                    "bar", RateLimit(120, 100, 9), f"request_uid{i}", "foo"
                 )
             assert return_val == RateLimitMeta(
                 rate_limit_type=RateLimitType.CONCURRENT,
@@ -50,12 +54,13 @@ class RatelimitMiddlewareTest(TestCase):
                 remaining=110,
                 concurrent_limit=9,
                 concurrent_requests=9,
+                rate_limit_category="foo",
             )
 
     def test_concurrent(self):
         def do_request():
             uid = uuid.uuid4().hex
-            meta = above_rate_limit_check("foo", RateLimit(10, 1, 3), uid)
+            meta = above_rate_limit_check("foo", RateLimit(10, 1, 3), uid, "foo")
             sleep(0.2)
             finish_request("foo", uid)
             return meta
@@ -72,6 +77,6 @@ class RatelimitMiddlewareTest(TestCase):
     def test_window_and_concurrent_limit(self):
         """Test that if there is a window limit and a concurrent limit, the
         FIXED_WINDOW limit takes precedence"""
-        return_val = above_rate_limit_check("xar", RateLimit(0, 100, 0), "request_uid")
+        return_val = above_rate_limit_check("xar", RateLimit(0, 100, 0), "request_uid", "foo")
         assert return_val.rate_limit_type == RateLimitType.FIXED_WINDOW
         assert return_val.concurrent_remaining is None


### PR DESCRIPTION
Rewrite the rate limit middleware to not use the deprecated `MiddlewareMixin` - follows the pattern suggested in the Django docs [here](https://docs.djangoproject.com/en/4.0/topics/http/middleware/#writing-your-own-middleware). 