### PR TITLE
feat(replays): Minor fixes to allow Replays to load list

### DIFF
--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -1,4 +1,3 @@
-import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -94,23 +93,21 @@ class ReplayDetails extends AsyncView<Props, State> {
     const projectSlug = event.projectSlug || event['project.name']; // seems janky
 
     return (
-      <Fragment>
-        <Fragment>
-          <Layout.Header>
-            <Layout.HeaderContent>
-              <Breadcrumbs
-                crumbs={[
-                  {
-                    to: `/organizations/${orgSlug}/replays/`,
-                    label: t('Replays'),
-                  },
-                  {label: t('Replay Details')}, // TODO: put replay ID or something here
-                ]}
-              />
-              <EventHeader event={event} />
-            </Layout.HeaderContent>
-          </Layout.Header>
-        </Fragment>
+      <NoPaddingContent>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Breadcrumbs
+              crumbs={[
+                {
+                  to: `/organizations/${orgSlug}/replays/`,
+                  label: t('Replays'),
+                },
+                {label: t('Replay Details')}, // TODO: put replay ID or something here
+              ]}
+            />
+            <EventHeader event={event} />
+          </Layout.HeaderContent>
+        </Layout.Header>
 
         <Layout.Body>
           <Layout.Main>
@@ -124,7 +121,7 @@ class ReplayDetails extends AsyncView<Props, State> {
             />
           </Layout.Side>
         </Layout.Body>
-      </Fragment>
+      </NoPaddingContent>
     );
   }
 }
@@ -140,6 +137,10 @@ const TitleWrapper = styled('div')`
 
 const MessageWrapper = styled('div')`
   margin-top: ${space(1)};
+`;
+
+const NoPaddingContent = styled(PageContent)`
+  padding: 0;
 `;
 
 export default ReplayDetails;

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -10,6 +10,7 @@ import RRWebIntegration from 'sentry/components/events/rrwebIntegration';
 import * as Layout from 'sentry/components/layouts/thirds';
 import TagsTable from 'sentry/components/tagsTable';
 import {t} from 'sentry/locale';
+import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Event} from 'sentry/types/event';
 import EventView from 'sentry/utils/discover/eventView';
@@ -68,8 +69,9 @@ class ReplayDetails extends AsyncView<Props, State> {
     return `Replays - ${this.props.params.orgId}`;
   }
 
-  onUpdate = (data: Event) =>
-    this.setState(state => ({event: {...state.event, ...data}}));
+  renderLoading() {
+    return <PageContent>{super.renderLoading()}</PageContent>;
+  }
 
   generateTagUrl = () => {
     return ''; // todo

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -39,9 +39,9 @@ class Replays extends AsyncView<Props, State> {
       version: 2,
       fields: ['eventID', 'timestamp'],
       orderby: '',
-      projects: [2],
+      projects: [],
       range: statsPeriod,
-      query: 'event.type:error', // future: change to replay event
+      query: 'transaction:sentry-replay', // future: change to replay event
     });
     const apiPayload = eventView.getEventsAPIPayload(location);
     return [
@@ -50,6 +50,10 @@ class Replays extends AsyncView<Props, State> {
   }
   getTitle() {
     return `Replays - ${this.props.params.orgId}`;
+  }
+
+  renderLoading() {
+    return <PageContent>{super.renderLoading()}</PageContent>;
   }
 
   renderBody() {


### PR DESCRIPTION
Removed the hard-coded project id for now and fixed up the query for updates in SDK.
Also wrapped the loaders with `<PageContent>` to affix footer to bottom of screen.