### PR TITLE
ref(fromEntries): use utility fn for fromEntries

### DIFF
--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -11,6 +11,7 @@ import {
 } from 'sentry/types';
 import {LocationQuery} from 'sentry/utils/discover/eventView';
 import {getPeriod} from 'sentry/utils/getPeriod';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import {PERFORMANCE_URL_PARAM} from 'sentry/utils/performance/constants';
 import {QueryBatching} from 'sentry/utils/performance/contexts/genericQueryBatcher';
 
@@ -85,7 +86,7 @@ export const doEventsRequest = (
   }: Options
 ): Promise<EventsStats | MultiSeriesEventsStats> => {
   const shouldDoublePeriod = canIncludePreviousPeriod(includePrevious, period);
-  const urlQuery = Object.fromEntries(
+  const urlQuery = objectFromEntries(
     Object.entries({
       interval,
       comparisonDelta,

--- a/static/app/actionCreators/metrics.tsx
+++ b/static/app/actionCreators/metrics.tsx
@@ -16,6 +16,7 @@ import {
 } from 'sentry/types';
 import {defined} from 'sentry/utils';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 
 export type DoMetricsRequestOptions = {
   field: string[];
@@ -59,7 +60,7 @@ export const doMetricsRequest = (
     allowEmptyPeriod: true,
   });
 
-  const urlQuery = Object.fromEntries(
+  const urlQuery = objectFromEntries(
     Object.entries({
       field: field.filter(f => !!f),
       cursor,

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -34,6 +34,7 @@ import {
 } from 'sentry/types';
 import {defined, valueIsEqual} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 
 /**
  * NOTE: this is the internal project.id, NOT the slug
@@ -540,7 +541,7 @@ function getNewQueryParams(
 
   const paramEntries = Object.entries(newQuery).filter(([_, value]) => defined(value));
 
-  return Object.fromEntries(paramEntries) as PageFilterQuery;
+  return objectFromEntries(paramEntries);
 }
 
 export function revertToPinnedFilters(orgSlug: string, router: InjectedRouter) {

--- a/static/app/components/charts/worldMapChart.tsx
+++ b/static/app/components/charts/worldMapChart.tsx
@@ -5,6 +5,7 @@ import * as echarts from 'echarts/core';
 import max from 'lodash/max';
 
 import {Series, SeriesDataUnit} from 'sentry/types/echarts';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import {Theme} from 'sentry/utils/theme';
 
 import VisualMap from './components/visualMap';
@@ -66,7 +67,7 @@ class WorldMapChart extends React.Component<Props, State> {
     this.setState({
       countryToCodeMap: countryToCodeMap.default,
       map: worldMap.default,
-      codeToCountryMap: Object.fromEntries(
+      codeToCountryMap: objectFromEntries(
         Object.entries(countryToCodeMap.default).map(([country, code]) => [code, country])
       ),
     });

--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -22,6 +22,7 @@ import {
   TRACING_FIELDS,
 } from 'sentry/utils/discover/fields';
 import Measurements from 'sentry/utils/measurements/measurements';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import withApi from 'sentry/utils/withApi';
 import withTags from 'sentry/utils/withTags';
 
@@ -105,7 +106,7 @@ class SearchBar extends React.PureComponent<SearchBarProps> {
     const {fields, organization, tags, omitTags} = this.props;
 
     const functionTags = fields
-      ? Object.fromEntries(
+      ? objectFromEntries(
           fields
             .filter(
               item =>

--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -15,6 +15,7 @@ import {
   IssueConfigField,
   SelectValue,
 } from 'sentry/types';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import {FormField} from 'sentry/views/alerts/issueRuleEditor/ruleNode';
 
 export type ExternalIssueAction = 'create' | 'link';
@@ -103,7 +104,7 @@ export default class AbstractExternalIssueForm<
     const {integrationDetails: integrationDetailsFromState} = this.state;
     const integrationDetails = integrationDetailsParam || integrationDetailsFromState;
     const config = (integrationDetails || {})[this.getConfigName()];
-    return Object.fromEntries(
+    return objectFromEntries(
       (config || [])
         .filter((field: IssueConfigField) => field.updatesForm)
         .map((field: IssueConfigField) => [field.name, field.default || null])

--- a/static/app/components/forms/choiceMapperField.tsx
+++ b/static/app/components/forms/choiceMapperField.tsx
@@ -11,6 +11,7 @@ import {IconAdd, IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {defined, objectIsEmpty} from 'sentry/utils';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 
 interface DefaultProps {
   /**
@@ -144,7 +145,7 @@ export default class ChoiceMapper extends React.Component<ChoiceMapperFieldProps
     const removeRow = (itemKey: string) => {
       // eslint-disable-next-line no-unused-vars
       saveChanges(
-        Object.fromEntries(Object.entries(value).filter(([key, _]) => key !== itemKey))
+        objectFromEntries(Object.entries(value).filter(([key, _]) => key !== itemKey))
       );
     };
 

--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -6,6 +6,7 @@ import {APIRequestMethod, Client} from 'sentry/api';
 import FormState from 'sentry/components/forms/state';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 
 type Snapshot = Map<string, FieldValue>;
 type SaveSnapshot = (() => number) | null;
@@ -118,7 +119,7 @@ class FormModel {
    */
   @computed
   get formChanged() {
-    return !isEqual(this.initialData, Object.fromEntries(this.fields.toJSON()));
+    return !isEqual(this.initialData, objectFromEntries(this.fields.toJSON()));
   }
 
   @computed
@@ -145,7 +146,7 @@ class FormModel {
    */
   setInitialData(initialData?: Record<string, FieldValue>) {
     this.fields.replace(initialData || {});
-    this.initialData = Object.fromEntries(this.fields.toJSON()) || {};
+    this.initialData = objectFromEntries(this.fields.toJSON()) || {};
 
     this.snapshots = [new Map(this.fields.entries())];
   }
@@ -243,7 +244,7 @@ class FormModel {
    * Data represented in UI
    */
   getData() {
-    return Object.fromEntries(this.fields.toJSON());
+    return objectFromEntries(this.fields.toJSON());
   }
 
   /**

--- a/static/app/components/forms/projectMapperField.tsx
+++ b/static/app/components/forms/projectMapperField.tsx
@@ -23,6 +23,7 @@ import {
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {safeGetQsParam} from 'sentry/utils/integrationUtil';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import {removeAtArrayIndex} from 'sentry/utils/removeAtArrayIndex';
 
 type MappedValue = string | number;
@@ -75,11 +76,11 @@ export class RenderField extends Component<RenderProps, State> {
     const {selectedSentryProjectId, selectedMappedValue} = this.state;
 
     // create maps by the project id for constant time lookups
-    const sentryProjectsById = Object.fromEntries(
+    const sentryProjectsById = objectFromEntries(
       sentryProjects.map(project => [project.id, project])
     );
 
-    const mappedItemsByValue = Object.fromEntries(
+    const mappedItemsByValue = objectFromEntries(
       mappedDropdownItems.map(item => [item.value, item])
     );
 

--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -6,6 +6,7 @@ import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/constants/pageFilters';
 import {IntervalPeriod, PageFilters} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 
 import {PageFiltersState} from './types';
 
@@ -272,7 +273,7 @@ export function normalizeDateTimeParams(
   // Filter null values
   const paramEntries = Object.entries(object).filter(([_, value]) => defined(value));
 
-  return Object.fromEntries(paramEntries);
+  return objectFromEntries(paramEntries);
 }
 
 /**
@@ -320,7 +321,7 @@ export function getStateFromQuery(
  * Extract the datetime component from the page filter state object
  */
 export function getDatetimeFromState(state: PageFiltersState) {
-  return Object.fromEntries(
+  return objectFromEntries(
     Object.entries(state).filter(([key]) => DATE_TIME_KEYS.includes(key))
   ) as PageFilters['datetime'];
 }

--- a/static/app/plugins/components/issueActions.tsx
+++ b/static/app/plugins/components/issueActions.tsx
@@ -7,6 +7,7 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {Group, Organization, Plugin, Project} from 'sentry/types';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 
 type Field = {
   depends?: string[];
@@ -159,7 +160,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
     const url = `/issues/${groupId}/plugins/${pluginSlug}/options/`;
 
     // find the fields that this field is dependent on
-    const dependentFormValues = Object.fromEntries(
+    const dependentFormValues = objectFromEntries(
       field.depends.map(fieldKey => [fieldKey, formData[fieldKey]])
     );
     const query = {

--- a/static/app/stores/projectsStore.tsx
+++ b/static/app/stores/projectsStore.tsx
@@ -3,6 +3,7 @@ import Reflux from 'reflux';
 import ProjectActions from 'sentry/actions/projectActions';
 import TeamActions from 'sentry/actions/teamActions';
 import {Project, Team} from 'sentry/types';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 
 import {CommonStoreInterface} from './types';
 
@@ -64,9 +65,9 @@ const storeConfig: Reflux.StoreDefinition & Internals & ProjectsStoreInterface =
   },
 
   loadInitialData(items: Project[]) {
-    const mapping = items.map(project => [project.id, project] as const);
+    const mapping = items.map(project => [project.id, project]);
 
-    this.itemsById = Object.fromEntries(mapping);
+    this.itemsById = objectFromEntries(mapping);
     this.loading = false;
 
     this.trigger(new Set(Object.keys(this.itemsById)));

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -3,6 +3,7 @@ import isEqual from 'lodash/isEqual';
 import {RELEASE_ADOPTION_STAGES} from 'sentry/constants';
 import {MetricsType, Organization, SelectValue} from 'sentry/types';
 import {assert} from 'sentry/types/utils';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 
 import {METRIC_TO_COLUMN_TYPE} from '../metrics/fields';
 
@@ -608,7 +609,7 @@ export type FieldTag = {
 };
 
 export const FIELD_TAGS = Object.freeze(
-  Object.fromEntries(Object.keys(FIELDS).map(item => [item, {key: item, name: item}]))
+  objectFromEntries(Object.keys(FIELDS).map(item => [item, {key: item, name: item}]))
 );
 
 export const SEMVER_TAGS = {

--- a/static/app/utils/measurements/measurements.tsx
+++ b/static/app/utils/measurements/measurements.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {MobileVital, WebVital} from 'sentry/utils/discover/fields';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import {
   MOBILE_VITAL_DETAILS,
   WEB_VITAL_DETAILS,
@@ -19,7 +20,7 @@ type VitalType = WebVital | MobileVital;
 function measurementsFromDetails(
   details: Partial<Record<VitalType, Vital>>
 ): MeasurementCollection {
-  return Object.fromEntries(
+  return objectFromEntries(
     Object.entries(details).map(([key, value]) => {
       const newValue: Measurement = {
         name: value.name,

--- a/static/app/utils/objectFromEntries.ts
+++ b/static/app/utils/objectFromEntries.ts
@@ -1,0 +1,25 @@
+type ArrayValue<A> = A extends readonly (infer T)[] ? T : never;
+// as const will cast all properties to readonly
+type RemoveReadOnly<T> = {-readonly [P in keyof T]: RemoveReadOnly<T[P]>};
+
+type FromEntries<T> = T extends [infer Key, any][]
+  ? {[K in Extract<Key, string>]: Extract<ArrayValue<T>, [K, any]>[1]}
+  : {[key in string]: any};
+
+function isIterable<T>(obj: any): obj is Iterable<T> {
+  return typeof obj?.[Symbol.iterator] === 'function';
+}
+
+export function objectFromEntries<T>(entries: T): FromEntries<RemoveReadOnly<T>> {
+  const target = {} as FromEntries<RemoveReadOnly<T>>;
+
+  if (!isIterable<T>(entries)) {
+    throw new TypeError(`Entries is not iterable, got ${JSON.stringify(entries)}`);
+  }
+
+  for (const entry of entries) {
+    target[entry[0]] = entry[1];
+  }
+
+  return target;
+}

--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -2,6 +2,7 @@ import isString from 'lodash/isString';
 import * as qs from 'query-string';
 
 import {escapeDoubleQuotes} from 'sentry/utils';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 
 // remove leading and trailing whitespace and remove double spaces
 export function formatQueryString(query: string): string {
@@ -24,7 +25,7 @@ export function addQueryParamsToExistingUrl(
   // Order the query params alphabetically.
   // Otherwise ``queryString`` orders them randomly and it's impossible to test.
   const params = JSON.parse(JSON.stringify(queryParams));
-  const query = {...Object.fromEntries(searchEntries), ...params};
+  const query = {...objectFromEntries(searchEntries), ...params};
 
   return `${url.protocol}//${url.host}${url.pathname}?${qs.stringify(query)}`;
 }

--- a/static/app/views/alerts/incidentRules/metricField.tsx
+++ b/static/app/views/alerts/incidentRules/metricField.tsx
@@ -11,11 +11,11 @@ import {Organization} from 'sentry/types';
 import {
   Aggregation,
   AGGREGATIONS,
-  ColumnType,
   explodeFieldString,
   FIELDS,
   generateFieldAsString,
 } from 'sentry/utils/discover/fields';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import {
   AlertType,
   hideParameterSelectorSet,
@@ -61,7 +61,7 @@ const getFieldOptionConfig = ({
   } else {
     config = dataset === Dataset.ERRORS ? errorFieldConfig : transactionFieldConfig;
   }
-  const aggregations = Object.fromEntries<Aggregation>(
+  const aggregations = objectFromEntries(
     config.aggregations.map(key => {
       // TODO(scttcper): Temporary hack for default value while we handle the translation of user
       if (key === 'count_unique') {
@@ -76,7 +76,7 @@ const getFieldOptionConfig = ({
     })
   );
 
-  const fields = Object.fromEntries<ColumnType>(
+  const fields = objectFromEntries(
     config.fields.map(key => {
       // XXX(epurkhiser): Temporary hack while we handle the translation of user ->
       // tags[sentry:user].

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -42,6 +42,7 @@ import {metric} from 'sentry/utils/analytics';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getDisplayName} from 'sentry/utils/environment';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -405,7 +406,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       CHANGE_ALERT_CONDITION_IDS.includes(configuration.id);
 
     return configuration?.formFields
-      ? Object.fromEntries(
+      ? objectFromEntries(
           Object.entries(configuration.formFields)
             // TODO(ts): Doesn't work if I cast formField as IssueAlertRuleFormField
             .map(([key, formField]: [string, any]) => [

--- a/static/app/views/alerts/issueRuleEditor/ticketRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ticketRuleModal.tsx
@@ -8,6 +8,7 @@ import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Choices, IssueConfigField, Organization} from 'sentry/types';
 import {IssueAlertRuleAction} from 'sentry/types/alerts';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import AsyncView from 'sentry/views/asyncView';
 
 const IGNORED_FIELDS = ['Sprint'];
@@ -37,7 +38,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     const issueConfigFieldsCache = Object.values(instance?.dynamic_form_fields || {});
     return {
       ...super.getDefaultState(),
-      fetchedFieldOptionsCache: Object.fromEntries(
+      fetchedFieldOptionsCache: objectFromEntries(
         issueConfigFieldsCache.map(field => [field.name, field.choices as Choices])
       ),
       issueConfigFieldsCache,

--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -5,6 +5,7 @@ import {t} from 'sentry/locale';
 import {Organization, TagCollection} from 'sentry/types';
 import {aggregateOutputType, isLegalYAxisType} from 'sentry/utils/discover/fields';
 import {MeasurementCollection} from 'sentry/utils/measurements/measurements';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import {SPAN_OP_BREAKDOWN_FIELDS} from 'sentry/utils/performance/spanOperationBreakdowns/constants';
 import {
   DisplayType,
@@ -226,7 +227,7 @@ export function normalizeQueries({
 export function getParsedDefaultWidgetQuery(query = ''): WidgetQuery | undefined {
   // "any" was needed here because it doesn't pass in getsentry
   const urlSeachParams = new URLSearchParams(query) as any;
-  const parsedQuery = Object.fromEntries(urlSeachParams.entries());
+  const parsedQuery = objectFromEntries(urlSeachParams.entries());
 
   if (!Object.keys(parsedQuery).length) {
     return undefined;

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -11,6 +11,7 @@ import {IconMail} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import withOrganizations from 'sentry/utils/withOrganizations';
 import {
   CONFIRMATION_MESSAGE,
@@ -105,7 +106,7 @@ class NotificationSettings extends AsyncComponent<Props, State> {
   getInitialData(): {[key: string]: string} {
     const {notificationSettings, legacyData} = this.state;
 
-    const notificationsInitialData = Object.fromEntries(
+    const notificationsInitialData = objectFromEntries(
       this.notificationSettingsType.map(notificationType => [
         notificationType,
         decideDefault(notificationType, notificationSettings),

--- a/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
@@ -8,6 +8,7 @@ import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import {Project} from 'sentry/types';
 import {sortProjects} from 'sentry/utils';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import {
   MIN_PROJECTS_FOR_PAGINATION,
   MIN_PROJECTS_FOR_SEARCH,
@@ -67,7 +68,7 @@ class NotificationSettingsByProjects extends AsyncComponent<Props, State> {
   getGroupedProjects = (): {[key: string]: Project[]} => {
     const {projects: stateProjects} = this.state;
 
-    return Object.fromEntries(
+    return objectFromEntries(
       Object.values(groupByOrganization(sortProjects(stateProjects))).map(
         ({organization, projects}) => [`${organization.name} Projects`, projects]
       )

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {Organization, OrganizationSummary} from 'sentry/types';
 import {OrganizationIntegration} from 'sentry/types/integrations';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import withOrganizations from 'sentry/utils/withOrganizations';
 import {
   ALL_PROVIDER_NAMES,
@@ -288,14 +289,14 @@ class NotificationSettingsByType extends AsyncComponent<Props, State> {
   getUnlinkedOrgs = (): OrganizationSummary[] => {
     const {organizations} = this.props;
     const {identities, organizationIntegrations} = this.state;
-    const integrationExternalIDsByOrganizationID = Object.fromEntries(
+    const integrationExternalIDsByOrganizationID = objectFromEntries(
       organizationIntegrations.map(organizationIntegration => [
         organizationIntegration.organizationId,
         organizationIntegration.externalId,
       ])
     );
 
-    const identitiesByExternalId = Object.fromEntries(
+    const identitiesByExternalId = objectFromEntries(
       identities.map(identity => [identity?.identityProvider?.externalId, identity])
     );
 

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -3,6 +3,7 @@ import set from 'lodash/set';
 import {FieldObject} from 'sentry/components/forms/type';
 import {t} from 'sentry/locale';
 import {OrganizationSummary, Project} from 'sentry/types';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import {
   ALL_PROVIDERS,
   MIN_PROJECTS_FOR_CONFIRMATION,
@@ -105,7 +106,7 @@ export const backfillMissingProvidersWithFallback = (
   }
 
   // Second pass: Fill in values for every provider.
-  return Object.fromEntries(
+  return objectFromEntries(
     Object.keys(ALL_PROVIDERS).map(provider => [
       provider,
       providerList.includes(provider) ? existingValue : 'never',
@@ -144,7 +145,7 @@ export const getUserDefaultValues = (
 ): NotificationSettingsByProviderObject => {
   return (
     Object.values(notificationSettings[notificationType]?.user || {}).pop() ||
-    Object.fromEntries(
+    objectFromEntries(
       Object.entries(ALL_PROVIDERS).map(([provider, value]) => [
         provider,
         value === 'default' ? getFallBackValue(notificationType) : value,
@@ -257,7 +258,7 @@ export const getParentData = (
 ): NotificationSettingsByProviderObject => {
   const provider = getCurrentProviders(notificationType, notificationSettings)[0];
 
-  return Object.fromEntries(
+  return objectFromEntries(
     parents.map(parent => [
       parent.id,
       getParentValues(notificationType, notificationSettings, parent.id)[provider],
@@ -293,18 +294,18 @@ export const getStateToPutForProvider = (
     return {
       [notificationType]: {
         user: {
-          me: Object.fromEntries(providerList.map(provider => [provider, fallbackValue])),
+          me: objectFromEntries(providerList.map(provider => [provider, fallbackValue])),
         },
       },
     };
   }
 
   return {
-    [notificationType]: Object.fromEntries(
+    [notificationType]: objectFromEntries(
       Object.entries(notificationSettings[notificationType]).map(
         ([scopeType, scopeTypeData]) => [
           scopeType,
-          Object.fromEntries(
+          objectFromEntries(
             Object.entries(scopeTypeData).map(([scopeId, scopeIdData]) => [
               scopeId,
               backfillMissingProvidersWithFallback(
@@ -342,17 +343,17 @@ export const getStateToPutForDefault = (
   const updatedNotificationSettings = {
     [notificationType]: {
       user: {
-        me: Object.fromEntries(providerList.map(provider => [provider, newValue])),
+        me: objectFromEntries(providerList.map(provider => [provider, newValue])),
       },
     },
   };
 
   if (newValue === 'never') {
     updatedNotificationSettings[notificationType][getParentKey(notificationType)] =
-      Object.fromEntries(
+      objectFromEntries(
         parentIds.map(parentId => [
           parentId,
-          Object.fromEntries(providerList.map(provider => [provider, 'default'])),
+          objectFromEntries(providerList.map(provider => [provider, 'default'])),
         ])
       );
   }
@@ -375,9 +376,7 @@ export const getStateToPutForParent = (
   return {
     [notificationType]: {
       [getParentKey(notificationType)]: {
-        [parentId]: Object.fromEntries(
-          providerList.map(provider => [provider, newValue])
-        ),
+        [parentId]: objectFromEntries(providerList.map(provider => [provider, newValue])),
       },
     },
   };

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -15,6 +15,7 @@ import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {ExternalTeam, Integration, Organization, Team} from 'sentry/types';
 import {toTitleCase} from 'sentry/utils';
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
 import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
@@ -110,7 +111,7 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
       );
     }
 
-    const integrationsById = Object.fromEntries(
+    const integrationsById = objectFromEntries(
       notificationIntegrations.map(integration => [integration.id, integration])
     );
 

--- a/tests/js/spec/utils/objectFromEntries.spec.tsx
+++ b/tests/js/spec/utils/objectFromEntries.spec.tsx
@@ -1,0 +1,16 @@
+import {objectFromEntries} from 'sentry/utils/objectFromEntries';
+
+describe('objectFromEntries', () => {
+  it.each([[null], [undefined]])('crashes if non iterable obj is passed', value => {
+    expect(() => objectFromEntries(value)).toThrow(TypeError);
+  });
+
+  it.each([
+    [new Map([['key', 'value']]), {key: 'value'}],
+    [new Set([['key']]), {key: undefined}],
+    [[['key', 'value']], {key: 'value'}],
+  ])('creates an obj entry for %s', (input, output) => {
+    expect(objectFromEntries(input)).toEqual(output);
+    expect(objectFromEntries(input)).toEqual(Object.fromEntries(input));
+  });
+});


### PR DESCRIPTION
Seeing some crashes from -> https://sentry.io/organizations/sentry/issues/3104893410/?query=is%3Aunresolved+fromEntries&statsPeriod=14d so I added a quick fix for fromEntries. We could optionally also extend browserslist so it includes this API, but that may bring in more stuff that we dont need... We could also import the polyfill from core-js, but I opted not to do that since we defer to babel for that rn..