### PR TITLE
ref(dropdown-autocomplete): Add minWidth prop

### DIFF
--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -135,6 +135,11 @@ type Props = {
   menuWithArrow?: boolean;
 
   /**
+   * Minimum menu width, defaults to 250
+   */
+  minWidth?: number;
+
+  /**
    * Message to display when there are no items that match the search
    */
   noResultsMessage?: React.ReactNode;
@@ -192,6 +197,7 @@ const Menu = ({
   blendCorner = true,
   detached = false,
   alignMenu = 'left',
+  minWidth = 250,
   hideInput = false,
   busy = false,
   busyItemsStillVisible = false,
@@ -309,8 +315,9 @@ const Menu = ({
               detached={detached}
               alignMenu={alignMenu}
               menuWithArrow={menuWithArrow}
+              minWidth={minWidth}
             >
-              <DropdownMainContent>
+              <DropdownMainContent minWidth={minWidth}>
                 {itemsLoading && <LoadingIndicator mini />}
                 {showInput && (
                   <InputWrapper>
@@ -414,17 +421,17 @@ export const AutoCompleteRoot = styled(({isOpen: _isOpen, ...props}) => (
   ${p => p.disabled && 'pointer-events: none;'}
 `;
 
-const StyledDropdownBubble = styled(DropdownBubble)`
+const StyledDropdownBubble = styled(DropdownBubble)<{minWidth: number}>`
   display: flex;
-  min-width: 250px;
+  min-width: ${p => p.minWidth}px;
 
   ${p => p.detached && p.alignMenu === 'left' && 'right: auto;'}
   ${p => p.detached && p.alignMenu === 'right' && 'left: auto;'}
 `;
 
-const DropdownMainContent = styled('div')`
+const DropdownMainContent = styled('div')<{minWidth: number}>`
   width: 100%;
-  min-width: 250px;
+  min-width: ${p => p.minWidth}px;
 `;
 
 const InputWrapper = styled('div')`

--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -188,6 +188,7 @@ const ProjectSelector = ({
       busyItemsStillVisible={searching}
       onScroll={onScroll}
       maxHeight={500}
+      minWidth={350}
       inputProps={{style: {padding: 8, paddingLeft: 10}}}
       rootClassName={rootClassName}
       className={className}


### PR DESCRIPTION
The project page filter is too narrow and cuts out some of the longer project names. Unfortunately, there doesn't seem to be a straightforward way to have the menu expand with its contents (since `react-virtualized` requires a `width` prop, which in our current implementation will be equal to the `min-width` set on `dropdownAutocomplete`).

We can add a special `minWidth` prop which will be passed to `dropdownAutocomplete` to widen the menu, leaving more space for project names.

**Before:**
<img width="417" alt="Screen Shot 2022-03-17 at 4 07 49 PM" src="https://user-images.githubusercontent.com/44172267/158908502-b1ec5d2a-6e2e-40b0-a357-2f651b0f3e8c.png">

**After:**
<img width="417" alt="Screen Shot 2022-03-17 at 4 11 00 PM" src="https://user-images.githubusercontent.com/44172267/158908771-1f187f30-21ab-4b1b-b21c-12b3a212886b.png">

