### PR TITLE
feat(ci): Change charcuterie coverage to be uploaded only on backend changes

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -284,8 +284,17 @@ jobs:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
 
+      # We use the below to determine the flag to use in codecov (only upload on backend changes)
+      - name: Check for python file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
+        if: ${{ steps.changes.outputs.backend == 'true' }}
 
   visual-diff:
     # This guarantees that we will only schedule Visual Snapshots if all

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,19 +14,19 @@ coverage:
         flags:
           - backend
   ignore:
-  - src/.*?/migrations/.*
-  - src/bitfield/.*
-  - src/sentry/debug/.*
-  - src/sentry/lint/.*
-  - src/sentry/runner/.*
-  - src/social_auth/.*
+  - src/*/migrations/
+  - src/bitfield/
+  - src/sentry/debug/
+  - src/sentry/lint/
+  - src/sentry/runner/
+  - src/social_auth/
   - static/app/routes.tsx
   - tests/
 
 flags:
   frontend:
     paths:
-    - "static/app"
+    - "static/app/"
     carryforward: true
   backend:
     paths:


### PR DESCRIPTION
Otherwise on frontend changes, this was being uploaded as backend flag and I believe it canceled out the rest of the backend coverages that should be carried forward.