### PR TITLE
fix(release-health): Do not compare get_project_sessions_count [INGEST-784 INGEST-1078]

### DIFF
--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -1194,9 +1194,13 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
         environment_id: Optional[int] = None,
     ) -> int:
         schema = ComparatorType.Counter
-        should_compare = lambda _: _coerce_utc(start) > self.metrics_start
+
+        # We verified the correctness of the metrics implementation manually.
+        # The results still differ because the sessions impl gets its results
+        # from hourly aggregations.
+        should_compare = False
+
         organization = self._org_from_projects([project_id])
-        set_tag("rh.duplex.environment_id", str(environment_id))
         return self._dispatch_call(  # type: ignore
             "get_project_sessions_count",
             should_compare,


### PR DESCRIPTION
We verified the correctness of the metrics implementation of `get_project_sessions_count` manually.
The results still differ because the sessions implementation gets its results
from hourly aggregations (see investigation [here](https://getsentry.atlassian.net/browse/INGEST-1078)).