### PR TITLE
feat(metrics): Hide `session.status` tag [INGEST-930 INGEST-1010]

### DIFF
--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -28,6 +28,7 @@ __all__ = (
     "NotSupportedOverCompositeEntityException",
     "TimeRange",
     "MetricEntity",
+    "UNALLOWED_TAGS",
 )
 
 
@@ -142,6 +143,7 @@ DEFAULT_AGGREGATES = {
     "percentage": None,
 }
 UNIT_TO_TYPE = {"sessions": "count", "percentage": "percentage", "users": "count"}
+UNALLOWED_TAGS = {"session.status"}
 
 
 def combine_dictionary_of_list_values(main_dict, other_dict):

--- a/tests/sentry/api/endpoints/test_organization_metric_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_details.py
@@ -123,7 +123,7 @@ class OrganizationMetricDetailsIntegrationTest(OrganizationMetricMetaIntegration
             "type": "numeric",
             "operations": [],
             "unit": "percentage",
-            "tags": [{"key": "environment"}, {"key": "release"}, {"key": "session.status"}],
+            "tags": [{"key": "environment"}, {"key": "release"}],
         }
 
     @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS_2)

--- a/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
@@ -63,6 +63,22 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
         )
         assert response.data == []
 
+    def test_tag_values_for_session_status_tag(self):
+        self.store_session(
+            self.build_session(
+                project_id=self.project.id,
+                started=(time.time() // 60) * 60,
+                status="ok",
+                release="foobar",
+                errors=2,
+            )
+        )
+        response = self.get_response(
+            self.organization.slug,
+            "session.status",
+        )
+        assert response.data["detail"] == "Tag name session.status is an unallowed tag"
+
     def test_tag_values_for_derived_metrics(self):
         self.store_session(
             self.build_session(

--- a/tests/sentry/api/endpoints/test_organization_metric_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tags.py
@@ -37,6 +37,27 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
         )
         assert response.data == []
 
+    def test_session_metric_tags(self):
+        self.store_session(
+            self.build_session(
+                project_id=self.project.id,
+                started=(time.time() // 60) * 60,
+                status="ok",
+                release="foobar@2.0",
+            )
+        )
+        response = self.get_success_response(
+            self.organization.slug,
+        )
+        assert response.data == [
+            {"key": "environment"},
+            {"key": "release"},
+            {"key": "tag1"},
+            {"key": "tag2"},
+            {"key": "tag3"},
+            {"key": "tag4"},
+        ]
+
     def test_metric_tags_metric_does_not_exist_in_indexer(self):
         assert (
             self.get_response(
@@ -57,15 +78,14 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
         )
 
     def test_derived_metric_tags(self):
-        for minute in range(4):
-            self.store_session(
-                self.build_session(
-                    project_id=self.project.id,
-                    started=(time.time() // 60 - minute) * 60,
-                    status="ok",
-                    release="foobar@2.0",
-                )
+        self.store_session(
+            self.build_session(
+                project_id=self.project.id,
+                started=(time.time() // 60) * 60,
+                status="ok",
+                release="foobar@2.0",
             )
+        )
         response = self.get_success_response(
             self.organization.slug,
             metric=["session.crash_free_rate"],
@@ -73,7 +93,6 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
         assert response.data == [
             {"key": "environment"},
             {"key": "release"},
-            {"key": "session.status"},
         ]
 
         response = self.get_success_response(
@@ -83,7 +102,6 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
         assert response.data == [
             {"key": "environment"},
             {"key": "release"},
-            {"key": "session.status"},
         ]
 
     def test_composite_derived_metrics(self):

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -17,7 +17,6 @@ from snuba_sdk import (
     Limit,
     Offset,
     Op,
-    Or,
     OrderBy,
     Query,
 )
@@ -86,21 +85,12 @@ def get_entity_of_metric_mocked(_, metric_name):
             ],
         ),
         (
-            "release:myapp@2.0.0 and environment:production or session.status:healthy",
+            "release:myapp@2.0.0 and environment:production",
             [
-                Or(
+                And(
                     [
-                        And(
-                            [
-                                Condition(Column(name="tags[6]"), Op.IN, rhs=[16]),
-                                Condition(Column(name="tags[2]"), Op.EQ, rhs=5),
-                            ]
-                        ),
-                        Condition(
-                            Column(name="tags[8]"),
-                            Op.EQ,
-                            rhs=4,
-                        ),
+                        Condition(Column(name="tags[6]"), Op.IN, rhs=[16]),
+                        Condition(Column(name="tags[2]"), Op.EQ, rhs=5),
                     ]
                 ),
             ],
@@ -115,6 +105,19 @@ def test_parse_query(monkeypatch, query_string, expected):
     monkeypatch.setattr("sentry.sentry_metrics.indexer.resolve", local_indexer.resolve)
     parsed = resolve_tags(parse_query(query_string))
     assert parsed == expected
+
+
+@pytest.mark.parametrize(
+    "query_string",
+    [
+        "release:myapp@2.0.0 or session.status:init",
+        "release:myapp@2.0.0 and environment:production or session.status:healthy",
+        "session.status:crashed",
+    ],
+)
+def test_parse_query_invalid(query_string):
+    with pytest.raises(InvalidParams):
+        parse_query(query_string)
 
 
 @freeze_time("2018-12-11 03:21:00")
@@ -192,7 +195,7 @@ def test_build_snuba_query(mock_now, mock_now2, monkeypatch):
             "query": [
                 "release:staging"
             ],  # weird release but we need a string exising in mock indexer
-            "groupBy": ["session.status", "environment"],
+            "groupBy": ["environment"],
             "field": [
                 "sum(sentry.sessions.session)",
                 "count_unique(sentry.sessions.user)",
@@ -220,7 +223,7 @@ def test_build_snuba_query(mock_now, mock_now2, monkeypatch):
                     alias=f"{alias}({metric_name})",
                 )
             ],
-            groupby=[Column("tags[8]"), Column("tags[2]")] + extra_groupby,
+            groupby=[Column("tags[2]")] + extra_groupby,
             where=[
                 Condition(Column("org_id"), Op.EQ, 1),
                 Condition(Column("project_id"), Op.IN, [1]),
@@ -397,7 +400,7 @@ def test_build_snuba_query_orderby(mock_now, mock_now2, monkeypatch):
             "query": [
                 "release:staging"
             ],  # weird release but we need a string exising in mock indexer
-            "groupBy": ["session.status", "environment"],
+            "groupBy": ["environment"],
             "field": [
                 "sum(sentry.sessions.session)",
             ],
@@ -425,7 +428,6 @@ def test_build_snuba_query_orderby(mock_now, mock_now2, monkeypatch):
         match=Entity("metrics_counters"),
         select=[select],
         groupby=[
-            Column("tags[8]"),
             Column("tags[2]"),
         ],
         where=[
@@ -446,7 +448,6 @@ def test_build_snuba_query_orderby(mock_now, mock_now2, monkeypatch):
         match=Entity("metrics_counters"),
         select=[select],
         groupby=[
-            Column("tags[8]"),
             Column("tags[2]"),
             Column("bucketed_time"),
         ],


### PR DESCRIPTION
Hides the `session.status` flag from all metrics
endpoints. For data endpoint, this means it is no
longer possible to filter by in query string nor
to use as a groupBy field. For metric tags, it
means it doesn't show in list of available tags.
For metric tag details, it means it is not possible
to get that values for that tag. For metric details,
`session.status` won't be listed as available tags