### PR TITLE
fix(ui): Fix timerange autocomplete

### DIFF
--- a/static/app/components/dropdownAutoComplete/autoCompleteFilter.tsx
+++ b/static/app/components/dropdownAutoComplete/autoCompleteFilter.tsx
@@ -17,7 +17,10 @@ function hasRootGroup(items: Items): items is ItemsWithChildren {
 function filterItems(items: Items, inputValue: string): ItemsBeforeFilter {
   return items.filter(
     item =>
-      (item.searchKey || `${item.value} ${item.label}`)
+      (typeof item.searchKey === 'string' && item.searchKey.length > 0
+        ? item.searchKey
+        : `${item.value} ${item.label}`
+      )
         .toLowerCase()
         .indexOf(inputValue.toLowerCase()) > -1
   );


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/pull/32349
Fixes JAVASCRIPT-26V0

Looks like `item.searchKey` can be truthy, but not a string -> probably because of translations.
This is a hotfix.