### PR TITLE
ci(flaky-test): Disable flaky create widget test

### DIFF
--- a/tests/js/spec/views/dashboardsV2/gridLayout/create.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/create.spec.tsx
@@ -69,7 +69,8 @@ describe('Dashboards > Create', function () {
       ProjectsStore.teardown();
     });
 
-    it('can create with new widget', async function () {
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('can create with new widget', async function () {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/',
         method: 'POST',


### PR DESCRIPTION
This test is failing master. It may be better covered as an acceptance test anyways so skipping it for now to follow up