### PR TITLE
feat(metric_alerts): Include `aggregation_value` in crash rate alert logs.

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -381,6 +381,7 @@ class SubscriptionProcessor:
                 },
             )
 
+        aggregation_value = self.get_aggregation_value(subscription_update)
         if self.subscription.snuba_query.dataset == QueryDatasets.SESSIONS.value:
             try:
                 # Temporarily logging results from session updates for comparison with data from metric
@@ -392,12 +393,12 @@ class SubscriptionProcessor:
                         "dataset": self.subscription.snuba_query.dataset,
                         "snuba_subscription_id": self.subscription.subscription_id,
                         "result": subscription_update,
+                        "aggregation_value": aggregation_value,
                     },
                 )
             except Exception:
                 logger.exception("Failed to log subscription results for session subscription")
 
-        aggregation_value = self.get_aggregation_value(subscription_update)
         if aggregation_value is None:
             metrics.incr("incidents.alert_rules.skipping_update_invalid_aggregation_value")
             return

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -110,8 +110,14 @@ def handle_subscription_metrics_logger(subscription_update, subscription):
     sentry.snuba.json_schemas.SUBSCRIPTION_PAYLOAD_VERSIONS
     :param subscription: The `QuerySubscription` that this update is for
     """
+    from sentry.incidents.subscription_processor import SubscriptionProcessor
+
     try:
         if subscription.snuba_query.dataset == QueryDatasets.METRICS.value:
+            aggregation_value = SubscriptionProcessor(subscription).get_aggregation_value(
+                subscription_update
+            )
+
             logger.info(
                 "handle_subscription_metrics_logger.message",
                 extra={
@@ -119,6 +125,7 @@ def handle_subscription_metrics_logger(subscription_update, subscription):
                     "dataset": subscription.snuba_query.dataset,
                     "snuba_subscription_id": subscription.subscription_id,
                     "result": subscription_update,
+                    "aggregation_value": aggregation_value,
                 },
             )
     except Exception:

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -232,6 +232,7 @@ class TestHandleSubscriptionMetricsLogger(TestCase):
                         "dataset": self.subscription.snuba_query.dataset,
                         "snuba_subscription_id": self.subscription.subscription_id,
                         "result": subscription_update,
+                        "aggregation_value": None,
                     },
                 )
             ]


### PR DESCRIPTION
Calculating this locally is a bit painful since we need access to the indexer to translate column
names. Just logging the actual value so that the comparison is easy to do.