### PR TITLE
Shrink RPS rate limit, expand concurrent for data collection

### DIFF
--- a/src/sentry/ratelimits/config.py
+++ b/src/sentry/ratelimits/config.py
@@ -21,11 +21,11 @@ HttpMethodName = str
 RateLimitOverrideDict = Mapping[HttpMethodName, Mapping[RateLimitCategory, RateLimit]]
 
 # This default value is going to shrink over time
-_SENTRY_RATELIMITER_DEFAULT = 520
+_SENTRY_RATELIMITER_DEFAULT = 470
 
 # The concurrent rate limiter stores a sorted set of requests, don't make this number
 # too large (e.g > 100)
-_SENTRY_CONCURRENT_RATE_LIMIT_DEFAULT = 40
+_SENTRY_CONCURRENT_RATE_LIMIT_DEFAULT = 100
 ENFORCE_CONCURRENT_RATE_LIMITS = False
 
 


### PR DESCRIPTION
* Continue the brownout for the RPS rate limit
* Increase the concurrent limit so we can collect more data about usage. We currently see a decent number of endpoints topping out at 40, so it would be good to see how many concurrent requests are actually being made. Redis impact has been barely noticeable so we have room to explore