### PR TITLE
ref(ratelimits): log cleaned up concurrent requests

### DIFF
--- a/src/sentry/ratelimits/concurrent.py
+++ b/src/sentry/ratelimits/concurrent.py
@@ -42,26 +42,28 @@ class ConcurrentRateLimiter:
 
     def start_request(self, key: str, limit: int, request_uid: str) -> ConcurrentLimitInfo:
         redis_key = self.namespaced_key(key)
+        current_executions, request_allowed, cleaned_up_requests = (-1, True, 0)
         try:
             current_executions, request_allowed, cleaned_up_requests = rate_limit_info(
                 self.client, [redis_key], [limit, request_uid, time(), self.max_ttl_seconds]
             )
-            logger.info(
-                "Cleaned up concurrent executions: %s",
-                cleaned_up_requests,
-                extra={
-                    "cleaned_up_requests": cleaned_up_requests,
-                    "key": key,
-                    "limit": limit,
-                    "request_uid": request_uid,
-                },
-            )
-            return ConcurrentLimitInfo(limit, int(current_executions), not bool(request_allowed))
         except Exception:
             logger.exception(
                 "Could not start request", dict(key=redis_key, limit=limit, request_uid=request_uid)
             )
             return ConcurrentLimitInfo(limit, -1, False)
+
+        logger.info(
+            "Cleaned up concurrent executions: %s",
+            cleaned_up_requests,
+            extra={
+                "cleaned_up_requests": cleaned_up_requests,
+                "key": key,
+                "limit": limit,
+                "request_uid": request_uid,
+            },
+        )
+        return ConcurrentLimitInfo(limit, int(current_executions), not bool(request_allowed))
 
     def get_concurrent_requests(self, key: str) -> int:
         redis_key = self.namespaced_key(key)


### PR DESCRIPTION
The concurrent rate limiter cleans up stale requests past a certain TTL (30 seconds). This step is mostly unnecessary unless:

1. The server crashed while servicing the request (it was never removed from the request sorted set)
2. The rate limiter or how it's being used is somehow broken

In order to make sure (2) is not the case, log the amount of requests that were cleaned up by the rate limiter. This adds some overhead to the call but it's just a temporary measure to make sure that we are not counting requests we shouldn't be.

Inspecting the logging during `test_redis_concurrent.py` tests showed the numbers to be accurate.