### PR TITLE
fix(test): Reduce number of nested orphan transactions in test

### DIFF
--- a/tests/acceptance/test_performance_trace_detail.py
+++ b/tests/acceptance/test_performance_trace_detail.py
@@ -81,7 +81,7 @@ class PerformanceTraceDetailTest(AcceptanceTestCase, SnubaTestCase):
         # a chain of transactions that are orphans
         self.task_transactions = []
         last_transaction_id = make_span_id()
-        for i in range(5):
+        for i in range(3):
             transaction_id = make_span_id()
             timestamp = self.day_ago + timedelta(seconds=i, microseconds=30000)
             self.create_error(


### PR DESCRIPTION
This PR aims to fix the flakiness of a visual snapshot test. The test modified in this PR flakes often, potentially due to an issue with ingestion, which causes some transactions in the orphan chain to not be nested correctly. This is only a potential fix, and we'll need to continue monitoring this test to see if it still flakes in the future.

### How the data is supposed to look
![image](https://user-images.githubusercontent.com/16740047/159969616-be658018-8d5e-4e65-b14e-8bcabd5c117c.png)

### What it looks like when it flakes
![image](https://user-images.githubusercontent.com/16740047/159969709-26c74ee9-880d-4192-a3d1-70b6067e2ab8.png)
