### PR TITLE
fix(snapshot): Wait for loading class to be removed

### DIFF
--- a/tests/acceptance/page_objects/dashboard_detail.py
+++ b/tests/acceptance/page_objects/dashboard_detail.py
@@ -17,6 +17,7 @@ class DashboardDetailPage(BasePage):
         self.browser.wait_until_not('[data-test-id="events-request-loading"]')
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
+        self.browser.wait_until_not(".loading")
 
     def visit_default_overview(self):
         self.browser.get(f"/organizations/{self.organization.slug}/dashboard/default-overview/")


### PR DESCRIPTION
Dashboard snapshots are flaking with the loading indicator
still showing, attempting to fix.

https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/022f842c0b0c4a115dc77cf21fc6c2fdcbb4c629/index.html