### PR TITLE
Revert "fix(metrics): Zerofill only on groupby session.status (#32775)"

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -770,9 +770,8 @@ def run_sessions_query(
     if len(data_points) == 0:
         # We're only interested in `session.status` group-byes. The rest of the
         # conditions require work (e.g. getting all environments) that we can't
-        # get without querying the DB, including group-byes consisting of
-        # multiple parameters (even if `session.status` is one of them).
-        if query_clone.raw_groupby == ["session.status"]:
+        # get without querying the DB.
+        if "session.status" in query_clone.raw_groupby:
             for status in get_args(_SessionStatus):
                 gkey: GroupKey = (("session.status", status),)
                 groups[gkey]

--- a/tests/js/spec/components/datePageFilter.spec.tsx
+++ b/tests/js/spec/components/datePageFilter.spec.tsx
@@ -11,10 +11,7 @@ describe('DatePageFilter', function () {
     project: undefined,
     projects: undefined,
     router: {
-      location: {
-        query: {},
-        pathname: '/test',
-      },
+      location: {query: {}},
       params: {orgId: 'org-slug'},
     },
   });

--- a/tests/sentry/release_health/test_metrics_sessions_v2.py
+++ b/tests/sentry/release_health/test_metrics_sessions_v2.py
@@ -1,5 +1,3 @@
-from itertools import chain, combinations
-from typing import Iterable, List
 from unittest.mock import patch
 
 from django.urls import reverse
@@ -40,13 +38,13 @@ class MetricsSessionsV2Test(APITestCase, SnubaTestCase):
         )
         return self.client.get(url, query, format="json")
 
-    def get_sessions_data(self, groupby: List[str], interval):
+    def get_sessions_data(self, groupby, interval):
         response = self.do_request(
             {
                 "organization_slug": [self.organization1],
                 "project": [self.project1.id],
                 "field": ["sum(session)"],
-                "groupBy": groupby,
+                "groupBy": [groupby],
                 "interval": interval,
             }
         )
@@ -62,10 +60,10 @@ class MetricsSessionsV2Test(APITestCase, SnubaTestCase):
         cache. Then, against the metrics implementation, and compares with
         cached results.
         """
+        empty_groupbyes = ["project", "release", "environment", "session.status"]
         interval_days = "1d"
-        groupbyes = _session_groupby_powerset()
 
-        for groupby in groupbyes:
+        for groupby in empty_groupbyes:
             with patch(
                 "sentry.api.endpoints.organization_sessions.release_health",
                 SessionsReleaseHealthBackend(),
@@ -86,8 +84,3 @@ class MetricsSessionsV2Test(APITestCase, SnubaTestCase):
                 rollup=interval_days * 24 * 60 * 60,  # days to seconds
             )
             assert len(errors) == 0
-
-
-def _session_groupby_powerset() -> Iterable[str]:
-    keys = ["project", "release", "environment", "session.status"]
-    return chain.from_iterable((combinations(keys, size)) for size in range(len(keys) + 1))


### PR DESCRIPTION
This reverts commit 6fd154c9bc876c80c03e18d1ae5eba6309111794.