### PR TITLE
fix(reflux): add store teardown and make sure .init doesnt leak memory

### DIFF
--- a/static/app/stores/alertStore.tsx
+++ b/static/app/stores/alertStore.tsx
@@ -3,6 +3,7 @@ import Reflux from 'reflux';
 import AlertActions from 'sentry/actions/alertActions';
 import {defined} from 'sentry/utils';
 import localStorage from 'sentry/utils/localStorage';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 import {Theme} from 'sentry/utils/theme';
 
 import {CommonStoreInterface} from './types';
@@ -109,6 +110,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & AlertStoreInterface = {
   },
 };
 
-const AlertStore = Reflux.createStore(storeConfig) as Reflux.Store & AlertStoreInterface;
+const AlertStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & Internals & AlertStoreInterface
+);
 
 export default AlertStore;

--- a/static/app/stores/alertStore.tsx
+++ b/static/app/stores/alertStore.tsx
@@ -110,8 +110,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & AlertStoreInterface = {
   },
 };
 
-const AlertStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & AlertStoreInterface
-);
+const AlertStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
+  AlertStoreInterface;
 
 export default AlertStore;

--- a/static/app/stores/alertStore.tsx
+++ b/static/app/stores/alertStore.tsx
@@ -111,7 +111,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & AlertStoreInterface = {
 };
 
 const AlertStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & Internals & AlertStoreInterface
+  Reflux.createStore(storeConfig) as Reflux.Store & AlertStoreInterface
 );
 
 export default AlertStore;

--- a/static/app/stores/alertStore.tsx
+++ b/static/app/stores/alertStore.tsx
@@ -3,7 +3,6 @@ import Reflux from 'reflux';
 import AlertActions from 'sentry/actions/alertActions';
 import {defined} from 'sentry/utils';
 import localStorage from 'sentry/utils/localStorage';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 import {Theme} from 'sentry/utils/theme';
 
 import {CommonStoreInterface} from './types';
@@ -110,7 +109,6 @@ const storeConfig: Reflux.StoreDefinition & Internals & AlertStoreInterface = {
   },
 };
 
-const AlertStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
-  AlertStoreInterface;
+const AlertStore = Reflux.createStore(storeConfig) as Reflux.Store & AlertStoreInterface;
 
 export default AlertStore;

--- a/static/app/stores/committerStore.tsx
+++ b/static/app/stores/committerStore.tsx
@@ -105,8 +105,8 @@ export function getCommitterStoreKey(
   return `${orgSlug} ${projectSlug} ${eventId}`;
 }
 
-const CommitterStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & CommitterStoreInterface
-);
+const CommitterStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & CommitterStoreInterface;
 
 export default CommitterStore;

--- a/static/app/stores/committerStore.tsx
+++ b/static/app/stores/committerStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import CommitterActions from 'sentry/actions/committerActions';
 import {Committer} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type State = {
   // Use `getCommitterStoreKey` to generate key

--- a/static/app/stores/committerStore.tsx
+++ b/static/app/stores/committerStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import CommitterActions from 'sentry/actions/committerActions';
 import {Committer} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type State = {
   // Use `getCommitterStoreKey` to generate key
   [key: string]: {
@@ -104,7 +106,8 @@ export function getCommitterStoreKey(
   return `${orgSlug} ${projectSlug} ${eventId}`;
 }
 
-const CommitterStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  CommitterStoreInterface;
+const CommitterStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & CommitterStoreInterface
+);
 
 export default CommitterStore;

--- a/static/app/stores/committerStore.tsx
+++ b/static/app/stores/committerStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import CommitterActions from 'sentry/actions/committerActions';
 import {Committer} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type State = {
   // Use `getCommitterStoreKey` to generate key
@@ -107,6 +107,6 @@ export function getCommitterStoreKey(
 
 const CommitterStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & CommitterStoreInterface;
+) as SafeRefluxStore & CommitterStoreInterface;
 
 export default CommitterStore;

--- a/static/app/stores/committerStore.tsx
+++ b/static/app/stores/committerStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import CommitterActions from 'sentry/actions/committerActions';
 import {Committer} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type State = {
   // Use `getCommitterStoreKey` to generate key
@@ -107,6 +107,6 @@ export function getCommitterStoreKey(
 
 const CommitterStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & CommitterStoreInterface;
+) as unknown as SafeRefluxStore & CommitterStoreInterface;
 
 export default CommitterStore;

--- a/static/app/stores/committerStore.tsx
+++ b/static/app/stores/committerStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import CommitterActions from 'sentry/actions/committerActions';
 import {Committer} from 'sentry/types';
-import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type State = {
   // Use `getCommitterStoreKey` to generate key
@@ -107,6 +107,6 @@ export function getCommitterStoreKey(
 
 const CommitterStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & CommitterStoreInterface;
+) as Reflux.Store & CommitterStoreInterface;
 
 export default CommitterStore;

--- a/static/app/stores/configStore.tsx
+++ b/static/app/stores/configStore.tsx
@@ -2,7 +2,7 @@ import moment from 'moment-timezone';
 import Reflux from 'reflux';
 
 import {Config} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -78,7 +78,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & ConfigStoreInterface = {
   },
 };
 
-const ConfigStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
-  ConfigStoreInterface;
+const ConfigStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as SafeRefluxStore & ConfigStoreInterface;
 
 export default ConfigStore;

--- a/static/app/stores/configStore.tsx
+++ b/static/app/stores/configStore.tsx
@@ -78,8 +78,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & ConfigStoreInterface = {
   },
 };
 
-const ConfigStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & ConfigStoreInterface
-);
+const ConfigStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
+  ConfigStoreInterface;
 
 export default ConfigStore;

--- a/static/app/stores/configStore.tsx
+++ b/static/app/stores/configStore.tsx
@@ -2,6 +2,7 @@ import moment from 'moment-timezone';
 import Reflux from 'reflux';
 
 import {Config} from 'sentry/types';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -77,7 +78,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & ConfigStoreInterface = {
   },
 };
 
-const ConfigStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  ConfigStoreInterface;
+const ConfigStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & ConfigStoreInterface
+);
 
 export default ConfigStore;

--- a/static/app/stores/debugMetaStore.tsx
+++ b/static/app/stores/debugMetaStore.tsx
@@ -1,10 +1,6 @@
 import Reflux from 'reflux';
 
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 const DebugMetaActions = Reflux.createActions(['updateFilter']);
 
@@ -57,7 +53,7 @@ const storeConfig: Reflux.StoreDefinition &
 
 const DebugMetaStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & DebugMetaStoreInterface;
+) as Reflux.Store & DebugMetaStoreInterface;
 
 export {DebugMetaActions, DebugMetaStore};
 export default DebugMetaStore;

--- a/static/app/stores/debugMetaStore.tsx
+++ b/static/app/stores/debugMetaStore.tsx
@@ -1,6 +1,6 @@
 import Reflux from 'reflux';
 
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 const DebugMetaActions = Reflux.createActions(['updateFilter']);
 

--- a/static/app/stores/debugMetaStore.tsx
+++ b/static/app/stores/debugMetaStore.tsx
@@ -1,5 +1,7 @@
 import Reflux from 'reflux';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 const DebugMetaActions = Reflux.createActions(['updateFilter']);
 
 type State = {
@@ -42,7 +44,9 @@ const storeConfig: Reflux.StoreDefinition & DebugMetaStoreInterface & Internals 
   },
 };
 
-const DebugMetaStore = Reflux.createStore(storeConfig);
+const DebugMetaStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & DebugMetaStoreInterface & Internals
+);
 
 export {DebugMetaActions, DebugMetaStore};
 export default DebugMetaStore;

--- a/static/app/stores/debugMetaStore.tsx
+++ b/static/app/stores/debugMetaStore.tsx
@@ -1,6 +1,10 @@
 import Reflux from 'reflux';
 
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 const DebugMetaActions = Reflux.createActions(['updateFilter']);
 
@@ -53,7 +57,7 @@ const storeConfig: Reflux.StoreDefinition &
 
 const DebugMetaStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & DebugMetaStoreInterface;
+) as SafeRefluxStore & DebugMetaStoreInterface;
 
 export {DebugMetaActions, DebugMetaStore};
 export default DebugMetaStore;

--- a/static/app/stores/debugMetaStore.tsx
+++ b/static/app/stores/debugMetaStore.tsx
@@ -1,6 +1,10 @@
 import Reflux from 'reflux';
 
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 const DebugMetaActions = Reflux.createActions(['updateFilter']);
 
@@ -53,7 +57,7 @@ const storeConfig: Reflux.StoreDefinition &
 
 const DebugMetaStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & DebugMetaStoreInterface;
+) as unknown as SafeRefluxStore & DebugMetaStoreInterface;
 
 export {DebugMetaActions, DebugMetaStore};
 export default DebugMetaStore;

--- a/static/app/stores/debugMetaStore.tsx
+++ b/static/app/stores/debugMetaStore.tsx
@@ -1,6 +1,6 @@
 import Reflux from 'reflux';
 
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 const DebugMetaActions = Reflux.createActions(['updateFilter']);
 
@@ -19,12 +19,19 @@ type Internals = {
   filter: string | null;
 };
 
-const storeConfig: Reflux.StoreDefinition & DebugMetaStoreInterface & Internals = {
+const storeConfig: Reflux.StoreDefinition &
+  DebugMetaStoreInterface &
+  Internals &
+  SafeStoreDefinition = {
   filter: null,
+  unsubscribeListeners: [],
 
   init() {
     this.reset();
-    this.listenTo(DebugMetaActions.updateFilter, this.updateFilter);
+
+    this.unsubscribeListeners.push(
+      this.listenTo(DebugMetaActions.updateFilter, this.updateFilter)
+    );
   },
 
   reset() {
@@ -44,9 +51,9 @@ const storeConfig: Reflux.StoreDefinition & DebugMetaStoreInterface & Internals 
   },
 };
 
-const DebugMetaStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & DebugMetaStoreInterface
-);
+const DebugMetaStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & DebugMetaStoreInterface;
 
 export {DebugMetaActions, DebugMetaStore};
 export default DebugMetaStore;

--- a/static/app/stores/debugMetaStore.tsx
+++ b/static/app/stores/debugMetaStore.tsx
@@ -45,7 +45,7 @@ const storeConfig: Reflux.StoreDefinition & DebugMetaStoreInterface & Internals 
 };
 
 const DebugMetaStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & DebugMetaStoreInterface & Internals
+  Reflux.createStore(storeConfig) as Reflux.Store & DebugMetaStoreInterface
 );
 
 export {DebugMetaActions, DebugMetaStore};

--- a/static/app/stores/eventStore.tsx
+++ b/static/app/stores/eventStore.tsx
@@ -4,6 +4,8 @@ import Reflux from 'reflux';
 
 import {Event} from 'sentry/types/event';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type Internals = {
   items: Event[];
   itemsById: Record<string, Event>;
@@ -98,6 +100,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & EventStoreInterface = {
   },
 };
 
-const EventStore = Reflux.createStore(storeConfig) as Reflux.Store & EventStoreInterface;
+const EventStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & EventStoreInterface
+);
 
 export default EventStore;

--- a/static/app/stores/eventStore.tsx
+++ b/static/app/stores/eventStore.tsx
@@ -3,7 +3,7 @@ import isArray from 'lodash/isArray';
 import Reflux from 'reflux';
 
 import {Event} from 'sentry/types/event';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type Internals = {
   items: Event[];
@@ -99,7 +99,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & EventStoreInterface = {
   },
 };
 
-const EventStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
-  EventStoreInterface;
+const EventStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as SafeRefluxStore & EventStoreInterface;
 
 export default EventStore;

--- a/static/app/stores/eventStore.tsx
+++ b/static/app/stores/eventStore.tsx
@@ -3,8 +3,7 @@ import isArray from 'lodash/isArray';
 import Reflux from 'reflux';
 
 import {Event} from 'sentry/types/event';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type Internals = {
   items: Event[];

--- a/static/app/stores/eventStore.tsx
+++ b/static/app/stores/eventStore.tsx
@@ -99,8 +99,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & EventStoreInterface = {
   },
 };
 
-const EventStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & EventStoreInterface
-);
+const EventStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
+  EventStoreInterface;
 
 export default EventStore;

--- a/static/app/stores/externalIssueStore.tsx
+++ b/static/app/stores/externalIssueStore.tsx
@@ -2,6 +2,8 @@ import Reflux from 'reflux';
 
 import {PlatformExternalIssue} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type ExternalIssueStoreInterface = {
   add(issue: PlatformExternalIssue): void;
   getInitialState(): PlatformExternalIssue[];
@@ -38,7 +40,8 @@ const storeConfig: Reflux.StoreDefinition & ExternalIssueStoreInterface = {
   },
 };
 
-const ExternalIssueStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  ExternalIssueStoreInterface;
+const ExternalIssueStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & ExternalIssueStoreInterface
+);
 
 export default ExternalIssueStore;

--- a/static/app/stores/externalIssueStore.tsx
+++ b/static/app/stores/externalIssueStore.tsx
@@ -39,8 +39,8 @@ const storeConfig: Reflux.StoreDefinition & ExternalIssueStoreInterface = {
   },
 };
 
-const ExternalIssueStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & ExternalIssueStoreInterface
-);
+const ExternalIssueStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & ExternalIssueStoreInterface;
 
 export default ExternalIssueStore;

--- a/static/app/stores/externalIssueStore.tsx
+++ b/static/app/stores/externalIssueStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 
 import {PlatformExternalIssue} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type ExternalIssueStoreInterface = {
   add(issue: PlatformExternalIssue): void;
@@ -41,6 +41,6 @@ const storeConfig: Reflux.StoreDefinition & ExternalIssueStoreInterface = {
 
 const ExternalIssueStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & ExternalIssueStoreInterface;
+) as unknown as SafeRefluxStore & ExternalIssueStoreInterface;
 
 export default ExternalIssueStore;

--- a/static/app/stores/externalIssueStore.tsx
+++ b/static/app/stores/externalIssueStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 
 import {PlatformExternalIssue} from 'sentry/types';
-import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type ExternalIssueStoreInterface = {
   add(issue: PlatformExternalIssue): void;
@@ -41,6 +41,6 @@ const storeConfig: Reflux.StoreDefinition & ExternalIssueStoreInterface = {
 
 const ExternalIssueStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & ExternalIssueStoreInterface;
+) as Reflux.Store & ExternalIssueStoreInterface;
 
 export default ExternalIssueStore;

--- a/static/app/stores/externalIssueStore.tsx
+++ b/static/app/stores/externalIssueStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 
 import {PlatformExternalIssue} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type ExternalIssueStoreInterface = {
   add(issue: PlatformExternalIssue): void;
@@ -41,6 +41,6 @@ const storeConfig: Reflux.StoreDefinition & ExternalIssueStoreInterface = {
 
 const ExternalIssueStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & ExternalIssueStoreInterface;
+) as SafeRefluxStore & ExternalIssueStoreInterface;
 
 export default ExternalIssueStore;

--- a/static/app/stores/externalIssueStore.tsx
+++ b/static/app/stores/externalIssueStore.tsx
@@ -1,8 +1,7 @@
 import Reflux from 'reflux';
 
 import {PlatformExternalIssue} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type ExternalIssueStoreInterface = {
   add(issue: PlatformExternalIssue): void;

--- a/static/app/stores/formSearchStore.tsx
+++ b/static/app/stores/formSearchStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import FormSearchActions from 'sentry/actions/formSearchActions';
 import {FieldObject} from 'sentry/components/forms/type';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 /**
  * Processed form field metadata.
  */
@@ -57,6 +59,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & StoreInterface = {
   },
 };
 
-const FormSearchStore = Reflux.createStore(storeConfig) as Reflux.Store & StoreInterface;
+const FormSearchStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & StoreInterface
+);
 
 export default FormSearchStore;

--- a/static/app/stores/formSearchStore.tsx
+++ b/static/app/stores/formSearchStore.tsx
@@ -2,11 +2,7 @@ import Reflux from 'reflux';
 
 import FormSearchActions from 'sentry/actions/formSearchActions';
 import {FieldObject} from 'sentry/components/forms/type';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 /**
  * Processed form field metadata.
@@ -70,6 +66,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const FormSearchStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & StoreInterface;
+) as Reflux.Store & StoreInterface;
 
 export default FormSearchStore;

--- a/static/app/stores/formSearchStore.tsx
+++ b/static/app/stores/formSearchStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import FormSearchActions from 'sentry/actions/formSearchActions';
 import {FieldObject} from 'sentry/components/forms/type';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 /**
  * Processed form field metadata.
@@ -66,6 +70,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const FormSearchStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & StoreInterface;
+) as unknown as SafeRefluxStore & StoreInterface;
 
 export default FormSearchStore;

--- a/static/app/stores/formSearchStore.tsx
+++ b/static/app/stores/formSearchStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import FormSearchActions from 'sentry/actions/formSearchActions';
 import {FieldObject} from 'sentry/components/forms/type';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 /**
  * Processed form field metadata.

--- a/static/app/stores/formSearchStore.tsx
+++ b/static/app/stores/formSearchStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import FormSearchActions from 'sentry/actions/formSearchActions';
 import {FieldObject} from 'sentry/components/forms/type';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 /**
  * Processed form field metadata.
@@ -27,12 +27,18 @@ type Internals = {
 /**
  * Store for "form" searches, but probably will include more
  */
-const storeConfig: Reflux.StoreDefinition & Internals & StoreInterface = {
+const storeConfig: Reflux.StoreDefinition &
+  Internals &
+  StoreInterface &
+  SafeStoreDefinition = {
   searchMap: null,
+  unsubscribeListeners: [],
 
   init() {
     this.reset();
-    this.listenTo(FormSearchActions.loadSearchMap, this.onLoadSearchMap);
+    this.unsubscribeListeners.push(
+      this.listenTo(FormSearchActions.loadSearchMap, this.onLoadSearchMap)
+    );
   },
 
   get() {
@@ -58,8 +64,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & StoreInterface = {
   },
 };
 
-const FormSearchStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & StoreInterface
-);
+const FormSearchStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & StoreInterface;
 
 export default FormSearchStore;

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -13,6 +13,7 @@ import {
   GroupRelease,
   GroupStats,
 } from 'sentry/types';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 function showAlert(msg, type) {
   IndicatorStore.addMessage(msg, type, {duration: 4000});

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -13,7 +13,7 @@ import {
   GroupRelease,
   GroupStats,
 } from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 function showAlert(msg, type) {
   IndicatorStore.addMessage(msg, type, {duration: 4000});
@@ -512,7 +512,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupStoreInterface = {
   },
 };
 
-const GroupStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
-  GroupStoreInterface;
+const GroupStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as SafeRefluxStore & GroupStoreInterface;
 
 export default GroupStore;

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -512,8 +512,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupStoreInterface = {
   },
 };
 
-const GroupStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & GroupStoreInterface
-);
+const GroupStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
+  GroupStoreInterface;
 
 export default GroupStore;

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -511,6 +511,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupStoreInterface = {
   },
 };
 
-const GroupStore = Reflux.createStore(storeConfig) as Reflux.Store & GroupStoreInterface;
+const GroupStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & GroupStoreInterface
+);
 
 export default GroupStore;

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -11,8 +11,7 @@ import GroupingActions from 'sentry/actions/groupingActions';
 import {Client} from 'sentry/api';
 import {Group, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 // Between 0-100
 const MIN_SCORE = 0.6;

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -11,7 +11,7 @@ import GroupingActions from 'sentry/actions/groupingActions';
 import {Client} from 'sentry/api';
 import {Group, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 // Between 0-100
 const MIN_SCORE = 0.6;
@@ -619,6 +619,6 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
 
 const GroupingStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & GroupingStoreInterface;
+) as unknown as SafeRefluxStore & GroupingStoreInterface;
 
 export default GroupingStore;

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -11,7 +11,7 @@ import GroupingActions from 'sentry/actions/groupingActions';
 import {Client} from 'sentry/api';
 import {Group, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 // Between 0-100
 const MIN_SCORE = 0.6;
@@ -619,6 +619,6 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
 
 const GroupingStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & GroupingStoreInterface;
+) as SafeRefluxStore & GroupingStoreInterface;
 
 export default GroupingStore;

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -11,7 +11,7 @@ import GroupingActions from 'sentry/actions/groupingActions';
 import {Client} from 'sentry/api';
 import {Group, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 // Between 0-100
 const MIN_SCORE = 0.6;
@@ -619,6 +619,6 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
 
 const GroupingStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & GroupingStoreInterface;
+) as Reflux.Store & GroupingStoreInterface;
 
 export default GroupingStore;

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -12,6 +12,8 @@ import {Client} from 'sentry/api';
 import {Group, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 // Between 0-100
 const MIN_SCORE = 0.6;
 
@@ -616,7 +618,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
   },
 };
 
-const GroupingStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  GroupingStoreInterface;
+const GroupingStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & GroupingStoreInterface
+);
 
 export default GroupingStore;

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -617,8 +617,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
   },
 };
 
-const GroupingStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & GroupingStoreInterface
-);
+const GroupingStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & GroupingStoreInterface;
 
 export default GroupingStore;

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -11,6 +11,7 @@ import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import {
   cleanupActiveRefluxSubscriptions,
   makeSafeRefluxStore,
+  SafeRefluxStore,
   SafeStoreDefinition,
 } from 'sentry/utils/makeSafeRefluxStore';
 
@@ -278,7 +279,8 @@ const storeConfig: Reflux.StoreDefinition & GuideStoreInterface & SafeStoreDefin
   },
 };
 
-const GuideStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
-  GuideStoreInterface;
+const GuideStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as SafeRefluxStore & GuideStoreInterface;
 
 export default GuideStore;

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -8,8 +8,7 @@ import getGuidesContent from 'sentry/components/assistant/getGuidesContent';
 import {Guide, GuidesContent, GuidesServerData} from 'sentry/components/assistant/types';
 import ConfigStore from 'sentry/stores/configStore';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 function guidePrioritySort(a: Guide, b: Guide) {
   const a_priority = a.priority ?? Number.MAX_SAFE_INTEGER;

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -9,6 +9,8 @@ import {Guide, GuidesContent, GuidesServerData} from 'sentry/components/assistan
 import ConfigStore from 'sentry/stores/configStore';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 function guidePrioritySort(a: Guide, b: Guide) {
   const a_priority = a.priority ?? Number.MAX_SAFE_INTEGER;
   const b_priority = b.priority ?? Number.MAX_SAFE_INTEGER;
@@ -250,6 +252,8 @@ const storeConfig: Reflux.StoreDefinition & GuideStoreInterface = {
   },
 };
 
-const GuideStore = Reflux.createStore(storeConfig) as Reflux.Store & GuideStoreInterface;
+const GuideStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & GuideStoreInterface
+);
 
 export default GuideStore;

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -2,6 +2,7 @@ import isUndefined from 'lodash/isUndefined';
 import Reflux from 'reflux';
 
 import {HookName, Hooks} from 'sentry/types/hooks';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type HookStoreInterface = {
   add<H extends HookName>(hookName: H, callback: Hooks[H]): void;
@@ -49,6 +50,8 @@ const storeConfig: Reflux.StoreDefinition & HookStoreInterface = {
  *
  * This functionality is primarily used by the SASS sentry.io product.
  */
-const HookStore = Reflux.createStore(storeConfig) as Reflux.Store & HookStoreInterface;
+const HookStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & HookStoreInterface
+);
 
 export default HookStore;

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -2,7 +2,7 @@ import isUndefined from 'lodash/isUndefined';
 import Reflux from 'reflux';
 
 import {HookName, Hooks} from 'sentry/types/hooks';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type HookStoreInterface = {
   add<H extends HookName>(hookName: H, callback: Hooks[H]): void;
@@ -27,7 +27,7 @@ const storeConfig: Reflux.StoreDefinition & HookStoreInterface = {
       this.hooks[hookName] = [];
     }
 
-    this.hooks[hookName]!.push(callback);
+    this.hooks[hookName].push(callback);
     this.trigger(hookName, this.hooks[hookName]);
   },
 
@@ -50,8 +50,9 @@ const storeConfig: Reflux.StoreDefinition & HookStoreInterface = {
  *
  * This functionality is primarily used by the SASS sentry.io product.
  */
+
 const HookStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & HookStoreInterface
-);
+  Reflux.createStore(storeConfig)
+) as HookStoreInterface & SafeRefluxStore;
 
 export default HookStore;

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -52,7 +52,7 @@ const storeConfig: Reflux.StoreDefinition & HookStoreInterface = {
  */
 
 const HookStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig)
-) as HookStoreInterface & SafeRefluxStore;
+  Reflux.createStore(storeConfig) as HookStoreInterface & SafeRefluxStore
+);
 
 export default HookStore;

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -51,8 +51,8 @@ const storeConfig: Reflux.StoreDefinition & HookStoreInterface = {
  * This functionality is primarily used by the SASS sentry.io product.
  */
 
-const HookStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as HookStoreInterface & Reflux.Store
-);
+const HookStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as HookStoreInterface & Reflux.Store;
 
 export default HookStore;

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -2,7 +2,7 @@ import isUndefined from 'lodash/isUndefined';
 import Reflux from 'reflux';
 
 import {HookName, Hooks} from 'sentry/types/hooks';
-import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type HookStoreInterface = {
   add<H extends HookName>(hookName: H, callback: Hooks[H]): void;
@@ -52,7 +52,7 @@ const storeConfig: Reflux.StoreDefinition & HookStoreInterface = {
  */
 
 const HookStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as HookStoreInterface & SafeRefluxStore
+  Reflux.createStore(storeConfig) as HookStoreInterface & Reflux.Store
 );
 
 export default HookStore;

--- a/static/app/stores/indicatorStore.tsx
+++ b/static/app/stores/indicatorStore.tsx
@@ -3,11 +3,7 @@ import Reflux from 'reflux';
 import {Indicator} from 'sentry/actionCreators/indicator';
 import IndicatorActions from 'sentry/actions/indicatorActions';
 import {t} from 'sentry/locale';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -152,6 +148,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const IndicatorStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & IndicatorStoreInterface;
+) as Reflux.Store & IndicatorStoreInterface;
 
 export default IndicatorStore;

--- a/static/app/stores/indicatorStore.tsx
+++ b/static/app/stores/indicatorStore.tsx
@@ -4,6 +4,8 @@ import {Indicator} from 'sentry/actionCreators/indicator';
 import IndicatorActions from 'sentry/actions/indicatorActions';
 import {t} from 'sentry/locale';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 import {CommonStoreInterface} from './types';
 
 type IndicatorStoreInterface = CommonStoreInterface<Indicator[]> & {
@@ -139,7 +141,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & IndicatorStoreInterface 
   },
 };
 
-const IndicatorStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  IndicatorStoreInterface;
+const IndicatorStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & IndicatorStoreInterface
+);
 
 export default IndicatorStore;

--- a/static/app/stores/indicatorStore.tsx
+++ b/static/app/stores/indicatorStore.tsx
@@ -3,8 +3,7 @@ import Reflux from 'reflux';
 import {Indicator} from 'sentry/actionCreators/indicator';
 import IndicatorActions from 'sentry/actions/indicatorActions';
 import {t} from 'sentry/locale';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 

--- a/static/app/stores/indicatorStore.tsx
+++ b/static/app/stores/indicatorStore.tsx
@@ -3,7 +3,11 @@ import Reflux from 'reflux';
 import {Indicator} from 'sentry/actionCreators/indicator';
 import IndicatorActions from 'sentry/actions/indicatorActions';
 import {t} from 'sentry/locale';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -148,6 +152,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const IndicatorStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & IndicatorStoreInterface;
+) as unknown as SafeRefluxStore & IndicatorStoreInterface;
 
 export default IndicatorStore;

--- a/static/app/stores/latestContextStore.tsx
+++ b/static/app/stores/latestContextStore.tsx
@@ -5,6 +5,8 @@ import OrganizationsActions from 'sentry/actions/organizationsActions';
 import ProjectActions from 'sentry/actions/projectActions';
 import {Organization, Project} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type OrgTypes = Organization | null;
 
 type State = {
@@ -130,7 +132,8 @@ const storeConfig: Reflux.StoreDefinition & LatestContextStoreInterface = {
   },
 };
 
-const LatestContextStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  LatestContextStoreInterface;
+const LatestContextStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & LatestContextStoreInterface
+);
 
 export default LatestContextStore;

--- a/static/app/stores/latestContextStore.tsx
+++ b/static/app/stores/latestContextStore.tsx
@@ -4,7 +4,11 @@ import OrganizationActions from 'sentry/actions/organizationActions';
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import ProjectActions from 'sentry/actions/projectActions';
 import {Organization, Project} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type OrgTypes = Organization | null;
 
@@ -148,6 +152,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const LatestContextStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & LatestContextStoreInterface;
+) as SafeRefluxStore & LatestContextStoreInterface;
 
 export default LatestContextStore;

--- a/static/app/stores/latestContextStore.tsx
+++ b/static/app/stores/latestContextStore.tsx
@@ -4,11 +4,7 @@ import OrganizationActions from 'sentry/actions/organizationActions';
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import ProjectActions from 'sentry/actions/projectActions';
 import {Organization, Project} from 'sentry/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type OrgTypes = Organization | null;
 
@@ -152,6 +148,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const LatestContextStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & LatestContextStoreInterface;
+) as Reflux.Store & LatestContextStoreInterface;
 
 export default LatestContextStore;

--- a/static/app/stores/latestContextStore.tsx
+++ b/static/app/stores/latestContextStore.tsx
@@ -4,8 +4,7 @@ import OrganizationActions from 'sentry/actions/organizationActions';
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import ProjectActions from 'sentry/actions/projectActions';
 import {Organization, Project} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type OrgTypes = Organization | null;
 

--- a/static/app/stores/latestContextStore.tsx
+++ b/static/app/stores/latestContextStore.tsx
@@ -4,7 +4,11 @@ import OrganizationActions from 'sentry/actions/organizationActions';
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import ProjectActions from 'sentry/actions/projectActions';
 import {Organization, Project} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type OrgTypes = Organization | null;
 
@@ -148,6 +152,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const LatestContextStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & LatestContextStoreInterface;
+) as unknown as SafeRefluxStore & LatestContextStoreInterface;
 
 export default LatestContextStore;

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -2,6 +2,8 @@ import Reflux from 'reflux';
 
 import {User} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type MemberListStoreInterface = {
   getAll(): User[];
   getByEmail(email: string): User | undefined;
@@ -67,7 +69,8 @@ const storeConfig: Reflux.StoreDefinition & MemberListStoreInterface = {
   },
 };
 
-const MemberListStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  MemberListStoreInterface;
+const MemberListStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & MemberListStoreInterface
+);
 
 export default MemberListStore;

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 
 import {User} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type MemberListStoreInterface = {
   getAll(): User[];
@@ -71,6 +71,6 @@ const storeConfig: Reflux.StoreDefinition & MemberListStoreInterface = {
 
 const MemberListStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & MemberListStoreInterface;
+) as SafeRefluxStore & MemberListStoreInterface;
 
 export default MemberListStore;

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -1,8 +1,7 @@
 import Reflux from 'reflux';
 
 import {User} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type MemberListStoreInterface = {
   getAll(): User[];

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -8,6 +8,7 @@ type MemberListStoreInterface = {
   getAll(): User[];
   getByEmail(email: string): User | undefined;
   getById(id: string): User | undefined;
+  init(): void;
   isLoaded(): boolean;
   loadInitialData(items: User[]): void;
   loaded: boolean;

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 
 import {User} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type MemberListStoreInterface = {
   getAll(): User[];
@@ -71,6 +71,6 @@ const storeConfig: Reflux.StoreDefinition & MemberListStoreInterface = {
 
 const MemberListStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & MemberListStoreInterface;
+) as unknown as SafeRefluxStore & MemberListStoreInterface;
 
 export default MemberListStore;

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 
 import {User} from 'sentry/types';
-import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type MemberListStoreInterface = {
   getAll(): User[];
@@ -71,6 +71,6 @@ const storeConfig: Reflux.StoreDefinition & MemberListStoreInterface = {
 
 const MemberListStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & MemberListStoreInterface;
+) as Reflux.Store & MemberListStoreInterface;
 
 export default MemberListStore;

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -69,8 +69,8 @@ const storeConfig: Reflux.StoreDefinition & MemberListStoreInterface = {
   },
 };
 
-const MemberListStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & MemberListStoreInterface
-);
+const MemberListStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & MemberListStoreInterface;
 
 export default MemberListStore;

--- a/static/app/stores/metricsMetaStore.tsx
+++ b/static/app/stores/metricsMetaStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import MetricsMetaActions from 'sentry/actions/metricsMetaActions';
 import {MetricsMeta, MetricsMetaCollection} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -19,11 +19,17 @@ type MetricsMetaStoreInterface = CommonStoreInterface<State> & {
   reset(): void;
 };
 
-const storeConfig: Reflux.StoreDefinition & Internals & MetricsMetaStoreInterface = {
+const storeConfig: Reflux.StoreDefinition &
+  Internals &
+  MetricsMetaStoreInterface &
+  SafeStoreDefinition = {
+  unsubscribeListeners: [],
   metricsMeta: {},
 
   init() {
-    this.listenTo(MetricsMetaActions.loadMetricsMetaSuccess, this.onLoadSuccess);
+    this.unsubscribeListeners.push(
+      this.listenTo(MetricsMetaActions.loadMetricsMetaSuccess, this.onLoadSuccess)
+    );
   },
 
   reset() {
@@ -50,8 +56,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & MetricsMetaStoreInterfac
   },
 };
 
-const MetricsMetaStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & MetricsMetaStoreInterface
-);
+const MetricsMetaStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & MetricsMetaStoreInterface;
 
 export default MetricsMetaStore;

--- a/static/app/stores/metricsMetaStore.tsx
+++ b/static/app/stores/metricsMetaStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import MetricsMetaActions from 'sentry/actions/metricsMetaActions';
 import {MetricsMeta, MetricsMetaCollection} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -58,6 +62,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const MetricsMetaStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & MetricsMetaStoreInterface;
+) as SafeRefluxStore & MetricsMetaStoreInterface;
 
 export default MetricsMetaStore;

--- a/static/app/stores/metricsMetaStore.tsx
+++ b/static/app/stores/metricsMetaStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import MetricsMetaActions from 'sentry/actions/metricsMetaActions';
 import {MetricsMeta, MetricsMetaCollection} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -58,6 +62,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const MetricsMetaStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & MetricsMetaStoreInterface;
+) as unknown as SafeRefluxStore & MetricsMetaStoreInterface;
 
 export default MetricsMetaStore;

--- a/static/app/stores/metricsMetaStore.tsx
+++ b/static/app/stores/metricsMetaStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import MetricsMetaActions from 'sentry/actions/metricsMetaActions';
 import {MetricsMeta, MetricsMetaCollection} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 

--- a/static/app/stores/metricsMetaStore.tsx
+++ b/static/app/stores/metricsMetaStore.tsx
@@ -2,11 +2,7 @@ import Reflux from 'reflux';
 
 import MetricsMetaActions from 'sentry/actions/metricsMetaActions';
 import {MetricsMeta, MetricsMetaCollection} from 'sentry/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -62,6 +58,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const MetricsMetaStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & MetricsMetaStoreInterface;
+) as Reflux.Store & MetricsMetaStoreInterface;
 
 export default MetricsMetaStore;

--- a/static/app/stores/metricsMetaStore.tsx
+++ b/static/app/stores/metricsMetaStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import MetricsMetaActions from 'sentry/actions/metricsMetaActions';
 import {MetricsMeta, MetricsMetaCollection} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 import {CommonStoreInterface} from './types';
 
 type State = {
@@ -49,7 +51,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & MetricsMetaStoreInterfac
   },
 };
 
-const MetricsMetaStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  MetricsMetaStoreInterface;
+const MetricsMetaStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & MetricsMetaStoreInterface
+);
 
 export default MetricsMetaStore;

--- a/static/app/stores/metricsTagStore.tsx
+++ b/static/app/stores/metricsTagStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import MetricsTagActions from 'sentry/actions/metricTagActions';
 import {MetricsTag, MetricsTagCollection} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 

--- a/static/app/stores/metricsTagStore.tsx
+++ b/static/app/stores/metricsTagStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import MetricsTagActions from 'sentry/actions/metricTagActions';
 import {MetricsTag, MetricsTagCollection} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -19,11 +19,17 @@ type MetricsTagStoreInterface = CommonStoreInterface<State> & {
   reset(): void;
 };
 
-const storeConfig: Reflux.StoreDefinition & Internals & MetricsTagStoreInterface = {
+const storeConfig: Reflux.StoreDefinition &
+  Internals &
+  MetricsTagStoreInterface &
+  SafeStoreDefinition = {
+  unsubscribeListeners: [],
   metricsTags: {},
 
   init() {
-    this.listenTo(MetricsTagActions.loadMetricsTagsSuccess, this.onLoadSuccess);
+    this.unsubscribeListeners.push(
+      this.listenTo(MetricsTagActions.loadMetricsTagsSuccess, this.onLoadSuccess)
+    );
   },
 
   reset() {
@@ -50,8 +56,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & MetricsTagStoreInterface
   },
 };
 
-const MetricsTagStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & MetricsTagStoreInterface
-);
+const MetricsTagStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & MetricsTagStoreInterface;
 
 export default MetricsTagStore;

--- a/static/app/stores/metricsTagStore.tsx
+++ b/static/app/stores/metricsTagStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import MetricsTagActions from 'sentry/actions/metricTagActions';
 import {MetricsTag, MetricsTagCollection} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -58,6 +62,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const MetricsTagStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & MetricsTagStoreInterface;
+) as unknown as SafeRefluxStore & MetricsTagStoreInterface;
 
 export default MetricsTagStore;

--- a/static/app/stores/metricsTagStore.tsx
+++ b/static/app/stores/metricsTagStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import MetricsTagActions from 'sentry/actions/metricTagActions';
 import {MetricsTag, MetricsTagCollection} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 import {CommonStoreInterface} from './types';
 
 type State = {
@@ -49,7 +51,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & MetricsTagStoreInterface
   },
 };
 
-const MetricsTagStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  MetricsTagStoreInterface;
+const MetricsTagStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & MetricsTagStoreInterface
+);
 
 export default MetricsTagStore;

--- a/static/app/stores/metricsTagStore.tsx
+++ b/static/app/stores/metricsTagStore.tsx
@@ -2,11 +2,7 @@ import Reflux from 'reflux';
 
 import MetricsTagActions from 'sentry/actions/metricTagActions';
 import {MetricsTag, MetricsTagCollection} from 'sentry/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -62,6 +58,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const MetricsTagStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & MetricsTagStoreInterface;
+) as Reflux.Store & MetricsTagStoreInterface;
 
 export default MetricsTagStore;

--- a/static/app/stores/modalStore.tsx
+++ b/static/app/stores/modalStore.tsx
@@ -16,26 +16,13 @@ type ModalStoreInterface = {
   onCloseModal(): void;
   onOpenModal(renderer: Renderer, options: ModalOptions): void;
   reset(): void;
-  teardown(): void;
-  unsubscribeListeners: (() => void)[];
 };
 
 const storeConfig: Reflux.StoreDefinition & ModalStoreInterface = {
-  unsubscribeListeners: [],
   init() {
     this.reset();
-    this.safeListenTo(ModalActions.closeModal, this.onCloseModal);
-    this.safeListenTo(ModalActions.openModal, this.onOpenModal);
-  },
-
-  safeListenTo(action, callback) {
-    this.unsubscribeListeners.push(this.listenTo(action), callback);
-  },
-
-  teardown() {
-    for (const unsubscribeListener of this.unsubscribeListeners) {
-      unsubscribeListener();
-    }
+    this.listenTo(ModalActions.closeModal, this.onCloseModal);
+    this.listenTo(ModalActions.openModal, this.onOpenModal);
   },
 
   get() {

--- a/static/app/stores/modalStore.tsx
+++ b/static/app/stores/modalStore.tsx
@@ -16,13 +16,26 @@ type ModalStoreInterface = {
   onCloseModal(): void;
   onOpenModal(renderer: Renderer, options: ModalOptions): void;
   reset(): void;
+  teardown(): void;
+  unsubscribeListeners: (() => void)[];
 };
 
 const storeConfig: Reflux.StoreDefinition & ModalStoreInterface = {
+  unsubscribeListeners: [],
   init() {
     this.reset();
-    this.listenTo(ModalActions.closeModal, this.onCloseModal);
-    this.listenTo(ModalActions.openModal, this.onOpenModal);
+    this.safeListenTo(ModalActions.closeModal, this.onCloseModal);
+    this.safeListenTo(ModalActions.openModal, this.onOpenModal);
+  },
+
+  safeListenTo(action, callback) {
+    this.unsubscribeListeners.push(this.listenTo(action), callback);
+  },
+
+  teardown() {
+    for (const unsubscribeListener of this.unsubscribeListeners) {
+      unsubscribeListener();
+    }
   },
 
   get() {

--- a/static/app/stores/modalStore.tsx
+++ b/static/app/stores/modalStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import {ModalOptions, ModalRenderProps} from 'sentry/actionCreators/modal';
 import ModalActions from 'sentry/actions/modalActions';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type Renderer = (renderProps: ModalRenderProps) => React.ReactNode;
 
@@ -19,11 +19,17 @@ type ModalStoreInterface = {
   reset(): void;
 };
 
-const storeConfig: Reflux.StoreDefinition & ModalStoreInterface = {
+const storeConfig: Reflux.StoreDefinition & ModalStoreInterface & SafeStoreDefinition = {
+  unsubscribeListeners: [],
+
   init() {
     this.reset();
-    this.listenTo(ModalActions.closeModal, this.onCloseModal);
-    this.listenTo(ModalActions.openModal, this.onOpenModal);
+    this.unsubscribeListeners.push(
+      this.listenTo(ModalActions.closeModal, this.onCloseModal)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(ModalActions.openModal, this.onOpenModal)
+    );
   },
 
   get() {
@@ -48,8 +54,7 @@ const storeConfig: Reflux.StoreDefinition & ModalStoreInterface = {
   },
 };
 
-const ModalStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & ModalStoreInterface
-);
+const ModalStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
+  ModalStoreInterface;
 
 export default ModalStore;

--- a/static/app/stores/modalStore.tsx
+++ b/static/app/stores/modalStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import {ModalOptions, ModalRenderProps} from 'sentry/actionCreators/modal';
 import ModalActions from 'sentry/actions/modalActions';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type Renderer = (renderProps: ModalRenderProps) => React.ReactNode;
 
@@ -54,7 +58,8 @@ const storeConfig: Reflux.StoreDefinition & ModalStoreInterface & SafeStoreDefin
   },
 };
 
-const ModalStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
-  ModalStoreInterface;
+const ModalStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as SafeRefluxStore & ModalStoreInterface;
 
 export default ModalStore;

--- a/static/app/stores/modalStore.tsx
+++ b/static/app/stores/modalStore.tsx
@@ -2,6 +2,7 @@ import Reflux from 'reflux';
 
 import {ModalOptions, ModalRenderProps} from 'sentry/actionCreators/modal';
 import ModalActions from 'sentry/actions/modalActions';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type Renderer = (renderProps: ModalRenderProps) => React.ReactNode;
 
@@ -47,6 +48,8 @@ const storeConfig: Reflux.StoreDefinition & ModalStoreInterface = {
   },
 };
 
-const ModalStore = Reflux.createStore(storeConfig) as Reflux.Store & ModalStoreInterface;
+const ModalStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & ModalStoreInterface
+);
 
 export default ModalStore;

--- a/static/app/stores/organizationEnvironmentsStore.tsx
+++ b/static/app/stores/organizationEnvironmentsStore.tsx
@@ -3,8 +3,7 @@ import Reflux from 'reflux';
 import EnvironmentActions from 'sentry/actions/environmentActions';
 import {Environment} from 'sentry/types';
 import {getDisplayName, getUrlRoutingName} from 'sentry/utils/environment';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type EnhancedEnvironment = Environment & {
   displayName: string;

--- a/static/app/stores/organizationEnvironmentsStore.tsx
+++ b/static/app/stores/organizationEnvironmentsStore.tsx
@@ -3,11 +3,7 @@ import Reflux from 'reflux';
 import EnvironmentActions from 'sentry/actions/environmentActions';
 import {Environment} from 'sentry/types';
 import {getDisplayName, getUrlRoutingName} from 'sentry/utils/environment';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type EnhancedEnvironment = Environment & {
   displayName: string;
@@ -93,6 +89,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const OrganizationEnvironmentsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & OrganizationEnvironmentsStoreInterface;
+) as Reflux.Store & OrganizationEnvironmentsStoreInterface;
 
 export default OrganizationEnvironmentsStore;

--- a/static/app/stores/organizationEnvironmentsStore.tsx
+++ b/static/app/stores/organizationEnvironmentsStore.tsx
@@ -3,7 +3,11 @@ import Reflux from 'reflux';
 import EnvironmentActions from 'sentry/actions/environmentActions';
 import {Environment} from 'sentry/types';
 import {getDisplayName, getUrlRoutingName} from 'sentry/utils/environment';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type EnhancedEnvironment = Environment & {
   displayName: string;
@@ -89,6 +93,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const OrganizationEnvironmentsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & OrganizationEnvironmentsStoreInterface;
+) as unknown as SafeRefluxStore & OrganizationEnvironmentsStoreInterface;
 
 export default OrganizationEnvironmentsStore;

--- a/static/app/stores/organizationEnvironmentsStore.tsx
+++ b/static/app/stores/organizationEnvironmentsStore.tsx
@@ -4,6 +4,8 @@ import EnvironmentActions from 'sentry/actions/environmentActions';
 import {Environment} from 'sentry/types';
 import {getDisplayName, getUrlRoutingName} from 'sentry/utils/environment';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type EnhancedEnvironment = Environment & {
   displayName: string;
   urlRoutingName: string;
@@ -76,7 +78,8 @@ const storeConfig: Reflux.StoreDefinition & OrganizationEnvironmentsStoreInterfa
   },
 };
 
-const OrganizationEnvironmentsStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  OrganizationEnvironmentsStoreInterface;
+const OrganizationEnvironmentsStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & OrganizationEnvironmentsStoreInterface
+);
 
 export default OrganizationEnvironmentsStore;

--- a/static/app/stores/organizationStore.tsx
+++ b/static/app/stores/organizationStore.tsx
@@ -3,9 +3,8 @@ import Reflux from 'reflux';
 import OrganizationActions from 'sentry/actions/organizationActions';
 import {ORGANIZATION_FETCH_ERROR_TYPES} from 'sentry/constants';
 import {Organization} from 'sentry/types';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 import RequestError from 'sentry/utils/requestError/requestError';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 

--- a/static/app/stores/organizationStore.tsx
+++ b/static/app/stores/organizationStore.tsx
@@ -3,11 +3,7 @@ import Reflux from 'reflux';
 import OrganizationActions from 'sentry/actions/organizationActions';
 import {ORGANIZATION_FETCH_ERROR_TYPES} from 'sentry/constants';
 import {Organization} from 'sentry/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 import RequestError from 'sentry/utils/requestError/requestError';
 
 import {CommonStoreInterface} from './types';
@@ -102,6 +98,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const OrganizationStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & OrganizationStoreInterface;
+) as Reflux.Store & OrganizationStoreInterface;
 
 export default OrganizationStore;

--- a/static/app/stores/organizationStore.tsx
+++ b/static/app/stores/organizationStore.tsx
@@ -5,6 +5,8 @@ import {ORGANIZATION_FETCH_ERROR_TYPES} from 'sentry/constants';
 import {Organization} from 'sentry/types';
 import RequestError from 'sentry/utils/requestError/requestError';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 import {CommonStoreInterface} from './types';
 
 type UpdateOptions = {
@@ -87,7 +89,8 @@ const storeConfig: Reflux.StoreDefinition & OrganizationStoreInterface = {
   },
 };
 
-const OrganizationStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  OrganizationStoreInterface;
+const OrganizationStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & OrganizationStoreInterface
+);
 
 export default OrganizationStore;

--- a/static/app/stores/organizationStore.tsx
+++ b/static/app/stores/organizationStore.tsx
@@ -3,7 +3,11 @@ import Reflux from 'reflux';
 import OrganizationActions from 'sentry/actions/organizationActions';
 import {ORGANIZATION_FETCH_ERROR_TYPES} from 'sentry/constants';
 import {Organization} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 import RequestError from 'sentry/utils/requestError/requestError';
 
 import {CommonStoreInterface} from './types';
@@ -98,6 +102,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const OrganizationStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & OrganizationStoreInterface;
+) as unknown as SafeRefluxStore & OrganizationStoreInterface;
 
 export default OrganizationStore;

--- a/static/app/stores/organizationsStore.tsx
+++ b/static/app/stores/organizationsStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import {Organization} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type OrganizationsStoreInterface = {
   add(item: Organization): void;
@@ -88,6 +88,6 @@ const storeConfig: Reflux.StoreDefinition & OrganizationsStoreInterface = {
 
 const OrganizationsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & OrganizationsStoreInterface;
+) as unknown as SafeRefluxStore & OrganizationsStoreInterface;
 
 export default OrganizationsStore;

--- a/static/app/stores/organizationsStore.tsx
+++ b/static/app/stores/organizationsStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import {Organization} from 'sentry/types';
-import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type OrganizationsStoreInterface = {
   add(item: Organization): void;
@@ -88,6 +88,6 @@ const storeConfig: Reflux.StoreDefinition & OrganizationsStoreInterface = {
 
 const OrganizationsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & OrganizationsStoreInterface;
+) as Reflux.Store & OrganizationsStoreInterface;
 
 export default OrganizationsStore;

--- a/static/app/stores/organizationsStore.tsx
+++ b/static/app/stores/organizationsStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import {Organization} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type OrganizationsStoreInterface = {
   add(item: Organization): void;
@@ -88,6 +88,6 @@ const storeConfig: Reflux.StoreDefinition & OrganizationsStoreInterface = {
 
 const OrganizationsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & OrganizationsStoreInterface;
+) as SafeRefluxStore & OrganizationsStoreInterface;
 
 export default OrganizationsStore;

--- a/static/app/stores/organizationsStore.tsx
+++ b/static/app/stores/organizationsStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import {Organization} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type OrganizationsStoreInterface = {
   add(item: Organization): void;

--- a/static/app/stores/organizationsStore.tsx
+++ b/static/app/stores/organizationsStore.tsx
@@ -86,8 +86,8 @@ const storeConfig: Reflux.StoreDefinition & OrganizationsStoreInterface = {
   },
 };
 
-const OrganizationsStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & OrganizationsStoreInterface
-);
+const OrganizationsStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & OrganizationsStoreInterface;
 
 export default OrganizationsStore;

--- a/static/app/stores/organizationsStore.tsx
+++ b/static/app/stores/organizationsStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import {Organization} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type OrganizationsStoreInterface = {
   add(item: Organization): void;
   get(slug: string): Organization | undefined;
@@ -85,7 +87,8 @@ const storeConfig: Reflux.StoreDefinition & OrganizationsStoreInterface = {
   },
 };
 
-const OrganizationsStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  OrganizationsStoreInterface;
+const OrganizationsStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & OrganizationsStoreInterface
+);
 
 export default OrganizationsStore;

--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -6,6 +6,8 @@ import {getDefaultSelection} from 'sentry/components/organizations/pageFilters/u
 import {PageFilters, PinnedPageFilter} from 'sentry/types';
 import {isEqualWithDates} from 'sentry/utils/isEqualWithDates';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 import {CommonStoreInterface} from './types';
 
 type State = {
@@ -145,7 +147,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & PageFiltersStoreInterfac
   },
 };
 
-const PageFiltersStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  PageFiltersStoreInterface;
+const PageFiltersStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & PageFiltersStoreInterface
+);
 
 export default PageFiltersStore;

--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -5,7 +5,11 @@ import PageFiltersActions from 'sentry/actions/pageFiltersActions';
 import {getDefaultSelection} from 'sentry/components/organizations/pageFilters/utils';
 import {PageFilters, PinnedPageFilter} from 'sentry/types';
 import {isEqualWithDates} from 'sentry/utils/isEqualWithDates';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -166,6 +170,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const PageFiltersStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & PageFiltersStoreInterface;
+) as unknown as SafeRefluxStore & PageFiltersStoreInterface;
 
 export default PageFiltersStore;

--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -37,6 +37,7 @@ type Internals = {
 };
 
 type PageFiltersStoreInterface = CommonStoreInterface<State> & {
+  init(): void;
   onInitializeUrlState(newSelection: PageFilters, pinned: Set<PinnedPageFilter>): void;
   onReset(): void;
   pin(filter: PinnedPageFilter, pin: boolean): void;
@@ -82,10 +83,12 @@ const storeConfig: Reflux.StoreDefinition & Internals & PageFiltersStoreInterfac
   },
 
   getState() {
-    const isReady = this._hasInitialState;
-    const {selection, pinnedFilters, desyncedFilters} = this;
-
-    return {selection, pinnedFilters, desyncedFilters, isReady};
+    return {
+      selection: this.selection,
+      pinnedFilters: this.pinnedFilters,
+      desyncedFilters: this.desyncedFilters,
+      isReady: this._hasInitialState,
+    };
   },
 
   onReset() {

--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -5,8 +5,7 @@ import PageFiltersActions from 'sentry/actions/pageFiltersActions';
 import {getDefaultSelection} from 'sentry/components/organizations/pageFilters/utils';
 import {PageFilters, PinnedPageFilter} from 'sentry/types';
 import {isEqualWithDates} from 'sentry/utils/isEqualWithDates';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 

--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -5,7 +5,11 @@ import PageFiltersActions from 'sentry/actions/pageFiltersActions';
 import {getDefaultSelection} from 'sentry/components/organizations/pageFilters/utils';
 import {PageFilters, PinnedPageFilter} from 'sentry/types';
 import {isEqualWithDates} from 'sentry/utils/isEqualWithDates';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -166,6 +170,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const PageFiltersStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & PageFiltersStoreInterface;
+) as SafeRefluxStore & PageFiltersStoreInterface;
 
 export default PageFiltersStore;

--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -5,11 +5,7 @@ import PageFiltersActions from 'sentry/actions/pageFiltersActions';
 import {getDefaultSelection} from 'sentry/components/organizations/pageFilters/utils';
 import {PageFilters, PinnedPageFilter} from 'sentry/types';
 import {isEqualWithDates} from 'sentry/utils/isEqualWithDates';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -170,6 +166,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const PageFiltersStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & PageFiltersStoreInterface;
+) as Reflux.Store & PageFiltersStoreInterface;
 
 export default PageFiltersStore;

--- a/static/app/stores/pluginsStore.tsx
+++ b/static/app/stores/pluginsStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import PluginActions from 'sentry/actions/pluginActions';
 import {Plugin} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type PluginStoreInterface = {
   plugins: Map<string, Plugin> | null;
   state: {
@@ -121,7 +123,8 @@ const storeConfig: Reflux.StoreDefinition & PluginStoreInterface = {
   },
 };
 
-const PluginStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  PluginStoreInterface;
+const PluginStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & PluginStoreInterface
+);
 
 export default PluginStore;

--- a/static/app/stores/pluginsStore.tsx
+++ b/static/app/stores/pluginsStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import PluginActions from 'sentry/actions/pluginActions';
 import {Plugin} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type PluginStoreInterface = {
   plugins: Map<string, Plugin> | null;
@@ -133,7 +137,8 @@ const storeConfig: Reflux.StoreDefinition & PluginStoreInterface & SafeStoreDefi
   },
 };
 
-const PluginStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
-  PluginStoreInterface;
+const PluginStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as SafeRefluxStore & PluginStoreInterface;
 
 export default PluginStore;

--- a/static/app/stores/pluginsStore.tsx
+++ b/static/app/stores/pluginsStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import PluginActions from 'sentry/actions/pluginActions';
 import {Plugin} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type PluginStoreInterface = {
   plugins: Map<string, Plugin> | null;

--- a/static/app/stores/preferencesStore.tsx
+++ b/static/app/stores/preferencesStore.tsx
@@ -1,7 +1,11 @@
 import Reflux from 'reflux';
 
 import PreferencesActions from 'sentry/actions/preferencesActions';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -74,6 +78,6 @@ const storeConfig: Reflux.StoreDefinition &
  */
 const PreferenceStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & PreferenceStoreInterface;
+) as unknown as SafeRefluxStore & PreferenceStoreInterface;
 
 export default PreferenceStore;

--- a/static/app/stores/preferencesStore.tsx
+++ b/static/app/stores/preferencesStore.tsx
@@ -1,8 +1,7 @@
 import Reflux from 'reflux';
 
 import PreferencesActions from 'sentry/actions/preferencesActions';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 

--- a/static/app/stores/preferencesStore.tsx
+++ b/static/app/stores/preferencesStore.tsx
@@ -2,6 +2,8 @@ import Reflux from 'reflux';
 
 import PreferencesActions from 'sentry/actions/preferencesActions';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 import {CommonStoreInterface} from './types';
 
 type Preferences = {
@@ -62,7 +64,8 @@ const storeConfig: Reflux.StoreDefinition & PreferenceStoreInterface = {
  * This store is used to hold local user preferences
  * Side-effects (like reading/writing to cookies) are done in associated actionCreators
  */
-const PreferenceStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  PreferenceStoreInterface;
+const PreferenceStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & PreferenceStoreInterface
+);
 
 export default PreferenceStore;

--- a/static/app/stores/preferencesStore.tsx
+++ b/static/app/stores/preferencesStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 
 import PreferencesActions from 'sentry/actions/preferencesActions';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -20,15 +20,24 @@ type PreferenceStoreInterface = CommonStoreInterface<Preferences> & {
   reset(): void;
 };
 
-const storeConfig: Reflux.StoreDefinition & PreferenceStoreInterface = {
+const storeConfig: Reflux.StoreDefinition &
+  PreferenceStoreInterface &
+  SafeStoreDefinition = {
   prefs: {},
+  unsubscribeListeners: [],
 
   init() {
     this.reset();
 
-    this.listenTo(PreferencesActions.hideSidebar, this.onHideSidebar);
-    this.listenTo(PreferencesActions.showSidebar, this.onShowSidebar);
-    this.listenTo(PreferencesActions.loadInitialState, this.loadInitialState);
+    this.unsubscribeListeners.push(
+      this.listenTo(PreferencesActions.hideSidebar, this.onHideSidebar)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(PreferencesActions.showSidebar, this.onShowSidebar)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(PreferencesActions.loadInitialState, this.loadInitialState)
+    );
   },
 
   getInitialState() {
@@ -63,8 +72,8 @@ const storeConfig: Reflux.StoreDefinition & PreferenceStoreInterface = {
  * This store is used to hold local user preferences
  * Side-effects (like reading/writing to cookies) are done in associated actionCreators
  */
-const PreferenceStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & PreferenceStoreInterface
-);
+const PreferenceStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & PreferenceStoreInterface;
 
 export default PreferenceStore;

--- a/static/app/stores/preferencesStore.tsx
+++ b/static/app/stores/preferencesStore.tsx
@@ -1,11 +1,7 @@
 import Reflux from 'reflux';
 
 import PreferencesActions from 'sentry/actions/preferencesActions';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -78,6 +74,6 @@ const storeConfig: Reflux.StoreDefinition &
  */
 const PreferenceStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & PreferenceStoreInterface;
+) as Reflux.Store & PreferenceStoreInterface;
 
 export default PreferenceStore;

--- a/static/app/stores/projectsStatsStore.tsx
+++ b/static/app/stores/projectsStatsStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import ProjectActions from 'sentry/actions/projectActions';
 import {Project} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type ProjectsStatsStoreInterface = {
   getAll(): ProjectsStatsStoreInterface['itemsBySlug'];
 
@@ -101,7 +103,8 @@ const storeConfig: Reflux.StoreDefinition & ProjectsStatsStoreInterface = {
   },
 };
 
-const ProjectsStatsStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  ProjectsStatsStoreInterface;
+const ProjectsStatsStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & ProjectsStatsStoreInterface
+);
 
 export default ProjectsStatsStore;

--- a/static/app/stores/projectsStatsStore.tsx
+++ b/static/app/stores/projectsStatsStore.tsx
@@ -2,11 +2,7 @@ import Reflux from 'reflux';
 
 import ProjectActions from 'sentry/actions/projectActions';
 import {Project} from 'sentry/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type ProjectsStatsStoreInterface = {
   getAll(): ProjectsStatsStoreInterface['itemsBySlug'];
@@ -116,6 +112,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const ProjectsStatsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & ProjectsStatsStoreInterface;
+) as Reflux.Store & ProjectsStatsStoreInterface;
 
 export default ProjectsStatsStore;

--- a/static/app/stores/projectsStatsStore.tsx
+++ b/static/app/stores/projectsStatsStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import ProjectActions from 'sentry/actions/projectActions';
 import {Project} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type ProjectsStatsStoreInterface = {
   getAll(): ProjectsStatsStoreInterface['itemsBySlug'];
@@ -112,6 +116,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const ProjectsStatsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & ProjectsStatsStoreInterface;
+) as unknown as SafeRefluxStore & ProjectsStatsStoreInterface;
 
 export default ProjectsStatsStore;

--- a/static/app/stores/projectsStatsStore.tsx
+++ b/static/app/stores/projectsStatsStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import ProjectActions from 'sentry/actions/projectActions';
 import {Project} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type ProjectsStatsStoreInterface = {
   getAll(): ProjectsStatsStoreInterface['itemsBySlug'];

--- a/static/app/stores/projectsStatsStore.tsx
+++ b/static/app/stores/projectsStatsStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import ProjectActions from 'sentry/actions/projectActions';
 import {Project} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type ProjectsStatsStoreInterface = {
   getAll(): ProjectsStatsStoreInterface['itemsBySlug'];
@@ -112,6 +116,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const ProjectsStatsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & ProjectsStatsStoreInterface;
+) as SafeRefluxStore & ProjectsStatsStoreInterface;
 
 export default ProjectsStatsStore;

--- a/static/app/stores/projectsStore.tsx
+++ b/static/app/stores/projectsStore.tsx
@@ -3,7 +3,11 @@ import Reflux from 'reflux';
 import ProjectActions from 'sentry/actions/projectActions';
 import TeamActions from 'sentry/actions/teamActions';
 import {Project, Team} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -214,6 +218,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const ProjectsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & ProjectsStoreInterface;
+) as unknown as SafeRefluxStore & ProjectsStoreInterface;
 
 export default ProjectsStore;

--- a/static/app/stores/projectsStore.tsx
+++ b/static/app/stores/projectsStore.tsx
@@ -3,7 +3,7 @@ import Reflux from 'reflux';
 import ProjectActions from 'sentry/actions/projectActions';
 import TeamActions from 'sentry/actions/teamActions';
 import {Project, Team} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -40,23 +40,43 @@ type ProjectsStoreInterface = CommonStoreInterface<State> & {
   reset(): void;
 };
 
-const storeConfig: Reflux.StoreDefinition & Internals & ProjectsStoreInterface = {
+const storeConfig: Reflux.StoreDefinition &
+  Internals &
+  ProjectsStoreInterface &
+  SafeStoreDefinition = {
   itemsById: {},
   loading: true,
+  unsubscribeListeners: [],
 
   init() {
     this.reset();
 
-    this.listenTo(ProjectActions.addTeamSuccess, this.onAddTeam);
-    this.listenTo(ProjectActions.changeSlug, this.onChangeSlug);
-    this.listenTo(ProjectActions.createSuccess, this.onCreateSuccess);
-    this.listenTo(ProjectActions.loadProjects, this.loadInitialData);
-    this.listenTo(ProjectActions.loadStatsSuccess, this.onStatsLoadSuccess);
-    this.listenTo(ProjectActions.removeTeamSuccess, this.onRemoveTeam);
-    this.listenTo(ProjectActions.reset, this.reset);
-    this.listenTo(ProjectActions.updateSuccess, this.onUpdateSuccess);
+    this.unsubscribeListeners.push(
+      this.listenTo(ProjectActions.addTeamSuccess, this.onAddTeam)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(ProjectActions.changeSlug, this.onChangeSlug)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(ProjectActions.createSuccess, this.onCreateSuccess)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(ProjectActions.loadProjects, this.loadInitialData)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(ProjectActions.loadStatsSuccess, this.onStatsLoadSuccess)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(ProjectActions.removeTeamSuccess, this.onRemoveTeam)
+    );
+    this.unsubscribeListeners.push(this.listenTo(ProjectActions.reset, this.reset));
+    this.unsubscribeListeners.push(
+      this.listenTo(ProjectActions.updateSuccess, this.onUpdateSuccess)
+    );
 
-    this.listenTo(TeamActions.removeTeamSuccess, this.onDeleteTeam);
+    this.unsubscribeListeners.push(
+      this.listenTo(TeamActions.removeTeamSuccess, this.onDeleteTeam)
+    );
   },
 
   reset() {
@@ -192,8 +212,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & ProjectsStoreInterface =
   },
 };
 
-const ProjectsStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & ProjectsStoreInterface
-);
+const ProjectsStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & ProjectsStoreInterface;
 
 export default ProjectsStore;

--- a/static/app/stores/projectsStore.tsx
+++ b/static/app/stores/projectsStore.tsx
@@ -3,11 +3,7 @@ import Reflux from 'reflux';
 import ProjectActions from 'sentry/actions/projectActions';
 import TeamActions from 'sentry/actions/teamActions';
 import {Project, Team} from 'sentry/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -218,6 +214,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const ProjectsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & ProjectsStoreInterface;
+) as Reflux.Store & ProjectsStoreInterface;
 
 export default ProjectsStore;

--- a/static/app/stores/projectsStore.tsx
+++ b/static/app/stores/projectsStore.tsx
@@ -3,8 +3,7 @@ import Reflux from 'reflux';
 import ProjectActions from 'sentry/actions/projectActions';
 import TeamActions from 'sentry/actions/teamActions';
 import {Project, Team} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 

--- a/static/app/stores/projectsStore.tsx
+++ b/static/app/stores/projectsStore.tsx
@@ -4,6 +4,8 @@ import ProjectActions from 'sentry/actions/projectActions';
 import TeamActions from 'sentry/actions/teamActions';
 import {Project, Team} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 import {CommonStoreInterface} from './types';
 
 type State = {
@@ -191,7 +193,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & ProjectsStoreInterface =
   },
 };
 
-const ProjectsStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  ProjectsStoreInterface;
+const ProjectsStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & ProjectsStoreInterface
+);
 
 export default ProjectsStore;

--- a/static/app/stores/releaseStore.tsx
+++ b/static/app/stores/releaseStore.tsx
@@ -3,11 +3,7 @@ import Reflux from 'reflux';
 import OrganizationActions from 'sentry/actions/organizationActions';
 import ReleaseActions from 'sentry/actions/releaseActions';
 import {Deploy, Organization, Release} from 'sentry/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type StoreRelease = Map<string, Release>;
 type StoreDeploys = Map<string, Array<Deploy>>;
@@ -233,6 +229,6 @@ const storeConfig: Reflux.StoreDefinition & ReleaseStoreInterface & SafeStoreDef
 
 const ReleaseStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & ReleaseStoreInterface;
+) as Reflux.Store & ReleaseStoreInterface;
 
 export default ReleaseStore;

--- a/static/app/stores/releaseStore.tsx
+++ b/static/app/stores/releaseStore.tsx
@@ -3,8 +3,7 @@ import Reflux from 'reflux';
 import OrganizationActions from 'sentry/actions/organizationActions';
 import ReleaseActions from 'sentry/actions/releaseActions';
 import {Deploy, Organization, Release} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type StoreRelease = Map<string, Release>;
 type StoreDeploys = Map<string, Array<Deploy>>;

--- a/static/app/stores/releaseStore.tsx
+++ b/static/app/stores/releaseStore.tsx
@@ -4,6 +4,8 @@ import OrganizationActions from 'sentry/actions/organizationActions';
 import ReleaseActions from 'sentry/actions/releaseActions';
 import {Deploy, Organization, Release} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type StoreRelease = Map<string, Release>;
 type StoreDeploys = Map<string, Array<Deploy>>;
 type StoreLoading = Map<string, boolean>;
@@ -222,7 +224,8 @@ const storeConfig: Reflux.StoreDefinition & ReleaseStoreInterface = {
   },
 };
 
-const ReleaseStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  ReleaseStoreInterface;
+const ReleaseStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & ReleaseStoreInterface
+);
 
 export default ReleaseStore;

--- a/static/app/stores/releaseStore.tsx
+++ b/static/app/stores/releaseStore.tsx
@@ -3,7 +3,11 @@ import Reflux from 'reflux';
 import OrganizationActions from 'sentry/actions/organizationActions';
 import ReleaseActions from 'sentry/actions/releaseActions';
 import {Deploy, Organization, Release} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type StoreRelease = Map<string, Release>;
 type StoreDeploys = Map<string, Array<Deploy>>;
@@ -229,6 +233,6 @@ const storeConfig: Reflux.StoreDefinition & ReleaseStoreInterface & SafeStoreDef
 
 const ReleaseStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & ReleaseStoreInterface;
+) as unknown as SafeRefluxStore & ReleaseStoreInterface;
 
 export default ReleaseStore;

--- a/static/app/stores/repositoryStore.tsx
+++ b/static/app/stores/repositoryStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import RepoActions from 'sentry/actions/repositoryActions';
 import {Repository} from 'sentry/types';
-import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type RepositoryStoreInterface = {
   get(): {
@@ -84,6 +84,6 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
 
 const RepositoryStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & RepositoryStoreInterface;
+) as Reflux.Store & RepositoryStoreInterface;
 
 export default RepositoryStore;

--- a/static/app/stores/repositoryStore.tsx
+++ b/static/app/stores/repositoryStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import RepoActions from 'sentry/actions/repositoryActions';
 import {Repository} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type RepositoryStoreInterface = {
   get(): {
     orgSlug?: string;
@@ -81,7 +83,8 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   },
 };
 
-const RepositoryStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  RepositoryStoreInterface;
+const RepositoryStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & RepositoryStoreInterface
+);
 
 export default RepositoryStore;

--- a/static/app/stores/repositoryStore.tsx
+++ b/static/app/stores/repositoryStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import RepoActions from 'sentry/actions/repositoryActions';
 import {Repository} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type RepositoryStoreInterface = {
   get(): {
@@ -84,6 +84,6 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
 
 const RepositoryStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & RepositoryStoreInterface;
+) as unknown as SafeRefluxStore & RepositoryStoreInterface;
 
 export default RepositoryStore;

--- a/static/app/stores/repositoryStore.tsx
+++ b/static/app/stores/repositoryStore.tsx
@@ -82,8 +82,8 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   },
 };
 
-const RepositoryStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & RepositoryStoreInterface
-);
+const RepositoryStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & RepositoryStoreInterface;
 
 export default RepositoryStore;

--- a/static/app/stores/repositoryStore.tsx
+++ b/static/app/stores/repositoryStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import RepoActions from 'sentry/actions/repositoryActions';
 import {Repository} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type RepositoryStoreInterface = {
   get(): {

--- a/static/app/stores/savedSearchesStore.tsx
+++ b/static/app/stores/savedSearchesStore.tsx
@@ -3,7 +3,7 @@ import Reflux from 'reflux';
 
 import SavedSearchesActions from 'sentry/actions/savedSearchesActions';
 import {SavedSearch, SavedSearchType} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type State = {
   hasError: boolean;
@@ -20,7 +20,11 @@ type SavedSearchesStoreInterface = {
   updateExistingSearch(id: string, changes: Partial<SavedSearch>): SavedSearch;
 };
 
-const storeConfig: Reflux.StoreDefinition & SavedSearchesStoreInterface = {
+const storeConfig: Reflux.StoreDefinition &
+  SavedSearchesStoreInterface &
+  SafeStoreDefinition = {
+  unsubscribeListeners: [],
+
   state: {
     savedSearches: [],
     hasError: false,
@@ -40,15 +44,27 @@ const storeConfig: Reflux.StoreDefinition & SavedSearchesStoreInterface = {
       unpinSearch,
     } = SavedSearchesActions;
 
-    this.listenTo(startFetchSavedSearches, this.onStartFetchSavedSearches);
-    this.listenTo(fetchSavedSearchesSuccess, this.onFetchSavedSearchesSuccess);
-    this.listenTo(fetchSavedSearchesError, this.onFetchSavedSearchesError);
-    this.listenTo(resetSavedSearches, this.onReset);
-    this.listenTo(createSavedSearchSuccess, this.onCreateSavedSearchSuccess);
-    this.listenTo(deleteSavedSearchSuccess, this.onDeleteSavedSearchSuccess);
-    this.listenTo(pinSearch, this.onPinSearch);
-    this.listenTo(pinSearchSuccess, this.onPinSearchSuccess);
-    this.listenTo(unpinSearch, this.onUnpinSearch);
+    this.unsubscribeListeners.push(
+      this.listenTo(startFetchSavedSearches, this.onStartFetchSavedSearches)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(fetchSavedSearchesSuccess, this.onFetchSavedSearchesSuccess)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(fetchSavedSearchesError, this.onFetchSavedSearchesError)
+    );
+    this.unsubscribeListeners.push(this.listenTo(resetSavedSearches, this.onReset));
+    this.unsubscribeListeners.push(
+      this.listenTo(createSavedSearchSuccess, this.onCreateSavedSearchSuccess)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(deleteSavedSearchSuccess, this.onDeleteSavedSearchSuccess)
+    );
+    this.unsubscribeListeners.push(this.listenTo(pinSearch, this.onPinSearch));
+    this.unsubscribeListeners.push(
+      this.listenTo(pinSearchSuccess, this.onPinSearchSuccess)
+    );
+    this.unsubscribeListeners.push(this.listenTo(unpinSearch, this.onUnpinSearch));
 
     this.reset();
   },
@@ -231,8 +247,8 @@ const storeConfig: Reflux.StoreDefinition & SavedSearchesStoreInterface = {
   },
 };
 
-const SavedSearchesStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & SavedSearchesStoreInterface
-);
+const SavedSearchesStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & SavedSearchesStoreInterface;
 
 export default SavedSearchesStore;

--- a/static/app/stores/savedSearchesStore.tsx
+++ b/static/app/stores/savedSearchesStore.tsx
@@ -4,6 +4,8 @@ import Reflux from 'reflux';
 import SavedSearchesActions from 'sentry/actions/savedSearchesActions';
 import {SavedSearch, SavedSearchType} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type State = {
   hasError: boolean;
   isLoading: boolean;
@@ -230,7 +232,8 @@ const storeConfig: Reflux.StoreDefinition & SavedSearchesStoreInterface = {
   },
 };
 
-const SavedSearchesStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  SavedSearchesStoreInterface;
+const SavedSearchesStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & SavedSearchesStoreInterface
+);
 
 export default SavedSearchesStore;

--- a/static/app/stores/savedSearchesStore.tsx
+++ b/static/app/stores/savedSearchesStore.tsx
@@ -3,8 +3,7 @@ import Reflux from 'reflux';
 
 import SavedSearchesActions from 'sentry/actions/savedSearchesActions';
 import {SavedSearch, SavedSearchType} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type State = {
   hasError: boolean;

--- a/static/app/stores/savedSearchesStore.tsx
+++ b/static/app/stores/savedSearchesStore.tsx
@@ -3,7 +3,11 @@ import Reflux from 'reflux';
 
 import SavedSearchesActions from 'sentry/actions/savedSearchesActions';
 import {SavedSearch, SavedSearchType} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type State = {
   hasError: boolean;
@@ -249,6 +253,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const SavedSearchesStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & SavedSearchesStoreInterface;
+) as unknown as SafeRefluxStore & SavedSearchesStoreInterface;
 
 export default SavedSearchesStore;

--- a/static/app/stores/savedSearchesStore.tsx
+++ b/static/app/stores/savedSearchesStore.tsx
@@ -3,11 +3,7 @@ import Reflux from 'reflux';
 
 import SavedSearchesActions from 'sentry/actions/savedSearchesActions';
 import {SavedSearch, SavedSearchType} from 'sentry/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type State = {
   hasError: boolean;
@@ -253,6 +249,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const SavedSearchesStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & SavedSearchesStoreInterface;
+) as Reflux.Store & SavedSearchesStoreInterface;
 
 export default SavedSearchesStore;

--- a/static/app/stores/sdkUpdatesStore.tsx
+++ b/static/app/stores/sdkUpdatesStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import SdkUpdatesActions from 'sentry/actions/sdkUpdatesActions';
 import {ProjectSdkUpdates} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type SdkUpdatesStoreInterface = {
   getUpdates(orgSlug: string): ProjectSdkUpdates[] | undefined;
   isSdkUpdatesLoaded(orgSlug: string): boolean;
@@ -37,7 +39,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & SdkUpdatesStoreInterface
   },
 };
 
-const SdkUpdatesStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  SdkUpdatesStoreInterface;
+const SdkUpdatesStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & SdkUpdatesStoreInterface
+);
 
 export default SdkUpdatesStore;

--- a/static/app/stores/sdkUpdatesStore.tsx
+++ b/static/app/stores/sdkUpdatesStore.tsx
@@ -2,11 +2,7 @@ import Reflux from 'reflux';
 
 import SdkUpdatesActions from 'sentry/actions/sdkUpdatesActions';
 import {ProjectSdkUpdates} from 'sentry/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type SdkUpdatesStoreInterface = {
   getUpdates(orgSlug: string): ProjectSdkUpdates[] | undefined;
@@ -50,6 +46,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const SdkUpdatesStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & SdkUpdatesStoreInterface;
+) as Reflux.Store & SdkUpdatesStoreInterface;
 
 export default SdkUpdatesStore;

--- a/static/app/stores/sdkUpdatesStore.tsx
+++ b/static/app/stores/sdkUpdatesStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import SdkUpdatesActions from 'sentry/actions/sdkUpdatesActions';
 import {ProjectSdkUpdates} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type SdkUpdatesStoreInterface = {
   getUpdates(orgSlug: string): ProjectSdkUpdates[] | undefined;
@@ -17,11 +17,17 @@ type Internals = {
   orgSdkUpdates: Map<string, ProjectSdkUpdates[]>;
 };
 
-const storeConfig: Reflux.StoreDefinition & Internals & SdkUpdatesStoreInterface = {
+const storeConfig: Reflux.StoreDefinition &
+  Internals &
+  SdkUpdatesStoreInterface &
+  SafeStoreDefinition = {
   orgSdkUpdates: new Map(),
+  unsubscribeListeners: [],
 
   init() {
-    this.listenTo(SdkUpdatesActions.load, this.onLoadSuccess);
+    this.unsubscribeListeners.push(
+      this.listenTo(SdkUpdatesActions.load, this.onLoadSuccess)
+    );
   },
 
   onLoadSuccess(orgSlug, data) {
@@ -38,8 +44,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & SdkUpdatesStoreInterface
   },
 };
 
-const SdkUpdatesStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & SdkUpdatesStoreInterface
-);
+const SdkUpdatesStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & SdkUpdatesStoreInterface;
 
 export default SdkUpdatesStore;

--- a/static/app/stores/sdkUpdatesStore.tsx
+++ b/static/app/stores/sdkUpdatesStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import SdkUpdatesActions from 'sentry/actions/sdkUpdatesActions';
 import {ProjectSdkUpdates} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type SdkUpdatesStoreInterface = {
   getUpdates(orgSlug: string): ProjectSdkUpdates[] | undefined;
@@ -46,6 +50,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const SdkUpdatesStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & SdkUpdatesStoreInterface;
+) as unknown as SafeRefluxStore & SdkUpdatesStoreInterface;
 
 export default SdkUpdatesStore;

--- a/static/app/stores/sdkUpdatesStore.tsx
+++ b/static/app/stores/sdkUpdatesStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import SdkUpdatesActions from 'sentry/actions/sdkUpdatesActions';
 import {ProjectSdkUpdates} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type SdkUpdatesStoreInterface = {
   getUpdates(orgSlug: string): ProjectSdkUpdates[] | undefined;

--- a/static/app/stores/selectedGroupStore.tsx
+++ b/static/app/stores/selectedGroupStore.tsx
@@ -2,6 +2,8 @@ import Reflux from 'reflux';
 
 import GroupStore from 'sentry/stores/groupStore';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type SelectedGroupStoreInterface = {
   add(ids: string[]): void;
   allSelected(): boolean;
@@ -118,7 +120,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & SelectedGroupStoreInterf
   },
 };
 
-const SelectedGroupStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  SelectedGroupStoreInterface;
+const SelectedGroupStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & SelectedGroupStoreInterface
+);
 
 export default SelectedGroupStore;

--- a/static/app/stores/selectedGroupStore.tsx
+++ b/static/app/stores/selectedGroupStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 
 import GroupStore from 'sentry/stores/groupStore';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type SelectedGroupStoreInterface = {
   add(ids: string[]): void;
@@ -23,13 +23,19 @@ type Internals = {
   records: Record<string, boolean>;
 };
 
-const storeConfig: Reflux.StoreDefinition & Internals & SelectedGroupStoreInterface = {
+const storeConfig: Reflux.StoreDefinition &
+  Internals &
+  SelectedGroupStoreInterface &
+  SafeStoreDefinition = {
   records: {},
+  unsubscribeListeners: [],
 
   init() {
     this.records = {};
 
-    this.listenTo(GroupStore, this.onGroupChange, this.onGroupChange);
+    this.unsubscribeListeners.push(
+      this.listenTo(GroupStore, this.onGroupChange, this.onGroupChange)
+    );
   },
 
   onGroupChange(itemIds) {
@@ -119,8 +125,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & SelectedGroupStoreInterf
   },
 };
 
-const SelectedGroupStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & SelectedGroupStoreInterface
-);
+const SelectedGroupStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & SelectedGroupStoreInterface;
 
 export default SelectedGroupStore;

--- a/static/app/stores/selectedGroupStore.tsx
+++ b/static/app/stores/selectedGroupStore.tsx
@@ -1,11 +1,7 @@
 import Reflux from 'reflux';
 
 import GroupStore from 'sentry/stores/groupStore';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type SelectedGroupStoreInterface = {
   add(ids: string[]): void;
@@ -131,6 +127,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const SelectedGroupStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & SelectedGroupStoreInterface;
+) as Reflux.Store & SelectedGroupStoreInterface;
 
 export default SelectedGroupStore;

--- a/static/app/stores/selectedGroupStore.tsx
+++ b/static/app/stores/selectedGroupStore.tsx
@@ -1,8 +1,7 @@
 import Reflux from 'reflux';
 
 import GroupStore from 'sentry/stores/groupStore';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type SelectedGroupStoreInterface = {
   add(ids: string[]): void;

--- a/static/app/stores/selectedGroupStore.tsx
+++ b/static/app/stores/selectedGroupStore.tsx
@@ -1,7 +1,11 @@
 import Reflux from 'reflux';
 
 import GroupStore from 'sentry/stores/groupStore';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type SelectedGroupStoreInterface = {
   add(ids: string[]): void;
@@ -127,6 +131,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const SelectedGroupStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & SelectedGroupStoreInterface;
+) as unknown as SafeRefluxStore & SelectedGroupStoreInterface;
 
 export default SelectedGroupStore;

--- a/static/app/stores/sentryAppComponentsStore.tsx
+++ b/static/app/stores/sentryAppComponentsStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import SentryAppComponentsActions from 'sentry/actions/sentryAppComponentActions';
 import {SentryAppComponent} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type SentryAppComponentsStoreInterface = {
   get: (uuid: string) => SentryAppComponent | undefined;

--- a/static/app/stores/sentryAppComponentsStore.tsx
+++ b/static/app/stores/sentryAppComponentsStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import SentryAppComponentsActions from 'sentry/actions/sentryAppComponentActions';
 import {SentryAppComponent} from 'sentry/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type SentryAppComponentsStoreInterface = {
   get: (uuid: string) => SentryAppComponent | undefined;
@@ -53,6 +57,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const SentryAppComponentsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & SentryAppComponentsStoreInterface;
+) as unknown as SafeRefluxStore & SentryAppComponentsStoreInterface;
 
 export default SentryAppComponentsStore;

--- a/static/app/stores/sentryAppComponentsStore.tsx
+++ b/static/app/stores/sentryAppComponentsStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import SentryAppComponentsActions from 'sentry/actions/sentryAppComponentActions';
 import {SentryAppComponent} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type SentryAppComponentsStoreInterface = {
   get: (uuid: string) => SentryAppComponent | undefined;
@@ -12,10 +12,16 @@ type SentryAppComponentsStoreInterface = {
   onLoadComponents: (items: SentryAppComponent[]) => void;
 };
 
-const storeConfig: Reflux.StoreDefinition & SentryAppComponentsStoreInterface = {
+const storeConfig: Reflux.StoreDefinition &
+  SentryAppComponentsStoreInterface &
+  SafeStoreDefinition = {
+  unsubscribeListeners: [],
+
   init() {
     this.items = [];
-    this.listenTo(SentryAppComponentsActions.loadComponents, this.onLoadComponents);
+    this.unsubscribeListeners.push(
+      this.listenTo(SentryAppComponentsActions.loadComponents, this.onLoadComponents)
+    );
   },
 
   getInitialState() {
@@ -45,8 +51,8 @@ const storeConfig: Reflux.StoreDefinition & SentryAppComponentsStoreInterface = 
   },
 };
 
-const SentryAppComponentsStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & SentryAppComponentsStoreInterface
-);
+const SentryAppComponentsStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & SentryAppComponentsStoreInterface;
 
 export default SentryAppComponentsStore;

--- a/static/app/stores/sentryAppComponentsStore.tsx
+++ b/static/app/stores/sentryAppComponentsStore.tsx
@@ -2,11 +2,7 @@ import Reflux from 'reflux';
 
 import SentryAppComponentsActions from 'sentry/actions/sentryAppComponentActions';
 import {SentryAppComponent} from 'sentry/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type SentryAppComponentsStoreInterface = {
   get: (uuid: string) => SentryAppComponent | undefined;
@@ -57,6 +53,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const SentryAppComponentsStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & SentryAppComponentsStoreInterface;
+) as Reflux.Store & SentryAppComponentsStoreInterface;
 
 export default SentryAppComponentsStore;

--- a/static/app/stores/sentryAppComponentsStore.tsx
+++ b/static/app/stores/sentryAppComponentsStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import SentryAppComponentsActions from 'sentry/actions/sentryAppComponentActions';
 import {SentryAppComponent} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type SentryAppComponentsStoreInterface = {
   get: (uuid: string) => SentryAppComponent | undefined;
   getAll: () => SentryAppComponent[];
@@ -44,7 +46,8 @@ const storeConfig: Reflux.StoreDefinition & SentryAppComponentsStoreInterface = 
   },
 };
 
-const SentryAppComponentsStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  SentryAppComponentsStoreInterface;
+const SentryAppComponentsStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & SentryAppComponentsStoreInterface
+);
 
 export default SentryAppComponentsStore;

--- a/static/app/stores/sentryAppInstallationsStore.tsx
+++ b/static/app/stores/sentryAppInstallationsStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 
 import {SentryAppInstallation} from 'sentry/types';
-import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type SentryAppInstallationStoreInterface = {
   getInitialState(): SentryAppInstallation[];
@@ -34,6 +34,6 @@ const storeConfig: Reflux.StoreDefinition & SentryAppInstallationStoreInterface 
 
 const SentryAppInstallationStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & SentryAppInstallationStoreInterface;
+) as Reflux.Store & SentryAppInstallationStoreInterface;
 
 export default SentryAppInstallationStore;

--- a/static/app/stores/sentryAppInstallationsStore.tsx
+++ b/static/app/stores/sentryAppInstallationsStore.tsx
@@ -1,8 +1,7 @@
 import Reflux from 'reflux';
 
 import {SentryAppInstallation} from 'sentry/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type SentryAppInstallationStoreInterface = {
   getInitialState(): SentryAppInstallation[];

--- a/static/app/stores/sentryAppInstallationsStore.tsx
+++ b/static/app/stores/sentryAppInstallationsStore.tsx
@@ -2,6 +2,8 @@ import Reflux from 'reflux';
 
 import {SentryAppInstallation} from 'sentry/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type SentryAppInstallationStoreInterface = {
   getInitialState(): SentryAppInstallation[];
   load(items: SentryAppInstallation[]): void;
@@ -31,7 +33,8 @@ const storeConfig: Reflux.StoreDefinition & SentryAppInstallationStoreInterface 
   },
 };
 
-const SentryAppInstallationStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  SentryAppInstallationStoreInterface;
+const SentryAppInstallationStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & SentryAppInstallationStoreInterface
+);
 
 export default SentryAppInstallationStore;

--- a/static/app/stores/sentryAppInstallationsStore.tsx
+++ b/static/app/stores/sentryAppInstallationsStore.tsx
@@ -32,8 +32,8 @@ const storeConfig: Reflux.StoreDefinition & SentryAppInstallationStoreInterface 
   },
 };
 
-const SentryAppInstallationStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & SentryAppInstallationStoreInterface
-);
+const SentryAppInstallationStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & SentryAppInstallationStoreInterface;
 
 export default SentryAppInstallationStore;

--- a/static/app/stores/sentryAppInstallationsStore.tsx
+++ b/static/app/stores/sentryAppInstallationsStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 
 import {SentryAppInstallation} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type SentryAppInstallationStoreInterface = {
   getInitialState(): SentryAppInstallation[];
@@ -34,6 +34,6 @@ const storeConfig: Reflux.StoreDefinition & SentryAppInstallationStoreInterface 
 
 const SentryAppInstallationStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & SentryAppInstallationStoreInterface;
+) as unknown as SafeRefluxStore & SentryAppInstallationStoreInterface;
 
 export default SentryAppInstallationStore;

--- a/static/app/stores/settingsBreadcrumbStore.tsx
+++ b/static/app/stores/settingsBreadcrumbStore.tsx
@@ -3,7 +3,11 @@ import Reflux from 'reflux';
 
 import SettingsBreadcrumbActions from 'sentry/actions/settingsBreadcrumbActions';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 type UpdateData = {
   routes: PlainRoute<any>[];
@@ -65,6 +69,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const SettingsBreadcrumbStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & SettingsBreadcrumbStoreInterface;
+) as unknown as SafeRefluxStore & SettingsBreadcrumbStoreInterface;
 
 export default SettingsBreadcrumbStore;

--- a/static/app/stores/settingsBreadcrumbStore.tsx
+++ b/static/app/stores/settingsBreadcrumbStore.tsx
@@ -4,6 +4,8 @@ import Reflux from 'reflux';
 import SettingsBreadcrumbActions from 'sentry/actions/settingsBreadcrumbActions';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 type UpdateData = {
   routes: PlainRoute<any>[];
   title: string;
@@ -54,7 +56,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & SettingsBreadcrumbStoreI
     },
   };
 
-const SettingsBreadcrumbStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  SettingsBreadcrumbStoreInterface;
+const SettingsBreadcrumbStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & SettingsBreadcrumbStoreInterface
+);
 
 export default SettingsBreadcrumbStore;

--- a/static/app/stores/settingsBreadcrumbStore.tsx
+++ b/static/app/stores/settingsBreadcrumbStore.tsx
@@ -3,11 +3,7 @@ import Reflux from 'reflux';
 
 import SettingsBreadcrumbActions from 'sentry/actions/settingsBreadcrumbActions';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 type UpdateData = {
   routes: PlainRoute<any>[];
@@ -69,6 +65,6 @@ const storeConfig: Reflux.StoreDefinition &
 
 const SettingsBreadcrumbStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & SettingsBreadcrumbStoreInterface;
+) as Reflux.Store & SettingsBreadcrumbStoreInterface;
 
 export default SettingsBreadcrumbStore;

--- a/static/app/stores/settingsBreadcrumbStore.tsx
+++ b/static/app/stores/settingsBreadcrumbStore.tsx
@@ -3,8 +3,7 @@ import Reflux from 'reflux';
 
 import SettingsBreadcrumbActions from 'sentry/actions/settingsBreadcrumbActions';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type UpdateData = {
   routes: PlainRoute<any>[];

--- a/static/app/stores/sidebarPanelStore.tsx
+++ b/static/app/stores/sidebarPanelStore.tsx
@@ -2,8 +2,7 @@ import Reflux from 'reflux';
 
 import SidebarPanelActions from 'sentry/actions/sidebarPanelActions';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 

--- a/static/app/stores/sidebarPanelStore.tsx
+++ b/static/app/stores/sidebarPanelStore.tsx
@@ -3,6 +3,8 @@ import Reflux from 'reflux';
 import SidebarPanelActions from 'sentry/actions/sidebarPanelActions';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 import {CommonStoreInterface} from './types';
 
 type ActivePanelType = SidebarPanelKey | '';
@@ -51,7 +53,8 @@ const storeConfig: Reflux.StoreDefinition & SidebarPanelStoreInterface = {
  * This store is used to hold local user preferences
  * Side-effects (like reading/writing to cookies) are done in associated actionCreators
  */
-const SidebarPanelStore = Reflux.createStore(storeConfig) as Reflux.Store &
-  SidebarPanelStoreInterface;
+const SidebarPanelStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & SidebarPanelStoreInterface
+);
 
 export default SidebarPanelStore;

--- a/static/app/stores/sidebarPanelStore.tsx
+++ b/static/app/stores/sidebarPanelStore.tsx
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import SidebarPanelActions from 'sentry/actions/sidebarPanelActions';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -16,13 +16,22 @@ type SidebarPanelStoreInterface = CommonStoreInterface<ActivePanelType> & {
   onTogglePanel(panel: SidebarPanelKey): void;
 };
 
-const storeConfig: Reflux.StoreDefinition & SidebarPanelStoreInterface = {
+const storeConfig: Reflux.StoreDefinition &
+  SidebarPanelStoreInterface &
+  SafeStoreDefinition = {
   activePanel: '',
+  unsubscribeListeners: [],
 
   init() {
-    this.listenTo(SidebarPanelActions.activatePanel, this.onActivatePanel);
-    this.listenTo(SidebarPanelActions.hidePanel, this.onHidePanel);
-    this.listenTo(SidebarPanelActions.togglePanel, this.onTogglePanel);
+    this.unsubscribeListeners.push(
+      this.listenTo(SidebarPanelActions.activatePanel, this.onActivatePanel)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(SidebarPanelActions.hidePanel, this.onHidePanel)
+    );
+    this.unsubscribeListeners.push(
+      this.listenTo(SidebarPanelActions.togglePanel, this.onTogglePanel)
+    );
   },
 
   onActivatePanel(panel: SidebarPanelKey) {
@@ -52,8 +61,8 @@ const storeConfig: Reflux.StoreDefinition & SidebarPanelStoreInterface = {
  * This store is used to hold local user preferences
  * Side-effects (like reading/writing to cookies) are done in associated actionCreators
  */
-const SidebarPanelStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & SidebarPanelStoreInterface
-);
+const SidebarPanelStore = Reflux.createStore(
+  makeSafeRefluxStore(storeConfig)
+) as Reflux.Store & SidebarPanelStoreInterface;
 
 export default SidebarPanelStore;

--- a/static/app/stores/sidebarPanelStore.tsx
+++ b/static/app/stores/sidebarPanelStore.tsx
@@ -2,7 +2,11 @@ import Reflux from 'reflux';
 
 import SidebarPanelActions from 'sentry/actions/sidebarPanelActions';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -63,6 +67,6 @@ const storeConfig: Reflux.StoreDefinition &
  */
 const SidebarPanelStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as Reflux.Store & SidebarPanelStoreInterface;
+) as unknown as SafeRefluxStore & SidebarPanelStoreInterface;
 
 export default SidebarPanelStore;

--- a/static/app/stores/sidebarPanelStore.tsx
+++ b/static/app/stores/sidebarPanelStore.tsx
@@ -2,11 +2,7 @@ import Reflux from 'reflux';
 
 import SidebarPanelActions from 'sentry/actions/sidebarPanelActions';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
-import {
-  makeSafeRefluxStore,
-  SafeRefluxStore,
-  SafeStoreDefinition,
-} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -67,6 +63,6 @@ const storeConfig: Reflux.StoreDefinition &
  */
 const SidebarPanelStore = Reflux.createStore(
   makeSafeRefluxStore(storeConfig)
-) as unknown as SafeRefluxStore & SidebarPanelStoreInterface;
+) as Reflux.Store & SidebarPanelStoreInterface;
 
 export default SidebarPanelStore;

--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -3,7 +3,7 @@ import Reflux from 'reflux';
 import TagActions from 'sentry/actions/tagActions';
 import {Tag, TagCollection} from 'sentry/types';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -62,12 +62,15 @@ type TagStoreInterface = CommonStoreInterface<TagCollection> & {
   state: TagCollection;
 };
 
-const storeConfig: Reflux.StoreDefinition & TagStoreInterface = {
+const storeConfig: Reflux.StoreDefinition & TagStoreInterface & SafeStoreDefinition = {
   state: {},
+  unsubscribeListeners: [],
 
   init() {
     this.state = {};
-    this.listenTo(TagActions.loadTagsSuccess, this.onLoadTagsSuccess);
+    this.unsubscribeListeners.push(
+      this.listenTo(TagActions.loadTagsSuccess, this.onLoadTagsSuccess)
+    );
   },
 
   getBuiltInTags() {
@@ -182,8 +185,7 @@ const storeConfig: Reflux.StoreDefinition & TagStoreInterface = {
   },
 };
 
-const TagStore = makeSafeRefluxStore(
-  Reflux.createStore(storeConfig) as Reflux.Store & TagStoreInterface
-);
+const TagStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
+  TagStoreInterface;
 
 export default TagStore;

--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -3,8 +3,7 @@ import Reflux from 'reflux';
 import TagActions from 'sentry/actions/tagActions';
 import {Tag, TagCollection} from 'sentry/types';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
-
-import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 

--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -4,6 +4,8 @@ import TagActions from 'sentry/actions/tagActions';
 import {Tag, TagCollection} from 'sentry/types';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
 
+import {makeSafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 import {CommonStoreInterface} from './types';
 
 // This list is only used on issues. Events/discover
@@ -181,6 +183,8 @@ const storeConfig: Reflux.StoreDefinition & TagStoreInterface = {
   },
 };
 
-const TagStore = Reflux.createStore(storeConfig) as Reflux.Store & TagStoreInterface;
+const TagStore = makeSafeRefluxStore(
+  Reflux.createStore(storeConfig) as Reflux.Store & TagStoreInterface
+);
 
 export default TagStore;

--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -3,7 +3,11 @@ import Reflux from 'reflux';
 import TagActions from 'sentry/actions/tagActions';
 import {Tag, TagCollection} from 'sentry/types';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -185,7 +189,7 @@ const storeConfig: Reflux.StoreDefinition & TagStoreInterface & SafeStoreDefinit
   },
 };
 
-const TagStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as Reflux.Store &
+const TagStore = Reflux.createStore(makeSafeRefluxStore(storeConfig)) as SafeRefluxStore &
   TagStoreInterface;
 
 export default TagStore;

--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -3,6 +3,7 @@ import Reflux from 'reflux';
 import TeamActions from 'sentry/actions/teamActions';
 import {Team} from 'sentry/types';
 import {defined} from 'sentry/utils';
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -182,7 +183,8 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
   },
 };
 
-const TeamStore = Reflux.createStore(teamStoreConfig) as Reflux.Store &
-  TeamStoreInterface;
+const TeamStore = makeSafeRefluxStore(
+  Reflux.createStore(teamStoreConfig) as Reflux.Store & TeamStoreInterface
+);
 
 export default TeamStore;

--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -26,15 +26,11 @@ type TeamStoreInterface = CommonStoreInterface<State> & {
   onRemoveSuccess(slug: string): void;
   onUpdateSuccess(itemId: string, response: Team): void;
   reset(): void;
-  safeListenTo(action: Reflux.ActionsDefinition, callback: (...data: any) => void);
 
   state: State;
-  teardown(): void;
-  unsubscribeListeners: (() => void)[];
 };
 
 const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
-  unsubscribeListeners: [],
   initialized: false,
   state: {
     teams: [],
@@ -47,31 +43,12 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
   init() {
     this.reset();
 
-    this.safeListenTo(TeamActions.createTeamSuccess, this.onCreateSuccess);
-    this.safeListenTo(TeamActions.fetchDetailsSuccess, this.onUpdateSuccess);
-    this.safeListenTo(TeamActions.loadTeams, this.loadInitialData);
-    this.safeListenTo(TeamActions.loadUserTeams, this.loadUserTeams);
-    this.safeListenTo(TeamActions.removeTeamSuccess, this.onRemoveSuccess);
-    this.safeListenTo(TeamActions.updateSuccess, this.onUpdateSuccess);
-  },
-
-  safeListenTo(action, callback) {
-    this.unsubscribeListeners.push(this.listenTo(action), callback);
-  },
-
-  teardown() {
-    while (this.unsubscribeListeners.length > 0) {
-      const unsubscribeListener = this.unsubscribeListeners.pop();
-
-      if (typeof unsubscribeListener !== 'function') {
-        throw new Error(
-          `Attempting to call ${JSON.stringify(
-            unsubscribeListener
-          )}. A falsy unsubscribe listener was stored, unsubscribe listeners should only include function calls`
-        );
-      }
-      unsubscribeListener();
-    }
+    this.listenTo(TeamActions.createTeamSuccess, this.onCreateSuccess);
+    this.listenTo(TeamActions.fetchDetailsSuccess, this.onUpdateSuccess);
+    this.listenTo(TeamActions.loadTeams, this.loadInitialData);
+    this.listenTo(TeamActions.loadUserTeams, this.loadUserTeams);
+    this.listenTo(TeamActions.removeTeamSuccess, this.onRemoveSuccess);
+    this.listenTo(TeamActions.updateSuccess, this.onUpdateSuccess);
   },
 
   reset() {

--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -25,10 +25,15 @@ type TeamStoreInterface = CommonStoreInterface<State> & {
   onRemoveSuccess(slug: string): void;
   onUpdateSuccess(itemId: string, response: Team): void;
   reset(): void;
+  safeListenTo(action: Reflux.ActionsDefinition, callback: (...data: any) => void);
+
   state: State;
+  teardown(): void;
+  unsubscribeListeners: (() => void)[];
 };
 
 const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
+  unsubscribeListeners: [],
   initialized: false,
   state: {
     teams: [],
@@ -41,12 +46,31 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
   init() {
     this.reset();
 
-    this.listenTo(TeamActions.createTeamSuccess, this.onCreateSuccess);
-    this.listenTo(TeamActions.fetchDetailsSuccess, this.onUpdateSuccess);
-    this.listenTo(TeamActions.loadTeams, this.loadInitialData);
-    this.listenTo(TeamActions.loadUserTeams, this.loadUserTeams);
-    this.listenTo(TeamActions.removeTeamSuccess, this.onRemoveSuccess);
-    this.listenTo(TeamActions.updateSuccess, this.onUpdateSuccess);
+    this.safeListenTo(TeamActions.createTeamSuccess, this.onCreateSuccess);
+    this.safeListenTo(TeamActions.fetchDetailsSuccess, this.onUpdateSuccess);
+    this.safeListenTo(TeamActions.loadTeams, this.loadInitialData);
+    this.safeListenTo(TeamActions.loadUserTeams, this.loadUserTeams);
+    this.safeListenTo(TeamActions.removeTeamSuccess, this.onRemoveSuccess);
+    this.safeListenTo(TeamActions.updateSuccess, this.onUpdateSuccess);
+  },
+
+  safeListenTo(action, callback) {
+    this.unsubscribeListeners.push(this.listenTo(action), callback);
+  },
+
+  teardown() {
+    while (this.unsubscribeListeners.length > 0) {
+      const unsubscribeListener = this.unsubscribeListeners.pop();
+
+      if (typeof unsubscribeListener !== 'function') {
+        throw new Error(
+          `Attempting to call ${JSON.stringify(
+            unsubscribeListener
+          )}. A falsy unsubscribe listener was stored, unsubscribe listeners should only include function calls`
+        );
+      }
+      unsubscribeListener();
+    }
   },
 
   reset() {

--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -3,7 +3,7 @@ import Reflux from 'reflux';
 import TeamActions from 'sentry/actions/teamActions';
 import {Team} from 'sentry/types';
 import {defined} from 'sentry/utils';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -30,135 +30,153 @@ type TeamStoreInterface = CommonStoreInterface<State> & {
   state: State;
 };
 
-const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
-  initialized: false,
-  state: {
-    teams: [],
-    loadedUserTeams: false,
-    loading: true,
-    hasMore: null,
-    cursor: null,
-  },
-
-  init() {
-    this.reset();
-
-    this.listenTo(TeamActions.createTeamSuccess, this.onCreateSuccess);
-    this.listenTo(TeamActions.fetchDetailsSuccess, this.onUpdateSuccess);
-    this.listenTo(TeamActions.loadTeams, this.loadInitialData);
-    this.listenTo(TeamActions.loadUserTeams, this.loadUserTeams);
-    this.listenTo(TeamActions.removeTeamSuccess, this.onRemoveSuccess);
-    this.listenTo(TeamActions.updateSuccess, this.onUpdateSuccess);
-  },
-
-  reset() {
-    this.state = {
+const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface & SafeStoreDefinition =
+  {
+    initialized: false,
+    state: {
       teams: [],
       loadedUserTeams: false,
       loading: true,
       hasMore: null,
       cursor: null,
-    };
-  },
+    },
 
-  loadInitialData(items, hasMore, cursor) {
-    this.initialized = true;
-    this.state = {
-      teams: items.sort((a, b) => a.slug.localeCompare(b.slug)),
-      loadedUserTeams: defined(hasMore) ? !hasMore : this.state.loadedUserTeams,
-      loading: false,
-      hasMore: hasMore ?? this.state.hasMore,
-      cursor: cursor ?? this.state.cursor,
-    };
-    this.trigger(new Set(items.map(item => item.id)));
-  },
+    unsubscribeListeners: [],
 
-  loadUserTeams(userTeams: Team[]) {
-    const teamIdMap = this.state.teams.reduce((acc: Record<string, Team>, team: Team) => {
-      acc[team.id] = team;
-      return acc;
-    }, {});
+    init() {
+      this.reset();
 
-    // Replace or insert new user teams
-    userTeams.reduce((acc: Record<string, Team>, userTeam: Team) => {
-      acc[userTeam.id] = userTeam;
-      return acc;
-    }, teamIdMap);
+      this.unsubscribeListeners.push(
+        this.listenTo(TeamActions.createTeamSuccess, this.onCreateSuccess)
+      );
+      this.unsubscribeListeners.push(
+        this.listenTo(TeamActions.fetchDetailsSuccess, this.onUpdateSuccess)
+      );
+      this.unsubscribeListeners.push(
+        this.listenTo(TeamActions.loadTeams, this.loadInitialData)
+      );
+      this.unsubscribeListeners.push(
+        this.listenTo(TeamActions.loadUserTeams, this.loadUserTeams)
+      );
+      this.unsubscribeListeners.push(
+        this.listenTo(TeamActions.removeTeamSuccess, this.onRemoveSuccess)
+      );
+      this.unsubscribeListeners.push(
+        this.listenTo(TeamActions.updateSuccess, this.onUpdateSuccess)
+      );
+    },
 
-    const teams = Object.values(teamIdMap).sort((a, b) => a.slug.localeCompare(b.slug));
-    this.state = {
-      ...this.state,
-      loadedUserTeams: true,
-      teams,
-    };
+    reset() {
+      this.state = {
+        teams: [],
+        loadedUserTeams: false,
+        loading: true,
+        hasMore: null,
+        cursor: null,
+      };
+    },
 
-    this.trigger(new Set(Object.keys(teamIdMap)));
-  },
+    loadInitialData(items, hasMore, cursor) {
+      this.initialized = true;
+      this.state = {
+        teams: items.sort((a, b) => a.slug.localeCompare(b.slug)),
+        loadedUserTeams: defined(hasMore) ? !hasMore : this.state.loadedUserTeams,
+        loading: false,
+        hasMore: hasMore ?? this.state.hasMore,
+        cursor: cursor ?? this.state.cursor,
+      };
+      this.trigger(new Set(items.map(item => item.id)));
+    },
 
-  onUpdateSuccess(itemId, response) {
-    if (!response) {
-      return;
-    }
+    loadUserTeams(userTeams: Team[]) {
+      const teamIdMap = this.state.teams.reduce(
+        (acc: Record<string, Team>, team: Team) => {
+          acc[team.id] = team;
+          return acc;
+        },
+        {}
+      );
 
-    const item = this.getBySlug(itemId);
+      // Replace or insert new user teams
+      userTeams.reduce((acc: Record<string, Team>, userTeam: Team) => {
+        acc[userTeam.id] = userTeam;
+        return acc;
+      }, teamIdMap);
 
-    if (!item) {
+      const teams = Object.values(teamIdMap).sort((a, b) => a.slug.localeCompare(b.slug));
       this.state = {
         ...this.state,
-        teams: [...this.state.teams, response],
+        loadedUserTeams: true,
+        teams,
       };
 
+      this.trigger(new Set(Object.keys(teamIdMap)));
+    },
+
+    onUpdateSuccess(itemId, response) {
+      if (!response) {
+        return;
+      }
+
+      const item = this.getBySlug(itemId);
+
+      if (!item) {
+        this.state = {
+          ...this.state,
+          teams: [...this.state.teams, response],
+        };
+
+        this.trigger(new Set([itemId]));
+        return;
+      }
+
+      // Slug was changed
+      // Note: This is the proper way to handle slug changes but unfortunately not all of our
+      // components use stores correctly. To be safe reload browser :((
+      if (response.slug !== itemId) {
+        // Replace the team
+        const teams = [...this.state.teams.filter(({slug}) => slug !== itemId), response];
+
+        this.state = {...this.state, teams};
+        this.trigger(new Set([response.slug]));
+        return;
+      }
+
+      const newTeams = [...this.state.teams];
+      const index = newTeams.findIndex(team => team.slug === response.slug);
+      newTeams[index] = response;
+
+      this.state = {...this.state, teams: newTeams};
       this.trigger(new Set([itemId]));
-      return;
-    }
+    },
 
-    // Slug was changed
-    // Note: This is the proper way to handle slug changes but unfortunately not all of our
-    // components use stores correctly. To be safe reload browser :((
-    if (response.slug !== itemId) {
-      // Replace the team
-      const teams = [...this.state.teams.filter(({slug}) => slug !== itemId), response];
+    onRemoveSuccess(slug: string) {
+      const {teams} = this.state;
+      this.loadInitialData(teams.filter(team => team.slug !== slug));
+    },
 
-      this.state = {...this.state, teams};
-      this.trigger(new Set([response.slug]));
-      return;
-    }
+    onCreateSuccess(team: Team) {
+      this.loadInitialData([...this.state.teams, team]);
+    },
 
-    const newTeams = [...this.state.teams];
-    const index = newTeams.findIndex(team => team.slug === response.slug);
-    newTeams[index] = response;
+    getState() {
+      return this.state;
+    },
 
-    this.state = {...this.state, teams: newTeams};
-    this.trigger(new Set([itemId]));
-  },
+    getById(id: string) {
+      const {teams} = this.state;
+      return teams.find(item => item.id.toString() === id.toString()) || null;
+    },
 
-  onRemoveSuccess(slug: string) {
-    const {teams} = this.state;
-    this.loadInitialData(teams.filter(team => team.slug !== slug));
-  },
+    getBySlug(slug: string) {
+      const {teams} = this.state;
+      return teams.find(item => item.slug === slug) || null;
+    },
 
-  onCreateSuccess(team: Team) {
-    this.loadInitialData([...this.state.teams, team]);
-  },
-
-  getState() {
-    return this.state;
-  },
-
-  getById(id: string) {
-    const {teams} = this.state;
-    return teams.find(item => item.id.toString() === id.toString()) || null;
-  },
-
-  getBySlug(slug: string) {
-    const {teams} = this.state;
-    return teams.find(item => item.slug === slug) || null;
-  },
-
-  getAll() {
-    return this.state.teams;
-  },
-};
+    getAll() {
+      return this.state.teams;
+    },
+  };
 
 const TeamStore = makeSafeRefluxStore(
   Reflux.createStore(teamStoreConfig) as Reflux.Store & TeamStoreInterface

--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -3,7 +3,11 @@ import Reflux from 'reflux';
 import TeamActions from 'sentry/actions/teamActions';
 import {Team} from 'sentry/types';
 import {defined} from 'sentry/utils';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
+import {
+  makeSafeRefluxStore,
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreInterface} from './types';
 
@@ -178,8 +182,8 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface & SafeStoreDe
     },
   };
 
-const TeamStore = makeSafeRefluxStore(
-  Reflux.createStore(teamStoreConfig) as Reflux.Store & TeamStoreInterface
-);
+const TeamStore = Reflux.createStore(
+  makeSafeRefluxStore(teamStoreConfig)
+) as unknown as SafeRefluxStore & TeamStoreInterface;
 
 export default TeamStore;

--- a/static/app/stores/useLegacyStore.tsx
+++ b/static/app/stores/useLegacyStore.tsx
@@ -31,7 +31,13 @@ export function useLegacyStore<T extends LegacyStoreShape>(
   // Not all stores emit the new state, call get on change
   const callback = () => window._legacyStoreHookUpdate(() => setState(store.getState()));
 
-  useEffect(() => store.listen(callback, undefined) as () => void, []);
+  useEffect(() => {
+    const listener = store.listen(callback, undefined);
+
+    return () => {
+      listener();
+    };
+  }, []);
 
   return state;
 }

--- a/static/app/stores/useLegacyStore.tsx
+++ b/static/app/stores/useLegacyStore.tsx
@@ -1,9 +1,13 @@
 import {useEffect, useState} from 'react';
 import Reflux from 'reflux';
 
+import {SafeRefluxStore} from '../utils/makeSafeRefluxStore';
+
 import {CommonStoreInterface} from './types';
 
-type LegacyStoreShape = Reflux.Store & CommonStoreInterface<any>;
+type LegacyStoreShape =
+  | (Reflux.Store & CommonStoreInterface<any>)
+  | (SafeRefluxStore & CommonStoreInterface<any>);
 
 /**
  * This wrapper exists because we have many old-style enzyme tests that trigger

--- a/static/app/utils/makeSafeRefluxStore.ts
+++ b/static/app/utils/makeSafeRefluxStore.ts
@@ -1,9 +1,9 @@
 export interface SafeStoreDefinition extends Reflux.StoreDefinition {
+  unsubscribeListeners: Reflux.Subscription[];
   /**
    * Teardown a store and all it's listeners
    */
   teardown?(): void;
-  unsubscribeListeners?: Reflux.Subscription[];
 }
 export interface SafeRefluxStore extends SafeStoreDefinition {
   teardown(): void;
@@ -36,9 +36,9 @@ export function cleanupActiveRefluxSubscriptions(
 // cleanup functions, our subscriptions are never cleaned up. This is fine
 // for production env where stores are only init once, but causes memory
 // leaks in tests when we call store.init inside a beforeEach hook.
-export function makeSafeRefluxStore<T extends SafeStoreDefinition>(
-  store: T
-): SafeRefluxStore {
+export function makeSafeRefluxStore<
+  T extends SafeStoreDefinition | Reflux.StoreDefinition
+>(store: T): SafeRefluxStore {
   // Allow for a store to pass it's own array of unsubscribeListeners, else initialize one
   const safeStore = store as unknown as SafeRefluxStore;
   safeStore.unsubscribeListeners = Array.isArray(safeStore.unsubscribeListeners)

--- a/static/app/utils/makeSafeRefluxStore.ts
+++ b/static/app/utils/makeSafeRefluxStore.ts
@@ -1,0 +1,33 @@
+interface SafeRefluxStore extends Reflux.Store {
+  teardown(): void;
+  unsubscribeListeners: Reflux.Subscription[];
+}
+
+export function makeSafeRefluxStore<T extends Reflux.Store>(
+  store: T
+): SafeRefluxStore & T {
+  return {
+    ...store,
+    listenTo(action: Reflux.Listenable, callback: (...data: any) => void) {
+      const unsubscribeListener = store.listenTo(action, callback);
+      this.unsubscribeListeners.push(unsubscribeListener);
+    },
+    teardown() {
+      while (this.unsubscribeListeners.length > 0) {
+        const unsubscribeListener = this.unsubscribeListeners.pop();
+
+        if (unsubscribeListener !== undefined && 'stop' in unsubscribeListener) {
+          unsubscribeListener.stop();
+          return;
+        }
+
+        throw new Error(
+          `Attempting to call ${JSON.stringify(
+            unsubscribeListener
+          )}. Unsubscribe listeners should only include function calls`
+        );
+      }
+    },
+    unsubscribeListeners: [],
+  };
+}

--- a/static/app/utils/makeSafeRefluxStore.ts
+++ b/static/app/utils/makeSafeRefluxStore.ts
@@ -1,4 +1,7 @@
 export interface SafeStoreDefinition extends Reflux.StoreDefinition {
+  /**
+   * Teardown a store and all it's listeners
+   */
   teardown?(): void;
   unsubscribeListeners?: Reflux.Subscription[];
 }

--- a/static/app/utils/makeSafeRefluxStore.ts
+++ b/static/app/utils/makeSafeRefluxStore.ts
@@ -1,9 +1,6 @@
 export interface SafeStoreDefinition extends Reflux.StoreDefinition {
-  unsubscribeListeners: Reflux.Subscription[];
-  /**
-   * Teardown a store and all it's listeners
-   */
   teardown?(): void;
+  unsubscribeListeners?: Reflux.Subscription[];
 }
 export interface SafeRefluxStore extends SafeStoreDefinition {
   teardown(): void;
@@ -36,9 +33,9 @@ export function cleanupActiveRefluxSubscriptions(
 // cleanup functions, our subscriptions are never cleaned up. This is fine
 // for production env where stores are only init once, but causes memory
 // leaks in tests when we call store.init inside a beforeEach hook.
-export function makeSafeRefluxStore<
-  T extends SafeStoreDefinition | Reflux.StoreDefinition
->(store: T): SafeRefluxStore {
+export function makeSafeRefluxStore<T extends SafeStoreDefinition>(
+  store: T
+): SafeRefluxStore {
   // Allow for a store to pass it's own array of unsubscribeListeners, else initialize one
   const safeStore = store as unknown as SafeRefluxStore;
   safeStore.unsubscribeListeners = Array.isArray(safeStore.unsubscribeListeners)

--- a/static/app/utils/makeSafeRefluxStore.ts
+++ b/static/app/utils/makeSafeRefluxStore.ts
@@ -1,6 +1,9 @@
 export interface SafeStoreDefinition extends Reflux.StoreDefinition {
+  unsubscribeListeners: Reflux.Subscription[];
+  /**
+   * Teardown a store and all it's listeners
+   */
   teardown?(): void;
-  unsubscribeListeners?: Reflux.Subscription[];
 }
 export interface SafeRefluxStore extends SafeStoreDefinition {
   teardown(): void;
@@ -33,9 +36,9 @@ export function cleanupActiveRefluxSubscriptions(
 // cleanup functions, our subscriptions are never cleaned up. This is fine
 // for production env where stores are only init once, but causes memory
 // leaks in tests when we call store.init inside a beforeEach hook.
-export function makeSafeRefluxStore<T extends SafeStoreDefinition>(
-  store: T
-): SafeRefluxStore {
+export function makeSafeRefluxStore<
+  T extends SafeStoreDefinition | Reflux.StoreDefinition
+>(store: T): SafeRefluxStore {
   // Allow for a store to pass it's own array of unsubscribeListeners, else initialize one
   const safeStore = store as unknown as SafeRefluxStore;
   safeStore.unsubscribeListeners = Array.isArray(safeStore.unsubscribeListeners)

--- a/static/app/utils/makeSafeRefluxStore.ts
+++ b/static/app/utils/makeSafeRefluxStore.ts
@@ -5,13 +5,13 @@ export interface SafeStoreDefinition extends Reflux.StoreDefinition {
    */
   teardown?(): void;
 }
-export interface SafeRefluxStore extends SafeStoreDefinition {
+export interface SafeRefluxStore extends Reflux.Store {
   teardown(): void;
   unsubscribeListeners: Reflux.Subscription[];
 }
 
-// XXX: Teardown will stop any listener subscriptions
-// that may have been started as a consequence of listenTo calls.
+// XXX: Teardown will call stop on any listener subscriptions
+// that have been started as a consequence of listenTo calls.
 export function cleanupActiveRefluxSubscriptions(
   subscriptions: Array<Reflux.Subscription>
 ) {

--- a/static/app/utils/makeSafeRefluxStore.ts
+++ b/static/app/utils/makeSafeRefluxStore.ts
@@ -6,6 +6,7 @@ export interface SafeRefluxStore extends Reflux.Store {
 export function makeSafeRefluxStore<T extends Reflux.Store>(
   store: T
 ): SafeRefluxStore & T {
+  const originalListenTo = store.listenTo.bind(store);
   const safeStore = store as SafeRefluxStore & T;
 
   // Warning: We are going to be overriding instance methods here!
@@ -21,7 +22,7 @@ export function makeSafeRefluxStore<T extends Reflux.Store>(
     action: Reflux.Listenable,
     callback: (...data: any) => void
   ) {
-    const unsubscribeListener = store.listenTo(action, callback);
+    const unsubscribeListener = originalListenTo(action, callback);
     this.unsubscribeListeners.push(unsubscribeListener);
     return unsubscribeListener;
   }
@@ -42,8 +43,8 @@ export function makeSafeRefluxStore<T extends Reflux.Store>(
     }
   }
 
-  safeStore.listenTo = listenTo.bind(store);
-  safeStore.teardown = teardown.bind(store);
+  safeStore.listenTo = listenTo.bind(safeStore);
+  safeStore.teardown = teardown.bind(safeStore);
 
   return safeStore;
 }

--- a/static/app/utils/makeSafeRefluxStore.ts
+++ b/static/app/utils/makeSafeRefluxStore.ts
@@ -1,50 +1,55 @@
-interface SafeRefluxStore extends Reflux.Store {
+export interface SafeStoreDefinition extends Reflux.StoreDefinition {
+  teardown?(): void;
+  unsubscribeListeners?: Reflux.Subscription[];
+}
+export interface SafeRefluxStore extends SafeStoreDefinition {
   teardown(): void;
   unsubscribeListeners: Reflux.Subscription[];
 }
 
-export function makeSafeRefluxStore<T extends Reflux.Store>(
-  store: T
-): SafeRefluxStore & T {
-  const originalListenTo = store.listenTo.bind(store);
-  const safeStore = store as SafeRefluxStore & T;
+// XXX: Teardown will stop any listener subscriptions
+// that may have been started as a consequence of listenTo calls.
+export function cleanupActiveRefluxSubscriptions(
+  subscriptions: Array<Reflux.Subscription>
+) {
+  while (subscriptions.length > 0) {
+    const unsubscribeListener = subscriptions.pop();
 
-  // Warning: We are going to be overriding instance methods here!
-  // The reason we cannot create a new store and extend it is that
-  // reflux throws whenever createStore() is called with a storeDefinition
-  // that implements listenTo and we cannot create a clone is because
-  // Reflux.createStore implicitly connects the store already and we cannot
-  // disconnect that store and connect our own...
-  safeStore.unsubscribeListeners = [];
-
-  function listenTo(
-    this: SafeRefluxStore,
-    action: Reflux.Listenable,
-    callback: (...data: any) => void
-  ) {
-    const unsubscribeListener = originalListenTo(action, callback);
-    this.unsubscribeListeners.push(unsubscribeListener);
-    return unsubscribeListener;
-  }
-  function teardown(this: SafeRefluxStore) {
-    while (this.unsubscribeListeners.length > 0) {
-      const unsubscribeListener = this.unsubscribeListeners.pop();
-
-      if (unsubscribeListener !== undefined && 'stop' in unsubscribeListener) {
-        unsubscribeListener.stop();
-        return;
-      }
-
-      throw new Error(
-        `Attempting to call ${JSON.stringify(
-          unsubscribeListener
-        )}. Unsubscribe listeners should only include function calls`
-      );
+    if (unsubscribeListener !== undefined && 'stop' in unsubscribeListener) {
+      unsubscribeListener.stop();
+      return;
     }
+
+    const stringifiedListenerType = JSON.stringify(unsubscribeListener);
+    throw new Error(
+      `Attempting to call ${stringifiedListenerType}. Unsubscribe listeners should only include function calls`
+    );
   }
+}
 
-  safeStore.listenTo = listenTo.bind(safeStore);
-  safeStore.teardown = teardown.bind(safeStore);
+// XXX: Reflux will implicitly call .init on a store when it is created
+// (see node_modules/reflux/dist/reflux.js L768), and because our stores
+// often subscribe to .listenTo inside init calls without storing the
+// cleanup functions, our subscriptions are never cleaned up. This is fine
+// for production env where stores are only init once, but causes memory
+// leaks in tests when we call store.init inside a beforeEach hook.
+export function makeSafeRefluxStore<T extends SafeStoreDefinition>(
+  store: T
+): SafeRefluxStore {
+  // Allow for a store to pass it's own array of unsubscribeListeners, else initialize one
+  const safeStore = store as unknown as SafeRefluxStore;
+  safeStore.unsubscribeListeners = Array.isArray(safeStore.unsubscribeListeners)
+    ? safeStore.unsubscribeListeners
+    : [];
 
+  // Cleanup any subscriptions that were stored
+  function teardown(this: SafeRefluxStore) {
+    cleanupActiveRefluxSubscriptions(this.unsubscribeListeners);
+  }
+  // We allow for some stores to implement their own teardown mechanism
+  // in case other listeners are attached to the store (eg. browser history listeners etc)
+  if (!safeStore.teardown) {
+    safeStore.teardown = teardown.bind(safeStore);
+  }
   return safeStore;
 }

--- a/static/app/utils/makeSafeRefluxStore.ts
+++ b/static/app/utils/makeSafeRefluxStore.ts
@@ -1,4 +1,4 @@
-export interface SafeRefluxStore extends Reflux.Store {
+interface SafeRefluxStore extends Reflux.Store {
   teardown(): void;
   unsubscribeListeners: Reflux.Subscription[];
 }

--- a/tests/js/spec/actionCreators/committers.spec.jsx
+++ b/tests/js/spec/actionCreators/committers.spec.jsx
@@ -1,4 +1,5 @@
 import {getCommitters} from 'sentry/actionCreators/committers';
+import CommitterActions from 'sentry/actions/committerActions';
 import CommitterStore, {getCommitterStoreKey} from 'sentry/stores/committerStore';
 
 describe('CommitterActionCreator', function () {
@@ -28,6 +29,11 @@ describe('CommitterActionCreator', function () {
     });
 
     CommitterStore.init();
+
+    jest.restoreAllMocks();
+    jest.spyOn(CommitterActions, 'load');
+    jest.spyOn(CommitterActions, 'loadSuccess');
+
     /**
      * XXX(leedongwei): We would want to ensure that Store methods are not
      * called to be 100% sure that the short-circuit is happening correctly.
@@ -39,27 +45,40 @@ describe('CommitterActionCreator', function () {
     // jest.spyOn(CommitterStore, 'loadSuccess');
   });
 
-  afterEach(() => {
-    CommitterStore.teardown();
-  });
-
+  /**
+   * XXX(leedongwei): I wanted to separate the ticks and run tests to assert the
+   * state change at every tick but it is incredibly flakey.
+   */
   it('fetches a Committer and emits actions', async () => {
     getCommitters(api, {
       orgSlug: organization.slug,
       projectSlug: project.slug,
       eventId: event.id,
-    });
+    }); // Fire Action.load
+    expect(CommitterActions.load).toHaveBeenCalledWith(
+      organization.slug,
+      project.slug,
+      event.id
+    );
+    expect(CommitterActions.loadSuccess).not.toHaveBeenCalled();
+
+    await tick(); // Run Store.load and fire Action.loadSuccess
+    await tick(); // Run Store.loadSuccess
 
     expect(mockResponse).toHaveBeenCalledWith(endpoint, expect.anything());
+    expect(CommitterActions.loadSuccess).toHaveBeenCalledWith(
+      organization.slug,
+      project.slug,
+      event.id,
+      mockData.committers
+    );
 
-    await waitFor(() => {
-      expect(CommitterStore.state).toEqual({
-        [storeKey]: {
-          committers: mockData.committers,
-          committersLoading: false,
-          committersError: undefined,
-        },
-      });
+    expect(CommitterStore.state).toEqual({
+      [storeKey]: {
+        committers: mockData.committers,
+        committersLoading: false,
+        committersError: undefined,
+      },
     });
   });
 
@@ -70,8 +89,10 @@ describe('CommitterActionCreator', function () {
       orgSlug: organization.slug,
       projectSlug: project.slug,
       eventId: event.id,
-    });
+    }); // Fire Action.load
 
+    expect(CommitterActions.load).toHaveBeenCalled();
+    // expect(CommitterStore.load).not.toHaveBeenCalled();
     expect(CommitterStore.state[storeKey].committersLoading).toEqual(true); // Short-circuit
   });
 });

--- a/tests/js/spec/components/hook.spec.jsx
+++ b/tests/js/spec/components/hook.spec.jsx
@@ -5,7 +5,8 @@ import HookStore from 'sentry/stores/hookStore';
 
 const HookWrapper = props => (
   <div data-test-id="hook-wrapper">
-    {props.children} {JSON.stringify(props?.organization ?? {}, null, 2)}
+    {props.children}
+    <span>{JSON.stringify(props?.organization ?? {}, null, 2)}</span>
   </div>
 );
 
@@ -104,7 +105,7 @@ describe('Hook', function () {
     ));
 
     for (let i = 0; i < idx; i++) {
-      expect(screen.getByText(new RegExp(`hook: ${idx}`))).toBeInTheDocument();
+      expect(screen.getByText(`hook: ${idx}`)).toBeInTheDocument();
     }
 
     // Has 2 Wrappers from store, and each is wrapped by another Wrapper

--- a/tests/js/spec/components/hook.spec.jsx
+++ b/tests/js/spec/components/hook.spec.jsx
@@ -3,25 +3,25 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import Hook from 'sentry/components/hook';
 import HookStore from 'sentry/stores/hookStore';
 
+const HookWrapper = props => (
+  <div data-test-id="hook-wrapper">
+    {props.children} {JSON.stringify(props?.organization ?? {}, null, 2)}
+  </div>
+);
+
 describe('Hook', function () {
-  const Wrapper = function Wrapper(props) {
-    return <div data-test-id="wrapper" {...props} />;
-  };
-
-  beforeEach(function () {
-    HookStore.add('footer', ({organization} = {}) => (
-      <Wrapper key="initial" organization={organization}>
-        {organization.slug}
-      </Wrapper>
-    ));
-  });
-
   afterEach(function () {
-    // Clear HookStore
+    HookStore.teardown();
     HookStore.init();
   });
 
   it('renders component from a hook', function () {
+    HookStore.add('footer', ({organization} = {}) => (
+      <HookWrapper key={0} organization={organization}>
+        {organization.slug}
+      </HookWrapper>
+    ));
+
     render(
       <div>
         <Hook name="footer" organization={TestStubs.Organization()} />
@@ -29,11 +29,17 @@ describe('Hook', function () {
     );
 
     expect(HookStore.hooks.footer).toHaveLength(1);
-    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
-    expect(screen.getByTestId('wrapper')).toHaveTextContent('org-slug');
+    expect(screen.getByTestId('hook-wrapper')).toBeInTheDocument();
+    expect(screen.getByTestId('hook-wrapper')).toHaveTextContent('org-slug');
   });
 
   it('renders an invalid hook', function () {
+    HookStore.add('footer', ({organization} = {}) => (
+      <HookWrapper key={0} organization={organization}>
+        {organization.slug}
+      </HookWrapper>
+    ));
+
     render(
       <div>
         <Hook name="invalid-hook" organization={TestStubs.Organization()} />
@@ -46,41 +52,62 @@ describe('Hook', function () {
   });
 
   it('can re-render when hooks get after initial render', function () {
-    render(
-      <div>
-        <Hook name="footer" organization={TestStubs.Organization()} />
-      </div>
-    );
-
-    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
-
-    HookStore.add('footer', () => (
-      <Wrapper key="new" organization={null}>
-        New Hook
-      </Wrapper>
+    HookStore.add('footer', ({organization} = {}) => (
+      <HookWrapper key={0} organization={organization}>
+        Old Hook
+      </HookWrapper>
     ));
 
-    expect(HookStore.hooks.footer).toHaveLength(2);
-    expect(screen.getAllByTestId('wrapper')).toHaveLength(2);
-    expect(screen.getAllByTestId('wrapper')[1]).toHaveTextContent('New Hook');
+    const {rerender} = render(
+      <Hook name="footer" organization={TestStubs.Organization()} />
+    );
+
+    expect(screen.getByTestId('hook-wrapper')).toBeInTheDocument();
+
+    HookStore.add('footer', () => (
+      <HookWrapper key="new" organization={null}>
+        New Hook
+      </HookWrapper>
+    ));
+
+    rerender(<Hook name="footer" organization={TestStubs.Organization()} />);
+
+    expect(screen.getAllByTestId('hook-wrapper')).toHaveLength(2);
+    expect(screen.getByText(/New Hook/)).toBeInTheDocument();
+    expect(screen.getByText(/Old Hook/)).toBeInTheDocument();
   });
 
   it('can use children as a render prop', function () {
+    let idx = 0;
     render(
-      <div>
-        <Hook name="footer" organization={TestStubs.Organization()}>
-          {({hooks}) => hooks.map((hook, i) => <Wrapper key={i}>{hook}</Wrapper>)}
-        </Hook>
-      </div>
+      <Hook name="footer" organization={TestStubs.Organization()}>
+        {({hooks}) =>
+          hooks.map((hook, i) => (
+            <HookWrapper key={i}>
+              {hook} {`hook: ${++idx}`}
+            </HookWrapper>
+          ))
+        }
+      </Hook>
     );
 
     HookStore.add('footer', () => (
-      <Wrapper key="new" organization={null}>
-        New Hook
-      </Wrapper>
+      <HookWrapper key="new" organization={null}>
+        First Hook
+      </HookWrapper>
     ));
 
+    HookStore.add('footer', () => (
+      <HookWrapper key="new" organization={null}>
+        Second Hook
+      </HookWrapper>
+    ));
+
+    for (let i = 0; i < idx; i++) {
+      expect(screen.getByText(new RegExp(`hook: ${idx}`))).toBeInTheDocument();
+    }
+
     // Has 2 Wrappers from store, and each is wrapped by another Wrapper
-    expect(screen.getAllByTestId('wrapper')).toHaveLength(4);
+    expect(screen.getAllByTestId('hook-wrapper')).toHaveLength(4);
   });
 });

--- a/tests/js/spec/components/idBadge/teamBadge.spec.tsx
+++ b/tests/js/spec/components/idBadge/teamBadge.spec.tsx
@@ -7,6 +7,9 @@ describe('TeamBadge', function () {
   beforeEach(() => {
     TeamStore.init();
   });
+  afterEach(() => {
+    TeamStore.teardown();
+  });
 
   it('renders with Avatar and team name', function () {
     render(<TeamBadge team={TestStubs.Team()} />);

--- a/tests/js/spec/components/projectPageFilter.spec.tsx
+++ b/tests/js/spec/components/projectPageFilter.spec.tsx
@@ -1,44 +1,48 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
-describe('ProjectPageFilter', function () {
-  const {organization, router, routerContext} = initializeOrg({
-    organization: {features: ['global-views', 'selection-filters-v2']},
-    project: undefined,
-    projects: [
-      {
-        id: 2,
-        slug: 'project-2',
-      },
-    ],
-    router: {
-      location: {
-        pathname: '/organizations/org-slug/issues/',
-        query: {},
-      },
-      params: {orgId: 'org-slug'},
+const {organization, router, routerContext} = initializeOrg({
+  organization: {features: ['global-views', 'selection-filters-v2']},
+  project: undefined,
+  projects: [
+    {
+      id: 2,
+      slug: 'project-2',
     },
-  });
-  OrganizationStore.onUpdate(organization, {replace: true});
-  ProjectsStore.loadInitialData(organization.projects);
+  ],
+  router: {
+    location: {
+      pathname: '/organizations/org-slug/issues/',
+      query: {},
+    },
+    params: {orgId: 'org-slug'},
+  },
+});
 
+describe('ProjectPageFilter', function () {
   beforeEach(() => {
-    act(() => {
-      PageFiltersStore.reset();
-      PageFiltersStore.onInitializeUrlState(
-        {
-          projects: [],
-          environments: [],
-          datetime: {start: null, end: null, period: '14d', utc: null},
-        },
-        new Set()
-      );
-    });
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(
+      {
+        projects: [],
+        environments: [],
+        datetime: {start: null, end: null, period: '14d', utc: null},
+      },
+      new Set()
+    );
+
+    OrganizationStore.onUpdate(organization, {replace: true});
+    ProjectsStore.loadInitialData(organization.projects);
+  });
+
+  afterEach(() => {
+    PageFiltersStore.teardown();
+    PageFiltersStore.reset();
   });
 
   it('can pick project', function () {
@@ -103,28 +107,28 @@ describe('ProjectPageFilter', function () {
     // Click the first project's checkbox
     userEvent.click(screen.getByText('project-2'));
 
-    // Verify we were redirected
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({query: {environment: [], project: ['2']}})
     );
 
     await screen.findByText('project-2');
 
-    // Verify store state
-    expect(PageFiltersStore.getState()).toEqual(
-      expect.objectContaining({
-        isReady: true,
-        selection: {
-          datetime: {
-            end: null,
-            period: '14d',
-            start: null,
-            utc: null,
+    await waitFor(() =>
+      expect(PageFiltersStore.getState()).toEqual(
+        expect.objectContaining({
+          isReady: true,
+          selection: {
+            datetime: {
+              end: null,
+              period: '14d',
+              start: null,
+              utc: null,
+            },
+            environments: [],
+            projects: [2],
           },
-          environments: [],
-          projects: [2],
-        },
-      })
+        })
+      )
     );
   });
 

--- a/tests/js/spec/stores/groupingStore.spec.jsx
+++ b/tests/js/spec/stores/groupingStore.spec.jsx
@@ -14,6 +14,7 @@ describe('Grouping Store', function () {
   });
 
   beforeEach(function () {
+    GroupingStore.init();
     trigger = jest.spyOn(GroupingStore, 'trigger');
     Client.clearMockResponses();
     Client.addMockResponse({
@@ -100,10 +101,14 @@ describe('Grouping Store', function () {
   });
 
   afterEach(function () {
+    GroupingStore.teardown();
     trigger.mockReset();
   });
 
   describe('onFetch()', function () {
+    beforeEach(() => GroupingStore.init());
+    afterEach(() => GroupingStore.teardown());
+
     it('initially gets called with correct state values', function () {
       GroupingStore.onFetch([]);
 
@@ -270,6 +275,7 @@ describe('Grouping Store', function () {
     let mergeState;
 
     beforeEach(function () {
+      GroupingStore.init();
       mergeList = [];
       mergeState = new Map();
       return GroupingStore.onFetch([
@@ -277,7 +283,12 @@ describe('Grouping Store', function () {
       ]);
     });
 
+    afterEach(() => GroupingStore.teardown());
+
     describe('onToggleMerge (checkbox state)', function () {
+      beforeEach(() => GroupingStore.init());
+      afterEach(() => GroupingStore.teardown());
+
       // Attempt to check first item but its "locked" so should not be able to do anything
       it('can check and uncheck item', function () {
         GroupingStore.onToggleMerge('1');
@@ -320,8 +331,10 @@ describe('Grouping Store', function () {
           method: 'PUT',
           url: '/projects/orgId/projectId/issues/',
         });
+        GroupingStore.init();
       });
-      afterEach(function () {});
+
+      afterEach(() => GroupingStore.teardown());
 
       it('disables rows to be merged', async function () {
         const mergeMock = jest.spyOn(GroupActionCreators, 'mergeGroups');
@@ -473,6 +486,7 @@ describe('Grouping Store', function () {
     let unmergeState;
 
     beforeEach(async function () {
+      GroupingStore.init();
       unmergeList = new Map();
       unmergeState = new Map();
       await GroupingStore.onFetch([
@@ -483,6 +497,11 @@ describe('Grouping Store', function () {
       unmergeState = new Map([...GroupingStore.unmergeState]);
     });
 
+    afterEach(() => GroupingStore.teardown());
+
+    // WARNING: all the tests in this describe block are not running in isolated state.
+    // There is a good chance that moving them around will break them. To simulate an isolated state,
+    // add a beforeEach(() => GroupingStore.init()) and afterEach(() => GroupingStore.teardown()).
     describe('onToggleUnmerge (checkbox state for hashes)', function () {
       // Attempt to check first item but its "locked" so should not be able to do anything
       it('can not check locked item', function () {
@@ -572,11 +591,10 @@ describe('Grouping Store', function () {
       });
     });
 
+    // WARNING: all the tests in this describe block are not running in isolated state.
+    // There is a good chance that moving them around will break them. To simulate an isolated state,
+    // add a beforeEach(() => GroupingStore.init()) and afterEach(() => GroupingStore.teardown()).
     describe('onUnmerge', function () {
-      beforeAll(function () {
-        GroupingStore.init();
-      });
-
       beforeEach(function () {
         Client.clearMockResponses();
         Client.addMockResponse({
@@ -584,7 +602,6 @@ describe('Grouping Store', function () {
           url: '/issues/groupId/hashes/',
         });
       });
-      afterEach(function () {});
 
       it('can not toggle unmerge for a locked item', function () {
         // Event 1 is locked

--- a/tests/js/spec/stores/groupingStore.spec.jsx
+++ b/tests/js/spec/stores/groupingStore.spec.jsx
@@ -15,6 +15,7 @@ describe('Grouping Store', function () {
 
   beforeEach(function () {
     GroupingStore.init();
+    GroupingStore.teardown();
     trigger = jest.spyOn(GroupingStore, 'trigger');
     Client.clearMockResponses();
     Client.addMockResponse({

--- a/tests/js/spec/stores/groupingStore.spec.jsx
+++ b/tests/js/spec/stores/groupingStore.spec.jsx
@@ -15,7 +15,6 @@ describe('Grouping Store', function () {
 
   beforeEach(function () {
     GroupingStore.init();
-    GroupingStore.teardown();
     trigger = jest.spyOn(GroupingStore, 'trigger');
     Client.clearMockResponses();
     Client.addMockResponse({

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -31,6 +31,10 @@ describe('GuideStore', function () {
     GuideStore.onRegisterAnchor('issue_stream');
   });
 
+  afterEach(() => {
+    GuideStore.teardown();
+  });
+
   it('should move through the steps in the guide', function () {
     GuideStore.onFetchSucceeded(data);
     // Should pick the first non-seen guide in alphabetic order.

--- a/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
+++ b/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
@@ -1,9 +1,11 @@
 import OrganizationEnvironmentsStore from 'sentry/stores/organizationEnvironmentsStore';
 
 describe('OrganizationEnvironmentsStore', function () {
-  afterEach(function () {
-    OrganizationEnvironmentsStore.teardown();
+  beforeEach(() => {
     OrganizationEnvironmentsStore.init();
+  });
+  afterEach(() => {
+    OrganizationEnvironmentsStore.teardown();
   });
 
   it('get()', function () {

--- a/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
+++ b/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
@@ -2,6 +2,7 @@ import OrganizationEnvironmentsStore from 'sentry/stores/organizationEnvironment
 
 describe('OrganizationEnvironmentsStore', function () {
   afterEach(function () {
+    OrganizationEnvironmentsStore.teardown();
     OrganizationEnvironmentsStore.init();
   });
 

--- a/tests/js/spec/stores/pageFiltersStore.spec.jsx
+++ b/tests/js/spec/stores/pageFiltersStore.spec.jsx
@@ -12,8 +12,12 @@ jest.mock('sentry/utils/localStorage', () => ({
 }));
 
 describe('PageFiltersStore', function () {
+  beforeEach(() => {
+    PageFiltersStore.init();
+  });
   afterEach(function () {
     PageFiltersStore.reset();
+    PageFiltersStore.teardown();
   });
 
   it('getState()', function () {

--- a/tests/js/spec/utils/makeSafeRefluxStore.spec.ts
+++ b/tests/js/spec/utils/makeSafeRefluxStore.spec.ts
@@ -1,0 +1,41 @@
+import Reflux from 'reflux';
+
+import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+
+describe('makeSafeRefluxStore', () => {
+  it('calls original listenTo', () => {
+    const store = Reflux.createStore({});
+    const safeStore = makeSafeRefluxStore(store);
+
+    const statusUpdateAction = Reflux.createAction({'status update': ''});
+    const storeListenToSpy = jest.spyOn(store, 'listenTo');
+
+    safeStore.listenTo(statusUpdateAction, () => null);
+
+    expect(storeListenToSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('stores listener', () => {
+    const safeStore = makeSafeRefluxStore(Reflux.createStore({}));
+
+    const statusUpdateAction = Reflux.createAction({'status update': ''});
+    safeStore.listenTo(statusUpdateAction, () => null);
+
+    expect(safeStore.unsubscribeListeners).toHaveLength(1);
+  });
+
+  it('cleans up listeners on teardown', () => {
+    const safeStore = makeSafeRefluxStore(Reflux.createStore({}));
+
+    const statusUpdateAction = Reflux.createAction({'status update': ''});
+    safeStore.listenTo(statusUpdateAction, () => null);
+
+    // @ts-ignore idk why this thinks it's a never type
+    const stopListenerSpy = jest.spyOn(safeStore.unsubscribeListeners[0], 'stop');
+
+    safeStore.teardown();
+
+    expect(stopListenerSpy).toHaveBeenCalled();
+    expect(safeStore.unsubscribeListeners).toHaveLength(0);
+  });
+});

--- a/tests/js/spec/utils/makeSafeRefluxStore.spec.ts
+++ b/tests/js/spec/utils/makeSafeRefluxStore.spec.ts
@@ -1,34 +1,17 @@
 import Reflux from 'reflux';
 
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
+import {makeSafeRefluxStore, SafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 describe('makeSafeRefluxStore', () => {
-  it('calls original listenTo', () => {
-    const store = Reflux.createStore({});
-    const safeStore = makeSafeRefluxStore(store);
-
-    const statusUpdateAction = Reflux.createAction({'status update': ''});
-    const storeListenToSpy = jest.spyOn(store, 'listenTo');
-
-    safeStore.listenTo(statusUpdateAction, () => null);
-
-    expect(storeListenToSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('stores listener', () => {
-    const safeStore = makeSafeRefluxStore(Reflux.createStore({}));
-
-    const statusUpdateAction = Reflux.createAction({'status update': ''});
-    safeStore.listenTo(statusUpdateAction, () => null);
-
-    expect(safeStore.unsubscribeListeners).toHaveLength(1);
-  });
-
   it('cleans up listeners on teardown', () => {
-    const safeStore = makeSafeRefluxStore(Reflux.createStore({}));
+    const safeStore = Reflux.createStore(
+      makeSafeRefluxStore({})
+    ) as unknown as SafeRefluxStore;
 
     const statusUpdateAction = Reflux.createAction({'status update': ''});
-    safeStore.listenTo(statusUpdateAction, () => null);
+    safeStore.unsubscribeListeners.push(
+      safeStore.listenTo(statusUpdateAction, () => null)
+    );
 
     // @ts-ignore idk why this thinks it's a never type
     const stopListenerSpy = jest.spyOn(safeStore.unsubscribeListeners[0], 'stop');
@@ -37,5 +20,56 @@ describe('makeSafeRefluxStore', () => {
 
     expect(stopListenerSpy).toHaveBeenCalled();
     expect(safeStore.unsubscribeListeners).toHaveLength(0);
+  });
+
+  it('does not override unsubscribeListeners', () => {
+    const stop = jest.fn();
+    const subscription = {stop, listenable: {} as unknown as Reflux.Listenable};
+
+    const safeStore = Reflux.createStore(
+      makeSafeRefluxStore({
+        unsubscribeListeners: [subscription],
+      })
+    ) as unknown as SafeRefluxStore;
+
+    expect(safeStore.unsubscribeListeners[0]).toBe(subscription);
+  });
+
+  it('tears down subscriptions', () => {
+    const stop = jest.fn();
+    const subscription = {stop, listenable: {} as unknown as Reflux.Listenable};
+
+    const safeStore = Reflux.createStore(
+      makeSafeRefluxStore({
+        unsubscribeListeners: [subscription],
+      })
+    ) as unknown as SafeRefluxStore;
+
+    safeStore.teardown();
+
+    expect(stop).toHaveBeenCalled();
+    expect(safeStore.unsubscribeListeners.length).toBe(0);
+  });
+
+  it('allows for custom tear down implementation', () => {
+    const teardown = jest.fn();
+    const subscription = {
+      stop: jest.fn(),
+      listenable: {} as unknown as Reflux.Listenable,
+    };
+
+    const safeStore = Reflux.createStore(
+      makeSafeRefluxStore({
+        unsubscribeListeners: [subscription],
+        teardown: function () {
+          teardown();
+        },
+      })
+    ) as unknown as SafeRefluxStore;
+
+    safeStore.teardown();
+
+    expect(teardown).toHaveBeenCalled();
+    expect(safeStore.unsubscribeListeners[0]).toBe(subscription);
   });
 });

--- a/tests/js/spec/utils/withCommitters.spec.jsx
+++ b/tests/js/spec/utils/withCommitters.spec.jsx
@@ -32,6 +32,10 @@ describe('withCommitters HoC', function () {
     CommitterStore.init();
   });
 
+  afterEach(() => {
+    CommitterStore.teardown();
+  });
+
   it('adds committers prop', async () => {
     const Component = () => null;
     const Container = withCommitters(Component);

--- a/tests/js/spec/utils/withConfig.spec.jsx
+++ b/tests/js/spec/utils/withConfig.spec.jsx
@@ -4,9 +4,14 @@ import ConfigStore from 'sentry/stores/configStore';
 import withConfig from 'sentry/utils/withConfig';
 
 describe('withConfig HoC', function () {
-  it('adds config prop', function () {
+  beforeEach(() => {
     ConfigStore.init();
+  });
 
+  afterEach(() => {
+    ConfigStore.teardown();
+  });
+  it('adds config prop', function () {
     const MyComponent = ({config}) => <div>{config.test}</div>;
     const Container = withConfig(MyComponent);
 

--- a/tests/js/spec/utils/withPageFilters.spec.jsx
+++ b/tests/js/spec/utils/withPageFilters.spec.jsx
@@ -9,6 +9,10 @@ describe('withPageFilters HoC', function () {
     PageFiltersStore.init();
   });
 
+  afterEach(() => {
+    PageFiltersStore.teardown();
+  });
+
   it('handles projects', function () {
     const MyComponent = () => null;
     const Container = withPageFilters(MyComponent);

--- a/tests/js/spec/utils/withRepositories.spec.jsx
+++ b/tests/js/spec/utils/withRepositories.spec.jsx
@@ -22,6 +22,10 @@ describe('withRepositories HoC', function () {
     RepositoryStore.init();
   });
 
+  afterEach(() => {
+    RepositoryStore.teardown();
+  });
+
   it('adds repositories prop', async () => {
     const Component = () => null;
     const Container = withRepositories(Component);

--- a/tests/js/spec/utils/withSentryAppComponents.spec.jsx
+++ b/tests/js/spec/utils/withSentryAppComponents.spec.jsx
@@ -8,6 +8,10 @@ describe('withSentryAppComponents HoC', function () {
     SentryAppComponentsStore.init();
   });
 
+  afterEach(() => {
+    SentryAppComponentsStore.teardown();
+  });
+
   it('handles components without a type', function () {
     const MyComponent = () => null;
     const Container = withSentryAppComponents(MyComponent);

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -160,9 +160,12 @@ describe('Dashboards > Dashboard', () => {
   });
 
   describe('Issue Widgets', () => {
-    afterEach(() => {
+    beforeEach(() => {
       // @ts-ignore
       MemberListStore.init();
+    });
+    afterEach(() => {
+      MemberListStore.teardown();
     });
     const mount = (dashboard, mockedOrg = initialData.organization) => {
       render(

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -161,7 +161,6 @@ describe('Dashboards > Dashboard', () => {
 
   describe('Issue Widgets', () => {
     beforeEach(() => {
-      // @ts-ignore
       MemberListStore.init();
     });
     afterEach(() => {

--- a/tests/js/spec/views/issueList/overview.polling.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.polling.spec.jsx
@@ -161,6 +161,7 @@ describe('IssueList -> Polling', function () {
       wrapper.unmount();
     }
     wrapper = null;
+    TagStore.teardown();
   });
 
   it('toggles polling for new issues', async function () {

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -162,6 +162,7 @@ describe('IssueList', function () {
       wrapper.unmount();
     }
     wrapper = null;
+    TagStore.teardown();
   });
 
   describe('withStores and feature flags', function () {

--- a/tests/js/spec/views/organizationContextContainer.spec.jsx
+++ b/tests/js/spec/views/organizationContextContainer.spec.jsx
@@ -62,16 +62,8 @@ describe('OrganizationContextContainer', function () {
   });
 
   afterEach(async function () {
-    // Ugh these stores are a pain
-    // It's possible that a test still has an update action in flight
-    // and caues store to update *AFTER* we reset. Attempt to flush out updates
-    await tick();
-    await tick();
     wrapper.unmount();
     OrganizationStore.reset();
-    // await for store change to finish propagating
-    await tick();
-    await tick();
 
     TeamActions.loadTeams.mockRestore();
     ProjectActions.loadProjects.mockRestore();

--- a/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.jsx
@@ -15,6 +15,10 @@ describe('groupEventDetailsContainer', () => {
     OrganizationEnvironmentsStore.init();
   });
 
+  beforeEach(() => {
+    OrganizationEnvironmentsStore.teardown();
+  });
+
   it('fetches environments', async function () {
     const environmentsCall = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/environments/`,

--- a/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -69,6 +69,7 @@ describe('IntegrationCodeMappings', function () {
   let wrapper;
 
   beforeEach(() => {
+    ModalStore.init();
     Client.clearMockResponses();
 
     mockResponse([

--- a/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -84,6 +84,7 @@ describe('IntegrationCodeMappings', function () {
   afterEach(() => {
     // Clear the fields from the GlobalModal after every test
     ModalStore.reset();
+    ModalStore.teardown();
   });
 
   it('shows the paths', async () => {

--- a/tests/js/spec/views/ownershipInput.spec.jsx
+++ b/tests/js/spec/views/ownershipInput.spec.jsx
@@ -23,13 +23,14 @@ describe('Project Ownership Input', function () {
       method: 'PUT',
       body: {raw: 'url:src @dummy@example.com'},
     });
+    MemberListStore.init();
     MemberListStore.loadInitialData([
       TestStubs.User({id: '1', email: 'bob@example.com'}),
     ]);
   });
 
-  afterEach(function () {
-    MemberListStore.init();
+  afterEach(() => {
+    MemberListStore.teardown();
   });
 
   it('renders', function () {


### PR DESCRIPTION
We are currently not cleaning up the listenTo calls from init on reflux stores in our test calls. I suspect this may be causing the intermittent node eventemitter errors. It is probably ok in production code where init is called only once, but we are leaking memory in jest by running Store.init() in beforeEach methods. As a consequence of lacking a teardown, lots of store tests actually do not rely on an isolated state, which makes them brittle and dependent on execution sequence, I've managed to fix most of them except `tests/js/spec/stores/groupingStore.spec.jsx`

The PR introduces a makeSafeReflux store that wrap the store.listenTo functionality and exposes a teardown method. It is slightly hacky as we are mutating the instance method and binding it back to the original store implementation - we do this because you cannot call Reflux.createStore with a Store definition that implements it's own listenTo (which makes sense).

An alternative approach to this could be to use JS proxies and intercept calls to listenTo and teardown methods. I've went with mutating the method as I found it simpler, but open to rewriting to use proxies (need to check if our browserslist would allow us to use them first tho)