### PR TITLE
chore(perf): Add slow and frozen frame columns back into mobile view for React Native

### DIFF
--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -558,10 +558,6 @@ function generateMobilePerformanceEventView(
       selectedProjects.length > 0 &&
       selectedProjects.every(project => project.platform === 'react-native')
     ) {
-      // TODO(tonyx): remove these once the SDKs are ready
-      fields.pop();
-      fields.pop();
-
       fields.push('p75(measurements.stall_percentage)');
     }
   }

--- a/static/app/views/performance/landing/data.tsx
+++ b/static/app/views/performance/landing/data.tsx
@@ -56,7 +56,6 @@ export const REACT_NATIVE_COLUMN_TITLES = [
   'tpm',
   'cold start',
   'warm start',
-  // TODO(tonyx): add these back in once the SDKs are ready
   'slow frame %',
   'frozen frame %',
   'stall %',

--- a/static/app/views/performance/landing/data.tsx
+++ b/static/app/views/performance/landing/data.tsx
@@ -57,8 +57,8 @@ export const REACT_NATIVE_COLUMN_TITLES = [
   'cold start',
   'warm start',
   // TODO(tonyx): add these back in once the SDKs are ready
-  // 'slow frame %',
-  // 'frozen frame %',
+  'slow frame %',
+  'frozen frame %',
   'stall %',
   'users',
   'user misery',

--- a/static/app/views/performance/landing/vitalsCards.tsx
+++ b/static/app/views/performance/landing/vitalsCards.tsx
@@ -278,21 +278,19 @@ function _MobileCards(props: MobileCardsProps) {
       kind: 'function',
       function: ['p75', 'measurements.app_start_warm', undefined, undefined],
     },
+    {
+      kind: 'function',
+      function: ['p75', 'measurements.frames_slow_rate', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['p75', 'measurements.frames_frozen_rate', undefined, undefined],
+    },
   ];
   if (props.showStallPercentage) {
     functions.push({
       kind: 'function',
       function: ['p75', 'measurements.stall_percentage', undefined, undefined],
-    });
-  } else {
-    // TODO(tonyx): add these by default once the SDKs are ready
-    functions.push({
-      kind: 'function',
-      function: ['p75', 'measurements.frames_slow_rate', undefined, undefined],
-    });
-    functions.push({
-      kind: 'function',
-      function: ['p75', 'measurements.frames_frozen_rate', undefined, undefined],
     });
   }
   return <GenericCards {...props} functions={functions} />;


### PR DESCRIPTION
Slow and frozen frames are added in https://github.com/getsentry/sentry-react-native/pull/1711

This is essentially a revert of https://github.com/getsentry/sentry/pull/27802

### Before


![Screen Shot 2022-03-21 at 3 57 15 PM](https://user-images.githubusercontent.com/139499/159354119-46ee046d-a36a-4bdc-bdb1-375f2dc64f19.png)

### After

![Screen Shot 2022-03-21 at 3 57 21 PM](https://user-images.githubusercontent.com/139499/159354120-a4feac07-e937-4c19-8ed4-b9920e1e3131.png)


