### PR TITLE
ref(perf): Attempt to wrap events in tests 

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -11,6 +11,14 @@ process.env.TZ = 'America/New_York';
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
 process.on('unhandledRejection', err => {
+  console.error('[scripts/test] unhandledRejection');
+  if (global._lastTest) {
+    console.error('Last run test: ', global._lastTest);
+  }
+  if (global.Sentry) {
+    // Needs Sentry from env to be provided as a global.
+    Sentry.captureException(err);
+  }
   throw err;
 });
 

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -56,6 +56,18 @@ configure({
   },
 });
 
+afterEach(() => {
+  global._lastTest = expect.getState().currentTestName;
+});
+process.on('unhandledRejection', reason => {
+  if (global._lastTest) {
+    // eslint-disable-next-line no-console
+    console.error('Last run test: ', global._lastTest);
+  }
+  // eslint-disable-next-line no-console
+  console.error(reason);
+});
+
 /**
  * Enzyme configuration
  *

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -3,7 +3,7 @@
 import {TextDecoder, TextEncoder} from 'util';
 
 import {InjectedRouter} from 'react-router';
-import {configure} from '@testing-library/react'; // eslint-disable-line no-restricted-imports
+import {configure, getConfig} from '@testing-library/react'; // eslint-disable-line no-restricted-imports
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import Enzyme from 'enzyme'; // eslint-disable-line no-restricted-imports
 import {Location} from 'history';
@@ -36,7 +36,25 @@ SVGElement.prototype.getTotalLength ??= () => 1;
  *
  * See: https://testing-library.com/docs/queries/bytestid/#overriding-data-testid
  */
-configure({testIdAttribute: 'data-test-id'});
+const currentRTLConfig = getConfig();
+configure({
+  testIdAttribute: 'data-test-id',
+  eventWrapper: (...args) => {
+    // This function will wrap any events that are created such as click.
+    const span = global.transaction
+      ? global.transaction.startChild({
+          op: 'event',
+          desc: 'eventWrapper',
+        })
+      : null;
+    const result = currentRTLConfig.eventWrapper(...args);
+    if (span) {
+      span.finish();
+    }
+
+    return result;
+  },
+});
 
 /**
  * Enzyme configuration

--- a/tests/js/setupFramework.ts
+++ b/tests/js/setupFramework.ts
@@ -17,5 +17,5 @@ declare global {
 
 process.on('unhandledRejection', reason => {
   // eslint-disable-next-line no-console
-  console.error(reason);
+  console.error('[setupFramework] Unhandled Rejection:', reason);
 });


### PR DESCRIPTION
This might show if events are happening outside of the bounds of a test.

Other:
- Added a bit of wrapping on rejection to remember last ran test, only will work because of runInBand now.