### PR TITLE
ci(pg): Add PostgreSQL v14 to testing matrix

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'pip cache version in order to bust cache'
     required: false
     default: '1630355466247'
+  pg-version:
+    description: 'PostgreSQL version to use'
+    default: '9.6'
+    required: false
 
 outputs:
   yarn-cache-dir:
@@ -160,6 +164,7 @@ runs:
         NEED_CLICKHOUSE: ${{ inputs.clickhouse }}
         NEED_CHARTCUTERIE: ${{ inputs.chartcuterie }}
         WORKDIR: ${{ inputs.workdir }}
+        PG_VERSION: ${{ inputs.pg-version }}
       run: |
         sentry init
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -152,7 +152,7 @@ jobs:
         python-version: [3.8.12]
         # XXX: When updating this, make sure you also update MATRIX_INSTANCE_TOTAL.
         instance: [0, 1, 2, 3]
-        pg-version: ['9.6', '12']
+        pg-version: ['9.6', '14']
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
       MATRIX_INSTANCE_TOTAL: 4

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -152,6 +152,7 @@ jobs:
         python-version: [3.8.12]
         # XXX: When updating this, make sure you also update MATRIX_INSTANCE_TOTAL.
         instance: [0, 1, 2, 3]
+        pg-version: ['9.6', '12']
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
       MATRIX_INSTANCE_TOTAL: 4
@@ -169,6 +170,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pip-cache-version: ${{ secrets.PIP_CACHE_VERSION }}
           snuba: true
+          pg-version: ${{ matrix.pg-version }}
 
       - name: Wait for frontend build
         uses: getsentry/action-wait-for-check@v1.0.0

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.8.12]
         # XXX: When updating this, make sure you also update MATRIX_INSTANCE_TOTAL.
         instance: [0, 1, 2]
-        pg-version: ['9.6', '12']
+        pg-version: ['9.6', '14']
 
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -16,6 +16,7 @@ jobs:
         python-version: [3.8.12]
         # XXX: When updating this, make sure you also update MATRIX_INSTANCE_TOTAL.
         instance: [0, 1, 2]
+        pg-version: ['9.6', '12']
 
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
@@ -53,6 +54,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pip-cache-version: ${{ secrets.PIP_CACHE_VERSION }}
           snuba: true
+          pg-version: ${{ matrix.pg-version }}
 
       - name: Run backend test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         if: steps.changes.outputs.backend == 'true'

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -42,6 +42,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8.12]
+        pg-version: ['9.6', '12']
     needs: did-migration-change
     if: ${{ needs.did-migration-change.outputs.added == 'true' }}
 
@@ -57,6 +58,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           pip-cache-version: ${{ secrets.PIP_CACHE_VERSION }}
+          pg-version: ${{ matrix.pg-version }}
 
       - name: Apply migrations
         run: |

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8.12]
-        pg-version: ['9.6', '12']
+        pg-version: ['9.6', '14']
     needs: did-migration-change
     if: ${{ needs.did-migration-change.outputs.added == 'true' }}
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1757,7 +1757,7 @@ SENTRY_DEVSERVICES = {
     ),
     "postgres": lambda settings, options: (
         {
-            "image": "postgres:9.6-alpine",
+            "image": f"postgres:{os.getenv('PG_VERSION') or '9.6'}-alpine",
             "pull": True,
             "ports": {"5432/tcp": 5432},
             "environment": {"POSTGRES_DB": "sentry", "POSTGRES_HOST_AUTH_METHOD": "trust"},


### PR DESCRIPTION
Since PostgreSQL v9.6 is no longer supported [^1] we will be migrating to a newer version. To make sure we are not breaking other environments with v9.6 in the process of migrations we'll be running tests for both versions.

[^1]:  https://www.postgresql.org/support/versioning/