### PR TITLE
feat(metrics): Add `session.crashed_user` to Derived metrics [INGEST-930 INGEST-1002]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -25,6 +25,7 @@ from sentry.snuba.metrics.fields.snql import (
     abnormal_sessions,
     all_sessions,
     crashed_sessions,
+    crashed_users,
     errored_preaggr_sessions,
     percentage,
     sessions_errored_set,
@@ -521,6 +522,12 @@ DERIVED_METRICS = {
             metrics=["sentry.sessions.session.error"],
             unit="sessions",
             snql=lambda *_, metric_ids, alias=None: sessions_errored_set(metric_ids, alias=alias),
+        ),
+        SingularEntityDerivedMetric(
+            metric_name="session.crashed_user",
+            metrics=["sentry.sessions.user"],
+            unit="users",
+            snql=lambda *_, metric_ids, alias=None: crashed_users(metric_ids, alias=alias),
         ),
         CompositeEntityDerivedMetric(
             metric_name="session.errored",

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -3,26 +3,41 @@ from snuba_sdk import Column, Function
 from sentry.sentry_metrics.utils import resolve_weak
 
 
+def _aggregation_on_session_status_func_factory(aggregate):
+    def _snql_on_session_status_factory(session_status, metric_ids, alias=None):
+        return Function(
+            aggregate,
+            [
+                Column("value"),
+                Function(
+                    "and",
+                    [
+                        Function(
+                            "equals",
+                            [
+                                Column(f"tags[{resolve_weak('session.status')}]"),
+                                resolve_weak(session_status),
+                            ],
+                        ),
+                        Function("in", [Column("metric_id"), list(metric_ids)]),
+                    ],
+                ),
+            ],
+            alias,
+        )
+
+    return _snql_on_session_status_factory
+
+
 def _counter_sum_aggregation_on_session_status_factory(session_status, metric_ids, alias=None):
-    return Function(
-        "sumIf",
-        [
-            Column("value"),
-            Function(
-                "and",
-                [
-                    Function(
-                        "equals",
-                        [
-                            Column(f"tags[{resolve_weak('session.status')}]"),
-                            resolve_weak(session_status),
-                        ],
-                    ),
-                    Function("in", [Column("metric_id"), list(metric_ids)]),
-                ],
-            ),
-        ],
-        alias,
+    return _aggregation_on_session_status_func_factory(aggregate="sumIf")(
+        session_status, metric_ids, alias
+    )
+
+
+def _set_uniq_aggregation_on_session_status_factory(session_status, metric_ids, alias=None):
+    return _aggregation_on_session_status_func_factory(aggregate="uniqIf")(
+        session_status, metric_ids, alias
     )
 
 
@@ -34,6 +49,12 @@ def all_sessions(metric_ids, alias=None):
 
 def crashed_sessions(metric_ids, alias=None):
     return _counter_sum_aggregation_on_session_status_factory(
+        session_status="crashed", metric_ids=metric_ids, alias=alias
+    )
+
+
+def crashed_users(metric_ids, alias=None):
+    return _set_uniq_aggregation_on_session_status_factory(
         session_status="crashed", metric_ids=metric_ids, alias=alias
     )
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -141,7 +141,7 @@ DEFAULT_AGGREGATES = {
     "sum": 0,
     "percentage": None,
 }
-UNIT_TO_TYPE = {"sessions": "count", "percentage": "percentage"}
+UNIT_TO_TYPE = {"sessions": "count", "percentage": "percentage", "users": "count"}
 
 
 class MetricDoesNotExistException(Exception):

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1177,3 +1177,58 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert bar_group["by"]["release"] == "bar"
         assert bar_group["totals"] == {"session.abnormal": 3}
         assert bar_group["series"] == {"session.abnormal": [0, 0, 0, 3, 0, 0]}
+
+    @freeze_time((timezone.now() - timedelta(days=2)).replace(hour=3, minute=0, second=0))
+    def test_crashed_user_sessions(self):
+        org_id = self.organization.id
+        indexer.record(org_id, "sentry.sessions.session.duration")
+        users_metric_id = indexer.record(org_id, "sentry.sessions.user")
+        session_status_tag = indexer.record(org_id, "session.status")
+        release_tag = indexer.record(org_id, "release")
+        user_ts = time.time()
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": users_metric_id,
+                    "timestamp": user_ts,
+                    "tags": {
+                        session_status_tag: indexer.record(org_id, "crashed"),
+                        release_tag: indexer.record(org_id, "foo"),
+                    },
+                    "type": "s",
+                    "value": [1, 2, 4],
+                    "retention_days": 90,
+                },
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": users_metric_id,
+                    "timestamp": user_ts,
+                    "tags": {
+                        session_status_tag: indexer.record(org_id, "crashed"),
+                        release_tag: indexer.record(org_id, "bar"),
+                    },
+                    "type": "s",
+                    "value": [1, 2, 4, 8, 9, 5],
+                    "retention_days": 90,
+                },
+            ],
+            entity="metrics_sets",
+        )
+        response = self.get_success_response(
+            self.organization.slug,
+            field=["session.crashed_user"],
+            statsPeriod="6m",
+            interval="1m",
+            groupBy=["release"],
+            orderBy=["-session.crashed_user"],
+        )
+        foo_group, bar_group = response.data["groups"][1], response.data["groups"][0]
+        assert foo_group["by"]["release"] == "foo"
+        assert foo_group["totals"] == {"session.crashed_user": 3}
+        assert foo_group["series"] == {"session.crashed_user": [0, 0, 0, 0, 0, 3]}
+        assert bar_group["by"]["release"] == "bar"
+        assert bar_group["totals"] == {"session.crashed_user": 6}
+        assert bar_group["series"] == {"session.crashed_user": [0, 0, 0, 0, 0, 6]}

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -91,6 +91,7 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
                 "unit": "percentage",
             },
             {"name": "session.crashed", "type": "numeric", "operations": [], "unit": "sessions"},
+            {"name": "session.crashed_user", "type": "numeric", "operations": [], "unit": "users"},
             {
                 "name": "session.errored_preaggregated",
                 "type": "numeric",

--- a/tests/sentry/snuba/metrics/test_fields.py
+++ b/tests/sentry/snuba/metrics/test_fields.py
@@ -28,6 +28,7 @@ from sentry.testutils import TestCase
 def get_entity_of_metric_mocked(_, metric_name):
     return {
         "sentry.sessions.session": EntityKey.MetricsCounters,
+        "sentry.sessions.user": EntityKey.MetricsSets,
         "sentry.sessions.session.error": EntityKey.MetricsSets,
     }[metric_name]
 


### PR DESCRIPTION
Adds `session.crashed_user` to list of derived
metrics. Modifies SNQL factory function to
produce session status filter snql for set
metrics as well