### PR TITLE
ref(types): `from typing_extensions import TypedDict`

### DIFF
--- a/src/sentry/api/endpoints/organization_events_span_ops.py
+++ b/src/sentry/api/endpoints/organization_events_span_ops.py
@@ -1,7 +1,8 @@
-from typing import Any, TypedDict
+from typing import Any
 
 from rest_framework.request import Request
 from rest_framework.response import Response
+from typing_extensions import TypedDict
 
 from sentry import features
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -12,7 +12,6 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -23,6 +22,7 @@ from django.http import Http404, HttpRequest, HttpResponse
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
+from typing_extensions import TypedDict
 
 from sentry import eventstore, features
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from datetime import datetime, timedelta
-from typing import Dict, Match, Optional, TypedDict
+from typing import Dict, Match, Optional
 
 import sentry_sdk
 from rest_framework.exceptions import ParseError
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.expressions import Limit, Offset
 from snuba_sdk.function import Function
+from typing_extensions import TypedDict
 
 from sentry import features
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -4,13 +4,14 @@ import functools
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Iterable, Mapping, Optional, Sequence, Tuple, TypedDict
+from typing import Iterable, Mapping, Optional, Sequence, Tuple
 
 import pytz
 import sentry_sdk
 from django.conf import settings
 from django.db.models import Min, prefetch_related_objects
 from django.utils import timezone
+from typing_extensions import TypedDict
 
 from sentry import release_health, tagstore, tsdb
 from sentry.api.serializers import Serializer, register, serialize

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, Literal, Mapping, Set, TypedDict
+from typing import Any, Dict, Literal, Mapping, Set
 
 from drf_spectacular.drainage import warn
+from typing_extensions import TypedDict
 
 from sentry.apidocs.build import OPENAPI_TAGS
 from sentry.apidocs.utils import SentryApiBuildError

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence, TypedDict, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from typing_extensions import TypedDict
 
 from sentry.utils.safe import get_path, safe_execute, set_path
 

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -1,5 +1,7 @@
 from abc import ABC
-from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple, TypedDict
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from typing_extensions import TypedDict
 
 from sentry.integrations.slack.message_builder import SlackBlock, SlackBody
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -1,10 +1,11 @@
 import logging
 import uuid
 from datetime import datetime
-from typing import Any, List, Mapping, Optional, TypedDict
+from typing import Any, List, Mapping, Optional
 
 from pytz import utc
 from sentry_sdk import Hub, capture_exception
+from typing_extensions import TypedDict
 
 from sentry import features, quotas, utils
 from sentry.api.endpoints.project_transaction_threshold import DEFAULT_THRESHOLD

--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -1,5 +1,7 @@
 from datetime import datetime
-from typing import Literal, Mapping, Optional, Sequence, Set, Tuple, TypedDict, TypeVar, Union
+from typing import Literal, Mapping, Optional, Sequence, Set, Tuple, TypeVar, Union
+
+from typing_extensions import TypedDict
 
 from sentry.snuba.sessions_v2 import QueryDefinition
 from sentry.utils.services import Service

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -20,7 +20,6 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    TypedDict,
     Union,
     cast,
     get_args,
@@ -40,6 +39,7 @@ from snuba_sdk import (
 )
 from snuba_sdk.legacy import json_to_snql
 from snuba_sdk.query import SelectableExpression
+from typing_extensions import TypedDict
 
 from sentry.release_health.base import (
     GroupByFieldName,

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Sequence, TypedDict
+from typing import TYPE_CHECKING, Sequence
 
 import pytz
 from django.db.models import Count, Max
 from django.db.models.functions import TruncHour
+from typing_extensions import TypedDict
 
 from sentry.api.paginator import OffsetPaginator
 from sentry.models import Group, RuleFireHistory

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Mapping, MutableMapping, Sequence, TypedDict
+from typing import Any, Mapping, MutableMapping, Sequence
 
 from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
+from typing_extensions import TypedDict
 
 from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.serializers import Serializer, serialize

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Mapping, TypedDict
+from typing import Any, Mapping
 
 from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
+from typing_extensions import TypedDict
 
 from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.serializers import Serializer, serialize

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -1,5 +1,7 @@
 import re
-from typing import Dict, TypedDict
+from typing import Dict
+
+from typing_extensions import TypedDict
 
 from sentry.snuba.dataset import Dataset
 from sentry.utils.snuba import DATASETS

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -2,7 +2,9 @@ import re
 from abc import ABC, abstractmethod
 from copy import copy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, TypedDict, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, Union
+
+from typing_extensions import TypedDict
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, CRASH_RATE_ALERT_SESSION_COUNT_ALIAS
 from sentry.eventstore import Filter

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -34,7 +34,9 @@ __all__ = (
 import re
 from abc import ABC
 from datetime import datetime
-from typing import Collection, Literal, Mapping, Optional, Protocol, Sequence, TypedDict
+from typing import Collection, Literal, Mapping, Optional, Protocol, Sequence
+
+from typing_extensions import TypedDict
 
 from sentry.snuba.dataset import EntityKey
 

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -1,7 +1,9 @@
 import re
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional, Sequence, TypedDict
+from typing import Any, Callable, Dict, Optional, Sequence
 from urllib.parse import urlparse
+
+from typing_extensions import TypedDict
 
 from sentry.spans.grouping.utils import Hash, parse_fingerprint_var
 


### PR DESCRIPTION
The API docs tests only work with the `typing_extensions` version. Otherwise CI fails with the message:
```
drf_spectacular.plumbing.UnableToProceedError: Wrong TypedDict class, please use typing_extensions.TypedDict
```
The only difference I can see is that the `typing_extensions` version has optional/required keys features:
```py
>>> import typing
>>> import typing_extensions
>>> set(dir(typing_extensions.TypedDict)).difference(set(dir(typing.TypedDict)))
{'__required_keys__', '__optional_keys__'}
```

This PR swaps out the versions. This might be overkill in some cases but I think it'd be a good idea to at least do globally in `/src/sentry/api/`.
