### PR TITLE
ci(tsconfig): Remove tests from tsc build path

### DIFF
--- a/config/tsconfig.build.json
+++ b/config/tsconfig.build.json
@@ -51,7 +51,7 @@
     },
     "plugins": [{"name": "typescript-styled-plugin"}]
   },
-  "include": ["../static", "../tests/js", "../tests/fixtures/js-stubs"],
+  "include": ["../static", "../tests/fixtures/js-stubs"],
   "exclude": ["../node_modules"],
   "ts-node": {
     "transpileOnly": true


### PR DESCRIPTION
We don't need to compile test files when building for production.
This avoids build errors when dev dependencies are used in typescript
test files, e.g. react-select-event

⚠️ This might not trigger the github-self-hosted-pr-check job, but I made the change here: https://github.com/getsentry/sentry/pull/32990/commits/028e6dff62f4361206eb812a9dd91250b033503a and the self-hosted check passed.