### PR TITLE
feat(metrics): Add `session.all` to derived metrics [INGEST-930 INGEST-1008]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -22,9 +22,9 @@ from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.utils import resolve_weak
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.fields.snql import (
+    all_sessions,
     crashed_sessions,
     errored_preaggr_sessions,
-    init_sessions,
     percentage,
     sessions_errored_set,
 )
@@ -482,10 +482,10 @@ DERIVED_METRICS = {
     derived_metric.metric_name: derived_metric
     for derived_metric in [
         SingularEntityDerivedMetric(
-            metric_name="session.init",
+            metric_name="session.all",
             metrics=["sentry.sessions.session"],
             unit="sessions",
-            snql=lambda *_, metric_ids, alias=None: init_sessions(metric_ids, alias=alias),
+            snql=lambda *_, metric_ids, alias=None: all_sessions(metric_ids, alias=alias),
         ),
         SingularEntityDerivedMetric(
             metric_name="session.crashed",
@@ -495,7 +495,7 @@ DERIVED_METRICS = {
         ),
         SingularEntityDerivedMetric(
             metric_name="session.crash_free_rate",
-            metrics=["session.crashed", "session.init"],
+            metrics=["session.crashed", "session.all"],
             unit="percentage",
             snql=lambda *args, metric_ids, alias=None: percentage(
                 *args, alias="session.crash_free_rate"

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -26,7 +26,7 @@ def _counter_sum_aggregation_on_session_status_factory(session_status, metric_id
     )
 
 
-def init_sessions(metric_ids, alias=None):
+def all_sessions(metric_ids, alias=None):
     return _counter_sum_aggregation_on_session_status_factory(
         session_status="init", metric_ids=metric_ids, alias=alias
     )

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -925,13 +925,13 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                 )
         response = self.get_success_response(
             self.organization.slug,
-            field=["session.crash_free_rate", "session.init", "session.crashed"],
+            field=["session.crash_free_rate", "session.all", "session.crashed"],
             statsPeriod="6m",
             interval="1m",
         )
         group = response.data["groups"][0]
         assert group["totals"]["session.crash_free_rate"] == 0.5
-        assert group["totals"]["session.init"] == 8
+        assert group["totals"]["session.all"] == 8
         assert group["totals"]["session.crashed"] == 4
         assert group["series"]["session.crash_free_rate"] == [None, None, 0.5, 0.5, 0.5, 0.5]
 

--- a/tests/sentry/api/endpoints/test_organization_metric_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_details.py
@@ -12,7 +12,7 @@ MOCKED_DERIVED_METRICS_2.update(
     {
         "derived_metric.multiple_metrics": SingularEntityDerivedMetric(
             metric_name="derived_metric.multiple_metrics",
-            metrics=["metric_foo_doe", "session.init"],
+            metrics=["metric_foo_doe", "session.all"],
             unit="percentage",
             snql=lambda *args, metric_ids, alias=None: percentage(
                 *args, alias="session.crash_free_rate"

--- a/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
@@ -76,7 +76,7 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
         response = self.get_response(
             self.organization.slug,
             "release",
-            metric=["session.crash_free_rate", "session.init"],
+            metric=["session.crash_free_rate", "session.all"],
         )
         assert response.data == [{"key": "release", "value": "foobar"}]
 

--- a/tests/sentry/api/endpoints/test_organization_metric_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tags.py
@@ -78,7 +78,7 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
 
         response = self.get_success_response(
             self.organization.slug,
-            metric=["session.crash_free_rate", "session.init"],
+            metric=["session.crash_free_rate", "session.all"],
         )
         assert response.data == [
             {"key": "environment"},

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -82,6 +82,7 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
                 "operations": ["count_unique"],
                 "unit": None,
             },
+            {"name": "session.all", "type": "numeric", "operations": [], "unit": "sessions"},
             {
                 "name": "session.crash_free_rate",
                 "type": "numeric",
@@ -95,7 +96,6 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
                 "operations": [],
                 "unit": "sessions",
             },
-            {"name": "session.init", "type": "numeric", "operations": [], "unit": "sessions"},
         ]
 
     def test_metrics_index(self):

--- a/tests/sentry/snuba/metrics/test_fields.py
+++ b/tests/sentry/snuba/metrics/test_fields.py
@@ -16,9 +16,9 @@ from sentry.snuba.metrics import (
 )
 from sentry.snuba.metrics.fields.base import CompositeEntityDerivedMetric
 from sentry.snuba.metrics.fields.snql import (
+    all_sessions,
     crashed_sessions,
     errored_preaggr_sessions,
-    init_sessions,
     percentage,
     sessions_errored_set,
 )
@@ -70,7 +70,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         - Return the entity of that derived metric
         """
         expected_derived_metrics_entities = {
-            "session.init": "metrics_counters",
+            "session.all": "metrics_counters",
             "session.crashed": "metrics_counters",
             "session.crash_free_rate": "metrics_counters",
             "session.errored_preaggregated": "metrics_counters",
@@ -97,7 +97,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         session_ids = [indexer.record(org_id, "sentry.sessions.session")]
 
         derived_name_snql = {
-            "session.init": (init_sessions, session_ids),
+            "session.all": (all_sessions, session_ids),
             "session.crashed": (crashed_sessions, session_ids),
             "session.errored_preaggregated": (errored_preaggr_sessions, session_ids),
             "session.errored_set": (
@@ -115,7 +115,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         ) == [
             percentage(
                 crashed_sessions(metric_ids=session_ids, alias="session.crashed"),
-                init_sessions(metric_ids=session_ids, alias="session.init"),
+                all_sessions(metric_ids=session_ids, alias="session.all"),
                 alias="session.crash_free_rate",
             )
         ]
@@ -134,7 +134,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
         session_error_metric_id = indexer.record(org_id, "sentry.sessions.session.error")
 
         for derived_metric_name in [
-            "session.init",
+            "session.all",
             "session.crashed",
             "session.crash_free_rate",
             "session.errored_preaggregated",
@@ -171,7 +171,7 @@ class SingleEntityDerivedMetricTestCase(TestCase):
 
     def test_generate_default_value(self):
         for derived_metric_name in [
-            "session.init",
+            "session.all",
             "session.crashed",
             "session.errored_set",
             "session.errored_preaggregated",

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -38,9 +38,9 @@ from sentry.snuba.metrics import (
     resolve_tags,
 )
 from sentry.snuba.metrics.fields.snql import (
+    all_sessions,
     crashed_sessions,
     errored_preaggr_sessions,
-    init_sessions,
     percentage,
     sessions_errored_set,
 )
@@ -293,7 +293,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2, monkeypatch):
             "field": [
                 "session.errored",
                 "session.crash_free_rate",
-                "session.init",
+                "session.all",
             ],
             "interval": ["1d"],
             "statsPeriod": ["2d"],
@@ -306,7 +306,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2, monkeypatch):
         "metrics_counters": [
             (None, "session.errored_preaggregated"),
             (None, "session.crash_free_rate"),
-            (None, "session.init"),
+            (None, "session.all"),
         ],
         "metrics_sets": [
             (None, "session.errored_set"),
@@ -328,14 +328,14 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2, monkeypatch):
                             metric_ids=[resolve_weak("sentry.sessions.session")],
                             alias="session.crashed",
                         ),
-                        init_sessions(
+                        all_sessions(
                             metric_ids=[resolve_weak("sentry.sessions.session")],
-                            alias="session.init",
+                            alias="session.all",
                         ),
                         alias="session.crash_free_rate",
                     ),
-                    init_sessions(
-                        metric_ids=[resolve_weak("sentry.sessions.session")], alias="session.init"
+                    all_sessions(
+                        metric_ids=[resolve_weak("sentry.sessions.session")], alias="session.all"
                     ),
                 ],
                 groupby=groupby,
@@ -648,7 +648,7 @@ def test_translate_results_derived_metrics(_1, _2, monkeypatch):
             "field": [
                 "session.errored",
                 "session.crash_free_rate",
-                "session.init",
+                "session.all",
             ],
             "interval": ["1d"],
             "statsPeriod": ["2d"],
@@ -659,7 +659,7 @@ def test_translate_results_derived_metrics(_1, _2, monkeypatch):
         "metrics_counters": [
             (None, "session.errored_preaggregated"),
             (None, "session.crash_free_rate"),
-            (None, "session.init"),
+            (None, "session.all"),
         ],
         "metrics_sets": [
             (None, "session.errored_set"),
@@ -673,7 +673,7 @@ def test_translate_results_derived_metrics(_1, _2, monkeypatch):
                 "data": [
                     {
                         "session.crash_free_rate": 0.5,
-                        "session.init": 8.0,
+                        "session.all": 8.0,
                         "session.errored_preaggregated": 3,
                     }
                 ],
@@ -683,13 +683,13 @@ def test_translate_results_derived_metrics(_1, _2, monkeypatch):
                     {
                         "bucketed_time": "2021-08-24T00:00Z",
                         "session.crash_free_rate": 0.5,
-                        "session.init": 4,
+                        "session.all": 4,
                         "session.errored_preaggregated": 1,
                     },
                     {
                         "bucketed_time": "2021-08-25T00:00Z",
                         "session.crash_free_rate": 0.5,
-                        "session.init": 4,
+                        "session.all": 4,
                         "session.errored_preaggregated": 2,
                     },
                 ],
@@ -718,12 +718,12 @@ def test_translate_results_derived_metrics(_1, _2, monkeypatch):
         {
             "by": {},
             "totals": {
-                "session.init": 8,
+                "session.all": 8,
                 "session.crash_free_rate": 0.5,
                 "session.errored": 6,
             },
             "series": {
-                "session.init": [4, 4],
+                "session.all": [4, 4],
                 "session.crash_free_rate": [0.5, 0.5],
                 "session.errored": [3, 3],
             },

--- a/tests/sentry/snuba/metrics/test_snql.py
+++ b/tests/sentry/snuba/metrics/test_snql.py
@@ -2,9 +2,9 @@ from snuba_sdk import Column, Function
 
 from sentry.sentry_metrics.utils import resolve_weak
 from sentry.snuba.metrics import (
+    all_sessions,
     crashed_sessions,
     errored_preaggr_sessions,
-    init_sessions,
     percentage,
     sessions_errored_set,
 )
@@ -17,7 +17,7 @@ class DerivedMetricSnQLTestCase(TestCase):
 
     def test_counter_sum_aggregation_on_session_status(self):
         for status, func in [
-            ("init", init_sessions),
+            ("init", all_sessions),
             ("crashed", crashed_sessions),
             ("errored_preaggr", errored_preaggr_sessions),
         ]:
@@ -61,7 +61,7 @@ class DerivedMetricSnQLTestCase(TestCase):
 
     def test_percentage_in_snql(self):
         alias = "foo.percentage"
-        init_session_snql = init_sessions(self.metric_ids, "init_sessions")
+        init_session_snql = all_sessions(self.metric_ids, "init_sessions")
         crashed_session_snql = crashed_sessions(self.metric_ids, "crashed_sessions")
 
         assert percentage(crashed_session_snql, init_session_snql, alias=alias) == Function(


### PR DESCRIPTION
Renames `session.init` to `session.all`