### PR TITLE
feat(dashboards): Widget Viewer hide pagination arrows if there are no pages to paginate to

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -463,6 +463,7 @@ function WidgetViewerModal(props: Props) {
                 if (totalResults === undefined) {
                   setTotalResults(totalCount);
                 }
+                const links = parseLinkHeader(pageLinks ?? null);
                 return (
                   <React.Fragment>
                     <GridEditable
@@ -486,37 +487,39 @@ function WidgetViewerModal(props: Props) {
                       }}
                       location={location}
                     />
-                    <StyledPagination
-                      pageLinks={pageLinks}
-                      onCursor={(nextCursor, _path, _query, delta) => {
-                        let nextPage = isNaN(page) ? delta : page + delta;
-                        let newCursor = nextCursor;
-                        // unset cursor and page when we navigate back to the first page
-                        // also reset cursor if somehow the previous button is enabled on
-                        // first page and user attempts to go backwards
-                        if (nextPage <= 0) {
-                          newCursor = undefined;
-                          nextPage = 0;
-                        }
-                        router.replace({
-                          pathname: location.pathname,
-                          query: {
-                            ...location.query,
-                            [WidgetViewerQueryField.CURSOR]: newCursor,
-                            [WidgetViewerQueryField.PAGE]: nextPage,
-                          },
-                        });
-
-                        trackAdvancedAnalyticsEvent(
-                          'dashboards_views.widget_viewer.paginate',
-                          {
-                            organization,
-                            widget_type: widget.widgetType ?? WidgetType.DISCOVER,
-                            display_type: widget.displayType,
+                    {(links?.previous?.results || links?.next?.results) && (
+                      <StyledPagination
+                        pageLinks={pageLinks}
+                        onCursor={(nextCursor, _path, _query, delta) => {
+                          let nextPage = isNaN(page) ? delta : page + delta;
+                          let newCursor = nextCursor;
+                          // unset cursor and page when we navigate back to the first page
+                          // also reset cursor if somehow the previous button is enabled on
+                          // first page and user attempts to go backwards
+                          if (nextPage <= 0) {
+                            newCursor = undefined;
+                            nextPage = 0;
                           }
-                        );
-                      }}
-                    />
+                          router.replace({
+                            pathname: location.pathname,
+                            query: {
+                              ...location.query,
+                              [WidgetViewerQueryField.CURSOR]: newCursor,
+                              [WidgetViewerQueryField.PAGE]: nextPage,
+                            },
+                          });
+
+                          trackAdvancedAnalyticsEvent(
+                            'dashboards_views.widget_viewer.paginate',
+                            {
+                              organization,
+                              widget_type: widget.widgetType ?? WidgetType.DISCOVER,
+                              display_type: widget.displayType,
+                            }
+                          );
+                        }}
+                      />
+                    )}
                   </React.Fragment>
                 );
               }}
@@ -539,6 +542,7 @@ function WidgetViewerModal(props: Props) {
                 const isFirstPage = pageLinks
                   ? parseLinkHeader(pageLinks).previous.results === false
                   : false;
+                const links = parseLinkHeader(pageLinks ?? null);
                 return (
                   <React.Fragment>
                     <GridEditable
@@ -564,27 +568,29 @@ function WidgetViewerModal(props: Props) {
                       }}
                       location={location}
                     />
-                    <StyledPagination
-                      pageLinks={pageLinks}
-                      onCursor={newCursor => {
-                        router.replace({
-                          pathname: location.pathname,
-                          query: {
-                            ...location.query,
-                            [WidgetViewerQueryField.CURSOR]: newCursor,
-                          },
-                        });
+                    {(links?.previous?.results || links?.next?.results) && (
+                      <StyledPagination
+                        pageLinks={pageLinks}
+                        onCursor={newCursor => {
+                          router.replace({
+                            pathname: location.pathname,
+                            query: {
+                              ...location.query,
+                              [WidgetViewerQueryField.CURSOR]: newCursor,
+                            },
+                          });
 
-                        trackAdvancedAnalyticsEvent(
-                          'dashboards_views.widget_viewer.paginate',
-                          {
-                            organization,
-                            widget_type: widget.widgetType ?? WidgetType.DISCOVER,
-                            display_type: widget.displayType,
-                          }
-                        );
-                      }}
-                    />
+                          trackAdvancedAnalyticsEvent(
+                            'dashboards_views.widget_viewer.paginate',
+                            {
+                              organization,
+                              widget_type: widget.widgetType ?? WidgetType.DISCOVER,
+                              display_type: widget.displayType,
+                            }
+                          );
+                        }}
+                      />
+                    )}
                   </React.Fragment>
                 );
               }}

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -411,6 +411,32 @@ describe('Modals -> WidgetViewerModal', function () {
       expect(screen.getByRole('button', {name: 'Next'})).toBeInTheDocument();
     });
 
+    it('does not render pagination buttons', async function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/eventsv2/',
+        headers: {
+          Link:
+            '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1",' +
+            '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=0:20:0>; rel="next"; results="false"; cursor="0:20:0"',
+        },
+        body: {
+          data: [
+            {
+              'error.type': ['No Pagination'],
+              count: 1,
+            },
+          ],
+          meta: {
+            'error.type': 'array',
+            count: 'integer',
+          },
+        },
+      });
+      await renderModal({initialData, widget: mockWidget});
+      expect(screen.queryByRole('button', {name: 'Previous'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Next'})).not.toBeInTheDocument();
+    });
+
     it('paginates to the next page', async function () {
       const {rerender} = await renderModal({initialData, widget: mockWidget});
       expect(screen.getByText('Test Error 1c')).toBeInTheDocument();


### PR DESCRIPTION
Hides the pagination arrows in the Widget Viewer if there are no pages to paginate to