### PR TITLE
fix(metrics): Zerofill only on groupby session.status [INGEST-1095]

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -770,8 +770,9 @@ def run_sessions_query(
     if len(data_points) == 0:
         # We're only interested in `session.status` group-byes. The rest of the
         # conditions require work (e.g. getting all environments) that we can't
-        # get without querying the DB.
-        if "session.status" in query_clone.raw_groupby:
+        # get without querying the DB, including group-byes consisting of
+        # multiple parameters (even if `session.status` is one of them).
+        if query_clone.raw_groupby == ["session.status"]:
             for status in get_args(_SessionStatus):
                 gkey: GroupKey = (("session.status", status),)
                 groups[gkey]


### PR DESCRIPTION
Zero-filling when there isn't any data must only happen when there's a single `groupBy` property, and that property is `session.status`. This PR fixes a bug where the data is zero-filled when `session.status` is present, even if it isn't the only property. The test has also been updated to consider every combination of `session.status` values.