### PR TITLE
ref(page-filters): Use counter badge & better trimming in project filter

### DIFF
--- a/static/app/components/badge.tsx
+++ b/static/app/components/badge.tsx
@@ -27,7 +27,6 @@ const Badge = styled(({children, text, ...props}: Props) => (
   transition: background 100ms linear;
 
   position: relative;
-  top: -1px;
 `;
 
 export default Badge;

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -4,8 +4,8 @@ import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 import partition from 'lodash/partition';
 
-import Badge from 'sentry/components/badge';
 import {updateProjects} from 'sentry/actionCreators/pageFilters';
+import Badge from 'sentry/components/badge';
 import MultipleProjectSelector from 'sentry/components/organizations/multipleProjectSelector';
 import PageFilterDropdownButton from 'sentry/components/organizations/pageFilters/pageFilterDropdownButton';
 import PlatformList from 'sentry/components/platformList';
@@ -17,6 +17,7 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {MinimalProject} from 'sentry/types';
+import {trimSlug} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
@@ -106,7 +107,7 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
     const selectedProjectIds = new Set(selection.projects);
     const hasSelected = !!selectedProjects.length;
     const title = hasSelected
-      ? selectedProjects[0]?.slug
+      ? trimSlug(selectedProjects[0]?.slug, 20)
       : selectedProjectIds.has(ALL_ACCESS_PROJECTS)
       ? t('All Projects')
       : t('My Projects');

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 import partition from 'lodash/partition';
 
+import Badge from 'sentry/components/badge';
 import {updateProjects} from 'sentry/actionCreators/pageFilters';
 import MultipleProjectSelector from 'sentry/components/organizations/multipleProjectSelector';
 import PageFilterDropdownButton from 'sentry/components/organizations/pageFilters/pageFilterDropdownButton';
@@ -105,14 +106,15 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
     const selectedProjectIds = new Set(selection.projects);
     const hasSelected = !!selectedProjects.length;
     const title = hasSelected
-      ? selectedProjects.map(({slug}) => slug).join(', ')
+      ? selectedProjects[0]?.slug
       : selectedProjectIds.has(ALL_ACCESS_PROJECTS)
       ? t('All Projects')
       : t('My Projects');
+
     const icon = hasSelected ? (
       <PlatformList
-        platforms={selectedProjects.map(p => p.platform ?? 'other').reverse()}
-        max={5}
+        platforms={selectedProjects.map(p => p.platform ?? 'other')}
+        max={1}
       />
     ) : (
       <IconProject />
@@ -126,6 +128,9 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
         <DropdownTitle>
           {icon}
           <TitleContainer>{title}</TitleContainer>
+          {selectedProjects.length > 1 && (
+            <StyledBadge text={`+${selectedProjects.length - 1}`} />
+          )}
         </DropdownTitle>
       </PageFilterDropdownButton>
     );
@@ -169,9 +174,12 @@ const TitleContainer = styled('div')`
 const DropdownTitle = styled('div')`
   width: max-content;
   display: flex;
-  overflow: hidden;
   align-items: center;
   flex: 1;
+`;
+
+const StyledBadge = styled(Badge)`
+  flex-shrink: 0;
 `;
 
 export default withRouter(ProjectPageFilter);

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -106,16 +106,21 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
   const customProjectDropdown = ({getActorProps, selectedProjects, isOpen}) => {
     const selectedProjectIds = new Set(selection.projects);
     const hasSelected = !!selectedProjects.length;
+
+    const projectsToShow =
+      selectedProjects[0]?.slug?.length + selectedProjects[1]?.slug?.length <= 18
+        ? selectedProjects.slice(0, 2)
+        : selectedProjects.slice(0, 1);
+
     const title = hasSelected
-      ? trimSlug(selectedProjects[0]?.slug, 20)
+      ? projectsToShow.map(proj => trimSlug(proj.slug, 20)).join(', ')
       : selectedProjectIds.has(ALL_ACCESS_PROJECTS)
       ? t('All Projects')
       : t('My Projects');
 
     const icon = hasSelected ? (
       <PlatformList
-        platforms={selectedProjects.map(p => p.platform ?? 'other')}
-        max={1}
+        platforms={projectsToShow.map(p => p.platform ?? 'other').reverse()}
       />
     ) : (
       <IconProject />
@@ -129,8 +134,8 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
         <DropdownTitle>
           {icon}
           <TitleContainer>{title}</TitleContainer>
-          {selectedProjects.length > 1 && (
-            <StyledBadge text={`+${selectedProjects.length - 1}`} />
+          {selectedProjects.length > projectsToShow.length && (
+            <StyledBadge text={`+${selectedProjects.length - projectsToShow.length}`} />
           )}
         </DropdownTitle>
       </PageFilterDropdownButton>

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -17,7 +17,7 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {MinimalProject} from 'sentry/types';
-import {trimSlug} from 'sentry/utils';
+import {trimSlug} from 'sentry/utils/trimSlug';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -118,6 +118,8 @@ export function ProjectPageFilter({
     const selectedProjectIds = new Set(selection.projects);
     const hasSelected = !!selectedProjects.length;
 
+    // Show 2 projects only if the combined string does not exceed maxTitleLength.
+    // Otherwise show only 1 project.
     const projectsToShow =
       selectedProjects[0]?.slug?.length + selectedProjects[1]?.slug?.length <=
       maxTitleLength - 2

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -39,6 +39,12 @@ type Props = WithRouterProps & {
   lockedMessageSubject?: string;
 
   /**
+   * Max character length for the dropdown title. Default is 20. This number
+   * is used to determine how many projects to show, and how much to truncate.
+   */
+  maxTitleLength?: number;
+
+  /**
    * A project will be forced from parent component (selection is disabled, and if user
    * does not have multi-project support enabled, it will not try to auto select a project).
    *
@@ -63,7 +69,12 @@ type Props = WithRouterProps & {
   specificProjectSlugs?: string[];
 };
 
-export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}: Props) {
+export function ProjectPageFilter({
+  router,
+  specificProjectSlugs,
+  maxTitleLength = 20,
+  ...otherProps
+}: Props) {
   const [currentSelectedProjects, setCurrentSelectedProjects] = useState<number[] | null>(
     null
   );
@@ -108,12 +119,13 @@ export function ProjectPageFilter({router, specificProjectSlugs, ...otherProps}:
     const hasSelected = !!selectedProjects.length;
 
     const projectsToShow =
-      selectedProjects[0]?.slug?.length + selectedProjects[1]?.slug?.length <= 18
+      selectedProjects[0]?.slug?.length + selectedProjects[1]?.slug?.length <=
+      maxTitleLength - 2
         ? selectedProjects.slice(0, 2)
         : selectedProjects.slice(0, 1);
 
     const title = hasSelected
-      ? projectsToShow.map(proj => trimSlug(proj.slug, 20)).join(', ')
+      ? projectsToShow.map(proj => trimSlug(proj.slug, maxTitleLength)).join(', ')
       : selectedProjectIds.has(ALL_ACCESS_PROJECTS)
       ? t('All Projects')
       : t('My Projects');

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -120,56 +120,6 @@ export function explodeSlug(slug: string): string {
   return trim(slug.replace(/[-_]+/g, ' '));
 }
 
-/**
- * Trim slug name with a preference for preserving whole words. Only cut up
- * whole words if the last remaining words are still too long. For example:
- * "javascript-project-backend" --> "javascript…backend"
- * "my-long-sentry-project-name" --> "my-long-sentry…name"
- * "javascriptproject-backend" --> "javascriptproje…ckend"
- */
-export function trimSlug(slug: string, maxLength: number = 20) {
-  // Return the original slug if it's already shorter than maxLength
-  if (slug.length <= maxLength) {
-    return slug;
-  }
-
-  /**
-   * Array of words inside the slug.
-   * E.g. "my-project-name" becomes ["my", "project", "name"]
-   */
-  const words: string[] = slug.split('-');
-  /**
-   * Returns the length (total number of letters plus hyphens in between
-   * words) of the current words array.
-   */
-  function getLength(arr: string[]): number {
-    return arr.reduce((acc, cur) => acc + cur.length + 1, 0) - 1;
-  }
-
-  // Progressively remove words in the middle until we're below maxLength,
-  // or when only two words are left
-  while (getLength(words) > maxLength && words.length > 2) {
-    words.splice(-2, 1);
-  }
-
-  // If the remaining words array satisfies the maxLength requirement,
-  // return the trimmed result.
-  if (getLength(words) <= maxLength) {
-    return `${words.slice(0, -1).join('-')}\u2026${words[words.length - 1]}`;
-  }
-
-  // If the remaining 2 words are still too long, trim those words starting
-  // from the middle.
-  const debt = getLength(words) - maxLength;
-  const toTrimFromLeftWord = Math.ceil(debt / 2);
-  const leftWordLength = Math.max(words[0].length - toTrimFromLeftWord, 3);
-  const leftWord = words[0].slice(0, leftWordLength);
-  const rightWordLength = maxLength - leftWord.length;
-  const rightWord = words[1].slice(-rightWordLength);
-
-  return `${leftWord}\u2026${rightWord}`;
-}
-
 export function defined<T>(item: T): item is Exclude<T, null | undefined> {
   return !isUndefined(item) && item !== null;
 }

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -120,6 +120,56 @@ export function explodeSlug(slug: string): string {
   return trim(slug.replace(/[-_]+/g, ' '));
 }
 
+/**
+ * Trim slug name with a preference for preserving whole words. Only cut up
+ * whole words if the last remaining words are still too long. For example:
+ * "javascript-project-backend" --> "javascript…backend"
+ * "my-long-sentry-project-name" --> "my-long-sentry…name"
+ * "javascriptproject-backend" --> "javascriptproje…ckend"
+ */
+export function trimSlug(slug: string, maxLength: number = 20) {
+  // Return the original slug if it's already shorter than maxLength
+  if (slug.length <= maxLength) {
+    return slug;
+  }
+
+  /**
+   * Array of words inside the slug.
+   * E.g. "my-project-name" becomes ["my", "project", "name"]
+   */
+  let words: string[] = slug.split('-');
+  /**
+   * Returns the length (total number of letters plus hyphens in between
+   * words) of the current words array.
+   */
+  function getLength(arr: string[]): number {
+    return arr.reduce((acc, cur) => acc + cur.length + 1, 0) - 1;
+  }
+
+  // Progressively remove words in the middle until we're below maxLength,
+  // or when only two words are left
+  while (getLength(words) > maxLength && words.length > 2) {
+    words.splice(-2, 1);
+  }
+
+  // If the remaining words array satisfies the maxLength requirement,
+  // return the trimmed result.
+  if (getLength(words) <= maxLength) {
+    return `${words.slice(0, -1).join('-')}…${words[words.length - 1]}`;
+  }
+
+  // If the remaining 2 words are still too long, trim those words starting
+  // from the middle.
+  const debt = getLength(words) - maxLength;
+  const toTrimFromLeftWord = Math.ceil(debt / 2);
+  const leftWordLength = Math.max(words[0].length - toTrimFromLeftWord, 3);
+  const leftWord = words[0].slice(0, leftWordLength);
+  const rightWordLength = maxLength - leftWord.length;
+  const rightWord = words[1].slice(-rightWordLength);
+
+  return `${leftWord}…${rightWord}`;
+}
+
 export function defined<T>(item: T): item is Exclude<T, null | undefined> {
   return !isUndefined(item) && item !== null;
 }

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -155,7 +155,7 @@ export function trimSlug(slug: string, maxLength: number = 20) {
   // If the remaining words array satisfies the maxLength requirement,
   // return the trimmed result.
   if (getLength(words) <= maxLength) {
-    return `${words.slice(0, -1).join('-')}…${words[words.length - 1]}`;
+    return `${words.slice(0, -1).join('-')}\u2026${words[words.length - 1]}`;
   }
 
   // If the remaining 2 words are still too long, trim those words starting
@@ -167,7 +167,7 @@ export function trimSlug(slug: string, maxLength: number = 20) {
   const rightWordLength = maxLength - leftWord.length;
   const rightWord = words[1].slice(-rightWordLength);
 
-  return `${leftWord}…${rightWord}`;
+  return `${leftWord}\u2026${rightWord}`;
 }
 
 export function defined<T>(item: T): item is Exclude<T, null | undefined> {

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -137,7 +137,7 @@ export function trimSlug(slug: string, maxLength: number = 20) {
    * Array of words inside the slug.
    * E.g. "my-project-name" becomes ["my", "project", "name"]
    */
-  let words: string[] = slug.split('-');
+  const words: string[] = slug.split('-');
   /**
    * Returns the length (total number of letters plus hyphens in between
    * words) of the current words array.

--- a/static/app/utils/trimSlug.tsx
+++ b/static/app/utils/trimSlug.tsx
@@ -1,0 +1,49 @@
+/**
+ * Trim slug name with a preference for preserving whole words. Only cut up
+ * whole words if the last remaining words are still too long. For example:
+ * "javascript-project-backend" --> "javascript…backend"
+ * "my-long-sentry-project-name" --> "my-long-sentry…name"
+ * "javascriptproject-backend" --> "javascriptproje…ckend"
+ */
+export function trimSlug(slug: string, maxLength: number = 20) {
+  // Return the original slug if it's already shorter than maxLength
+  if (slug.length <= maxLength) {
+    return slug;
+  }
+
+  /**
+   * Array of words inside the slug.
+   * E.g. "my-project-name" becomes ["my", "project", "name"]
+   */
+  const words: string[] = slug.split('-');
+  /**
+   * Returns the length (total number of letters plus hyphens in between
+   * words) of the current words array.
+   */
+  function getLength(arr: string[]): number {
+    return arr.reduce((acc, cur) => acc + cur.length + 1, 0) - 1;
+  }
+
+  // Progressively remove words in the middle until we're below maxLength,
+  // or when only two words are left
+  while (getLength(words) > maxLength && words.length > 2) {
+    words.splice(-2, 1);
+  }
+
+  // If the remaining words array satisfies the maxLength requirement,
+  // return the trimmed result.
+  if (getLength(words) <= maxLength) {
+    return `${words.slice(0, -1).join('-')}\u2026${words[words.length - 1]}`;
+  }
+
+  // If the remaining 2 words are still too long, trim those words starting
+  // from the middle.
+  const debt = getLength(words) - maxLength;
+  const toTrimFromLeftWord = Math.ceil(debt / 2);
+  const leftWordLength = Math.max(words[0].length - toTrimFromLeftWord, 3);
+  const leftWord = words[0].slice(0, leftWordLength);
+  const rightWordLength = maxLength - leftWord.length;
+  const rightWord = words[1].slice(-rightWordLength);
+
+  return `${leftWord}\u2026${rightWord}`;
+}

--- a/static/less/shared-components.less
+++ b/static/less/shared-components.less
@@ -1112,6 +1112,8 @@ header + .alert {
     }
 
     > a {
+      display: flex;
+      align-items: center;
       padding: 0 0 10px;
       margin: 0;
       border: 0;

--- a/tests/js/spec/utils/trimSlug.spec.tsx
+++ b/tests/js/spec/utils/trimSlug.spec.tsx
@@ -1,0 +1,18 @@
+import {trimSlug} from 'sentry/utils/trimSlug';
+
+describe('trimSlug', function () {
+  it('returns slug if it is already short enough', function () {
+    expect(trimSlug('javascript', 20)).toBe('javascript');
+  });
+
+  it('trims slug from the middle, preserves whole words', function () {
+    expect(trimSlug('symbol-collector-console', 20)).toBe('symbol…console');
+    expect(trimSlug('symbol-collector-mobile', 20)).toBe('symbol…mobile');
+    expect(trimSlug('visual-snapshot-cloud-run', 20)).toBe('visual-snapshot…run');
+  });
+
+  it('trims slug from the middle, cuts whole words', function () {
+    expect(trimSlug('sourcemapsio-javascript', 20)).toBe('sourcemaps…javascript');
+    expect(trimSlug('armcknight-ios-ephemeraldemo', 20)).toBe('armcknig…phemeraldemo');
+  });
+});


### PR DESCRIPTION
* Limit the number of shown projects to 2, and show a counter badge when user selects more than 2 projects.
    <img width="456" alt="Screen Shot 2022-03-28 at 10 33 26 AM" src="https://user-images.githubusercontent.com/44172267/160454730-e1ce9a13-bc43-4e8e-8bfa-3930c513883b.png">
    <img width="255" alt="Screen Shot 2022-03-28 at 10 33 42 AM" src="https://user-images.githubusercontent.com/44172267/160454769-0ead4a90-c1b3-42e2-8e37-61b0b58d56b4.png">
* Use a custom trimming function to trim long project names from the middle. This is useful because a lot of projects names contain important information at the end, e.g. `symbol-collector-mobile` and `symbol-collector-server`. 
    <img width="254" alt="Screen Shot 2022-03-28 at 10 39 41 AM" src="https://user-images.githubusercontent.com/44172267/160455630-cd0e4a8b-eff4-4244-990e-2111be9d6fb7.png">
    <img width="255" alt="Screen Shot 2022-03-28 at 10 34 55 AM" src="https://user-images.githubusercontent.com/44172267/160454950-3402384a-2dbb-49ba-badf-d8171d127394.png">