### PR TITLE
fix(tests): Fix flaky tests for GitLab updates

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -49,12 +49,6 @@ class Webhook:
 
     def update_repo_data(self, repo, event):
         """
-        # TODO(kmclb): the name w namespace bit is currently causing false positives
-        # for people with three or more levels in their repo names. Need to research
-        # exactly how gitlab handles these cases (what's the name, what's the namespace,
-        # does the url reliably have the info we need?) and then fix this for those
-        # cases.
-
         Given a webhook payload, update stored repo data if needed.
 
         Assumes a 'project' key in event payload, with certain subkeys. Rework
@@ -63,17 +57,11 @@ class Webhook:
 
         project = event["project"]
 
-        name_from_event = "{} / {}".format(project["namespace"], project["name"])
         url_from_event = project["web_url"]
         path_from_event = project["path_with_namespace"]
 
-        if (
-            repo.name != name_from_event
-            or repo.url != url_from_event
-            or repo.config.get("path") != path_from_event
-        ):
+        if repo.url != url_from_event or repo.config.get("path") != path_from_event:
             repo.update(
-                name=name_from_event,
                 url=url_from_event,
                 config=dict(repo.config, path=path_from_event),
             )
@@ -91,9 +79,8 @@ class MergeEventWebhook(Webhook):
         if repo is None:
             return
 
-        # TODO(kmclb): turn this back on once tri-level repo problem has been solved
         # while we're here, make sure repo data is up to date
-        # self.update_repo_data(repo, event)
+        self.update_repo_data(repo, event)
 
         try:
             number = event["object_attributes"]["iid"]
@@ -152,9 +139,8 @@ class PushEventWebhook(Webhook):
         if repo is None:
             return
 
-        # TODO(kmclb): turn this back on once tri-level repo problem has been solved
         # while we're here, make sure repo data is up to date
-        # self.update_repo_data(repo, event)
+        self.update_repo_data(repo, event)
 
         authors = {}
 

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sentry.models import Commit, CommitAuthor, GroupLink, PullRequest
 from sentry.utils import json
 
@@ -274,33 +272,6 @@ class WebhookTest(GitLabTestCase):
         self.assert_pull_request(pull, author)
         self.assert_group_link(group, pull)
 
-    # TODO(kmclb): update the first test, add others back in once repo updating
-    # is fixed
-    @pytest.mark.xfail(reason="renaming breaks tri-level repos")
-    def test_update_repo_name(self):
-        repo_out_of_date_name = self.create_repo(
-            name="Uncool Group / Sentry",  # name out of date
-            url="http://example.com/cool-group/sentry",
-        )
-        repo_out_of_date_name.update(
-            config=dict(repo_out_of_date_name.config, path="cool-group/sentry")
-        )
-
-        response = self.client.post(
-            self.url,
-            data=PUSH_EVENT,
-            content_type="application/json",
-            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
-            HTTP_X_GITLAB_EVENT="Push Hook",
-        )
-
-        assert response.status_code == 204
-
-        # name has been updated
-        repo_out_of_date_name.refresh_from_db()
-        assert repo_out_of_date_name.name == "Cool Group / Sentry"
-
-    @pytest.mark.xfail(reason="renaming breaks tri-level repos")
     def test_update_repo_path(self):
         repo_out_of_date_path = self.create_repo(
             name="Cool Group / Sentry", url="http://example.com/cool-group/sentry"
@@ -325,7 +296,6 @@ class WebhookTest(GitLabTestCase):
         repo_out_of_date_path.refresh_from_db()
         assert repo_out_of_date_path.config["path"] == "cool-group/sentry"
 
-    @pytest.mark.xfail(reason="renaming breaks tri-level repos")
     def test_update_repo_url(self):
         repo_out_of_date_url = self.create_repo(
             name="Cool Group / Sentry",


### PR DESCRIPTION
See [API-2585](https://getsentry.atlassian.net/browse/API-2585)

Prev PR: https://github.com/getsentry/sentry/pull/33000

In a previous PR I'd suggested we make a change to the naming scheme of repositories coming from GitLab, but as it turns out, we enforce unique constraints on Repositories (with OrganizationId and Name), meaning it doesn't even make sense to be updating the name.

Instead, I've removed the name updates and now we just perform updates on the link and path.