### PR TITLE
feat(metrics): Add `session.all_users` to derived metrics [INGEST-930 INGEST-1009]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -24,6 +24,7 @@ from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.fields.snql import (
     abnormal_sessions,
     all_sessions,
+    all_users,
     crashed_sessions,
     crashed_users,
     errored_preaggr_sessions,
@@ -522,6 +523,12 @@ DERIVED_METRICS = {
             metrics=["sentry.sessions.session.error"],
             unit="sessions",
             snql=lambda *_, metric_ids, alias=None: sessions_errored_set(metric_ids, alias=alias),
+        ),
+        SingularEntityDerivedMetric(
+            metric_name="session.all_user",
+            metrics=["sentry.sessions.user"],
+            unit="users",
+            snql=lambda *_, metric_ids, alias=None: all_users(metric_ids, alias=alias),
         ),
         SingularEntityDerivedMetric(
             metric_name="session.crashed_user",

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -47,6 +47,12 @@ def all_sessions(metric_ids, alias=None):
     )
 
 
+def all_users(metric_ids, alias=None):
+    return _set_uniq_aggregation_on_session_status_factory(
+        session_status="init", metric_ids=metric_ids, alias=alias
+    )
+
+
 def crashed_sessions(metric_ids, alias=None):
     return _counter_sum_aggregation_on_session_status_factory(
         session_status="crashed", metric_ids=metric_ids, alias=alias

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1232,3 +1232,34 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert bar_group["by"]["release"] == "bar"
         assert bar_group["totals"] == {"session.crashed_user": 6}
         assert bar_group["series"] == {"session.crashed_user": [0, 0, 0, 0, 0, 6]}
+
+    @freeze_time((timezone.now() - timedelta(days=2)).replace(hour=3, minute=0, second=0))
+    def test_all_user_sessions(self):
+        indexer.record(self.organization.id, "sentry.sessions.session.duration")
+        users_metric_id = indexer.record(self.organization.id, "sentry.sessions.user")
+        session_status_tag = indexer.record(self.organization.id, "session.status")
+        user_ts = time.time()
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": users_metric_id,
+                    "timestamp": user_ts,
+                    "tags": {session_status_tag: indexer.record(self.organization.id, "init")},
+                    "type": "s",
+                    "value": [1, 2, 4],
+                    "retention_days": 90,
+                },
+            ],
+            entity="metrics_sets",
+        )
+        response = self.get_success_response(
+            self.organization.slug,
+            field=["session.all_user"],
+            statsPeriod="6m",
+            interval="1m",
+        )
+        group = response.data["groups"][0]
+        assert group["totals"] == {"session.all_user": 3}
+        assert group["series"] == {"session.all_user": [0, 0, 0, 0, 0, 3]}

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -84,6 +84,7 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
             },
             {"name": "session.abnormal", "operations": [], "type": "numeric", "unit": "sessions"},
             {"name": "session.all", "type": "numeric", "operations": [], "unit": "sessions"},
+            {"name": "session.all_user", "type": "numeric", "operations": [], "unit": "users"},
             {
                 "name": "session.crash_free_rate",
                 "type": "numeric",


### PR DESCRIPTION
Adds `session.all_user` to derived metrics