### PR TITLE
feat(ci): Use codecov "carryforward" feature

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,15 @@ coverage:
         target: 90%
         flags:
           - backend
+  ignore:
+  - src/.*?/migrations/.*
+  - src/bitfield/.*
+  - src/sentry/debug/.*
+  - src/sentry/lint/.*
+  - src/sentry/runner/.*
+  - src/social_auth/.*
+  - static/app/routes.tsx
+  - tests/
 
 flags:
   frontend:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,24 +1,27 @@
+# Setting coverage targets per flag
 coverage:
   status:
     project:
       default: false
     patch:
       default: false
-      python:
-        paths:
-        - "src/sentry/**/*.py"
-        target: 90%
-      javascript:
-        paths:
-        - "static/app"
+      frontend:
         target: 60%
-  ignore:
-  - src/.*?/migrations/.*
-  - src/bitfield/.*
-  - src/sentry/debug/.*
-  - src/sentry/lint/.*
-  - src/sentry/runner/.*
-  - src/social_auth/.*
-  - static/app/routes.tsx
-  - tests/
+        flags:
+        - frontend
+      backend:
+        target: 90%
+        flags:
+          - backend
+
+flags:
+  frontend:
+    paths:
+    - "static/app"
+    carryforward: true
+  backend:
+    paths:
+    - "src/sentry/**/*.py"
+    carryforward: true
+
 comment: false


### PR DESCRIPTION
This tells codecov to use a previous commits coverage values when calculating the coverage for current commit. This is necessary because we do not run the full test suite for every commit.

This should solve the problem where our coverage jumps back and forth because of the partial test runs.

See https://docs.codecov.com/docs/carryforward-flags