### PR TITLE
chore: Remove unused .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,0 @@
-Matt Robenolt <matt@ydekproductions.com> Matt Robenolt <m@robenolt.com>


### PR DESCRIPTION
Matt is no longer an active contributor to Sentry, I don't think we need this anymore.

https://git-scm.com/docs/gitmailmap