### PR TITLE
fix(twilio): Stop sending configuration errors to Sentry

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -187,7 +187,6 @@ class NotificationPlugin(Plugin):
             elif hasattr(exc, "read") and callable(exc.read):
                 test_results = f"{exc}\n{exc.read()[:256]}"
             else:
-                logging.exception("Plugin(%s) raised an error during test, %s", self.slug, str(exc))
                 if str(exc).lower().startswith("error communicating with"):
                     test_results = str(exc)[:256]
                 else:

--- a/src/sentry/shared_integrations/constants.py
+++ b/src/sentry/shared_integrations/constants.py
@@ -1,7 +1,7 @@
 ERR_INTERNAL = (
-    "An internal error occurred with the integration and the Sentry team has" " been notified"
+    "An internal error occurred with the integration and the Sentry team has been notified"
 )
 
-ERR_UNAUTHORIZED = "Unauthorized: either your access token was invalid or you do not have" " access"
+ERR_UNAUTHORIZED = "Unauthorized: either your access token was invalid or you do not have access"
 
 ERR_UNSUPPORTED_RESPONSE_TYPE = "An unsupported response type was returned: {content_type}"


### PR DESCRIPTION
When a user tests their Twilio plugin configuration, we display any errors to the UI. We no longer need to see these errors in Sentry.

Fixes [SENTRY-SFJ](https://sentry.io/organizations/sentry/issues/2735861561), [SENTRY-SHP](https://sentry.io/organizations/sentry/issues/2743628578), [SENTRY-TH2](https://sentry.io/organizations/sentry/issues/3084023373).