### PR TITLE
Revert "fix(ci): Prevent Visual Snapshots from triggering when not al…

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -265,22 +265,3 @@ jobs:
 
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-
-  visual-diff:
-    # This guarantees that we will only schedule Visual Snapshots if all
-    # workflows that generate artifacts succeed
-    needs: [acceptance, frontend, chartcuterie]
-    name: triggers visual snapshot
-    # Do not execute on forks or on master
-    if: github.repository == 'getsentry/sentry' && github.ref != 'refs/heads/master'
-    runs-on: ubuntu-20.04
-    timeout-minutes: 20
-
-    steps:
-      - name: Diff snapshots
-        id: visual-snapshots-diff
-        uses: getsentry/action-visual-snapshot@v2
-        with:
-          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
-          gcs-bucket: 'sentry-visual-snapshots'
-          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -1,0 +1,22 @@
+name: visual diff
+on:
+  workflow_run:
+    workflows:
+      - acceptance
+    types:
+      - completed
+
+jobs:
+  visual-diff:
+    if: github.repository == 'getsentry/sentry'
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Diff snapshots
+        id: visual-snapshots-diff
+        uses: getsentry/action-visual-snapshot@v2
+        with:
+          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
+          gcs-bucket: 'sentry-visual-snapshots'
+          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}


### PR DESCRIPTION
…l jobs complete (#32915)"

This reverts commit f9014d6c26ea1328247a3870d551c88ec584005f.

There's few PRs that have timed out when generating the Visual Snapshots. I don't know if it's my change or if VS is simply timing out and we couldn't see it before.
https://github.com/getsentry/sentry/actions/workflows/acceptance.yml?query=is%3Afailure

Examples:
https://github.com/getsentry/sentry/actions/runs/2036323621
https://github.com/getsentry/sentry/actions/runs/2036287095

<img width="988" alt="image" src="https://user-images.githubusercontent.com/44410/160005558-97716de8-0ae3-464c-a3b0-7b905550f352.png">
