### PR TITLE
fix(ts): Use default exported GuideAnchor

### DIFF
--- a/static/app/views/performance/transactionSummary/filter.tsx
+++ b/static/app/views/performance/transactionSummary/filter.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import {GuideAnchor} from 'sentry/components/assistant/guideAnchor';
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import DropdownButton from 'sentry/components/dropdownButton';
 import DropdownControl from 'sentry/components/dropdownControl';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import Feature from 'sentry/components/acl/feature';
-import {GuideAnchor} from 'sentry/components/assistant/guideAnchor';
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
 import FeatureBadge from 'sentry/components/featureBadge';

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -3,7 +3,7 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location, LocationDescriptorObject} from 'history';
 
-import {GuideAnchor} from 'sentry/components/assistant/guideAnchor';
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Button from 'sentry/components/button';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import GridEditable, {

--- a/static/app/views/projectDetail/projectFilters.tsx
+++ b/static/app/views/projectDetail/projectFilters.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {GuideAnchor} from 'sentry/components/assistant/guideAnchor';
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';


### PR DESCRIPTION
We're exporting both a named `GuideAnchor` and default `GuideAnchor`. Unfortunately the named GuideAnchor by deafult is imported in the LSP, since the name of the default GuideAnchor is GuideAnchorWrapper.

I'll fix the exports in a followup PR