### PR TITLE
feat(page-filters): Add page filters to releases page

### DIFF
--- a/static/app/components/organizations/pageFilters/utils.tsx
+++ b/static/app/components/organizations/pageFilters/utils.tsx
@@ -79,7 +79,15 @@ export function isSelectionEqual(selection: PageFilters, other: PageFilters): bo
 export function doesPathHaveNewFilters(pathname: string, organization: Organization) {
   const newFilterPaths = (
     organization.features.includes('selection-filters-v2')
-      ? ['user-feedback', 'alerts', 'monitors', 'issues', 'projects', 'dashboard']
+      ? [
+          'user-feedback',
+          'alerts',
+          'monitors',
+          'issues',
+          'projects',
+          'dashboard',
+          'releases',
+        ]
       : ['user-feedback', 'alerts', 'monitors']
   ).map(route => `/organizations/${organization.slug}/${route}/`);
 

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -360,6 +360,7 @@ class ReleasesDetailContainer extends AsyncComponent<
         showProjectSettingsLink
         projectsFooterMessage={this.renderProjectsFooterMessage()}
         showDateSelector={false}
+        hideGlobalHeader={organization.features.includes('selection-filters-v2')}
       >
         <ReleasesDetail {...this.props} releaseMeta={releaseMeta} />
       </PageFiltersContainer>

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -505,13 +505,11 @@ class ReleasesList extends AsyncView<Props, State> {
             {this.renderHealthCta()}
 
             {hasPageFilters && (
-              <PageFilterWrapper>
-                <PageFilterBar>
-                  <ProjectPageFilter />
-                  <EnvironmentPageFilter />
-                  <DatePageFilter />
-                </PageFilterBar>
-              </PageFilterWrapper>
+              <ReleasesPageFilterBar>
+                <ProjectPageFilter />
+                <EnvironmentPageFilter />
+                <DatePageFilter />
+              </ReleasesPageFilterBar>
             )}
 
             <SortAndFilterWrapper>
@@ -591,9 +589,9 @@ const AlertText = styled('div')`
   }
 `;
 
-const PageFilterWrapper = styled('div')`
-  display: grid;
-  grid-template-columns: minmax(0, max-content);
+const ReleasePageFilterBar = styled(PageFilterBar)`
+  width: max-content;
+  max-width: 100%;
   margin-bottom: ${space(1)};
 `;
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -7,14 +7,18 @@ import pick from 'lodash/pick';
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import Alert from 'sentry/components/alert';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
+import DatePageFilter from 'sentry/components/datePageFilter';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {getRelativeSummary} from 'sentry/components/organizations/timeRangeSelector/utils';
 import PageHeading from 'sentry/components/pageHeading';
 import Pagination from 'sentry/components/pagination';
+import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
 import {ItemType} from 'sentry/components/smartSearchBar/types';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
@@ -482,12 +486,15 @@ class ReleasesList extends AsyncView<Props, State> {
       hasAnyMobileProject && selection.environments.length === 1;
     const hasReleasesSetup = releases && releases.length > 0;
 
+    const hasPageFilters = organization.features.includes('selection-filters-v2');
+
     return (
       <PageFiltersContainer
         showAbsolute={false}
         timeRangeHint={t(
           'Changing this date range will recalculate the release metrics.'
         )}
+        hideGlobalHeader={hasPageFilters}
       >
         <PageContent>
           <NoProjectMessage organization={organization}>
@@ -496,6 +503,16 @@ class ReleasesList extends AsyncView<Props, State> {
             </PageHeader>
 
             {this.renderHealthCta()}
+
+            {hasPageFilters && (
+              <PageFilterWrapper>
+                <PageFilterBar>
+                  <ProjectPageFilter />
+                  <EnvironmentPageFilter />
+                  <DatePageFilter />
+                </PageFilterBar>
+              </PageFilterWrapper>
+            )}
 
             <SortAndFilterWrapper>
               <GuideAnchor
@@ -572,6 +589,12 @@ const AlertText = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     flex-direction: row;
   }
+`;
+
+const PageFilterWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(0, max-content);
+  margin-bottom: ${space(1)};
 `;
 
 const SortAndFilterWrapper = styled('div')`

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -589,7 +589,7 @@ const AlertText = styled('div')`
   }
 `;
 
-const ReleasePageFilterBar = styled(PageFilterBar)`
+const ReleasesPageFilterBar = styled(PageFilterBar)`
   width: max-content;
   max-width: 100%;
   margin-bottom: ${space(1)};


### PR DESCRIPTION
Internal release for `releases` page

Before:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9372512/160718097-39231c8b-c387-419c-8250-37dcf97cf139.png">

After:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9372512/160718056-04a710e3-9b99-4df6-bc3c-2dab3edc9bcb.png">

Release Details Page

Before:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9372512/161166087-bdc50f2e-f065-4e5c-86c9-5bb303e67bb9.png">

After:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9372512/161166627-eeb9255d-606e-4e9c-8d32-25fae65297b1.png">
