### PR TITLE
fix(ui): Consistent page content margins

### DIFF
--- a/static/app/styles/organization.tsx
+++ b/static/app/styles/organization.tsx
@@ -7,7 +7,7 @@ export const PageContent = styled('div')`
   display: flex;
   flex-direction: column;
   flex: 1;
-  padding: ${space(2)} ${space(4)} ${space(3)};
+  padding: ${space(3)} ${space(4)};
   margin-bottom: -20px; /* <footer> has margin-top: 20px; */
 
   /* No footer at smallest breakpoint */


### PR DESCRIPTION
The Layout.Heading components have a top margin of 20px, the PageContent had a top margin of 16px, this brings the two inline so that headings on older pages that use PageContent will align with newer Layout.* pages.