### PR TITLE
chore(deps): Bump copy-text-to-clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "classnames": "2.3.1",
     "color": "^4.2.1",
     "compression-webpack-plugin": "9.2.0",
-    "copy-text-to-clipboard": "2.2.0",
+    "copy-text-to-clipboard": "3.0.1",
     "core-js": "^3.21.1",
     "crypto-browserify": "^3.12.0",
     "crypto-js": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6540,10 +6540,10 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-text-to-clipboard@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-2.2.0.tgz#329dd6daf8c42034c763ace567418401764579ae"
-  integrity sha512-WRvoIdnTs1rgPMkgA2pUOa/M4Enh2uzCwdKsOMYNAJiz/4ZvEJgmbF4OmninPmlFdAWisfeh0tH+Cpf7ni3RqQ==
+copy-text-to-clipboard@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-3.0.1.tgz#8cbf8f90e0a47f12e4a24743736265d157bce69c"
+  integrity sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q==
 
 copy-to-clipboard@^3.3.1:
   version "3.3.1"


### PR DESCRIPTION
Verified everything works OK.

Only difference is that webpack has to compile the ESM module now, since that's what changed https://github.com/sindresorhus/copy-text-to-clipboard/releases/tag/v3.0.0