### PR TITLE
fix(stats): Don't count token requests in FE stats

### DIFF
--- a/src/sentry/middleware/__init__.py
+++ b/src/sentry/middleware/__init__.py
@@ -23,6 +23,14 @@ def get_path(view_func: ViewFunc) -> str | None:
 
 
 def is_frontend_request(request: Request) -> bool:
+    """
+    Used to determine if a request came from the UI or not. UI requests will have cookies and no
+    authentication tokens, while requests coming from user scripts will tend to be the opposite.
+
+    Users could make backend requests directly with cookies which would be counted here. The
+    belief is that that's a fraction of the total requests. Either way, this function should not be
+    used expecting it to be 100% accurate. We are using it only for statistics.
+    """
     return bool(getattr(request, "COOKIES", {})) and getattr(request, "auth", None) is None
 
 

--- a/src/sentry/middleware/__init__.py
+++ b/src/sentry/middleware/__init__.py
@@ -23,7 +23,7 @@ def get_path(view_func: ViewFunc) -> str | None:
 
 
 def is_frontend_request(request: Request) -> bool:
-    return bool(getattr(request, "COOKIES", {}))
+    return bool(getattr(request, "COOKIES", {})) and getattr(request, "auth", None) is None
 
 
 __all__ = ("get_path", "is_frontend_request", "ViewFunc")


### PR DESCRIPTION
When looking at the frontend stats that we had been getting, some of the cookie requests also had bearer tokens too. These are most likely not done by the UI.
I added this check to reduce some noise on the "UI" request counts.