### PR TITLE
feat(dashboards): Widget Viewer chart zoom changes reflected in url

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -338,7 +338,7 @@ function WidgetViewerModal(props: Props) {
                     period: null,
                   },
                 });
-                router.replace({
+                router.push({
                   pathname: location.pathname,
                   query: {
                     ...location.query,

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -83,7 +83,7 @@ const EMPTY_QUERY_NAME = '(Empty Query Condition)';
 // causing unnecessary rerenders which can break persistent legends functionality.
 const MemoizedWidgetCardChartContainer = React.memo(
   WidgetCardChartContainer,
-  (props, prevProps) => {
+  (prevProps, props) => {
     return (
       props.selection === prevProps.selection &&
       props.location.query[WidgetViewerQueryField.QUERY] ===
@@ -139,12 +139,23 @@ function WidgetViewerModal(props: Props) {
   const start = decodeScalar(location.query[WidgetViewerQueryField.START]);
   const end = decodeScalar(location.query[WidgetViewerQueryField.END]);
   const isTableWidget = widget.displayType === DisplayType.TABLE;
-
-  const [modalSelection, setModalSelection] = React.useState<PageFilters>(
+  const locationPageFilter =
     start && end
-      ? {...selection, datetime: {start, end, period: null, utc: null}}
-      : selection
-  );
+      ? {
+          ...selection,
+          datetime: {start, end, period: null, utc: null},
+        }
+      : selection;
+  const [modalSelection, setModalSelection] =
+    React.useState<PageFilters>(locationPageFilter);
+
+  // Detect when a user clicks back and set the PageFilter state to match the location
+  // We need to use useEffect to prevent infinite looping rerenders due to the setModalSelection call
+  React.useEffect(() => {
+    if (location.action === 'POP') {
+      setModalSelection(locationPageFilter);
+    }
+  }, [location]);
 
   // Get legends toggle settings from location
   // We use the legend query params for just the initial state

--- a/static/app/components/modals/widgetViewerModal/utils.tsx
+++ b/static/app/components/modals/widgetViewerModal/utils.tsx
@@ -6,6 +6,8 @@ export enum WidgetViewerQueryField {
   PAGE = 'page',
   CURSOR = 'cursor',
   WIDTH = 'width',
+  START = 'viewerStart',
+  END = 'viewerEnd',
 }
 
 export function isWidgetViewerPath(pathname: string) {

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -201,7 +201,7 @@ describe('Modals -> WidgetViewerModal', function () {
           }),
         })
       );
-      expect(initialData.router.replace).toHaveBeenCalledWith(
+      expect(initialData.router.push).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {viewerEnd: '2022-03-01T07:33:20', viewerStart: '2022-03-01T02:00:00'},
         })

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -201,6 +201,11 @@ describe('Modals -> WidgetViewerModal', function () {
           }),
         })
       );
+      expect(initialData.router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {viewerEnd: '2022-03-01T07:33:20', viewerStart: '2022-03-01T02:00:00'},
+        })
+      );
     });
 
     it('renders multiquery label and selector', async function () {


### PR DESCRIPTION
Updates Widget Viewer chart zoom events to reflect `start` and `end` in the url as query parameters.
This allows chart zoom to propagate when url is copied and shared.
Had to store legends in state (still using url params as initial value) to continue avoiding rerenders to `MemoizedWidgetCardChartContainer` on zoom and legend url changes (these rerenders conflict with echarts handlers and can cause errors). 