### PR TITLE
fix(widget-builder): Change from Line -> Table in Add to Dashboard doesn't request table data

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -30,6 +30,7 @@ import {
   explodeField,
   generateFieldAsString,
   getAggregateAlias,
+  getColumnsAndAggregates,
   getColumnsAndAggregatesAsStrings,
   QueryFieldValue,
 } from 'sentry/utils/discover/fields';
@@ -362,8 +363,9 @@ function WidgetBuilder({
           // This is so the widget can reflect the same columns as the table in Discover without requiring additional user input
           if (newDisplayType === DisplayType.TABLE) {
             normalized.forEach(query => {
-              query.columns = [...defaultWidgetQuery.columns];
-              query.aggregates = [...defaultWidgetQuery.aggregates];
+              const tableQuery = getColumnsAndAggregates(defaultTableColumns);
+              query.columns = [...tableQuery.columns];
+              query.aggregates = [...tableQuery.aggregates];
               query.fields = [...defaultTableColumns];
             });
           } else if (newDisplayType === displayType) {


### PR DESCRIPTION
When a user arrives at the widget builder through the Add to Dashboard flow, and they switch to a table chart, they were getting `n/a` as results. 

This is because the logic was setting `columns` and `aggregates` to be the values of the chart query we see in Discover. Instead, we actually want to see the Table of results below the chart in Discover.

To accomplish this, I used `getColumnsAndAggregates` to split the default string of table columns up into columns and aggregates to make a request with.