### PR TITLE
ref(endpoints): Integration Directory

### DIFF
--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -9,34 +9,6 @@ from sentry.api.serializers import serialize
 from sentry.models import ObjectStatus, Organization, OrganizationIntegration
 
 
-def query_param_to_bool(value: bool | int | str | None, default: bool = False) -> bool:
-    """
-    Generic parser for boolean-like query parameters.
-    TODO(mgaeta): Move this to somewhere in utils.
-    """
-    if value is None:
-        return default
-
-    if isinstance(value, int):
-        return value > 0
-
-    if isinstance(value, bool):
-        return value
-
-    try:
-        int_value = int(value)
-    except ValueError:
-        int_value = None
-
-    if int_value is not None:
-        return int_value > 0
-
-    if value == "":
-        return default
-
-    return value.lower() in {"on", "true"}
-
-
 class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission,)
 
@@ -72,7 +44,8 @@ class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
             integrations = integrations.filter(integration__provider=provider_key.lower())
 
         # Include the configurations by default if includeConfig is not present.
-        include_config = query_param_to_bool(include_config_raw, default=True)
+        # TODO(mgaeta): HACK. We need a consistent way to get booleans from query parameters.
+        include_config = include_config_raw != "0"
 
         def on_results(results):
             if len(features):

--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -71,10 +71,8 @@ class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
         if provider_key:
             integrations = integrations.filter(integration__provider=provider_key.lower())
 
-        # include the configurations by default if no param
-        include_config = True
-        if request.GET.get("includeConfig") == "0":
-            include_config = False
+        # Include the configurations by default if includeConfig is not present.
+        include_config = query_param_to_bool(include_config_raw, default=True)
 
         def on_results(results):
             if len(features):

--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -5,6 +7,29 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationInte
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import ObjectStatus, OrganizationIntegration
+
+def query_param_to_bool(value: bool | int | str | None, default: bool = False) -> bool:
+    if value is None:
+        return default
+
+    if isinstance(value, int):
+        return value > 0
+
+    if isinstance(value, bool):
+        return value
+
+    try:
+        int_value = int(value)
+    except ValueError:
+        int_value = None
+
+    if int_value is not None:
+        return int_value > 0
+
+    if value == "":
+        return default
+
+    return value.lower() in {"on", "true"}
 
 
 class OrganizationIntegrationsEndpoint(OrganizationEndpoint):

--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, Mapping, Sequence
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -7,6 +9,33 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationInte
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import ObjectStatus, Organization, OrganizationIntegration
+
+
+def prepare_feature_filters(features_raw: Sequence[str]) -> set[str]:
+    """Normalize feature names from query params."""
+    return {feature.lower().strip() for feature in features_raw}
+
+
+def prepare_features(organization_integration: OrganizationIntegration) -> set[str]:
+    """Normalize feature names Integration provider feature lists."""
+    return {
+        feature.name.lower().strip()
+        for feature in organization_integration.integration.get_provider().features
+    }
+
+
+def filter_by_features(
+    organization_integrations: Sequence[OrganizationIntegration],
+    feature_filters: Sequence[str],
+) -> Sequence[OrganizationIntegration]:
+    """Filter the list of organization integrations by feature."""
+    return [
+        organization_integration
+        for organization_integration in organization_integrations
+        if prepare_feature_filters(feature_filters).intersection(
+            prepare_features(organization_integration)
+        )
+    ]
 
 
 class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
@@ -26,53 +55,35 @@ class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
 
         :auth: required
         """
-
         feature_filters = request.GET.getlist("features", [])
         provider_key = request.GET.get("provider_key", "")
         include_config_raw = request.GET.get("includeConfig")
 
-        # filter by integration provider features
-        features = [feature.lower() for feature in feature_filters]
-
-        # show disabled org integrations but not ones being deleted
-        integrations = OrganizationIntegration.objects.filter(
+        # Show disabled organization integrations but not the ones currently
+        # undergoing deletion.
+        queryset = OrganizationIntegration.objects.filter(
             organization=organization,
-            status__in=[ObjectStatus.VISIBLE, ObjectStatus.DISABLED, ObjectStatus.PENDING_DELETION],
+            status__in=[
+                ObjectStatus.VISIBLE,
+                ObjectStatus.DISABLED,
+                ObjectStatus.PENDING_DELETION,
+            ],
         )
 
         if provider_key:
-            integrations = integrations.filter(integration__provider=provider_key.lower())
+            queryset = queryset.filter(integration__provider=provider_key.lower())
 
         # Include the configurations by default if includeConfig is not present.
         # TODO(mgaeta): HACK. We need a consistent way to get booleans from query parameters.
         include_config = include_config_raw != "0"
 
-        def on_results(results):
-            if len(features):
-                return [
-                    serialize(
-                        i,
-                        request.user,
-                        include_config=include_config,
-                    )
-                    for i in filter(
-                        # check if any feature in query param is in the provider feature list
-                        lambda i: any(
-                            f
-                            in [
-                                feature.name.lower()
-                                for feature in list(i.integration.get_provider().features)
-                            ]
-                            for f in features
-                        ),
-                        results,
-                    )
-                ]
-
+        def on_results(results: Sequence[OrganizationIntegration]) -> Sequence[Mapping[str, Any]]:
+            if feature_filters:
+                results = filter_by_features(results, feature_filters)
             return serialize(results, request.user, include_config=include_config)
 
         return self.paginate(
-            queryset=integrations,
+            queryset=queryset,
             request=request,
             order_by="integration__name",
             on_results=on_results,

--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -55,8 +55,12 @@ class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
         :auth: required
         """
 
+        feature_filters = request.GET.getlist("features", [])
+        provider_key = request.GET.get("provider_key", "")
+        include_config_raw = request.GET.get("includeConfig")
+
         # filter by integration provider features
-        features = [feature.lower() for feature in request.GET.getlist("features", [])]
+        features = [feature.lower() for feature in feature_filters]
 
         # show disabled org integrations but not ones being deleted
         integrations = OrganizationIntegration.objects.filter(
@@ -64,8 +68,8 @@ class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
             status__in=[ObjectStatus.VISIBLE, ObjectStatus.DISABLED, ObjectStatus.PENDING_DELETION],
         )
 
-        if "provider_key" in request.GET:
-            integrations = integrations.filter(integration__provider=request.GET["provider_key"])
+        if provider_key:
+            integrations = integrations.filter(integration__provider=provider_key.lower())
 
         # include the configurations by default if no param
         include_config = True

--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -6,9 +6,14 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models import ObjectStatus, OrganizationIntegration
+from sentry.models import ObjectStatus, Organization, OrganizationIntegration
+
 
 def query_param_to_bool(value: bool | int | str | None, default: bool = False) -> bool:
+    """
+    Generic parser for boolean-like query parameters.
+    TODO(mgaeta): Move this to somewhere in utils.
+    """
     if value is None:
         return default
 
@@ -35,7 +40,20 @@ def query_param_to_bool(value: bool | int | str | None, default: bool = False) -
 class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission,)
 
-    def get(self, request: Request, organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
+        """
+        List the available Integrations for an Organization
+        ```````````````````````````````````````````````````
+
+        :pparam string organization_slug: The slug of the organization.
+
+        :qparam string provider_key: Filter by specific integration provider. (e.g. "slack")
+        :qparam string[] features: Filter by integration features names.
+        :qparam bool includeConfig: Should integrations configurations be fetched from third-party
+            APIs? This can add several thousand ms to the request round trip.
+
+        :auth: required
+        """
 
         # filter by integration provider features
         features = [feature.lower() for feature in request.GET.getlist("features", [])]

--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -51,7 +51,7 @@ class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
         :qparam string provider_key: Filter by specific integration provider. (e.g. "slack")
         :qparam string[] features: Filter by integration features names.
         :qparam bool includeConfig: Should integrations configurations be fetched from third-party
-            APIs? This can add several thousand ms to the request round trip.
+            APIs? This can add several seconds to the request round trip.
 
         :auth: required
         """

--- a/tests/sentry/api/endpoints/test_organization_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_integrations.py
@@ -1,5 +1,31 @@
+from unittest import TestCase
+
+from sentry.api.endpoints.organization_integrations import query_param_to_bool
 from sentry.models import Integration
 from sentry.testutils import APITestCase
+
+
+class QueryParamToBoolTest(TestCase):
+    def test_empty(self):
+        assert not query_param_to_bool(None)
+        assert not query_param_to_bool("")
+
+    def test_int(self):
+        assert query_param_to_bool(1)
+        assert query_param_to_bool("1")
+
+        assert not query_param_to_bool(0)
+        assert not query_param_to_bool(-1)
+        assert not query_param_to_bool("0")
+        assert not query_param_to_bool("-1")
+
+    def test_bool(self):
+        assert query_param_to_bool(True)
+        assert query_param_to_bool("true")
+        assert query_param_to_bool("True")
+
+        assert not query_param_to_bool(False)
+        assert not query_param_to_bool("False")
 
 
 class OrganizationIntegrationsListTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_integrations.py
@@ -3,26 +3,23 @@ from sentry.testutils import APITestCase
 
 
 class OrganizationIntegrationsListTest(APITestCase):
+    endpoint = "sentry-api-0-organization-integrations"
+
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.org = self.create_organization(owner=self.user, name="baz")
+
         self.integration = Integration.objects.create(provider="example", name="Example")
-        self.integration.add_organization(self.org, self.user)
+        self.integration.add_organization(self.organization, self.user)
 
     def test_simple(self):
-        path = f"/api/0/organizations/{self.org.slug}/integrations/"
+        response = self.get_success_response(self.organization.slug)
 
-        response = self.client.get(path, format="json")
-
-        assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(self.integration.id)
         assert "configOrganization" in response.data[0]
 
     def test_no_config(self):
-        path = f"/api/0/organizations/{self.org.slug}/integrations/?includeConfig=0"
+        response = self.get_success_response(self.organization.slug, qs_params={"includeConfig": 0})
 
-        response = self.client.get(path, format="json")
-        assert response.status_code == 200, response.content
         assert "configOrganization" not in response.data[0]

--- a/tests/sentry/api/endpoints/test_organization_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_integrations.py
@@ -1,31 +1,5 @@
-from unittest import TestCase
-
-from sentry.api.endpoints.organization_integrations import query_param_to_bool
 from sentry.models import Integration
 from sentry.testutils import APITestCase
-
-
-class QueryParamToBoolTest(TestCase):
-    def test_empty(self):
-        assert not query_param_to_bool(None)
-        assert not query_param_to_bool("")
-
-    def test_int(self):
-        assert query_param_to_bool(1)
-        assert query_param_to_bool("1")
-
-        assert not query_param_to_bool(0)
-        assert not query_param_to_bool(-1)
-        assert not query_param_to_bool("0")
-        assert not query_param_to_bool("-1")
-
-    def test_bool(self):
-        assert query_param_to_bool(True)
-        assert query_param_to_bool("true")
-        assert query_param_to_bool("True")
-
-        assert not query_param_to_bool(False)
-        assert not query_param_to_bool("False")
 
 
 class OrganizationIntegrationsListTest(APITestCase):


### PR DESCRIPTION
I have a theory that bad query parameter parsing is causing us to accidentally fetch third-party configurations for every integration on the Integrations Directory. I can see what parameters are sent to the backend but I don't really have a great way to test how they're being interpreted. 

This PR creates a generic parser for query params and hopefully when this is merged page load times will go down.