### PR TITLE
fix(serializer): Project `session_stats`

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -100,16 +100,17 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 serialize(list(queryset), request.user, ProjectSummarySerializer(collapse=collapse))
             )
         else:
+            collapse = set(collapse)
+            if not request.GET.get("transactionStats"):
+                collapse.add("transaction_stats")
+            if not request.GET.get("sessionStats"):
+                collapse.add("session_stats")
 
             def serialize_on_result(result):
-                transaction_stats = request.GET.get("transactionStats")
-                session_stats = request.GET.get("sessionStats")
                 environment_id = self._get_environment_id_from_request(request, organization.id)
                 serializer = ProjectSummarySerializer(
                     environment_id=environment_id,
                     stats_period=stats_period,
-                    transaction_stats=transaction_stats,
-                    session_stats=session_stats,
                     collapse=collapse,
                 )
                 return serialize(result, request.user, serializer)

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -100,17 +100,18 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 serialize(list(queryset), request.user, ProjectSummarySerializer(collapse=collapse))
             )
         else:
-            collapse = set(collapse)
-            if not request.GET.get("transactionStats"):
-                collapse.add("transaction_stats")
-            if not request.GET.get("sessionStats"):
-                collapse.add("session_stats")
+            expand = set()
+            if request.GET.get("transactionStats"):
+                expand.add("transaction_stats")
+            if request.GET.get("sessionStats"):
+                expand.add("session_stats")
 
             def serialize_on_result(result):
                 environment_id = self._get_environment_id_from_request(request, organization.id)
                 serializer = ProjectSummarySerializer(
                     environment_id=environment_id,
                     stats_period=stats_period,
+                    expand=expand,
                     collapse=collapse,
                 )
                 return serialize(result, request.user, serializer)

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -230,13 +230,13 @@ class ProjectSerializer(Serializer):  # type: ignore
             transaction_stats = None
             session_stats = None
             project_ids = [o.id for o in item_list]
-            if self.transaction_stats and self.stats_period:
+
+            if self.stats_period:
                 stats = self.get_stats(project_ids, "!event.type:transaction")
-                transaction_stats = self.get_stats(project_ids, "event.type:transaction")
-            elif self.stats_period:
-                stats = self.get_stats(project_ids, "!event.type:transaction")
-            if self.session_stats:
-                session_stats = self.get_session_stats(project_ids)
+                if not self._collapse("transaction_stats"):
+                    transaction_stats = self.get_stats(project_ids, "event.type:transaction")
+                if not self._collapse("session_stats"):
+                    session_stats = self.get_session_stats(project_ids)
 
         avatars = {a.project_id: a for a in ProjectAvatar.objects.filter(project__in=item_list)}
         project_ids = [i.id for i in item_list]

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -183,6 +183,7 @@ class ProjectSerializer(Serializer):  # type: ignore
         self,
         environment_id: str | None = None,
         stats_period: str | None = None,
+        expand: Iterable[str] | None = None,
         collapse: Iterable[str] | None = None,
     ) -> None:
         if stats_period is not None:
@@ -190,7 +191,14 @@ class ProjectSerializer(Serializer):  # type: ignore
 
         self.environment_id = environment_id
         self.stats_period = stats_period
+        self.expand = expand
         self.collapse = collapse
+
+    def _expand(self, key: str) -> bool:
+        if self.expand is None:
+            return False
+
+        return key in self.expand
 
     def _collapse(self, key: str) -> bool:
         if self.collapse is None:
@@ -233,9 +241,9 @@ class ProjectSerializer(Serializer):  # type: ignore
 
             if self.stats_period:
                 stats = self.get_stats(project_ids, "!event.type:transaction")
-                if not self._collapse("transaction_stats"):
+                if self._expand("transaction_stats"):
                     transaction_stats = self.get_stats(project_ids, "event.type:transaction")
-                if not self._collapse("session_stats"):
+                if self._expand("session_stats"):
                     session_stats = self.get_session_stats(project_ids)
 
         avatars = {a.project_id: a for a in ProjectAvatar.objects.filter(project__in=item_list)}

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -441,7 +441,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         )
         transaction = load_data("transaction", timestamp=two_min_ago)
         self.store_event(data=transaction, project_id=self.project.id)
-        serializer = ProjectSummarySerializer(stats_period="24h", collapse=["transaction_stats"])
+        serializer = ProjectSummarySerializer(stats_period="24h", expand=["transaction_stats"])
         results = serialize([self.project], self.user, serializer)
         assert "stats" in results[0]
         assert 24 == len(results[0]["stats"])
@@ -465,7 +465,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
                 "previousCrashFreeRate": 99.324543,
             }
         }
-        serializer = ProjectSummarySerializer(stats_period="24h", collapse=["session_stats"])
+        serializer = ProjectSummarySerializer(stats_period="24h", expand=["session_stats"])
         results = serialize([self.project], self.user, serializer)
 
         assert "sessionStats" in results[0]
@@ -494,7 +494,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
                 "previousCrashFreeRate": None,
             }
         }
-        serializer = ProjectSummarySerializer(stats_period="24h", collapse=["session_stats"])
+        serializer = ProjectSummarySerializer(stats_period="24h", expand=["session_stats"])
         results = serialize([self.project], self.user, serializer)
 
         assert "sessionStats" in results[0]

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -441,7 +441,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         )
         transaction = load_data("transaction", timestamp=two_min_ago)
         self.store_event(data=transaction, project_id=self.project.id)
-        serializer = ProjectSummarySerializer(stats_period="24h", transaction_stats=True)
+        serializer = ProjectSummarySerializer(stats_period="24h", collapse=["transaction_stats"])
         results = serialize([self.project], self.user, serializer)
         assert "stats" in results[0]
         assert 24 == len(results[0]["stats"])
@@ -465,7 +465,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
                 "previousCrashFreeRate": 99.324543,
             }
         }
-        serializer = ProjectSummarySerializer(stats_period="24h", session_stats=True)
+        serializer = ProjectSummarySerializer(stats_period="24h", collapse=["session_stats"])
         results = serialize([self.project], self.user, serializer)
 
         assert "sessionStats" in results[0]
@@ -494,7 +494,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
                 "previousCrashFreeRate": None,
             }
         }
-        serializer = ProjectSummarySerializer(stats_period="24h", session_stats=True)
+        serializer = ProjectSummarySerializer(stats_period="24h", collapse=["session_stats"])
         results = serialize([self.project], self.user, serializer)
 
         assert "sessionStats" in results[0]


### PR DESCRIPTION
There is currently a `KeyError` when a user is trying to include "session stats" without selecting a "stats period". This PR updates `get_attrs()` to nest `self.session_stats` under a check that `self.stats_period` is set.
Before:
```py
if self.transaction_stats and self.stats_period:
    stats = ...
    transaction_stats = ...
elif self.stats_period:
    stats = ...
if self.session_stats:
    session_stats = ...
```
After:
```py
if self.stats_period:
    stats = ...
    if self._expand("transaction_stats"):
        transaction_stats = ...
    if self._expand("session_stats"):
        session_stats = ...
```

Fixes [SENTRY-TA7](https://sentry.io/organizations/sentry/issues/2996422553).