### PR TITLE
fix(perf): Fix quotaExceededError on widgets

### DIFF
--- a/static/app/views/performance/landing/widgets/utils.tsx
+++ b/static/app/views/performance/landing/widgets/utils.tsx
@@ -1,3 +1,5 @@
+import localStorage from 'sentry/utils/localStorage';
+
 import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
 
 import {PerformanceWidgetSetting} from './widgetDefinitions';


### PR DESCRIPTION
### Summary
Saving widgets would cause this to fire, on occasion, since localStorage was using global vs. our custom one.

Refs JAVASCRIPT-26C9