### PR TITLE
fix(trimSlug): Handle long unhyphenated strings

### DIFF
--- a/static/app/utils/trimSlug.tsx
+++ b/static/app/utils/trimSlug.tsx
@@ -16,6 +16,13 @@ export function trimSlug(slug: string, maxLength: number = 20) {
    * E.g. "my-project-name" becomes ["my", "project", "name"]
    */
   const words: string[] = slug.split('-');
+
+  // If the string is too long but not hyphenated, return an end-trimmed
+  // string. E.g. "javascriptfrontendproject" --> "javascriptfrontendp…"
+  if (words.length === 1) {
+    return `${slug.slice(0, maxLength - 1)}\u2026`;
+  }
+
   /**
    * Returns the length (total number of letters plus hyphens in between
    * words) of the current words array.

--- a/tests/js/spec/utils/trimSlug.spec.tsx
+++ b/tests/js/spec/utils/trimSlug.spec.tsx
@@ -5,6 +5,10 @@ describe('trimSlug', function () {
     expect(trimSlug('javascript', 20)).toBe('javascript');
   });
 
+  it('trims long but unhyphenated slug', function () {
+    expect(trimSlug('javascriptfrontendproject', 20)).toBe('javascriptfrontendp…');
+  });
+
   it('trims slug from the middle, preserves whole words', function () {
     expect(trimSlug('symbol-collector-console', 20)).toBe('symbol…console');
     expect(trimSlug('symbol-collector-mobile', 20)).toBe('symbol…mobile');


### PR DESCRIPTION
There were some errors coming from users with long, unhyphenated project slugs.
https://sentry.io/organizations/sentry/issues/3139799473/?project=11276


fixes JAVASCRIPT-26WZ