### PR TITLE
fix(ui): changed color of delete actions

### DIFF
--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -436,6 +436,7 @@ class Actions extends Component<Props, State> {
                       },
                       {
                         key: 'delete-issue',
+                        priority: 'danger',
                         label: t('Delete'),
                         hidden: !hasAccess,
                         onAction: () =>
@@ -461,6 +462,7 @@ class Actions extends Component<Props, State> {
                       },
                       {
                         key: 'delete-and-discard',
+                        priority: 'danger',
                         label: t('Delete and discard future events'),
                         hidden: !hasAccess,
                         onAction: () => this.openDiscardModal(),


### PR DESCRIPTION
Updated these delete actions in the dropdown to be red, like other delete actions within dropdowns

![CleanShot 2022-03-29 at 14 19 03](https://user-images.githubusercontent.com/1900676/160709067-5d15444d-ab49-4a77-b0c3-2532099e55d9.png)
