### PR TITLE
fix(projectalertscreate): init and teardown store in jest

### DIFF
--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -30,9 +30,9 @@ jest.mock('sentry/utils/analytics', () => ({
 jest.mock('sentry/utils/analytics/trackAdvancedAnalyticsEvent');
 
 describe('ProjectAlertsCreate', function () {
-  TeamStore.loadInitialData([], false, null);
-
   beforeEach(function () {
+    TeamStore.init();
+    TeamStore.loadInitialData([], false, null);
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/rules/configuration/',
       body: TestStubs.ProjectAlertRuleConfiguration(),
@@ -54,6 +54,7 @@ describe('ProjectAlertsCreate', function () {
   afterEach(function () {
     MockApiClient.clearMockResponses();
     jest.clearAllMocks();
+    TeamStore.teardown();
   });
 
   const createWrapper = (props = {}, location = {}) => {


### PR DESCRIPTION
Make sure store is isolated, init and teardown before and after each test