### PR TITLE
fix(saved-searches): Use gray300 for `<TooltipSearchQuery />`

### DIFF
--- a/static/app/views/issueList/savedSearchMenu.tsx
+++ b/static/app/views/issueList/savedSearchMenu.tsx
@@ -163,7 +163,7 @@ const SearchSort = styled('span')`
 `;
 
 const TooltipSearchQuery = styled('span')`
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.subText};
   font-weight: normal;
   font-family: ${p => p.theme.text.familyMono};
 `;


### PR DESCRIPTION
**Before:**
<img width="246" alt="Screen Shot 2022-03-22 at 3 43 56 PM" src="https://user-images.githubusercontent.com/44172267/159588519-03dedc5d-406e-4aa2-a691-e3fbc25d6ea5.png">

**After:**
<img width="249" alt="Screen Shot 2022-03-22 at 3 44 08 PM" src="https://user-images.githubusercontent.com/44172267/159588538-87eed9d8-e0b0-451a-aa4c-072ed5ef7fba.png">
