### PR TITLE
feat(metrics): Add derived metric to get total count of failed transactions [INGEST-1134 INGEST-982]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -45,6 +45,7 @@ from sentry.snuba.metrics.fields.snql import (
     crashed_users,
     errored_all_users,
     errored_preaggr_sessions,
+    failure_count_transaction,
     percentage,
     session_duration_filters,
     sessions_errored_set,
@@ -757,6 +758,7 @@ class DerivedMetricKey(Enum):
     SESSION_DURATION = "session.duration"
 
     TRANSACTION_ALL = "transaction.all"
+    TRANSACTION_FAILURE_COUNT = "transaction.failure_count"
 
 
 # ToDo(ahmed): Investigate dealing with derived metric keys as Enum objects rather than string
@@ -909,6 +911,14 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metrics=[TransactionMetricKey.DURATION.value],
             unit="transactions",
             snql=lambda *_, org_id, metric_ids, alias=None: all_transactions(
+                org_id, metric_ids=metric_ids, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
+            metric_name=DerivedMetricKey.TRANSACTION_FAILURE_COUNT.value,
+            metrics=[TransactionMetricKey.DURATION.value],
+            unit="transactions",
+            snql=lambda *_, org_id, metric_ids, alias=None: failure_count_transaction(
                 org_id, metric_ids=metric_ids, alias=alias
             ),
         ),

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -2,7 +2,7 @@ from typing import List
 
 from snuba_sdk import Column, Function
 
-from sentry.sentry_metrics.transactions import TransactionTagsKey
+from sentry.sentry_metrics.transactions import TransactionStatusTagValue, TransactionTagsKey
 from sentry.sentry_metrics.utils import resolve_weak
 
 
@@ -162,6 +162,19 @@ def all_transactions(org_id, metric_ids, alias=None):
     return _dist_count_aggregation_on_tx_status_factory(
         org_id,
         exclude_tx_statuses=[],
+        metric_ids=metric_ids,
+        alias=alias,
+    )
+
+
+def failure_count_transaction(org_id, metric_ids, alias=None):
+    return _dist_count_aggregation_on_tx_status_factory(
+        org_id,
+        exclude_tx_statuses=[
+            TransactionStatusTagValue.OK.value,
+            TransactionStatusTagValue.CANCELLED.value,
+            TransactionStatusTagValue.UNKNOWN.value,
+        ],
         metric_ids=metric_ids,
         alias=alias,
     )


### PR DESCRIPTION
Adds a `transaction.failure_count` derived metric, returning the count of failed transactions. A transaction is considered failed on every transaction status but `ok`, `cancelled` or `unknown`.