### PR TITLE
fix(ui): link to correct category on integrations page 

### DIFF
--- a/static/app/components/group/externalIssuesList.tsx
+++ b/static/app/components/group/externalIssuesList.tsx
@@ -230,7 +230,7 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
           <AlertLink
             priority="muted"
             size="small"
-            to={`/settings/${this.props.organization.slug}/integrations/issue-tracking`}
+            to={`/settings/${this.props.organization.slug}/integrations/?category=issue%20tracking`}
           >
             {t('Track this issue in Jira, GitHub, etc.')}
           </AlertLink>


### PR DESCRIPTION
Fixing a link to the integrations page, filtered down to Issue Tracking category