### PR TITLE
fix: pin click in pre-commit requirements txt

### DIFF
--- a/requirements-pre-commit.txt
+++ b/requirements-pre-commit.txt
@@ -4,3 +4,4 @@ sentry-flake8==2.0.0
 pyupgrade==2.29.0
 isort==5.9.3
 requirements-parser>=0.2.0
+click==8.0.4


### PR DESCRIPTION
backend CI builds currently failing due to https://github.com/psf/black/issues/2964

attempts to fix by pinning click to 8.0.4 on the pre-commit requirements