### PR TITLE
ref(team-filter): Detach alert's team filter

### DIFF
--- a/static/app/views/alerts/rules/filter.tsx
+++ b/static/app/views/alerts/rules/filter.tsx
@@ -144,6 +144,7 @@ function Filter({onFilterChange, header, dropdownSections}: Props) {
           blendCorner
           alignMenu="left"
           width="240px"
+          detached
         >
           <List>
             {header}


### PR DESCRIPTION
Detach the filter to match with the project page filter right next to it.

Before:
<img width="355" alt="image" src="https://user-images.githubusercontent.com/9372512/160215223-5ecedf0d-dd4a-48bb-a430-8c379466f26b.png">


After:
<img width="389" alt="image" src="https://user-images.githubusercontent.com/9372512/160215215-c3486db8-2840-4d1f-b625-5337a594d5c9.png">

Project Page Filter:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/9372512/160215260-3d7fd7aa-5e22-4bb2-9509-7451c04ad9ca.png">
