### PR TITLE
ref: Normalize more in Symbolicator Snapshots

### DIFF
--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-17T16:59:10.116713Z'
+created: '2022-03-28T11:44:28.487657Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_missing_dsym.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_missing_dsym.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-01-05T09:42:10.564022Z'
+created: '2022-03-28T11:44:46.522208Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_initial.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_initial.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-01-05T09:42:17.220118Z'
+created: '2022-03-28T11:44:52.208370Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_reprocessed.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_reprocessed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-01-05T10:23:58.428788Z'
+created: '2022-03-28T11:44:53.352546Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T19:33:18.859595Z'
+created: '2022-03-28T11:44:58.859263Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_missing_debug_images.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_missing_debug_images.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T19:33:26.234043Z'
+created: '2022-03-28T11:45:04.293878Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_missing_dsym.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_missing_dsym.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-11-19T11:20:01.932672Z'
+created: '2022-03-28T11:45:09.928480Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_real_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_real_resolving.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T19:33:42.975020Z'
+created: '2022-03-28T11:45:15.556666Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-31T11:13:08.932876Z'
+created: '2022-03-28T12:03:04.745358Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-12-02T13:53:08.216475Z'
+created: '2022-03-28T12:03:11.737053Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -141,6 +141,12 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
         assert not EventAttachment.objects.filter(event_id=event.event_id)
 
     def test_reprocessing(self):
+        # NOTE:
+        # When running this test against a local symbolicator instance,
+        # make sure that instance has its caches disabled. This test assumes
+        # that a symbol upload has immediate effect, whereas in reality the
+        # negative cache needs to expire first.
+
         self.project.update_option("sentry:store_crash_reports", STORE_CRASH_REPORTS_ALL)
 
         features = dict(self._FEATURES)

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -9,7 +9,8 @@ from django.urls import reverse
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 from sentry.models import EventAttachment, File
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
-from tests.symbolicator import get_fixture_path
+from sentry.utils.safe import get_path
+from tests.symbolicator import get_fixture_path, normalize_exception
 
 # IMPORTANT:
 # For these tests to run, write `symbolicator.enabled: true` into your
@@ -82,7 +83,12 @@ class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
         self.insta_snapshot(
             {
                 "contexts": event.data.get("contexts"),
-                "exception": event.data.get("exception"),
+                "exception": {
+                    "values": [
+                        normalize_exception(x)
+                        for x in get_path(event.data, "exception", "values") or ()
+                    ]
+                },
                 "stacktrace": event.data.get("stacktrace"),
                 "threads": event.data.get("threads"),
                 "extra": event.data.get("extra"),


### PR DESCRIPTION
This makes it possible to normalize more pieces of the symbolicator snapshots, in order to make it easier to land changes.

See https://github.com/getsentry/symbolicator/pull/731