### PR TITLE
fix(perf): Add Electron to Browser JS SDK list

### DIFF
--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -473,6 +473,7 @@ export function isEventFromBrowserJavaScriptSDK(event: EventTransaction): boolea
     'sentry.javascript.vue',
     'sentry.javascript.angular',
     'sentry.javascript.nextjs',
+    'sentry.javascript.electron',
   ].includes(sdkName.toLowerCase());
 }
 


### PR DESCRIPTION
Electron renderer instances are just browser webviews, so we should add
`sentry.javascript.electron` to the Browser JS SDK list. This means we
can avoid having the `missing instrumentation` sections like we do with
the other browser JS SDKs.