### PR TITLE
fix(dashboards): Widget Viewer removes magnifying glass icon in query selector

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -26,7 +26,6 @@ import QuestionTooltip from 'sentry/components/questionTooltip';
 import {parseSearch} from 'sentry/components/searchSyntax/parser';
 import HighlightQuery from 'sentry/components/searchSyntax/renderer';
 import Tooltip from 'sentry/components/tooltip';
-import {IconSearch} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters, SelectValue} from 'sentry/types';
@@ -432,7 +431,6 @@ function WidgetViewerModal(props: Props) {
                         display: 'flex',
                       })}
                     >
-                      <StyledIconSearch />
                       {queryOptions[selectedQueryIndex].getHighlightedQuery({
                         display: 'block',
                       }) ??
@@ -823,10 +821,6 @@ const StyledButtonBar = styled(ButtonBar)`
 
 const EmptyQueryContainer = styled('span')`
   color: ${p => p.theme.disabled};
-`;
-
-const StyledIconSearch = styled(IconSearch)`
-  margin: auto ${space(1.5)} auto 0;
 `;
 
 const StyledSelectControlRowContainer = styled('span')`


### PR DESCRIPTION
Removes the magnifying glass
![image](https://user-images.githubusercontent.com/83961295/161092593-a8a86c4a-9caa-4b9f-8ce8-8157f7a8ecfc.png)
