### PR TITLE
fix(dashboards): Widget Viewer use widget index for default dashboard

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -191,7 +191,7 @@ function WidgetCardContextMenu({
           priority="link"
           size="zero"
           icon={<IconExpand size="xs" />}
-          onClick={() => openWidgetViewerPath(widget.id)}
+          onClick={() => openWidgetViewerPath(widget.id ?? index)}
         />
       )}
     </ContextWrapper>


### PR DESCRIPTION
Default Dashboard widgets dont have ids, so we should use the widget index as the identifier when opening the widget viewer.