### PR TITLE
ref(types): Remove circular dependencies

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -11,7 +11,7 @@ from sentry.eventstore.models import Event
 from sentry.integrations.slack.message_builder.issues import build_group_attachment
 from sentry.models import Integration
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
-from sentry.rules import EventState, RuleFuture
+from sentry.rules import EventState
 from sentry.rules.actions.base import IntegrationEventAction
 from sentry.rules.base import CallbackFuture
 from sentry.shared_integrations.exceptions import (
@@ -19,6 +19,7 @@ from sentry.shared_integrations.exceptions import (
     ApiRateLimitedError,
     DuplicateDisplayNameError,
 )
+from sentry.types.rules import RuleFuture
 from sentry.utils import json, metrics
 
 from .client import SlackClient

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -12,8 +12,8 @@ from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.notifications.user_report import UserReportNotification
 from sentry.notifications.types import ActionTargetType
 from sentry.plugins.base.structs import Notification
-from sentry.rules import RuleFuture
 from sentry.tasks.digests import deliver_digest
+from sentry.types.rules import RuleFuture
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/rules/__init__.py
+++ b/src/sentry/rules/__init__.py
@@ -1,7 +1,3 @@
-from collections import namedtuple
-
-RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
-
 from .base import EventState, RuleBase
 from .match import LEVEL_MATCH_CHOICES, MATCH_CHOICES, MatchType
 from .registry import RuleRegistry
@@ -13,7 +9,6 @@ __all__ = (
     "MATCH_CHOICES",
     "MatchType",
     "RuleBase",
-    "RuleFuture",
     "rules",
 )
 

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -12,8 +12,8 @@ from sentry.constants import ObjectStatus
 from sentry.eventstore.models import Event
 from sentry.integrations import IntegrationInstallation
 from sentry.models import ExternalIssue, GroupLink, Integration
-from sentry.rules import RuleFuture
 from sentry.rules.base import CallbackFuture, EventState, RuleBase
+from sentry.types.rules import RuleFuture
 
 logger = logging.getLogger("sentry.rules")
 

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -9,7 +9,7 @@ from django import forms
 
 from sentry.eventstore.models import Event
 from sentry.models import Project, Rule
-from sentry.rules import RuleFuture
+from sentry.types.rules import RuleFuture
 
 """
 Rules apply either before an event gets stored, or immediately after.

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -11,7 +11,8 @@ from django.utils import timezone
 from sentry import analytics
 from sentry.eventstore.models import Event
 from sentry.models import GroupRuleStatus, Rule
-from sentry.rules import EventState, RuleFuture, history, rules
+from sentry.rules import EventState, history, rules
+from sentry.types.rules import RuleFuture
 from sentry.utils.hashlib import hash_values
 from sentry.utils.safe import safe_execute
 

--- a/src/sentry/types/rules.py
+++ b/src/sentry/types/rules.py
@@ -1,0 +1,3 @@
+from collections import namedtuple
+
+RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -1,14 +1,11 @@
-from collections import namedtuple
-
 import responses
 
 from sentry.integrations.jira.notify_action import JiraCreateTicketAction
 from sentry.models import ExternalIssue, GroupLink, Integration, Rule
 from sentry.testutils.cases import RuleTestCase
+from sentry.types.rules import RuleFuture
 from sentry.utils import json
 from tests.fixtures.integrations.mock_service import StubService
-
-RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
 
 
 class JiraCreateTicketActionTest(RuleTestCase):

--- a/tests/sentry/integrations/test_ticket_rules.py
+++ b/tests/sentry/integrations/test_ticket_rules.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from unittest import mock
 
 from django.urls import reverse
@@ -8,9 +7,8 @@ from sentry.eventstore.models import Event
 from sentry.integrations.jira import JiraCreateTicketAction
 from sentry.models import ExternalIssue, Integration, Rule
 from sentry.testutils import RuleTestCase
+from sentry.types.rules import RuleFuture
 from tests.fixtures.integrations.jira import MockJira
-
-RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
 
 
 class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from time import time
 
 import responses
@@ -7,12 +6,11 @@ from sentry.integrations.vsts.integration import VstsIntegration
 from sentry.integrations.vsts.notify_action import AzureDevopsCreateTicketAction
 from sentry.models import ExternalIssue, GroupLink, Identity, IdentityProvider, Integration, Rule
 from sentry.testutils.cases import RuleTestCase
+from sentry.types.rules import RuleFuture
 from sentry.utils import json
 
 from .test_issues import VstsIssueBase
 from .testutils import GET_PROJECTS_RESPONSE, WORK_ITEM_RESPONSE
-
-RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
 
 
 class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -41,10 +41,10 @@ from sentry.notifications.utils.digest import get_digest_subject
 from sentry.ownership import grammar
 from sentry.ownership.grammar import Matcher, Owner, dump_schema
 from sentry.plugins.base import Notification
-from sentry.rules import RuleFuture
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.types.integrations import ExternalProviders
+from sentry.types.rules import RuleFuture
 from sentry.utils.email import MessageBuilder, get_email_addresses
 from sentry_plugins.opsgenie.plugin import OpsGeniePlugin
 from tests.sentry.mail import make_event_data, send_notification

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -9,7 +9,6 @@ from requests.exceptions import Timeout
 from sentry.api.serializers import serialize
 from sentry.constants import SentryAppStatus
 from sentry.models import Activity, Rule, SentryApp, SentryAppInstallation
-from sentry.receivers.sentry_apps import *  # NOQA
 from sentry.shared_integrations.exceptions import ClientError
 from sentry.tasks.post_process import post_process_group
 from sentry.tasks.sentry_apps import (
@@ -26,6 +25,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.helpers.faux import faux
+from sentry.types.rules import RuleFuture
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
@@ -42,8 +42,6 @@ def raiseStatusTrue():
 def raiseException():
     raise Exception
 
-
-RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
 
 MockResponse = namedtuple(
     "MockResponse", ["headers", "content", "text", "ok", "status_code", "raise_for_status"]


### PR DESCRIPTION
We're constantly redefining `RuleFuture` rather than importing it from a common source. This PR creates the common source. 