### PR TITLE
ref(sentry-metrics): add StringIndexerCache

### DIFF
--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -71,7 +71,11 @@ class StringIndexerCache:
 
     def delete(self, key: str) -> None:
         cache_key = self.make_cache_key(key)
-        cache.delete(cache_key)
+        cache.delete(cache_key, version=self.version)
+
+    def delete_many(self, keys: Sequence[str]) -> None:
+        cache_keys = [self.make_cache_key(key) for key in keys]
+        cache.delete_many(cache_keys, version=self.version)
 
 
 # todo: dont hard code 1 as the version

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -1,0 +1,78 @@
+import logging
+import random
+from typing import Mapping, MutableMapping, Optional, Sequence
+
+from django.conf import settings
+
+from sentry.utils.cache import cache
+from sentry.utils.hashlib import md5_text
+
+logger = logging.getLogger(__name__)
+
+
+class StringIndexerCache:
+    def __init__(self, version: int):
+        self.version = version
+
+    @property
+    def randomized_ttl(self) -> int:
+        # introduce jitter in the cache_ttl so that when we have large
+        # amount of new keys written into the cache, they don't expire all at once
+        cache_ttl = settings.SENTRY_METRICS_INDEXER_CACHE_TTL
+        jitter = random.uniform(0, 0.25) * cache_ttl
+        return int(cache_ttl + jitter)
+
+    def make_cache_key(self, key: str) -> str:
+        hashed = md5_text(key).hexdigest()
+        return f"indexer:org:str:{hashed}"
+
+    def _format_results(
+        self,
+        keys: Sequence[str],
+        results: Mapping[str, Optional[int]],
+    ) -> MutableMapping[str, Optional[int]]:
+        """
+        Takes in keys formatted like "org_id:string", and results that have the
+        internally used hashed key such as:
+            {"indexer:org:str:b0a0e436f6fa42b9e33e73befbdbb9ba": 2}
+        and returns results that replace the hashed internal key with the externally
+        used key:
+            {"1.2.0": 2}
+        """
+        formatted: MutableMapping[str, Optional[int]] = {}
+        for key in keys:
+            cache_key = self.make_cache_key(key)
+            formatted[key] = results.get(cache_key)
+
+        return formatted
+
+    def get(self, key: str) -> int:
+        result: int = cache.get(self.make_cache_key(key), version=self.version)
+        return result
+
+    def set(self, key: str, value: int) -> None:
+        cache.set(
+            key=self.make_cache_key(key),
+            value=value,
+            timeout=self.randomized_ttl,
+            version=self.version,
+        )
+
+    def get_many(self, keys: Sequence[str]) -> MutableMapping[str, Optional[int]]:
+        cache_keys = {self.make_cache_key(key): key for key in keys}
+        results: Mapping[str, Optional[int]] = cache.get_many(
+            cache_keys.keys(), version=self.version
+        )
+        return self._format_results(keys, results)
+
+    def set_many(self, key_values: Mapping[str, int]) -> None:
+        cache_key_values = {self.make_cache_key(k): v for k, v in key_values.items()}
+        cache.set_many(cache_key_values, timeout=self.randomized_ttl, version=self.version)
+
+    def delete(self, key: str) -> None:
+        cache_key = self.make_cache_key(key)
+        cache.delete(cache_key)
+
+
+# todo: dont hard code 1 as the version
+indexer_cache = StringIndexerCache(version=1)

--- a/src/sentry/sentry_metrics/indexer/models.py
+++ b/src/sentry/sentry_metrics/indexer/models.py
@@ -1,6 +1,5 @@
 import logging
-import random
-from typing import Any, Mapping, MutableMapping, Sequence, Union
+from typing import Any
 
 from django.conf import settings
 from django.db import connections, models, router
@@ -9,8 +8,6 @@ from django.utils import timezone
 from sentry.db.models import Model
 from sentry.db.models.fields.bounded import BoundedBigIntegerField
 from sentry.db.models.manager.base import BaseManager
-from sentry.utils.cache import cache
-from sentry.utils.hashlib import md5_text
 
 logger = logging.getLogger(__name__)
 
@@ -50,82 +47,11 @@ class StringIndexer(Model):  # type: ignore
     last_seen = models.DateTimeField(default=timezone.now, db_index=True)
     retention_days = models.IntegerField(default=90)
 
+    objects = BaseManager(cache_fields=("pk",), cache_ttl=settings.SENTRY_METRICS_INDEXER_CACHE_TTL)  # type: ignore
+
     class Meta:
         db_table = "sentry_stringindexer"
         app_label = "sentry"
         constraints = [
             models.UniqueConstraint(fields=["string", "organization_id"], name="unique_org_string"),
         ]
-
-
-class StringIndexerCache:
-    def __init__(self, model: Any, version: int):
-        self.model = model
-        self.version = version
-        self.cache_ttl: int = settings.SENTRY_METRICS_INDEXER_CACHE_TTL
-
-    @property
-    def randomized_ttl(self) -> int:
-        # introduce jitter in the cache_ttl so that when we have large
-        # amount of new keys written into the cache, they don't expire all at once
-        jitter = random.uniform(0, 0.25) * self.cache_ttl
-        return int(self.cache_ttl + jitter)
-
-    def make_cache_key(self, key: Union[str, int]) -> str:
-        hashed = md5_text(key).hexdigest()
-        # key is either the str => "org_id:string" or the id => 1
-        if isinstance(key, int):
-            cache_key = f"indexer:org:str:{hashed}"
-        elif isinstance(key, str):
-            cache_key = f"indexer:int:{hashed}"
-        else:
-            raise Exception("Invalid type: must be str or int")
-
-        return cache_key
-
-    def _format_results(
-        self,
-        keys: Sequence[Union[str, int]],
-        results: Mapping[Union[str, int], Union[str, int, None]],
-    ) -> MutableMapping[Union[str, int], Union[str, int, None]]:
-        # make the results look like {"org_id:string": 3} or {id: "string"} instead of the
-        # internally used hashed cache key e.g 'indexer:int:b0a0e436f6fa42b9e33e73befbdbb9ba'
-        formatted: MutableMapping[Union[str, int], Union[str, int, None]] = {}
-        for key in keys:
-            cache_key = self.make_cache_key(key)
-            formatted[key] = results.get(cache_key)
-
-        return formatted
-
-    def get(self, key: Union[str, int]) -> Union[str, int]:
-        result: Union[str, int] = cache.get(self.make_cache_key(key), version=self.version)
-        return result
-
-    def set(self, key: Union[str, int], value: Union[str, int]) -> None:
-        cache.set(
-            key=self.make_cache_key(key),
-            value=value,
-            timeout=self.randomized_ttl,
-            version=self.version,
-        )
-
-    def get_many(
-        self, keys: Sequence[Union[str, int]]
-    ) -> MutableMapping[Union[str, int], Union[str, int, None]]:
-        cache_keys = {self.make_cache_key(key): key for key in keys}
-        results: Mapping[Union[str, int], Union[str, int, None]] = cache.get_many(
-            cache_keys.keys(), version=self.version
-        )
-        return self._format_results(keys, results)
-
-    def set_many(self, key_values: Mapping[str, Union[str, int]]) -> None:
-        cache_key_values = {self.make_cache_key(k): v for k, v in key_values.items()}
-        cache.set_many(cache_key_values, timeout=self.randomized_ttl, version=self.version)
-
-    def delete(self, key: Union[str, int]) -> None:
-        cache_key = self.make_cache_key(key)
-        cache.delete(cache_key)
-
-
-# todo: dont hard code 1 as the version
-indexer_cache = StringIndexerCache(StringIndexer, version=1)

--- a/src/sentry/sentry_metrics/indexer/models.py
+++ b/src/sentry/sentry_metrics/indexer/models.py
@@ -1,4 +1,5 @@
-from typing import Any
+import logging
+from typing import Any, Mapping, Sequence, Union
 
 from django.conf import settings
 from django.db import connections, models, router
@@ -7,6 +8,13 @@ from django.utils import timezone
 from sentry.db.models import Model
 from sentry.db.models.fields.bounded import BoundedBigIntegerField
 from sentry.db.models.manager.base import BaseManager
+from sentry.utils import metrics
+from sentry.utils.cache import cache
+from sentry.utils.hashlib import md5_text
+
+logger = logging.getLogger(__name__)
+
+_INDEXER_CACHE_METRIC = "sentry_metrics.indexer.memcache"
 
 
 class MetricsKeyIndexer(Model):  # type: ignore
@@ -50,3 +58,146 @@ class StringIndexer(Model):  # type: ignore
         constraints = [
             models.UniqueConstraint(fields=["string", "organization_id"], name="unique_org_string"),
         ]
+
+    @classmethod
+    def get_many_ids(cls, keys) -> Mapping[str, str]:
+        # keys => "organization_id:string"
+        final_results = {}
+        cache_results = indexer_cache.get_many(keys, field_type=str)
+        # {"key" => result}
+        db_look_up_keys = set()
+        for key in keys:
+            cache_key = indexer_cache.make_cache_key(key, field_type=str)
+            result = cache_results.get(cache_key)
+            if not result:
+                db_look_up_keys.add(key)
+
+            final_results[key] = result
+
+        cache_hits = len(final_results.keys())
+        cache_misses = len(db_look_up_keys)
+        # todo q: should this have an extra tag to know its from the write path?
+        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "true"}, amount=cache_hits)
+        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "false"}, amount=cache_misses)
+
+        if not db_look_up_keys:
+            return final_results
+
+        db_results = cls.get_db_ids_and_set_cache(db_look_up_keys)
+        final_results.update(db_results)
+
+        return final_results
+
+    @classmethod
+    def record_many_strings(cls, keys):
+        records = []
+        for key in keys:
+            organization_id, string = key.split(":")
+            records.append(cls(organization_id=int(organization_id), string=string))
+
+        with metrics.timer("sentry_metrics.indexer.pg_bulk_create"):
+            cls.objects.bulk_create(records, ignore_conflicts=True)
+
+        return cls.get_db_ids_and_set_cache(keys)
+
+    @classmethod
+    def get_db_ids_and_set_cache(cls, keys):
+        org_ids = []
+        strings = []
+        for key in keys:
+            organization_id, string = key.split(":")
+            org_ids.append(int(organization_id))
+            strings.append(string)
+
+        db_objects = cls.objects.filter(
+            organization_id__in=org_ids,
+            string__in=strings,
+        )
+        db_results = {}
+        reverse_db_results = {}
+        for db_result in db_objects:
+            key = f"{db_result.organization_id}:{db_result.string}"
+            if key in keys:
+                db_results[key] = db_result.id
+                reverse_key = f"{db_result.organization_id}:{db_result.id}"
+                reverse_db_results[reverse_key] = db_result.string
+
+        indexer_cache.set_many(db_results, field_type=str)
+        indexer_cache.set_many(reverse_db_results, field_type=int)
+        return db_results
+
+    @classmethod
+    def get_id(cls, org_id, string) -> int:
+        key = f"{org_id}:{string}"
+        result = indexer_cache.get(key, field_type=str)
+        if result:
+            metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "true"})
+            return result
+
+        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "false"})
+        db_result = cls.objects.get(organization_id=org_id, string=string).id
+        indexer_cache.set(key, db_result, field_type=str)
+
+        return db_result
+
+    @classmethod
+    def get_string(cls, org_id, id) -> str:
+        key = f"{org_id}:{id}"
+        result = indexer_cache.get(key, field_type=str)
+        if result:
+            metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "true"})
+            return result
+
+        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "false"})
+        db_result = cls.objects.get(organization_id=org_id, id=id).string
+        indexer_cache.set(key, db_result, field_type=int)
+
+        return db_result
+
+    def delete(self, **kwargs):
+        # TODO(meredith): remove from cache on delete.
+        # maybe should be done with post_delete signal instead
+        return super().delete(**kwargs)
+
+
+class StringIndexerCache:
+    def __init__(self, model, version):
+        self.model = model
+        self.version = version
+        self.cache_ttl = settings.SENTRY_METRICS_INDEXER_CACHE_TTL
+
+    def make_cache_key(self, key: str, field_type: type) -> str:
+        hashed = md5_text(key).hexdigest()
+        if field_type == int:
+            cache_key = f"indexer:org:int:{hashed}"
+        elif field_type == str:
+            cache_key = f"indexer:org:str:{hashed}"
+        else:
+            raise Exception("Invalid type: must be str or int")
+
+        return cache_key
+
+    def get(self, key: str, field_type: type):
+        return cache.get(self.make_cache_key(key, field_type), version=self.version)
+
+    def set(self, key: str, value: Union[str, int], field_type: type):
+        return cache.set(
+            key=self.make_cache_key(key, field_type),
+            value=value,
+            timeout=self.cache_ttl,
+            version=self.version,
+        )
+
+    def get_many(self, keys: Sequence[str], field_type: type):
+        cache_keys = [self.make_cache_key(key, field_type) for key in keys]
+        return cache.get_many(cache_keys, version=self.version)
+
+    def set_many(self, key_values: Mapping[str, Union[str, int]], field_type: type):
+        cache_key_values = {self.make_cache_key(k, field_type): v for k, v in key_values.items()}
+        # TODO(meredith): introduce jitter in the cache_ttl so that when we have large
+        # amount of new keys written into the cache, they don't expire all at once
+        return cache.set_many(cache_key_values, timeout=self.cache_ttl, version=self.version)
+
+
+# todo: dont hard code 1 as the version
+indexer_cache = StringIndexerCache(StringIndexer, version=1)

--- a/src/sentry/sentry_metrics/indexer/models.py
+++ b/src/sentry/sentry_metrics/indexer/models.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Mapping, Sequence, Union
+import random
+from typing import Any, Mapping, MutableMapping, Sequence, Union
 
 from django.conf import settings
 from django.db import connections, models, router
@@ -8,13 +9,10 @@ from django.utils import timezone
 from sentry.db.models import Model
 from sentry.db.models.fields.bounded import BoundedBigIntegerField
 from sentry.db.models.manager.base import BaseManager
-from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 
 logger = logging.getLogger(__name__)
-
-_INDEXER_CACHE_METRIC = "sentry_metrics.indexer.memcache"
 
 
 class MetricsKeyIndexer(Model):  # type: ignore
@@ -59,144 +57,74 @@ class StringIndexer(Model):  # type: ignore
             models.UniqueConstraint(fields=["string", "organization_id"], name="unique_org_string"),
         ]
 
-    @classmethod
-    def get_many_ids(cls, keys) -> Mapping[str, str]:
-        # keys => "organization_id:string"
-        final_results = {}
-        cache_results = indexer_cache.get_many(keys, field_type=str)
-        # {"key" => result}
-        db_look_up_keys = set()
-        for key in keys:
-            cache_key = indexer_cache.make_cache_key(key, field_type=str)
-            result = cache_results.get(cache_key)
-            if not result:
-                db_look_up_keys.add(key)
-
-            final_results[key] = result
-
-        cache_hits = len(final_results.keys())
-        cache_misses = len(db_look_up_keys)
-        # todo q: should this have an extra tag to know its from the write path?
-        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "true"}, amount=cache_hits)
-        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "false"}, amount=cache_misses)
-
-        if not db_look_up_keys:
-            return final_results
-
-        db_results = cls.get_db_ids_and_set_cache(db_look_up_keys)
-        final_results.update(db_results)
-
-        return final_results
-
-    @classmethod
-    def record_many_strings(cls, keys):
-        records = []
-        for key in keys:
-            organization_id, string = key.split(":")
-            records.append(cls(organization_id=int(organization_id), string=string))
-
-        with metrics.timer("sentry_metrics.indexer.pg_bulk_create"):
-            cls.objects.bulk_create(records, ignore_conflicts=True)
-
-        return cls.get_db_ids_and_set_cache(keys)
-
-    @classmethod
-    def get_db_ids_and_set_cache(cls, keys):
-        org_ids = []
-        strings = []
-        for key in keys:
-            organization_id, string = key.split(":")
-            org_ids.append(int(organization_id))
-            strings.append(string)
-
-        db_objects = cls.objects.filter(
-            organization_id__in=org_ids,
-            string__in=strings,
-        )
-        db_results = {}
-        reverse_db_results = {}
-        for db_result in db_objects:
-            key = f"{db_result.organization_id}:{db_result.string}"
-            if key in keys:
-                db_results[key] = db_result.id
-                reverse_key = f"{db_result.organization_id}:{db_result.id}"
-                reverse_db_results[reverse_key] = db_result.string
-
-        indexer_cache.set_many(db_results, field_type=str)
-        indexer_cache.set_many(reverse_db_results, field_type=int)
-        return db_results
-
-    @classmethod
-    def get_id(cls, org_id, string) -> int:
-        key = f"{org_id}:{string}"
-        result = indexer_cache.get(key, field_type=str)
-        if result:
-            metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "true"})
-            return result
-
-        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "false"})
-        db_result = cls.objects.get(organization_id=org_id, string=string).id
-        indexer_cache.set(key, db_result, field_type=str)
-
-        return db_result
-
-    @classmethod
-    def get_string(cls, org_id, id) -> str:
-        key = f"{org_id}:{id}"
-        result = indexer_cache.get(key, field_type=str)
-        if result:
-            metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "true"})
-            return result
-
-        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "false"})
-        db_result = cls.objects.get(organization_id=org_id, id=id).string
-        indexer_cache.set(key, db_result, field_type=int)
-
-        return db_result
-
-    def delete(self, **kwargs):
-        # TODO(meredith): remove from cache on delete.
-        # maybe should be done with post_delete signal instead
-        return super().delete(**kwargs)
-
 
 class StringIndexerCache:
-    def __init__(self, model, version):
+    def __init__(self, model: Any, version: int):
         self.model = model
         self.version = version
-        self.cache_ttl = settings.SENTRY_METRICS_INDEXER_CACHE_TTL
+        self.cache_ttl: int = settings.SENTRY_METRICS_INDEXER_CACHE_TTL
 
-    def make_cache_key(self, key: str, field_type: type) -> str:
+    @property
+    def randomized_ttl(self) -> int:
+        # introduce jitter in the cache_ttl so that when we have large
+        # amount of new keys written into the cache, they don't expire all at once
+        jitter = random.uniform(0, 0.25) * self.cache_ttl
+        return int(self.cache_ttl + jitter)
+
+    def make_cache_key(self, key: Union[str, int]) -> str:
         hashed = md5_text(key).hexdigest()
-        if field_type == int:
-            cache_key = f"indexer:org:int:{hashed}"
-        elif field_type == str:
+        # key is either the str => "org_id:string" or the id => 1
+        if isinstance(key, int):
             cache_key = f"indexer:org:str:{hashed}"
+        elif isinstance(key, str):
+            cache_key = f"indexer:int:{hashed}"
         else:
             raise Exception("Invalid type: must be str or int")
 
         return cache_key
 
-    def get(self, key: str, field_type: type):
-        return cache.get(self.make_cache_key(key, field_type), version=self.version)
+    def _format_results(
+        self,
+        keys: Sequence[Union[str, int]],
+        results: Mapping[Union[str, int], Union[str, int, None]],
+    ) -> MutableMapping[Union[str, int], Union[str, int, None]]:
+        # make the results look like {"org_id:string": 3} or {id: "string"} instead of the
+        # internally used hashed cache key e.g 'indexer:int:b0a0e436f6fa42b9e33e73befbdbb9ba'
+        formatted: MutableMapping[Union[str, int], Union[str, int, None]] = {}
+        for key in keys:
+            cache_key = self.make_cache_key(key)
+            formatted[key] = results.get(cache_key)
 
-    def set(self, key: str, value: Union[str, int], field_type: type):
-        return cache.set(
-            key=self.make_cache_key(key, field_type),
+        return formatted
+
+    def get(self, key: Union[str, int]) -> Union[str, int]:
+        result: Union[str, int] = cache.get(self.make_cache_key(key), version=self.version)
+        return result
+
+    def set(self, key: Union[str, int], value: Union[str, int]) -> None:
+        cache.set(
+            key=self.make_cache_key(key),
             value=value,
-            timeout=self.cache_ttl,
+            timeout=self.randomized_ttl,
             version=self.version,
         )
 
-    def get_many(self, keys: Sequence[str], field_type: type):
-        cache_keys = [self.make_cache_key(key, field_type) for key in keys]
-        return cache.get_many(cache_keys, version=self.version)
+    def get_many(
+        self, keys: Sequence[Union[str, int]]
+    ) -> MutableMapping[Union[str, int], Union[str, int, None]]:
+        cache_keys = {self.make_cache_key(key): key for key in keys}
+        results: Mapping[Union[str, int], Union[str, int, None]] = cache.get_many(
+            cache_keys.keys(), version=self.version
+        )
+        return self._format_results(keys, results)
 
-    def set_many(self, key_values: Mapping[str, Union[str, int]], field_type: type):
-        cache_key_values = {self.make_cache_key(k, field_type): v for k, v in key_values.items()}
-        # TODO(meredith): introduce jitter in the cache_ttl so that when we have large
-        # amount of new keys written into the cache, they don't expire all at once
-        return cache.set_many(cache_key_values, timeout=self.cache_ttl, version=self.version)
+    def set_many(self, key_values: Mapping[str, Union[str, int]]) -> None:
+        cache_key_values = {self.make_cache_key(k): v for k, v in key_values.items()}
+        cache.set_many(cache_key_values, timeout=self.randomized_ttl, version=self.version)
+
+    def delete(self, key: Union[str, int]) -> None:
+        cache_key = self.make_cache_key(key)
+        cache.delete(cache_key)
 
 
 # todo: dont hard code 1 as the version

--- a/src/sentry/sentry_metrics/indexer/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres_v2.py
@@ -170,7 +170,6 @@ class PGStringIndexerV2(Service):
             tags={"cache_hit": "false", "caller": "get_many_ids"},
             amount=cache_misses,
         )
-
         mapped_results.update(cache_keys.get_mapped_results())
 
         db_read_keys = cache_keys.get_unmapped_keys()
@@ -185,7 +184,7 @@ class PGStringIndexerV2(Service):
 
         db_read_key_results = db_read_keys.get_mapped_results()
 
-        if len(db_read_key_results) > 1:
+        if len(db_read_key_results.keys()) > 0:
             results_to_cache = db_read_keys.get_mapped_key_strings_to_ints()
             indexer_cache.set_many(results_to_cache)
             mapped_results.update(db_read_key_results)
@@ -215,10 +214,9 @@ class PGStringIndexerV2(Service):
 
         db_write_key_results = db_write_keys.get_mapped_results()
 
-        if len(db_write_key_results) > 1:
+        if len(db_write_key_results) > 0:
             results_to_cache = db_write_keys.get_mapped_key_strings_to_ints()
             indexer_cache.set_many(results_to_cache)
-
             mapped_results.update(db_write_key_results)
 
         return mapped_results

--- a/src/sentry/sentry_metrics/indexer/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres_v2.py
@@ -1,0 +1,222 @@
+from collections import defaultdict
+from functools import reduce
+from operator import or_
+from typing import List, Mapping, MutableMapping, Optional, Sequence, Set, Union
+
+from django.db.models import Q
+
+from sentry.sentry_metrics.indexer.models import StringIndexer as StringIndexerTable
+from sentry.sentry_metrics.indexer.models import indexer_cache
+from sentry.utils import metrics
+from sentry.utils.services import Service
+
+_INDEXER_CACHE_METRIC = "sentry_metrics.indexer.memcache"
+
+
+class PGStringIndexerV2(Service):
+    """
+    Provides integer IDs for metric names, tag keys and tag values
+    and the corresponding reverse lookup.
+    """
+
+    __all__ = ("record", "resolve", "reverse_resolve", "bulk_record")
+
+    def _record_many_strings(self, keys: Sequence[str]) -> Mapping[str, int]:
+        """
+        Bulk create db records for org_id:string pairs. As noted below, bulk_create with
+        ignore_conflicts=True returns objects that don't have the pk set on them (aka the `id`
+        that we need), so that's why we use `_get_db_ids_and_set_cache` to look up the records
+        and return a mapping of org_id:string -> id:
+            {
+                "1:release": 3,
+                "2:v1": 4
+            }
+        """
+        records = []
+        for key in keys:
+            organization_id, string = key.split(":")
+            records.append(StringIndexerTable(organization_id=int(organization_id), string=string))
+
+        with metrics.timer("sentry_metrics.indexer.pg_bulk_create"):
+            # We use `ignore_conflicts=True` here to avoid race conditions where metric indexer
+            # records might have be created between when we queried in `bulk_record` and the
+            # attempt to create the rows down below.
+            StringIndexerTable.objects.bulk_create(records, ignore_conflicts=True)
+
+        # We re-query the database to fetch the rows (which should all exist point at this point),
+        # in addition to setting the results in the cache
+        results = self._get_db_ids_and_set_cache(keys)
+        # we _just_ created this records, there is no reason for results to be None
+        assert results
+        return results
+
+    def _get_db_ids_and_set_cache(self, keys: Sequence[str]) -> Union[Mapping[str, int], None]:
+        """
+        Query the db for the org_id and string pairs given by the keys (e.g "1:release")
+
+        If we find no records out of the entire list of keys, return None. Otherwise, we
+        return a mapping of org_id:string key -> id:
+            {
+                "1:release": 3,
+                "2:v1": 4
+            }
+
+        When setting values in the cache we need to cache both ways:
+            * "org_id:string" -> id
+            * id -> "string"
+        The id doesn't need the org_id as part of the cache key because it's unique
+        across the StringIndexerTable.
+        """
+        conditions = []
+        for key in keys:
+            organization_id, string = key.split(":")
+            conditions.append(Q(organization_id=int(organization_id), string=string))
+
+        query_statement = reduce(or_, conditions)
+
+        db_results = {}
+        reverse_db_results = {}
+        db_objs = StringIndexerTable.objects.filter(query_statement)
+        if not db_objs:
+            return None
+
+        for db_obj in db_objs:
+            key = f"{db_obj.organization_id}:{db_obj.string}"
+
+            db_results[key] = db_obj.id
+            reverse_db_results[db_obj.id] = db_obj.string
+
+        indexer_cache.set_many(db_results)
+        indexer_cache.set_many(reverse_db_results)
+        return db_results
+
+    def _get_many_ids(self, keys: Sequence[str]) -> MutableMapping[str, Optional[int]]:
+        """
+        Takes a list of keys formatted as such "org_string:string". Ex. "1:release"
+
+        Returns a mapping of the key to the id (or None if the id doesn't exist):
+            {
+                "1:release": 3,
+                "2:v1": None
+            }
+
+        This method first attempts to check memcache to see if we have the id
+        there and if not, we attempt to look up records in the db. We record
+        the cache hits and misses here, but the misses don't mean that the
+        records were in the db, just means they weren't in the cache.
+        """
+        final_results: MutableMapping[str, Optional[int]] = {}
+        cache_results = indexer_cache.get_many(keys)
+
+        db_look_up_keys = set()
+        for key in keys:
+            result = cache_results.get(key)
+            if isinstance(result, int):
+                final_results[key] = result
+            else:
+                final_results[key] = None
+                db_look_up_keys.add(key)
+
+        cache_hits = len(final_results.keys())
+        cache_misses = len(db_look_up_keys)
+
+        metrics.incr(
+            _INDEXER_CACHE_METRIC,
+            tags={"cache_hit": "true", "caller": "get_many_ids"},
+            amount=cache_hits,
+        )
+        metrics.incr(
+            _INDEXER_CACHE_METRIC,
+            tags={"cache_hit": "false", "caller": "get_many_ids"},
+            amount=cache_misses,
+        )
+
+        # if we found everything we need in the cache, return early
+        # otherwise attempt to look up records in db (and cache results
+        # if we find them in the db)
+        if len(db_look_up_keys) == 0:
+            return final_results
+
+        db_results = self._get_db_ids_and_set_cache(list(db_look_up_keys))
+        if db_results:
+            final_results.update(db_results)
+
+        return final_results
+
+    def bulk_record(
+        self, org_strings: MutableMapping[int, Set[str]]
+    ) -> MutableMapping[int, MutableMapping[str, int]]:
+        keys: List[str] = []
+        for org_id in org_strings:
+            keys.extend([f"{org_id}:{string}" for string in org_strings[org_id]])
+
+        results: MutableMapping[int, MutableMapping[str, int]] = defaultdict(dict)
+        keys_to_ids = self._get_many_ids(keys)
+
+        unmapped: List[str] = []
+        for key, id in keys_to_ids.items():
+            if id is None:
+                unmapped.append(key)
+                continue
+            org, string = key.split(":")
+            results[int(org)][string] = id
+
+        if not unmapped:
+            return results
+
+        new_mapped = self._record_many_strings(unmapped)
+        for key, id in new_mapped.items():
+            org, string = key.split(":")
+            results[int(org)][string] = id
+
+        return results
+
+    def record(self, org_id: int, string: str) -> int:
+        """Store a string and return the integer ID generated for it"""
+        result = self.bulk_record({org_id: {string}})
+        return result[org_id][string]
+
+    def resolve(self, org_id: int, string: str) -> Optional[int]:
+        """Lookup the integer ID for a string.
+
+        Returns None if the entry cannot be found.
+
+        """
+        key = f"{org_id}:{string}"
+        result = indexer_cache.get(key)
+        if result and isinstance(result, int):
+            metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "true", "caller": "resolve"})
+            return result
+
+        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "false", "caller": "resolve"})
+        try:
+            id: int = StringIndexerTable.objects.get(organization_id=org_id, string=string).id
+        except StringIndexerTable.DoesNotExist:
+            return None
+        indexer_cache.set(key, id)
+
+        return id
+
+    def reverse_resolve(self, id: int) -> Optional[str]:
+        """Lookup the stored string for a given integer ID.
+
+        Returns None if the entry cannot be found.
+        """
+        result = indexer_cache.get(id)
+        if result and isinstance(result, str):
+            metrics.incr(
+                _INDEXER_CACHE_METRIC, tags={"cache_hit": "true", "caller": "reverse_resolve"}
+            )
+            return result
+
+        metrics.incr(
+            _INDEXER_CACHE_METRIC, tags={"cache_hit": "false", "caller": "reverse_resolve"}
+        )
+        try:
+            string: str = StringIndexerTable.objects.get(id=id).string
+        except StringIndexerTable.DoesNotExist:
+            return None
+
+        indexer_cache.set(id, string)
+
+        return string

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -1,0 +1,61 @@
+from functools import wraps
+
+from sentry.sentry_metrics.indexer.cache import indexer_cache
+from sentry.utils.hashlib import md5_text
+
+TEST_KEYS = ["blah", "hello", "bye"]
+
+
+def clear_cache(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        indexer_cache.delete_many(TEST_KEYS)
+        result = func(*args, **kwargs)
+        return result
+
+    return wrapper
+
+
+@clear_cache
+def test_cache() -> None:
+    assert indexer_cache.get("blah") is None
+    indexer_cache.set("blah", 1)
+    assert indexer_cache.get("blah") == 1
+
+    indexer_cache.delete("blah")
+    assert indexer_cache.get("blah") is None
+
+
+@clear_cache
+def test_cache_many() -> None:
+    values = {"hello": 2, "bye": 3}
+    assert indexer_cache.get_many(list(values.keys())) == {"hello": None, "bye": None}
+    indexer_cache.set_many(values)
+    assert indexer_cache.get_many(list(values.keys())) == values
+
+    indexer_cache.delete_many(list(values.keys()))
+    assert indexer_cache.get_many(list(values.keys())) == {"hello": None, "bye": None}
+
+
+def test_make_cache_key() -> None:
+    key = indexer_cache.make_cache_key("blah")
+    assert key == f"indexer:org:str:{md5_text('blah').hexdigest()}"
+
+
+def test_formatted_results() -> None:
+    values = {"hello": 2, "bye": 3}
+    results = {indexer_cache.make_cache_key(k): v for k, v in values.items()}
+    assert indexer_cache._format_results(list(values.keys()), results) == values
+
+
+def test_ttl_jitter() -> None:
+    base_ttl = 3600 * 2
+    max_ttl = base_ttl + 1800  # 25% of base_ttl
+
+    ttl_1 = indexer_cache.randomized_ttl
+    assert base_ttl <= ttl_1 <= max_ttl
+
+    ttl_2 = indexer_cache.randomized_ttl
+    assert base_ttl <= ttl_2 <= max_ttl
+
+    assert not ttl_1 == ttl_2

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -1,23 +1,10 @@
-from functools import wraps
-
 from sentry.sentry_metrics.indexer.cache import indexer_cache
+from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 
-TEST_KEYS = ["blah", "hello", "bye"]
 
-
-def clear_cache(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        indexer_cache.delete_many(TEST_KEYS)
-        result = func(*args, **kwargs)
-        return result
-
-    return wrapper
-
-
-@clear_cache
 def test_cache() -> None:
+    cache.clear()
     assert indexer_cache.get("blah") is None
     indexer_cache.set("blah", 1)
     assert indexer_cache.get("blah") == 1
@@ -26,8 +13,8 @@ def test_cache() -> None:
     assert indexer_cache.get("blah") is None
 
 
-@clear_cache
 def test_cache_many() -> None:
+    cache.clear()
     values = {"hello": 2, "bye": 3}
     assert indexer_cache.get_many(list(values.keys())) == {"hello": None, "bye": None}
     indexer_cache.set_many(values)

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -1,4 +1,5 @@
-from sentry.sentry_metrics.indexer.models import MetricsKeyIndexer, StringIndexer, indexer_cache
+from sentry.sentry_metrics.indexer.cache import indexer_cache
+from sentry.sentry_metrics.indexer.models import MetricsKeyIndexer, StringIndexer
 from sentry.sentry_metrics.indexer.postgres import PGStringIndexer
 from sentry.sentry_metrics.indexer.postgres_v2 import PGStringIndexerV2
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -1,5 +1,6 @@
-from sentry.sentry_metrics.indexer.models import MetricsKeyIndexer
+from sentry.sentry_metrics.indexer.models import MetricsKeyIndexer, StringIndexer, indexer_cache
 from sentry.sentry_metrics.indexer.postgres import PGStringIndexer
+from sentry.sentry_metrics.indexer.postgres_v2 import PGStringIndexerV2
 from sentry.testutils.cases import TestCase
 
 
@@ -30,3 +31,48 @@ class PostgresIndexerTest(TestCase):
         # test invalid values
         assert PGStringIndexer().resolve("beep") is None
         assert PGStringIndexer().reverse_resolve(1234) is None
+
+
+class PostgresIndexerV2Test(TestCase):
+    def setUp(self) -> None:
+        self.strings = {"hello", "hey", "hi"}
+        self.indexer = PGStringIndexerV2()
+
+    def tearDown(self) -> None:
+        for obj in StringIndexer.objects.all():
+            key = f"{obj.organization_id}:{obj.string}"
+            indexer_cache.delete(key)
+            indexer_cache.delete(obj.id)
+
+    def test_indexer(self):
+        org_id = self.organization.id
+        org_strings = {org_id: self.strings}
+
+        assert list(
+            indexer_cache.get_many([f"{org_id}:{string}" for string in self.strings]).values()
+        ) == [None, None, None]
+
+        results = PGStringIndexerV2().bulk_record(org_strings=org_strings)
+        obj_ids = list(
+            StringIndexer.objects.filter(string__in=["hello", "hey", "hi"]).values_list(
+                "id", flat=True
+            )
+        )
+        assert list(results[org_id].values()) == obj_ids
+        assert (
+            list(indexer_cache.get_many([f"{org_id}:{string}" for string in self.strings]).values())
+            == obj_ids
+        )
+
+        # test resolve and reverse_resolve
+        obj = StringIndexer.objects.get(string="hello")
+        assert PGStringIndexerV2().resolve(org_id, "hello") == obj.id
+        assert PGStringIndexerV2().reverse_resolve(obj.id) == obj.string
+
+        # test record on a string that already exists
+        PGStringIndexerV2().record(org_id, "hello")
+        assert PGStringIndexerV2().resolve(org_id, "hello") == obj.id
+
+        # test invalid values
+        assert PGStringIndexerV2().resolve(org_id, "beep") is None
+        assert PGStringIndexerV2().reverse_resolve(1234) is None


### PR DESCRIPTION
**context**
We changed the indexer schema in https://github.com/getsentry/sentry/pull/32540. We now have an extra param of `organization_id` for when we want to look up strings or ids. This is **step 2** of the steps outlined in https://github.com/getsentry/sentry/pull/32811 in order to get the new implementation in production.

**changes**

* `bulk_record`: The signature of `bulk_record` was changed in https://github.com/getsentry/sentry/pull/32811 but now it will return a format like the following

```python
{ 
    1: {"v1": 2, "production": 4},
    2: {"1.2.0": 3, "dev-1": 5}
    
}
```
because `process_messages` batches up messages, it's very likely that there will be more than one organization batched up. And per metric, all the strings will be for a specific org. 


**TODOs**:
- [x] Add tests
- [x] ~Add local cache that can have the hardcoded special tag values (like `release`, `environment`, `session etc) (Can be done in future PR)~ Hardcoded strings were added in https://github.com/getsentry/sentry/pull/33399
