### PR TITLE
ref(tests): Flaky ProjectAlertsCreate > Issue Alert > updates values and saves test

### DIFF
--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -236,102 +236,109 @@ describe('ProjectAlertsCreate', function () {
       );
     });
 
-    it('updates values and saves', async function () {
-      const {router} = createWrapper({
-        organization: {
-          features: ['alert-filters'],
-        },
-      });
-      const mock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/rules/',
-        method: 'POST',
-        body: TestStubs.ProjectAlertRule(),
-      });
+    describe('updates and saves', function () {
+      let wrapper, mock;
 
-      // Change target environment
-      await selectEvent.select(screen.getByText('All Environments'), ['production']);
-
-      // Change actionMatch and filterMatch dropdown
-      const allDropdowns = screen.getAllByText('all');
-      expect(allDropdowns).toHaveLength(2);
-      await selectEvent.select(allDropdowns[0], ['any']);
-      await selectEvent.select(allDropdowns[1], ['any']);
-
-      // `userEvent.paste` isn't really ideal, but since `userEvent.type` doesn't provide good performance and
-      // the purpose of this test is not focused on how the user interacts with the fields,
-      // but rather on whether the form will be saved and updated, we decided use `userEvent.paste`
-      // so that this test does not time out from the default jest value of 5000ms
-
-      // Change name of alert rule
-      userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
-
-      // Add another condition
-      await selectEvent.select(screen.getByText('Add optional condition...'), [
-        "An event's tags match {key} {match} {value}",
-      ]);
-      // Edit new Condition
-      userEvent.paste(screen.getByPlaceholderText('key'), 'conditionKey');
-
-      userEvent.paste(screen.getByPlaceholderText('value'), 'conditionValue');
-      await selectEvent.select(screen.getByText('equals'), ['does not equal']);
-
-      // Add a new filter
-      await selectEvent.select(screen.getByText('Add optional filter...'), [
-        'The issue is {comparison_type} than {value} {time}',
-      ]);
-      userEvent.paste(screen.getByPlaceholderText('10'), '12');
-
-      // Add a new action
-      await selectEvent.select(screen.getByText('Add action...'), [
-        'Send a notification via {service}',
-      ]);
-
-      // Update action interval
-      await selectEvent.select(screen.getByText('30 minutes'), ['60 minutes']);
-
-      userEvent.click(screen.getByText('Save Rule'));
-
-      expect(mock).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          data: {
-            actionMatch: 'any',
-            filterMatch: 'any',
-            actions: [
-              {
-                id: 'sentry.rules.actions.notify_event_service.NotifyEventServiceAction',
-                service: 'mail',
-              },
-            ],
-            conditions: [
-              {
-                id: 'sentry.rules.conditions.tagged_event.TaggedEventCondition',
-                key: 'conditionKey',
-                match: 'ne',
-                value: 'conditionValue',
-              },
-            ],
-            filters: [
-              {
-                id: 'sentry.rules.filters.age_comparison.AgeComparisonFilter',
-                comparison_type: 'older',
-                time: 'minute',
-                value: '12',
-              },
-            ],
-            environment: 'production',
-            frequency: '60',
-            name: 'My Rule Name',
-            owner: null,
+      beforeEach(async function () {
+        wrapper = createWrapper({
+          organization: {
+            features: ['alert-filters'],
           },
-        })
-      );
-      expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
+        });
 
-      await waitFor(() => {
-        expect(router.push).toHaveBeenCalledWith({
-          pathname: '/organizations/org-slug/alerts/rules/',
-          query: {project: '2'},
+        mock = MockApiClient.addMockResponse({
+          url: '/projects/org-slug/project-slug/rules/',
+          method: 'POST',
+          body: TestStubs.ProjectAlertRule(),
+        });
+      });
+
+      it('all', async function () {
+        // Change target environment
+        await selectEvent.select(screen.getByText('All Environments'), ['production']);
+
+        // Change actionMatch and filterMatch dropdown
+        const allDropdowns = screen.getAllByText('all');
+        expect(allDropdowns).toHaveLength(2);
+        await selectEvent.select(allDropdowns[0], ['any']);
+        await selectEvent.select(allDropdowns[1], ['any']);
+
+        // `userEvent.paste` isn't really ideal, but since `userEvent.type` doesn't provide good performance and
+        // the purpose of this test is not focused on how the user interacts with the fields,
+        // but rather on whether the form will be saved and updated, we decided use `userEvent.paste`
+        // so that this test does not time out from the default jest value of 5000ms
+
+        // Change name of alert rule
+        userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
+
+        // Add another condition
+        await selectEvent.select(screen.getByText('Add optional condition...'), [
+          "An event's tags match {key} {match} {value}",
+        ]);
+        // Edit new Condition
+        userEvent.paste(screen.getByPlaceholderText('key'), 'conditionKey');
+
+        userEvent.paste(screen.getByPlaceholderText('value'), 'conditionValue');
+        await selectEvent.select(screen.getByText('equals'), ['does not equal']);
+
+        // Add a new filter
+        await selectEvent.select(screen.getByText('Add optional filter...'), [
+          'The issue is {comparison_type} than {value} {time}',
+        ]);
+        userEvent.paste(screen.getByPlaceholderText('10'), '12');
+
+        // Add a new action
+        await selectEvent.select(screen.getByText('Add action...'), [
+          'Send a notification via {service}',
+        ]);
+
+        // Update action interval
+        await selectEvent.select(screen.getByText('30 minutes'), ['60 minutes']);
+
+        userEvent.click(screen.getByText('Save Rule'));
+
+        expect(mock).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            data: {
+              actionMatch: 'any',
+              filterMatch: 'any',
+              actions: [
+                {
+                  id: 'sentry.rules.actions.notify_event_service.NotifyEventServiceAction',
+                  service: 'mail',
+                },
+              ],
+              conditions: [
+                {
+                  id: 'sentry.rules.conditions.tagged_event.TaggedEventCondition',
+                  key: 'conditionKey',
+                  match: 'ne',
+                  value: 'conditionValue',
+                },
+              ],
+              filters: [
+                {
+                  id: 'sentry.rules.filters.age_comparison.AgeComparisonFilter',
+                  comparison_type: 'older',
+                  time: 'minute',
+                  value: '12',
+                },
+              ],
+              environment: 'production',
+              frequency: '60',
+              name: 'My Rule Name',
+              owner: null,
+            },
+          })
+        );
+        expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
+
+        await waitFor(() => {
+          expect(wrapper.router.push).toHaveBeenCalledWith({
+            pathname: '/organizations/org-slug/alerts/rules/',
+            query: {project: '2'},
+          });
         });
       });
     });

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -358,15 +358,6 @@ describe('ProjectAlertsCreate', function () {
           },
         });
 
-        // Change target environment
-        await selectEvent.select(screen.getByText('All Environments'), ['production']);
-
-        // Change actionMatch and filterMatch dropdown
-        const allDropdowns = screen.getAllByText('all');
-        expect(allDropdowns).toHaveLength(2);
-        await selectEvent.select(allDropdowns[0], ['any']);
-        await selectEvent.select(allDropdowns[1], ['any']);
-
         // Change name of alert rule
         userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
@@ -382,8 +373,8 @@ describe('ProjectAlertsCreate', function () {
           expect.any(String),
           expect.objectContaining({
             data: {
-              actionMatch: 'any',
-              filterMatch: 'any',
+              actionMatch: 'all',
+              filterMatch: 'all',
               filters: [
                 {
                   id: 'sentry.rules.filters.age_comparison.AgeComparisonFilter',
@@ -394,7 +385,6 @@ describe('ProjectAlertsCreate', function () {
               ],
               actions: [],
               conditions: [],
-              environment: 'production',
               frequency: 30,
               name: 'My Rule Name',
               owner: null,
@@ -418,15 +408,6 @@ describe('ProjectAlertsCreate', function () {
           },
         });
 
-        // Change target environment
-        await selectEvent.select(screen.getByText('All Environments'), ['production']);
-
-        // Change actionMatch and filterMatch dropdown
-        const allDropdowns = screen.getAllByText('all');
-        expect(allDropdowns).toHaveLength(2);
-        await selectEvent.select(allDropdowns[0], ['any']);
-        await selectEvent.select(allDropdowns[1], ['any']);
-
         // Change name of alert rule
         userEvent.paste(screen.getByPlaceholderText('My Rule Name'), 'My Rule Name');
 
@@ -444,8 +425,8 @@ describe('ProjectAlertsCreate', function () {
           expect.any(String),
           expect.objectContaining({
             data: {
-              actionMatch: 'any',
-              filterMatch: 'any',
+              actionMatch: 'all',
+              filterMatch: 'all',
               actions: [
                 {
                   id: 'sentry.rules.actions.notify_event_service.NotifyEventServiceAction',
@@ -454,7 +435,6 @@ describe('ProjectAlertsCreate', function () {
               ],
               conditions: [],
               filters: [],
-              environment: 'production',
               frequency: '60',
               name: 'My Rule Name',
               owner: null,

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -237,15 +237,9 @@ describe('ProjectAlertsCreate', function () {
     });
 
     describe('updates and saves', function () {
-      let wrapper, mock;
+      let mock;
 
       beforeEach(function () {
-        wrapper = createWrapper({
-          organization: {
-            features: ['alert-filters'],
-          },
-        });
-
         mock = MockApiClient.addMockResponse({
           url: '/projects/org-slug/project-slug/rules/',
           method: 'POST',
@@ -258,6 +252,12 @@ describe('ProjectAlertsCreate', function () {
       });
 
       it('new condition', async function () {
+        const wrapper = createWrapper({
+          organization: {
+            features: ['alert-filters'],
+          },
+        });
+
         // Change target environment
         await selectEvent.select(screen.getByText('All Environments'), ['production']);
 
@@ -315,6 +315,12 @@ describe('ProjectAlertsCreate', function () {
       });
 
       it('new filter', async function () {
+        const wrapper = createWrapper({
+          organization: {
+            features: ['alert-filters'],
+          },
+        });
+
         // Change target environment
         await selectEvent.select(screen.getByText('All Environments'), ['production']);
 
@@ -369,6 +375,12 @@ describe('ProjectAlertsCreate', function () {
       });
 
       it('new action', async function () {
+        const wrapper = createWrapper({
+          organization: {
+            features: ['alert-filters'],
+          },
+        });
+
         // Change target environment
         await selectEvent.select(screen.getByText('All Environments'), ['production']);
 


### PR DESCRIPTION
ProjectAlertsCreate > Issue Alert > updates values and saves test has been a flaky test, might be because of the many ui interactions and waiting for them in a row in the test. Split the action, filter, condition select and save to 3 different tests. We can further investigate if one seems to be the source.

Jira: [WOR-1706](https://getsentry.atlassian.net/browse/WOR-1706)