### PR TITLE
chore(testutils): Ignore resource warnings in test runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ filterwarnings = [
 
     "ignore::django.utils.deprecation.RemovedInDjango30Warning",
 
+    # It would be really nice not to ignore these but unfortunately a lot of tests
+    # are failing locally in certain environments due to temporary files not being
+    # closed all over the place
+    "ignore::ResourceWarning",
+
     # DeprecationWarnings from Python 3.6's sre_parse are just so painful,
     # and I haven't found a way to ignore it specifically from a module.
     # This one in particular is from the "cookies" packages as depended

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -1,3 +1,4 @@
+import unittest
 from datetime import datetime
 from unittest.mock import patch
 
@@ -5,7 +6,6 @@ import pytest
 import pytz
 
 from sentry.analytics import Attribute, Event, Map
-from sentry.testutils import TestCase
 
 
 class ExampleEvent(Event):
@@ -22,7 +22,7 @@ class DummyType:
     key = "value"
 
 
-class EventTest(TestCase):
+class EventTest(unittest.TestCase):
     @patch("sentry.analytics.event.uuid1")
     def test_simple(self, mock_uuid1):
         mock_uuid1.return_value = self.get_mock_uuid()

--- a/tests/sentry/test_stacktraces.py
+++ b/tests/sentry/test_stacktraces.py
@@ -1,3 +1,5 @@
+import unittest
+
 import pytest
 
 from sentry.grouping.api import get_default_grouping_config_dict, load_grouping_config
@@ -6,10 +8,9 @@ from sentry.stacktraces.processing import (
     get_crash_frame_from_event_data,
     normalize_stacktraces_for_grouping,
 )
-from sentry.testutils import TestCase
 
 
-class FindStacktracesTest(TestCase):
+class FindStacktracesTest(unittest.TestCase):
     def test_stacktraces_basics(self):
         data = {
             "message": "hello",
@@ -157,7 +158,7 @@ class FindStacktracesTest(TestCase):
         assert len(infos[0].stacktrace["frames"]) == 3
 
 
-class NormalizeInApptest(TestCase):
+class NormalizeInApptest(unittest.TestCase):
     def test_normalize_with_system_frames(self):
         data = {
             "stacktrace": {


### PR DESCRIPTION
Related to #33114. I still get lots of test failures form legitimate resource warnings locally. Unsure why this apparently does not affect everybody and CI. I can only assume the resource warnings are not consistently emitted. Generally speaking this error should be ignored out of the box anyways and only the dev mode turns it on (https://docs.python.org/3/library/devmode.html#devmode) however the config in the pyproject toml currently turns it into an error.

As to why it seems that not everybody gets it: unclear.