### PR TITLE
fix(alerts): Use newer input component for Alerts team filter

### DIFF
--- a/static/app/views/alerts/rules/teamFilter.tsx
+++ b/static/app/views/alerts/rules/teamFilter.tsx
@@ -2,7 +2,7 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
-import Input from 'sentry/components/deprecatedforms/input';
+import Input from 'sentry/components/forms/controls/input';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -115,8 +115,9 @@ const InputWrapper = styled('div')`
 
 const StyledInput = styled(Input)`
   border: none;
-  border-bottom: 1px solid transparent;
   border-radius: 0;
+  border-bottom: solid 1px ${p => p.theme.border};
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`


### PR DESCRIPTION
We currently use a deprecated input component that is not dark mode-compatible.

**Before:**
<img width="342" alt="Screen Shot 2022-03-25 at 10 41 11 AM" src="https://user-images.githubusercontent.com/44172267/160173482-23bfbdf5-af01-4f51-8929-7d973de2335b.png">
<img width="342" alt="Screen Shot 2022-03-25 at 10 41 42 AM" src="https://user-images.githubusercontent.com/44172267/160173557-86e11c6a-7951-4ab9-9be7-e270027dfe03.png">
<img width="342" alt="Screen Shot 2022-03-25 at 10 42 06 AM" src="https://user-images.githubusercontent.com/44172267/160173618-85070050-5ae3-426c-be41-b7016687a742.png">


**After:**
<img width="342" alt="Screen Shot 2022-03-25 at 10 41 31 AM" src="https://user-images.githubusercontent.com/44172267/160173527-5e28a5e1-dc9d-4b42-8a84-7c8a25c86a50.png">
<img width="342" alt="Screen Shot 2022-03-25 at 10 41 56 AM" src="https://user-images.githubusercontent.com/44172267/160173591-2c1cbf89-0696-4ad7-8ca8-00e026781914.png">
<img width="342" alt="Screen Shot 2022-03-25 at 10 42 23 AM" src="https://user-images.githubusercontent.com/44172267/160173663-b1773967-d850-4e71-8342-5363a1aa7b31.png">
