### PR TITLE
feat(onboarding): makes new version of onboarding welcome page experiment

### DIFF
--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -14,7 +14,7 @@ export const unassignedValue = -1;
  */
 export const experimentList = [
   {
-    key: 'TargetedOnboardingWelcomePageExperiment',
+    key: 'TargetedOnboardingWelcomePageExperimentV2',
     type: ExperimentType.Organization,
     parameter: 'exposed',
     assignments: [0, 1],

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -196,7 +196,11 @@ export type InterfaceChromeHooks = {
 export type OnboardingHooks = {
   'onboarding-wizard:skip-help': GenericOrganizationComponentHook;
   'onboarding:extra-chrome': GenericComponentHook;
-  'onboarding:targeted-onboarding-header': GenericComponentHook;
+  'onboarding:targeted-onboarding-header': ({
+    source,
+  }: {
+    source: string;
+  }) => React.ReactNode;
 };
 
 /**

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -196,11 +196,7 @@ export type InterfaceChromeHooks = {
 export type OnboardingHooks = {
   'onboarding-wizard:skip-help': GenericOrganizationComponentHook;
   'onboarding:extra-chrome': GenericComponentHook;
-  'onboarding:targeted-onboarding-header': ({
-    source,
-  }: {
-    source: string;
-  }) => React.ReactNode;
+  'onboarding:targeted-onboarding-header': (opts: {source: string}) => React.ReactNode;
 };
 
 /**

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -193,7 +193,10 @@ class Onboarding extends React.Component<Props, State> {
           <LogoSvg />
           <HeaderRight>
             {this.renderProgressBar()}
-            <Hook name="onboarding:extra-chrome" />
+            <Hook
+              name="onboarding:targeted-onboarding-header"
+              source="simple-onboarding"
+            />
           </HeaderRight>
         </Header>
         <this.Contents />

--- a/static/app/views/onboarding/onboardingController.tsx
+++ b/static/app/views/onboarding/onboardingController.tsx
@@ -15,7 +15,7 @@ type Props = Omit<ComponentPropsWithoutRef<typeof Onboarding>, 'projects'> & {
 function OnboardingController({experimentAssignment, ...rest}: Props) {
   useEffect(() => {
     logExperiment({
-      key: 'TargetedOnboardingWelcomePageExperiment',
+      key: 'TargetedOnboardingWelcomePageExperimentV2',
       organization: rest.organization,
     });
   }, []);
@@ -30,7 +30,7 @@ function OnboardingController({experimentAssignment, ...rest}: Props) {
 
 export default withOrganization(
   withExperiment(OnboardingController, {
-    experiment: 'TargetedOnboardingWelcomePageExperiment',
+    experiment: 'TargetedOnboardingWelcomePageExperimentV2',
     injectLogExperiment: true,
   })
 );

--- a/static/app/views/onboarding/targetedOnboarding/onboarding.tsx
+++ b/static/app/views/onboarding/targetedOnboarding/onboarding.tsx
@@ -121,7 +121,7 @@ function Onboarding(props: Props) {
       <SentryDocumentTitle title={stepObj.title} />
       <Header>
         <LogoSvg />
-        <Hook name="onboarding:targeted-onboarding-header" />
+        <Hook name="onboarding:targeted-onboarding-header" source="targeted-onboarding" />
       </Header>
       <Container hasFooter={!!stepObj.hasFooter}>
         <Back

--- a/static/app/views/onboarding/targetedOnboarding/welcome.tsx
+++ b/static/app/views/onboarding/targetedOnboarding/welcome.tsx
@@ -3,12 +3,10 @@ import styled from '@emotion/styled';
 import {motion, MotionProps} from 'framer-motion';
 
 import OnboardingInstall from 'sentry-images/spot/onboarding-install.svg';
-import OnboardingPreview from 'sentry-images/spot/onboarding-preview.svg';
 import OnboardingSetup from 'sentry-images/spot/onboarding-setup.svg';
 
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';
 import Button from 'sentry/components/button';
-import DemoSandboxButton from 'sentry/components/demoSandboxButton';
 import Link from 'sentry/components/links/link';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -123,38 +121,6 @@ function TargetedOnboardingWelcome({organization, ...props}: StepProps) {
               }
             />
           </ActionItem>
-          {!organization.features.includes('sandbox-kill-switch') && (
-            <ActionItem>
-              <InnerAction
-                title={t('Preview before you (git) commit')}
-                subText={t(
-                  'Check out sample issue reports, transactions, and tour all of Sentry '
-                )}
-                src={OnboardingPreview}
-                cta={
-                  <SandboxBtnWithFill
-                    scenario="oneIssue"
-                    priority="primary"
-                    clientData={{
-                      cta: {
-                        id: 'onboarding',
-                        shortTitle: t('Continue'),
-                        title: t('Continue Onboarding'),
-                        url: new URL(
-                          `/onboarding/${organization.slug}/welcome/`,
-                          window.location.origin
-                        ).toString(),
-                      },
-                      skipEmail: true,
-                    }}
-                    {...{source}}
-                  >
-                    {t('Explore')}
-                  </SandboxBtnWithFill>
-                }
-              />
-            </ActionItem>
-          )}
           <motion.p style={{margin: 0}}>
             {t("Gee, I've used Sentry before.")}
             <br />
@@ -260,8 +226,4 @@ const ButtonWithFill = styled(Button)`
   width: 100%;
   position: relative;
   z-index: 1;
-`;
-
-const SandboxBtnWithFill = styled(DemoSandboxButton)`
-  width: 100%;
 `;

--- a/tests/js/spec/views/onboarding/onboardingController.spec.jsx
+++ b/tests/js/spec/views/onboarding/onboardingController.spec.jsx
@@ -9,7 +9,7 @@ describe('OnboardingController', function () {
     const {organization, router, routerContext} = initializeOrg({
       organization: {
         experiments: {
-          TargetedOnboardingWelcomePageExperiment: 1,
+          TargetedOnboardingWelcomePageExperimentV2: 1,
         },
       },
       router: {
@@ -34,7 +34,7 @@ describe('OnboardingController', function () {
     const {organization, router, routerContext} = initializeOrg({
       organization: {
         experiments: {
-          TargetedOnboardingWelcomePageExperiment: 0,
+          TargetedOnboardingWelcomePageExperimentV2: 0,
         },
       },
       router: {
@@ -58,7 +58,7 @@ describe('OnboardingController', function () {
     const {organization, router, routerContext} = initializeOrg({
       organization: {
         experiments: {
-          TargetedOnboardingWelcomePageExperiment: 1,
+          TargetedOnboardingWelcomePageExperimentV2: 1,
         },
       },
       router: {

--- a/tests/js/spec/views/onboarding/targetedOnboarding/onboarding.spec.jsx
+++ b/tests/js/spec/views/onboarding/targetedOnboarding/onboarding.spec.jsx
@@ -24,7 +24,6 @@ describe('Onboarding', function () {
     );
     expect(screen.getByLabelText('Start')).toBeInTheDocument();
     expect(screen.getByLabelText('Invite Team')).toBeInTheDocument();
-    expect(screen.getByLabelText('Explore')).toBeInTheDocument();
   });
 });
 it('renders the setup docs step', function () {


### PR DESCRIPTION
This PR does the following:
- Makes a new onboarding welcome page experiment
- Removes the sandbox option from the test group which was low performing
- Uses the new header for the old onboarding flow with the upgrade button which was performing quite well with driving upgrades

Before:
![Screen Shot 2022-03-29 at 9 18 03 AM](https://user-images.githubusercontent.com/8533851/160658860-fbf1d710-a750-496c-8a84-f50473024319.png)

After:
![Screen Shot 2022-03-29 at 9 17 28 AM](https://user-images.githubusercontent.com/8533851/160658864-a892a79a-d22b-445e-b05e-590b7de00b20.png)

Before:
![Screen Shot 2022-03-29 at 9 18 17 AM](https://user-images.githubusercontent.com/8533851/160658858-6e84dd47-4b1d-49e1-8c35-6e1f19de2db1.png)

Afteer
![Screen Shot 2022-03-29 at 9 19 01 AM](https://user-images.githubusercontent.com/8533851/160658851-1df71fc3-8d8a-4b16-86f8-2684ad6cc275.png)


requires: https://github.com/getsentry/getsentry/pull/7251