### PR TITLE
fix(reprocessing): Apply fresh grouping config [ISSUE-1415]

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -854,12 +854,12 @@ def _nodestore_save_many(jobs):
 
         if job["group"]:
             event = job["event"]
-            data = event_processing_store.get(
+            unprocessed = event_processing_store.get(
                 cache_key_for_event({"project": event.project_id, "event_id": event.event_id}),
                 unprocessed=True,
             )
-            if data is not None:
-                subkeys["unprocessed"] = data
+            if unprocessed is not None:
+                subkeys["unprocessed"] = unprocessed
 
         job["event"].data["nodestore_insert"] = inserted_time
         job["event"].data.save(subkeys=subkeys)

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -448,12 +448,10 @@ def test_apply_new_fingerprinting_rules(
     register_event_preprocessor,
     process_and_save,
     burst_task_runner,
-    default_user,
 ):
     """
-    Assert that both unmodified and concurrently inserted events go into "the
-    new group", i.e. the successor of the reprocessed (old) group that
-    inherited the group hashes.
+    Assert that after changing fingerprinting rules, the new fingerprinting config
+    is respected by reprocessing.
     """
 
     @register_event_preprocessor
@@ -511,9 +509,8 @@ def test_apply_new_stack_trace_rules(
     burst_task_runner,
 ):
     """
-    Assert that both unmodified and concurrently inserted events go into "the
-    new group", i.e. the successor of the reprocessed (old) group that
-    inherited the group hashes.
+    Assert that after changing stack trace rules, the new grouping config
+    is respected by reprocessing.
     """
 
     @register_event_preprocessor

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -482,7 +482,6 @@ def test_apply_new_fingerprinting_rules(
     with mock.patch(
         "sentry.event_manager.get_fingerprinting_config_for_project", return_value=new_rules
     ):
-        # TODO: test stack trace rules as well
         # Reprocess
         with burst_task_runner() as burst_reprocess:
             reprocess_group(default_project.id, event1.group_id)

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -1,6 +1,7 @@
 import uuid
 from io import BytesIO
 from time import time
+from unittest import mock
 
 import pytest
 
@@ -8,6 +9,7 @@ from sentry import eventstore
 from sentry.attachments import attachment_cache
 from sentry.event_manager import EventManager
 from sentry.eventstore.processing import event_processing_store
+from sentry.grouping.fingerprinting import FingerprintingRules
 from sentry.models import (
     Activity,
     EventAttachment,
@@ -434,3 +436,64 @@ def test_nodestore_missing(
         )
 
     assert logs == ["reprocessing2.unprocessed_event.not_found"]
+
+
+@pytest.mark.django_db
+@pytest.mark.snuba
+def test_apply_new_grouping_config(
+    default_project,
+    reset_snuba,
+    register_event_preprocessor,
+    process_and_save,
+    burst_task_runner,
+    default_user,
+):
+    """
+    Assert that both unmodified and concurrently inserted events go into "the
+    new group", i.e. the successor of the reprocessed (old) group that
+    inherited the group hashes.
+    """
+
+    @register_event_preprocessor
+    def event_preprocessor(data):
+        extra = data.setdefault("extra", {})
+        extra.setdefault("processing_counter", 0)
+        extra["processing_counter"] += 1
+        return data
+
+    event_id1 = process_and_save({"message": "hello world 1"})
+    event_id2 = process_and_save({"message": "hello world 2"})
+
+    event1 = eventstore.get_event_by_id(default_project.id, event_id1)
+    event2 = eventstore.get_event_by_id(default_project.id, event_id2)
+
+    # Same group, because grouping scrubs integers from message:
+    assert event1.group.id == event2.group.id
+    original_issue_id = event1.group.id
+    assert event1.group.message == "hello world 2"
+
+    # Change fingerprinting rules
+    new_rules = FingerprintingRules.from_config_string(
+        """
+    message:"hello world 1" -> hw1 title="HW1"
+    """
+    )
+
+    with mock.patch(
+        "sentry.event_manager.get_fingerprinting_config_for_project", return_value=new_rules
+    ):
+        # TODO: test stack trace rules as well
+        # Reprocess
+        with burst_task_runner() as burst_reprocess:
+            reprocess_group(default_project.id, event1.group_id)
+        burst_reprocess(max_jobs=100)
+
+    assert is_group_finished(event1.group_id)
+
+    # Events should now be in different groups:
+    event1 = eventstore.get_event_by_id(default_project.id, event_id1)
+    event2 = eventstore.get_event_by_id(default_project.id, event_id2)
+    assert event1.group.id != original_issue_id
+    assert event1.group.id != event2.group.id
+    assert event1.group.message == "hello world 1 HW1"
+    assert event2.group.message == "hello world 2"


### PR DESCRIPTION
Reprocessing is a feature for native platforms intended to re-apply debug files, as stated in our [docs](https://docs.sentry.io/product/issues/reprocessing/):

> Reprocessing allows you to apply debug information files to error events that have already occurred.

The behavior of reprocessing with regards to grouping configuration has been inconsistent: While fingerprinting rules were always taken fresh from the project, stack trace rules and the grouping strategy were taken from the event:

https://github.com/getsentry/sentry/blob/c69ac2e5d8962499659c3b22608911927782d366/src/sentry/event_manager.py#L1716

https://github.com/getsentry/sentry/blob/c69ac2e5d8962499659c3b22608911927782d366/src/sentry/event_manager.py#L392-L394

This PR aligns this behavior by always loading the grouping config from the project when handling a reprocessed event.