### PR TITLE
fix(page-filters): Date filter spans whole width in Safari

### DIFF
--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -88,7 +88,6 @@ const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
   flex-shrink: 0;
   flex-basis: fit-content;
   position: relative;
-  width: 100%;
   height: 100%;
   background: ${p => p.theme.background};
   border: none;


### PR DESCRIPTION
Looks like Safari interprets `width: 100%` on a flex item as "span the whole width of the flex container". This messes up the filter bar layout.

**Before:**
<img width="457" alt="Screen Shot 2022-03-31 at 10 51 37 AM" src="https://user-images.githubusercontent.com/44172267/161118681-249c6869-0bca-4425-b667-19eec7f0e768.png">

**After:**
<img width="457" alt="Screen Shot 2022-03-31 at 10 51 46 AM" src="https://user-images.githubusercontent.com/44172267/161118714-302bc3cc-eb30-4489-bdcc-8bf6886cc1a2.png">

