### PR TITLE
ref(sentry apps): Update developer settings page

### DIFF
--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -95,7 +95,6 @@ const organizationNavigation: NavigationSection[] = [
         title: t('Developer Settings'),
         description: t('Manage developer applications'),
         id: 'developer-settings',
-        badge: () => 'new',
       },
     ],
   },

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -172,7 +172,7 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
         />
         <Alert type="info">
           {tct(
-            'You can now create integrations that subscribe to webhooks which notify you when a comment on an issue is added or changes.  [link:Learn more].',
+            'Integrations can now detect when a comment on an issue is added or changes.  [link:Learn more].',
             {
               link: (
                 <ExternalLink href="https://docs.sentry.io/product/integrations/integration-platform/webhooks/#comments" />

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -1,5 +1,4 @@
 import {RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 
 import {removeSentryApp} from 'sentry/actionCreators/sentryApps';
 import Access from 'sentry/components/acl/access';
@@ -156,20 +155,22 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
   renderBody() {
     return (
       <div>
-        <Container>
+        <div>
           <SettingsPageHeader
             title={t('Developer Settings')}
             body={t(
               `Create integrations to interact with Sentry using the REST API and webhooks.`
             )}
+            action={
+              <Button
+                external
+                href="https://docs.sentry.io/product/integrations/integration-platform/"
+              >
+                {t('View Docs')}
+              </Button>
+            }
           />
-          <Button
-            external
-            href="https://docs.sentry.io/product/integrations/integration-platform/"
-          >
-            {t('View Docs')}
-          </Button>
-        </Container>
+        </div>
         <Alert type="info">
           {tct(
             'You can create integrations with webhooks notifying you when a comment on an issue is added or changes.  [link:Learn more].',
@@ -186,10 +187,5 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
     );
   }
 }
-
-const Container = styled('div')`
-  display: flex;
-  justify-content: space-between;
-`;
 
 export default withOrganization(OrganizationDeveloperSettings);

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -159,7 +159,7 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
           <SettingsPageHeader
             title={t('Developer Settings')}
             body={t(
-              `Create integrations to interact with Sentry using the REST API and webhooks.`
+              `Create integrations that interact with Sentry using the REST API and webhooks.`
             )}
             action={
               <Button
@@ -173,7 +173,7 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
         </div>
         <Alert type="info">
           {tct(
-            'You can create integrations with webhooks notifying you when a comment on an issue is added or changes.  [link:Learn more].',
+            'You can now create integrations that subscribe to webhooks which notify you when a comment on an issue is added or changes.  [link:Learn more].',
             {
               link: (
                 <ExternalLink href="https://docs.sentry.io/product/integrations/integration-platform/webhooks/#comments" />

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -77,7 +77,7 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
             priority="primary"
             disabled={!hasAccess}
             title={!hasAccess ? permissionTooltipText : undefined}
-            size="small"
+            size="xsmall"
             to={`/settings/${orgId}/developer-settings/new-internal/`}
             icon={<IconAdd size="xs" isCircled />}
           >
@@ -123,7 +123,7 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
             priority="primary"
             disabled={!hasAccess}
             title={!hasAccess ? permissionTooltipText : undefined}
-            size="small"
+            size="xsmall"
             to={`/settings/${orgId}/developer-settings/new-public/`}
             icon={<IconAdd size="xs" isCircled />}
           >
@@ -155,22 +155,21 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
   renderBody() {
     return (
       <div>
-        <div>
-          <SettingsPageHeader
-            title={t('Developer Settings')}
-            body={t(
-              `Create integrations that interact with Sentry using the REST API and webhooks.`
-            )}
-            action={
-              <Button
-                external
-                href="https://docs.sentry.io/product/integrations/integration-platform/"
-              >
-                {t('View Docs')}
-              </Button>
-            }
-          />
-        </div>
+        <SettingsPageHeader
+          title={t('Developer Settings')}
+          body={t(
+            `Create integrations that interact with Sentry using the REST API and webhooks.`
+          )}
+          action={
+            <Button
+              size="small"
+              external
+              href="https://docs.sentry.io/product/integrations/integration-platform/"
+            >
+              {t('View Docs')}
+            </Button>
+          }
+        />
         <Alert type="info">
           {tct(
             'You can now create integrations that subscribe to webhooks which notify you when a comment on an issue is added or changes.  [link:Learn more].',

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -1,11 +1,12 @@
 import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
 
 import {removeSentryApp} from 'sentry/actionCreators/sentryApps';
 import Access from 'sentry/components/acl/access';
-import AlertLink from 'sentry/components/alertLink';
+import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Panel, PanelAlert, PanelBody, PanelHeader} from 'sentry/components/panels';
+import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import {IconAdd} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {Organization, SentryApp} from 'sentry/types';
@@ -155,27 +156,40 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
   renderBody() {
     return (
       <div>
-        <SettingsPageHeader title={t('Developer Settings')} />
-        <PanelAlert type="info">
+        <Container>
+          <SettingsPageHeader
+            title={t('Developer Settings')}
+            body={t(
+              `Create integrations to interact with Sentry using the REST API and webhooks.`
+            )}
+          />
+          <Button
+            external
+            href="https://docs.sentry.io/product/integrations/integration-platform/"
+          >
+            {t('View Docs')}
+          </Button>
+        </Container>
+        <Alert type="info">
           {tct(
-            "We've added new webhooks for comments on issues! Read more in our [link:webhook documentation].",
+            'You can create integrations with webhooks notifying you when a comment on an issue is added or changes.  [link:Learn more].',
             {
               link: (
                 <ExternalLink href="https://docs.sentry.io/product/integrations/integration-platform/webhooks/#comments" />
               ),
             }
           )}
-        </PanelAlert>
-        <AlertLink href="https://docs.sentry.io/product/integrations/integration-platform/">
-          {t(
-            'Have questions about the Integration Platform? Learn more about it in our docs.'
-          )}
-        </AlertLink>
+        </Alert>
         {this.renderExernalIntegrations()}
         {this.renderInternalIntegrations()}
       </div>
     );
   }
 }
+
+const Container = styled('div')`
+  display: flex;
+  justify-content: space-between;
+`;
 
 export default withOrganization(OrganizationDeveloperSettings);

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/actionButtons.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/actionButtons.tsx
@@ -32,7 +32,7 @@ const ActionButtons = ({
 }: Props) => {
   const appDashboardButton = (
     <StyledButton
-      size="small"
+      size="xsmall"
       icon={<IconStats />}
       to={`/settings/${org.slug}/developer-settings/${app.slug}/dashboard/`}
     >
@@ -45,7 +45,7 @@ const ActionButtons = ({
       disabled={!!disablePublishReason}
       title={disablePublishReason}
       icon={<IconUpgrade />}
-      size="small"
+      size="xsmall"
       onClick={onPublish}
     >
       {t('Publish')}
@@ -61,7 +61,7 @@ const ActionButtons = ({
       <StyledButton
         disabled
         title={disableDeleteReason}
-        size="small"
+        size="xsmall"
         icon={<IconDelete />}
         aria-label="Delete"
       />
@@ -73,7 +73,7 @@ const ActionButtons = ({
           priority="danger"
           onConfirm={() => onDelete(app)}
         >
-          <StyledButton size="small" icon={<IconDelete />} aria-label="Delete" />
+          <StyledButton size="xsmall" icon={<IconDelete />} aria-label="Delete" />
         </ConfirmDelete>
       )
     )


### PR DESCRIPTION
Update the design of the developer settings page - this removes the panel alert linking to the integration platform docs and replaces it with text and a button, updates the copy and design of the comment webhook alert, and removes the "new" badge from the sidebar as per the design team's wishes. There will also be a broadcast added to announce the feature as a replacement for the "new" badge, but that's not a code change.

**Before**
<img width="1216" alt="Screen Shot 2022-03-21 at 2 13 07 PM" src="https://user-images.githubusercontent.com/29959063/159364814-49fbfc3a-b4b0-4313-b70f-daef45571d9c.png">

**After**
<img width="1211" alt="Screen Shot 2022-03-21 at 4 18 21 PM" src="https://user-images.githubusercontent.com/29959063/159378467-470809b1-ec43-47ab-9090-ef159e9de6a0.png">


