### PR TITLE
feat(release-health): Ignore releases queries in comparison [INGEST-784]

### DIFF
--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -1109,7 +1109,7 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
     ) -> Sequence[ProjectRelease]:
         rollup = self.DEFAULT_ROLLUP  # not used
 
-        schema = ListSet(schema=ComparatorType.Exact, index_by=identity)
+        schema = ComparatorType.Ignore
 
         should_compare = (
             lambda _: datetime.now(timezone.utc) - timedelta(days=3) > self.metrics_start
@@ -1290,11 +1290,7 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
         environments: Optional[Sequence[str]] = None,
         now: Optional[datetime] = None,
     ) -> Sequence[ProjectRelease]:
-        schema = ListSet(schema=ComparatorType.Exact, index_by=identity)
-
-        set_tag("gprbs.limit", str(limit))
-        set_tag("gprbs.offset", str(offset))
-        set_tag("gprbs.scope", str(scope))
+        schema = ComparatorType.Ignore
 
         if stats_period is None:
             stats_period = "24h"


### PR DESCRIPTION
* Differences in `get_project_releases_by_stability` can be explained by different sort order of results.
* Differences in `get_changed_project_release_model_adoptions` can be explained by the fact that sessions-based queries create release groups even for session updates that are not counted (`seq >0`) -> those are missing from metrics queries.

See investigations on INGEST-1050 and INGEST-1126.