### PR TITLE
chore(js): Avoid ReactDOM default export

### DIFF
--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import {findDOMNode, render} from 'react-dom';
 import * as ReactRouter from 'react-router';
 import * as Sentry from '@sentry/react';
 import moment from 'moment';
@@ -17,10 +17,7 @@ const globals = {
   Sentry,
   moment,
   Router: ReactRouter,
-  ReactDOM: {
-    findDOMNode: ReactDOM.findDOMNode,
-    render: ReactDOM.render,
-  },
+  ReactDOM: {findDOMNode, render},
 
   // django templates make use of these globals
   SentryApp: {},

--- a/static/app/bootstrap/renderDom.tsx
+++ b/static/app/bootstrap/renderDom.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import {render} from 'react-dom';
 
 export function renderDom(
   Component: React.ComponentType,
@@ -13,5 +13,5 @@ export function renderDom(
     return;
   }
 
-  ReactDOM.render(<Component {...props} />, rootEl);
+  render(<Component {...props} />, rootEl);
 }

--- a/static/app/bootstrap/renderPipelineView.tsx
+++ b/static/app/bootstrap/renderPipelineView.tsx
@@ -1,15 +1,15 @@
-import ReactDOM from 'react-dom';
+import {render} from 'react-dom';
 
 import {ROOT_ELEMENT} from 'sentry/constants';
 import {PipelineInitialData} from 'sentry/types';
 import PipelineView from 'sentry/views/integrationPipeline/pipelineView';
 
-function render(pipelineName: string, props: PipelineInitialData['props']) {
+function renderDom(pipelineName: string, props: PipelineInitialData['props']) {
   const rootEl = document.getElementById(ROOT_ELEMENT);
-  ReactDOM.render(<PipelineView pipelineName={pipelineName} {...props} />, rootEl);
+  render(<PipelineView pipelineName={pipelineName} {...props} />, rootEl);
 }
 
 export function renderPipelineView() {
   const {name, props} = window.__pipelineInitialData;
-  render(name, props);
+  renderDom(name, props);
 }

--- a/static/app/components/clipboard.tsx
+++ b/static/app/components/clipboard.tsx
@@ -1,5 +1,5 @@
 import {cloneElement, Component, isValidElement} from 'react';
-import ReactDOM from 'react-dom';
+import {findDOMNode} from 'react-dom';
 import copy from 'copy-text-to-clipboard';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -39,7 +39,7 @@ class Clipboard extends Component<Props> {
     this.element?.removeEventListener('click', this.handleClick);
   }
 
-  element?: ReturnType<typeof ReactDOM.findDOMNode>;
+  element?: ReturnType<typeof findDOMNode>;
 
   handleClick = () => {
     const {value, hideMessages, successMessage, errorMessage, onSuccess, onError} =
@@ -66,7 +66,7 @@ class Clipboard extends Component<Props> {
     }
 
     // eslint-disable-next-line react/no-find-dom-node
-    this.element = ReactDOM.findDOMNode(ref);
+    this.element = findDOMNode(ref);
     this.element?.addEventListener('click', this.handleClick);
   };
 

--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import {findDOMNode} from 'react-dom';
 import styled from '@emotion/styled';
 import color from 'color';
 
@@ -42,7 +42,7 @@ class ClippedBox extends React.PureComponent<Props, State> {
 
   componentDidMount() {
     // eslint-disable-next-line react/no-find-dom-node
-    const renderedHeight = (ReactDOM.findDOMNode(this) as HTMLElement).offsetHeight;
+    const renderedHeight = (findDOMNode(this) as HTMLElement).offsetHeight;
     this.calcHeight(renderedHeight);
   }
 
@@ -61,7 +61,7 @@ class ClippedBox extends React.PureComponent<Props, State> {
 
     if (!this.props.renderedHeight) {
       // eslint-disable-next-line react/no-find-dom-node
-      const renderedHeight = (ReactDOM.findDOMNode(this) as HTMLElement).offsetHeight;
+      const renderedHeight = (findDOMNode(this) as HTMLElement).offsetHeight;
 
       if (renderedHeight < this.props.clipHeight) {
         this.reveal();

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -1,5 +1,5 @@
 import {Component, Fragment} from 'react';
-import ReactDOM from 'react-dom';
+import {findDOMNode} from 'react-dom';
 import {components, StylesConfig} from 'react-select';
 import styled from '@emotion/styled';
 
@@ -167,7 +167,7 @@ class ContextPickerModal extends Component<Props> {
     }
 
     // eslint-disable-next-line react/no-find-dom-node
-    const el = ReactDOM.findDOMNode(ref) as HTMLElement;
+    const el = findDOMNode(ref) as HTMLElement;
 
     if (el !== null) {
       const input = el.querySelector('input');

--- a/static/app/components/forms/textCopyInput.tsx
+++ b/static/app/components/forms/textCopyInput.tsx
@@ -1,6 +1,6 @@
 import {CSSProperties} from 'react';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import {findDOMNode} from 'react-dom';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
@@ -79,7 +79,7 @@ class TextCopyInput extends React.Component<Props> {
 
     // We use findDOMNode here because `this.textRef` is not a dom node,
     // it's a ref to AutoSelectText
-    const node = ReactDOM.findDOMNode(this.textRef.current); // eslint-disable-line react/no-find-dom-node
+    const node = findDOMNode(this.textRef.current); // eslint-disable-line react/no-find-dom-node
     if (!node || !(node instanceof HTMLElement)) {
       return;
     }

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import {browserHistory} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -180,7 +180,7 @@ function GlobalModal({visible = false, options = {}, children, onClose}: Props) 
   const clickClose = (e: React.MouseEvent) =>
     containerRef.current === e.target && allowClickClose && closeModal();
 
-  return ReactDOM.createPortal(
+  return createPortal(
     <React.Fragment>
       <Backdrop
         style={backdrop && visible ? {opacity: 0.5, pointerEvents: 'auto'} : {}}

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import {Manager, Popper, PopperProps, Reference} from 'react-popper';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
@@ -155,7 +155,7 @@ function Hovercard(props: HovercardProps): React.ReactElement {
           </span>
         )}
       </Reference>
-      {ReactDOM.createPortal(
+      {createPortal(
         <Popper placement={props.position ?? 'top'} modifiers={popperModifiers}>
           {({ref, style, placement, arrowProps, scheduleUpdate}) => {
             scheduleUpdateRef.current = scheduleUpdate;

--- a/static/app/components/passwordStrength.tsx
+++ b/static/app/components/passwordStrength.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import ReactDOM from 'react-dom';
+import {render} from 'react-dom';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import throttle from 'lodash/throttle';
@@ -110,6 +110,6 @@ export const attachTo = ({input, element}) =>
   input.addEventListener(
     'input',
     throttle(e => {
-      ReactDOM.render(<PasswordStrength value={e.target.value} />, element);
+      render(<PasswordStrength value={e.target.value} />, element);
     })
   );

--- a/static/app/components/performance/teamKeyTransaction.tsx
+++ b/static/app/components/performance/teamKeyTransaction.tsx
@@ -1,5 +1,5 @@
 import {Component, Fragment} from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import {Manager, Popper, Reference} from 'react-popper';
 import styled from '@emotion/styled';
 import * as PopperJS from 'popper.js';
@@ -219,7 +219,7 @@ class TeamKeyTransaction extends Component<Props, State> {
       },
     };
 
-    return ReactDOM.createPortal(
+    return createPortal(
       <Popper placement="top" modifiers={modifiers}>
         {({ref: popperRef, style, placement}) => (
           <DropdownWrapper

--- a/static/app/components/sidebar/sidebarPanel.tsx
+++ b/static/app/components/sidebar/sidebarPanel.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useRef} from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -92,7 +92,7 @@ function SidebarPanel({
     };
   }, []);
 
-  return ReactDOM.createPortal(
+  return createPortal(
     <PanelContainer
       role="dialog"
       collapsed={collapsed}

--- a/static/app/components/themeAndStyleProvider.tsx
+++ b/static/app/components/themeAndStyleProvider.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useEffect} from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import {cache} from '@emotion/css'; // eslint-disable-line emotion/no-vanilla
 import {CacheProvider, ThemeProvider} from '@emotion/react'; // This is needed to set "speedy" = false (for percy)
 
@@ -28,7 +28,7 @@ function ThemeAndStyleProvider({children}: Props) {
     <ThemeProvider theme={theme}>
       <GlobalStyles isDark={config.theme === 'dark'} theme={theme} />
       <CacheProvider value={cache}>{children}</CacheProvider>
-      {ReactDOM.createPortal(
+      {createPortal(
         <Fragment>
           <meta name="color-scheme" content={config.theme} />
           <meta name="theme-color" content={theme.sidebar.background} />

--- a/static/app/plugins/sessionstack/contexts/sessionstack.tsx
+++ b/static/app/plugins/sessionstack/contexts/sessionstack.tsx
@@ -1,5 +1,5 @@
 import {Component} from 'react';
-import ReactDOM from 'react-dom';
+import {findDOMNode} from 'react-dom';
 
 const ASPECT_RATIO = 16 / 9;
 
@@ -22,7 +22,7 @@ class SessionStackContextType extends Component<Props, State> {
 
   componentDidMount() {
     // eslint-disable-next-line react/no-find-dom-node
-    const domNode = ReactDOM.findDOMNode(this) as HTMLElement;
+    const domNode = findDOMNode(this) as HTMLElement;
     this.parentNode = domNode.parentNode as HTMLElement;
     window.addEventListener('resize', () => this.setIframeSize(), false);
     this.setIframeSize();

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import {Manager, Popper, Reference} from 'react-popper';
 import styled from '@emotion/styled';
 import color from 'color';
@@ -377,7 +377,7 @@ class CellAction extends React.Component<Props, State> {
     let menu: React.ReactPortal | null = null;
 
     if (isOpen) {
-      menu = ReactDOM.createPortal(
+      menu = createPortal(
         <Popper placement="top" modifiers={modifiers}>
           {({ref: popperRef, style, placement, arrowProps}) => (
             <Menu

--- a/static/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/static/app/views/eventsV2/table/columnEditCollection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 
 import {parseArithmetic} from 'sentry/components/arithmeticInput/parser';
@@ -383,7 +383,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
       </Ghost>
     );
 
-    return ReactDOM.createPortal(ghost, this.portal);
+    return createPortal(ghost, this.portal);
   }
 
   renderItem(

--- a/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
@@ -1,5 +1,5 @@
 import {Component} from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import {Manager, Popper, Reference} from 'react-popper';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
@@ -140,7 +140,7 @@ class OperationSort extends Component<Props, State> {
       },
     };
 
-    return ReactDOM.createPortal(
+    return createPortal(
       <Popper placement="top" modifiers={modifiers}>
         {({ref: popperRef, style, placement}) => (
           <DropdownWrapper

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useRef, useState} from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import {Popper} from 'react-popper';
 import styled from '@emotion/styled';
 import {truncate} from '@sentry/utils';
@@ -416,7 +416,7 @@ const TagsHeatMap = (
 
             return (
               <Fragment>
-                {ReactDOM.createPortal(<div>{portaledContent}</div>, getPortal())}
+                {createPortal(<div>{portaledContent}</div>, getPortal())}
                 {getDynamicText({
                   value: (
                     <HeatMapChart

--- a/static/app/views/settings/project/projectOwnership/selectOwners.tsx
+++ b/static/app/views/settings/project/projectOwnership/selectOwners.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import {findDOMNode} from 'react-dom';
 import {MultiValueProps} from 'react-select';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
@@ -187,7 +187,7 @@ class SelectOwners extends React.Component<Props, State> {
     // Close select menu
     if (this.selectRef.current) {
       // eslint-disable-next-line react/no-find-dom-node
-      const node = ReactDOM.findDOMNode(this.selectRef.current);
+      const node = findDOMNode(this.selectRef.current);
       const input: HTMLInputElement | null = (node as Element)?.querySelector(
         '.Select-input input'
       );


### PR DESCRIPTION
Making this change before bumping to react 18. In the future this should also help us with tree shaking potentially 