### PR TITLE
chore(platformicons): update to 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "papaparse": "^5.3.2",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.6",
-    "platformicons": "^4.3.0",
+    "platformicons": "4.4.0",
     "po-catalog-loader": "2.0.0",
     "prettier": "2.6.0",
     "prism-sentry": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12313,10 +12313,10 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-platformicons@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.3.0.tgz#ab579cd48cc6e3126fbd1f1a45779b9b0ff0e587"
-  integrity sha512-eH/mJRiOpDA03Ky65tTw9NNm0b5zWJZvCB5vMIrmtENAh565DC12PN+XmjX+7bpAIvWEmGS4YZD/0FVcfwkIyQ==
+platformicons@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.4.0.tgz#4188696c73fcc40afff212aa3ed0d0559cb25607"
+  integrity sha512-aC1akUKsIh9WJe7uRpfbuiMz/Xp4WzsxIx1z07OXahFOf2+QNlnNcN/D1Lpt2ymdJ8y86KCkjunl4WbPn3BArw==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Related to https://github.com/getsentry/platformicons/pull/55
