### PR TITLE
Client State endpoint

### DIFF
--- a/src/sentry/api/endpoints/client_state.py
+++ b/src/sentry/api/endpoints/client_state.py
@@ -25,7 +25,7 @@ class ClientStateEndpoint(OrganizationEndpoint):
 
     def get_key(self, organization, category, user):
         if category not in STATE_CATEGORIES:
-            return NotFound(detail="Category not found")
+            raise NotFound(detail="Category not found")
         scope = STATE_CATEGORIES[category]["scope"]
         if scope == "member":
             return f"client-state:{category}:{organization}:{user}"

--- a/src/sentry/api/endpoints/client_state.py
+++ b/src/sentry/api/endpoints/client_state.py
@@ -1,0 +1,55 @@
+# This endpoint helps managing persisted client state with a TTL for a member, organization or user
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+from sentry.api.exceptions import ParameterValidationError
+from sentry.utils import json, redis
+
+STATE_CATEGORIES = {
+    "onboarding": {
+        "ttl": 30 * 24 * 60 * 60,  # the time in seconds that the state will be persisted
+        "scope": "member",  # Can be "user", "org", or "user-org"
+    }
+}
+
+
+class ClientStateEndpoint(Endpoint):
+    permission_classes = (IsAuthenticated,)
+
+    def get_key(self, request: Request, category):
+        scope = STATE_CATEGORIES[category]["scope"]
+        org = request.query_params.get("org")
+        if scope == "member":
+            if not org:
+                raise ParameterValidationError("Missing org parameter")
+            return f"client-state:{category}:{org}:{request.user.id}"
+        elif scope == "org":
+            if not org:
+                raise ParameterValidationError("Missing org parameter")
+            return f"client-state:{category}:{org}"
+        else:
+            return f"client-state:{category}:{request.user.id}"
+
+    def get(self, request: Request, category) -> Response:
+        if category not in STATE_CATEGORIES:
+            return Response({"detail": "Category not found"}, status=404)
+        key = self.get_key(request, category)
+        res = None
+        with redis.clusters.get("default").map() as client:
+            res = client.get(key)
+            client.expire(key, STATE_CATEGORIES[category]["ttl"])
+        if res.value:
+            return Response(res.value)
+        else:
+            return Response({})
+
+    def put(self, request: Request, category):
+        if category not in STATE_CATEGORIES:
+            return Response({"detail": "Category not found"}, status=404)
+        key = self.get_key(request, category)
+        with redis.clusters.get("default").map() as client:
+            client.setex(key, STATE_CATEGORIES[category]["ttl"], json.dumps(request.data))
+        return Response(status=201)

--- a/src/sentry/api/endpoints/client_state.py
+++ b/src/sentry/api/endpoints/client_state.py
@@ -18,6 +18,8 @@ STATE_CATEGORIES = {
 
 
 class ClientStateEndpoint(OrganizationEndpoint):
+    private = True
+
     def __init__(self, **options) -> None:
         cluster_key = getattr(settings, "SENTRY_CLIENT_STATE_REDIS_CLUSTER", "default")
         self.client = redis.redis_clusters.get(cluster_key)

--- a/src/sentry/api/endpoints/client_state.py
+++ b/src/sentry/api/endpoints/client_state.py
@@ -1,42 +1,33 @@
 # This endpoint helps managing persisted client state with a TTL for a member, organization or user
 
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint
-from sentry.api.exceptions import ParameterValidationError
+from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.utils import json, redis
 
 STATE_CATEGORIES = {
     "onboarding": {
         "ttl": 30 * 24 * 60 * 60,  # the time in seconds that the state will be persisted
-        "scope": "member",  # Can be "user", "org", or "user-org"
+        "scope": "member",  # Can be "org" or "member"
+        "max_payload_size": 1024,
     }
 }
 
 
-class ClientStateEndpoint(Endpoint):
-    permission_classes = (IsAuthenticated,)
-
-    def get_key(self, request: Request, category):
-        scope = STATE_CATEGORIES[category]["scope"]
-        org = request.query_params.get("org")
-        if scope == "member":
-            if not org:
-                raise ParameterValidationError("Missing org parameter")
-            return f"client-state:{category}:{org}:{request.user.id}"
-        elif scope == "org":
-            if not org:
-                raise ParameterValidationError("Missing org parameter")
-            return f"client-state:{category}:{org}"
-        else:
-            return f"client-state:{category}:{request.user.id}"
-
-    def get(self, request: Request, category) -> Response:
+class ClientStateEndpoint(OrganizationEndpoint):
+    def get_key(self, organization, category, user):
         if category not in STATE_CATEGORIES:
-            return Response({"detail": "Category not found"}, status=404)
-        key = self.get_key(request, category)
+            return NotFound(detail="Category not found")
+        scope = STATE_CATEGORIES[category]["scope"]
+        if scope == "member":
+            return f"client-state:{category}:{organization}:{user}"
+        elif scope == "org":
+            return f"client-state:{category}:{organization}"
+
+    def get(self, request: Request, organization, category) -> Response:
+        key = self.get_key(organization.slug, category, request.user)
         res = None
         with redis.clusters.get("default").map() as client:
             res = client.get(key)
@@ -46,10 +37,11 @@ class ClientStateEndpoint(Endpoint):
         else:
             return Response({})
 
-    def put(self, request: Request, category):
-        if category not in STATE_CATEGORIES:
-            return Response({"detail": "Category not found"}, status=404)
-        key = self.get_key(request, category)
+    def put(self, request: Request, organization, category):
+        key = self.get_key(organization.slug, category, request.user)
+        data_to_write = json.dumps(request.data)
+        if len(data_to_write) > STATE_CATEGORIES[category]["max_payload_size"]:
+            return Response(status=413)
         with redis.clusters.get("default").map() as client:
-            client.setex(key, STATE_CATEGORIES[category]["ttl"], json.dumps(request.data))
+            client.setex(key, STATE_CATEGORIES[category]["ttl"], data_to_write)
         return Response(status=201)

--- a/src/sentry/api/endpoints/client_state.py
+++ b/src/sentry/api/endpoints/client_state.py
@@ -1,6 +1,7 @@
 # This endpoint helps managing persisted client state with a TTL for a member, organization or user
 
 from django.conf import settings
+from django.http import HttpResponse
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -36,10 +37,11 @@ class ClientStateEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, organization, category) -> Response:
         key = self.get_key(organization.slug, category, request.user)
-        res = self.client.get(key)
-        if res:
-            self.client.expire(key, STATE_CATEGORIES[category]["ttl"])
-            return Response(json.loads(res))
+        value = self.client.get(key)
+        if value:
+            response = HttpResponse(value)
+            response["Content-Type"] = "application/json"
+            return response
         else:
             return Response({})
 

--- a/src/sentry/api/endpoints/client_state.py
+++ b/src/sentry/api/endpoints/client_state.py
@@ -1,5 +1,6 @@
 # This endpoint helps managing persisted client state with a TTL for a member, organization or user
 
+from django.conf import settings
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -17,6 +18,11 @@ STATE_CATEGORIES = {
 
 
 class ClientStateEndpoint(OrganizationEndpoint):
+    def __init__(self, **options) -> None:
+        cluster_key = getattr(settings, "SENTRY_CLIENT_STATE_REDIS_CLUSTER", "default")
+        self.client = redis.redis_clusters.get(cluster_key)
+        super().__init__(**options)
+
     def get_key(self, organization, category, user):
         if category not in STATE_CATEGORIES:
             return NotFound(detail="Category not found")
@@ -28,12 +34,10 @@ class ClientStateEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, organization, category) -> Response:
         key = self.get_key(organization.slug, category, request.user)
-        res = None
-        with redis.clusters.get("default").map() as client:
-            res = client.get(key)
-            client.expire(key, STATE_CATEGORIES[category]["ttl"])
-        if res.value:
-            return Response(res.value)
+        res = self.client.get(key)
+        if res:
+            self.client.expire(key, STATE_CATEGORIES[category]["ttl"])
+            return Response(json.loads(res))
         else:
             return Response({})
 
@@ -42,6 +46,5 @@ class ClientStateEndpoint(OrganizationEndpoint):
         data_to_write = json.dumps(request.data)
         if len(data_to_write) > STATE_CATEGORIES[category]["max_payload_size"]:
             return Response(status=413)
-        with redis.clusters.get("default").map() as client:
-            client.setex(key, STATE_CATEGORIES[category]["ttl"], data_to_write)
+        self.client.setex(key, STATE_CATEGORIES[category]["ttl"], data_to_write)
         return Response(status=201)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -591,11 +591,6 @@ urlpatterns = [
         PromptsActivityEndpoint.as_view(),
         name="sentry-api-0-prompts-activity",
     ),
-    url(
-        r"^client-state/(?P<category>[^\/]+)/$",
-        ClientStateEndpoint.as_view(),
-        name="sentry-api-0-client-state",
-    ),
     # Auth
     url(
         r"^auth/",
@@ -1575,6 +1570,11 @@ urlpatterns = [
                             ),
                         ],
                     ),
+                ),
+                url(
+                    r"^(?P<organization_slug>[^/]+)/client-state/(?P<category>[^\/]+)/$",
+                    ClientStateEndpoint.as_view(),
+                    name="sentry-api-0-organization-client-state",
                 ),
             ]
         ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -91,6 +91,7 @@ from .endpoints.broadcast_index import BroadcastIndexEndpoint
 from .endpoints.builtin_symbol_sources import BuiltinSymbolSourcesEndpoint
 from .endpoints.catchall import CatchallEndpoint
 from .endpoints.chunk import ChunkUploadEndpoint
+from .endpoints.client_state import ClientStateEndpoint
 from .endpoints.codeowners import (
     ExternalTeamDetailsEndpoint,
     ExternalTeamEndpoint,
@@ -589,6 +590,11 @@ urlpatterns = [
         r"^prompts-activity/$",
         PromptsActivityEndpoint.as_view(),
         name="sentry-api-0-prompts-activity",
+    ),
+    url(
+        r"^client-state/(?P<category>[^\/]+)/$",
+        ClientStateEndpoint.as_view(),
+        name="sentry-api-0-client-state",
     ),
     # Auth
     url(

--- a/tests/sentry/api/test_client_state.py
+++ b/tests/sentry/api/test_client_state.py
@@ -1,0 +1,48 @@
+from django.urls import reverse
+
+from sentry.testutils import APITestCase
+
+
+class ClientStateTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user, name="baz")
+        self.path = reverse(
+            "sentry-api-0-organization-client-state", args=[self.org.slug, "onboarding"]
+        )
+
+    def test_add_state(self):
+        # Invalid feature prompt name
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp.data == {}
+
+        resp = self.client.put(
+            self.path,
+            {"test": "data"},
+        )
+        assert resp.status_code == 201
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp.data == {"test": "data"}
+
+    def test_category_not_exist(self):
+        path = reverse(
+            "sentry-api-0-organization-client-state", args=[self.org.slug, "onboarding-aaa"]
+        )
+        resp = self.client.get(path)
+        assert resp.status_code == 404
+
+    def test_org_not_exist(self):
+        path = reverse("sentry-api-0-organization-client-state", args=["ggg", "onboarding"])
+        resp = self.client.get(path)
+        assert resp.status_code == 404
+
+    def test_large_payload(self):
+        resp = self.client.put(
+            self.path,
+            {"test": 300 * "Dummy Data"},
+        )
+        assert resp.status_code == 413

--- a/tests/sentry/api/test_client_state.py
+++ b/tests/sentry/api/test_client_state.py
@@ -1,15 +1,15 @@
 from django.urls import reverse
 
 from sentry.testutils import APITestCase
+from sentry.utils import json
 
 
 class ClientStateTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.org = self.create_organization(owner=self.user, name="baz")
         self.path = reverse(
-            "sentry-api-0-organization-client-state", args=[self.org.slug, "onboarding"]
+            "sentry-api-0-organization-client-state", args=[self.organization.slug, "onboarding"]
         )
 
     def test_add_state(self):
@@ -26,11 +26,13 @@ class ClientStateTest(APITestCase):
 
         resp = self.client.get(self.path)
         assert resp.status_code == 200
-        assert resp.data == {"test": "data"}
+        assert resp["Content-Type"] == "application/json"
+        assert json.loads(resp.content) == {"test": "data"}
 
     def test_category_not_exist(self):
         path = reverse(
-            "sentry-api-0-organization-client-state", args=[self.org.slug, "onboarding-aaa"]
+            "sentry-api-0-organization-client-state",
+            args=[self.organization.slug, "onboarding-aaa"],
         )
         resp = self.client.get(path)
         assert resp.status_code == 404


### PR DESCRIPTION
This PR creates a new endpoint for storing arbitrary client state with a TTL.
Our use case for this is that we would like to save onboarding state for a fixed period of time so that when the user comes back to the onboarding page, the selected projects & integrations would still be there.

The config for the redis cluster was added here:
https://github.com/getsentry/getsentry/pull/7266

The payload size is limited by a parameter set in each category. For the case of onboarding state, that's 1024 characters for each organization member.