### PR TITLE
fix(metric_alerts): Fix metric crash rate alert logger

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -121,7 +121,7 @@ class SubscriptionProcessor:
         incident_trigger = self.incident_triggers.get(trigger.id)
         return incident_trigger is not None and incident_trigger.status == status.value
 
-    def __reset_trigger_counts(self):
+    def reset_trigger_counts(self):
         """
         Helper method that clears both the trigger alert and the trigger resolve counts
         """
@@ -232,7 +232,7 @@ class SubscriptionProcessor:
             CRASH_RATE_ALERT_AGGREGATE_ALIAS
         ]
         if aggregation_value is None:
-            self.__reset_trigger_counts()
+            self.reset_trigger_counts()
             metrics.incr("incidents.alert_rules.ignore_update_no_session_data")
             return
 
@@ -243,7 +243,7 @@ class SubscriptionProcessor:
             if CRASH_RATE_ALERT_MINIMUM_THRESHOLD is not None:
                 min_threshold = int(CRASH_RATE_ALERT_MINIMUM_THRESHOLD)
                 if total_count < min_threshold:
-                    self.__reset_trigger_counts()
+                    self.reset_trigger_counts()
                     metrics.incr(
                         "incidents.alert_rules.ignore_update_count_lower_than_min_threshold"
                     )
@@ -294,14 +294,14 @@ class SubscriptionProcessor:
         )
 
         if total_session_count == 0:
-            self.__reset_trigger_counts()
+            self.reset_trigger_counts()
             metrics.incr("incidents.alert_rules.ignore_update_no_session_data")
             return
 
         if CRASH_RATE_ALERT_MINIMUM_THRESHOLD is not None:
             min_threshold = int(CRASH_RATE_ALERT_MINIMUM_THRESHOLD)
             if total_session_count < min_threshold:
-                self.__reset_trigger_counts()
+                self.reset_trigger_counts()
                 metrics.incr("incidents.alert_rules.ignore_update_count_lower_than_min_threshold")
                 return
 

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -114,9 +114,10 @@ def handle_subscription_metrics_logger(subscription_update, subscription):
 
     try:
         if subscription.snuba_query.dataset == QueryDatasets.METRICS.value:
-            aggregation_value = SubscriptionProcessor(subscription).get_aggregation_value(
-                subscription_update
-            )
+            processor = SubscriptionProcessor(subscription)
+            # XXX: Temporary hack so that we can extract these values without raising an exception
+            processor.reset_trigger_counts = lambda *arg, **kwargs: None
+            aggregation_value = processor.get_aggregation_value(subscription_update)
 
             logger.info(
                 "handle_subscription_metrics_logger.message",


### PR DESCRIPTION
Tests missed this because we created the subscription with a related alert. In production, these
test subscriptions have no related alert rule, and so the logging fails.

Updated the test so that we'd catch this, and mocked out the method that fails in production. We
don't need this method for this logging, so this won't cause any issues.