### PR TITLE
fix(seen-info): Use dynamic color aliases

### DIFF
--- a/static/app/components/group/seenInfo.tsx
+++ b/static/app/components/group/seenInfo.tsx
@@ -75,7 +75,6 @@ class SeenInfo extends React.Component<Props> {
             )
           }
           position="top"
-          tipColor={theme.gray500}
         >
           <DateWrapper>
             {date ? (
@@ -151,7 +150,6 @@ const TooltipWrapper = styled('span')`
 `;
 
 const TimeSinceWrapper = styled('div')`
-  font-size: ${p => p.theme.fontSizeSmall};
   margin-bottom: ${space(0.5)};
   display: flex;
   justify-content: space-between;
@@ -163,14 +161,9 @@ const StyledTimeSince = styled(TimeSince)`
 
 const StyledHovercard = styled(Hovercard)`
   width: 250px;
-  font-weight: normal;
-  border: 1px solid ${p => p.theme.gray500};
-  background: ${p => p.theme.gray500};
   ${Header} {
     font-weight: normal;
-    color: ${p => p.theme.white};
-    background: ${p => p.theme.gray500};
-    border-bottom: 1px solid ${p => p.theme.gray400};
+    border-bottom: 1px solid ${p => p.theme.innerBorder};
   }
   ${Body} {
     padding: ${space(1.5)};

--- a/static/app/components/group/seenInfo.tsx
+++ b/static/app/components/group/seenInfo.tsx
@@ -12,7 +12,6 @@ import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
 import {Organization, Release} from 'sentry/types';
 import {defined, toTitleCase} from 'sentry/utils';
-import theme from 'sentry/utils/theme';
 
 type RelaxedDateType = React.ComponentProps<typeof TimeSince>['date'];
 


### PR DESCRIPTION
**Before:**
<img width="406" alt="Screen Shot 2022-03-29 at 1 01 00 PM" src="https://user-images.githubusercontent.com/44172267/160697019-370b7565-667c-4d98-a6da-a01eba21b408.png">
<img width="406" alt="Screen Shot 2022-03-29 at 1 01 13 PM" src="https://user-images.githubusercontent.com/44172267/160697054-432bf1cc-5d45-4853-a19c-dab23d09b940.png">


**After:**
<img width="406" alt="Screen Shot 2022-03-29 at 1 01 52 PM" src="https://user-images.githubusercontent.com/44172267/160697143-bb143f44-09f3-4e29-b784-cb0ed255abb6.png">
<img width="406" alt="Screen Shot 2022-03-29 at 1 02 00 PM" src="https://user-images.githubusercontent.com/44172267/160697168-9e81ceb5-edde-4f90-b29e-8aee134926dd.png">

