### PR TITLE
fix(access): Give global membership to Sentry app tokens

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -236,6 +236,8 @@ class OrganizationMemberAccess(Access):
 
 
 class OrganizationGlobalAccess(Access):
+    """Access to all an organization's teams and projects."""
+
     def __init__(self, organization: Organization, scopes: Iterable[str], **kwargs):
         self._organization = organization
 
@@ -249,6 +251,23 @@ class OrganizationGlobalAccess(Access):
             project.organization_id == self._organization.id
             and project.status == ProjectStatus.VISIBLE
         )
+
+
+class OrganizationGlobalMembership(OrganizationGlobalAccess):
+    """Access to all an organization's teams and projects with simulated membership."""
+
+    @cached_property
+    def teams(self) -> FrozenSet[Team]:
+        return frozenset(Team.objects.filter(organization=self._organization))
+
+    @cached_property
+    def projects(self) -> FrozenSet[Project]:
+        return frozenset(
+            Project.objects.filter(status=ProjectStatus.VISIBLE, teams__in=self.teams).distinct()
+        )
+
+    def has_project_membership(self, project: Project) -> bool:
+        return self.has_project_access(project)
 
 
 class OrganizationlessAccess(Access):
@@ -331,7 +350,7 @@ def _from_sentry_app(user, organization: Optional[Organization] = None) -> Acces
     if not sentry_app.is_installed_on(organization):
         return NoAccess()
 
-    return OrganizationGlobalAccess(organization, sentry_app.scope_list, sso_is_valid=True)
+    return OrganizationGlobalMembership(organization, sentry_app.scope_list, sso_is_valid=True)
 
 
 def from_user(

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -258,12 +258,14 @@ class OrganizationGlobalMembership(OrganizationGlobalAccess):
 
     @cached_property
     def teams(self) -> FrozenSet[Team]:
-        return frozenset(Team.objects.filter(organization=self._organization))
+        return frozenset(
+            Team.objects.filter(organization=self._organization, status=TeamStatus.VISIBLE)
+        )
 
     @cached_property
     def projects(self) -> FrozenSet[Project]:
         return frozenset(
-            Project.objects.filter(status=ProjectStatus.VISIBLE, teams__in=self.teams).distinct()
+            Project.objects.filter(organization=self._organization, status=ProjectStatus.VISIBLE)
         )
 
     def has_project_membership(self, project: Project) -> bool:

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -372,9 +372,10 @@ class FromSentryAppTest(TestCase):
         result = access.from_request(request, self.org)
         assert result.has_global_access
         assert result.has_team_access(self.team)
-        assert result.teams == frozenset()
+        assert result.teams == frozenset({self.team})
         assert result.scopes == frozenset()
         assert result.has_project_access(self.project)
+        assert result.has_project_membership(self.project)
         assert not result.has_project_access(self.out_of_scope_project)
         assert not result.permissions
 


### PR DESCRIPTION
Partially revert a change from #32327, such that access tokens for Sentry app integrations now are shown as having membership for all teams and projects in the parent organization.

Sorry about the churn. Even with the reverted behavior, I feel better with this factoring than before. The `teams` and `projects` attributes in the return value from `_from_sentry_app` are now clearly meant to represent pseudo-membership, where before it was unclear whether those values were only meant to affect the behavior of `has_team_access` and `has_project_access`.

If possible, it would be nice to add some unit test coverage to the endpoints where the Sentry app token was changing behavior. But it's probably better not to delay the fix.