### PR TITLE
chore(sentry-instrumentation): Add run_id as a tag on jest tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -56,7 +56,6 @@ jobs:
         env:
           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_PR_REF: ${{ github.event.pull_request.head.ref || github.ref }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
           # XXX: CI_NODE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
           #      Otherwise, if there are other things in the matrix, using strategy.job-total
           #      wouldn't be correct.

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_PR_REF: ${{ github.event.pull_request.head.ref || github.ref }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
           # XXX: CI_NODE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
           #      Otherwise, if there are other things in the matrix, using strategy.job-total
           #      wouldn't be correct.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -211,7 +211,7 @@ const config: Config.InitialOptions = {
         tags: {
           branch: GITHUB_PR_REF,
           commit: GITHUB_PR_SHA,
-          run_id: GITHUB_RUN_ID,
+          github_action_run: `https://github.com/getsentry/sentry/actions/runs/${GITHUB_RUN_ID}`,
         },
       },
     },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,7 @@ const {
   CI_NODE_INDEX,
   GITHUB_PR_SHA,
   GITHUB_PR_REF,
+  GITHUB_RUN_ID,
 } = process.env;
 
 /**
@@ -210,6 +211,7 @@ const config: Config.InitialOptions = {
         tags: {
           branch: GITHUB_PR_REF,
           commit: GITHUB_PR_SHA,
+          run_id: GITHUB_RUN_ID,
         },
       },
     },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,7 +18,6 @@ const {
   GITHUB_PR_REF,
   GITHUB_RUN_ID,
   GITHUB_RUN_ATTEMPT,
-  GITHUB_JOB,
 } = process.env;
 
 /**
@@ -214,8 +213,7 @@ const config: Config.InitialOptions = {
           branch: GITHUB_PR_REF,
           commit: GITHUB_PR_SHA,
           gitub_run_attempt: GITHUB_RUN_ATTEMPT,
-          github_run_id: GITHUB_RUN_ID,
-          github_actions_job: `https://github.com/getsentry/sentry/actions/runs/${GITHUB_JOB}`,
+          github_actions_run: `https://github.com/getsentry/sentry/actions/runs/${GITHUB_RUN_ID}`,
         },
       },
     },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -211,7 +211,7 @@ const config: Config.InitialOptions = {
         tags: {
           branch: GITHUB_PR_REF,
           commit: GITHUB_PR_SHA,
-          github_action_run: `https://github.com/getsentry/sentry/actions/runs/${GITHUB_RUN_ID}`,
+          github_actions_run: `https://github.com/getsentry/sentry/actions/runs/${GITHUB_RUN_ID}`,
         },
       },
     },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,6 +18,7 @@ const {
   GITHUB_PR_REF,
   GITHUB_RUN_ID,
   GITHUB_RUN_ATTEMPT,
+  GITHUB_JOB,
 } = process.env;
 
 /**
@@ -213,7 +214,8 @@ const config: Config.InitialOptions = {
           branch: GITHUB_PR_REF,
           commit: GITHUB_PR_SHA,
           gitub_run_attempt: GITHUB_RUN_ATTEMPT,
-          github_actions_run: `https://github.com/getsentry/sentry/actions/runs/${GITHUB_RUN_ID}`,
+          github_run_id: GITHUB_RUN_ID,
+          github_actions_job: `https://github.com/getsentry/sentry/actions/runs/${GITHUB_JOB}`,
         },
       },
     },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,6 +17,7 @@ const {
   GITHUB_PR_SHA,
   GITHUB_PR_REF,
   GITHUB_RUN_ID,
+  GITHUB_RUN_ATTEMPT,
 } = process.env;
 
 /**
@@ -211,6 +212,7 @@ const config: Config.InitialOptions = {
         tags: {
           branch: GITHUB_PR_REF,
           commit: GITHUB_PR_SHA,
+          gitub_run_attempt: GITHUB_RUN_ATTEMPT,
           github_actions_run: `https://github.com/getsentry/sentry/actions/runs/${GITHUB_RUN_ID}`,
         },
       },


### PR DESCRIPTION
Links us to the job so it's easier to investigate
failed runs.
https://sentry.io/organizations/sentry/discover/results/?field=title&field=timestamp&field=github_actions_run&field=branch&name=All+Events&project=4857230&query=branch%3Afeat%2Fadd-run-id-as-a-tag-jest-tests&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29