### PR TITLE
fix(new-widget-builder-experience): Remove feedback button

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/header.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/header.tsx
@@ -55,14 +55,6 @@ export function Header({
       <Layout.HeaderActions>
         <ButtonBar gap={1}>
           <Button
-            title={t(
-              'How do you like the new widget builder? Send us feedback via email.'
-            )}
-            href="mailto:new-widget-builder-experience@sentry.io?subject=New Widget Builder Experience Feedback"
-          >
-            {t('Give Feedback')}
-          </Button>
-          <Button
             external
             href="https://docs.sentry.io/product/dashboards/custom-dashboards/#widget-builder"
           >


### PR DESCRIPTION
Removing this feedback button until we can decide if the email is actually created and will have someone checking it. We also want to consider a more generic feedback email for the discover & dashboard team if we decide to reintroduce this.

cc: @jas-kas 