### PR TITLE
ref(ui): Combine rule name and owner in alert wizard v3 ui

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleNameOwnerForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleNameOwnerForm.tsx
@@ -25,8 +25,11 @@ export default function RuleNameOwnerForm({disabled, project, hasAlertWizardV3}:
       name="name"
       label={hasAlertWizardV3 ? null : t('Rule Name')}
       help={hasAlertWizardV3 ? null : t('Add a name so it’s easy to find later.')}
-      placeholder={t('Something really bad happened')}
+      placeholder={
+        hasAlertWizardV3 ? t('Enter Alert Name') : t('Something really bad happened')
+      }
       required
+      hideControlState
     />
   );
 
@@ -37,6 +40,7 @@ export default function RuleNameOwnerForm({disabled, project, hasAlertWizardV3}:
       label={hasAlertWizardV3 ? null : t('Team')}
       help={hasAlertWizardV3 ? null : t('The team that can edit this alert.')}
       disabled={disabled}
+      hideControlState
     >
       {({model}) => {
         const owner = model.getValue('owner');
@@ -61,9 +65,8 @@ export default function RuleNameOwnerForm({disabled, project, hasAlertWizardV3}:
 
   return hasAlertWizardV3 ? (
     <Fragment>
-      <StyledListItem>{t('Add a name')}</StyledListItem>
+      <StyledListItem>{t('Establish ownership')}</StyledListItem>
       {renderRuleName()}
-      <StyledListItem>{t('Assign this alert')}</StyledListItem>
       {renderTeamSelect()}
     </Fragment>
   ) : (
@@ -93,9 +96,10 @@ const StyledTextField = styled(TextField)<{hasAlertWizardV3: boolean}>`
 
     & > div {
       padding: 0;
+      width: 100%;
     }
 
-    margin-bottom: ${space(2)};
+    margin-bottom: ${space(1)};
   `}
 `;
 
@@ -107,8 +111,9 @@ const StyledFormField = styled(FormField)<{hasAlertWizardV3: boolean}>`
 
     & > div {
       padding: 0;
+      width: 100%;
     }
 
-    margin-bottom: ${space(2)};
+    margin-bottom: ${space(1)};
   `}
 `;


### PR DESCRIPTION
This updates the alert wizard v3/v4 ui according to the design changes.

Before (w/ v3 flag):
![Screen Shot 2022-03-25 at 7 57 28 AM](https://user-images.githubusercontent.com/15015880/160145689-15f30166-3384-4769-87c4-13bbd20ae4c3.png)


After (also w/ v3 flag):
![Screen Shot 2022-03-25 at 7 57 37 AM](https://user-images.githubusercontent.com/15015880/160145705-a6a7c674-345c-4770-b6f8-76dcb4fa07c4.png)

Design: [Alert-Wizard-v4](https://www.figma.com/file/yskaUlIaLj7raPo5RDR9aJ/Alert-Wizard-v4?node-id=6%3A6158)
