### PR TITLE
fix(release-health): Fix should_compare for get_project_releases_by_stability [INGEST-784 INGEST-1091]

### DIFF
--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -1309,7 +1309,8 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
             now = datetime.now(pytz.utc)
 
         rollup, stats_start, _ = get_rollup_starts_and_buckets(stats_period, now=now)
-        should_compare = lambda _: now > self.metrics_start
+        assert stats_start is not None  # because stats_period is not None
+        should_compare = lambda _: stats_start > self.metrics_start
         organization = self._org_from_projects(project_ids)
 
         return self._dispatch_call(  # type: ignore

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -551,7 +551,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         if now is None:
             now = datetime.now(pytz.utc)
 
-        start = now - timedelta(days=3)
+        start = now - timedelta(days=90)
 
         projects_list = list(projects_list)
 
@@ -607,7 +607,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             select=query_cols,
             where=where_clause,
             groupby=group_by_clause,
-            granularity=Granularity(LEGACY_SESSIONS_DEFAULT_ROLLUP),
+            granularity=Granularity(24 * 60 * 60),  # daily
         )
 
         result = raw_snql_query(


### PR DESCRIPTION
Compare the metrics cutoff date to the start of the queried period instead of now.

Also, use 90 day period in metrics implementation of `check_has_health_data` to be consistent.