### PR TITLE
feat(new-widget-builder-experience): Add feature flag to access the modal

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -994,6 +994,8 @@ SENTRY_FEATURES = {
     "organizations:new-widget-builder-experience": False,
     # Enable the new widget builder experience "design" on Dashboards
     "organizations:new-widget-builder-experience-design": False,
+    # Enable access to the Add to Dashboard modal for metrics work
+    "organizations:new-widget-builder-experience-modal-access": False,
     # Automatically extract metrics during ingestion.
     #
     # XXX(ja): DO NOT ENABLE UNTIL THIS NOTICE IS GONE. Relay experiences

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -84,6 +84,9 @@ default_manager.add("organizations:metric-alert-threshold-period", OrganizationF
 default_manager.add("organizations:metrics", OrganizationFeature, True)
 default_manager.add("organizations:new-widget-builder-experience", OrganizationFeature, True)
 default_manager.add("organizations:new-widget-builder-experience-design", OrganizationFeature, True)
+default_manager.add(
+    "organizations:new-widget-builder-experience-modal-access", OrganizationFeature, True
+)
 default_manager.add("organizations:metrics-extraction", OrganizationFeature)
 default_manager.add("organizations:metrics-performance-ui", OrganizationFeature, True)
 default_manager.add("organizations:minute-resolution-sessions", OrganizationFeature)


### PR DESCRIPTION
We're going to start switching all users to using the widget builder. The internal team requires the modal still to continue working with metrics data for dashboards so this adds a feature flag to enable those individuals while the widget builder rolls out.