### PR TITLE
fix(discover): Don't treat tags that look like functions as numeric

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1038,6 +1038,7 @@ default_config = SearchConfig(
     duration_keys={"transaction.duration"},
     percentage_keys={"percentage"},
     text_operator_keys={SEMVER_ALIAS, SEMVER_BUILD_ALIAS},
+    # do not put aggregate functions in this list
     numeric_keys={
         "project_id",
         "project.id",
@@ -1046,15 +1047,6 @@ default_config = SearchConfig(
         "stack.lineno",
         "stack.stack_level",
         "transaction.duration",
-        "apdex",
-        "p75",
-        "p95",
-        "p99",
-        "failure_rate",
-        "count_miserable",
-        "user_misery",
-        "count_miserable_new",
-        "user_miser_new",
     },
     date_keys={
         "start",

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -766,6 +766,7 @@ const defaultConfig: SearchConfig = {
   ]),
   durationKeys: new Set(['transaction.duration']),
   percentageKeys: new Set(['percentage']),
+  // do not put functions in this Set
   numericKeys: new Set([
     'project_id',
     'project.id',
@@ -774,15 +775,6 @@ const defaultConfig: SearchConfig = {
     'stack.lineno',
     'stack.stack_level',
     'transaction.duration',
-    'apdex',
-    'p75',
-    'p95',
-    'p99',
-    'failure_rate',
-    'count_miserable',
-    'user_misery',
-    'count_miserable_new',
-    'user_miser_new',
   ]),
   dateKeys: new Set([
     'start',

--- a/tests/fixtures/search-syntax/custom_tag.json
+++ b/tests/fixtures/search-syntax/custom_tag.json
@@ -22,5 +22,35 @@
       },
       {"type": "spaces", "value": ""}
     ]
+  },
+  {
+    "query": "p95:>5s",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "text",
+        "negated": false,
+        "key": {"type": "keySimple", "value": "p95", "quoted": false},
+        "operator": "",
+        "value": {"type": "valueText", "value": ">5s", "quoted": false}
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "p95:>5k",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "text",
+        "negated": false,
+        "key": {"type": "keySimple", "value": "p95", "quoted": false},
+        "operator": "",
+        "value": {"type": "valueText", "value": ">5k", "quoted": false}
+      },
+      {"type": "spaces", "value": ""}
+    ]
   }
 ]

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -4945,6 +4945,22 @@ class OrganizationEventsV2EndpointTestWithSnql(OrganizationEventsV2EndpointTest)
         response = self.do_request(query)
         assert response.status_code == 400, response.content
 
+    def test_tag_that_looks_like_aggregate(self):
+        data = load_data("transaction", timestamp=before_now(minutes=1))
+        data["tags"] = {"p95": "<5k"}
+        self.store_event(data, project_id=self.project.id)
+
+        query = {
+            "field": ["p95"],
+            "query": "p95:<5k",
+            "project": [self.project.id],
+        }
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["p95"] == "<5k"
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPerformanceTestCase):
     # Poor intentionally omitted for test_measurement_rating_that_does_not_exist


### PR DESCRIPTION
- This fixes a bug where a filter like `p95:>5k` would be treated as a
  numeric filter, when p95 here should be a tag instead since its
  missing the `()`
- Fixes SENTRY-T00