### PR TITLE
fix(prettier): Fix jsxBracketSameLine warning

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 module.exports = {
   bracketSpacing: false,
-  jsxBracketSameLine: false,
+  bracketSameLine: false,
   printWidth: 90,
   semi: true,
   singleQuote: true,


### PR DESCRIPTION
fyi

> This release renames the jsxBracketSameLine option to bracketSameLine, which supports HTML, Vue, and Angular in addition to JSX. The old name has been deprecated.

from https://prettier.io/blog/2021/09/09/2.4.0.html