### PR TITLE
Increase concurrent "limit" to 300

### DIFF
--- a/src/sentry/ratelimits/config.py
+++ b/src/sentry/ratelimits/config.py
@@ -24,8 +24,8 @@ RateLimitOverrideDict = Mapping[HttpMethodName, Mapping[RateLimitCategory, RateL
 _SENTRY_RATELIMITER_DEFAULT = 470
 
 # The concurrent rate limiter stores a sorted set of requests, don't make this number
-# too large (e.g > 100)
-_SENTRY_CONCURRENT_RATE_LIMIT_DEFAULT = 100
+# too large (e.g > 300)
+_SENTRY_CONCURRENT_RATE_LIMIT_DEFAULT = 300
 ENFORCE_CONCURRENT_RATE_LIMITS = False
 
 


### PR DESCRIPTION
After some data analysis, it seems that some orgs are hitting the 100 concurrent requests limit (which is A LOT). In order to find out how much they are actually using, increase the limit even more.

There is plenty headroom on redis to allow this