### PR TITLE
feat(metrics): Adds `session.errored_user` to derived metrics [INGEST-930 INGEST-1000]

### DIFF
--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -83,6 +83,12 @@ def abnormal_users(metric_ids, alias=None):
     )
 
 
+def errored_all_users(metric_ids, alias=None):
+    return _set_uniq_aggregation_on_session_status_factory(
+        session_status="errored", metric_ids=metric_ids, alias=alias
+    )
+
+
 def sessions_errored_set(metric_ids, alias=None):
     return Function(
         "uniqIf",
@@ -102,3 +108,11 @@ def sessions_errored_set(metric_ids, alias=None):
 
 def percentage(arg1_snql, arg2_snql, alias=None):
     return Function("minus", [1, Function("divide", [arg1_snql, arg2_snql])], alias)
+
+
+def subtraction(arg1_snql, arg2_snql, alias=None):
+    return Function("minus", [arg1_snql, arg2_snql], alias)
+
+
+def addition(arg1_snql, arg2_snql, alias=None):
+    return Function("plus", [arg1_snql, arg2_snql], alias)

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -99,12 +99,30 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
                 "unit": "percentage",
             },
             {"name": "session.crashed", "type": "numeric", "operations": [], "unit": "sessions"},
+            {
+                "name": "session.crashed_and_abnormal_user",
+                "operations": [],
+                "type": "numeric",
+                "unit": "users",
+            },
             {"name": "session.crashed_user", "type": "numeric", "operations": [], "unit": "users"},
             {
                 "name": "session.errored_preaggregated",
                 "type": "numeric",
                 "operations": [],
                 "unit": "sessions",
+            },
+            {
+                "name": "session.errored_user",
+                "type": "numeric",
+                "operations": [],
+                "unit": "users",
+            },
+            {
+                "name": "session.errored_user_all",
+                "type": "numeric",
+                "operations": [],
+                "unit": "users",
             },
         ]
 

--- a/tests/sentry/snuba/metrics/test_fields.py
+++ b/tests/sentry/snuba/metrics/test_fields.py
@@ -18,13 +18,16 @@ from sentry.snuba.metrics.fields.base import CompositeEntityDerivedMetric
 from sentry.snuba.metrics.fields.snql import (
     abnormal_sessions,
     abnormal_users,
+    addition,
     all_sessions,
     all_users,
     crashed_sessions,
     crashed_users,
+    errored_all_users,
     errored_preaggr_sessions,
     percentage,
     sessions_errored_set,
+    subtraction,
 )
 from sentry.testutils import TestCase
 
@@ -85,6 +88,9 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             "session.crash_free_user_rate": "metrics_sets",
             "session.errored_preaggregated": "metrics_counters",
             "session.errored_set": "metrics_sets",
+            "session.errored_user_all": "metrics_sets",
+            "session.crashed_and_abnormal_user": "metrics_sets",
+            "session.errored_user": "metrics_sets",
         }
         for key, value in expected_derived_metrics_entities.items():
             assert (MOCKED_DERIVED_METRICS[key].get_entity(projects=[self.project])) == value
@@ -119,11 +125,35 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             "session.all_user": (all_users, session_user_ids),
             "session.crashed_user": (crashed_users, session_user_ids),
             "session.abnormal_user": (abnormal_users, session_user_ids),
+            "session.errored_user_all": (errored_all_users, session_user_ids),
         }
         for metric_name, (func, metric_ids_list) in derived_name_snql.items():
             assert DERIVED_METRICS[metric_name].generate_select_statements([self.project]) == [
                 func(metric_ids=metric_ids_list, alias=metric_name),
             ]
+
+        assert MOCKED_DERIVED_METRICS[
+            "session.crashed_and_abnormal_user"
+        ].generate_select_statements([self.project]) == [
+            addition(
+                crashed_users(session_user_ids, alias="session.crashed_user"),
+                abnormal_users(session_user_ids, alias="session.abnormal_user"),
+                alias="session.crashed_and_abnormal_user",
+            )
+        ]
+        assert MOCKED_DERIVED_METRICS["session.errored_user"].generate_select_statements(
+            [self.project]
+        ) == [
+            subtraction(
+                errored_all_users(session_user_ids, alias="session.errored_user_all"),
+                addition(
+                    crashed_users(session_user_ids, alias="session.crashed_user"),
+                    abnormal_users(session_user_ids, alias="session.abnormal_user"),
+                    alias="session.crashed_and_abnormal_user",
+                ),
+                alias="session.errored_user",
+            )
+        ]
 
         assert MOCKED_DERIVED_METRICS["session.crash_free_rate"].generate_select_statements(
             [self.project]
@@ -173,6 +203,9 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             "session.crashed_user",
             "session.abnormal_user",
             "session.crash_free_user_rate",
+            "session.crashed_and_abnormal_user",
+            "session.errored_user_all",
+            "session.errored_user",
         ]:
             assert MOCKED_DERIVED_METRICS[derived_metric_name].generate_metric_ids() == {
                 session_user_id
@@ -214,6 +247,9 @@ class SingleEntityDerivedMetricTestCase(TestCase):
             "session.abnormal_user",
             "session.errored_set",
             "session.errored_preaggregated",
+            "session.errored_user",
+            "session.errored_user_all",
+            "session.crashed_and_abnormal_user",
         ]:
             assert MOCKED_DERIVED_METRICS[derived_metric_name].generate_default_null_values() == 0
 


### PR DESCRIPTION
Adds `session.errored_user`, and its components
`session.errored_user_all` and
`session.crashed_and_abnormal_user` to list
of derived metrics. Also, adds instances
of SingularEntityDerivedMetric to
bottom up dependency tree so we are able to run
post query functions on them