### PR TITLE
fix(new-widget-builder-experience): Add back feedback button

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/header.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/header.tsx
@@ -55,6 +55,15 @@ export function Header({
       <Layout.HeaderActions>
         <ButtonBar gap={1}>
           <Button
+            title={t(
+              'How do you like the new widget builder? Submit feedback on GitHub.'
+            )}
+            href="https://github.com/getsentry/sentry/issues/new/choose"
+            target="_blank"
+          >
+            {t('Give Feedback')}
+          </Button>
+          <Button
             external
             href="https://docs.sentry.io/product/dashboards/custom-dashboards/#widget-builder"
           >

--- a/static/app/views/dashboardsV2/widgetBuilder/header.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/header.tsx
@@ -55,11 +55,11 @@ export function Header({
       <Layout.HeaderActions>
         <ButtonBar gap={1}>
           <Button
+            external
             title={t(
               'How do you like the new widget builder? Submit feedback on GitHub.'
             )}
             href="https://github.com/getsentry/sentry/issues/new/choose"
-            target="_blank"
           >
             {t('Give Feedback')}
           </Button>


### PR DESCRIPTION
The button now points to GitHub as a more visible space to collect
feedback