### PR TITLE
feat(new-widget-builder-experience): Stacked charts when using grouping

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -209,11 +209,14 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps, State> {
   }
 
   chartComponent(chartProps): React.ReactNode {
-    const {widget} = this.props;
+    const {organization, widget} = this.props;
+    const stacked =
+      organization.features.includes('new-widget-builder-experience-design') &&
+      widget.queries[0].columns.length > 0;
 
     switch (widget.displayType) {
       case 'bar':
-        return <BarChart {...chartProps} />;
+        return <BarChart {...chartProps} stacked={stacked} />;
       case 'area':
       case 'top_n':
         return <AreaChart stacked {...chartProps} />;


### PR DESCRIPTION
We have three time series charts: Line, Bar, Area
When a grouping is applied we should be displaying some of these as stacked. Multiple queries will display in the same stack for now in bar charts. We discussed that this is aligned to the Discover experience and we can iterate on it later to find ways to split queries and multiple y-axes into separate bars.

Area - Stacked
<img width="761" alt="Screen Shot 2022-03-18 at 9 59 49 AM" src="https://user-images.githubusercontent.com/22846452/159019010-ce8cdbe2-f0d5-44ea-b67b-459c220eb0c8.png">

Bar - Stacked when grouping is added
<img width="760" alt="Screen Shot 2022-03-18 at 9 59 37 AM" src="https://user-images.githubusercontent.com/22846452/159019102-f1c9cb58-5f17-49bd-9c66-cb86388bf5c4.png">

Line - Unstacked even when grouping is added
<img width="763" alt="Screen Shot 2022-03-18 at 10 00 03 AM" src="https://user-images.githubusercontent.com/22846452/159019170-a2a1b81b-6e00-4483-87de-64eba9cd24b9.png">

I'm leaving tests out of this PR because in Jest we mock the echarts library so we won't be able to visualize the library for a snapshot, nor look for some kind of accessibility aria-label if there was one.