### PR TITLE
fix(build): Avoid prettier stdout error

### DIFF
--- a/scripts/extract-ios-device-names.ts
+++ b/scripts/extract-ios-device-names.ts
@@ -74,7 +74,7 @@ const template = (contents: string) => {
 const formatOutput = async (unformatted: string) => {
   const config = await prettier.resolveConfig(outputPath);
   if (config) {
-    return prettier.format(unformatted, config);
+    return prettier.format(unformatted, {...config, parser: 'babel'});
   }
 
   return unformatted;


### PR DESCRIPTION
The error was:

  No parser and no filepath given, using 'babel' the parser now but this
  will throw an error in the future. Please specify a parser or a
  filepath so one can be inferred.

The error was being produced anytime the ios device list script was being run