### PR TITLE
feat(metric): Adds support for composite metrics in meta [INGEST-924 INGEST-1103]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -402,20 +402,31 @@ class CompositeEntityDerivedMetric(DerivedMetric):
     def get_entity(self, projects: Sequence[Project]) -> Dict[MetricEntity, Sequence[str]]:
         if not projects:
             self._raise_entity_validation_exception("get_entity")
-        return self.__recursively_generate_singular_entity_constituents(projects, self)
+        return self.__recursively_generate_singular_entity_constituents(
+            projects=projects, derived_metric_obj=self
+        )
 
     def generate_available_operations(self):
         return []
 
     @classmethod
-    def __recursively_generate_singular_entity_constituents(cls, projects, derived_metric_obj):
+    def __recursively_generate_singular_entity_constituents(
+        cls,
+        projects: Optional[Sequence[Project]],
+        derived_metric_obj: DerivedMetric,
+        is_naive: bool = False,
+    ) -> Dict[MetricEntity, Sequence[str]]:
         entities_and_metric_names = {}
         for metric_name in derived_metric_obj.metrics:
             if metric_name not in DERIVED_METRICS:
                 continue
             constituent_metric_obj = DERIVED_METRICS[metric_name]
             if isinstance(constituent_metric_obj, SingularEntityDerivedMetric):
-                entity = constituent_metric_obj.get_entity(projects=projects)
+                if is_naive:
+                    entity = None
+                else:
+                    entity = constituent_metric_obj.get_entity(projects=projects)
+
                 entities_and_metric_names.setdefault(entity, []).append(
                     constituent_metric_obj.metric_name
                 )
@@ -424,7 +435,7 @@ class CompositeEntityDerivedMetric(DerivedMetric):
             entities_and_metric_names = combine_dictionary_of_list_values(
                 entities_and_metric_names,
                 cls.__recursively_generate_singular_entity_constituents(
-                    projects, constituent_metric_obj
+                    projects, constituent_metric_obj, is_naive
                 ),
             )
 
@@ -484,6 +495,11 @@ class CompositeEntityDerivedMetric(DerivedMetric):
                 if metric in DERIVED_METRICS:
                     metric_nodes.append(DERIVED_METRICS[metric])
         return reversed(results)
+
+    def naively_generate_singular_entity_constituents(self):
+        return self.__recursively_generate_singular_entity_constituents(
+            projects=None, derived_metric_obj=self, is_naive=True
+        )
 
     def run_post_query_function(self, data, idx=None):
         compute_func_args = [

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -159,7 +159,7 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
         assert response.data == self.session_metrics_meta
 
     @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
-    def test_metrics_index_invalid_derived_metric(self):
+    def test_metrics_index_derived_metrics_and_invalid_derived_metric(self):
         for errors, minute in [(0, 0), (2, 1)]:
             self.store_session(
                 self.build_session(
@@ -183,6 +183,18 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
                 },
                 {
                     "name": "session.errored_set",
+                    "type": "numeric",
+                    "operations": [],
+                    "unit": "sessions",
+                },
+                {
+                    "name": "session.errored",
+                    "type": "numeric",
+                    "operations": [],
+                    "unit": "sessions",
+                },
+                {
+                    "name": "session.healthy",
                     "type": "numeric",
                     "operations": [],
                     "unit": "sessions",


### PR DESCRIPTION
This PR:-
- Modify a method on class `CompositeEntityDerivedMetric` to also support naively fetching the `SingularEntityDerivedMetric` constituents
- Adds support for instances of CompositeEntityDerivedMetric in meta endpoint