### PR TITLE
chore: Fix threading module related DeprecationWarning

### DIFF
--- a/src/sentry/bgtasks/api.py
+++ b/src/sentry/bgtasks/api.py
@@ -55,7 +55,7 @@ class BgTask:
             return
         logger.info("bgtask.spawn", extra=dict(task_name=self.name))
         t = threading.Thread(target=self.run)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
     def stop(self):

--- a/src/sentry/debug/utils/thread_collector.py
+++ b/src/sentry/debug/utils/thread_collector.py
@@ -8,13 +8,13 @@ class ThreadCollector:
 
     def enable(self, thread=None):
         if thread is None:
-            thread = threading.currentThread()
+            thread = threading.current_thread()
         self.collections[thread] = []
         return self.collections[thread]
 
     def disable(self, thread=None):
         if thread is None:
-            thread = threading.currentThread()
+            thread = threading.current_thread()
         try:
             del self.collections[thread]
         except KeyError:
@@ -22,12 +22,12 @@ class ThreadCollector:
 
     def get(self, thread=None):
         if thread is None:
-            thread = threading.currentThread()
+            thread = threading.current_thread()
         return self.collections[thread]
 
     def append(self, item, thread=None):
         if thread is None:
-            thread = threading.currentThread()
+            thread = threading.current_thread()
         # fail silently if not active for thread
         if thread not in self.collections:
             return

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -102,7 +102,7 @@ class InternalMetrics:
                     q.task_done()
 
         t = Thread(target=worker)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
         self._started = True

--- a/src/sentry/utils/pubsub.py
+++ b/src/sentry/utils/pubsub.py
@@ -37,7 +37,7 @@ class QueuedPublisherService:
                     q.task_done()
 
         t = Thread(target=worker)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
         self._started = True


### PR DESCRIPTION
The camel case methods were deprecated in https://github.com/python/cpython/pull/25174.

* Use `current_thread` instead of `currentThread` .
* Set daemon attribute directly instead of using `setDaemon` .