### PR TITLE
fix(ui): Consistent spacing from search bar in alerts

### DIFF
--- a/static/app/views/alerts/filterBar.tsx
+++ b/static/app/views/alerts/filterBar.tsx
@@ -50,7 +50,7 @@ const Wrapper = styled('div')`
   display: grid;
   grid-template-columns: min-content 1fr;
   gap: ${space(1.5)};
-  margin-bottom: ${space(1.5)};
+  margin-bottom: ${space(2)};
 `;
 
 const FilterButtons = styled(ButtonBar)`


### PR DESCRIPTION
All other pages use 2 spacing units

old
![image](https://user-images.githubusercontent.com/1421724/160202930-1a593569-c181-4bd2-b1c6-48f52186c053.png)


new
![image](https://user-images.githubusercontent.com/1421724/160202896-b716a1c2-c4e8-4560-8e53-8210aa208372.png)
