### PR TITLE
ref(ratelimits): add (unenforced) concurrent limits to custom limited endpoints

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -23,7 +23,7 @@ from sentry.models import Activity, Group, GroupSeen, GroupSubscriptionManager, 
 from sentry.models.groupinbox import get_inbox_details
 from sentry.plugins.base import plugins
 from sentry.plugins.bases import IssueTrackingPlugin2
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
@@ -34,7 +34,7 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
-        group="issues",
+        group=RateLimitGroup.issues,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(5, 1, 3),

--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -5,18 +5,22 @@ from sentry.api import client
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import EventSerializer, serialize
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class GroupEventsLatestEndpoint(GroupEndpoint):
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(15, 1),
-            RateLimitCategory.USER: RateLimit(15, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(15, 1),
-        }
-    }
+    rate_limits = RateLimitConfig(
+        group="issues",
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(15, 1, 8),
+                RateLimitCategory.USER: RateLimit(15, 1, 8),
+                RateLimitCategory.ORGANIZATION: RateLimit(15, 1, 8),
+            }
+        },
+    )
 
     def get(self, request: Request, group) -> Response:
         """

--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -5,14 +5,14 @@ from sentry.api import client
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import EventSerializer, serialize
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class GroupEventsLatestEndpoint(GroupEndpoint):
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
-        group="issues",
+        group=RateLimitGroup.issues,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(15, 1, 8),

--- a/src/sentry/api/endpoints/group_first_last_release.py
+++ b/src/sentry/api/endpoints/group_first_last_release.py
@@ -4,18 +4,22 @@ from rest_framework.response import Response
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
 from sentry.api.helpers.group_index import get_first_last_release
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class GroupFirstLastReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
-        }
-    }
+    rate_limits = RateLimitConfig(
+        group="releases",
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(5, 1, 3),
+                RateLimitCategory.USER: RateLimit(5, 1, 3),
+                RateLimitCategory.ORGANIZATION: RateLimit(5, 1, 3),
+            }
+        },
+    )
 
     def get(self, request: Request, group) -> Response:
         """Get the first and last release for a group.

--- a/src/sentry/api/endpoints/group_first_last_release.py
+++ b/src/sentry/api/endpoints/group_first_last_release.py
@@ -4,14 +4,14 @@ from rest_framework.response import Response
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
 from sentry.api.helpers.group_index import get_first_last_release
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class GroupFirstLastReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
-        group="releases",
+        group=RateLimitGroup.releases,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(5, 1, 3),

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -6,19 +6,23 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models import Project
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
 
 
 class EventIdLookupEndpoint(OrganizationEndpoint):
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(1, 1),
-            RateLimitCategory.USER: RateLimit(1, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(1, 1),
-        }
-    }
+    rate_limits = RateLimitConfig(
+        group="issues",
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(1, 1, 1),
+                RateLimitCategory.USER: RateLimit(1, 1, 1),
+                RateLimitCategory.ORGANIZATION: RateLimit(1, 1, 1),
+            }
+        },
+    )
 
     def get(self, request: Request, organization, event_id) -> Response:
         """

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -6,7 +6,7 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models import Project
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
 
@@ -14,7 +14,7 @@ from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
 class EventIdLookupEndpoint(OrganizationEndpoint):
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
-        group="issues",
+        group=RateLimitGroup.issues,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(1, 1, 1),

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -34,7 +34,7 @@ from sentry.models import (
     GroupStatus,
     Project,
 )
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.search.snuba.backend import assigned_or_suggested_filter
 from sentry.search.snuba.executors import get_search_filter
@@ -141,7 +141,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
     enforce_rate_limit = True
 
     rate_limits = RateLimitConfig(
-        group="issues",
+        group=RateLimitGroup.issues,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(10, 1, 5),

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -9,7 +9,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.models import Group
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.compat import map
 
@@ -19,7 +19,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
     enforce_rate_limit = True
 
     rate_limits = RateLimitConfig(
-        group="orgstats",
+        group=RateLimitGroup.orgstats,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(10, 1, 5),

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -9,6 +9,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.models import Group
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.compat import map
 
@@ -17,13 +18,16 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
     permission_classes = (OrganizationEventPermission,)
     enforce_rate_limit = True
 
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(10, 1),
-            RateLimitCategory.USER: RateLimit(10, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(10, 1),
-        }
-    }
+    rate_limits = RateLimitConfig(
+        group="orgstats",
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(10, 1, 5),
+                RateLimitCategory.USER: RateLimit(10, 1, 5),
+                RateLimitCategory.ORGANIZATION: RateLimit(10, 1, 5),
+            }
+        },
+    )
 
     def get(self, request: Request, organization) -> Response:
         """

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -7,7 +7,7 @@ from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.helpers.group_index import ValidationError, validate_search_filter_permissions
 from sentry.api.issue_search import convert_query_values, parse_search_query
 from sentry.api.utils import InvalidParams, get_date_range_from_params
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.snuba import discover
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -20,7 +20,7 @@ ISSUES_COUNT_MAX_HITS_LIMIT = 100
 class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
-        group="issues",
+        group=RateLimitGroup.issues,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(10, 1),

--- a/src/sentry/api/endpoints/organization_join_request.py
+++ b/src/sentry/api/endpoints/organization_join_request.py
@@ -12,7 +12,7 @@ from sentry.app import ratelimiter
 from sentry.models import AuthProvider, InviteStatus, OrganizationMember
 from sentry.notifications.notifications.organization_request import JoinRequestNotification
 from sentry.notifications.utils.tasks import async_send_notification
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.signals import join_request_created
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -45,7 +45,7 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
     permission_classes = []
 
     rate_limits = RateLimitConfig(
-        group="auth",
+        group=RateLimitGroup.auth,
         limit_overrides={
             "POST": {
                 RateLimitCategory.IP: RateLimit(5, 86400),

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -15,7 +15,7 @@ from sentry.apidocs.constants import RESPONSE_NOTFOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.parameters import GLOBAL_PARAMS
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ALL_ACCESS_PROJECTS
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.search.utils import InvalidQuery
 from sentry.snuba.outcomes import (
     COLUMN_MAP,
@@ -126,7 +126,7 @@ class StatsApiResponse(TypedDict):
 class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
-        group="orgstats",
+        group=RateLimitGroup.orgstats,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(20, 1, 10),

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -8,14 +8,14 @@ from rest_framework.response import Response
 from sentry import eventstore, features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectEventsEndpoint(ProjectEndpoint):
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
-        group="issues",
+        group=RateLimitGroup.issues,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(5, 1, 3),

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -8,18 +8,22 @@ from rest_framework.response import Response
 from sentry import eventstore, features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectEventsEndpoint(ProjectEndpoint):
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
-        }
-    }
+    rate_limits = RateLimitConfig(
+        group="issues",
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(5, 1, 3),
+                RateLimitCategory.USER: RateLimit(5, 1, 3),
+                RateLimitCategory.ORGANIZATION: RateLimit(5, 1, 3),
+            }
+        },
+    )
 
     def get(self, request: Request, project) -> Response:
         """

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -17,7 +17,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializer
 from sentry.models import QUERY_STATUS_LOOKUP, Environment, Group, GroupStatus
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.signals import advanced_search
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -31,7 +31,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
     enforce_rate_limit = True
 
     rate_limits = RateLimitConfig(
-        group="issues",
+        group=RateLimitGroup.issues,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(3, 1, 1),

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -6,14 +6,14 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.app import tsdb
 from sentry.models import Environment, Group
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
-        group="issues",
+        group=RateLimitGroup.issues,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(20, 1, 10),

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -6,18 +6,22 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.app import tsdb
 from sentry.models import Environment, Group
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(20, 1),
-            RateLimitCategory.USER: RateLimit(20, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
-        }
-    }
+    rate_limits = RateLimitConfig(
+        group="issues",
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(20, 1, 10),
+                RateLimitCategory.USER: RateLimit(20, 1, 10),
+                RateLimitCategory.ORGANIZATION: RateLimit(20, 1, 10),
+            }
+        },
+    )
 
     def get(self, request: Request, project) -> Response:
         try:

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -9,18 +9,22 @@ from sentry.api.base import StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models import ProjectKey
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
     enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(20, 1),
-            RateLimitCategory.USER: RateLimit(20, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
-        }
-    }
+    rate_limits = RateLimitConfig(
+        group="issues",
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(20, 1),
+                RateLimitCategory.USER: RateLimit(20, 1),
+                RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
+            }
+        },
+    )
 
     def get(self, request: Request, project, key_id) -> Response:
         try:

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -9,14 +9,14 @@ from sentry.api.base import StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models import ProjectKey
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
-        group="issues",
+        group=RateLimitGroup.issues,
         limit_overrides={
             "GET": {
                 RateLimitCategory.IP: RateLimit(20, 1),

--- a/src/sentry/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/api/endpoints/user_emails_confirm.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.validators import AllowedEmailField
 from sentry.models import UserEmail
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger("sentry.accounts")
@@ -33,12 +34,15 @@ class EmailSerializer(serializers.Serializer):
 
 
 class UserEmailsConfirmEndpoint(UserEndpoint):
-    rate_limits = {
-        "POST": {
-            RateLimitCategory.USER: RateLimit(10, 60),
-            RateLimitCategory.ORGANIZATION: RateLimit(10, 60),
-        }
-    }
+    rate_limits = RateLimitConfig(
+        group="auth",
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.USER: RateLimit(10, 60),
+                RateLimitCategory.ORGANIZATION: RateLimit(10, 60),
+            }
+        },
+    )
 
     def post(self, request: Request, user) -> Response:
         """

--- a/src/sentry/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/api/endpoints/user_emails_confirm.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.validators import AllowedEmailField
 from sentry.models import UserEmail
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger("sentry.accounts")
@@ -35,7 +35,7 @@ class EmailSerializer(serializers.Serializer):
 
 class UserEmailsConfirmEndpoint(UserEndpoint):
     rate_limits = RateLimitConfig(
-        group="auth",
+        group=RateLimitGroup.auth,
         limit_overrides={
             "POST": {
                 RateLimitCategory.USER: RateLimit(10, 60),

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -11,7 +11,7 @@ from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.discover.utils import transform_aliases_and_query
-from sentry.ratelimits.config import RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig, RateLimitGroup
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import snuba
 from sentry.utils.compat import map
@@ -30,7 +30,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
     enforce_rate_limit = True
 
     rate_limits = RateLimitConfig(
-        group="discover",
+        group=RateLimitGroup.discover,
         limit_overrides={
             "POST": {
                 RateLimitCategory.IP: RateLimit(4, 1, 2),

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -136,12 +136,12 @@ class RatelimitMiddlewareTest(TestCase):
         # Import an endpoint
 
         view = OrganizationGroupIndexEndpoint.as_view()
-
+        endpoint_group = OrganizationGroupIndexEndpoint.rate_limits.group
         # Test for default IP
         request = self.factory.get("/")
         assert (
             get_rate_limit_key(view, request)
-            == "ip:default:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
+            == f"ip:{endpoint_group}:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
         )
         # Test when IP address is missing
         request.META["REMOTE_ADDR"] = None
@@ -151,7 +151,7 @@ class RatelimitMiddlewareTest(TestCase):
         request.META["REMOTE_ADDR"] = "684D:1111:222:3333:4444:5555:6:77"
         assert (
             get_rate_limit_key(view, request)
-            == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+            == f"ip:{endpoint_group}:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
         # Test for users
@@ -159,7 +159,7 @@ class RatelimitMiddlewareTest(TestCase):
         request.user = self.user
         assert (
             get_rate_limit_key(view, request)
-            == f"user:default:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
+            == f"user:{endpoint_group}:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
         )
 
         # Test for user auth tokens
@@ -168,14 +168,14 @@ class RatelimitMiddlewareTest(TestCase):
         request.user = self.user
         assert (
             get_rate_limit_key(view, request)
-            == f"user:default:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
+            == f"user:{endpoint_group}:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
         )
 
         # Test for sentryapp auth tokens:
         self.populate_sentry_app_request(request)
         assert (
             get_rate_limit_key(view, request)
-            == f"org:default:OrganizationGroupIndexEndpoint:GET:{self.organization.id}"
+            == f"org:{endpoint_group}:OrganizationGroupIndexEndpoint:GET:{self.organization.id}"
         )
 
         # Test for apikey
@@ -186,7 +186,7 @@ class RatelimitMiddlewareTest(TestCase):
         request.auth = api_key
         assert (
             get_rate_limit_key(view, request)
-            == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+            == f"ip:{endpoint_group}:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
 

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -23,7 +23,6 @@ from sentry.models import ApiKey, ApiToken, SentryAppInstallation, User
 from sentry.ratelimits.config import RateLimitConfig, get_default_rate_limits_for_group
 from sentry.testutils import APITestCase, TestCase
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.ratelimits.config import RateLimitConfig
 
 
 class RatelimitMiddlewareTest(TestCase):
@@ -217,7 +216,7 @@ class TestGetRateLimitValue(TestCase):
                 limit_overrides={
                     "GET": {RateLimitCategory.IP: RateLimit(100, 5)},
                     "POST": {RateLimitCategory.USER: RateLimit(20, 4)},
-                }
+                },
             )
 
         assert get_rate_limit_value("GET", TestEndpoint, "ip") == RateLimit(100, 5)
@@ -236,7 +235,9 @@ class RateLimitHeaderTestEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
     enforce_rate_limit = True
-    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(2, 100)}}
+    rate_limits = RateLimitConfig(
+        group="default", limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(2, 100)}}
+    )
 
     def inject_call(self):
         return
@@ -250,7 +251,9 @@ class RaceConditionEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
     enforce_rate_limit = False
-    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(40, 100)}}
+    rate_limits = RateLimitConfig(
+        group="default", limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(40, 100)}}
+    )
 
     def get(self, request):
         return Response({"ok": True})

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -23,6 +23,7 @@ from sentry.models import ApiKey, ApiToken, SentryAppInstallation, User
 from sentry.ratelimits.config import RateLimitConfig, get_default_rate_limits_for_group
 from sentry.testutils import APITestCase, TestCase
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.ratelimits.config import RateLimitConfig
 
 
 class RatelimitMiddlewareTest(TestCase):
@@ -211,10 +212,13 @@ class TestGetRateLimitValue(TestCase):
         """Override one or more of the default rate limits"""
 
         class TestEndpoint(Endpoint):
-            rate_limits = {
-                "GET": {RateLimitCategory.IP: RateLimit(100, 5)},
-                "POST": {RateLimitCategory.USER: RateLimit(20, 4)},
-            }
+            rate_limits = RateLimitConfig(
+                group="default",
+                limit_overrides={
+                    "GET": {RateLimitCategory.IP: RateLimit(100, 5)},
+                    "POST": {RateLimitCategory.USER: RateLimit(20, 4)},
+                }
+            )
 
         assert get_rate_limit_value("GET", TestEndpoint, "ip") == RateLimit(100, 5)
         # get is not overriddent for user, hence we use the default

--- a/tests/sentry/ratelimits/utils/test_enforce_rate_limit.py
+++ b/tests/sentry/ratelimits/utils/test_enforce_rate_limit.py
@@ -6,6 +6,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.testutils import APITestCase
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -13,7 +14,9 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 class RateLimitTestEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
-    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(1, 100)}}
+    rate_limits = RateLimitConfig(
+        limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(1, 100)}}
+    )
 
     def get(self, request):
         return Response({"ok": True})

--- a/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
+++ b/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
@@ -27,10 +27,12 @@ class TestGetRateLimitValue(TestCase):
         """Override one or more of the default rate limits."""
 
         class TestEndpoint(Endpoint):
-            rate_limits = {
-                "GET": {RateLimitCategory.IP: RateLimit(100, 5)},
-                "POST": {RateLimitCategory.USER: RateLimit(20, 4)},
-            }
+            rate_limits = RateLimitConfig(
+                limit_overrides={
+                    "GET": {RateLimitCategory.IP: RateLimit(100, 5)},
+                    "POST": {RateLimitCategory.USER: RateLimit(20, 4)},
+                }
+            )
 
         assert get_rate_limit_value("GET", TestEndpoint, RateLimitCategory.IP) == RateLimit(100, 5)
         assert get_rate_limit_value(

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -13,12 +13,13 @@ from sentry.testutils.cases import TestCase
 class GetRateLimitKeyTest(TestCase):
     def setUp(self) -> None:
         self.view = OrganizationGroupIndexEndpoint.as_view()
+        self.rate_limit_group = OrganizationGroupIndexEndpoint.rate_limits.group
         self.request = RequestFactory().get("/")
 
     def test_default_ip(self):
         assert (
             get_rate_limit_key(self.view, self.request)
-            == "ip:default:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
+            == f"ip:{self.rate_limit_group}:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
         )
 
     def test_ip_address_missing(self):
@@ -29,7 +30,7 @@ class GetRateLimitKeyTest(TestCase):
         self.request.META["REMOTE_ADDR"] = "684D:1111:222:3333:4444:5555:6:77"
         assert (
             get_rate_limit_key(self.view, self.request)
-            == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+            == f"ip:{self.rate_limit_group}:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
     def test_system_token(self):
@@ -42,7 +43,7 @@ class GetRateLimitKeyTest(TestCase):
         self.request.user = user
         assert (
             get_rate_limit_key(self.view, self.request)
-            == f"user:default:OrganizationGroupIndexEndpoint:GET:{user.id}"
+            == f"user:{self.rate_limit_group}:OrganizationGroupIndexEndpoint:GET:{user.id}"
         )
 
     def test_organization(self):
@@ -67,7 +68,7 @@ class GetRateLimitKeyTest(TestCase):
 
         assert (
             get_rate_limit_key(self.view, self.request)
-            == f"org:default:OrganizationGroupIndexEndpoint:GET:{install.organization_id}"
+            == f"org:{self.rate_limit_group}:OrganizationGroupIndexEndpoint:GET:{install.organization_id}"
         )
 
 


### PR DESCRIPTION
### Context

The concurrent rate limiter (tech spec [here](https://www.notion.so/sentry/Concurrent-Rate-Limiter-ebd5b7562aed4d01b102d83774a06b11)) is being rolled out. The current concurrent rate limiter logic ignores endpoints which have overridden limits but no concurrent limit defined. The endpoints with custom limiting are our more dangerous endpoints, as such concurrent rate limiting is especially important for them.

### What are ratelimit groups

For context: [Rate limiting dimensions](https://www.notion.so/sentry/Rate-Limiting-Dimensions-449d8d5d1fa34bc5bc5c723d6cd06e28)

Groups are arbitrary clusters of endpoints that are useful to the business in the same dimension (there are some examples in this PR). Most endpoints belong to the `default` group. When endpoints belong to the same group, their rate limit uses the same key. Example:

```
EndpointA:
     rate_limits = RateLimitConfig(group="foo")

EndpointB:
     rate_limits = RateLimitConfig(group="foo")
```

If a user is being rate limited on calls to `EndpointA`, they will also be rate limited on calls to `EndpointB`.

**However**, endpoints with rate limit overrides disregard the group limit and have their own. We should work to remove these limits and have endpoints which are closely tied by business usecase simply be in the same group. The custom overrides that exist today are holdovers from a time where we could **only** rate limit by endpoint. We don't have to do that anymore

### What this PR does

* Uses the new RateLimitConfig on all custom rate limits
* Defines concurrent limits where they make sense. NOTE: they are currently not enforced, only logged. 
* Assigns placeholder groups to these custom endpoints. NOTE: since the limits are custom limits anyways, the groups are purely descriptive. They are put there in this PR as a suggestion of what the groups could be. If that label is inaccurate, please comment on it



