### PR TITLE
fix(new-widget-builder-experience): Show builder when editing

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -351,11 +351,13 @@ class Dashboard extends Component<Props, State> {
       location,
       paramDashboardId,
       handleAddCustomWidget,
+      isEditing,
     } = this.props;
 
     if (
       organization.features.includes('new-widget-builder-experience') &&
-      !organization.features.includes('new-widget-builder-experience-modal-access')
+      (!organization.features.includes('new-widget-builder-experience-modal-access') ||
+        isEditing)
     ) {
       if (paramDashboardId) {
         router.push({

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -285,7 +285,7 @@ describe('Dashboards > Dashboard', () => {
       expect(screen.getAllByText('Test Discover Widget')).toHaveLength(2);
     });
 
-    it('opens the widget builder when editing with the modal access flag',  function () {
+    it('opens the widget builder when editing with the modal access flag', function () {
       const testData = initializeOrg({
         ...initializeOrg(),
         organization: {

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -285,7 +285,7 @@ describe('Dashboards > Dashboard', () => {
       expect(screen.getAllByText('Test Discover Widget')).toHaveLength(2);
     });
 
-    it('opens the widget builder when editing with the modal access flag', async function () {
+    it('opens the widget builder when editing with the modal access flag',  function () {
       const testData = initializeOrg({
         ...initializeOrg(),
         organization: {

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -241,20 +241,25 @@ describe('Dashboards > Dashboard', () => {
 
   describe('Edit mode', () => {
     let widgets: Widget[];
-    const mount = dashboard => {
+    const mount = (
+      dashboard,
+      mockedOrg = initialData.organization,
+      mockedRouter = initialData.router,
+      mockedLocation = initialData.location
+    ) => {
       const getDashboardComponent = () => (
         <Dashboard
           paramDashboardId="1"
           dashboard={dashboard}
-          organization={initialData.organization}
+          organization={mockedOrg}
           isEditing
           onUpdate={newWidgets => {
             widgets.splice(0, widgets.length, ...newWidgets);
           }}
           handleUpdateWidgetList={() => undefined}
           handleAddCustomWidget={() => undefined}
-          router={initialData.router}
-          location={initialData.location}
+          router={mockedRouter}
+          location={mockedLocation}
           widgetLimitReached={false}
         />
       );
@@ -278,6 +283,40 @@ describe('Dashboards > Dashboard', () => {
       userEvent.click(screen.getByLabelText('Duplicate Widget'));
       rerender();
       expect(screen.getAllByText('Test Discover Widget')).toHaveLength(2);
+    });
+
+    it('opens the widget builder when editing with the modal access flag', async function () {
+      const testData = initializeOrg({
+        ...initializeOrg(),
+        organization: {
+          features: [
+            'dashboards-basic',
+            'dashboards-edit',
+            'dashboard-grid-layout',
+            'new-widget-builder-experience',
+            'new-widget-builder-experience-design',
+          ],
+        },
+      });
+      const dashboardWithOneWidget = {
+        ...mockDashboard,
+        widgets: [newWidget],
+      };
+
+      mount(
+        dashboardWithOneWidget,
+        testData.organization,
+        testData.router,
+        testData.router.location
+      );
+
+      userEvent.click(screen.getByLabelText('Edit Widget'));
+
+      expect(testData.router.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pathname: '/organizations/org-slug/dashboard/1/widget/0/edit/',
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
The builder should be accessible through the edit state's Edit Widget
button even when the modal flag is on.

If it isn't accessible, then we don't have a way to edit using the builder if the modal is turned on.

I removed the `isEditing` by accident when switching the leftover modal pathways to opening the builder. See: https://github.com/getsentry/sentry/pull/33012/files#diff-f31a7455ebe4fc5038b163d509258d674d6804163c903317f953921c2c60ec44L358