### PR TITLE
ref(nav-tabs): Use 14px font size

### DIFF
--- a/static/app/components/navTabs.tsx
+++ b/static/app/components/navTabs.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import styled from '@emotion/styled';
 import classnames from 'classnames';
 
 interface NavProps extends React.HTMLAttributes<HTMLUListElement> {
@@ -10,7 +10,11 @@ function NavTabs({underlined, className, ...tabProps}: NavProps) {
     'border-bottom': underlined,
   });
 
-  return <ul className={mergedClassName} {...tabProps} />;
+  return <Wrap className={mergedClassName} {...tabProps} />;
 }
 
 export default NavTabs;
+
+const Wrap = styled('ul')`
+  font-size: ${p => p.theme.fontSizeMedium};
+`;

--- a/static/app/views/issueList/savedSearchTab.tsx
+++ b/static/app/views/issueList/savedSearchTab.tsx
@@ -134,8 +134,6 @@ const StyledDropdownLink = styled(DropdownLink)<{isActive?: boolean}>`
   position: relative;
   display: block;
   padding: ${space(1)} 0;
-  /* Important to override a media query from .nav-tabs */
-  font-size: ${p => p.theme.fontSizeLarge} !important;
   text-align: center;
   text-transform: capitalize;
   /* TODO(scttcper): Replace hex color when nav-tabs is replaced */


### PR DESCRIPTION
**Before:**
<img width="1415" alt="issues-before" src="https://user-images.githubusercontent.com/44172267/159587963-0187bfae-ecdc-472d-9e7b-ba837e40d0a4.png">
<img width="1415" alt="performance-before" src="https://user-images.githubusercontent.com/44172267/159587969-ca504c95-04ae-499e-8a6a-6379ced66bdf.png">


**After:**
<img width="1415" alt="issues-after" src="https://user-images.githubusercontent.com/44172267/159587977-c93d517e-26a7-47f3-85c0-009a287be219.png">
<img width="1415" alt="performance-after" src="https://user-images.githubusercontent.com/44172267/159587982-3702e8ad-a920-411f-83c1-24cfd17b10c6.png">
