### PR TITLE
feat(alerts): Alert Wizard V3 template selector

### DIFF
--- a/static/app/views/alerts/incidentRules/metricField.tsx
+++ b/static/app/views/alerts/incidentRules/metricField.tsx
@@ -44,7 +44,7 @@ type Props = Omit<FormField['props'], 'children'> & {
   inFieldLabels?: boolean;
 };
 
-const getFieldOptionConfig = ({
+export const getFieldOptionConfig = ({
   dataset,
   alertType,
 }: {

--- a/static/app/views/alerts/incidentRules/metricFieldV2.tsx
+++ b/static/app/views/alerts/incidentRules/metricFieldV2.tsx
@@ -1,0 +1,166 @@
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import {InjectedRouter, withRouter} from 'react-router';
+
+import Button from 'sentry/components/button';
+import FormField from 'sentry/components/forms/formField';
+import {t} from 'sentry/locale';
+import {AlertWizardAlertNames, AlertWizardRuleTemplates, MetricAlertType} from 'sentry/views/alerts/wizard/options';
+
+import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
+import {Location} from 'history';
+
+type Props = Omit<FormField['props'], 'children'> & {
+  location: Location;
+  router: InjectedRouter;
+};
+
+function MetricFieldV2 (props: Props) {
+  const  {location, router, ...fieldProps} = props;
+
+  return (
+    <FormField {...fieldProps}>
+      {() => {
+        const menuOptions = [
+          {
+            label: t("ERRORS"),
+            header: true,
+            eventKey: 'errors_section_title',
+          },
+          {
+            label: AlertWizardAlertNames['num_errors'],
+            eventKey: 'num_errors',
+            template: AlertWizardRuleTemplates['num_errors'],
+          },
+          {
+            label: AlertWizardAlertNames['users_experiencing_errors'],
+            eventKey: 'users_experiencing_errors',
+            template: AlertWizardRuleTemplates['users_experiencing_errors'],
+          },
+          {
+            label: t("SESSIONS"),
+            header: true,
+            eventKey: 'sessions_section_title',
+          },
+          {
+            label: AlertWizardAlertNames['crash_free_sessions'],
+            eventKey: 'crash_free_sessions',
+            template: AlertWizardRuleTemplates['crash_free_sessions'],
+          },
+          {
+            label: AlertWizardAlertNames['crash_free_users'],
+            eventKey: 'crash_free_users',
+            template: AlertWizardRuleTemplates['crash_free_users'],
+          },
+          {
+            label: t("PERFORMANCE"),
+            header: true,
+            eventKey: 'performance_section_title',
+          },
+          {
+            label: AlertWizardAlertNames['throughput'],
+            eventKey: 'throughput',
+            template: AlertWizardRuleTemplates['throughput'],
+          },
+          {
+            label: AlertWizardAlertNames['trans_duration'],
+            eventKey: 'trans_duration',
+            template: AlertWizardRuleTemplates['trans_duration'],
+          },
+          {
+            label: AlertWizardAlertNames['apdex'],
+            eventKey: 'apdex',
+            template: AlertWizardRuleTemplates['apdex'],
+          },
+          {
+            label: AlertWizardAlertNames['failure_rate'],
+            eventKey: 'failure_rate',
+            template: AlertWizardRuleTemplates['failure_rate'],
+          },
+          {
+            label: AlertWizardAlertNames['lcp'],
+            eventKey: 'lcp',
+            template: AlertWizardRuleTemplates['lcp'],
+          },
+          {
+            label: AlertWizardAlertNames['fid'],
+            eventKey: 'fid',
+            template: AlertWizardRuleTemplates['fid'],
+          },
+          {
+            label: AlertWizardAlertNames['cls'],
+            eventKey: 'cls',
+            template: AlertWizardRuleTemplates['cls'],
+          },
+          {
+            label: t("CUSTOM"),
+            header: true,
+            eventKey: 'custom_section_title',
+          },
+          {
+            label: AlertWizardAlertNames['custom'],
+            eventKey: 'custom',
+            template: AlertWizardRuleTemplates['custom'],
+          },
+        ];
+
+        const selected = (menuOptions.find(op => op.template?.aggregate === location.query.aggregate) || menuOptions[1]);
+
+        return (
+            <StyledDropdownControl
+              label={selected.label}
+            >
+              {
+                menuOptions.map(({label, eventKey, header}) => (<DropdownItem
+                  key={eventKey}
+                  onSelect={(eventKey: MetricAlertType) => router.replace({
+                    ...location,
+                    query: {
+                      ...location.query,
+                      aggregate: AlertWizardRuleTemplates[eventKey].aggregate,
+                      dataset: AlertWizardRuleTemplates[eventKey].dataset,
+                      eventTypes: AlertWizardRuleTemplates[eventKey].eventTypes,
+                    }
+                  })}
+                  isActive={eventKey === selected.eventKey}
+                  eventKey={eventKey}
+                  disabled={header}
+                >
+                  {label}
+                </DropdownItem>))
+              }
+            </StyledDropdownControl>
+        );
+      }}
+    </FormField>
+  );
+}
+
+export default withRouter(MetricFieldV2);
+
+const PresetButton = styled(Button)<{disabled: boolean}>`
+  ${p =>
+  p.disabled &&
+  css`
+      color: ${p.theme.textColor};
+      &:hover,
+      &:focus {
+        color: ${p.theme.textColor};
+      }
+    `}
+`;
+
+PresetButton.defaultProps = {
+  priority: 'link',
+  borderless: true,
+};
+
+const StyledDropdownControl = styled(DropdownControl)`
+  width: 100%;
+  button {
+    width: 100%;
+    span {
+      justify-content: space-between;
+    }
+  }
+`;

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -19,12 +19,13 @@ import space from 'sentry/styles/space';
 import {Environment, Organization, SelectValue} from 'sentry/types';
 import {MobileVital, WebVital} from 'sentry/utils/discover/fields';
 import {getDisplayName} from 'sentry/utils/environment';
+import MetricFieldV2 from 'sentry/views/alerts/incidentRules/metricFieldV2';
 import {
   convertDatasetEventTypesToSource,
   DATA_SOURCE_LABELS,
   DATA_SOURCE_TO_SET_AND_EVENT_TYPES,
 } from 'sentry/views/alerts/utils';
-import {AlertType, getFunctionHelpText} from 'sentry/views/alerts/wizard/options';
+import {AlertType, getFunctionHelpText, hidePrimarySelectorSet} from 'sentry/views/alerts/wizard/options';
 
 import {isCrashFreeAlert} from './utils/isCrashFreeAlert';
 import {
@@ -145,6 +146,25 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
     return undefined;
   }
 
+  renderMetricFieldV2() {
+    const {disabled} = this.props;
+
+    return (
+      <MetricFieldV2
+        name="aggregate"
+        help={null}
+        disabled={disabled}
+        style={{
+          ...this.formElemBaseStyle,
+          flex: 1,
+        }}
+        inline={false}
+        flexibleControlStateSize
+        required
+      />
+    );
+  }
+
   renderEventTypeFilter() {
     const {organization, disabled, alertType} = this.props;
 
@@ -237,7 +257,6 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
       timeWindow,
       comparisonDelta,
       comparisonType,
-      allowChangeEventTypes,
       onTimeWindowChange,
       onComparisonDeltaChange,
     } = this.props;
@@ -259,9 +278,9 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             </Tooltip>
           </StyledListTitle>
         </StyledListItem>
-        {hasAlertWizardV3 && allowChangeEventTypes && this.renderEventTypeFilter()}
         <FormRow>
-          {timeWindowText && (
+          {hasAlertWizardV3 && this.renderMetricFieldV2()}
+          {!hidePrimarySelectorSet.has(alertType) && timeWindowText && (
             <MetricField
               name="aggregate"
               help={null}
@@ -375,7 +394,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
         ) : (
           <StyledListItem>{t('Filter events')}</StyledListItem>
         )}
-        <FormRow>
+        <FormRow noMargin>
           <SelectField
             name="environment"
             placeholder={t('All')}
@@ -399,7 +418,9 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             flexibleControlStateSize
             inFieldLabel={t('Environment: ')}
           />
-          {!hasAlertWizardV3 && allowChangeEventTypes && this.renderEventTypeFilter()}
+          {allowChangeEventTypes && this.renderEventTypeFilter()}
+        </FormRow>
+        <FormRow>
           <FormField
             name="query"
             inline={false}
@@ -496,12 +517,12 @@ const StyledListItem = styled(ListItem)`
   line-height: 1.3;
 `;
 
-const FormRow = styled('div')`
+const FormRow = styled('div')<{noMargin?: boolean}>`
   display: flex;
   flex-direction: row;
   align-items: center;
   flex-wrap: wrap;
-  margin-bottom: ${space(4)};
+  margin-bottom: ${p => (p.noMargin ? 0 : space(4))};
 `;
 
 const FormRowText = styled('div')`

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -25,7 +25,11 @@ import {
   DATA_SOURCE_LABELS,
   DATA_SOURCE_TO_SET_AND_EVENT_TYPES,
 } from 'sentry/views/alerts/utils';
-import {AlertType, getFunctionHelpText, hidePrimarySelectorSet} from 'sentry/views/alerts/wizard/options';
+import {
+  AlertType,
+  getFunctionHelpText,
+  hidePrimarySelectorSet,
+} from 'sentry/views/alerts/wizard/options';
 
 import {isCrashFreeAlert} from './utils/isCrashFreeAlert';
 import {
@@ -74,14 +78,15 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   state: State = {
     environments: null,
   };
-  formElemBaseStyle = {
-    padding: `${space(0.5)}`,
-    border: 'none',
-  };
 
   componentDidMount() {
     this.fetchData();
   }
+
+  formElemBaseStyle = {
+    padding: `${space(0.5)}`,
+    border: 'none',
+  };
 
   async fetchData() {
     const {api, organization, projectSlug} = this.props;
@@ -269,13 +274,15 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
         <StyledListItem>
           <StyledListTitle>
             <div>{intervalLabelText}</div>
-            {!hasAlertWizardV3 && <Tooltip
-              title={t(
-                'Time window over which the metric is evaluated. Alerts are evaluated every minute regardless of this value.'
-              )}
-            >
-              <IconQuestion size="sm" color="gray200" />
-            </Tooltip>}
+            {!hasAlertWizardV3 && (
+              <Tooltip
+                title={t(
+                  'Time window over which the metric is evaluated. Alerts are evaluated every minute regardless of this value.'
+                )}
+              >
+                <IconQuestion size="sm" color="gray200" />
+              </Tooltip>
+            )}
           </StyledListTitle>
         </StyledListItem>
         <FormRow>

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -151,25 +151,6 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
     return undefined;
   }
 
-  renderWizardField() {
-    const {disabled} = this.props;
-
-    return (
-      <WizardField
-        name="aggregate"
-        help={null}
-        disabled={disabled}
-        style={{
-          ...this.formElemBaseStyle,
-          flex: 1,
-        }}
-        inline={false}
-        flexibleControlStateSize
-        required
-      />
-    );
-  }
-
   renderEventTypeFilter() {
     const {organization, disabled, alertType} = this.props;
 
@@ -286,7 +267,20 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
           </StyledListTitle>
         </StyledListItem>
         <FormRow>
-          {hasAlertWizardV3 && this.renderWizardField()}
+          {hasAlertWizardV3 && (
+            <WizardField
+              name="aggregate"
+              help={null}
+              disabled={disabled}
+              style={{
+                ...this.formElemBaseStyle,
+                flex: 1,
+              }}
+              inline={false}
+              flexibleControlStateSize
+              required
+            />
+          )}
           {!hidePrimarySelectorSet.has(alertType) && timeWindowText && (
             <MetricField
               name="aggregate"

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -73,6 +73,10 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   state: State = {
     environments: null,
   };
+  formElemBaseStyle = {
+    padding: `${space(0.5)}`,
+    border: 'none',
+  };
 
   componentDidMount() {
     this.fetchData();
@@ -175,17 +179,13 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
         ],
       });
     }
-    const formElemBaseStyle = {
-      padding: `${space(0.5)}`,
-      border: 'none',
-    };
 
     return (
       <FormField
         name="datasource"
         inline={false}
         style={{
-          ...formElemBaseStyle,
+          ...this.formElemBaseStyle,
           minWidth: 300,
           flex: 2,
         }}
@@ -242,11 +242,6 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
       onComparisonDeltaChange,
     } = this.props;
 
-    const formElemBaseStyle = {
-      padding: `${space(0.5)}`,
-      border: 'none',
-    };
-
     const {labelText, timeWindowText} = getFunctionHelpText(alertType);
     const intervalLabelText = hasAlertWizardV3 ? t('Define your metric') : labelText;
 
@@ -273,7 +268,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
               organization={organization}
               disabled={disabled}
               style={{
-                ...formElemBaseStyle,
+                ...this.formElemBaseStyle,
               }}
               inline={false}
               flexibleControlStateSize
@@ -369,11 +364,6 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
     const eventOmitTags =
       dataset === 'events' ? [...measurementTags, ...transactionTags] : [];
 
-    const formElemBaseStyle = {
-      padding: `${space(0.5)}`,
-      border: 'none',
-    };
-
     return (
       <React.Fragment>
         <ChartPanel>
@@ -390,7 +380,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             name="environment"
             placeholder={t('All')}
             style={{
-              ...formElemBaseStyle,
+              ...this.formElemBaseStyle,
               minWidth: 230,
               flex: 1,
             }}
@@ -414,7 +404,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             name="query"
             inline={false}
             style={{
-              ...formElemBaseStyle,
+              ...this.formElemBaseStyle,
               flex: '6 0 500px',
             }}
             flexibleControlStateSize

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -19,7 +19,7 @@ import space from 'sentry/styles/space';
 import {Environment, Organization, SelectValue} from 'sentry/types';
 import {MobileVital, WebVital} from 'sentry/utils/discover/fields';
 import {getDisplayName} from 'sentry/utils/environment';
-import MetricFieldV2 from 'sentry/views/alerts/incidentRules/metricFieldV2';
+import WizardField from 'sentry/views/alerts/incidentRules/wizardField';
 import {
   convertDatasetEventTypesToSource,
   DATA_SOURCE_LABELS,
@@ -146,11 +146,11 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
     return undefined;
   }
 
-  renderMetricFieldV2() {
+  renderWizardField() {
     const {disabled} = this.props;
 
     return (
-      <MetricFieldV2
+      <WizardField
         name="aggregate"
         help={null}
         disabled={disabled}
@@ -269,17 +269,17 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
         <StyledListItem>
           <StyledListTitle>
             <div>{intervalLabelText}</div>
-            <Tooltip
+            {!hasAlertWizardV3 && <Tooltip
               title={t(
                 'Time window over which the metric is evaluated. Alerts are evaluated every minute regardless of this value.'
               )}
             >
               <IconQuestion size="sm" color="gray200" />
-            </Tooltip>
+            </Tooltip>}
           </StyledListTitle>
         </StyledListItem>
         <FormRow>
-          {hasAlertWizardV3 && this.renderMetricFieldV2()}
+          {hasAlertWizardV3 && this.renderWizardField()}
           {!hidePrimarySelectorSet.has(alertType) && timeWindowText && (
             <MetricField
               name="aggregate"

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -713,8 +713,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const canEdit =
       isActiveSuperuser() || (ownerId ? userTeamIds.includes(ownerId) : true);
 
-    const hasAlertWizardV3 =
-      Boolean(isCustomMetric) && organization.features.includes('alert-wizard-v3');
+    const hasAlertWizardV3 = organization.features.includes('alert-wizard-v3');
 
     const triggerForm = (hasAccess: boolean) => (
       <Triggers

--- a/static/app/views/alerts/incidentRules/triggers/form.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/form.tsx
@@ -311,7 +311,6 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
           // Flip rule thresholdType to opposite
           thresholdPeriod={thresholdPeriod}
           thresholdType={+!thresholdType}
-          hideControl={hasAlertWizardV3}
           comparisonType={comparisonType}
           aggregate={aggregate}
           resolveThreshold={resolveThreshold}

--- a/static/app/views/alerts/incidentRules/wizardField.tsx
+++ b/static/app/views/alerts/incidentRules/wizardField.tsx
@@ -1,21 +1,21 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import {Location} from 'history';
 import {InjectedRouter, withRouter} from 'react-router';
 
-import Button from 'sentry/components/button';
 import FormField from 'sentry/components/forms/formField';
 import {t} from 'sentry/locale';
 import {AlertWizardAlertNames, AlertWizardRuleTemplates, MetricAlertType} from 'sentry/views/alerts/wizard/options';
+import space from 'sentry/styles/space';
 
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
-import {Location} from 'history';
 
 type Props = Omit<FormField['props'], 'children'> & {
   location: Location;
   router: InjectedRouter;
 };
 
-function MetricFieldV2 (props: Props) {
+function WizardField (props: Props) {
   const  {location, router, ...fieldProps} = props;
 
   return (
@@ -23,7 +23,7 @@ function MetricFieldV2 (props: Props) {
       {() => {
         const menuOptions = [
           {
-            label: t("ERRORS"),
+            label: t('ERRORS'),
             header: true,
             eventKey: 'errors_section_title',
           },
@@ -38,7 +38,7 @@ function MetricFieldV2 (props: Props) {
             template: AlertWizardRuleTemplates['users_experiencing_errors'],
           },
           {
-            label: t("SESSIONS"),
+            label: t('SESSIONS'),
             header: true,
             eventKey: 'sessions_section_title',
           },
@@ -53,7 +53,7 @@ function MetricFieldV2 (props: Props) {
             template: AlertWizardRuleTemplates['crash_free_users'],
           },
           {
-            label: t("PERFORMANCE"),
+            label: t('PERFORMANCE'),
             header: true,
             eventKey: 'performance_section_title',
           },
@@ -93,7 +93,7 @@ function MetricFieldV2 (props: Props) {
             template: AlertWizardRuleTemplates['cls'],
           },
           {
-            label: t("CUSTOM"),
+            label: t('CUSTOM'),
             header: true,
             eventKey: 'custom_section_title',
           },
@@ -107,27 +107,28 @@ function MetricFieldV2 (props: Props) {
         const selected = (menuOptions.find(op => op.template?.aggregate === location.query.aggregate) || menuOptions[1]);
 
         return (
-            <StyledDropdownControl
-              label={selected.label}
-            >
+            <StyledDropdownControl label={selected.label}>
               {
-                menuOptions.map(({label, eventKey, header}) => (<DropdownItem
-                  key={eventKey}
-                  onSelect={(eventKey: MetricAlertType) => router.replace({
-                    ...location,
-                    query: {
-                      ...location.query,
-                      aggregate: AlertWizardRuleTemplates[eventKey].aggregate,
-                      dataset: AlertWizardRuleTemplates[eventKey].dataset,
-                      eventTypes: AlertWizardRuleTemplates[eventKey].eventTypes,
-                    }
-                  })}
-                  isActive={eventKey === selected.eventKey}
-                  eventKey={eventKey}
-                  disabled={header}
-                >
-                  {label}
-                </DropdownItem>))
+                menuOptions.map(({label, eventKey, header}) => (
+                  <StyledDropdownItem
+                    key={eventKey}
+                    onSelect={(eventKey: MetricAlertType) => router.replace({
+                      ...location,
+                      query: {
+                        ...location.query,
+                        aggregate: AlertWizardRuleTemplates[eventKey].aggregate,
+                        dataset: AlertWizardRuleTemplates[eventKey].dataset,
+                        eventTypes: AlertWizardRuleTemplates[eventKey].eventTypes,
+                      }
+                    })}
+                    isActive={eventKey === selected.eventKey}
+                    eventKey={eventKey}
+                    disabled={header}
+                    header={header}
+                  >
+                    {label}
+                  </StyledDropdownItem>
+                ))
               }
             </StyledDropdownControl>
         );
@@ -136,24 +137,7 @@ function MetricFieldV2 (props: Props) {
   );
 }
 
-export default withRouter(MetricFieldV2);
-
-const PresetButton = styled(Button)<{disabled: boolean}>`
-  ${p =>
-  p.disabled &&
-  css`
-      color: ${p.theme.textColor};
-      &:hover,
-      &:focus {
-        color: ${p.theme.textColor};
-      }
-    `}
-`;
-
-PresetButton.defaultProps = {
-  priority: 'link',
-  borderless: true,
-};
+export default withRouter(WizardField);
 
 const StyledDropdownControl = styled(DropdownControl)`
   width: 100%;
@@ -163,4 +147,15 @@ const StyledDropdownControl = styled(DropdownControl)`
       justify-content: space-between;
     }
   }
+`;
+
+const StyledDropdownItem = styled(DropdownItem)<{header?: boolean}>`
+  line-height: ${p => p.theme.text.lineHeightBody};
+  white-space: nowrap;
+  ${p => p.header && css`
+    background-color: ${p.theme.backgroundSecondary};
+    color: ${p.theme.subText};
+    padding: ${space(0.75)} ${space(1.5)};
+  `}
+  border-top: 1px solid ${p => p.theme.border};
 `;

--- a/static/app/views/alerts/incidentRules/wizardField.tsx
+++ b/static/app/views/alerts/incidentRules/wizardField.tsx
@@ -44,12 +44,10 @@ const menuOptions = [
   {
     label: AlertWizardAlertNames.num_errors,
     key: 'num_errors',
-    template: AlertWizardRuleTemplates.num_errors,
   },
   {
     label: AlertWizardAlertNames.users_experiencing_errors,
     key: 'users_experiencing_errors',
-    template: AlertWizardRuleTemplates.users_experiencing_errors,
   },
   {
     label: t('SESSIONS'),
@@ -59,12 +57,10 @@ const menuOptions = [
   {
     label: AlertWizardAlertNames.crash_free_sessions,
     key: 'crash_free_sessions',
-    template: AlertWizardRuleTemplates.crash_free_sessions,
   },
   {
     label: AlertWizardAlertNames.crash_free_users,
     key: 'crash_free_users',
-    template: AlertWizardRuleTemplates.crash_free_users,
   },
   {
     label: t('PERFORMANCE'),
@@ -74,37 +70,30 @@ const menuOptions = [
   {
     label: AlertWizardAlertNames.throughput,
     key: 'throughput',
-    template: AlertWizardRuleTemplates.throughput,
   },
   {
     label: AlertWizardAlertNames.trans_duration,
     key: 'trans_duration',
-    template: AlertWizardRuleTemplates.trans_duration,
   },
   {
     label: AlertWizardAlertNames.apdex,
     key: 'apdex',
-    template: AlertWizardRuleTemplates.apdex,
   },
   {
     label: AlertWizardAlertNames.failure_rate,
     key: 'failure_rate',
-    template: AlertWizardRuleTemplates.failure_rate,
   },
   {
     label: AlertWizardAlertNames.lcp,
     key: 'lcp',
-    template: AlertWizardRuleTemplates.lcp,
   },
   {
     label: AlertWizardAlertNames.fid,
     key: 'fid',
-    template: AlertWizardRuleTemplates.fid,
   },
   {
     label: AlertWizardAlertNames.cls,
     key: 'cls',
-    template: AlertWizardRuleTemplates.cls,
   },
   {
     label: t('CUSTOM'),
@@ -114,7 +103,6 @@ const menuOptions = [
   {
     label: AlertWizardAlertNames.custom,
     key: 'custom',
-    template: AlertWizardRuleTemplates.custom,
   },
 ];
 
@@ -130,9 +118,9 @@ function WizardField({
   const selected =
     menuOptions.find(
       op =>
-        op.template?.aggregate === location.query.aggregate &&
-        op.template?.dataset === location.query.dataset &&
-        op.template?.dataset === location.query.dataset
+        AlertWizardRuleTemplates[op.key]?.aggregate === location.query.aggregate &&
+        AlertWizardRuleTemplates[op.key]?.dataset === location.query.dataset &&
+        AlertWizardRuleTemplates[op.key]?.dataset === location.query.dataset
     ) || menuOptions[1];
 
   return (

--- a/static/app/views/alerts/incidentRules/wizardField.tsx
+++ b/static/app/views/alerts/incidentRules/wizardField.tsx
@@ -3,7 +3,6 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import Button from 'sentry/components/button';
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
 import FormField from 'sentry/components/forms/formField';
 import {t} from 'sentry/locale';
@@ -23,6 +22,12 @@ import {generateFieldOptions} from 'sentry/views/eventsV2/utils';
 
 import {getFieldOptionConfig} from './metricField';
 
+type MenuOption = {
+  key: string;
+  label: string;
+  header?: boolean;
+};
+
 type Props = Omit<FormField['props'], 'children'> & {
   location: Location;
   organization: Organization;
@@ -35,7 +40,7 @@ type Props = Omit<FormField['props'], 'children'> & {
   inFieldLabels?: boolean;
 };
 
-const menuOptions = [
+const menuOptions: MenuOption[] = [
   {
     label: t('ERRORS'),
     header: true,
@@ -116,12 +121,15 @@ function WizardField({
   ...fieldProps
 }: Props) {
   const selected =
-    menuOptions.find(
-      op =>
-        AlertWizardRuleTemplates[op.key]?.aggregate === location.query.aggregate &&
-        AlertWizardRuleTemplates[op.key]?.dataset === location.query.dataset &&
-        AlertWizardRuleTemplates[op.key]?.dataset === location.query.dataset
-    ) || menuOptions[1];
+    menuOptions.find(op => {
+      const {aggregate, dataset, eventTypes} = AlertWizardRuleTemplates[op.key] || {};
+
+      return (
+        aggregate === location.query.aggregate &&
+        dataset === location.query.dataset &&
+        eventTypes === location.query.eventTypes
+      );
+    }) || menuOptions[1];
 
   return (
     <FormField {...fieldProps}>
@@ -242,20 +250,3 @@ const StyledQueryField = styled(QueryField)<{gridColumns: number; columnWidth?: 
       width: ${p.gridColumns * p.columnWidth}px;
     `}
 `;
-
-const PresetButton = styled(Button)<{disabled: boolean}>`
-  ${p =>
-    p.disabled &&
-    css`
-      color: ${p.theme.textColor};
-      &:hover,
-      &:focus {
-        color: ${p.theme.textColor};
-      }
-    `}
-`;
-
-PresetButton.defaultProps = {
-  priority: 'link',
-  borderless: true,
-};

--- a/static/app/views/alerts/incidentRules/wizardField.tsx
+++ b/static/app/views/alerts/incidentRules/wizardField.tsx
@@ -1,22 +1,25 @@
+import {InjectedRouter, withRouter} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import {InjectedRouter, withRouter} from 'react-router';
-
-import FormField from 'sentry/components/forms/formField';
-import {t} from 'sentry/locale';
-import {AlertWizardAlertNames, AlertWizardRuleTemplates, MetricAlertType} from 'sentry/views/alerts/wizard/options';
-import space from 'sentry/styles/space';
 
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
+import FormField from 'sentry/components/forms/formField';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {
+  AlertWizardAlertNames,
+  AlertWizardRuleTemplates,
+  MetricAlertType,
+} from 'sentry/views/alerts/wizard/options';
 
 type Props = Omit<FormField['props'], 'children'> & {
   location: Location;
   router: InjectedRouter;
 };
 
-function WizardField (props: Props) {
-  const  {location, router, ...fieldProps} = props;
+function WizardField(props: Props) {
+  const {location, router, ...fieldProps} = props;
 
   return (
     <FormField {...fieldProps}>
@@ -25,112 +28,114 @@ function WizardField (props: Props) {
           {
             label: t('ERRORS'),
             header: true,
-            eventKey: 'errors_section_title',
+            key: 'errors_section_title',
           },
           {
-            label: AlertWizardAlertNames['num_errors'],
-            eventKey: 'num_errors',
-            template: AlertWizardRuleTemplates['num_errors'],
+            label: AlertWizardAlertNames.num_errors,
+            key: 'num_errors',
+            template: AlertWizardRuleTemplates.num_errors,
           },
           {
-            label: AlertWizardAlertNames['users_experiencing_errors'],
-            eventKey: 'users_experiencing_errors',
-            template: AlertWizardRuleTemplates['users_experiencing_errors'],
+            label: AlertWizardAlertNames.users_experiencing_errors,
+            key: 'users_experiencing_errors',
+            template: AlertWizardRuleTemplates.users_experiencing_errors,
           },
           {
             label: t('SESSIONS'),
             header: true,
-            eventKey: 'sessions_section_title',
+            key: 'sessions_section_title',
           },
           {
-            label: AlertWizardAlertNames['crash_free_sessions'],
-            eventKey: 'crash_free_sessions',
-            template: AlertWizardRuleTemplates['crash_free_sessions'],
+            label: AlertWizardAlertNames.crash_free_sessions,
+            key: 'crash_free_sessions',
+            template: AlertWizardRuleTemplates.crash_free_sessions,
           },
           {
-            label: AlertWizardAlertNames['crash_free_users'],
-            eventKey: 'crash_free_users',
-            template: AlertWizardRuleTemplates['crash_free_users'],
+            label: AlertWizardAlertNames.crash_free_users,
+            key: 'crash_free_users',
+            template: AlertWizardRuleTemplates.crash_free_users,
           },
           {
             label: t('PERFORMANCE'),
             header: true,
-            eventKey: 'performance_section_title',
+            key: 'performance_section_title',
           },
           {
-            label: AlertWizardAlertNames['throughput'],
-            eventKey: 'throughput',
-            template: AlertWizardRuleTemplates['throughput'],
+            label: AlertWizardAlertNames.throughput,
+            key: 'throughput',
+            template: AlertWizardRuleTemplates.throughput,
           },
           {
-            label: AlertWizardAlertNames['trans_duration'],
-            eventKey: 'trans_duration',
-            template: AlertWizardRuleTemplates['trans_duration'],
+            label: AlertWizardAlertNames.trans_duration,
+            key: 'trans_duration',
+            template: AlertWizardRuleTemplates.trans_duration,
           },
           {
-            label: AlertWizardAlertNames['apdex'],
-            eventKey: 'apdex',
-            template: AlertWizardRuleTemplates['apdex'],
+            label: AlertWizardAlertNames.apdex,
+            key: 'apdex',
+            template: AlertWizardRuleTemplates.apdex,
           },
           {
-            label: AlertWizardAlertNames['failure_rate'],
-            eventKey: 'failure_rate',
-            template: AlertWizardRuleTemplates['failure_rate'],
+            label: AlertWizardAlertNames.failure_rate,
+            key: 'failure_rate',
+            template: AlertWizardRuleTemplates.failure_rate,
           },
           {
-            label: AlertWizardAlertNames['lcp'],
-            eventKey: 'lcp',
-            template: AlertWizardRuleTemplates['lcp'],
+            label: AlertWizardAlertNames.lcp,
+            key: 'lcp',
+            template: AlertWizardRuleTemplates.lcp,
           },
           {
-            label: AlertWizardAlertNames['fid'],
-            eventKey: 'fid',
-            template: AlertWizardRuleTemplates['fid'],
+            label: AlertWizardAlertNames.fid,
+            key: 'fid',
+            template: AlertWizardRuleTemplates.fid,
           },
           {
-            label: AlertWizardAlertNames['cls'],
-            eventKey: 'cls',
-            template: AlertWizardRuleTemplates['cls'],
+            label: AlertWizardAlertNames.cls,
+            key: 'cls',
+            template: AlertWizardRuleTemplates.cls,
           },
           {
             label: t('CUSTOM'),
             header: true,
-            eventKey: 'custom_section_title',
+            key: 'custom_section_title',
           },
           {
-            label: AlertWizardAlertNames['custom'],
-            eventKey: 'custom',
-            template: AlertWizardRuleTemplates['custom'],
+            label: AlertWizardAlertNames.custom,
+            key: 'custom',
+            template: AlertWizardRuleTemplates.custom,
           },
         ];
 
-        const selected = (menuOptions.find(op => op.template?.aggregate === location.query.aggregate) || menuOptions[1]);
+        const selected =
+          menuOptions.find(op => op.template?.aggregate === location.query.aggregate) ||
+          menuOptions[1];
 
         return (
-            <StyledDropdownControl label={selected.label}>
-              {
-                menuOptions.map(({label, eventKey, header}) => (
-                  <StyledDropdownItem
-                    key={eventKey}
-                    onSelect={(eventKey: MetricAlertType) => router.replace({
-                      ...location,
-                      query: {
-                        ...location.query,
-                        aggregate: AlertWizardRuleTemplates[eventKey].aggregate,
-                        dataset: AlertWizardRuleTemplates[eventKey].dataset,
-                        eventTypes: AlertWizardRuleTemplates[eventKey].eventTypes,
-                      }
-                    })}
-                    isActive={eventKey === selected.eventKey}
-                    eventKey={eventKey}
-                    disabled={header}
-                    header={header}
-                  >
-                    {label}
-                  </StyledDropdownItem>
-                ))
-              }
-            </StyledDropdownControl>
+          <StyledDropdownControl label={selected.label}>
+            {menuOptions.map(({label, key, header}) => (
+              <StyledDropdownItem
+                key={key}
+                eventKey={key}
+                onSelect={(eventKey: MetricAlertType) =>
+                  router.replace({
+                    ...location,
+                    query: {
+                      ...location.query,
+                      aggregate: AlertWizardRuleTemplates[eventKey].aggregate,
+                      dataset: AlertWizardRuleTemplates[eventKey].dataset,
+                      eventTypes: AlertWizardRuleTemplates[eventKey].eventTypes,
+                    },
+                  })
+                }
+                isActive={key === selected.key}
+                disabled={header}
+                header={header}
+              >
+                {label}
+              </StyledDropdownItem>
+            ))}
+          </StyledDropdownControl>
         );
       }}
     </FormField>
@@ -152,10 +157,12 @@ const StyledDropdownControl = styled(DropdownControl)`
 const StyledDropdownItem = styled(DropdownItem)<{header?: boolean}>`
   line-height: ${p => p.theme.text.lineHeightBody};
   white-space: nowrap;
-  ${p => p.header && css`
-    background-color: ${p.theme.backgroundSecondary};
-    color: ${p.theme.subText};
-    padding: ${space(0.75)} ${space(1.5)};
-  `}
+  ${p =>
+    p.header &&
+    css`
+      background-color: ${p.theme.backgroundSecondary};
+      color: ${p.theme.subText};
+      padding: ${space(0.75)} ${space(1.5)};
+    `}
   border-top: 1px solid ${p => p.theme.border};
 `;

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -326,7 +326,6 @@ export function getFunctionHelpText(alertType: AlertType): {
   if (hidePrimarySelectorSet.has(alertType)) {
     return {
       labelText: t('Select time interval'),
-      timeWindowText,
     };
   }
   return {

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -35,6 +35,8 @@ export type AlertType =
   | 'crash_free_sessions'
   | 'crash_free_users';
 
+export type MetricAlertType = Exclude<AlertType, 'issues'>;
+
 export const AlertWizardAlertNames: Record<AlertType, string> = {
   issues: t('Issues'),
   num_errors: t('Number of Errors'),
@@ -226,7 +228,7 @@ export type WizardRuleTemplate = {
 };
 
 export const AlertWizardRuleTemplates: Record<
-  Exclude<AlertType, 'issues'>,
+  MetricAlertType,
   Readonly<WizardRuleTemplate>
 > = {
   num_errors: {
@@ -324,6 +326,7 @@ export function getFunctionHelpText(alertType: AlertType): {
   if (hidePrimarySelectorSet.has(alertType)) {
     return {
       labelText: t('Select time interval'),
+      timeWindowText,
     };
   }
   return {


### PR DESCRIPTION
This adds a dropdown in the metric selector in the alert wizard that can change the aggregate function, same way you would select an aggregate in the radio button selection step before the alert form step. Aggregate is changed in the url and the dropdown field follows the value from the url.

Wizard selector for aggregate:
<img width="831" alt="Screen Shot 2022-04-06 at 1 51 14 PM" src="https://user-images.githubusercontent.com/15015880/162068625-a1abba65-4240-46de-94a2-fc3278b6f176.png">

Expanded with all values:
<img width="819" alt="Screen Shot 2022-04-06 at 1 50 24 PM" src="https://user-images.githubusercontent.com/15015880/162068641-9b5f14a7-f8a6-49d4-a940-e73d1e4400ca.png">


