### PR TITLE
fix(ui): Do not show marklines on clamped/ancient releases [INGEST-898]

### DIFF
--- a/static/app/views/releases/detail/utils.tsx
+++ b/static/app/views/releases/detail/utils.tsx
@@ -208,9 +208,10 @@ export function generateReleaseMarkLines(
   const markLines: Series[] = [];
   const adoptionStages = release.adoptionStages?.[project.slug];
   const isSingleEnv = decodeList(location.query.environment).length === 1;
+  const releaseBounds = getReleaseBounds(release);
   const {statsPeriod, ...releaseParamsRest} = getReleaseParams({
     location,
-    releaseBounds: getReleaseBounds(release),
+    releaseBounds,
   });
   let {start, end} = releaseParamsRest;
   const isDefaultPeriod = !(
@@ -226,7 +227,10 @@ export function generateReleaseMarkLines(
   }
 
   const releaseCreated = moment(release.dateCreated).startOf('minute');
-  if (releaseCreated.isBetween(start, end) || isDefaultPeriod) {
+  if (
+    releaseCreated.isBetween(start, end) ||
+    (isDefaultPeriod && releaseBounds.type === 'normal')
+  ) {
     markLines.push(
       generateReleaseMarkLine(
         releaseMarkLinesLabels.created,

--- a/tests/js/spec/views/releases/detail/utils.spec.tsx
+++ b/tests/js/spec/views/releases/detail/utils.spec.tsx
@@ -87,5 +87,16 @@ describe('releases/detail/utils', () => {
 
       expect(marklines.map(markline => markline.seriesName)).toEqual([adopted]);
     });
+
+    it('does not generate out-of-bounds marklines on ancient/clamped releases', () => {
+      const marklines = generateReleaseMarkLines(
+        {...release, dateCreated: '2010-03-24T01:00:30Z'},
+        project,
+        lightTheme,
+        router.location
+      );
+
+      expect(marklines).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
Relates to: https://github.com/getsentry/sentry/pull/32769

We do not want to display "Release Created" mark lines on the charts of ancient/clamped releases.
![image](https://user-images.githubusercontent.com/9060071/159930077-44bd5855-d348-4065-9f56-3a765b504f43.png)
