### PR TITLE
fix(tests): Cleanup tooltip timers on unmount

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -216,6 +216,19 @@ function Tooltip({
     [useGlobalPortal]
   );
 
+  // When the component is unmounted, make sure to stop the timeouts
+  useEffect(
+    () => () => {
+      if (delayOpenTimeoutRef.current) {
+        window.clearTimeout(delayOpenTimeoutRef.current);
+      }
+      if (delayHideTimeoutRef.current) {
+        window.clearTimeout(delayHideTimeoutRef.current);
+      }
+    },
+    []
+  );
+
   // When not using a global portal we need to be sure to cleanup tooltip
   // portals from the DOM
   useEffect(


### PR DESCRIPTION
Tooltips can open/close using a timeout mechanism which can happen after the
component unmounts. This can result in unexpected test failures.