### PR TITLE
build(ui): Limit files checked by fork-ts-checkerr

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -352,7 +352,6 @@ let appConfig: Configuration = {
                 compilerOptions: {incremental: true},
                 // Path is "../" to match paths in tsconfig file
                 include: ['../static'],
-                exclude: ['../node_modules'],
               },
             },
             devServer: false,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -350,6 +350,9 @@ let appConfig: Configuration = {
               configFile: path.resolve(__dirname, './config/tsconfig.build.json'),
               configOverwrite: {
                 compilerOptions: {incremental: true},
+                // Path is "../" to match paths in tsconfig file
+                include: ['../static'],
+                exclude: ['../node_modules'],
               },
             },
             devServer: false,


### PR DESCRIPTION
the tsconfig.build.json includes these files
```
"include": ["../static", "../tests/js", "../tests/fixtures/js-stubs"]
```

some slight pickup by including fewer files

before
![image](https://user-images.githubusercontent.com/1400464/159569837-bc0ceb0c-5f83-4164-8eb7-a7ce920b93f8.png)

after
![image](https://user-images.githubusercontent.com/1400464/159569885-128d931a-0f6c-43d7-ab8a-432e4d900d04.png)

ts error included because it spits out the total time