### PR TITLE
ci(flaky-test): Improve dashboard create test

### DIFF
--- a/tests/js/spec/views/dashboardsV2/gridLayout/create.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/create.spec.tsx
@@ -103,12 +103,11 @@ describe('Dashboards > Create', function () {
 
       // Add a custom widget to the dashboard
       userEvent.click(await screen.findByText('Custom Widget'));
-      userEvent.type(await screen.findByTestId('widget-title-input'), widgetTitle);
-      screen.getByText('Save').click();
+      userEvent.paste(screen.getByTestId('widget-title-input'), widgetTitle);
+      userEvent.click(screen.getByText('Save'));
 
       // Committing dashboard should complete without throwing error
-      screen.getByText('Save and Finish').click();
-      await tick();
+      userEvent.click(screen.getByText('Save and Finish'));
     });
   });
 });


### PR DESCRIPTION
Fixed some incorrect usages of `.click()` to use `userEvent` and use `userEvent.paste` instead of type to try to improve performance.

This might not fully address #33019 but we can get this in and monitor for other occurrences.