### PR TITLE
fix(new-widget-builder-experience): Fix sort by not matching orderby value

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -3,7 +3,11 @@ import isEqual from 'lodash/isEqual';
 import {generateOrderOptions} from 'sentry/components/dashboards/widgetQueriesForm';
 import {t} from 'sentry/locale';
 import {Organization, TagCollection} from 'sentry/types';
-import {aggregateOutputType, isLegalYAxisType} from 'sentry/utils/discover/fields';
+import {
+  aggregateOutputType,
+  getAggregateAlias,
+  isLegalYAxisType,
+} from 'sentry/utils/discover/fields';
 import {MeasurementCollection} from 'sentry/utils/measurements/measurements';
 import {SPAN_OP_BREAKDOWN_FIELDS} from 'sentry/utils/performance/spanOperationBreakdowns/constants';
 import {
@@ -122,11 +126,14 @@ export function normalizeQueries({
       }
 
       if (!!query.orderby) {
-        return query;
+        return {
+          ...query,
+          orderby: getAggregateAlias(query.orderby),
+        };
       }
 
       const orderBy =
-        queries[0].orderby ||
+        getAggregateAlias(queries[0].orderby) ||
         (widgetType === WidgetType.DISCOVER
           ? generateOrderOptions({
               widgetType,


### PR DESCRIPTION
Some already persisted widget, have the sortby label saved instead of its value causing the dropdown to be empty when editing a widget. This PR uses the function `getAggregateAlias` inside of the `normalizeQueries`  function, solving the issue.