### PR TITLE
feat(replay): Show replayId column in the list view

### DIFF
--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -37,7 +37,7 @@ class Replays extends AsyncView<Props, State> {
       id: '',
       name: '',
       version: 2,
-      fields: ['eventID', 'timestamp'],
+      fields: ['eventID', 'timestamp', 'replayId'],
       orderby: '-timestamp',
       projects: [],
       range: statsPeriod,
@@ -78,14 +78,15 @@ class Replays extends AsyncView<Props, State> {
             <PanelBody>
               {replayList?.map(replay => (
                 <PanelItemCentered key={replay.id}>
-                  <StyledLink
+                  <Link
                     to={`/organizations/${organization.slug}/replays/${generateEventSlug({
                       project: replay['project.name'],
                       id: replay.id,
                     })}/`}
                   >
                     {replay.timestamp}
-                  </StyledLink>
+                  </Link>
+                  {replay.replayId}
                 </PanelItemCentered>
               ))}
             </PanelBody>
@@ -107,14 +108,9 @@ const HeaderTitle = styled(PageHeading)`
 `;
 
 const PanelItemCentered = styled(PanelItem)`
-  align-items: center;
-  padding: 0;
-  padding-left: ${space(2)};
-  padding-right: ${space(2)};
-`;
-
-const StyledLink = styled(Link)`
-  flex: 1;
+  display: grid;
+  grid-template-columns: auto max-content;
+  gap: ${space(2)};
   padding: ${space(2)};
 `;
 


### PR DESCRIPTION
Currently there are multiple `transaction:sentry-replay` with the same `replayId` tag. We want to group them up when we're looking at the details page, but we also should see which Replay's in the list will be grouped together.

<img width="888" alt="Screen Shot 2022-03-29 at 3 58 20 PM" src="https://user-images.githubusercontent.com/187460/160721703-e7add1d1-93aa-45bd-85fb-8f92a557b92a.png">

