### PR TITLE
fix(settings): `isActiveRouter` weirdness

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -101,7 +101,8 @@ const SidebarItem = ({
     (labelString === 'Discover' && location.pathname.includes('/discover/')) ||
     (labelString === 'Dashboards' &&
       (location.pathname.includes('/dashboards/') ||
-        location.pathname.includes('/dashboard/'))) ||
+        location.pathname.includes('/dashboard/')) &&
+      !location.pathname.startsWith('/settings/')) ||
     // TODO: this won't be necessary once we remove settingsHome
     (labelString === 'Settings' && location.pathname.startsWith('/settings/')) ||
     (labelString === 'Alerts' &&

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -106,7 +106,7 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
     );
   }
 
-  renderExernalIntegrations() {
+  renderExternalIntegrations() {
     const {orgId} = this.props.params;
     const {organization} = this.props;
     const integrations = this.state.applications.filter(app => app.status !== 'internal');
@@ -180,7 +180,7 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
             }
           )}
         </Alert>
-        {this.renderExernalIntegrations()}
+        {this.renderExternalIntegrations()}
         {this.renderInternalIntegrations()}
       </div>
     );


### PR DESCRIPTION
Add an exception when `"/dashboards/"` is in the route.

Before:
![Screen Shot 2022-03-30 at 4 45 29 PM](https://user-images.githubusercontent.com/31750075/160948682-c3b51f82-377a-4eb7-ba3a-1fb5c1924daf.png)

After:
![Screen Shot 2022-03-30 at 4 55 31 PM](https://user-images.githubusercontent.com/31750075/160949583-657d77b6-8663-45e5-8c65-b982de834f50.png)