### PR TITLE
ref(jest): Wrap promises/count for isolation detection 

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         # XXX: When updating this, make sure you also update CI_NODE_TOTAL.
-        instance: [0, 1, 2, 3]
+        instance: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     env:
       VISUAL_HTML_ENABLE: 1
@@ -62,7 +62,7 @@ jobs:
           # XXX: CI_NODE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
           #      Otherwise, if there are other things in the matrix, using strategy.job-total
           #      wouldn't be correct.
-          CI_NODE_TOTAL: 4
+          CI_NODE_TOTAL: 10
           CI_NODE_INDEX: ${{ matrix.instance }}
         run: |
           JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit

--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -163,6 +163,9 @@ class Client implements ApiNamespace.Client {
     }: {includeAllArgs?: boolean} & Readonly<ApiNamespace.RequestOptions> = {}
   ): any {
     return new Promise((resolve, reject) => {
+      if ((global as any)._registerAutoResolve) {
+        (global as any)._registerAutoResolve(resolve);
+      }
       this.request(path, {
         ...options,
         success: (data, ...args) => {

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -419,7 +419,12 @@ async function updateDesyncedUrlState(router?: Router) {
   // This function *should* be called only after persistPageFilters has been
   // called as well This function *should* be called only after
   // persistPageFilters has been called as well
-  await new Promise(resolve => setTimeout(resolve, 0));
+  await new Promise(resolve => {
+    if ((global as any)._registerAutoResolve) {
+      (global as any)._registerAutoResolve(resolve);
+    }
+    setTimeout(resolve, 0);
+  });
 
   const {organization} = OrganizationStore.getState();
 

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -110,8 +110,6 @@ function testIsolationChecks() {
   });
 
   afterEach(() => {
-    global._lastTest = expect.getState().currentTestName;
-
     _resolveFns.forEach(resolve =>
       resolve('If you are seeing this then you are outside the bounds of a test')
     );
@@ -132,15 +130,6 @@ function testIsolationChecks() {
 }
 
 testIsolationChecks();
-
-process.on('unhandledRejection', reason => {
-  if (global._lastTest) {
-    // eslint-disable-next-line no-console
-    console.error('Last run test: ', global._lastTest);
-  }
-  // eslint-disable-next-line no-console
-  console.error(reason);
-});
 
 /**
  * Enzyme configuration

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -3,7 +3,7 @@
 import {TextDecoder, TextEncoder} from 'util';
 
 import {InjectedRouter} from 'react-router';
-import {configure} from '@testing-library/react'; // eslint-disable-line no-restricted-imports
+import {configure, getConfig} from '@testing-library/react'; // eslint-disable-line no-restricted-imports
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import Enzyme from 'enzyme'; // eslint-disable-line no-restricted-imports
 import {Location} from 'history';
@@ -36,9 +36,6 @@ SVGElement.prototype.getTotalLength ??= () => 1;
  *
  * See: https://testing-library.com/docs/queries/bytestid/#overriding-data-testid
  */
-<<<<<<< Updated upstream
-configure({testIdAttribute: 'data-test-id'});
-=======
 const currentRTLConfig = getConfig();
 configure({
   testIdAttribute: 'data-test-id',
@@ -121,6 +118,7 @@ function testIsolationChecks() {
 
     const remainingInflight = _inflightTestPromises.length;
     if (remainingInflight) {
+      // eslint-disable-next-line no-console
       console.log(
         _inflightTestPromises.map(p => p.__promiseCreationStack).join('\n\n\n')
       );
@@ -143,7 +141,6 @@ process.on('unhandledRejection', reason => {
   // eslint-disable-next-line no-console
   console.error(reason);
 });
->>>>>>> Stashed changes
 
 /**
  * Enzyme configuration


### PR DESCRIPTION
### Summary
This monitors all promise creation and catches their stacks so we can see sources of unresolved promises outside of test boundaries.

#### Other
- This PR will definitely fail, but I wanted to get an idea of coverage and also put up the branch for others to look at. Might work against reducing these promise flakes.

#### Screenshots
![Screen Shot 2022-03-25 at 1 32 48 PM](https://user-images.githubusercontent.com/6111995/160178612-70447ff5-1b64-4bc0-9f87-087691b05728.png)

