### PR TITLE
ref(metrics-indexer): Change bulk_record, record signatures

### DIFF
--- a/src/sentry/sentry_metrics/indexer/base.py
+++ b/src/sentry/sentry_metrics/indexer/base.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, MutableMapping, Optional, Set
 
 from sentry.utils.services import Service
 
@@ -13,10 +13,10 @@ class StringIndexer(Service):
 
     __all__ = ("record", "resolve", "reverse_resolve", "bulk_record")
 
-    def bulk_record(self, strings: List[str]) -> Dict[str, int]:
+    def bulk_record(self, org_strings: MutableMapping[int, Set[str]]) -> Dict[str, int]:
         raise NotImplementedError()
 
-    def record(self, string: str) -> int:
+    def record(self, org_id: int, string: str) -> int:
         """Store a string and return the integer ID generated for it
 
         With every call to this method, the lifetime of the entry will be

--- a/src/sentry/sentry_metrics/indexer/mock.py
+++ b/src/sentry/sentry_metrics/indexer/mock.py
@@ -1,6 +1,6 @@
 import itertools
 from collections import defaultdict
-from typing import DefaultDict, Dict, List, Optional
+from typing import DefaultDict, Dict, MutableMapping, Optional, Set
 
 from sentry.sentry_metrics.sessions import SessionMetricKey
 
@@ -33,10 +33,13 @@ class SimpleIndexer(StringIndexer):
         self._strings: DefaultDict[str, int] = defaultdict(self._counter.__next__)
         self._reverse: Dict[int, str] = {}
 
-    def bulk_record(self, strings: List[str]) -> Dict[str, int]:
+    def bulk_record(self, org_strings: MutableMapping[int, Set[str]]) -> Dict[str, int]:
+        strings = set()
+        for _, strs in org_strings.items():
+            strings.update(strs)
         return {string: self._record(string) for string in strings}
 
-    def record(self, string: str) -> int:
+    def record(self, org_id: int, string: str) -> int:
         return self._record(string)
 
     def resolve(self, string: str) -> Optional[int]:

--- a/src/sentry/sentry_metrics/indexer/postgres.py
+++ b/src/sentry/sentry_metrics/indexer/postgres.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Mapping, MutableMapping, Optional, Sequence, Set
+from typing import Any, Mapping, MutableMapping, Optional, Sequence, Set
 
 from sentry.sentry_metrics.indexer.models import MetricsKeyIndexer
 from sentry.utils import metrics
@@ -31,10 +31,16 @@ class PGStringIndexer(Service):
         # (which should all exist point at this point), but also cache the results
         return MetricsKeyIndexer.objects.get_many_from_cache(list(unmapped_strings), key="string")
 
-    def bulk_record(self, strings: List[str]) -> Mapping[str, int]:
+    def bulk_record(self, org_strings: MutableMapping[int, Set[str]]) -> Mapping[str, int]:
+        # XXX(meredith): We are going to be changing the implementation of bulk_record
+        # in a future PR, so for now we don't need to do anything with the org_id, we just
+        # want the signature to be correct for the new implementation
+        strings = set()
+        for _, strs in org_strings.items():
+            strings.update(strs)
 
         cache_results: Sequence[Any] = MetricsKeyIndexer.objects.get_many_from_cache(
-            strings, key="string"
+            list(strings), key="string"
         )
 
         mapped_result: MutableMapping[str, int] = {r.string: r.id for r in cache_results}
@@ -60,9 +66,9 @@ class PGStringIndexer(Service):
 
         return mapped_result
 
-    def record(self, string: str) -> int:
+    def record(self, org_id: int, string: str) -> int:
         """Store a string and return the integer ID generated for it"""
-        result = self.bulk_record(strings=[string])
+        result = self.bulk_record({org_id: {string}})
         return result[string]
 
     def resolve(self, string: str) -> Optional[int]:

--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 import time
-from collections import deque
+from collections import defaultdict, deque
 from concurrent.futures import Future
 from copy import deepcopy
 from dataclasses import dataclass
@@ -355,15 +355,16 @@ def process_messages(
     indexer = get_indexer()
     metrics = get_metrics()
 
+    org_strings = defaultdict(set)
     strings = set()
     with metrics.timer("process_messages.parse_outer_message"):
         parsed_payloads_by_offset = {
             msg.offset: json.loads(msg.payload.value.decode("utf-8"), use_rapid_json=True)
             for msg in outer_message.payload
         }
-
         for message in parsed_payloads_by_offset.values():
             metric_name = message["name"]
+            org_id = message["org_id"]
             tags = message.get("tags", {})
 
             parsed_strings = {
@@ -371,12 +372,13 @@ def process_messages(
                 *tags.keys(),
                 *tags.values(),
             }
+            org_strings[org_id].update(parsed_strings)
             strings.update(parsed_strings)
 
     metrics.incr("process_messages.total_strings_indexer_lookup", amount=len(strings))
 
     with metrics.timer("metrics_consumer.bulk_record"):
-        mapping = indexer.bulk_record(list(strings))
+        mapping = indexer.bulk_record(org_strings)
 
     new_messages: List[Message[KafkaPayload]] = []
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1055,17 +1055,17 @@ class SessionMetricsTestCase(SnubaTestCase):
     @classmethod
     def _push_metric(cls, session, type, key: SessionMetricKey, tags, value):
         def metric_id(key: SessionMetricKey):
-            res = indexer.record(key.value)
+            res = indexer.record(1, key.value)
             assert res is not None, key
             return res
 
         def tag_key(name):
-            res = indexer.record(name)
+            res = indexer.record(1, name)
             assert res is not None, name
             return res
 
         def tag_value(name):
-            res = indexer.record(name)
+            res = indexer.record(1, name)
             assert res is not None, name
             return res
 
@@ -1133,22 +1133,22 @@ class MetricsEnhancedPerformanceTestCase(SessionMetricsTestCase, TestCase):
         self._index_metric_strings()
 
     def _index_metric_strings(self):
-        PGStringIndexer().bulk_record(
-            strings=[
-                "transaction",
-                "environment",
-                "http.status",
-                "transaction.status",
-                METRIC_SATISFIED_TAG_KEY,
-                METRIC_TOLERATED_TAG_KEY,
-                METRIC_MISERABLE_TAG_KEY,
-                METRIC_TRUE_TAG_VALUE,
-                METRIC_FALSE_TAG_VALUE,
-                *self.METRIC_STRINGS,
-                *list(SPAN_STATUS_NAME_TO_CODE.keys()),
-                *list(METRICS_MAP.values()),
-            ]
-        )
+        strings = [
+            "transaction",
+            "environment",
+            "http.status",
+            "transaction.status",
+            METRIC_SATISFIED_TAG_KEY,
+            METRIC_TOLERATED_TAG_KEY,
+            METRIC_MISERABLE_TAG_KEY,
+            METRIC_TRUE_TAG_VALUE,
+            METRIC_FALSE_TAG_VALUE,
+            *self.METRIC_STRINGS,
+            *list(SPAN_STATUS_NAME_TO_CODE.keys()),
+            *list(METRICS_MAP.values()),
+        ]
+        org_strings = {self.organization.id: set(strings)}
+        PGStringIndexer().bulk_record(org_strings=org_strings)
 
     def store_metric(
         self,
@@ -1605,28 +1605,29 @@ class OrganizationMetricMetaIntegrationTestCase(MetricsAPIBaseTestCase):
         now = int(time.time())
 
         # TODO: move _send to SnubaMetricsTestCase
+        org_id = self.organization.id
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
-                    "metric_id": indexer.record("metric1"),
+                    "metric_id": indexer.record(org_id, "metric1"),
                     "timestamp": now,
                     "tags": {
-                        indexer.record("tag1"): indexer.record("value1"),
-                        indexer.record("tag2"): indexer.record("value2"),
+                        indexer.record(org_id, "tag1"): indexer.record(org_id, "value1"),
+                        indexer.record(org_id, "tag2"): indexer.record(org_id, "value2"),
                     },
                     "type": "c",
                     "value": 1,
                     "retention_days": 90,
                 },
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
-                    "metric_id": indexer.record("metric1"),
+                    "metric_id": indexer.record(org_id, "metric1"),
                     "timestamp": now,
                     "tags": {
-                        indexer.record("tag3"): indexer.record("value3"),
+                        indexer.record(org_id, "tag3"): indexer.record(org_id, "value3"),
                     },
                     "type": "c",
                     "value": 1,
@@ -1638,23 +1639,23 @@ class OrganizationMetricMetaIntegrationTestCase(MetricsAPIBaseTestCase):
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
-                    "metric_id": indexer.record("metric2"),
+                    "metric_id": indexer.record(org_id, "metric2"),
                     "timestamp": now,
                     "tags": {
-                        indexer.record("tag4"): indexer.record("value3"),
-                        indexer.record("tag1"): indexer.record("value2"),
-                        indexer.record("tag2"): indexer.record("value1"),
+                        indexer.record(org_id, "tag4"): indexer.record(org_id, "value3"),
+                        indexer.record(org_id, "tag1"): indexer.record(org_id, "value2"),
+                        indexer.record(org_id, "tag2"): indexer.record(org_id, "value1"),
                     },
                     "type": "s",
                     "value": [123],
                     "retention_days": 90,
                 },
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
-                    "metric_id": indexer.record("metric3"),
+                    "metric_id": indexer.record(org_id, "metric3"),
                     "timestamp": now,
                     "tags": {},
                     "type": "s",

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -33,7 +33,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             assert response.status_code == 400
 
     def test_groupby_single(self):
-        indexer.record("environment")
+        indexer.record(self.project.organization_id, "environment")
         response = self.get_response(
             self.project.organization.slug,
             field="sum(sentry.sessions.session)",
@@ -54,7 +54,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
 
     def test_valid_filter(self):
         for tag in ("release", "environment"):
-            indexer.record(tag)
+            indexer.record(self.project.organization_id, tag)
         query = "release:myapp@2.0.0"
         response = self.get_success_response(
             self.project.organization.slug,
@@ -148,20 +148,21 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
 
     def test_orderby(self):
         # Record some strings
-        metric_id = indexer.record("sentry.transactions.measurements.lcp")
-        k_transaction = indexer.record("transaction")
-        v_foo = indexer.record("/foo")
-        v_bar = indexer.record("/bar")
-        v_baz = indexer.record("/baz")
-        k_rating = indexer.record("measurement_rating")
-        v_good = indexer.record("good")
-        v_meh = indexer.record("meh")
-        v_poor = indexer.record("poor")
+        org_id = self.organization.id
+        metric_id = indexer.record(org_id, "sentry.transactions.measurements.lcp")
+        k_transaction = indexer.record(org_id, "transaction")
+        v_foo = indexer.record(org_id, "/foo")
+        v_bar = indexer.record(org_id, "/bar")
+        v_baz = indexer.record(org_id, "/baz")
+        k_rating = indexer.record(org_id, "measurement_rating")
+        v_good = indexer.record(org_id, "good")
+        v_meh = indexer.record(org_id, "meh")
+        v_poor = indexer.record(org_id, "poor")
 
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
                     "metric_id": metric_id,
                     "timestamp": int(time.time()),
@@ -209,15 +210,16 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
 
     def test_orderby_percentile(self):
         # Record some strings
-        metric_id = indexer.record("sentry.transactions.measurements.lcp")
-        tag1 = indexer.record("tag1")
-        value1 = indexer.record("value1")
-        value2 = indexer.record("value2")
+        org_id = self.organization.id
+        metric_id = indexer.record(org_id, "sentry.transactions.measurements.lcp")
+        tag1 = indexer.record(org_id, "tag1")
+        value1 = indexer.record(org_id, "value1")
+        value2 = indexer.record(org_id, "value2")
 
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
                     "metric_id": metric_id,
                     "timestamp": int(time.time()),
@@ -258,15 +260,16 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             }
 
     def test_orderby_percentile_with_pagination(self):
-        metric_id = indexer.record("sentry.transactions.measurements.lcp")
-        tag1 = indexer.record("tag1")
-        value1 = indexer.record("value1")
-        value2 = indexer.record("value2")
+        org_id = self.organization.id
+        metric_id = indexer.record(org_id, "sentry.transactions.measurements.lcp")
+        tag1 = indexer.record(org_id, "tag1")
+        value1 = indexer.record(org_id, "value1")
+        value2 = indexer.record(org_id, "value2")
 
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
                     "metric_id": metric_id,
                     "timestamp": int(time.time()),
@@ -317,15 +320,16 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         Test that ensures when an `orderBy` clause is set, then the paginator limit overrides the
         `limit` parameter
         """
-        metric_id = indexer.record("sentry.transactions.measurements.lcp")
-        tag1 = indexer.record("tag1")
-        value1 = indexer.record("value1")
-        value2 = indexer.record("value2")
+        org_id = self.organization.id
+        metric_id = indexer.record(org_id, "sentry.transactions.measurements.lcp")
+        tag1 = indexer.record(org_id, "tag1")
+        value1 = indexer.record(org_id, "value1")
+        value2 = indexer.record(org_id, "value2")
 
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
                     "metric_id": metric_id,
                     "timestamp": int(time.time()),
@@ -364,7 +368,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             "sentry.transactions.measurements.fcp",
             "transaction",
         ]:
-            indexer.record(metric)
+            indexer.record(self.organization.id, metric)
 
         response = self.get_success_response(
             self.organization.slug,
@@ -385,16 +389,17 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         Test that ensures when transactions are ordered correctly when all the fields requested
         are from the same entity
         """
-        metric_id = indexer.record("sentry.transactions.measurements.lcp")
-        metric_id_fcp = indexer.record("sentry.transactions.measurements.fcp")
-        transaction_id = indexer.record("transaction")
-        transaction_1 = indexer.record("/foo/")
-        transaction_2 = indexer.record("/bar/")
+        org_id = self.organization.id
+        metric_id = indexer.record(org_id, "sentry.transactions.measurements.lcp")
+        metric_id_fcp = indexer.record(org_id, "sentry.transactions.measurements.fcp")
+        transaction_id = indexer.record(org_id, "transaction")
+        transaction_1 = indexer.record(org_id, "/foo/")
+        transaction_2 = indexer.record(org_id, "/bar/")
 
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
                     "metric_id": metric_id,
                     "timestamp": int(time.time()),
@@ -413,7 +418,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
                     "metric_id": metric_id_fcp,
                     "timestamp": int(time.time()),
@@ -467,16 +472,17 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         Test that ensures when transactions are ordered correctly when all the fields requested
         are from multiple entities
         """
-        transaction_id = indexer.record("transaction")
-        transaction_1 = indexer.record("/foo/")
-        transaction_2 = indexer.record("/bar/")
+        org_id = self.organization.id
+        transaction_id = indexer.record(org_id, "transaction")
+        transaction_1 = indexer.record(org_id, "/foo/")
+        transaction_2 = indexer.record(org_id, "/bar/")
 
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
-                    "metric_id": indexer.record("sentry.transactions.measurements.lcp"),
+                    "metric_id": indexer.record(org_id, "sentry.transactions.measurements.lcp"),
                     "timestamp": int(time.time()),
                     "type": "d",
                     "value": numbers,
@@ -493,9 +499,9 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
-                    "metric_id": indexer.record("sentry.transactions.user"),
+                    "metric_id": indexer.record(org_id, "sentry.transactions.user"),
                     "timestamp": int(time.time()),
                     "tags": {tag: value},
                     "type": "s",
@@ -546,16 +552,17 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         Test that ensures when transactions are ordered correctly when all the fields requested
         are from multiple entities
         """
-        transaction_id = indexer.record("transaction")
-        transaction_1 = indexer.record("/foo/")
-        transaction_2 = indexer.record("/bar/")
+        org_id = self.organization.id
+        transaction_id = indexer.record(org_id, "transaction")
+        transaction_1 = indexer.record(org_id, "/foo/")
+        transaction_2 = indexer.record(org_id, "/bar/")
 
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
-                    "metric_id": indexer.record("sentry.transactions.measurements.lcp"),
+                    "metric_id": indexer.record(org_id, "sentry.transactions.measurements.lcp"),
                     "timestamp": int(time.time()),
                     "type": "d",
                     "value": numbers,
@@ -569,7 +576,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             ],
             entity="metrics_distributions",
         )
-        user_metric = indexer.record("sentry.transactions.user")
+        user_metric = indexer.record(org_id, "sentry.transactions.user")
         user_ts = time.time()
         for ts, ranges in [
             (int(user_ts), [range(4, 5), range(6, 11)]),
@@ -578,7 +585,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             self._send_buckets(
                 [
                     {
-                        "org_id": self.organization.id,
+                        "org_id": org_id,
                         "project_id": self.project.id,
                         "metric_id": user_metric,
                         "timestamp": ts,
@@ -697,16 +704,17 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         with a different entity than the entity of the field in the order by), then the table gets
         populated accordingly
         """
-        transaction_id = indexer.record("transaction")
-        transaction_1 = indexer.record("/foo/")
-        transaction_2 = indexer.record("/bar/")
+        org_id = self.organization.id
+        transaction_id = indexer.record(org_id, "transaction")
+        transaction_1 = indexer.record(org_id, "/foo/")
+        transaction_2 = indexer.record(org_id, "/bar/")
 
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
-                    "metric_id": indexer.record("sentry.transactions.measurements.lcp"),
+                    "metric_id": indexer.record(org_id, "sentry.transactions.measurements.lcp"),
                     "timestamp": int(time.time()),
                     "type": "d",
                     "value": numbers,
@@ -785,7 +793,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         self.store_session(self.build_session(project_id=self.project.id))
 
         # "foo" is known by indexer, "bar" is not
-        indexer.record("foo")
+        indexer.record(self.organization.id, "foo")
 
         response = self.get_success_response(
             self.organization.slug,
@@ -815,7 +823,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
     @freeze_time((timezone.now() - timedelta(days=2)).replace(hour=3, minute=21, second=30))
     def test_no_limit_with_series(self):
         """Pagination args do not apply to series"""
-        indexer.record("session.status")
+        indexer.record(self.organization.id, "session.status")
         for minute in range(4):
             self.store_session(
                 self.build_session(
@@ -982,7 +990,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["series"]["session.crash_free_rate"] == [None]
 
     def test_crash_free_rate_when_no_session_metrics_data_with_orderby_and_groupby(self):
-        indexer.record("release")
+        indexer.record(self.organization.id, "release")
         response = self.get_success_response(
             self.organization.slug,
             project=[self.project.id],
@@ -1007,36 +1015,37 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         )
 
     def test_errored_sessions(self):
-        session_metric = indexer.record(SessionMetricKey.SESSION.value)
-        indexer.record("sentry.sessions.session.duration")
-        indexer.record("sentry.sessions.user")
-        session_error_metric = indexer.record("sentry.sessions.session.error")
-        session_status_tag = indexer.record("session.status")
-        release_tag = indexer.record("release")
+        org_id = self.organization.id
+        session_metric = indexer.record(org_id, SessionMetricKey.SESSION.value)
+        indexer.record(org_id, "sentry.sessions.session.duration")
+        indexer.record(org_id, "sentry.sessions.user")
+        session_error_metric = indexer.record(org_id, "sentry.sessions.session.error")
+        session_status_tag = indexer.record(org_id, "session.status")
+        release_tag = indexer.record(org_id, "release")
         user_ts = time.time()
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
                     "metric_id": session_metric,
                     "timestamp": (user_ts // 60 - 4) * 60,
                     "tags": {
-                        session_status_tag: indexer.record("errored_preaggr"),
-                        release_tag: indexer.record("foo"),
+                        session_status_tag: indexer.record(org_id, "errored_preaggr"),
+                        release_tag: indexer.record(org_id, "foo"),
                     },
                     "type": "c",
                     "value": 4,
                     "retention_days": 90,
                 },
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
                     "metric_id": session_metric,
                     "timestamp": user_ts,
                     "tags": {
-                        session_status_tag: indexer.record("init"),
-                        release_tag: indexer.record("foo"),
+                        session_status_tag: indexer.record(org_id, "init"),
+                        release_tag: indexer.record(org_id, "foo"),
                     },
                     "type": "c",
                     "value": 10,
@@ -1048,7 +1057,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
                     "metric_id": session_error_metric,
                     "timestamp": user_ts,
@@ -1057,7 +1066,9 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     "value": numbers,
                     "retention_days": 90,
                 }
-                for tag, value, numbers in ((release_tag, indexer.record("foo"), list(range(3))),)
+                for tag, value, numbers in (
+                    (release_tag, indexer.record(org_id, "foo"), list(range(3))),
+                )
             ],
             entity="metrics_sets",
         )

--- a/tests/sentry/api/endpoints/test_organization_metric_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_details.py
@@ -86,14 +86,14 @@ class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegration
         )
 
     def test_metric_details_metric_does_not_have_data(self):
-        indexer.record("foo.bar")
+        indexer.record(self.organization.id, "foo.bar")
         response = self.get_response(
             self.organization.slug,
             "foo.bar",
         )
         assert response.status_code == 404
 
-        indexer.record("sentry.sessions.session")
+        indexer.record(self.organization.id, "sentry.sessions.session")
         response = self.get_response(
             self.organization.slug,
             "session.crash_free_rate",
@@ -174,16 +174,16 @@ class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegration
             "Not all the requested metrics or the constituent metrics in "
             "['derived_metric.multiple_metrics'] have data in the dataset"
         )
-
+        org_id = self.organization.id
         self._send_buckets(
             [
                 {
-                    "org_id": self.organization.id,
+                    "org_id": org_id,
                     "project_id": self.project.id,
-                    "metric_id": indexer.record("metric_foo_doe"),
+                    "metric_id": indexer.record(org_id, "metric_foo_doe"),
                     "timestamp": int(time.time()),
                     "tags": {
-                        resolve_weak("release"): indexer.record("foo"),
+                        resolve_weak("release"): indexer.record(org_id, "foo"),
                     },
                     "type": "c",
                     "value": 1,

--- a/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
@@ -11,7 +11,7 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
     endpoint = "sentry-api-0-organization-metrics-tag-details"
 
     def test_unknown_tag(self):
-        indexer.record("bar")
+        indexer.record(self.organization.id, "bar")
         response = self.get_success_response(self.project.organization.slug, "bar")
         assert response.data == []
 
@@ -20,7 +20,7 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
         assert response.status_code == 400
 
     def test_non_existing_filter(self):
-        indexer.record("bar")
+        indexer.record(self.organization.id, "bar")
         response = self.get_response(self.project.organization.slug, "bar", metric="bad")
         assert response.status_code == 200
         assert response.data == []
@@ -55,7 +55,7 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
 
         # We need to ensure that if the tag is present in the indexer but has no values in the
         # dataset, the intersection of it and other tags should not yield any results
-        indexer.record("random_tag")
+        indexer.record(self.organization.id, "random_tag")
         response = self.get_success_response(
             self.organization.slug,
             "tag1",

--- a/tests/sentry/api/endpoints/test_organization_metric_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tags.py
@@ -47,7 +47,7 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
         )
 
     def test_metric_tags_metric_does_not_have_data(self):
-        indexer.record("foo.bar")
+        indexer.record(self.organization.id, "foo.bar")
         assert (
             self.get_response(
                 self.organization.slug,

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -712,4 +712,4 @@ class MetricsCrashRateAlertCreationTest(AlertRuleCreateEndpointTestCrashRateAler
             "init",
             "crashed",
         ]:
-            indexer.record(tag)
+            indexer.record(self.organization.id, tag)

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -8,7 +8,9 @@ class PostgresIndexerTest(TestCase):
         self.indexer = PGStringIndexer()
 
     def test_indexer(self):
-        results = PGStringIndexer().bulk_record(strings=["hello", "hey", "hi"])
+        org_id = self.organization.id
+        org_strings = {org_id: {"hello", "hey", "hi"}}
+        results = PGStringIndexer().bulk_record(org_strings=org_strings)
         obj_ids = list(
             MetricsKeyIndexer.objects.filter(string__in=["hello", "hey", "hi"]).values_list(
                 "id", flat=True
@@ -22,7 +24,7 @@ class PostgresIndexerTest(TestCase):
         assert PGStringIndexer().reverse_resolve(obj.id) == obj.string
 
         # test record on a string that already exists
-        PGStringIndexer().record("hello")
+        PGStringIndexer().record(org_id, "hello")
         assert PGStringIndexer().resolve("hello") == obj.id
 
         # test invalid values

--- a/tests/sentry/snuba/metrics/test_fields.py
+++ b/tests/sentry/snuba/metrics/test_fields.py
@@ -73,9 +73,10 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         Test that ensures that method generate_select_statements generates the equivalent SnQL
         required to query for the instance of DerivedMetric
         """
+        org_id = self.project.organization_id
         for status in ("init", "crashed"):
-            indexer.record(status)
-        session_ids = [indexer.record("sentry.sessions.session")]
+            indexer.record(org_id, status)
+        session_ids = [indexer.record(org_id, "sentry.sessions.session")]
 
         derived_name_snql = {
             "session.init": (init_sessions, session_ids),
@@ -83,7 +84,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             "session.errored_preaggregated": (errored_preaggr_sessions, session_ids),
             "session.errored_set": (
                 sessions_errored_set,
-                [indexer.record("sentry.sessions.session.error")],
+                [indexer.record(org_id, "sentry.sessions.session.error")],
             ),
         }
         for metric_name, (func, metric_ids_list) in derived_name_snql.items():
@@ -110,8 +111,9 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         "sentry.snuba.metrics.fields.base._get_entity_of_metric_name", get_entity_of_metric_mocked
     )
     def test_generate_metric_ids(self):
-        session_metric_id = indexer.record("sentry.sessions.session")
-        session_error_metric_id = indexer.record("sentry.sessions.session.error")
+        org_id = self.project.organization_id
+        session_metric_id = indexer.record(org_id, "sentry.sessions.session")
+        session_error_metric_id = indexer.record(org_id, "sentry.sessions.session.error")
 
         for derived_metric_name in [
             "session.init",

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -96,7 +96,7 @@ MOCK_NOW = datetime(2021, 8, 25, 23, 59, tzinfo=pytz.utc)
 def test_parse_query(monkeypatch, query_string, expected):
     local_indexer = MockIndexer()
     for s in ("", "myapp@2.0.0", "transaction", "/bar/:orgId/"):
-        local_indexer.record(s)
+        local_indexer.record(1, s)
     monkeypatch.setattr("sentry.sentry_metrics.indexer.resolve", local_indexer.resolve)
     parsed = resolve_tags(parse_query(query_string))
     assert parsed == expected

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -26,7 +26,7 @@ class EntitySubscriptionTestCase(TestCase):
             "init",
             "crashed",
         ]:
-            indexer.record(tag)
+            indexer.record(self.organization.id, tag)
 
     def test_get_entity_subscriptions_for_sessions_dataset_non_supported_aggregate(self) -> None:
         aggregate = "count(sessions)"

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -158,7 +158,7 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
     @responses.activate
     def test_granularity_on_metrics_crash_rate_alerts(self):
         for tag in [SessionMetricKey.SESSION.value, SessionMetricKey.USER.value, "session.status"]:
-            indexer.record(tag)
+            indexer.record(self.organization.id, tag)
         for (time_window, expected_granularity) in [
             (30, 10),
             (90, 60),
@@ -293,13 +293,14 @@ class BuildSnubaFilterTest(TestCase):
         ]
 
     def test_simple_sessions_for_metrics(self):
+        org_id = self.organization.id
         for tag in [SessionMetricKey.SESSION.value, "session.status", "crashed", "init"]:
-            indexer.record(tag)
+            indexer.record(org_id, tag)
         entity_subscription = get_entity_subscription_for_dataset(
             dataset=QueryDatasets.METRICS,
             time_window=3600,
             aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
-            extra_fields={"org_id": self.organization.id},
+            extra_fields={"org_id": org_id},
         )
         snuba_filter = build_snuba_filter(
             entity_subscription,
@@ -317,13 +318,14 @@ class BuildSnubaFilterTest(TestCase):
         assert snuba_filter.groupby == [session_status]
 
     def test_simple_users_for_metrics(self):
+        org_id = self.organization.id
         for tag in [SessionMetricKey.USER.value, "session.status", "crashed", "init"]:
-            indexer.record(tag)
+            indexer.record(org_id, tag)
         entity_subscription = get_entity_subscription_for_dataset(
             dataset=QueryDatasets.METRICS,
             time_window=3600,
             aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
-            extra_fields={"org_id": self.organization.id},
+            extra_fields={"org_id": org_id},
         )
         snuba_filter = build_snuba_filter(
             entity_subscription,
@@ -383,6 +385,7 @@ class BuildSnubaFilterTest(TestCase):
 
     def test_query_and_environment_sessions_metrics(self):
         env = self.create_environment(self.project, name="development")
+        org_id = self.organization.id
         for tag in [
             SessionMetricKey.SESSION.value,
             "session.status",
@@ -393,12 +396,12 @@ class BuildSnubaFilterTest(TestCase):
             "release",
             "ahmed@12.2",
         ]:
-            indexer.record(tag)
+            indexer.record(org_id, tag)
         entity_subscription = get_entity_subscription_for_dataset(
             dataset=QueryDatasets.METRICS,
             time_window=3600,
             aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
-            extra_fields={"org_id": self.organization.id},
+            extra_fields={"org_id": org_id},
         )
         snuba_filter = build_snuba_filter(
             entity_subscription,
@@ -448,6 +451,7 @@ class BuildSnubaFilterTest(TestCase):
 
     def test_query_and_environment_users_metrics(self):
         env = self.create_environment(self.project, name="development")
+        org_id = self.organization.id
         for tag in [
             SessionMetricKey.USER.value,
             "session.status",
@@ -458,12 +462,12 @@ class BuildSnubaFilterTest(TestCase):
             "release",
             "ahmed@12.2",
         ]:
-            indexer.record(tag)
+            indexer.record(org_id, tag)
         entity_subscription = get_entity_subscription_for_dataset(
             dataset=QueryDatasets.METRICS,
             time_window=3600,
             aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
-            extra_fields={"org_id": self.organization.id},
+            extra_fields={"org_id": org_id},
         )
         snuba_filter = build_snuba_filter(
             entity_subscription,


### PR DESCRIPTION
**context**
We are changing the implementation of metric indexer. This is due to the change to the schema that was added in https://github.com/getsentry/sentry/pull/32540. The new schema was the first step. The rest of the steps are outlined below.

**Steps**
1. Add a new indexer schema - added in https://github.com/getsentry/sentry/pull/32540
2. Add new indexer interface - going to be added in https://github.com/getsentry/sentry/pull/32780
3. Update the current implementation to match the new signatures:
    1. Update `bulk_record` and `record` signatures since `bulk_record` is only in the indexer, and `record` is only used in tests. 
    2. Update `resolve` and `reverse_resolve`
4. Switch the implementation

It should be fine to do step 2 and 3 in parallel since adding the new signatures shouldn't change the functionality of the indexer. We won't use the `org_id` until we switch to the new implementation. 