### PR TITLE
chore: Update sentry-jest-environment to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "jest-canvas-mock": "^2.3.1",
     "jest-fetch-mock": "^3.0.3",
     "jest-junit": "13.0.0",
-    "jest-sentry-environment": "1.4.0",
+    "jest-sentry-environment": "^1.5.0",
     "postcss-jsx": "0.36.4",
     "postcss-syntax": "0.36.2",
     "prettier": "2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10444,10 +10444,10 @@ jest-runtime@^27.5.1:
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
-jest-sentry-environment@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jest-sentry-environment/-/jest-sentry-environment-1.4.0.tgz#3d553583b7e14df2b2eea25191a284aacda23a8e"
-  integrity sha512-NXh+ikXP0vs4RRREHdKANc1fcCYGIl78hgfBvpsW/mJCzDWr8J3CgI3IalzGp0eOOM+kQ6cvQX0yjFOiwJJ7Rg==
+jest-sentry-environment@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/jest-sentry-environment/-/jest-sentry-environment-1.5.0.tgz#b5838ad3225ed4991226ac4f953740031ac2b45e"
+  integrity sha512-jbpZWDEcdJyqYAZIy0fCn6vcLfhthmnD1Q+id19aRcTakruO2hNkXn083UDENH1qJ+pGCtAYKzMIk+6eagidSw==
 
 jest-serializer@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
Added Sentry instrumentation to capture Jest test
errors as Errors in sentry, upgrading the package
to get this functionality into sentry https://github.com/getsentry/jest-sentry-environment/pull/2

Ooh, example test failure from this CI run
 https://sentry.io/organizations/sentry/issues/3136968003/?project=4857230&query=is%3Aunresolved