### PR TITLE
fix(span-tree): Autogrouped sibling spans bugs

### DIFF
--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -523,7 +523,6 @@ class ActualMinimap extends React.PureComponent<{
       switch (payload.type) {
         case 'root_span':
         case 'span':
-        case 'span_group_sibling':
         case 'span_group_chain': {
           const {span} = payload;
 
@@ -539,14 +538,39 @@ class ActualMinimap extends React.PureComponent<{
             <MinimapSpanBar
               style={{
                 backgroundColor:
-                  payload.type === 'span_group_chain' ||
-                  payload.type === 'span_group_sibling'
-                    ? theme.blue300
-                    : spanBarColor,
+                  payload.type === 'span_group_chain' ? theme.blue300 : spanBarColor,
                 left: spanLeft,
                 width: spanWidth,
               }}
             />
+          );
+        }
+        case 'span_group_sibling': {
+          const {spanSiblingGrouping} = payload;
+
+          return (
+            <MinimapSiblingGroupBar>
+              {spanSiblingGrouping?.map(({span}, index) => {
+                const bounds = generateBounds({
+                  startTimestamp: span.start_timestamp,
+                  endTimestamp: span.timestamp,
+                });
+                const {left: spanLeft, width: spanWidth} = this.getBounds(bounds);
+
+                return (
+                  <MinimapSpanBar
+                    style={{
+                      backgroundColor: theme.blue300,
+                      left: spanLeft,
+                      width: spanWidth,
+                      minWidth: 0,
+                      position: 'absolute',
+                    }}
+                    key={index}
+                  />
+                );
+              })}
+            </MinimapSiblingGroupBar>
           );
         }
         default: {
@@ -767,6 +791,15 @@ const MinimapSpanBar = styled('div')`
   min-width: 1px;
   border-radius: 1px;
   box-sizing: border-box;
+`;
+
+const MinimapSiblingGroupBar = styled('div')`
+  display: flex;
+  position: relative;
+  height: 2px;
+  min-height: 2px;
+  max-height: 2px;
+  top: -2px;
 `;
 
 const BackgroundSlider = styled('div')`

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -523,6 +523,7 @@ class ActualMinimap extends React.PureComponent<{
       switch (payload.type) {
         case 'root_span':
         case 'span':
+        case 'span_group_sibling':
         case 'span_group_chain': {
           const {span} = payload;
 
@@ -538,7 +539,10 @@ class ActualMinimap extends React.PureComponent<{
             <MinimapSpanBar
               style={{
                 backgroundColor:
-                  payload.type === 'span_group_chain' ? theme.blue300 : spanBarColor,
+                  payload.type === 'span_group_chain' ||
+                  payload.type === 'span_group_sibling'
+                    ? theme.blue300
+                    : spanBarColor,
                 left: spanLeft,
                 width: spanWidth,
               }}

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -545,7 +545,7 @@ class ActualMinimap extends React.PureComponent<{
             />
           );
         }
-        case 'span_group_sibling': {
+        case 'span_group_siblings': {
           const {spanSiblingGrouping} = payload;
 
           return (

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -61,10 +61,10 @@ import * as DividerHandlerManager from './dividerHandlerManager';
 import * as ScrollbarManager from './scrollbarManager';
 import SpanBarCursorGuide from './spanBarCursorGuide';
 import SpanDetail from './spanDetail';
-import {GroupType} from './spanGroupBar';
 import {MeasurementMarker} from './styles';
 import {
   FetchEmbeddedChildrenState,
+  GroupType,
   ParsedTraceType,
   ProcessedSpanType,
   SpanType,

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -44,12 +44,13 @@ import {EnhancedSpan, ProcessedSpanType, SpanType, TreeDepthType} from './types'
 import {
   getMeasurementBounds,
   getMeasurements,
+  getSpanGroupBounds,
+  getSpanGroupTimestamps,
   getSpanOperation,
   isOrphanSpan,
   isOrphanTreeDepth,
   SpanBoundsType,
   SpanGeneratedBoundsType,
-  SpanViewBoundsType,
   unwrapTreeDepth,
 } from './utils';
 
@@ -73,79 +74,6 @@ type Props = {
   treeDepth: number;
   toggleSiblingSpanGroup?: (span: SpanType) => void;
 };
-
-function getSpanGroupTimestamps(spanGroup: EnhancedSpan[]) {
-  return spanGroup.reduce(
-    (acc, spanGroupItem) => {
-      const {start_timestamp, timestamp} = spanGroupItem.span;
-
-      let newStartTimestamp = acc.startTimestamp;
-      let newEndTimestamp = acc.endTimestamp;
-
-      if (start_timestamp < newStartTimestamp) {
-        newStartTimestamp = start_timestamp;
-      }
-
-      if (newEndTimestamp < timestamp) {
-        newEndTimestamp = timestamp;
-      }
-
-      return {
-        startTimestamp: newStartTimestamp,
-        endTimestamp: newEndTimestamp,
-      };
-    },
-    {
-      startTimestamp: spanGroup[0].span.start_timestamp,
-      endTimestamp: spanGroup[0].span.timestamp,
-    }
-  );
-}
-
-function getSpanGroupBounds(
-  spanGroup: EnhancedSpan[],
-  generateBounds: Props['generateBounds']
-): SpanViewBoundsType {
-  const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGroup);
-
-  const bounds = generateBounds({
-    startTimestamp,
-    endTimestamp,
-  });
-
-  switch (bounds.type) {
-    case 'TRACE_TIMESTAMPS_EQUAL':
-    case 'INVALID_VIEW_WINDOW': {
-      return {
-        warning: void 0,
-        left: void 0,
-        width: void 0,
-        isSpanVisibleInView: bounds.isSpanVisibleInView,
-      };
-    }
-    case 'TIMESTAMPS_EQUAL': {
-      return {
-        warning: void 0,
-        left: bounds.start,
-        width: 0.00001,
-        isSpanVisibleInView: bounds.isSpanVisibleInView,
-      };
-    }
-    case 'TIMESTAMPS_REVERSED':
-    case 'TIMESTAMPS_STABLE': {
-      return {
-        warning: void 0,
-        left: bounds.start,
-        width: bounds.end - bounds.start,
-        isSpanVisibleInView: bounds.isSpanVisibleInView,
-      };
-    }
-    default: {
-      const _exhaustiveCheck: never = bounds;
-      return _exhaustiveCheck;
-    }
-  }
-}
 
 class SpanGroupBar extends React.Component<Props> {
   renderGroupedSpansToggler() {

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -44,12 +44,13 @@ import {EnhancedSpan, ProcessedSpanType, TreeDepthType} from './types';
 import {
   getMeasurementBounds,
   getMeasurements,
+  getSpanGroupBounds,
+  getSpanGroupTimestamps,
   getSpanOperation,
   isOrphanSpan,
   isOrphanTreeDepth,
   SpanBoundsType,
   SpanGeneratedBoundsType,
-  SpanViewBoundsType,
   unwrapTreeDepth,
 } from './utils';
 
@@ -67,78 +68,6 @@ type Props = {
 };
 
 class SpanGroupBar extends React.Component<Props> {
-  getSpanGroupTimestamps(spanGroup: EnhancedSpan[]) {
-    return spanGroup.reduce(
-      (acc, spanGroupItem) => {
-        const {start_timestamp, timestamp} = spanGroupItem.span;
-
-        let newStartTimestamp = acc.startTimestamp;
-        let newEndTimestamp = acc.endTimestamp;
-
-        if (start_timestamp < newStartTimestamp) {
-          newStartTimestamp = start_timestamp;
-        }
-
-        if (newEndTimestamp < timestamp) {
-          newEndTimestamp = timestamp;
-        }
-
-        return {
-          startTimestamp: newStartTimestamp,
-          endTimestamp: newEndTimestamp,
-        };
-      },
-      {
-        startTimestamp: spanGroup[0].span.start_timestamp,
-        endTimestamp: spanGroup[0].span.timestamp,
-      }
-    );
-  }
-
-  getSpanGroupBounds(spanGroup: EnhancedSpan[]): SpanViewBoundsType {
-    const {generateBounds} = this.props;
-
-    const {startTimestamp, endTimestamp} = this.getSpanGroupTimestamps(spanGroup);
-
-    const bounds = generateBounds({
-      startTimestamp,
-      endTimestamp,
-    });
-
-    switch (bounds.type) {
-      case 'TRACE_TIMESTAMPS_EQUAL':
-      case 'INVALID_VIEW_WINDOW': {
-        return {
-          warning: void 0,
-          left: void 0,
-          width: void 0,
-          isSpanVisibleInView: bounds.isSpanVisibleInView,
-        };
-      }
-      case 'TIMESTAMPS_EQUAL': {
-        return {
-          warning: void 0,
-          left: bounds.start,
-          width: 0.00001,
-          isSpanVisibleInView: bounds.isSpanVisibleInView,
-        };
-      }
-      case 'TIMESTAMPS_REVERSED':
-      case 'TIMESTAMPS_STABLE': {
-        return {
-          warning: void 0,
-          left: bounds.start,
-          width: bounds.end - bounds.start,
-          isSpanVisibleInView: bounds.isSpanVisibleInView,
-        };
-      }
-      default: {
-        const _exhaustiveCheck: never = bounds;
-        return _exhaustiveCheck;
-      }
-    }
-  }
-
   renderGroupedSpansToggler() {
     const {spanGrouping, treeDepth, toggleSpanGroup} = this.props;
 
@@ -154,7 +83,6 @@ class SpanGroupBar extends React.Component<Props> {
           isSpanGroupToggler
           onClick={event => {
             event.stopPropagation();
-
             toggleSpanGroup();
           }}
         >
@@ -321,10 +249,9 @@ class SpanGroupBar extends React.Component<Props> {
               const {generateContentSpanBarRef} = scrollbarManagerChildrenProps;
               const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
 
-              const bounds = this.getSpanGroupBounds(spanGrouping);
+              const bounds = getSpanGroupBounds(spanGrouping, generateBounds);
               const durationDisplay = getDurationDisplay(bounds);
-              const {startTimestamp, endTimestamp} =
-                this.getSpanGroupTimestamps(spanGrouping);
+              const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
               const duration = Math.abs(endTimestamp - startTimestamp);
               const durationString = getHumanDuration(duration);
 

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -40,24 +40,18 @@ import * as DividerHandlerManager from './dividerHandlerManager';
 import * as ScrollbarManager from './scrollbarManager';
 import SpanBarCursorGuide from './spanBarCursorGuide';
 import {MeasurementMarker} from './styles';
-import {EnhancedSpan, ProcessedSpanType, SpanType, TreeDepthType} from './types';
+import {EnhancedSpan, ProcessedSpanType, TreeDepthType} from './types';
 import {
   getMeasurementBounds,
   getMeasurements,
-  getSpanGroupBounds,
-  getSpanGroupTimestamps,
   getSpanOperation,
   isOrphanSpan,
   isOrphanTreeDepth,
   SpanBoundsType,
   SpanGeneratedBoundsType,
+  SpanViewBoundsType,
   unwrapTreeDepth,
 } from './utils';
-
-export enum GroupType {
-  DESCENDANTS,
-  SIBLINGS,
-}
 
 const MARGIN_LEFT = 0;
 
@@ -65,20 +59,88 @@ type Props = {
   continuingTreeDepths: Array<TreeDepthType>;
   event: Readonly<EventTransaction>;
   generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
-  groupType: GroupType;
-  isLastSibling: boolean;
   span: Readonly<ProcessedSpanType>;
   spanGrouping: EnhancedSpan[];
   spanNumber: number;
   toggleSpanGroup: () => void;
   treeDepth: number;
-  toggleSiblingSpanGroup?: (span: SpanType) => void;
 };
 
 class SpanGroupBar extends React.Component<Props> {
+  getSpanGroupTimestamps(spanGroup: EnhancedSpan[]) {
+    return spanGroup.reduce(
+      (acc, spanGroupItem) => {
+        const {start_timestamp, timestamp} = spanGroupItem.span;
+
+        let newStartTimestamp = acc.startTimestamp;
+        let newEndTimestamp = acc.endTimestamp;
+
+        if (start_timestamp < newStartTimestamp) {
+          newStartTimestamp = start_timestamp;
+        }
+
+        if (newEndTimestamp < timestamp) {
+          newEndTimestamp = timestamp;
+        }
+
+        return {
+          startTimestamp: newStartTimestamp,
+          endTimestamp: newEndTimestamp,
+        };
+      },
+      {
+        startTimestamp: spanGroup[0].span.start_timestamp,
+        endTimestamp: spanGroup[0].span.timestamp,
+      }
+    );
+  }
+
+  getSpanGroupBounds(spanGroup: EnhancedSpan[]): SpanViewBoundsType {
+    const {generateBounds} = this.props;
+
+    const {startTimestamp, endTimestamp} = this.getSpanGroupTimestamps(spanGroup);
+
+    const bounds = generateBounds({
+      startTimestamp,
+      endTimestamp,
+    });
+
+    switch (bounds.type) {
+      case 'TRACE_TIMESTAMPS_EQUAL':
+      case 'INVALID_VIEW_WINDOW': {
+        return {
+          warning: void 0,
+          left: void 0,
+          width: void 0,
+          isSpanVisibleInView: bounds.isSpanVisibleInView,
+        };
+      }
+      case 'TIMESTAMPS_EQUAL': {
+        return {
+          warning: void 0,
+          left: bounds.start,
+          width: 0.00001,
+          isSpanVisibleInView: bounds.isSpanVisibleInView,
+        };
+      }
+      case 'TIMESTAMPS_REVERSED':
+      case 'TIMESTAMPS_STABLE': {
+        return {
+          warning: void 0,
+          left: bounds.start,
+          width: bounds.end - bounds.start,
+          isSpanVisibleInView: bounds.isSpanVisibleInView,
+        };
+      }
+      default: {
+        const _exhaustiveCheck: never = bounds;
+        return _exhaustiveCheck;
+      }
+    }
+  }
+
   renderGroupedSpansToggler() {
-    const {spanGrouping, treeDepth, toggleSpanGroup, toggleSiblingSpanGroup, groupType} =
-      this.props;
+    const {spanGrouping, treeDepth, toggleSpanGroup} = this.props;
 
     const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
 
@@ -92,9 +154,8 @@ class SpanGroupBar extends React.Component<Props> {
           isSpanGroupToggler
           onClick={event => {
             event.stopPropagation();
-            groupType === GroupType.DESCENDANTS
-              ? toggleSpanGroup()
-              : toggleSiblingSpanGroup?.(spanGrouping[0].span);
+
+            toggleSpanGroup();
           }}
         >
           <Count value={spanGrouping.length} />
@@ -161,13 +222,7 @@ class SpanGroupBar extends React.Component<Props> {
   }
 
   renderSpanTreeConnector() {
-    const {
-      treeDepth: spanTreeDepth,
-      continuingTreeDepths,
-      span,
-      groupType,
-      isLastSibling,
-    } = this.props;
+    const {treeDepth: spanTreeDepth, continuingTreeDepths, span} = this.props;
 
     const connectorBars: Array<React.ReactNode> = continuingTreeDepths.map(treeDepth => {
       const depth: number = unwrapTreeDepth(treeDepth);
@@ -189,39 +244,21 @@ class SpanGroupBar extends React.Component<Props> {
       );
     });
 
-    if (groupType === GroupType.DESCENDANTS) {
-      connectorBars.push(
-        <ConnectorBar
-          style={{
-            right: '15px',
-            height: `${ROW_HEIGHT / 2}px`,
-            bottom: `-${ROW_HEIGHT / 2 + 1}px`,
-            top: 'auto',
-          }}
-          key="collapsed-span-group-row-bottom"
-          orphanBranch={false}
-        />
-      );
-    } else if (groupType === GroupType.SIBLINGS && !isLastSibling) {
-      const depth: number = unwrapTreeDepth(spanTreeDepth - 1);
-      const left = ((spanTreeDepth - depth) * (TOGGLE_BORDER_BOX / 2) + 2) * -1;
-      connectorBars.push(
-        <ConnectorBar
-          style={{
-            left,
-          }}
-          key={`${span.description}-${depth}`}
-          orphanBranch={false}
-        />
-      );
-    }
+    connectorBars.push(
+      <ConnectorBar
+        style={{
+          right: '15px',
+          height: `${ROW_HEIGHT / 2}px`,
+          bottom: `-${ROW_HEIGHT / 2 + 1}px`,
+          top: 'auto',
+        }}
+        key="collapsed-span-group-row-bottom"
+        orphanBranch={false}
+      />
+    );
 
     return (
-      <TreeConnector
-        isLast={groupType === GroupType.DESCENDANTS || isLastSibling}
-        hasToggler
-        orphanBranch={isOrphanSpan(span)}
-      >
+      <TreeConnector isLast hasToggler orphanBranch={isOrphanSpan(span)}>
         {connectorBars}
       </TreeConnector>
     );
@@ -272,8 +309,6 @@ class SpanGroupBar extends React.Component<Props> {
                 spanGrouping,
                 toggleSpanGroup,
                 spanNumber,
-                toggleSiblingSpanGroup,
-                groupType,
               } = this.props;
 
               const {isSpanVisibleInView: isSpanVisible} = generateBounds({
@@ -285,6 +320,13 @@ class SpanGroupBar extends React.Component<Props> {
                 dividerHandlerChildrenProps;
               const {generateContentSpanBarRef} = scrollbarManagerChildrenProps;
               const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
+
+              const bounds = this.getSpanGroupBounds(spanGrouping);
+              const durationDisplay = getDurationDisplay(bounds);
+              const {startTimestamp, endTimestamp} =
+                this.getSpanGroupTimestamps(spanGrouping);
+              const duration = Math.abs(endTimestamp - startTimestamp);
+              const durationString = getHumanDuration(duration);
 
               return (
                 <Row
@@ -300,11 +342,7 @@ class SpanGroupBar extends React.Component<Props> {
                         paddingTop: 0,
                       }}
                       onClick={() => {
-                        if (groupType === GroupType.DESCENDANTS) {
-                          toggleSpanGroup();
-                        } else if (groupType === GroupType.SIBLINGS) {
-                          toggleSiblingSpanGroup?.(spanGrouping[0].span);
-                        }
+                        toggleSpanGroup();
                       }}
                     >
                       <RowTitleContainer ref={generateContentSpanBarRef()}>
@@ -331,30 +369,25 @@ class SpanGroupBar extends React.Component<Props> {
                         width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
                       }}
                       onClick={() => {
-                        if (groupType === GroupType.DESCENDANTS) {
-                          toggleSpanGroup();
-                        } else if (groupType === GroupType.SIBLINGS) {
-                          toggleSiblingSpanGroup?.(spanGrouping[0].span);
-                        }
+                        toggleSpanGroup();
                       }}
                     >
-                      {groupType === GroupType.DESCENDANTS ? (
-                        <SpanRectangle
-                          spanGrouping={spanGrouping}
-                          generateBounds={generateBounds}
-                        />
-                      ) : (
-                        <React.Fragment>
-                          {spanGrouping.map((_, index) => (
-                            <SpanRectangle
-                              key={index}
-                              spanGrouping={spanGrouping}
-                              index={index}
-                              generateBounds={generateBounds}
-                            />
-                          ))}{' '}
-                        </React.Fragment>
-                      )}
+                      <RowRectangle
+                        spanBarHatch={false}
+                        style={{
+                          backgroundColor: theme.blue300,
+                          left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+                          width: toPercent(bounds.width || 0),
+                        }}
+                      >
+                        <DurationPill
+                          durationDisplay={durationDisplay}
+                          showDetail={false}
+                          spanBarHatch={false}
+                        >
+                          {durationString}
+                        </DurationPill>
+                      </RowRectangle>
                       {this.renderMeasurements()}
                       <SpanBarCursorGuide />
                     </RowCell>
@@ -387,87 +420,6 @@ class SpanGroupBar extends React.Component<Props> {
       </ScrollbarManager.Consumer>
     );
   }
-}
-
-function SpanRectangle({
-  spanGrouping,
-  index,
-  generateBounds,
-}: {
-  generateBounds: Props['generateBounds'];
-  spanGrouping: EnhancedSpan[];
-  index?: number;
-}) {
-  // If an index is provided, we treat this as an individual block for a single span in the grouping
-  if (index !== undefined) {
-    const grouping = [spanGrouping[index]];
-    const bounds = getSpanGroupBounds(grouping, generateBounds);
-
-    // If this is not the last span in the grouping, the duration does not need to be rendered
-    if (index !== spanGrouping.length - 1) {
-      return (
-        <RowRectangle
-          spanBarHatch={false}
-          style={{
-            backgroundColor: theme.blue300,
-            left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
-            width: toPercent(bounds.width || 0),
-          }}
-        />
-      );
-    }
-
-    const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
-    const duration = Math.abs(endTimestamp - startTimestamp);
-    const durationDisplay = getDurationDisplay(bounds);
-    const durationString = getHumanDuration(duration);
-
-    return (
-      <RowRectangle
-        spanBarHatch={false}
-        style={{
-          backgroundColor: theme.blue300,
-          left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
-          width: toPercent(bounds.width || 0),
-        }}
-      >
-        {index === spanGrouping.length - 1 && (
-          <DurationPill
-            durationDisplay={durationDisplay}
-            showDetail={false}
-            spanBarHatch={false}
-          >
-            {durationString}
-          </DurationPill>
-        )}
-      </RowRectangle>
-    );
-  }
-  const bounds = getSpanGroupBounds(spanGrouping, generateBounds);
-  const durationDisplay = getDurationDisplay(bounds);
-  const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
-  const duration = Math.abs(endTimestamp - startTimestamp);
-  const durationString = getHumanDuration(duration);
-  return (
-    <RowRectangle
-      spanBarHatch={false}
-      style={{
-        backgroundColor: theme.blue300,
-        left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
-        width: toPercent(bounds.width || 0),
-      }}
-    >
-      {
-        <DurationPill
-          durationDisplay={durationDisplay}
-          showDetail={false}
-          spanBarHatch={false}
-        >
-          {durationString}
-        </DurationPill>
-      }
-    </RowRectangle>
-  );
 }
 
 export default SpanGroupBar;

--- a/static/app/components/events/interfaces/spans/spanRectangle.tsx
+++ b/static/app/components/events/interfaces/spans/spanRectangle.tsx
@@ -1,48 +1,16 @@
-import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
-import {
-  getDurationDisplay,
-  getHumanDuration,
-  toPercent,
-} from 'sentry/components/performance/waterfall/utils';
+import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
+import {toPercent} from 'sentry/components/performance/waterfall/utils';
 import theme from 'sentry/utils/theme';
 
 import {EnhancedSpan} from './types';
-import {getSpanGroupTimestamps, SpanViewBoundsType} from './utils';
+import {SpanViewBoundsType} from './utils';
 
 export default function SpanRectangle({
-  spanGrouping,
   bounds,
-  isOverlayRectangle,
 }: {
   bounds: SpanViewBoundsType;
   spanGrouping: EnhancedSpan[];
-  isOverlayRectangle?: boolean;
 }) {
-  if (isOverlayRectangle) {
-    const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
-    const duration = Math.abs(endTimestamp - startTimestamp);
-    const durationDisplay = getDurationDisplay(bounds);
-    const durationString = getHumanDuration(duration);
-
-    return (
-      <RowRectangle
-        spanBarHatch={false}
-        style={{
-          left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
-          width: toPercent(bounds.width || 0),
-        }}
-      >
-        <DurationPill
-          durationDisplay={durationDisplay}
-          showDetail={false}
-          spanBarHatch={false}
-        >
-          {durationString}
-        </DurationPill>
-      </RowRectangle>
-    );
-  }
-
   return (
     <RowRectangle
       spanBarHatch={false}

--- a/static/app/components/events/interfaces/spans/spanRectangle.tsx
+++ b/static/app/components/events/interfaces/spans/spanRectangle.tsx
@@ -7,43 +7,41 @@ import {
 import theme from 'sentry/utils/theme';
 
 import {EnhancedSpan} from './types';
-import {
-  getSpanGroupBounds,
-  getSpanGroupTimestamps,
-  SpanBoundsType,
-  SpanGeneratedBoundsType,
-} from './utils';
+import {getSpanGroupTimestamps, SpanViewBoundsType} from './utils';
 
 export default function SpanRectangle({
   spanGrouping,
-  index,
-  generateBounds,
+  bounds,
+  isOverlayRectangle,
 }: {
-  generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
-  index: number;
+  bounds: SpanViewBoundsType;
   spanGrouping: EnhancedSpan[];
+  isOverlayRectangle?: boolean;
 }) {
-  const grouping = [spanGrouping[index]];
-  const bounds = getSpanGroupBounds(grouping, generateBounds);
+  if (isOverlayRectangle) {
+    const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
+    const duration = Math.abs(endTimestamp - startTimestamp);
+    const durationDisplay = getDurationDisplay(bounds);
+    const durationString = getHumanDuration(duration);
 
-  // If this is not the last span in the grouping, the duration does not need to be rendered
-  if (index !== spanGrouping.length - 1) {
     return (
       <RowRectangle
         spanBarHatch={false}
         style={{
-          backgroundColor: theme.blue300,
           left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
           width: toPercent(bounds.width || 0),
         }}
-      />
+      >
+        <DurationPill
+          durationDisplay={durationDisplay}
+          showDetail={false}
+          spanBarHatch={false}
+        >
+          {durationString}
+        </DurationPill>
+      </RowRectangle>
     );
   }
-
-  const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
-  const duration = Math.abs(endTimestamp - startTimestamp);
-  const durationDisplay = getDurationDisplay(bounds);
-  const durationString = getHumanDuration(duration);
 
   return (
     <RowRectangle
@@ -53,16 +51,6 @@ export default function SpanRectangle({
         left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
         width: toPercent(bounds.width || 0),
       }}
-    >
-      {index === spanGrouping.length - 1 && (
-        <DurationPill
-          durationDisplay={durationDisplay}
-          showDetail={false}
-          spanBarHatch={false}
-        >
-          {durationString}
-        </DurationPill>
-      )}
-    </RowRectangle>
+    />
   );
 }

--- a/static/app/components/events/interfaces/spans/spanRectangle.tsx
+++ b/static/app/components/events/interfaces/spans/spanRectangle.tsx
@@ -1,0 +1,96 @@
+import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
+import {
+  getDurationDisplay,
+  getHumanDuration,
+  toPercent,
+} from 'sentry/components/performance/waterfall/utils';
+import theme from 'sentry/utils/theme';
+
+import {EnhancedSpan} from './types';
+import {
+  getSpanGroupBounds,
+  getSpanGroupTimestamps,
+  SpanBoundsType,
+  SpanGeneratedBoundsType,
+} from './utils';
+
+export default function SpanRectangle({
+  spanGrouping,
+  index,
+  generateBounds,
+}: {
+  generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
+  index: number;
+  spanGrouping: EnhancedSpan[];
+}) {
+  // If an index is provided, we treat this as an individual block for a single span in the grouping
+  if (index !== undefined) {
+    const grouping = [spanGrouping[index]];
+    const bounds = getSpanGroupBounds(grouping, generateBounds);
+
+    // If this is not the last span in the grouping, the duration does not need to be rendered
+    if (index !== spanGrouping.length - 1) {
+      return (
+        <RowRectangle
+          spanBarHatch={false}
+          style={{
+            backgroundColor: theme.blue300,
+            left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+            width: toPercent(bounds.width || 0),
+          }}
+        />
+      );
+    }
+
+    const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
+    const duration = Math.abs(endTimestamp - startTimestamp);
+    const durationDisplay = getDurationDisplay(bounds);
+    const durationString = getHumanDuration(duration);
+
+    return (
+      <RowRectangle
+        spanBarHatch={false}
+        style={{
+          backgroundColor: theme.blue300,
+          left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+          width: toPercent(bounds.width || 0),
+        }}
+      >
+        {index === spanGrouping.length - 1 && (
+          <DurationPill
+            durationDisplay={durationDisplay}
+            showDetail={false}
+            spanBarHatch={false}
+          >
+            {durationString}
+          </DurationPill>
+        )}
+      </RowRectangle>
+    );
+  }
+  const bounds = getSpanGroupBounds(spanGrouping, generateBounds);
+  const durationDisplay = getDurationDisplay(bounds);
+  const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
+  const duration = Math.abs(endTimestamp - startTimestamp);
+  const durationString = getHumanDuration(duration);
+  return (
+    <RowRectangle
+      spanBarHatch={false}
+      style={{
+        backgroundColor: theme.blue300,
+        left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+        width: toPercent(bounds.width || 0),
+      }}
+    >
+      {
+        <DurationPill
+          durationDisplay={durationDisplay}
+          showDetail={false}
+          spanBarHatch={false}
+        >
+          {durationString}
+        </DurationPill>
+      }
+    </RowRectangle>
+  );
+}

--- a/static/app/components/events/interfaces/spans/spanRectangle.tsx
+++ b/static/app/components/events/interfaces/spans/spanRectangle.tsx
@@ -23,30 +23,11 @@ export default function SpanRectangle({
   index: number;
   spanGrouping: EnhancedSpan[];
 }) {
-  // If an index is provided, we treat this as an individual block for a single span in the grouping
-  if (index !== undefined) {
-    const grouping = [spanGrouping[index]];
-    const bounds = getSpanGroupBounds(grouping, generateBounds);
+  const grouping = [spanGrouping[index]];
+  const bounds = getSpanGroupBounds(grouping, generateBounds);
 
-    // If this is not the last span in the grouping, the duration does not need to be rendered
-    if (index !== spanGrouping.length - 1) {
-      return (
-        <RowRectangle
-          spanBarHatch={false}
-          style={{
-            backgroundColor: theme.blue300,
-            left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
-            width: toPercent(bounds.width || 0),
-          }}
-        />
-      );
-    }
-
-    const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
-    const duration = Math.abs(endTimestamp - startTimestamp);
-    const durationDisplay = getDurationDisplay(bounds);
-    const durationString = getHumanDuration(duration);
-
+  // If this is not the last span in the grouping, the duration does not need to be rendered
+  if (index !== spanGrouping.length - 1) {
     return (
       <RowRectangle
         spanBarHatch={false}
@@ -55,24 +36,15 @@ export default function SpanRectangle({
           left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
           width: toPercent(bounds.width || 0),
         }}
-      >
-        {index === spanGrouping.length - 1 && (
-          <DurationPill
-            durationDisplay={durationDisplay}
-            showDetail={false}
-            spanBarHatch={false}
-          >
-            {durationString}
-          </DurationPill>
-        )}
-      </RowRectangle>
+      />
     );
   }
-  const bounds = getSpanGroupBounds(spanGrouping, generateBounds);
-  const durationDisplay = getDurationDisplay(bounds);
+
   const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
   const duration = Math.abs(endTimestamp - startTimestamp);
+  const durationDisplay = getDurationDisplay(bounds);
   const durationString = getHumanDuration(duration);
+
   return (
     <RowRectangle
       spanBarHatch={false}
@@ -82,7 +54,7 @@ export default function SpanRectangle({
         width: toPercent(bounds.width || 0),
       }}
     >
-      {
+      {index === spanGrouping.length - 1 && (
         <DurationPill
           durationDisplay={durationDisplay}
           showDetail={false}
@@ -90,7 +62,7 @@ export default function SpanRectangle({
         >
           {durationString}
         </DurationPill>
-      }
+      )}
     </RowRectangle>
   );
 }

--- a/static/app/components/events/interfaces/spans/spanRectangleOverlay.tsx
+++ b/static/app/components/events/interfaces/spans/spanRectangleOverlay.tsx
@@ -1,0 +1,40 @@
+import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
+import {
+  getDurationDisplay,
+  getHumanDuration,
+  toPercent,
+} from 'sentry/components/performance/waterfall/utils';
+
+import {EnhancedSpan} from './types';
+import {getSpanGroupTimestamps, SpanViewBoundsType} from './utils';
+
+export function SpanRectangleOverlay({
+  bounds,
+  spanGrouping,
+}: {
+  bounds: SpanViewBoundsType;
+  spanGrouping: EnhancedSpan[];
+}) {
+  const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
+  const duration = Math.abs(endTimestamp - startTimestamp);
+  const durationDisplay = getDurationDisplay(bounds);
+  const durationString = getHumanDuration(duration);
+
+  return (
+    <RowRectangle
+      spanBarHatch={false}
+      style={{
+        left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+        width: toPercent(bounds.width || 0),
+      }}
+    >
+      <DurationPill
+        durationDisplay={durationDisplay}
+        showDetail={false}
+        spanBarHatch={false}
+      >
+        {durationString}
+      </DurationPill>
+    </RowRectangle>
+  );
+}

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -7,7 +7,6 @@ import {
   RowCell,
   RowCellContainer,
 } from 'sentry/components/performance/waterfall/row';
-import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {
   DividerContainer,
   DividerLine,
@@ -25,26 +24,20 @@ import {
   TreeToggle,
   TreeToggleContainer,
 } from 'sentry/components/performance/waterfall/treeConnector';
-import {
-  getDurationDisplay,
-  getHumanDuration,
-  toPercent,
-} from 'sentry/components/performance/waterfall/utils';
+import {toPercent} from 'sentry/components/performance/waterfall/utils';
 import {t} from 'sentry/locale';
 import {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
-import theme from 'sentry/utils/theme';
 
 import * as DividerHandlerManager from './dividerHandlerManager';
 import * as ScrollbarManager from './scrollbarManager';
 import SpanBarCursorGuide from './spanBarCursorGuide';
+import SpanRectangle from './spanRectangle';
 import {MeasurementMarker} from './styles';
 import {EnhancedSpan, ProcessedSpanType, SpanType, TreeDepthType} from './types';
 import {
   getMeasurementBounds,
   getMeasurements,
-  getSpanGroupBounds,
-  getSpanGroupTimestamps,
   getSpanOperation,
   isOrphanSpan,
   isOrphanTreeDepth,
@@ -335,85 +328,4 @@ export default function SpanSiblingGroupBar(props: Props) {
       )}
     </ScrollbarManager.Consumer>
   );
-
-  function SpanRectangle({
-    spanGrouping,
-    index,
-    generateBounds,
-  }: {
-    generateBounds: Props['generateBounds'];
-    spanGrouping: EnhancedSpan[];
-    index?: number;
-  }) {
-    // If an index is provided, we treat this as an individual block for a single span in the grouping
-    if (index !== undefined) {
-      const grouping = [spanGrouping[index]];
-      const bounds = getSpanGroupBounds(grouping, generateBounds);
-
-      // If this is not the last span in the grouping, the duration does not need to be rendered
-      if (index !== spanGrouping.length - 1) {
-        return (
-          <RowRectangle
-            spanBarHatch={false}
-            style={{
-              backgroundColor: theme.blue300,
-              left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
-              width: toPercent(bounds.width || 0),
-            }}
-          />
-        );
-      }
-
-      const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
-      const duration = Math.abs(endTimestamp - startTimestamp);
-      const durationDisplay = getDurationDisplay(bounds);
-      const durationString = getHumanDuration(duration);
-
-      return (
-        <RowRectangle
-          spanBarHatch={false}
-          style={{
-            backgroundColor: theme.blue300,
-            left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
-            width: toPercent(bounds.width || 0),
-          }}
-        >
-          {index === spanGrouping.length - 1 && (
-            <DurationPill
-              durationDisplay={durationDisplay}
-              showDetail={false}
-              spanBarHatch={false}
-            >
-              {durationString}
-            </DurationPill>
-          )}
-        </RowRectangle>
-      );
-    }
-    const bounds = getSpanGroupBounds(spanGrouping, generateBounds);
-    const durationDisplay = getDurationDisplay(bounds);
-    const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
-    const duration = Math.abs(endTimestamp - startTimestamp);
-    const durationString = getHumanDuration(duration);
-    return (
-      <RowRectangle
-        spanBarHatch={false}
-        style={{
-          backgroundColor: theme.blue300,
-          left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
-          width: toPercent(bounds.width || 0),
-        }}
-      >
-        {
-          <DurationPill
-            durationDisplay={durationDisplay}
-            showDetail={false}
-            spanBarHatch={false}
-          >
-            {durationString}
-          </DurationPill>
-        }
-      </RowRectangle>
-    );
-  }
 }

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -37,6 +37,7 @@ import {EnhancedSpan, ProcessedSpanType, SpanType, TreeDepthType} from './types'
 import {
   getMeasurementBounds,
   getMeasurements,
+  getSpanGroupBounds,
   isOrphanSpan,
   isOrphanTreeDepth,
   SpanBoundsType,
@@ -274,18 +275,19 @@ export default function SpanSiblingGroupBar(props: Props) {
                       toggleSiblingSpanGroup?.(spanGrouping[0].span);
                     }}
                   >
-                    {
-                      <React.Fragment>
-                        {spanGrouping.map((_, index) => (
-                          <SpanRectangle
-                            key={index}
-                            spanGrouping={spanGrouping}
-                            index={index}
-                            generateBounds={generateBounds}
-                          />
-                        ))}{' '}
-                      </React.Fragment>
-                    }
+                    {spanGrouping.map((_, index) => (
+                      <SpanRectangle
+                        key={index}
+                        spanGrouping={spanGrouping}
+                        bounds={getSpanGroupBounds([spanGrouping[index]], generateBounds)}
+                      />
+                    ))}
+                    <SpanRectangle
+                      spanGrouping={spanGrouping}
+                      bounds={getSpanGroupBounds(spanGrouping, generateBounds)}
+                      isOverlayRectangle
+                    />
+
                     {renderMeasurements()}
                     <SpanBarCursorGuide />
                   </RowCell>

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import countBy from 'lodash/countBy';
 
 import Count from 'sentry/components/count';
 import {
@@ -38,7 +37,6 @@ import {EnhancedSpan, ProcessedSpanType, SpanType, TreeDepthType} from './types'
 import {
   getMeasurementBounds,
   getMeasurements,
-  getSpanOperation,
   isOrphanSpan,
   isOrphanTreeDepth,
   SpanBoundsType,
@@ -90,25 +88,16 @@ export default function SpanSiblingGroupBar(props: Props) {
       return '';
     }
 
-    const operationCounts = countBy(spanGroup, enhancedSpan =>
-      getSpanOperation(enhancedSpan.span)
-    );
-
-    const hasOthers = Object.keys(operationCounts).length > 1;
-
-    const [mostFrequentOperationName] = Object.entries(operationCounts).reduce(
-      (acc, [operationNameKey, count]) => {
-        if (count > acc[1]) {
-          return [operationNameKey, count];
-        }
-        return acc;
-      }
-    );
+    const operation = spanGroup[0].span.op;
+    const description = spanGroup[0].span.description;
 
     return (
-      <strong>{`${t('Autogrouped ')}\u2014 ${mostFrequentOperationName}${
-        hasOthers ? t(' and more') : ''
-      }`}</strong>
+      <React.Fragment>
+        <strong>{`${t('Autogrouped ')}\u2014 ${operation} ${
+          description && '\u2014 '
+        }`}</strong>
+        {description && `${description}`}
+      </React.Fragment>
     );
   }
 

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -1,0 +1,419 @@
+import * as React from 'react';
+import countBy from 'lodash/countBy';
+
+import Count from 'sentry/components/count';
+import {
+  Row,
+  RowCell,
+  RowCellContainer,
+} from 'sentry/components/performance/waterfall/row';
+import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
+import {
+  DividerContainer,
+  DividerLine,
+  DividerLineGhostContainer,
+} from 'sentry/components/performance/waterfall/rowDivider';
+import {
+  RowTitle,
+  RowTitleContainer,
+  SpanGroupRowTitleContent,
+} from 'sentry/components/performance/waterfall/rowTitle';
+import {
+  ConnectorBar,
+  TOGGLE_BORDER_BOX,
+  TreeConnector,
+  TreeToggle,
+  TreeToggleContainer,
+} from 'sentry/components/performance/waterfall/treeConnector';
+import {
+  getDurationDisplay,
+  getHumanDuration,
+  toPercent,
+} from 'sentry/components/performance/waterfall/utils';
+import {t} from 'sentry/locale';
+import {EventTransaction} from 'sentry/types/event';
+import {defined} from 'sentry/utils';
+import theme from 'sentry/utils/theme';
+
+import * as DividerHandlerManager from './dividerHandlerManager';
+import * as ScrollbarManager from './scrollbarManager';
+import SpanBarCursorGuide from './spanBarCursorGuide';
+import {MeasurementMarker} from './styles';
+import {EnhancedSpan, ProcessedSpanType, SpanType, TreeDepthType} from './types';
+import {
+  getMeasurementBounds,
+  getMeasurements,
+  getSpanGroupBounds,
+  getSpanGroupTimestamps,
+  getSpanOperation,
+  isOrphanSpan,
+  isOrphanTreeDepth,
+  SpanBoundsType,
+  SpanGeneratedBoundsType,
+  unwrapTreeDepth,
+} from './utils';
+
+const MARGIN_LEFT = 0;
+
+type Props = {
+  continuingTreeDepths: Array<TreeDepthType>;
+  event: Readonly<EventTransaction>;
+  generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
+  isLastSibling: boolean;
+  span: Readonly<ProcessedSpanType>;
+  spanGrouping: EnhancedSpan[];
+  spanNumber: number;
+  treeDepth: number;
+  toggleSiblingSpanGroup?: (span: SpanType) => void;
+};
+
+export default function SpanSiblingGroupBar(props: Props) {
+  function renderGroupedSpansToggler() {
+    const {spanGrouping, treeDepth, toggleSiblingSpanGroup} = props;
+
+    const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
+
+    return (
+      <TreeToggleContainer style={{left: `${left}px`}} hasToggler>
+        {renderSpanTreeConnector()}
+        <TreeToggle
+          disabled={false}
+          isExpanded={false}
+          errored={false}
+          isSpanGroupToggler
+          onClick={event => {
+            event.stopPropagation();
+            toggleSiblingSpanGroup?.(spanGrouping[0].span);
+          }}
+        >
+          <Count value={spanGrouping.length} />
+        </TreeToggle>
+      </TreeToggleContainer>
+    );
+  }
+
+  function generateGroupSpansTitle(spanGroup: EnhancedSpan[]): React.ReactNode {
+    if (spanGroup.length === 0) {
+      return '';
+    }
+
+    const operationCounts = countBy(spanGroup, enhancedSpan =>
+      getSpanOperation(enhancedSpan.span)
+    );
+
+    const hasOthers = Object.keys(operationCounts).length > 1;
+
+    const [mostFrequentOperationName] = Object.entries(operationCounts).reduce(
+      (acc, [operationNameKey, count]) => {
+        if (count > acc[1]) {
+          return [operationNameKey, count];
+        }
+        return acc;
+      }
+    );
+
+    return (
+      <strong>{`${t('Autogrouped ')}\u2014 ${mostFrequentOperationName}${
+        hasOthers ? t(' and more') : ''
+      }`}</strong>
+    );
+  }
+
+  function renderDivider(
+    dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
+  ) {
+    const {addDividerLineRef} = dividerHandlerChildrenProps;
+
+    return (
+      <DividerLine
+        ref={addDividerLineRef()}
+        style={{
+          position: 'absolute',
+        }}
+        onMouseEnter={() => {
+          dividerHandlerChildrenProps.setHover(true);
+        }}
+        onMouseLeave={() => {
+          dividerHandlerChildrenProps.setHover(false);
+        }}
+        onMouseOver={() => {
+          dividerHandlerChildrenProps.setHover(true);
+        }}
+        onMouseDown={dividerHandlerChildrenProps.onDragStart}
+        onClick={event => {
+          // we prevent the propagation of the clicks from this component to prevent
+          // the span detail from being opened.
+          event.stopPropagation();
+        }}
+      />
+    );
+  }
+
+  function renderSpanTreeConnector() {
+    const {treeDepth: spanTreeDepth, continuingTreeDepths, span, isLastSibling} = props;
+
+    const connectorBars: Array<React.ReactNode> = continuingTreeDepths.map(treeDepth => {
+      const depth: number = unwrapTreeDepth(treeDepth);
+
+      if (depth === 0) {
+        // do not render a connector bar at depth 0,
+        // if we did render a connector bar, this bar would be placed at depth -1
+        // which does not exist.
+        return null;
+      }
+      const left = ((spanTreeDepth - depth) * (TOGGLE_BORDER_BOX / 2) + 2) * -1;
+
+      return (
+        <ConnectorBar
+          style={{left}}
+          key={`span-group-${depth}`}
+          orphanBranch={isOrphanTreeDepth(treeDepth)}
+        />
+      );
+    });
+
+    if (!isLastSibling) {
+      const depth: number = unwrapTreeDepth(spanTreeDepth - 1);
+      const left = ((spanTreeDepth - depth) * (TOGGLE_BORDER_BOX / 2) + 2) * -1;
+      connectorBars.push(
+        <ConnectorBar
+          style={{
+            left,
+          }}
+          key={`${span.description}-${depth}`}
+          orphanBranch={false}
+        />
+      );
+    }
+
+    return (
+      <TreeConnector isLast={isLastSibling} hasToggler orphanBranch={isOrphanSpan(span)}>
+        {connectorBars}
+      </TreeConnector>
+    );
+  }
+
+  function renderMeasurements() {
+    const {event, generateBounds} = props;
+
+    const measurements = getMeasurements(event);
+
+    return (
+      <React.Fragment>
+        {Array.from(measurements).map(([timestamp, verticalMark]) => {
+          const bounds = getMeasurementBounds(timestamp, generateBounds);
+
+          const shouldDisplay = defined(bounds.left) && defined(bounds.width);
+
+          if (!shouldDisplay || !bounds.isSpanVisibleInView) {
+            return null;
+          }
+
+          return (
+            <MeasurementMarker
+              key={String(timestamp)}
+              style={{
+                left: `clamp(0%, ${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+              }}
+              failedThreshold={verticalMark.failedThreshold}
+            />
+          );
+        })}
+      </React.Fragment>
+    );
+  }
+
+  return (
+    <ScrollbarManager.Consumer>
+      {scrollbarManagerChildrenProps => (
+        <DividerHandlerManager.Consumer>
+          {(
+            dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
+          ) => {
+            const {
+              span,
+              generateBounds,
+              treeDepth,
+              spanGrouping,
+              spanNumber,
+              toggleSiblingSpanGroup,
+            } = props;
+
+            const {isSpanVisibleInView: isSpanVisible} = generateBounds({
+              startTimestamp: span.start_timestamp,
+              endTimestamp: span.timestamp,
+            });
+
+            const {dividerPosition, addGhostDividerLineRef} = dividerHandlerChildrenProps;
+            const {generateContentSpanBarRef} = scrollbarManagerChildrenProps;
+            const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
+
+            return (
+              <Row
+                visible={isSpanVisible}
+                showBorder={false}
+                data-test-id={`span-row-${spanNumber}`}
+              >
+                <RowCellContainer>
+                  <RowCell
+                    data-type="span-row-cell"
+                    style={{
+                      width: `calc(${toPercent(dividerPosition)} - 0.5px)`,
+                      paddingTop: 0,
+                    }}
+                    onClick={() => {
+                      toggleSiblingSpanGroup?.(spanGrouping[0].span);
+                    }}
+                  >
+                    <RowTitleContainer ref={generateContentSpanBarRef()}>
+                      {renderGroupedSpansToggler()}
+                      <RowTitle
+                        style={{
+                          left: `${left}px`,
+                          width: '100%',
+                        }}
+                      >
+                        <SpanGroupRowTitleContent>
+                          {generateGroupSpansTitle(spanGrouping)}
+                        </SpanGroupRowTitleContent>
+                      </RowTitle>
+                    </RowTitleContainer>
+                  </RowCell>
+                  <DividerContainer>
+                    {renderDivider(dividerHandlerChildrenProps)}
+                  </DividerContainer>
+                  <RowCell
+                    data-type="span-row-cell"
+                    showStriping={spanNumber % 2 !== 0}
+                    style={{
+                      width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
+                    }}
+                    onClick={() => {
+                      toggleSiblingSpanGroup?.(spanGrouping[0].span);
+                    }}
+                  >
+                    {
+                      <React.Fragment>
+                        {spanGrouping.map((_, index) => (
+                          <SpanRectangle
+                            key={index}
+                            spanGrouping={spanGrouping}
+                            index={index}
+                            generateBounds={generateBounds}
+                          />
+                        ))}{' '}
+                      </React.Fragment>
+                    }
+                    {renderMeasurements()}
+                    <SpanBarCursorGuide />
+                  </RowCell>
+                  <DividerLineGhostContainer
+                    style={{
+                      width: `calc(${toPercent(dividerPosition)} + 0.5px)`,
+                      display: 'none',
+                    }}
+                  >
+                    <DividerLine
+                      ref={addGhostDividerLineRef()}
+                      style={{
+                        right: 0,
+                      }}
+                      className="hovering"
+                      onClick={event => {
+                        // the ghost divider line should not be interactive.
+                        // we prevent the propagation of the clicks from this component to prevent
+                        // the span detail from being opened.
+                        event.stopPropagation();
+                      }}
+                    />
+                  </DividerLineGhostContainer>
+                </RowCellContainer>
+              </Row>
+            );
+          }}
+        </DividerHandlerManager.Consumer>
+      )}
+    </ScrollbarManager.Consumer>
+  );
+
+  function SpanRectangle({
+    spanGrouping,
+    index,
+    generateBounds,
+  }: {
+    generateBounds: Props['generateBounds'];
+    spanGrouping: EnhancedSpan[];
+    index?: number;
+  }) {
+    // If an index is provided, we treat this as an individual block for a single span in the grouping
+    if (index !== undefined) {
+      const grouping = [spanGrouping[index]];
+      const bounds = getSpanGroupBounds(grouping, generateBounds);
+
+      // If this is not the last span in the grouping, the duration does not need to be rendered
+      if (index !== spanGrouping.length - 1) {
+        return (
+          <RowRectangle
+            spanBarHatch={false}
+            style={{
+              backgroundColor: theme.blue300,
+              left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+              width: toPercent(bounds.width || 0),
+            }}
+          />
+        );
+      }
+
+      const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
+      const duration = Math.abs(endTimestamp - startTimestamp);
+      const durationDisplay = getDurationDisplay(bounds);
+      const durationString = getHumanDuration(duration);
+
+      return (
+        <RowRectangle
+          spanBarHatch={false}
+          style={{
+            backgroundColor: theme.blue300,
+            left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+            width: toPercent(bounds.width || 0),
+          }}
+        >
+          {index === spanGrouping.length - 1 && (
+            <DurationPill
+              durationDisplay={durationDisplay}
+              showDetail={false}
+              spanBarHatch={false}
+            >
+              {durationString}
+            </DurationPill>
+          )}
+        </RowRectangle>
+      );
+    }
+    const bounds = getSpanGroupBounds(spanGrouping, generateBounds);
+    const durationDisplay = getDurationDisplay(bounds);
+    const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
+    const duration = Math.abs(endTimestamp - startTimestamp);
+    const durationString = getHumanDuration(duration);
+    return (
+      <RowRectangle
+        spanBarHatch={false}
+        style={{
+          backgroundColor: theme.blue300,
+          left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+          width: toPercent(bounds.width || 0),
+        }}
+      >
+        {
+          <DurationPill
+            durationDisplay={durationDisplay}
+            showDetail={false}
+            spanBarHatch={false}
+          >
+            {durationString}
+          </DurationPill>
+        }
+      </RowRectangle>
+    );
+  }
+}

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -32,6 +32,7 @@ import * as DividerHandlerManager from './dividerHandlerManager';
 import * as ScrollbarManager from './scrollbarManager';
 import SpanBarCursorGuide from './spanBarCursorGuide';
 import SpanRectangle from './spanRectangle';
+import {SpanRectangleOverlay} from './spanRectangleOverlay';
 import {MeasurementMarker} from './styles';
 import {EnhancedSpan, ProcessedSpanType, SpanType, TreeDepthType} from './types';
 import {
@@ -282,10 +283,9 @@ export default function SpanSiblingGroupBar(props: Props) {
                         bounds={getSpanGroupBounds([spanGrouping[index]], generateBounds)}
                       />
                     ))}
-                    <SpanRectangle
+                    <SpanRectangleOverlay
                       spanGrouping={spanGrouping}
                       bounds={getSpanGroupBounds(spanGrouping, generateBounds)}
-                      isOverlayRectangle
                     />
 
                     {renderMeasurements()}

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -10,12 +10,13 @@ import {Organization} from 'sentry/types';
 import {DragManagerChildrenProps} from './dragManager';
 import {ScrollbarManagerChildrenProps, withScrollbarManager} from './scrollbarManager';
 import SpanBar from './spanBar';
-import SpanGroupBar, {GroupType} from './spanGroupBar';
+import SpanGroupBar from './spanGroupBar';
 import SpanSiblingGroupBar from './spanSiblingGroupBar';
 import {
   EnhancedProcessedSpanType,
   EnhancedSpan,
   FilterSpans,
+  GroupType,
   ParsedTraceType,
   SpanType,
 } from './types';
@@ -218,8 +219,6 @@ class SpanTree extends React.Component<PropType> {
               spanNumber={spanNumber}
               spanGrouping={payload.spanNestedGrouping as EnhancedSpan[]}
               toggleSpanGroup={payload.toggleNestedSpanGroup as () => void}
-              groupType={GroupType.DESCENDANTS}
-              isLastSibling={false}
             />
           );
           acc.spanNumber = spanNumber + 1;

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -11,6 +11,7 @@ import {DragManagerChildrenProps} from './dragManager';
 import {ScrollbarManagerChildrenProps, withScrollbarManager} from './scrollbarManager';
 import SpanBar from './spanBar';
 import SpanGroupBar, {GroupType} from './spanGroupBar';
+import SpanSiblingGroupBar from './spanSiblingGroupBar';
 import {
   EnhancedProcessedSpanType,
   EnhancedSpan,
@@ -227,7 +228,7 @@ class SpanTree extends React.Component<PropType> {
 
         if (payload.type === 'span_group_sibling') {
           acc.spanTree.push(
-            <SpanGroupBar
+            <SpanSiblingGroupBar
               key={`${spanNumber}-span-sibling`}
               event={waterfallModel.event}
               span={span}
@@ -236,9 +237,7 @@ class SpanTree extends React.Component<PropType> {
               continuingTreeDepths={continuingTreeDepths}
               spanNumber={spanNumber}
               spanGrouping={payload.spanSiblingGrouping as EnhancedSpan[]}
-              toggleSpanGroup={payload.toggleSiblingSpanGroup as () => void}
               toggleSiblingSpanGroup={payload.toggleSiblingSpanGroup}
-              groupType={GroupType.SIBLINGS}
               isLastSibling={payload.isLastSibling ?? false}
             />
           );

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -225,7 +225,7 @@ class SpanTree extends React.Component<PropType> {
           return acc;
         }
 
-        if (payload.type === 'span_group_sibling') {
+        if (payload.type === 'span_group_siblings') {
           acc.spanTree.push(
             <SpanSiblingGroupBar
               key={`${spanNumber}-span-sibling`}

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -451,7 +451,7 @@ class SpanTreeModel {
           }
 
           const groupedSiblingsSpan: EnhancedProcessedSpanType = {
-            type: 'span_group_sibling',
+            type: 'span_group_siblings',
             span: this.span,
             treeDepth: treeDepth + 1,
             continuingTreeDepths,

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -417,7 +417,8 @@ class SpanTreeModel {
 
           const key = getSiblingGroupKey(group[0].span);
           if (this.expandedSiblingGroups.has(key)) {
-            // Check if any of the spans in the sibling group are filtered out (possible when filtering by span ID)
+            // This check is needed here, since it is possible that a user could be filtering for a specific span ID.
+            // In this case, we must add only the specificied span into the accumulator's descendants
             group.forEach((spanModel, index) => {
               if (this.isSpanFilteredOut(props, spanModel)) {
                 acc.descendants.push({
@@ -454,7 +455,9 @@ class SpanTreeModel {
             return acc;
           }
 
-          // Check if the sibling group is filtered out
+          // Since we are not recursively traversing elements in this group, need to check
+          // if the spans are filtered or out of bounds here
+
           if (this.isSpanFilteredOut(props, group[0])) {
             group.forEach(spanModel =>
               acc.descendants.push({
@@ -465,7 +468,6 @@ class SpanTreeModel {
             return acc;
           }
 
-          // Check if the sibling group is out of bounds
           const bounds = generateBounds({
             startTimestamp: group[0].span.start_timestamp,
             endTimestamp: group[group.length - 1].span.timestamp,

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -464,7 +464,7 @@ class SpanTreeModel {
             wrappedSiblings[wrappedSiblings.length - 1].span.timestamp;
 
           // Check if the group is currently expanded or not
-          const key = `${group[0].span.op}.${group[0].span.description}`;
+          const key = getSiblingGroupKey(group[0].span);
           if (this.expandedSiblingGroups.has(key)) {
             acc.descendants.push(...wrappedSiblings);
             return acc;

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -454,10 +454,27 @@ class SpanTreeModel {
             return acc;
           }
 
+          // Check if the sibling group is filtered out
           if (this.isSpanFilteredOut(props, group[0])) {
             group.forEach(spanModel =>
               acc.descendants.push({
                 type: 'filtered_out',
+                span: spanModel.span,
+              })
+            );
+            return acc;
+          }
+
+          // Check if the sibling group is out of bounds
+          const bounds = generateBounds({
+            startTimestamp: group[0].span.start_timestamp,
+            endTimestamp: group[group.length - 1].span.timestamp,
+          });
+
+          if (!bounds.isSpanVisibleInView) {
+            group.forEach(spanModel =>
+              acc.descendants.push({
+                type: 'out_of_view',
                 span: spanModel.span,
               })
             );

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -418,7 +418,7 @@ class SpanTreeModel {
           const key = getSiblingGroupKey(group[0].span);
           if (this.expandedSiblingGroups.has(key)) {
             // This check is needed here, since it is possible that a user could be filtering for a specific span ID.
-            // In this case, we must add only the specificied span into the accumulator's descendants
+            // In this case, we must add only the specified span into the accumulator's descendants
             group.forEach((spanModel, index) => {
               if (this.isSpanFilteredOut(props, spanModel)) {
                 acc.descendants.push({

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -192,3 +192,8 @@ export type TraceBound = {
   traceEndTimestamp: number;
   traceStartTimestamp: number;
 };
+
+export enum GroupType {
+  DESCENDANTS,
+  SIBLINGS,
+}

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -120,7 +120,7 @@ export type EnhancedProcessedSpanType =
       continuingTreeDepths: Array<TreeDepthType>;
       span: SpanType;
       treeDepth: number;
-      type: 'span_group_sibling';
+      type: 'span_group_siblings';
     } & SpanSiblingGroupProps);
 
 export type SpanEntry = {

--- a/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
@@ -583,10 +583,10 @@ describe('SpanTreeModel', () => {
     });
 
     expect(spans.length).toEqual(2);
-    expect(spans[1].type).toEqual('span_group_sibling');
+    expect(spans[1].type).toEqual('span_group_siblings');
 
     // If statement here is required to avoid TS linting issues
-    if (spans[1].type === 'span_group_sibling') {
+    if (spans[1].type === 'span_group_siblings') {
       expect(spans[1].spanSiblingGrouping!.length).toEqual(5);
     }
   });
@@ -758,8 +758,8 @@ describe('SpanTreeModel', () => {
     });
 
     expect(spans.length).toEqual(4);
-    expect(spans[1].type).toEqual('span_group_sibling');
+    expect(spans[1].type).toEqual('span_group_siblings');
     expect(spans[2].type).toEqual('span');
-    expect(spans[3].type).toEqual('span_group_sibling');
+    expect(spans[3].type).toEqual('span_group_siblings');
   });
 });


### PR DESCRIPTION
This PR fixes several bugs associated with the autogrouped sibling spans in the span tree:

- [x] Duration text gets messed up when you narrow the view in the span view
- [x] Autogrouped sibling spans don’t show up on the minimap
- [x] Can’t search by ID for individual spans within expanded sibling span groups
- [x] Show description as well as op in the autogrouped sibling spans, instead of just the op
- [x] Autogrouped sibling spans should properly by marked as out of view when they are not in highlighted in the minimap

### Also includes some slight refactors:

- [x] Make a separate component for autogrouped sibling spans vs autogrouped descendants
- [x] Move `GroupType` into `types.tsx`

### Bugs that still need to be addressed (Will come in a follow up PR)
- [ ] Sibling groups can have the same op and description, this causes separate groups to get expanded/collapsed at the same time

Fixes PERF-1499