### PR TITLE
feat(workflow): Remove stack trace preview guide

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -22,7 +22,6 @@ GUIDES = {
     "issue_stream": {"id": 3, "required_targets": ["issue_stream"]},
     "alerts_write_member": {"id": 10, "required_targets": ["alerts_write_member"]},
     "alerts_write_owner": {"id": 11, "required_targets": ["alerts_write_owner"]},
-    "stack_trace_preview": {"id": 15, "required_targets": ["issue_stream_title"]},
     "trace_view": {
         "id": 16,
         "required_targets": ["trace_view_guide_row", "trace_view_guide_row_details"],

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -123,20 +123,6 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
       ],
     },
     {
-      guide: 'stack_trace_preview',
-      requiredTargets: ['issue_stream_title'],
-      dateThreshold: new Date(2021, 2, 15),
-      steps: [
-        {
-          title: t('Stack Trace Preview'),
-          target: 'issue_stream_title',
-          description: t(
-            `Hover over the issue title to see the stack trace of the latest event.`
-          ),
-        },
-      ],
-    },
-    {
       guide: 'trace_view',
       requiredTargets: ['trace_view_guide_row', 'trace_view_guide_row_details'],
       steps: [

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -84,7 +84,6 @@ function EventOrGroupHeader({
             hasSeen={hasGroupingTreeUI && hasSeen === undefined ? true : hasSeen}
             withStackTracePreview
             hasGuideAnchor={index === 0}
-            guideAnchorName="issue_stream_title"
             grouping={grouping}
           />
         </ErrorBoundary>

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -12,23 +12,17 @@ import withOrganization from 'sentry/utils/withOrganization';
 import EventTitleTreeLabel from './eventTitleTreeLabel';
 import {StackTracePreview} from './stacktracePreview';
 
-type Props = Partial<DefaultProps> & {
+type Props = {
   data: Event | BaseGroup | GroupTombstone;
   organization: Organization;
   className?: string;
   /* is issue breakdown? */
   grouping?: boolean;
-  guideAnchorName?: string;
   hasGuideAnchor?: boolean;
   withStackTracePreview?: boolean;
 };
 
-type DefaultProps = {
-  guideAnchorName: string;
-};
-
 function EventOrGroupTitle({
-  guideAnchorName = 'issue_title',
   organization,
   data,
   withStackTracePreview,
@@ -49,7 +43,7 @@ function EventOrGroupTitle({
 
   return (
     <Wrapper className={className} hasGroupingTreeUI={hasGroupingTreeUI}>
-      <GuideAnchor disabled={!hasGuideAnchor} target={guideAnchorName} position="bottom">
+      <GuideAnchor disabled={!hasGuideAnchor} target="issue_title" position="bottom">
         {withStackTracePreview ? (
           <StyledStacktracePreview
             organization={organization}


### PR DESCRIPTION
This had a date threshold, existing users have had > 1 year to see this guide.