### PR TITLE
feat(workflow): log when transferring projects to teams

### DIFF
--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -126,7 +126,9 @@ class AcceptProjectTransferEndpoint(Endpoint):
 
             if not is_team_org_owner:
                 return Response({"detail": "Invalid team"}, status=400)
+            from sentry.utils import metrics
 
+            metrics.incr("accept_project_transfer.post.to_team")
             project.transfer_to(team=team)
 
         if org_slug:


### PR DESCRIPTION
feat(workflow): log when transferring projects to teams

* simple change to log when a (suspect) dead code-path is actually being hit. will clean up after 1-2 weeks of no activity on datadog. 