### PR TITLE
feat(metrics): Respect is_private flag on derived metrics [INGEST-930 INGEST-1118]

### DIFF
--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -29,8 +29,11 @@ from sentry.sentry_metrics.utils import (
     reverse_resolve_weak,
 )
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.metrics.fields import DERIVED_METRICS, DerivedMetric, metric_object_factory
-from sentry.snuba.metrics.fields.base import generate_bottom_up_dependency_tree_for_metrics
+from sentry.snuba.metrics.fields import DerivedMetric, metric_object_factory
+from sentry.snuba.metrics.fields.base import (
+    generate_bottom_up_dependency_tree_for_metrics,
+    get_derived_metrics,
+)
 from sentry.snuba.metrics.utils import (
     ALLOWED_GROUPBY_COLUMNS,
     FIELD_REGEX,
@@ -54,21 +57,22 @@ from sentry.utils.snuba import parse_snuba_datetime
 
 
 def parse_field(field: str) -> Tuple[Optional[str], str]:
+    derived_metrics = get_derived_metrics(exclude_private=True)
     matches = FIELD_REGEX.match(field)
     try:
         if matches is None:
             raise TypeError
         operation = matches[1]
         metric_name = matches[2]
-        if metric_name in DERIVED_METRICS and isinstance(
-            DERIVED_METRICS[metric_name], DerivedMetric
+        if metric_name in derived_metrics and isinstance(
+            derived_metrics[metric_name], DerivedMetric
         ):
             raise DerivedMetricParseException(
                 f"Failed to parse {field}. No operations can be applied on this field as it is "
                 f"already a derived metric with an aggregation applied to it."
             )
     except (IndexError, TypeError):
-        if field in DERIVED_METRICS and isinstance(DERIVED_METRICS[field], DerivedMetric):
+        if field in derived_metrics and isinstance(derived_metrics[field], DerivedMetric):
             # The isinstance check is there to foreshadow adding raw metric aliases
             return None, field
         raise InvalidField(
@@ -317,7 +321,7 @@ class SnubaQueryBuilder:
         return where
 
     def _build_groupby(self, query_definition: QueryDefinition) -> List[Column]:
-        # ToDo ensure we cannot add any other cols than tags and groupBy as columns
+        # ToDo(ahmed): ensure we cannot add any other cols than tags and groupBy as columns
         return [
             Column(resolve_tag_key(field))
             if field not in ALLOWED_GROUPBY_COLUMNS

--- a/tests/sentry/api/endpoints/test_organization_metric_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_details.py
@@ -127,8 +127,9 @@ class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegration
         }
 
     @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS_2)
-    @patch("sentry.snuba.metrics.datasource.DERIVED_METRICS", MOCKED_DERIVED_METRICS_2)
-    def test_incorrectly_setup_derived_metric(self):
+    @patch("sentry.snuba.metrics.datasource.get_derived_metrics")
+    def test_incorrectly_setup_derived_metric(self, mocked_derived_metrics):
+        mocked_derived_metrics.return_value = MOCKED_DERIVED_METRICS_2
         self.store_session(
             self.build_session(
                 project_id=self.project.id,
@@ -149,13 +150,14 @@ class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegration
         )
 
     @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS_2)
-    @patch("sentry.snuba.metrics.datasource.DERIVED_METRICS", MOCKED_DERIVED_METRICS_2)
-    def test_same_entity_multiple_metric_ids(self):
+    @patch("sentry.snuba.metrics.datasource.get_derived_metrics")
+    def test_same_entity_multiple_metric_ids(self, mocked_derived_metrics):
         """
         Test that ensures that if a derived metric is defined with constituent metrics that
         belong to the same entity but have different ids, then we are able to correctly return
         its detail info
         """
+        mocked_derived_metrics.return_value = MOCKED_DERIVED_METRICS_2
         self.store_session(
             self.build_session(
                 project_id=self.project.id,

--- a/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
@@ -80,6 +80,29 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
         )
         assert response.data == [{"key": "release", "value": "foobar"}]
 
+    def test_private_derived_metrics(self):
+        self.store_session(
+            self.build_session(
+                project_id=self.project.id,
+                started=(time.time() // 60) * 60,
+                status="ok",
+                release="foobar@2.0",
+                errors=2,
+            )
+        )
+        for private_name in [
+            "session.crashed_and_abnormal_user",
+            "session.errored_preaggregated",
+            "session.errored_set",
+            "session.errored_user_all",
+        ]:
+            response = self.get_success_response(
+                self.organization.slug,
+                "release",
+                metric=[private_name],
+            )
+            assert response.data == []
+
     def test_tag_values_for_composite_derived_metrics(self):
         self.store_session(
             self.build_session(

--- a/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
@@ -130,8 +130,9 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
         assert response.json()["detail"] == "Tag release is not available in the indexer"
 
     @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
-    @patch("sentry.snuba.metrics.datasource.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
-    def test_incorrectly_setup_derived_metric(self):
+    @patch("sentry.snuba.metrics.datasource.get_derived_metrics")
+    def test_incorrectly_setup_derived_metric(self, mocked_derived_metrics):
+        mocked_derived_metrics.return_value = MOCKED_DERIVED_METRICS
         self.store_session(
             self.build_session(
                 project_id=self.project.id,

--- a/tests/sentry/api/endpoints/test_organization_metric_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tags.py
@@ -106,6 +106,28 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
             {"key": "release"},
         ]
 
+    def test_private_derived_metrics(self):
+        self.store_session(
+            self.build_session(
+                project_id=self.project.id,
+                started=(time.time() // 60) * 60,
+                status="ok",
+                release="foobar@2.0",
+                errors=2,
+            )
+        )
+        for private_name in [
+            "session.crashed_and_abnormal_user",
+            "session.errored_preaggregated",
+            "session.errored_set",
+            "session.errored_user_all",
+        ]:
+            response = self.get_success_response(
+                self.organization.slug,
+                metric=[private_name],
+            )
+            assert response.data == []
+
     @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
     @patch("sentry.snuba.metrics.datasource.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
     def test_incorrectly_setup_derived_metric(self):

--- a/tests/sentry/api/endpoints/test_organization_metric_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tags.py
@@ -129,8 +129,9 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
             assert response.data == []
 
     @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
-    @patch("sentry.snuba.metrics.datasource.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
-    def test_incorrectly_setup_derived_metric(self):
+    @patch("sentry.snuba.metrics.datasource.get_derived_metrics")
+    def test_incorrectly_setup_derived_metric(self, mocked_derived_metrics):
+        mocked_derived_metrics.return_value = MOCKED_DERIVED_METRICS
         self.store_session(
             self.build_session(
                 project_id=self.project.id,

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -99,27 +99,9 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
                 "unit": "percentage",
             },
             {"name": "session.crashed", "type": "numeric", "operations": [], "unit": "sessions"},
-            {
-                "name": "session.crashed_and_abnormal_user",
-                "operations": [],
-                "type": "numeric",
-                "unit": "users",
-            },
             {"name": "session.crashed_user", "type": "numeric", "operations": [], "unit": "users"},
             {
-                "name": "session.errored_preaggregated",
-                "type": "numeric",
-                "operations": [],
-                "unit": "sessions",
-            },
-            {
                 "name": "session.errored_user",
-                "type": "numeric",
-                "operations": [],
-                "unit": "users",
-            },
-            {
-                "name": "session.errored_user_all",
                 "type": "numeric",
                 "operations": [],
                 "unit": "users",
@@ -180,12 +162,6 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
                     "type": "set",
                     "operations": ["count_unique"],
                     "unit": None,
-                },
-                {
-                    "name": "session.errored_set",
-                    "type": "numeric",
-                    "operations": [],
-                    "unit": "sessions",
                 },
                 {
                     "name": "session.errored",


### PR DESCRIPTION
This PR:
- Adds functionality that hides derived metrics with is_private flag set to True from meta, tag, tag_values and data endpoint
- Adds function `get_derived_metrics` that returns all derived metrics depending on if the `exclude_private` arg is True or not