### PR TITLE
fix(id-badge): Increase line height in project badges

### DIFF
--- a/static/app/components/idBadge/baseBadge.tsx
+++ b/static/app/components/idBadge/baseBadge.tsx
@@ -74,14 +74,14 @@ const StyledAvatar = styled(Avatar)<{hideName: boolean}>`
 const DisplayNameAndDescription = styled('div')`
   display: flex;
   flex-direction: column;
-  line-height: 1;
+  line-height: 1.2;
   overflow: hidden;
 `;
 
 const DisplayName = styled('span')`
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 1;
+  line-height: 1.2;
 `;
 
 const Description = styled('div')`


### PR DESCRIPTION
We set `line-height: 1;` on display names inside id badges. This results in some characters' descenders being cut off. Using a `line-height` of `1.2` fixes this and does not increase the overall height of the badge.

**Before:**
<img width="202" alt="Screen Shot 2022-03-31 at 10 34 12 AM" src="https://user-images.githubusercontent.com/44172267/161115722-94174fa3-ce71-4474-b8f5-33f9cbd7f0d2.png">

**After:**
<img width="202" alt="Screen Shot 2022-03-31 at 10 34 25 AM" src="https://user-images.githubusercontent.com/44172267/161115765-58d5d6d3-fb34-4b88-841f-a311775409e4.png">