### PR TITLE
fix(integrations): SentryApp error message

### DIFF
--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -57,7 +57,8 @@ class AlertRuleActionRequester(Mediator):
                     "error_message": str(e),
                 },
             )
-            text = e.response.text if e.response else None
+            # NOTE: bool(e.response) is always False because non-2xx responses are Falsey.
+            text = e.response.text if e.response is not None else None
             message = f"{self.sentry_app.name}: {text or DEFAULT_ERROR_MESSAGE}"
             # Bubble up error message from Sentry App to the UI for the user.
             return {"success": False, "message": message}

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -3,6 +3,8 @@ from typing import Mapping, Union
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
+from requests import RequestException
+
 from sentry.http import safe_urlread
 from sentry.mediators import Mediator, Param
 from sentry.mediators.external_requests.util import send_and_save_sentry_app_request
@@ -35,9 +37,8 @@ class AlertRuleActionRequester(Mediator):
         return urlunparse(urlparts)
 
     def _make_request(self) -> Mapping[str, Union[bool, str]]:
-
         try:
-            req = send_and_save_sentry_app_request(
+            request = send_and_save_sentry_app_request(
                 self._build_url(),
                 self.sentry_app,
                 self.install.organization_id,
@@ -46,7 +47,7 @@ class AlertRuleActionRequester(Mediator):
                 method=self.http_method,
                 data=self.body,
             )
-        except Exception as e:
+        except RequestException as e:
             logger.info(
                 "alert_rule_action.error",
                 extra={
@@ -56,11 +57,12 @@ class AlertRuleActionRequester(Mediator):
                     "error_message": str(e),
                 },
             )
-            message = f"{self.sentry_app.name}: {str(e.response.text) or DEFAULT_ERROR_MESSAGE}"
+            text = e.response.text if e.response else None
+            message = f"{self.sentry_app.name}: {text or DEFAULT_ERROR_MESSAGE}"
             # Bubble up error message from Sentry App to the UI for the user.
             return {"success": False, "message": message}
 
-        body_raw = safe_urlread(req)
+        body_raw = safe_urlread(request)
         body = body_raw.decode() if body_raw else None
         message = f"{self.sentry_app.name}: {body or DEFAULT_SUCCESS_MESSAGE}"
         return {"success": True, "message": message}

--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -80,7 +80,7 @@ def send_and_save_sentry_app_request(
         # Response code of 0 represents timeout
         buffer.add_request(response_code=0, org_id=org_id, event=event, url=url)
         # Re-raise the exception because some of these tasks might retry on the exception
-        raise e
+        raise
 
     track_response_code(resp.status_code, slug, event)
     buffer.add_request(

--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -1,9 +1,12 @@
 import logging
+from typing import Any
 
 from jsonschema import Draft7Validator
 from requests.exceptions import ConnectionError, Timeout
+from rest_framework.response import Response
 
 from sentry.http import safe_urlopen
+from sentry.models import SentryApp
 from sentry.models.integrations.sentry_app import track_response_code
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 
@@ -44,21 +47,25 @@ def validate(instance, schema_type):
     return True
 
 
-def send_and_save_sentry_app_request(url, sentry_app, org_id, event, **kwargs):
+def send_and_save_sentry_app_request(
+    url: str,
+    sentry_app: SentryApp,
+    org_id: int,
+    event: str,
+    **kwargs: Any,
+) -> Response:
     """
-    Send a webhook request, and save the request into the Redis buffer for the app dashboard request log
-    Returns the response of the request
+    Send a webhook request, and save the request into the Redis buffer for the
+    app dashboard request log. Returns the response of the request.
 
     kwargs ends up being the arguments passed into safe_urlopen
     """
 
     buffer = SentryAppWebhookRequestsBuffer(sentry_app)
-
     slug = sentry_app.slug_for_metrics
 
     try:
         resp = safe_urlopen(url=url, **kwargs)
-
     except (Timeout, ConnectionError) as e:
         error_type = e.__class__.__name__.lower()
         logger.info(
@@ -73,17 +80,16 @@ def send_and_save_sentry_app_request(url, sentry_app, org_id, event, **kwargs):
         # Response code of 0 represents timeout
         buffer.add_request(response_code=0, org_id=org_id, event=event, url=url)
         # Re-raise the exception because some of these tasks might retry on the exception
-        raise
+        raise e
 
-    else:
-        track_response_code(resp.status_code, slug, event)
-        buffer.add_request(
-            response_code=resp.status_code,
-            org_id=org_id,
-            event=event,
-            url=url,
-            error_id=resp.headers.get("Sentry-Hook-Error"),
-            project_id=resp.headers.get("Sentry-Hook-Project"),
-        )
-        resp.raise_for_status()
-        return resp
+    track_response_code(resp.status_code, slug, event)
+    buffer.add_request(
+        response_code=resp.status_code,
+        org_id=org_id,
+        event=event,
+        url=url,
+        error_id=resp.headers.get("Sentry-Hook-Error"),
+        project_id=resp.headers.get("Sentry-Hook-Project"),
+    )
+    resp.raise_for_status()
+    return resp

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -1,4 +1,8 @@
-from sentry.models import GroupAssignee, SentryAppInstallation
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from sentry.models import Group, GroupAssignee, Organization, SentryAppInstallation, User
 from sentry.signals import (
     comment_created,
     comment_deleted,
@@ -73,7 +77,13 @@ def send_comment_webhooks(organization, issue, user, event, data=None):
         )
 
 
-def send_workflow_webhooks(organization, issue, user, event, data=None):
+def send_workflow_webhooks(
+    organization: Organization,
+    issue: Group,
+    user: User,
+    event: str,
+    data: Mapping[str, Any] | None = None,
+) -> None:
     data = data or {}
 
     for install in installations_to_notify(organization, event):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -980,7 +980,6 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
         assert len(alert_rule_trigger_actions) == 0
 
     def test_sentry_app_action_missing_params(self):
-
         self.run_fail_validation_test(
             {
                 "type": AlertRuleTriggerAction.get_registered_type(


### PR DESCRIPTION
This PR sends a `RequestException` from `send_and_save_sentry_app_request()` to an `except` block that can correctly return its error message.

Fixes [SENTRY-TKV](https://sentry.io/organizations/sentry/issues/3135543722).