### PR TITLE
fix(ui): Adjust formatting on webhook checkboxes

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -92,6 +92,9 @@ export default class Subscriptions extends Component<Props> {
 }
 
 const SubscriptionGrid = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template: auto / 1fr 1fr 1fr;
+  @media (max-width: ${props => props.theme.breakpoints[2]}) {
+    grid-template: 1fr 1fr 1fr / auto;
+  }
 `;

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -11,6 +11,7 @@ import withOrganization from 'sentry/utils/withOrganization';
 import {
   DESCRIPTIONS,
   EVENT_CHOICES,
+  PERMISSIONS_MAP,
 } from 'sentry/views/settings/organizationDeveloperSettings/constants';
 
 type Resource = typeof EVENT_CHOICES[number];
@@ -44,7 +45,7 @@ export class SubscriptionBox extends React.Component<Props> {
     const features = new Set(organization.features);
 
     let disabled = this.props.disabledFromPermissions || webhookDisabled;
-    let message = `Must have at least 'Read' permissions enabled for ${resource}`;
+    let message = `Must have at least 'Read' permissions enabled for ${PERMISSIONS_MAP[resource]}`;
     if (resource === 'error' && !features.has('integrations-event-hooks')) {
       disabled = true;
       message =

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -5,6 +5,7 @@ import Checkbox from 'sentry/components/checkbox';
 import FeatureBadge from 'sentry/components/featureBadge';
 import Tooltip from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 import {
@@ -55,29 +56,27 @@ export class SubscriptionBox extends React.Component<Props> {
 
     return (
       <React.Fragment>
-        <SubscriptionGridItemWrapper key={resource}>
-          <Tooltip disabled={!disabled} title={message}>
-            <SubscriptionGridItem disabled={disabled}>
-              <SubscriptionInfo>
-                <SubscriptionTitle>
-                  {t(`${resource}`)}
-                  {isNew && <FeatureBadge type="new" />}
-                </SubscriptionTitle>
-                <SubscriptionDescription>
-                  {t(`${DESCRIPTIONS[resource]}`)}
-                </SubscriptionDescription>
-              </SubscriptionInfo>
-              <Checkbox
-                key={`${resource}${checked}`}
-                disabled={disabled}
-                id={resource}
-                value={resource}
-                checked={checked}
-                onChange={this.onChange}
-              />
-            </SubscriptionGridItem>
-          </Tooltip>
-        </SubscriptionGridItemWrapper>
+        <Tooltip disabled={!disabled} title={message} key={resource}>
+          <SubscriptionGridItem disabled={disabled}>
+            <SubscriptionInfo>
+              <SubscriptionTitle>
+                {t(`${resource}`)}
+                {isNew && <FeatureBadge type="new" />}
+              </SubscriptionTitle>
+              <SubscriptionDescription>
+                {t(`${DESCRIPTIONS[resource]}`)}
+              </SubscriptionDescription>
+            </SubscriptionInfo>
+            <Checkbox
+              key={`${resource}${checked}`}
+              disabled={disabled}
+              id={resource}
+              value={resource}
+              checked={checked}
+              onChange={this.onChange}
+            />
+          </SubscriptionGridItem>
+        </Tooltip>
       </React.Fragment>
     );
   }
@@ -85,39 +84,33 @@ export class SubscriptionBox extends React.Component<Props> {
 
 export default withOrganization(SubscriptionBox);
 
+const SubscriptionGridItem = styled('div')<{disabled: boolean}>`
+  display: flex;
+  justify-content: space-between;
+  background: ${p => p.theme.backgroundSecondary};
+  opacity: ${p => (p.disabled ? 0.3 : 1)};
+  border-radius: ${p => p.theme.borderRadius};
+  margin: ${space(1.5)};
+  padding: ${space(1.5)};
+  box-sizing: border-box;
+`;
+
 const SubscriptionInfo = styled('div')`
   display: flex;
   flex-direction: column;
-`;
-
-const SubscriptionGridItem = styled('div')<{disabled: boolean}>`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  background: ${p => p.theme.backgroundSecondary};
-  opacity: ${({disabled}: {disabled: boolean}) => (disabled ? 0.3 : 1)};
-  border-radius: 3px;
-  flex: 1;
-  padding: 12px;
-  height: 100%;
-`;
-
-const SubscriptionGridItemWrapper = styled('div')`
-  padding: 12px;
-  width: 33%;
+  align-self: center;
 `;
 
 const SubscriptionDescription = styled('div')`
-  font-size: 12px;
+  font-size: ${p => p.theme.fontSizeMedium};
   line-height: 1;
   color: ${p => p.theme.gray300};
-  white-space: nowrap;
 `;
 
 const SubscriptionTitle = styled('div')`
-  font-size: 16px;
+  font-size: ${p => p.theme.fontSizeLarge};
   line-height: 1;
   color: ${p => p.theme.textColor};
   white-space: nowrap;
-  margin-bottom: 5px;
+  margin-bottom: ${space(0.75)};
 `;


### PR DESCRIPTION
See [ISSUE-1429](https://getsentry.atlassian.net/browse/ISSUE-1429)

This PR just adjusts how the CSS is applied to the webhook checkboxes on the create integration pages. It also changes the tootltip to be a bit more accurate (e.g. there is no 'Comment' permission to enable, we're looking for 'Event').

Before: 

![image](https://user-images.githubusercontent.com/35509934/158901776-6037559a-bf70-4326-92ab-80b552680427.png)

![image](https://user-images.githubusercontent.com/35509934/158902460-8d7a6d41-7200-40dd-bd3d-ea09f87b568d.png)

![image](https://user-images.githubusercontent.com/35509934/158901926-01ba4564-9536-48c7-b6e1-b3a06fc652a1.png)


After:



![image](https://user-images.githubusercontent.com/35509934/158902004-9eeac75b-08a2-4076-a8ee-cf176aa42076.png)

![image](https://user-images.githubusercontent.com/35509934/158902380-0fb34b9c-502a-4098-abbf-4c7f303ba4cb.png)


![image](https://user-images.githubusercontent.com/35509934/158901971-d61c3a99-2abc-4e69-9975-745b9c00bfa9.png)


