### PR TITLE
ref(page-filters): Use counter badge in env filter

### DIFF
--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -2,6 +2,7 @@ import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {updateEnvironments} from 'sentry/actionCreators/pageFilters';
+import Badge from 'sentry/components/badge';
 import MultipleEnvironmentSelector from 'sentry/components/organizations/multipleEnvironmentSelector';
 import PageFilterDropdownButton from 'sentry/components/organizations/pageFilters/pageFilterDropdownButton';
 import {IconWindow} from 'sentry/icons';
@@ -9,21 +10,33 @@ import {t} from 'sentry/locale';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
+import {trimSlug} from 'sentry/utils/trimSlug';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
+type EnvironmentSelectorProps = React.ComponentProps<typeof MultipleEnvironmentSelector>;
+
 type Props = {
   router: WithRouterProps['router'];
-  alignDropdown?: React.ComponentProps<
-    typeof MultipleEnvironmentSelector
-  >['alignDropdown'];
+  alignDropdown?: EnvironmentSelectorProps['alignDropdown'];
+  /**
+   * Max character length for the dropdown title. Default is 20. This number
+   * is used to determine how many projects to show, and how much to truncate.
+   */
+  maxTitleLength?: number;
+
   /**
    * Reset these URL params when we fire actions (custom routing only)
    */
   resetParamsOnChange?: string[];
 };
 
-function EnvironmentPageFilter({router, resetParamsOnChange = [], alignDropdown}: Props) {
+function EnvironmentPageFilter({
+  router,
+  resetParamsOnChange = [],
+  alignDropdown,
+  maxTitleLength = 20,
+}: Props) {
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const organization = useOrganization();
   const {selection, isReady, desyncedFilters} = useLegacyStore(PageFiltersStore);
@@ -35,7 +48,19 @@ function EnvironmentPageFilter({router, resetParamsOnChange = [], alignDropdown}
     });
   };
 
-  const customDropdownButton = ({isOpen, getActorProps, summary}) => {
+  const customDropdownButton: EnvironmentSelectorProps['customDropdownButton'] = ({
+    isOpen,
+    getActorProps,
+    value,
+  }) => {
+    const environmentsToShow =
+      value[0]?.length + value[1]?.length <= maxTitleLength - 2
+        ? value.slice(0, 2)
+        : value.slice(0, 1);
+    const summary = value.length
+      ? environmentsToShow.map(env => trimSlug(env, maxTitleLength)).join(', ')
+      : t('All Environments');
+
     return (
       <PageFilterDropdownButton
         detached
@@ -46,7 +71,12 @@ function EnvironmentPageFilter({router, resetParamsOnChange = [], alignDropdown}
       >
         <DropdownTitle>
           <IconWindow />
-          <TitleContainer>{summary}</TitleContainer>
+          <TitleContainer>
+            {summary}
+            {!!value.length && value.length > environmentsToShow.length && (
+              <Badge text={`+${value.length - environmentsToShow.length}`} />
+            )}
+          </TitleContainer>
         </DropdownTitle>
       </PageFilterDropdownButton>
     );
@@ -79,11 +109,14 @@ function EnvironmentPageFilter({router, resetParamsOnChange = [], alignDropdown}
 }
 
 const TitleContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1 1 0%;
+  margin-left: ${space(1)};
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  flex: 1 1 0%;
-  margin-left: ${space(1)};
 `;
 
 const DropdownTitle = styled('div')`

--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -24,7 +24,6 @@ type Props = {
    * is used to determine how many projects to show, and how much to truncate.
    */
   maxTitleLength?: number;
-
   /**
    * Reset these URL params when we fire actions (custom routing only)
    */

--- a/static/app/components/organizations/multipleEnvironmentSelector.tsx
+++ b/static/app/components/organizations/multipleEnvironmentSelector.tsx
@@ -44,7 +44,7 @@ type Props = WithRouterProps & {
   customDropdownButton?: (config: {
     getActorProps: GetActorPropsFn;
     isOpen: boolean;
-    summary: string;
+    value: string[];
   }) => React.ReactElement;
   customLoadingIndicator?: React.ReactNode;
   detached?: boolean;
@@ -278,7 +278,7 @@ function MultipleEnvironmentSelector({
         >
           {({isOpen, getActorProps}) =>
             customDropdownButton ? (
-              customDropdownButton({isOpen, getActorProps, summary})
+              customDropdownButton({isOpen, getActorProps, value: validatedValue})
             ) : (
               <StyledHeaderItem
                 data-test-id="global-header-environment-selector"


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/33002.

**Before:**
<img width="371" alt="Screen Shot 2022-03-30 at 12 06 45 PM" src="https://user-images.githubusercontent.com/44172267/160911793-32e156ef-0559-4600-95e2-78c2b27170c5.png">

**After:**
<img width="201" alt="Screen Shot 2022-03-30 at 12 07 02 PM" src="https://user-images.githubusercontent.com/44172267/160911831-38de6735-2e55-47a3-8de6-cf3270559b1f.png">

