### PR TITLE
fix(discover): Aggregates without args should still highlight

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -536,8 +536,13 @@ export class TokenConverter {
 
     const {isNumeric, isDuration, isBoolean, isDate, isPercentage} = this.keyValidation;
 
-    const checkAggregate = (check: (s: string) => boolean) =>
-      aggregateKey.args?.args.some(arg => check(arg?.value?.value ?? ''));
+    const checkAggregate = (check: (s: string) => boolean) => {
+      if (aggregateKey.args === null) {
+        // Aggregate keys without args will rely on default values
+        return true;
+      }
+      return aggregateKey.args.args.some(arg => check(arg?.value?.value ?? ''));
+    };
 
     switch (type) {
       case FilterType.Numeric:

--- a/tests/fixtures/search-syntax/aggregate_duration_filter.json
+++ b/tests/fixtures/search-syntax/aggregate_duration_filter.json
@@ -31,5 +31,26 @@
       },
       {"type": "spaces", "value": ""}
     ]
+  },
+  {
+    "query": "p95():>500s",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateDuration",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "p95", "quoted": false},
+          "args": null,
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {"type": "valueDuration", "value": 500, "unit": "s"}
+      },
+      {"type": "spaces", "value": ""}
+    ]
   }
 ]


### PR DESCRIPTION
The query `p95():>2.95s` wasn't highlighting in the search bar, although it's valid syntax and the default arg is `transaction.duration` when added to Discover.

The problem was that this was being picked up as an `aggregate_duration_filter` by the `searchSyntax/grammar.pegjs` file, but when it was running `return tc.predicateFilter(FilterType.AggregateDuration, key)` (`grammar.pegjs:121`), the check function inside the predicate filter call was returning `undefined` because it tries to apply the check to the args. Since there are no args, it just failed silently and returned `undefined` because of `aggregateKey.args?.args`

Instead, if there are no args I think we should return `true` because there are default arguments being handled.