### PR TITLE
fix(metrics): Add 'ops.' to breakdown metric names

### DIFF
--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -469,7 +469,9 @@ def get_transaction_metrics_settings(
                     assert breakdown_config["type"] == "spanOperations"
 
                     for op_name in breakdown_config["matches"]:
-                        metrics.append(f"sentry.transactions.breakdowns.{breakdown_name}.{op_name}")
+                        metrics.append(
+                            f"sentry.transactions.breakdowns.{breakdown_name}.ops.{op_name}"
+                        )
             except Exception:
                 capture_exception()
 

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/with_metrics.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2022-02-28T13:20:49.143037Z'
+created: '2022-03-29T08:56:52.712372Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -34,10 +34,10 @@ transactionMetrics:
   - sentry.transactions.measurements.stall_total_time
   - sentry.transactions.measurements.ttfb
   - sentry.transactions.measurements.ttfb.requesttime
-  - sentry.transactions.breakdowns.span_ops.http
-  - sentry.transactions.breakdowns.span_ops.db
-  - sentry.transactions.breakdowns.span_ops.browser
-  - sentry.transactions.breakdowns.span_ops.resource
+  - sentry.transactions.breakdowns.span_ops.ops.http
+  - sentry.transactions.breakdowns.span_ops.ops.db
+  - sentry.transactions.breakdowns.span_ops.ops.browser
+  - sentry.transactions.breakdowns.span_ops.ops.resource
   satisfactionThresholds:
     projectThreshold:
       metric: duration


### PR DESCRIPTION
Metrics extracted from spans actually contain an additional prefix to distinguish between e.g. `ops.browser` and `total.time`. This prefix was missing from the allow-list generated in relay config.

https://github.com/getsentry/relay/blob/4b7bfc0c38c0e78056054e8b5d4b66c78c4798f5/relay-server/src/metrics_extraction/transactions.rs#L440