### PR TITLE
chore(statsd): statsd tests are failing if resource warnings are enabled

### DIFF
--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -5,10 +5,29 @@ import statsd
 from .base import MetricsBackend
 
 
+class PatchedStatsClient(statsd.StatsClient):
+    """The Python statsd client has a bug in the latest release version where it's
+    impossible to close the socket.  This is a patched version of the client that
+    fixes this issue.
+    """
+
+    if not hasattr(statsd.StatsClient, "close"):
+
+        def close(self):
+            sock = getattr(self, "_sock", None)
+            if sock and hasattr(sock, "close"):
+                sock.close()
+            self._sock = None
+
+
 class StatsdMetricsBackend(MetricsBackend):
     def __init__(self, host="127.0.0.1", port=8125, **kwargs):
-        self.client = statsd.StatsClient(host=host, port=port)
+        self.client = PatchedStatsClient(host=host, port=port)
         super().__init__(**kwargs)
+
+    def __del__(self):
+        # be explicit here to avoid the resource warning.
+        self.client.close()
 
     def _full_key(self, key, instance=None):
         if instance:

--- a/tests/sentry/metrics/test_statsd.py
+++ b/tests/sentry/metrics/test_statsd.py
@@ -1,10 +1,10 @@
+import unittest
 from unittest.mock import patch
 
 from sentry.metrics.statsd import StatsdMetricsBackend
-from sentry.testutils import TestCase
 
 
-class StatsdMetricsBackendTest(TestCase):
+class StatsdMetricsBackendTest(unittest.TestCase):
     def setUp(self):
         self.backend = StatsdMetricsBackend(prefix="sentrytest.")
 


### PR DESCRIPTION
Not sure under which circumstances one can run into this, but when running tests locally they fail for me.

This has been fixed upstream in the statsd library (https://github.com/jsocol/pystatsd/commit/e7a36f9d68c44476184261371276c76bf7f22ff8) but unfortunately a fix hasn't been released in two years.