### PR TITLE
feat(Superuser): added optional argument for _admin's su access form

### DIFF
--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -285,7 +285,7 @@ class Superuser:
         self.is_valid = False
         self.request.session.pop(SESSION_KEY, None)
 
-    def set_logged_in(self, user, current_datetime=None):
+    def set_logged_in(self, user, current_datetime=None, su_access_json=None):
         """
         Mark a session as superuser-enabled.
         """
@@ -309,11 +309,12 @@ class Superuser:
             )
             return
 
-        try:
-            # need to use json loads as the data is no longer in request.data
-            su_access_json = json.loads(request.body)
-        except AttributeError:
-            su_access_json = {}
+        if not su_access_json:
+            try:
+                # need to use json loads as the data is no longer in request.data
+                su_access_json = json.loads(request.body)
+            except AttributeError:
+                su_access_json = {}
 
         su_access_info = SuperuserAccessSerializer(data=su_access_json)
 


### PR DESCRIPTION
for the[ new _admin flow](https://github.com/getsentry/getsentry/pull/7226) the su access form's prompts needs to be passed to `set_logged_in()`. Therefore, `set_logged_in()` has been modified to allow the optional argument `su_access_json`