### PR TITLE
ref(ui): Small widget card padding adjustment

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -263,7 +263,7 @@ const WidgetTitle = styled(HeaderTitle)`
 `;
 
 const WidgetHeader = styled('div')`
-  padding: ${space(2)} ${space(3)} 0 ${space(3)};
+  padding: ${space(2)} ${space(1)} 0 ${space(3)};
   width: 100%;
   display: flex;
   align-items: center;


### PR DESCRIPTION
old
<img width="1319" alt="image" src="https://user-images.githubusercontent.com/1421724/160270457-6b71ad64-4646-400c-8626-f4e0ff03588f.png">

new
<img width="1324" alt="image" src="https://user-images.githubusercontent.com/1421724/160270557-b0e54e02-403e-4244-b397-e47391420537.png">

Notice that the alignment of the icons is now aligned to the right table headings