### PR TITLE
fix(ui): padding and line-height of tags in sidebar

### DIFF
--- a/static/app/components/tagDistributionMeter.tsx
+++ b/static/app/components/tagDistributionMeter.tsx
@@ -227,6 +227,8 @@ const Title = styled('div')`
   display: flex;
   font-size: ${p => p.theme.fontSizeSmall};
   justify-content: space-between;
+  margin-bottom: ${space(0.25)};
+  line-height: 1.1;
 `;
 
 const TitleType = styled('div')`


### PR DESCRIPTION
## Before
![CleanShot 2022-03-30 at 10 42 45](https://user-images.githubusercontent.com/1900676/160898093-4a242c64-6eef-452c-8554-e95f08a4c0d8.png)


## After
![CleanShot 2022-03-30 at 10 42 56](https://user-images.githubusercontent.com/1900676/160898062-d3215a8a-b303-4e4e-92d4-6e86f0dfd6a1.png)

