### PR TITLE
feat(metrics): Adds support for CompositeEntityDerivedMetrics [INGEST-924 INGEST-1044 INGEST-1064]

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -15,10 +15,7 @@ from sentry.snuba.metrics import (
     get_tag_values,
     get_tags,
 )
-from sentry.snuba.metrics.utils import (
-    DerivedMetricParseException,
-    NotSupportedOverCompositeEntityException,
-)
+from sentry.snuba.metrics.utils import DerivedMetricException, DerivedMetricParseException
 from sentry.snuba.sessions_v2 import InvalidField
 from sentry.utils.cursors import Cursor, CursorResult
 
@@ -128,8 +125,7 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
             except (
                 InvalidField,
                 InvalidParams,
-                DerivedMetricParseException,
-                NotSupportedOverCompositeEntityException,
+                DerivedMetricException,
             ) as exc:
                 raise (ParseError(detail=str(exc)))
             return data

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -15,7 +15,10 @@ from sentry.snuba.metrics import (
     get_tag_values,
     get_tags,
 )
-from sentry.snuba.metrics.utils import DerivedMetricParseException
+from sentry.snuba.metrics.utils import (
+    DerivedMetricParseException,
+    NotSupportedOverCompositeEntityException,
+)
 from sentry.snuba.sessions_v2 import InvalidField
 from sentry.utils.cursors import Cursor, CursorResult
 
@@ -122,7 +125,12 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
                     request.GET, paginator_kwargs={"limit": limit, "offset": offset}
                 )
                 data = get_series(projects, query)
-            except (InvalidField, InvalidParams, DerivedMetricParseException) as exc:
+            except (
+                InvalidField,
+                InvalidParams,
+                DerivedMetricParseException,
+                NotSupportedOverCompositeEntityException,
+            ) as exc:
                 raise (ParseError(detail=str(exc)))
             return data
 

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -357,7 +357,7 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
     """Get time series for the given query"""
     intervals = list(get_intervals(query))
     results = {}
-    queries_by_entities = {}
+    fields_in_entities = {}
 
     if not query.groupby:
         # When there is no groupBy columns specified, we don't want to go through running an
@@ -420,7 +420,7 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
             query.fields = original_query_fields
 
             query_builder = SnubaQueryBuilder(projects, query)
-            snuba_queries, queries_by_entities = query_builder.get_snuba_queries()
+            snuba_queries, fields_in_entities = query_builder.get_snuba_queries()
 
             # Translate the groupby fields of the query into their tag keys because these fields
             # will be used to filter down and order the results of the 2nd query.
@@ -522,7 +522,7 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
                     for group_tuple in ordered_tag_conditions[groupby_tags]:
                         results[entity][key]["data"] += snuba_query_data_dict.get(group_tuple, [])
     else:
-        snuba_queries, queries_by_entities = SnubaQueryBuilder(projects, query).get_snuba_queries()
+        snuba_queries, fields_in_entities = SnubaQueryBuilder(projects, query).get_snuba_queries()
         for entity, queries in snuba_queries.items():
             results.setdefault(entity, {})
             for key, snuba_query in queries.items():
@@ -534,7 +534,7 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
 
     assert projects
     converter = SnubaResultConverter(
-        projects[0].organization_id, query, queries_by_entities, intervals, results
+        projects[0].organization_id, query, fields_in_entities, intervals, results
     )
 
     return {

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -9,8 +9,8 @@ __all__ = (
     "resolve_tags",
 )
 
+import copy
 import math
-from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
@@ -30,12 +30,13 @@ from sentry.sentry_metrics.utils import (
 )
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.fields import DERIVED_METRICS, DerivedMetric, metric_object_factory
+from sentry.snuba.metrics.fields.base import generate_bottom_up_dependency_tree_for_metrics
 from sentry.snuba.metrics.utils import (
-    _OPERATIONS_PERCENTILES,
     ALLOWED_GROUPBY_COLUMNS,
     FIELD_REGEX,
     MAX_POINTS,
     OPERATIONS,
+    OPERATIONS_PERCENTILES,
     TS_COL_GROUP,
     TS_COL_QUERY,
     DerivedMetricParseException,
@@ -295,6 +296,7 @@ class SnubaQueryBuilder:
 
     def __init__(self, projects: Sequence[Project], query_definition: QueryDefinition):
         self._projects = projects
+        self._queries_by_entity = {}
         self._queries = self._build_queries(query_definition)
 
     def _build_where(
@@ -359,17 +361,53 @@ class SnubaQueryBuilder:
 
         return {"totals": totals_query, "series": series_query}
 
+    def __update_query_dicts_with_component_entities(
+        self, component_entities, metric_name_to_obj_dict
+    ):
+        # At this point in time, we are only supporting raw metrics in the metrics attribute of
+        # any instance of DerivedMetric, and so in this case the op will always be None
+        # ToDo(ahmed): In future PR, we might want to allow for dependency metrics to also have an
+        #  an aggregate and in this case, we would need to parse the op here
+        op = None
+        for entity, metric_names in component_entities.items():
+            for metric_name in metric_names:
+                metric_key = (op, metric_name)
+                if metric_key not in metric_name_to_obj_dict:
+                    metric_name_to_obj_dict[metric_key] = metric_object_factory(op, metric_name)
+                    self._queries_by_entity.setdefault(entity, []).append(metric_key)
+        return metric_name_to_obj_dict
+
     def _build_queries(self, query_definition):
         metric_name_to_obj_dict = {}
 
-        queries_by_entity = OrderedDict()
         for op, metric_name in query_definition.fields.values():
             metric_field_obj = metric_object_factory(op, metric_name)
             # `get_entity` is called the first, to fetch the entities of constituent metrics,
             # and validate especially in the case of SingularEntityDerivedMetric that it is
             # actually composed of metrics that belong to the same entity
             try:
-                entity = metric_field_obj.get_entity(projects=self._projects)
+                #  When we get to an instance of a MetricFieldBase where the entity is an
+                #  instance of dict, we know it is from a composite entity derived metric, and
+                #  we need to traverse down the constituent metrics dependency tree until we get
+                #  to instances of SingleEntityDerivedMetric, and add those to our queries so
+                #  that we are able to generate the original CompositeEntityDerivedMetric later
+                #  on as a result of a post query operation on the results of the constituent
+                #  SingleEntityDerivedMetric instances
+                component_entities = metric_field_obj.get_entity(projects=self._projects)
+                if isinstance(component_entities, dict):
+                    # In this case, component_entities is a dictionary with entity keys and
+                    # lists of metric_names as values representing all the entities and
+                    # metric_names combination that this metric_object is composed of, or rather
+                    # the instances of SingleEntityDerivedMetric that it is composed of
+                    metric_name_to_obj_dict = self.__update_query_dicts_with_component_entities(
+                        component_entities=component_entities,
+                        metric_name_to_obj_dict=metric_name_to_obj_dict,
+                    )
+                    continue
+                elif isinstance(component_entities, str):
+                    entity = component_entities
+                else:
+                    raise DerivedMetricParseException("Entity parsed is in incorrect format")
             except MetricDoesNotExistException:
                 # If we get here, it means that one or more of the constituent metrics for a
                 # derived metric does not exist, and so no further attempts to query that derived
@@ -377,28 +415,17 @@ class SnubaQueryBuilder:
                 # the response
                 continue
 
-            if not entity:
-                # ToDo(ahmed): When we get to an instance of a MetricFieldBase where entity is
-                #  None, we know it is from a composite entity derived metric, and we need to
-                #  traverse down the constituent metrics dependency tree until we get to instances
-                #  of SingleEntityDerivedMetric, and add those to our queries so that we are able
-                #  to generate the original CompositeEntityDerivedMetric later on as a result of
-                #  a post query operation on the results of the constituent
-                #  SingleEntityDerivedMetric instances
-                continue
-
             if entity not in self._implemented_datasets:
                 raise NotImplementedError(f"Dataset not yet implemented: {entity}")
 
             metric_name_to_obj_dict[(op, metric_name)] = metric_field_obj
-
-            queries_by_entity.setdefault(entity, []).append((op, metric_name))
+            self._queries_by_entity.setdefault(entity, []).append((op, metric_name))
 
         where = self._build_where(query_definition)
         groupby = self._build_groupby(query_definition)
 
         queries_dict = {}
-        for entity, fields in queries_by_entity.items():
+        for entity, fields in self._queries_by_entity.items():
             select = []
             metric_ids_set = set()
             for op, name in fields:
@@ -430,7 +457,7 @@ class SnubaQueryBuilder:
         return queries_dict
 
     def get_snuba_queries(self):
-        return self._queries
+        return self._queries, self._queries_by_entity
 
 
 class SnubaResultConverter:
@@ -440,13 +467,34 @@ class SnubaResultConverter:
         self,
         organization_id: int,
         query_definition: QueryDefinition,
+        queries_by_entities: dict,
         intervals: List[datetime],
         results,
     ):
         self._organization_id = organization_id
-        self._query_definition = query_definition
         self._intervals = intervals
         self._results = results
+
+        # This is a set of all the `(op, metric_name)` combinations passed in the query_definition
+        self._query_definition_fields_set = set(query_definition.fields.values())
+        # This is a set of all queryable `(op, metric_name)` combinations. Queryable can mean it
+        # includes one of the following: AggregatedRawMetric (op, metric_name), instance of
+        # SingularEntityDerivedMetric or the instances of SingularEntityDerivedMetric that are
+        # the constituents necessary to calculate instances of CompositeEntityDerivedMetric but
+        # are not necessarily requested in the query definition
+        self._queries_in_entity_set = {
+            elem for queries_in_entity in queries_by_entities.values() for elem in queries_in_entity
+        }
+        self._set_of_constituent_queries = self._queries_in_entity_set.union(
+            self._query_definition_fields_set
+        )
+
+        # This basically generate a dependency tree for all instances of `MetricFieldBase` so
+        # that in the case of a CompositeEntityDerivedMetric, we are able to calculate it but
+        # only after calculating its dependencies
+        self._bottom_up_dependency_tree = generate_bottom_up_dependency_tree_for_metrics(
+            self._query_definition_fields_set
+        )
 
         self._timestamp_index = {timestamp: index for index, timestamp in enumerate(intervals)}
 
@@ -470,7 +518,10 @@ class SnubaResultConverter:
         if bucketed_time is not None:
             bucketed_time = parse_snuba_datetime(bucketed_time)
 
-        for op, metric_name in self._query_definition.fields.values():
+        # We query the union of the query_definition fields, and the queries_by_entities from the
+        # QueryBuilder necessary as it contains the constituent instances of
+        # SingularEntityDerivedMetric for instances of CompositeEntityDerivedMetric
+        for op, metric_name in self._set_of_constituent_queries:
             key = f"{op}({metric_name})" if op else metric_name
 
             default_null_value = metric_object_factory(
@@ -485,7 +536,7 @@ class SnubaResultConverter:
                 # or also from raw_metrics that don't exist in clickhouse yet
                 cleaned_value = default_null_value
             else:
-                if op in _OPERATIONS_PERCENTILES:
+                if op in OPERATIONS_PERCENTILES:
                     value = value[0]
                 cleaned_value = finite_or_none(value)
 
@@ -527,4 +578,33 @@ class SnubaResultConverter:
             )
             for tags, data in groups.items()
         ]
+
+        # Applying post query operations for totals and series
+        for group in groups:
+            totals, series = group["totals"], group["series"]
+            for op, metric_name in self._bottom_up_dependency_tree:
+                metric_obj = metric_object_factory(op=op, metric_name=metric_name)
+                # Totals
+                totals[metric_name] = metric_obj.run_post_query_function(totals)
+                # Series
+                for idx in range(0, len(self._intervals)):
+                    series[metric_name][idx] = metric_obj.run_post_query_function(series, idx)
+
+        # Remove the extra fields added due to the constituent metrics that were added
+        # from the generated dependency tree. These metrics that are to be removed were added to
+        # be able to generate fields that require further processing post query, but are not
+        # required nor expected in the response
+        for group in groups:
+            totals, series = group["totals"], group["series"]
+            for key in copy.deepcopy(list(totals.keys())):
+                matches = FIELD_REGEX.match(key)
+                if matches:
+                    operation = matches[1]
+                    metric_name = matches[2]
+                else:
+                    operation = None
+                    metric_name = key
+                if (operation, metric_name) not in self._query_definition_fields_set:
+                    del totals[key], series[key]
+
         return groups

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -21,6 +21,7 @@ __all__ = (
     "OPERATIONS_PERCENTILES",
     "DEFAULT_AGGREGATES",
     "UNIT_TO_TYPE",
+    "DerivedMetricException",
     "DerivedMetricParseException",
     "MetricDoesNotExistException",
     "MetricDoesNotExistInIndexer",
@@ -31,6 +32,7 @@ __all__ = (
 
 
 import re
+from abc import ABC
 from datetime import datetime
 from typing import Collection, Literal, Mapping, Optional, Protocol, Sequence, TypedDict
 
@@ -142,10 +144,6 @@ DEFAULT_AGGREGATES = {
 UNIT_TO_TYPE = {"sessions": "count", "percentage": "percentage"}
 
 
-class DerivedMetricParseException(Exception):
-    ...
-
-
 class MetricDoesNotExistException(Exception):
     ...
 
@@ -154,7 +152,15 @@ class MetricDoesNotExistInIndexer(Exception):
     ...
 
 
-class NotSupportedOverCompositeEntityException(Exception):
+class DerivedMetricException(Exception, ABC):
+    ...
+
+
+class DerivedMetricParseException(DerivedMetricException):
+    ...
+
+
+class NotSupportedOverCompositeEntityException(DerivedMetricException):
     ...
 
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -18,10 +18,15 @@ __all__ = (
     "MetricMeta",
     "MetricMetaWithTagKeys",
     "OPERATIONS",
+    "OPERATIONS_PERCENTILES",
     "DEFAULT_AGGREGATES",
     "UNIT_TO_TYPE",
     "DerivedMetricParseException",
+    "MetricDoesNotExistException",
+    "MetricDoesNotExistInIndexer",
+    "NotSupportedOverCompositeEntityException",
     "TimeRange",
+    "MetricEntity",
 )
 
 
@@ -104,7 +109,7 @@ class MetricMetaWithTagKeys(MetricMeta):
     tags: Sequence[Tag]
 
 
-_OPERATIONS_PERCENTILES = (
+OPERATIONS_PERCENTILES = (
     "p50",
     "p75",
     "p90",
@@ -119,7 +124,7 @@ OPERATIONS = (
     "count",
     "max",
     "sum",
-) + _OPERATIONS_PERCENTILES
+) + OPERATIONS_PERCENTILES
 
 DEFAULT_AGGREGATES = {
     "avg": None,
@@ -146,6 +151,10 @@ class MetricDoesNotExistException(Exception):
 
 
 class MetricDoesNotExistInIndexer(Exception):
+    ...
+
+
+class NotSupportedOverCompositeEntityException(Exception):
     ...
 
 

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1063,10 +1063,51 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         )
         response = self.get_success_response(
             self.organization.slug,
-            field=["session.errored_preaggregated", "session.errored_set"],
+            field=["session.errored_preaggregated", "session.errored_set", "session.errored"],
             statsPeriod="6m",
             interval="1m",
         )
         group = response.data["groups"][0]
         assert group["totals"]["session.errored_set"] == 3
         assert group["totals"]["session.errored_preaggregated"] == 4
+        assert group["totals"]["session.errored"] == 7
+        assert group["series"]["session.errored_set"] == [0, 0, 0, 0, 0, 3]
+        assert group["series"]["session.errored_preaggregated"] == [0, 4, 0, 0, 0, 0]
+        assert group["series"]["session.errored"] == [0, 4, 0, 0, 0, 3]
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=["session.errored"],
+            statsPeriod="6m",
+            interval="1m",
+        )
+        group = response.data["groups"][0]
+        assert group == {
+            "by": {},
+            "totals": {"session.errored": 7},
+            "series": {"session.errored": [0, 4, 0, 0, 0, 3]},
+        }
+
+    def test_orderby_composite_entity_derived_metric(self):
+        self.store_session(
+            self.build_session(
+                project_id=self.project.id,
+                started=(time.time() // 60) * 60,
+                status="ok",
+                release="foobar@2.0",
+                errors=2,
+            )
+        )
+        response = self.get_response(
+            self.organization.slug,
+            field=["session.errored"],
+            statsPeriod="6m",
+            interval="1m",
+            groupBy=["release"],
+            orderBy=["session.errored"],
+        )
+        assert response.status_code == 400
+        assert response.data["detail"] == (
+            "It is not possible to orderBy field session.errored as it does not "
+            "have a direct mapping to a query alias"
+        )

--- a/tests/sentry/snuba/metrics/test_fields.py
+++ b/tests/sentry/snuba/metrics/test_fields.py
@@ -248,15 +248,17 @@ class CompositeEntityDerivedMetricTestCase(TestCase):
 
     @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
     def test_generate_bottom_up_derived_metrics_dependencies(self):
-        assert self.sessions_errored.generate_bottom_up_derived_metrics_dependencies() == [
+        assert list(self.sessions_errored.generate_bottom_up_derived_metrics_dependencies()) == [
             (None, "session.errored_set"),
             (None, "session.errored_preaggregated"),
             (None, "session.errored"),
         ]
 
-        assert MOCKED_DERIVED_METRICS[
-            "random_composite"
-        ].generate_bottom_up_derived_metrics_dependencies() == [
+        assert list(
+            MOCKED_DERIVED_METRICS[
+                "random_composite"
+            ].generate_bottom_up_derived_metrics_dependencies()
+        ) == [
             (None, "session.errored_set"),
             (None, "session.errored_preaggregated"),
             (None, "session.errored"),

--- a/tests/sentry/snuba/metrics/test_fields.py
+++ b/tests/sentry/snuba/metrics/test_fields.py
@@ -1,4 +1,6 @@
+import copy
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 from snuba_sdk import Direction, OrderBy
@@ -8,8 +10,11 @@ from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics import (
     DERIVED_METRICS,
     DerivedMetricParseException,
+    MetricDoesNotExistException,
+    NotSupportedOverCompositeEntityException,
     SingularEntityDerivedMetric,
 )
+from sentry.snuba.metrics.fields.base import CompositeEntityDerivedMetric
 from sentry.snuba.metrics.fields.snql import (
     crashed_sessions,
     errored_preaggr_sessions,
@@ -27,17 +32,30 @@ def get_entity_of_metric_mocked(_, metric_name):
     }[metric_name]
 
 
-class SingleEntityDerivedMetricTestCase(TestCase):
-    def setUp(self):
-        self.crash_free_fake = SingularEntityDerivedMetric(
+MOCKED_DERIVED_METRICS = copy.deepcopy(DERIVED_METRICS)
+MOCKED_DERIVED_METRICS.update(
+    {
+        "crash_free_fake": SingularEntityDerivedMetric(
             metric_name="crash_free_fake",
             metrics=["session.crashed", "session.errored_set"],
             unit="percentage",
-            snql=lambda *args, metric_ids, alias=None: percentage(
-                *args, metric_ids, alias="crash_free_fake"
+            snql=lambda *args, entity, metric_ids, alias=None: percentage(
+                *args, entity, metric_ids, alias="crash_free_fake"
             ),
-        )
-        DERIVED_METRICS.update({"crash_free_fake": self.crash_free_fake})
+        ),
+        "random_composite": CompositeEntityDerivedMetric(
+            metric_name="random_composite",
+            metrics=["session.errored"],
+            unit="sessions",
+        ),
+    }
+)
+
+
+@patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
+class SingleEntityDerivedMetricTestCase(TestCase):
+    def setUp(self):
+        self.crash_free_fake = MOCKED_DERIVED_METRICS["crash_free_fake"]
 
     @mock.patch(
         "sentry.snuba.metrics.fields.base._get_entity_of_metric_name", get_entity_of_metric_mocked
@@ -59,7 +77,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             "session.errored_set": "metrics_sets",
         }
         for key, value in expected_derived_metrics_entities.items():
-            assert (DERIVED_METRICS[key].get_entity(projects=[self.project])) == value
+            assert (MOCKED_DERIVED_METRICS[key].get_entity(projects=[self.project])) == value
 
         # Incorrectly setup SingularEntityDerivedMetric with metrics spanning multiple entities
         with pytest.raises(DerivedMetricParseException):
@@ -91,7 +109,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
                 func(metric_ids=metric_ids_list, alias=metric_name),
             ]
 
-        assert DERIVED_METRICS["session.crash_free_rate"].generate_select_statements(
+        assert MOCKED_DERIVED_METRICS["session.crash_free_rate"].generate_select_statements(
             [self.project]
         ) == [
             percentage(
@@ -119,8 +137,10 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             "session.crash_free_rate",
             "session.errored_preaggregated",
         ]:
-            assert DERIVED_METRICS[derived_metric_name].generate_metric_ids() == {session_metric_id}
-        assert DERIVED_METRICS["session.errored_set"].generate_metric_ids() == {
+            assert MOCKED_DERIVED_METRICS[derived_metric_name].generate_metric_ids() == {
+                session_metric_id
+            }
+        assert MOCKED_DERIVED_METRICS["session.errored_set"].generate_metric_ids() == {
             session_error_metric_id
         }
 
@@ -128,10 +148,12 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         "sentry.snuba.metrics.fields.base._get_entity_of_metric_name", get_entity_of_metric_mocked
     )
     def test_generate_order_by_clause(self):
-        for derived_metric_name in DERIVED_METRICS.keys():
+        for derived_metric_name in MOCKED_DERIVED_METRICS.keys():
             if derived_metric_name == self.crash_free_fake.metric_name:
                 continue
-            derived_metric_obj = DERIVED_METRICS[derived_metric_name]
+            derived_metric_obj = MOCKED_DERIVED_METRICS[derived_metric_name]
+            if not isinstance(derived_metric_obj, SingularEntityDerivedMetric):
+                continue
             assert derived_metric_obj.generate_orderby_clause(
                 projects=[self.project], direction=Direction.ASC
             ) == [
@@ -152,7 +174,106 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             "session.errored_set",
             "session.errored_preaggregated",
         ]:
-            assert DERIVED_METRICS[derived_metric_name].generate_default_null_values() == 0
+            assert MOCKED_DERIVED_METRICS[derived_metric_name].generate_default_null_values() == 0
 
         for derived_metric_name in ["session.crash_free_rate", "crash_free_fake"]:
-            assert DERIVED_METRICS[derived_metric_name].generate_default_null_values() is None
+            assert (
+                MOCKED_DERIVED_METRICS[derived_metric_name].generate_default_null_values() is None
+            )
+
+    def test_create_singular_entity_derived_metric_without_snql(self):
+        """
+        Test that ensures that if we try to create an instance of SingularEntityDerivedMetric
+        without snql, then an exception is raised
+        """
+        with pytest.raises(DerivedMetricParseException):
+            SingularEntityDerivedMetric(
+                metric_name="session.errored_set",
+                metrics=["sentry.sessions.session.error"],
+                unit="sessions",
+                snql=None,
+            )
+
+    def test_run_post_query_function(self):
+        totals = {
+            "session.crashed": 7,
+        }
+        series = {
+            "session.crashed": [4, 0, 0, 0, 3, 0],
+        }
+        crashed_sessions = MOCKED_DERIVED_METRICS["session.crashed"]
+        assert crashed_sessions.run_post_query_function(totals) == 7
+        assert crashed_sessions.run_post_query_function(series, idx=0) == 4
+        assert crashed_sessions.run_post_query_function(series, idx=4) == 3
+
+
+class CompositeEntityDerivedMetricTestCase(TestCase):
+    def setUp(self):
+        self.sessions_errored = MOCKED_DERIVED_METRICS["session.errored"]
+
+    def test_get_entity(self):
+        """
+        Test that ensures that the even when generating the component entities dict of instances
+        of SingleEntityDerivedMetric, we are still validating that they exist
+        """
+        with pytest.raises(MetricDoesNotExistException):
+            assert self.sessions_errored.get_entity(projects=[1]) == {
+                "metrics_counters": ["session.errored_preaggregated"],
+                "metrics_sets": ["session.errored_set"],
+            }
+
+    @mock.patch(
+        "sentry.snuba.metrics.fields.base._get_entity_of_metric_name", get_entity_of_metric_mocked
+    )
+    def test_get_entity_and_validate_dependency_tree_of_single_entity_constituents(self):
+        assert self.sessions_errored.get_entity(projects=[1]) == {
+            "metrics_counters": ["session.errored_preaggregated"],
+            "metrics_sets": ["session.errored_set"],
+        }
+
+    def test_generate_metric_ids(self):
+        with pytest.raises(NotSupportedOverCompositeEntityException):
+            self.sessions_errored.generate_metric_ids()
+
+    def test_generate_select_snql_of_derived_metric(self):
+        with pytest.raises(NotSupportedOverCompositeEntityException):
+            self.sessions_errored.generate_select_statements(projects=[1])
+
+    def test_generate_orderby_clause(self):
+        with pytest.raises(NotSupportedOverCompositeEntityException):
+            self.sessions_errored.generate_orderby_clause(direction=Direction.ASC, projects=[1])
+
+    def test_generate_default_value(self):
+        assert self.sessions_errored.generate_default_null_values() == 0
+
+    @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
+    def test_generate_bottom_up_derived_metrics_dependencies(self):
+        assert self.sessions_errored.generate_bottom_up_derived_metrics_dependencies() == [
+            (None, "session.errored_set"),
+            (None, "session.errored_preaggregated"),
+            (None, "session.errored"),
+        ]
+
+        assert MOCKED_DERIVED_METRICS[
+            "random_composite"
+        ].generate_bottom_up_derived_metrics_dependencies() == [
+            (None, "session.errored_set"),
+            (None, "session.errored_preaggregated"),
+            (None, "session.errored"),
+            (None, "random_composite"),
+        ]
+
+    def test_run_post_query_function(self):
+        totals = {
+            "session.errored_set": 3,
+            "session.errored_preaggregated": 4.0,
+            "session.errored": 0,
+        }
+        series = {
+            "session.errored_set": [0, 0, 0, 0, 3, 0],
+            "session.errored": [0, 0, 0, 0, 0, 0],
+            "session.errored_preaggregated": [4.0, 0, 0, 0, 0, 0],
+        }
+        assert self.sessions_errored.run_post_query_function(totals) == 7
+        assert self.sessions_errored.run_post_query_function(series, idx=0) == 4
+        assert self.sessions_errored.run_post_query_function(series, idx=4) == 3

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -301,8 +301,8 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2, monkeypatch):
     )
     query_definition = QueryDefinition(query_params)
     query_builder = SnubaQueryBuilder([PseudoProject(1, 1)], query_definition)
-    snuba_queries, queries_by_entity = query_builder.get_snuba_queries()
-    assert queries_by_entity == {
+    snuba_queries, fields_in_entities = query_builder.get_snuba_queries()
+    assert fields_in_entities == {
         "metrics_counters": [
             (None, "session.errored_preaggregated"),
             (None, "session.crash_free_rate"),
@@ -486,7 +486,7 @@ def test_translate_results(_1, _2, monkeypatch):
         }
     )
     query_definition = QueryDefinition(query_params)
-    queries_by_entity = {
+    fields_in_entities = {
         "metrics_counters": [("sum", "sentry.sessions.session")],
         "metrics_distributions": [
             ("max", "sentry.sessions.session.duration"),
@@ -600,7 +600,7 @@ def test_translate_results(_1, _2, monkeypatch):
     }
 
     assert SnubaResultConverter(
-        1, query_definition, queries_by_entity, intervals, results
+        1, query_definition, fields_in_entities, intervals, results
     ).translate_results() == [
         {
             "by": {"session.status": "healthy"},
@@ -655,7 +655,7 @@ def test_translate_results_derived_metrics(_1, _2, monkeypatch):
         }
     )
     query_definition = QueryDefinition(query_params)
-    queries_by_entity = {
+    fields_in_entities = {
         "metrics_counters": [
             (None, "session.errored_preaggregated"),
             (None, "session.crash_free_rate"),
@@ -713,7 +713,7 @@ def test_translate_results_derived_metrics(_1, _2, monkeypatch):
     }
 
     assert SnubaResultConverter(
-        1, query_definition, queries_by_entity, intervals, results
+        1, query_definition, fields_in_entities, intervals, results
     ).translate_results() == [
         {
             "by": {},
@@ -747,7 +747,7 @@ def test_translate_results_missing_slots(_1, _2, monkeypatch):
         }
     )
     query_definition = QueryDefinition(query_params)
-    queries_by_entity = {
+    fields_in_entities = {
         "metrics_counters": [
             ("sum", "sentry.sessions.session"),
         ],
@@ -783,7 +783,7 @@ def test_translate_results_missing_slots(_1, _2, monkeypatch):
 
     intervals = list(get_intervals(query_definition))
     assert SnubaResultConverter(
-        1, query_definition, queries_by_entity, intervals, results
+        1, query_definition, fields_in_entities, intervals, results
     ).translate_results() == [
         {
             "by": {},


### PR DESCRIPTION
This PR:
- Adds support for `CompositeEntityDerivedMetrics`
- Adds derived metric for `sessions.errored`
- Renames`RawMetric` class to `RawAggregatedMetric`
- Modifies QueryBuilder to always perform post query operations
- Adds a `run_post_query_function` to ABC `MetricFieldBase`
- Adds validation on `SingleEntityDerivedMetric` to make sure its not possible to create an instance without SnQL
- Adds logic that when creating queries in the QueryBuilder for Composite Entity Derived Metrics, we discard the actual derived metric and rather create queries for its constituent `SingularEntityDerivedMetric` components