### PR TITLE
perf(test): runInBad

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
   "scripts": {
     "test": "node scripts/test.js",
     "test-precommit": "yarn test --bail --findRelatedTests -u",
-    "test-ci": "yarn test --ci --coverage",
+    "test-ci": "yarn test --ci --coverage --runInBand",
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
     "lint": "yarn eslint tests/js static/app --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
Enabling the `--runInBand` flag in jest to run tests in serial in the same
process. This is in contrast to Jest's default behaviour which uses the same
number of workers as there are cpu cores. This sounds counter intuitive at first
but Github actions only give us 2 cpu cores to work with. Allowing Jest to spawn
multiple workers to parallelize the tests may cause resource contention, leading
to the test timeouts we've been experiencing.

From the small number of tests, it seems that `--runInBand` doesn't affect CI
performance in a very noticeable way, perhaps a little faster, but it's hard to
say without more data.