### PR TITLE
fix(perf): Landing widget line charts yAxis and tooltips

### DIFF
--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -223,6 +223,8 @@ function Chart({
               series={series}
               previousPeriod={previousData}
               xAxis={xAxis}
+              yAxis={areaChartProps.yAxes[0]}
+              tooltip={areaChartProps.tooltip}
             />
           );
         }


### PR DESCRIPTION
### Summary
Both the yAxis and tooltips weren't using the correct value formatter, this should fix it for now, will stop using the duration chart in the long run since we've now removed the other side of landing (v2).
![Screen Shot 2022-03-21 at 3 58 35 PM](https://user-images.githubusercontent.com/6111995/159354181-6f5ccc0d-7beb-45c6-aa3b-74d0f1f5ddcf.png)

