### PR TITLE
fix(discover): Stabilize most of the flakey test_discover tests

### DIFF
--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1468,17 +1468,22 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
                 if expected_length > 1:
                     assert data[1]["failure_rate"] == 0.3, use_snql
 
+    def _create_percentile_events(self, project):
+        for i in range(6):
+            start = before_now(minutes=3)
+            end = start - timedelta(minutes=1 + i)
+            data = load_data(
+                "transaction",
+                timestamp=start,
+                start_timestamp=end,
+            )
+            data["transaction"] = "/p50"
+            self.store_event(data, project_id=project.id)
+
     def test_percentile(self):
         project = self.create_project()
 
-        for i in range(6):
-            data = load_data(
-                "transaction",
-                timestamp=before_now(minutes=3),
-                start_timestamp=before_now(minutes=4 + i),
-            )
-            data["transaction"] = "/percentile"
-            self.store_event(data, project_id=project.id)
+        self._create_percentile_events(project)
 
         queries = [
             ("", 1, True),
@@ -1509,20 +1514,13 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
                 assert len(data) == expected_length, use_snql
                 if expected_length > 0:
-                    assert round(data[0]["percentile_transaction_duration_0_7"]) == 270000, use_snql
-                    assert round(data[0]["percentile_transaction_duration_0_5"]) == 210000, use_snql
+                    assert data[0]["percentile_transaction_duration_0_7"] == 270000, use_snql
+                    assert data[0]["percentile_transaction_duration_0_5"] == 210000, use_snql
 
     def test_p50(self):
         project = self.create_project()
 
-        for i in range(6):
-            data = load_data(
-                "transaction",
-                timestamp=before_now(minutes=3),
-                start_timestamp=before_now(minutes=4 + i),
-            )
-            data["transaction"] = "/p50"
-            self.store_event(data, project_id=project.id)
+        self._create_percentile_events(project)
 
         queries = [
             ("", 1, True),
@@ -1552,19 +1550,12 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
                 assert len(data) == expected_length, use_snql
                 if expected_length > 0:
-                    assert round(data[0]["p50_transaction_duration"]) == 210000, use_snql
+                    assert data[0]["p50_transaction_duration"] == 210000, use_snql
 
     def test_p75(self):
         project = self.create_project()
 
-        for i in range(6):
-            data = load_data(
-                "transaction",
-                timestamp=before_now(minutes=3),
-                start_timestamp=before_now(minutes=4 + i),
-            )
-            data["transaction"] = "/p75"
-            self.store_event(data, project_id=project.id)
+        self._create_percentile_events(project)
 
         queries = [
             ("", 1, True),
@@ -1594,19 +1585,12 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
                 assert len(data) == expected_length, use_snql
                 if expected_length > 0:
-                    assert round(data[0]["p75_transaction_duration"]) == 285000, use_snql
+                    assert data[0]["p75_transaction_duration"] == 285000, use_snql
 
     def test_p95(self):
         project = self.create_project()
 
-        for i in range(6):
-            data = load_data(
-                "transaction",
-                timestamp=before_now(minutes=3),
-                start_timestamp=before_now(minutes=4 + i),
-            )
-            data["transaction"] = "/p95"
-            self.store_event(data, project_id=project.id)
+        self._create_percentile_events(project)
 
         queries = [
             ("", 1, True),
@@ -1636,19 +1620,12 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
                 assert len(data) == expected_length, use_snql
                 if expected_length > 0:
-                    assert round(data[0]["p95_transaction_duration"]) == 345000, use_snql
+                    assert data[0]["p95_transaction_duration"] == 345000, use_snql
 
     def test_p99(self):
         project = self.create_project()
 
-        for i in range(6):
-            data = load_data(
-                "transaction",
-                timestamp=before_now(minutes=3),
-                start_timestamp=before_now(minutes=4 + i),
-            )
-            data["transaction"] = "/p99"
-            self.store_event(data, project_id=project.id)
+        self._create_percentile_events(project)
 
         queries = [
             ("", 1, True),
@@ -1678,19 +1655,12 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
                 assert len(data) == expected_length, use_snql
                 if expected_length > 0:
-                    assert round(data[0]["p99_transaction_duration"]) == 357000, use_snql
+                    assert data[0]["p99_transaction_duration"] == 357000, use_snql
 
     def test_p100(self):
         project = self.create_project()
 
-        for i in range(6):
-            data = load_data(
-                "transaction",
-                timestamp=before_now(minutes=3),
-                start_timestamp=before_now(minutes=4 + i),
-            )
-            data["transaction"] = "/p100"
-            self.store_event(data, project_id=project.id)
+        self._create_percentile_events(project)
 
         queries = [
             ("", 1, True),
@@ -1720,7 +1690,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
                 assert len(data) == expected_length, use_snql
                 if expected_length > 0:
-                    assert round(data[0]["p100_transaction_duration"]) == 360000, use_snql
+                    assert data[0]["p100_transaction_duration"] == 360000, use_snql
 
     def test_p100_with_measurement(self):
         project = self.create_project()
@@ -1796,10 +1766,12 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
     def test_min_max(self):
         """Testing both min and max since they're so similar"""
         for idx in range(3):
+            start = before_now(minutes=3)
+            end = start - timedelta(minutes=1 + idx)
             data = load_data(
                 "transaction",
-                timestamp=before_now(minutes=3),
-                start_timestamp=before_now(minutes=4 + idx),
+                timestamp=start,
+                start_timestamp=end,
             )
             self.store_event(data, project_id=self.project.id)
 
@@ -1826,10 +1798,12 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
     def test_stats_functions(self):
         for idx in range(3):
+            start = before_now(minutes=3)
+            end = start - timedelta(minutes=1 + idx)
             data = load_data(
                 "transaction",
-                timestamp=before_now(minutes=3),
-                start_timestamp=before_now(minutes=4 + idx),
+                timestamp=start,
+                start_timestamp=end,
             )
             self.store_event(data, project_id=self.project.id)
 
@@ -1868,11 +1842,14 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
                 assert data[0][alias] == expected, column
 
     def test_count_at_least(self):
+        end = before_now(minutes=3)
+        start_one_minute = end - timedelta(minutes=1)
+        start_two_minute = end - timedelta(minutes=2)
         for idx in range(3):
             data = load_data(
                 "transaction",
-                timestamp=before_now(minutes=3),
-                start_timestamp=before_now(minutes=4 if idx < 1 else 5),
+                timestamp=end,
+                start_timestamp=start_one_minute if idx < 1 else start_two_minute,
             )
             self.store_event(data, project_id=self.project.id)
         for use_snql in [False, True]:


### PR DESCRIPTION
- This stabilized the tests by setting the end timestamp based on the
  start so that there isn't potentially some drift in the durations
- Fixes SENTRY-TESTS-327
- Fixes SENTRY-TESTS-329
- Fixes SENTRY-TESTS-32A
- Fixes SENTRY-TESTS-32B
- Fixes SENTRY-TESTS-32C
- Fixes SENTRY-TESTS-32D
- Fixes SENTRY-TESTS-32F
- Fixes SENTRY-TESTS-32H