### PR TITLE
Revert "fix(discover): Aggregates without args should still highlight"

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -536,13 +536,8 @@ export class TokenConverter {
 
     const {isNumeric, isDuration, isBoolean, isDate, isPercentage} = this.keyValidation;
 
-    const checkAggregate = (check: (s: string) => boolean) => {
-      if (aggregateKey.args === null) {
-        // Aggregate keys without args will rely on default values
-        return true;
-      }
-      return aggregateKey.args.args.some(arg => check(arg?.value?.value ?? ''));
-    };
+    const checkAggregate = (check: (s: string) => boolean) =>
+      aggregateKey.args?.args.some(arg => check(arg?.value?.value ?? ''));
 
     switch (type) {
       case FilterType.Numeric:

--- a/tests/fixtures/search-syntax/aggregate_duration_filter.json
+++ b/tests/fixtures/search-syntax/aggregate_duration_filter.json
@@ -31,26 +31,5 @@
       },
       {"type": "spaces", "value": ""}
     ]
-  },
-  {
-    "query": "p95():>500s",
-    "result": [
-      {"type": "spaces", "value": ""},
-      {
-        "type": "filter",
-        "filter": "aggregateDuration",
-        "negated": false,
-        "key": {
-          "type": "keyAggregate",
-          "name": {"type": "keySimple", "value": "p95", "quoted": false},
-          "args": null,
-          "argsSpaceBefore": {"type": "spaces", "value": ""},
-          "argsSpaceAfter": {"type": "spaces", "value": ""}
-        },
-        "operator": ">",
-        "value": {"type": "valueDuration", "value": 500, "unit": "s"}
-      },
-      {"type": "spaces", "value": ""}
-    ]
   }
 ]


### PR DESCRIPTION
Reverts getsentry/sentry#32837

The backend tests didn't run because the test file that changed was a fixture file. This is busted in `getsentry` so I'm reverting