### PR TITLE
fix(metrics): Add org_id to calls to resolve in metrics API

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -196,7 +196,7 @@ def _fetch_tags_or_values_per_ids(
     """
     assert len({p.organization_id for p in projects}) == 1
     try:
-        metric_ids = _get_metrics_filter_ids(projects, metric_names)
+        metric_ids = _get_metrics_filter_ids(projects=projects, metric_names=metric_names)
     except MetricDoesNotExistInIndexer:
         raise InvalidParams(
             f"Some or all of the metric names in {metric_names} do not exist in the indexer"

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -3,7 +3,9 @@ from snuba_sdk import Column, Function
 from sentry.sentry_metrics.utils import resolve_weak
 
 
-def _counter_sum_aggregation_on_session_status_factory(session_status, metric_ids, alias=None):
+def _counter_sum_aggregation_on_session_status_factory(
+    org_id: int, session_status, metric_ids, alias=None
+):
     return Function(
         "sumIf",
         [
@@ -14,8 +16,8 @@ def _counter_sum_aggregation_on_session_status_factory(session_status, metric_id
                     Function(
                         "equals",
                         [
-                            Column(f"tags[{resolve_weak('session.status')}]"),
-                            resolve_weak(session_status),
+                            Column(f"tags[{resolve_weak(org_id, 'session.status')}]"),
+                            resolve_weak(org_id, session_status),
                         ],
                     ),
                     Function("in", [Column("metric_id"), list(metric_ids)]),
@@ -26,25 +28,25 @@ def _counter_sum_aggregation_on_session_status_factory(session_status, metric_id
     )
 
 
-def init_sessions(metric_ids, alias=None):
+def init_sessions(org_id: int, metric_ids, alias=None):
     return _counter_sum_aggregation_on_session_status_factory(
-        session_status="init", metric_ids=metric_ids, alias=alias
+        org_id, session_status="init", metric_ids=metric_ids, alias=alias
     )
 
 
-def crashed_sessions(metric_ids, alias=None):
+def crashed_sessions(org_id: int, metric_ids, alias=None):
     return _counter_sum_aggregation_on_session_status_factory(
-        session_status="crashed", metric_ids=metric_ids, alias=alias
+        org_id, session_status="crashed", metric_ids=metric_ids, alias=alias
     )
 
 
-def errored_preaggr_sessions(metric_ids, alias=None):
+def errored_preaggr_sessions(org_id: int, metric_ids, alias=None):
     return _counter_sum_aggregation_on_session_status_factory(
-        session_status="errored_preaggr", metric_ids=metric_ids, alias=alias
+        org_id, session_status="errored_preaggr", metric_ids=metric_ids, alias=alias
     )
 
 
-def sessions_errored_set(metric_ids, alias=None):
+def sessions_errored_set(org_id: int, metric_ids, alias=None):
     return Function(
         "uniqIf",
         [

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -30,6 +30,7 @@ from sentry.sentry_metrics.utils import (
 )
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.fields import DERIVED_METRICS, DerivedMetric, metric_object_factory
+from sentry.snuba.metrics.fields.base import org_id_from_projects
 from sentry.snuba.metrics.utils import (
     _OPERATIONS_PERCENTILES,
     ALLOWED_GROUPBY_COLUMNS,
@@ -83,7 +84,7 @@ def parse_field(field: str) -> Tuple[Optional[str], str]:
         return operation, metric_name
 
 
-def resolve_tags(input_: Any) -> Any:
+def resolve_tags(org_id: int, input_: Any) -> Any:
     """Translate tags in snuba condition
 
     This assumes that all strings are either tag names or tag values, so do not
@@ -91,28 +92,33 @@ def resolve_tags(input_: Any) -> Any:
 
     """
     if isinstance(input_, list):
-        return [resolve_tags(item) for item in input_]
+        return [resolve_tags(org_id, item) for item in input_]
     if isinstance(input_, Function):
         if input_.function == "ifNull":
             # This was wrapped automatically by QueryBuilder, remove wrapper
-            return resolve_tags(input_.parameters[0])
+            return resolve_tags(org_id, input_.parameters[0])
         return Function(
             function=input_.function,
-            parameters=input_.parameters and [resolve_tags(item) for item in input_.parameters],
+            parameters=input_.parameters
+            and [resolve_tags(org_id, item) for item in input_.parameters],
         )
     if isinstance(input_, Condition):
-        return Condition(lhs=resolve_tags(input_.lhs), op=input_.op, rhs=resolve_tags(input_.rhs))
+        return Condition(
+            lhs=resolve_tags(org_id, input_.lhs), op=input_.op, rhs=resolve_tags(org_id, input_.rhs)
+        )
     if isinstance(input_, BooleanCondition):
-        return input_.__class__(conditions=[resolve_tags(item) for item in input_.conditions])
+        return input_.__class__(
+            conditions=[resolve_tags(org_id, item) for item in input_.conditions]
+        )
     if isinstance(input_, Column):
         # HACK: Some tags already take the form "tags[...]" in discover, take that into account:
         if input_.subscriptable == "tags":
             name = input_.key
         else:
             name = input_.name
-        return Column(name=resolve_tag_key(name))
+        return Column(name=resolve_tag_key(org_id, name))
     if isinstance(input_, str):
-        return resolve_weak(input_)
+        return resolve_weak(org_id, input_)
 
     return input_
 
@@ -295,20 +301,19 @@ class SnubaQueryBuilder:
 
     def __init__(self, projects: Sequence[Project], query_definition: QueryDefinition):
         self._projects = projects
+        self._org_id = org_id_from_projects(projects)
         self._queries = self._build_queries(query_definition)
 
     def _build_where(
         self, query_definition: QueryDefinition
     ) -> List[Union[BooleanCondition, Condition]]:
-        assert self._projects
-        org_id = self._projects[0].organization_id
         where: List[Union[BooleanCondition, Condition]] = [
-            Condition(Column("org_id"), Op.EQ, org_id),
+            Condition(Column("org_id"), Op.EQ, self._org_id),
             Condition(Column("project_id"), Op.IN, [p.id for p in self._projects]),
             Condition(Column(TS_COL_QUERY), Op.GTE, query_definition.start),
             Condition(Column(TS_COL_QUERY), Op.LT, query_definition.end),
         ]
-        filter_ = resolve_tags(query_definition.parsed_query)
+        filter_ = resolve_tags(self._org_id, query_definition.parsed_query)
         if filter_:
             where.extend(filter_)
 
@@ -317,7 +322,7 @@ class SnubaQueryBuilder:
     def _build_groupby(self, query_definition: QueryDefinition) -> List[Column]:
         # ToDo ensure we cannot add any other cols than tags and groupBy as columns
         return [
-            Column(resolve_tag_key(field))
+            Column(resolve_tag_key(self._org_id, field))
             if field not in ALLOWED_GROUPBY_COLUMNS
             else Column(field)
             for field in query_definition.groupby
@@ -404,7 +409,7 @@ class SnubaQueryBuilder:
             for op, name in fields:
                 metric_field_obj = metric_name_to_obj_dict[(op, name)]
                 select += metric_field_obj.generate_select_statements(projects=self._projects)
-                metric_ids_set |= metric_field_obj.generate_metric_ids()
+                metric_ids_set |= metric_field_obj.generate_metric_ids(self._projects)
 
             where_for_entity = [
                 Condition(

--- a/tests/sentry/api/endpoints/test_organization_metric_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_details.py
@@ -183,7 +183,7 @@ class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegration
                     "metric_id": indexer.record("metric_foo_doe"),
                     "timestamp": int(time.time()),
                     "tags": {
-                        resolve_weak("release"): indexer.record("foo"),
+                        resolve_weak(self.organization.id, "release"): indexer.record("foo"),
                     },
                     "type": "c",
                     "value": 1,

--- a/tests/sentry/snuba/metrics/test_snql.py
+++ b/tests/sentry/snuba/metrics/test_snql.py
@@ -16,12 +16,13 @@ class DerivedMetricSnQLTestCase(TestCase):
         self.metric_ids = [0, 1, 2]
 
     def test_counter_sum_aggregation_on_session_status(self):
+        org_id = 0
         for status, func in [
             ("init", init_sessions),
             ("crashed", crashed_sessions),
             ("errored_preaggr", errored_preaggr_sessions),
         ]:
-            assert func(self.metric_ids, alias=status) == Function(
+            assert func(org_id, self.metric_ids, alias=status) == Function(
                 "sumIf",
                 [
                     Column("value"),
@@ -31,8 +32,8 @@ class DerivedMetricSnQLTestCase(TestCase):
                             Function(
                                 "equals",
                                 [
-                                    Column(f"tags[{resolve_weak('session.status')}]"),
-                                    resolve_weak(status),
+                                    Column(f"tags[{resolve_weak(org_id, 'session.status')}]"),
+                                    resolve_weak(org_id, status),
                                 ],
                             ),
                             Function("in", [Column("metric_id"), list(self.metric_ids)]),

--- a/tests/sentry/snuba/metrics/test_snql.py
+++ b/tests/sentry/snuba/metrics/test_snql.py
@@ -44,8 +44,9 @@ class DerivedMetricSnQLTestCase(TestCase):
             )
 
     def test_set_sum_aggregation_for_errored_sessions(self):
+        org_id = 666
         alias = "whatever"
-        assert sessions_errored_set(self.metric_ids, alias) == Function(
+        assert sessions_errored_set(org_id, self.metric_ids, alias) == Function(
             "uniqIf",
             [
                 Column("value"),
@@ -61,9 +62,10 @@ class DerivedMetricSnQLTestCase(TestCase):
         )
 
     def test_percentage_in_snql(self):
+        org_id = 666
         alias = "foo.percentage"
-        init_session_snql = init_sessions(self.metric_ids, "init_sessions")
-        crashed_session_snql = crashed_sessions(self.metric_ids, "crashed_sessions")
+        init_session_snql = init_sessions(org_id, self.metric_ids, "init_sessions")
+        crashed_session_snql = crashed_sessions(org_id, self.metric_ids, "crashed_sessions")
 
         assert percentage(crashed_session_snql, init_session_snql, alias=alias) == Function(
             "minus", [1, Function("divide", [crashed_session_snql, init_session_snql])], alias


### PR DESCRIPTION
As in https://github.com/getsentry/sentry/pull/32830, add the org_id to all calls of `indexer.resolve` and related functions in the metrics API code.