### PR TITLE
fix(ui): Platform picker clear button was an oval

### DIFF
--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -224,6 +224,7 @@ const ClearButton = styled(Button)`
   position: absolute;
   top: -6px;
   right: -6px;
+  min-height: 0;
   height: 22px;
   width: 22px;
   display: flex;


### PR DESCRIPTION
<img width="62" alt="image" src="https://user-images.githubusercontent.com/1421724/160257629-875a424b-12fb-4e76-9cd2-e11815bdda9d.png">

It was an oval bc we set a min-height on buttons.

Wonder if there are other places this has broken things cc @vuluongj20 