### PR TITLE
feat(kafka) Introduce KAFKA_CONSUMERS settings

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2214,6 +2214,15 @@ KAFKA_CLUSTERS = {
     }
 }
 
+# Allows individual consumers to override their Kafka broker settings.
+# KAFKA_CLUSTER instead is used to apply settings across the board for
+# all consumers/producers for a broker.
+#
+# Consumers are identified by "[cluster]_[consumer_group]". In code
+# this is managed by kafka_config.ConsumerKey
+KAFKA_CONSUMERS = {"default_snuba-post-processor": {}}
+
+
 KAFKA_EVENTS = "events"
 KAFKA_OUTCOMES = "outcomes"
 KAFKA_OUTCOMES_BILLING = "outcomes-billing"

--- a/src/sentry/eventstream/kafka/consumer.py
+++ b/src/sentry/eventstream/kafka/consumer.py
@@ -62,7 +62,9 @@ def run_commit_log_consumer(
     # partitions of the commit log topic and get a comprehensive view of the
     # state of the consumer groups it is tracking.
     consumer_config = kafka_config.get_kafka_consumer_cluster_options(
-        cluster_name,
+        consumer_key=kafka_config.ConsumerKey(
+            cluster_name=cluster_name, consumer_group=consumer_group
+        ),
         override_params={
             "group.id": consumer_group,
             "enable.auto.commit": "false",
@@ -189,7 +191,9 @@ class SynchronizedConsumer(KafkaConsumerFacade):
                 return on_commit(error, partitions)
 
         consumer_configuration = kafka_config.get_kafka_consumer_cluster_options(
-            cluster_name,
+            consumer_key=kafka_config.ConsumerKey(
+                cluster_name=cluster_name, consumer_group=self.consumer_group
+            ),
             override_params={
                 "group.id": self.consumer_group,
                 "enable.auto.commit": "false",

--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -65,7 +65,7 @@ def get_metrics():  # type: ignore
 def get_config(topic: str, group_id: str, auto_offset_reset: str) -> MutableMapping[Any, Any]:
     cluster_name: str = settings.KAFKA_TOPICS[topic]["cluster"]
     consumer_config: MutableMapping[Any, Any] = kafka_config.get_kafka_consumer_cluster_options(
-        cluster_name,
+        consumer_key=kafka_config.ConsumerKey(cluster_name=cluster_name, consumer_group=group_id),
         override_params={
             "auto.offset.reset": auto_offset_reset,
             "enable.auto.commit": False,

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -87,8 +87,10 @@ class QuerySubscriptionConsumer:
         self.offsets: Dict[int, Optional[int]] = {}
         self.consumer: Consumer = None
         self.cluster_options = kafka_config.get_kafka_consumer_cluster_options(
-            cluster_name,
-            {
+            consumer_key=kafka_config.ConsumerKey(
+                cluster_name=cluster_name, consumer_group=self.group_id
+            ),
+            override_params={
                 "group.id": self.group_id,
                 "session.timeout.ms": 6000,
                 "auto.offset.reset": self.initial_offset_reset,

--- a/src/sentry/utils/batching_kafka_consumer.py
+++ b/src/sentry/utils/batching_kafka_consumer.py
@@ -281,7 +281,9 @@ class BatchingKafkaConsumer:
         queued_min_messages,
     ):
         consumer_config = kafka_config.get_kafka_consumer_cluster_options(
-            cluster_name,
+            consumer_key=kafka_config.ConsumerKey(
+                cluster_name=cluster_name, consumer_group=group_id
+            ),
             override_params={
                 "enable.auto.commit": False,
                 "group.id": group_id,


### PR DESCRIPTION
Today we are able to provide settings to the Kafka broker in two ways: changing KAFKA_CLUSTERS setting or hardcoding override parameters in your consumer.
We are missing a use case in between: consumer specific parameters that can be overridden through settings. KAFKA_CLUSTERS is across consumers on the same broker, and consumer specific ones have to be hardcoded or passed as CLI arguments.

It is a reasonable scenario to customize parameters (like session timeout) for specific consumers, and apply a different parameters across environments: dev, saas, single tenant, self hosted. 

This introduces `KAFKA_CONSUMERS` setting that is partitioned by a consumer identifier. The consumer identifier is made by cluster and consumer group. These settings override the KAFKA_CLUSTER settings and are overridden by the hardcoded override parameters passed by the consumer code.