### PR TITLE
chore(frontend): Delete onGoLegacyDiscover

### DIFF
--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -16,7 +16,6 @@ import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import Switch from 'sentry/components/switchButton';
 import {t} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
 import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization, SavedQuery, SelectValue} from 'sentry/types';
@@ -239,17 +238,6 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     this.setState({renderPrebuilt: !renderPrebuilt}, () => {
       setRenderPrebuilt(!renderPrebuilt);
       this.fetchData({reloading: true});
-    });
-  };
-
-  onGoLegacyDiscover = () => {
-    localStorage.setItem('discover:version', '1');
-    const user = ConfigStore.get('user');
-    trackAnalyticsEvent({
-      eventKey: 'discover_v2.opt_out',
-      eventName: 'Discoverv2: Go to discover',
-      organization_id: parseInt(this.props.organization.id, 10),
-      user_id: parseInt(user.id, 10),
     });
   };
 


### PR DESCRIPTION
`onGoLegacyDiscover` is no longer used as Discover v1 no longer exists within the product. So I've removed it altogether. 