### PR TITLE
chore(pytest): Upgrade pytest to 6.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ filterwarnings = [
 
     "ignore::django.utils.deprecation.RemovedInDjango30Warning",
 
+    # It would be really nice not to ignore these but unfortunately a lot of tests
+    # are failing locally in certain environments due to temporary files not being
+    # closed all over the place
+    "ignore::ResourceWarning",
+
     # DeprecationWarnings from Python 3.6's sre_parse are just so painful,
     # and I haven't found a way to ignore it specifically from a module.
     # This one in particular is from the "cookies" packages as depended

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ freezegun==1.1.0
 honcho>=1.0.0,<1.1.0
 mypy>=0.800,<0.900
 openapi-core==0.14.2
-pytest==6.1.0
+pytest==6.2.0
 pytest-cov==2.11.1
 pytest-django==3.10.0
 pytest-sentry==0.1.9

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -1,3 +1,4 @@
+import unittest
 from datetime import datetime
 from unittest.mock import patch
 
@@ -5,7 +6,6 @@ import pytest
 import pytz
 
 from sentry.analytics import Attribute, Event, Map
-from sentry.testutils import TestCase
 
 
 class ExampleEvent(Event):
@@ -22,7 +22,7 @@ class DummyType:
     key = "value"
 
 
-class EventTest(TestCase):
+class EventTest(unittest.TestCase):
     @patch("sentry.analytics.event.uuid1")
     def test_simple(self, mock_uuid1):
         mock_uuid1.return_value = self.get_mock_uuid()

--- a/tests/sentry/test_stacktraces.py
+++ b/tests/sentry/test_stacktraces.py
@@ -1,3 +1,5 @@
+import unittest
+
 import pytest
 
 from sentry.grouping.api import get_default_grouping_config_dict, load_grouping_config
@@ -6,10 +8,9 @@ from sentry.stacktraces.processing import (
     get_crash_frame_from_event_data,
     normalize_stacktraces_for_grouping,
 )
-from sentry.testutils import TestCase
 
 
-class FindStacktracesTest(TestCase):
+class FindStacktracesTest(unittest.TestCase):
     def test_stacktraces_basics(self):
         data = {
             "message": "hello",
@@ -157,7 +158,7 @@ class FindStacktracesTest(TestCase):
         assert len(infos[0].stacktrace["frames"]) == 3
 
 
-class NormalizeInApptest(TestCase):
+class NormalizeInApptest(unittest.TestCase):
     def test_normalize_with_system_frames(self):
         data = {
             "stacktrace": {


### PR DESCRIPTION
pytest 6.2.0 does hide a lot `ResourceWarning` we have in our tests.
    
We need to ignore the warning until we figure out how to fix it.