### PR TITLE
ref(frontend): improve type for PlatformIntegration

### DIFF
--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -22,7 +22,7 @@ export default ([] as PlatformIntegration[]).concat(
   [],
   ...[...platforms.platforms, otherPlatform].map(platform =>
     platform.integrations
-      .map(i => ({...i, language: platform.id}))
+      .map(i => ({...i, language: platform.id} as PlatformIntegration))
       // filter out any tracing platforms; as they're not meant to be used as a platform for
       // the project creation flow
       .filter(integration => !(tracing as readonly string[]).includes(integration.id))

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -110,7 +110,7 @@ export type Environment = {
 export type TeamWithProjects = Team & {projects: Project[]};
 
 export type PlatformIntegration = {
-  id: string;
+  id: PlatformKey;
   language: string;
   link: string | null;
   name: string;


### PR DESCRIPTION
We do a lot of typecasting of the id to `PlatformKey` so this will mean we won't have to anymore