### PR TITLE
fix(dx): Check for prettier verison in dependencies also

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "pegjs-loader": "^0.5.6",
     "platformicons": "^4.3.0",
     "po-catalog-loader": "2.0.0",
-    "prettier": "^2.6.0",
+    "prettier": "2.6.0",
     "prism-sentry": "^1.0.2",
     "process": "^0.11.10",
     "prop-types": "^15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12708,7 +12708,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.6.0:
+prettier@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
   integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==


### PR DESCRIPTION
We moved prettier to be a dependency here https://github.com/getsentry/sentry/pull/32690#discussion_r834752700