### PR TITLE
ref(tests): Flaky GroupActions > reprocessing > open dialog by clicking on the ReprocessAction component test

### DIFF
--- a/tests/js/spec/views/organizationGroupDetails/actions.spec.tsx
+++ b/tests/js/spec/views/organizationGroupDetails/actions.spec.tsx
@@ -116,8 +116,8 @@ describe('GroupActions', function () {
       expect(reprocessActionButton).toBeTruthy();
 
       reprocessActionButton.simulate('click');
-
       await tick();
+      wrapper.update();
 
       expect(onReprocessEventFunc).toHaveBeenCalled();
     });


### PR DESCRIPTION
GroupActions > reprocessing > open dialog by clicking on the ReprocessAction component has been a flaky test, might be solved by rerendering after await tick.

Jira: [WOR-1707](https://getsentry.atlassian.net/browse/WOR-1707)