### PR TITLE
fix(dashboards): Removes alias for Errors By Country widget

### DIFF
--- a/static/app/views/dashboardsV2/data.tsx
+++ b/static/app/views/dashboardsV2/data.tsx
@@ -130,7 +130,7 @@ export const DASHBOARDS_TEMPLATES: DashboardTemplate[] = [
         interval: '5m',
         queries: [
           {
-            name: t('Error counts'),
+            name: '',
             fields: ['count()'],
             aggregates: ['count()'],
             columns: [],


### PR DESCRIPTION
`Errors By Country` is a World Map widget and World Map widgets cannot edit query aliases. We should remove the default alias because users cannot update this field.