### PR TITLE
ref(alerts): Change look of team filter to match page filters

### DIFF
--- a/static/app/views/alerts/rules/filter.tsx
+++ b/static/app/views/alerts/rules/filter.tsx
@@ -4,12 +4,10 @@ import styled from '@emotion/styled';
 import CheckboxFancy from 'sentry/components/checkboxFancy/checkboxFancy';
 import DropdownButton from 'sentry/components/dropdownButton';
 import DropdownControl, {Content} from 'sentry/components/dropdownControl';
-import {IconFilter} from 'sentry/icons';
-import {t, tn} from 'sentry/locale';
+import {IconUser} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
-
-type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
 
 type DropdownSection = {
   id: string;
@@ -92,31 +90,14 @@ function Filter({onFilterChange, header, dropdownSections}: Props) {
     onFilterChange(sectionId, newSelection);
   }
 
-  function getNumberOfActiveFilters() {
+  function getActiveFilters() {
     return dropdownSections
       .map(section => section.items)
       .flat()
-      .filter(item => item.checked).length;
+      .filter(item => item.checked);
   }
 
-  const checkedQuantity = getNumberOfActiveFilters();
-
-  const dropDownButtonProps: Pick<DropdownButtonProps, 'children' | 'priority'> & {
-    hasDarkBorderBottomColor: boolean;
-  } = {
-    children: t('Filter'),
-    priority: 'default',
-    hasDarkBorderBottomColor: false,
-  };
-
-  if (checkedQuantity > 0) {
-    dropDownButtonProps.children = tn(
-      '%s Active Filter',
-      '%s Active Filters',
-      checkedQuantity
-    );
-    dropDownButtonProps.hasDarkBorderBottomColor = true;
-  }
+  const activeFilters = getActiveFilters();
 
   return (
     <DropdownControl
@@ -128,12 +109,15 @@ function Filter({onFilterChange, header, dropdownSections}: Props) {
           {...getActorProps()}
           showChevron={false}
           isOpen={isOpen}
-          icon={<IconFilter />}
-          hasDarkBorderBottomColor={dropDownButtonProps.hasDarkBorderBottomColor}
-          priority={dropDownButtonProps.priority as DropdownButtonProps['priority']}
+          icon={<IconUser />}
+          priority="default"
           data-test-id="filter-button"
         >
-          {dropDownButtonProps.children}
+          <DropdownButtonText>
+            {activeFilters.length > 0
+              ? activeFilters.map(filter => filter.label).join(', ')
+              : t('All Teams')}
+          </DropdownButtonText>
         </StyledDropdownButton>
       )}
     >
@@ -182,11 +166,18 @@ const Header = styled('div')`
   border-bottom: 1px solid ${p => p.theme.border};
 `;
 
-const StyledDropdownButton = styled(DropdownButton)<{hasDarkBorderBottomColor?: boolean}>`
+const StyledDropdownButton = styled(DropdownButton)`
   white-space: nowrap;
   max-width: 200px;
 
   z-index: ${p => p.theme.zIndex.dropdown};
+`;
+
+const DropdownButtonText = styled('span')`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  flex: 1;
 `;
 
 const List = styled('ul')`

--- a/static/app/views/alerts/rules/filter.tsx
+++ b/static/app/views/alerts/rules/filter.tsx
@@ -107,7 +107,6 @@ function Filter({onFilterChange, header, dropdownSections}: Props) {
       button={({isOpen, getActorProps}) => (
         <StyledDropdownButton
           {...getActorProps()}
-          showChevron={false}
           isOpen={isOpen}
           icon={<IconUser />}
           priority="default"

--- a/static/app/views/alerts/rules/filter.tsx
+++ b/static/app/views/alerts/rules/filter.tsx
@@ -99,6 +99,14 @@ function Filter({onFilterChange, header, dropdownSections}: Props) {
 
   const activeFilters = getActiveFilters();
 
+  let filterDescription = t('All Teams');
+  if (activeFilters.length > 0) {
+    filterDescription = activeFilters[0].label;
+  }
+  if (activeFilters.length > 1) {
+    filterDescription = `${activeFilters[0].label} + ${activeFilters.length - 1}`;
+  }
+
   return (
     <DropdownControl
       menuWidth="240px"
@@ -112,11 +120,7 @@ function Filter({onFilterChange, header, dropdownSections}: Props) {
           priority="default"
           data-test-id="filter-button"
         >
-          <DropdownButtonText>
-            {activeFilters.length > 0
-              ? activeFilters.map(filter => filter.label).join(', ')
-              : t('All Teams')}
-          </DropdownButtonText>
+          <DropdownButtonText>{filterDescription}</DropdownButtonText>
         </StyledDropdownButton>
       )}
     >

--- a/static/app/views/alerts/rules/teamFilter.tsx
+++ b/static/app/views/alerts/rules/teamFilter.tsx
@@ -72,7 +72,7 @@ function TeamFilter({
         <InputWrapper>
           <StyledInput
             autoFocus
-            placeholder={t('Filter by team slug')}
+            placeholder={t('Filter teams')}
             onClick={event => {
               event.stopPropagation();
             }}

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -215,7 +215,8 @@ describe('OrganizationRuleList', () => {
     userEvent.click(await screen.findByTestId('filter-button'));
 
     // Uncheck myteams
-    userEvent.click(await screen.findByText('My Teams'));
+    const myTeams = await screen.findAllByText('My Teams');
+    userEvent.click(myTeams[1]);
 
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
As we prepare for the rollout of page filters onto the issue page, we wanted to make this team filter more consistent with the other page filters we have on this page.

Before:
<img width="1179" alt="image" src="https://user-images.githubusercontent.com/9372512/158913706-5456bb1d-1ee4-4953-92c1-36fb6cc3a69e.png">


After:
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/9372512/158914075-a26b20ec-2073-4bf2-a081-f65608d7df41.png">



