### PR TITLE
test: transpile modal ahead of tests

### DIFF
--- a/tests/js/spec/views/settings/projectDebugFiles/customRepositories.spec.tsx
+++ b/tests/js/spec/views/settings/projectDebugFiles/customRepositories.spec.tsx
@@ -88,6 +88,11 @@ describe('Custom Repositories', function () {
     type: CustomRepoType.APP_STORE_CONNECT,
   };
 
+  beforeAll(async function () {
+    // transpile the modal upfront so the test runs fast
+    await import('sentry/components/modals/debugFileCustomRepository');
+  });
+
   it('renders', async function () {
     const {rerender} = render(<TestComponent {...props} />, {context: routerContext});
 

--- a/tests/js/spec/views/settings/projectDebugFiles/customRepositories.spec.tsx
+++ b/tests/js/spec/views/settings/projectDebugFiles/customRepositories.spec.tsx
@@ -89,6 +89,7 @@ describe('Custom Repositories', function () {
   };
 
   beforeAll(async function () {
+    // TODO: figure out why this transpile is so slow
     // transpile the modal upfront so the test runs fast
     await import('sentry/components/modals/debugFileCustomRepository');
   });


### PR DESCRIPTION
The modals are being loaded during the test lazily. This change preloads the
modal in question in a before all so that the individual tests run fast.

Tries to fix https://github.com/getsentry/sentry/issues/32731