### PR TITLE
fix(ops genie): URL Validation

### DIFF
--- a/src/sentry_plugins/opsgenie/plugin.py
+++ b/src/sentry_plugins/opsgenie/plugin.py
@@ -30,7 +30,7 @@ class OpsGenieOptionsForm(notify.NotificationConfigurationForm):
         help_text="The user names of individual users or groups (comma separated)",
         required=False,
     )
-    alert_url = forms.CharField(
+    alert_url = forms.URLField(
         max_length=255,
         label="OpsGenie Alert URL",
         widget=forms.TextInput(

--- a/src/sentry_plugins/opsgenie/plugin.py
+++ b/src/sentry_plugins/opsgenie/plugin.py
@@ -74,8 +74,9 @@ class OpsGeniePlugin(CorePluginMixin, notify.NotificationPlugin):
     def get_form_initial(self, project=None):
         return {"alert_url": "https://api.opsgenie.com/v2/alerts"}
 
-    def build_payload(self, group, event, triggering_rules):
-        payload = {
+    @staticmethod
+    def build_payload(group, event, triggering_rules):
+        return {
             "message": event.message or event.title,
             "alias": "sentry: %d" % group.id,
             "source": "Sentry",
@@ -90,13 +91,11 @@ class OpsGeniePlugin(CorePluginMixin, notify.NotificationPlugin):
                 "Triggering Rules": json.dumps(triggering_rules),
             },
             "entity": group.culprit,
+            "tags": [
+                "{}:{}".format(str(x).replace(",", ""), str(y).replace(",", ""))
+                for x, y in event.tags
+            ],
         }
-
-        payload["tags"] = [
-            "{}:{}".format(str(x).replace(",", ""), str(y).replace(",", "")) for x, y in event.tags
-        ]
-
-        return payload
 
     def notify_users(self, group, event, fail_silently=False, triggering_rules=None, **kwargs):
         if not self.is_configured(group.project):

--- a/src/sentry_plugins/opsgenie/plugin.py
+++ b/src/sentry_plugins/opsgenie/plugin.py
@@ -78,7 +78,7 @@ class OpsGeniePlugin(CorePluginMixin, notify.NotificationPlugin):
     def build_payload(group, event, triggering_rules):
         return {
             "message": event.message or event.title,
-            "alias": "sentry: %d" % group.id,
+            "alias": f"sentry: {group.id}",
             "source": "Sentry",
             "details": {
                 "Sentry ID": str(group.id),
@@ -91,10 +91,7 @@ class OpsGeniePlugin(CorePluginMixin, notify.NotificationPlugin):
                 "Triggering Rules": json.dumps(triggering_rules),
             },
             "entity": group.culprit,
-            "tags": [
-                "{}:{}".format(str(x).replace(",", ""), str(y).replace(",", ""))
-                for x, y in event.tags
-            ],
+            "tags": [f'{str(x).replace(",", "")}:{str(y).replace(",", "")}' for x, y in event.tags],
         }
 
     def notify_users(self, group, event, fail_silently=False, triggering_rules=None, **kwargs):


### PR DESCRIPTION
It looks like a user accidentally put their `api_key` in the `alert_url` field and now we're getting `RequestError`s. This PR adds basic validation to the field to hopefully prevent this problem for future users.

![Screen Shot 2022-03-30 at 1 55 03 PM](https://user-images.githubusercontent.com/31750075/160929253-9addc1ad-422d-4c63-9515-378cac897e15.png)

Because this is only a problem for a few users I don't recommend a migration to repair or delete their configurations.

Fixes [SENTRY-S0N](https://sentry.io/organizations/sentry/issues/2601042990).