### PR TITLE
fix(discover): Retrieve tags from TagStore directly in ColumnEditModal

### DIFF
--- a/static/app/utils/useTags.tsx
+++ b/static/app/utils/useTags.tsx
@@ -1,0 +1,17 @@
+import TagStore from 'sentry/stores/tagStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {TagCollection} from 'sentry/types';
+
+type Result = {
+  tags: TagCollection;
+};
+
+function useTags(): Result {
+  const tags = useLegacyStore(TagStore);
+
+  return {
+    tags,
+  };
+}
+
+export default useTags;

--- a/static/app/views/eventsV2/table/columnEditModal.tsx
+++ b/static/app/views/eventsV2/table/columnEditModal.tsx
@@ -8,6 +8,8 @@ import ButtonBar from 'sentry/components/buttonBar';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {DISCOVER2_DOCS_URL} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
+import TagStore from 'sentry/stores/tagStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
@@ -32,7 +34,6 @@ function ColumnEditModal(props: Props) {
     Header,
     Body,
     Footer,
-    tagKeys,
     measurementKeys,
     spanOperationBreakdownKeys,
     organization,
@@ -48,6 +49,9 @@ function ColumnEditModal(props: Props) {
       organization_id: parseInt(organization.id, 10),
     });
   }, []);
+
+  const tags = useLegacyStore(TagStore);
+  const tagKeys = Object.values(tags).map(({key}) => key);
 
   const [columns, setColumns] = useState<Column[]>(props.columns);
 

--- a/static/app/views/eventsV2/table/columnEditModal.tsx
+++ b/static/app/views/eventsV2/table/columnEditModal.tsx
@@ -40,14 +40,14 @@ function ColumnEditModal(props: Props) {
     closeModal,
   } = props;
 
-  // Run on initial render.
+  // Only run once for each organization.id.
   useEffect(() => {
     trackAnalyticsEvent({
       eventKey: 'discover_v2.column_editor.open',
       eventName: 'Discoverv2: Open column editor',
       organization_id: parseInt(organization.id, 10),
     });
-  }, []);
+  }, [organization.id]);
 
   const tags = useLegacyStore(TagStore);
   const tagKeys = Object.values(tags).map(({key}) => key);

--- a/static/app/views/eventsV2/table/columnEditModal.tsx
+++ b/static/app/views/eventsV2/table/columnEditModal.tsx
@@ -25,7 +25,6 @@ type Props = {
   // Fired when column selections have been applied.
   onApply: (columns: Column[]) => void;
   organization: Organization;
-  tagKeys: null | string[];
   spanOperationBreakdownKeys?: string[];
 } & ModalRenderProps;
 

--- a/static/app/views/eventsV2/table/columnEditModal.tsx
+++ b/static/app/views/eventsV2/table/columnEditModal.tsx
@@ -8,13 +8,12 @@ import ButtonBar from 'sentry/components/buttonBar';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {DISCOVER2_DOCS_URL} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
-import TagStore from 'sentry/stores/tagStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import {Column} from 'sentry/utils/discover/fields';
 import theme from 'sentry/utils/theme';
+import useTags from 'sentry/utils/useTags';
 import {generateFieldOptions} from 'sentry/views/eventsV2/utils';
 
 import ColumnEditCollection from './columnEditCollection';
@@ -49,7 +48,7 @@ function ColumnEditModal(props: Props) {
     });
   }, [organization.id]);
 
-  const tags = useLegacyStore(TagStore);
+  const {tags} = useTags();
   const tagKeys = Object.values(tags).map(({key}) => key);
 
   const [columns, setColumns] = useState<Column[]>(props.columns);

--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -5,7 +5,7 @@ import {Location} from 'history';
 import {Client} from 'sentry/api';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
-import {Organization, TagCollection} from 'sentry/types';
+import {Organization} from 'sentry/types';
 import {metric, trackAnalyticsEvent} from 'sentry/utils/analytics';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 import EventView, {isAPIPayloadSimilar} from 'sentry/utils/discover/eventView';
@@ -13,7 +13,6 @@ import Measurements from 'sentry/utils/measurements/measurements';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {SPAN_OP_BREAKDOWN_FIELDS} from 'sentry/utils/performance/spanOperationBreakdowns/constants';
 import withApi from 'sentry/utils/withApi';
-import withTags from 'sentry/utils/withTags';
 
 import TableView from './tableView';
 
@@ -26,7 +25,6 @@ type TableProps = {
   organization: Organization;
   setError: (msg: string, code: number) => void;
   showTags: boolean;
-  tags: TagCollection;
   title: string;
 };
 
@@ -160,9 +158,8 @@ class Table extends PureComponent<TableProps, TableState> {
   };
 
   render() {
-    const {eventView, tags} = this.props;
+    const {eventView} = this.props;
     const {pageLinks, tableData, isLoading, error} = this.state;
-    const tagKeys = Object.values(tags).map(({key}) => key);
 
     const isFirstPage = pageLinks
       ? parseLinkHeader(pageLinks).previous.results === false
@@ -182,7 +179,6 @@ class Table extends PureComponent<TableProps, TableState> {
                 error={error}
                 eventView={eventView}
                 tableData={tableData}
-                tagKeys={tagKeys}
                 measurementKeys={measurementKeys}
                 spanOperationBreakdownKeys={SPAN_OP_BREAKDOWN_FIELDS}
               />
@@ -195,7 +191,7 @@ class Table extends PureComponent<TableProps, TableState> {
   }
 }
 
-export default withApi(withTags(Table));
+export default withApi(Table);
 
 const Container = styled('div')`
   min-width: 0;

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -64,7 +64,6 @@ export type TableViewProps = {
   projects: Project[];
   showTags: boolean;
   tableData: TableData | null | undefined;
-  tagKeys: null | string[];
 
   title: string;
   spanOperationBreakdownKeys?: string[];

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -327,13 +327,8 @@ class TableView extends Component<TableViewProps> {
   };
 
   handleEditColumns = () => {
-    const {
-      organization,
-      eventView,
-      tagKeys,
-      measurementKeys,
-      spanOperationBreakdownKeys,
-    } = this.props;
+    const {organization, eventView, measurementKeys, spanOperationBreakdownKeys} =
+      this.props;
 
     const hasBreakdownFeature = organization.features.includes(
       'performance-ops-breakdown'
@@ -344,7 +339,6 @@ class TableView extends Component<TableViewProps> {
         <ColumnEditModal
           {...modalProps}
           organization={organization}
-          tagKeys={tagKeys}
           measurementKeys={measurementKeys}
           spanOperationBreakdownKeys={
             hasBreakdownFeature ? spanOperationBreakdownKeys : undefined

--- a/tests/js/spec/utils/useTags.spec.tsx
+++ b/tests/js/spec/utils/useTags.spec.tsx
@@ -1,0 +1,22 @@
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import TagStore from 'sentry/stores/tagStore';
+import useTags from 'sentry/utils/useTags';
+
+describe('useTags', function () {
+  beforeEach(() => {
+    TagStore.reset();
+  });
+
+  it('provides tags from the tag store', function () {
+    reactHooks.act(
+      () => void TagStore.loadTagsSuccess([{name: 'Mechanism', key: 'mechanism'}])
+    );
+
+    const {result} = reactHooks.renderHook(() => useTags());
+    const {tags} = result.current;
+
+    const expected = {mechanism: {name: 'Mechanism', key: 'mechanism', values: []}};
+    expect(tags).toEqual(expected);
+  });
+});

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -27,7 +27,7 @@ describe('EventsV2 -> ColumnEditModal', function () {
 
   beforeEach(() => {
     TagStore.reset();
-    TagStore.onLoadTagsSuccess([
+    TagStore.loadTagsSuccess([
       {name: 'browser.name', key: 'browser.name', count: 1},
       {name: 'custom-field', key: 'custom-field', count: 1},
       {name: 'user', key: 'user', count: 1},
@@ -141,7 +141,7 @@ describe('EventsV2 -> ColumnEditModal', function () {
     );
     beforeEach(() => {
       TagStore.reset();
-      TagStore.onLoadTagsSuccess([
+      TagStore.loadTagsSuccess([
         {name: 'project', key: 'project', count: 1},
         {name: 'count', key: 'count', count: 1},
       ]);

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -1,7 +1,8 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {enforceActOnUseLegacyStoreHook, mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {changeInputValue, openMenu, selectByLabel} from 'sentry-test/select-new';
 
+import TagStore from 'sentry/stores/tagStore';
 import ColumnEditModal from 'sentry/views/eventsV2/table/columnEditModal';
 
 const stubEl = props => <div>{props.children}</div>;
@@ -23,6 +24,16 @@ function mountModal({tagKeys, columns, onApply}, initialData) {
 }
 
 describe('EventsV2 -> ColumnEditModal', function () {
+  enforceActOnUseLegacyStoreHook();
+
+  beforeEach(() => {
+    TagStore.reset();
+    TagStore.onLoadTagsSuccess([
+      {name: 'browser.name', key: 'browser.name', count: 1},
+      {name: 'custom-field', key: 'custom-field', count: 1},
+      {name: 'user', key: 'user', count: 1},
+    ]);
+  });
   const initialData = initializeOrg({
     organization: {
       features: ['performance-view'],
@@ -133,6 +144,13 @@ describe('EventsV2 -> ColumnEditModal', function () {
       },
       initialData
     );
+    beforeEach(() => {
+      TagStore.reset();
+      TagStore.onLoadTagsSuccess([
+        {name: 'project', key: 'project', count: 1},
+        {name: 'count', key: 'count', count: 1},
+      ]);
+    });
 
     it('selects tag expressions that overlap fields', function () {
       const funcRow = wrapper.find('QueryField').first();

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -7,14 +7,13 @@ import ColumnEditModal from 'sentry/views/eventsV2/table/columnEditModal';
 
 const stubEl = props => <div>{props.children}</div>;
 
-function mountModal({tagKeys, columns, onApply}, initialData) {
+function mountModal({columns, onApply}, initialData) {
   return mountWithTheme(
     <ColumnEditModal
       Header={stubEl}
       Footer={stubEl}
       Body={stubEl}
       organization={initialData.organization}
-      tagKeys={tagKeys}
       columns={columns}
       onApply={onApply}
       closeModal={() => void 0}
@@ -39,7 +38,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
       features: ['performance-view'],
     },
   });
-  const tagKeys = ['browser.name', 'custom-field', 'user'];
   const columns = [
     {
       kind: 'field',
@@ -76,7 +74,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
       {
         columns,
         onApply: () => void 0,
-        tagKeys,
       },
       initialData
     );
@@ -107,7 +104,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
           {kind: 'field', field: 'user-def'},
         ],
         onApply: () => void 0,
-        tagKeys,
       },
       initialData
     );
@@ -140,7 +136,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
           {kind: 'field', field: 'tags[count]'},
         ],
         onApply: () => void 0,
-        tagKeys: ['project', 'count'],
       },
       initialData
     );
@@ -178,7 +173,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
           {kind: 'function', function: ['percentile', 'transaction.duration', '0.66']},
         ],
         onApply: () => void 0,
-        tagKeys,
       },
       initialData
     );
@@ -205,7 +199,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
         {
           columns: [columns[0]],
           onApply,
-          tagKeys,
         },
         initialData
       );
@@ -356,7 +349,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
             },
           ],
           onApply,
-          tagKeys,
         },
         initialData
       );
@@ -391,7 +383,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
             },
           ],
           onApply,
-          tagKeys,
         },
         initialData
       );
@@ -438,7 +429,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
             },
           ],
           onApply,
-          tagKeys,
         },
         initialData
       );
@@ -471,7 +461,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
             },
           ],
           onApply,
-          tagKeys,
         },
         initialData
       );
@@ -506,7 +495,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
             },
           ],
           onApply,
-          tagKeys,
         },
         initialData
       );
@@ -543,7 +531,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
             },
           ],
           onApply,
-          tagKeys,
         },
         initialData
       );
@@ -575,7 +562,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
             },
           ],
           onApply,
-          tagKeys,
         },
         initialData
       );
@@ -604,7 +590,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
       {
         columns: [columns[0]],
         onApply: () => void 0,
-        tagKeys,
       },
       initialData
     );
@@ -624,7 +609,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
       {
         columns: [columns[0], columns[1]],
         onApply: () => void 0,
-        tagKeys,
       },
       initialData
     );
@@ -657,7 +641,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
             },
           ],
           onApply: () => void 0,
-          tagKeys,
         },
         initialData
       );
@@ -690,7 +673,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
             columns[1],
           ],
           onApply: () => void 0,
-          tagKeys,
         },
         initialData
       );
@@ -713,7 +695,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
       {
         columns: [columns[0], columns[1]],
         onApply,
-        tagKeys,
       },
       initialData
     );

--- a/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
@@ -5,6 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
+import TagStore from 'sentry/stores/tagStore';
 import EventView from 'sentry/utils/discover/eventView';
 import TableView from 'sentry/views/eventsV2/table/tableView';
 
@@ -33,7 +34,6 @@ describe('TableView > CellActions', function () {
     },
   };
   const eventView = EventView.fromLocation(location);
-  const tagKeys = ['size', 'shape', 'direction'];
 
   function makeWrapper(context, tableData, view) {
     return mountWithTheme(
@@ -41,7 +41,6 @@ describe('TableView > CellActions', function () {
         organization={context.organization}
         location={location}
         eventView={view}
-        tagKeys={tagKeys}
         isLoading={false}
         projects={context.organization.projects}
         tableData={tableData}
@@ -77,7 +76,15 @@ describe('TableView > CellActions', function () {
       organization,
       router: {location},
     });
-    act(() => ProjectsStore.loadInitialData(initialData.organization.projects));
+    act(() => {
+      ProjectsStore.loadInitialData(initialData.organization.projects);
+      TagStore.reset();
+      TagStore.onLoadTagsSuccess([
+        {name: 'size', key: 'size', count: 1},
+        {name: 'shape', key: 'shape', count: 1},
+        {name: 'direction', key: 'direction', count: 1},
+      ]);
+    });
 
     onChangeShowTags = jest.fn();
 

--- a/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
@@ -79,7 +79,7 @@ describe('TableView > CellActions', function () {
     act(() => {
       ProjectsStore.loadInitialData(initialData.organization.projects);
       TagStore.reset();
-      TagStore.onLoadTagsSuccess([
+      TagStore.loadTagsSuccess([
         {name: 'size', key: 'size', count: 1},
         {name: 'shape', key: 'shape', count: 1},
         {name: 'direction', key: 'direction', count: 1},


### PR DESCRIPTION
When opening the Discover column editor modal before tags are loaded, tags will not properly propagate via props. This can occur if an org has numerous tags, and/or if a long time range is used via the page filters (e.g. 14+ days). The user would need to close and re-open the column editor to properly load the tags in the dropdown(s) after the tag store is properly populated with tags. 

I've removed the tags prop drilling, and instead, source the tags from the tag reflux store directly using the `useLegacyStore()` hook. 