### PR TITLE
fix(slack): `AlertRuleTriggerActionSerializer` weirdness

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -121,20 +121,20 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                 )
 
         elif attrs.get("type") == AlertRuleTriggerAction.Type.SENTRY_APP:
+            sentry_app_installation_uuid = attrs.pop("sentry_app_installation_uuid", None)
+
             if not attrs.get("sentry_app"):
                 raise serializers.ValidationError(
                     {"sentry_app": "SentryApp must be provided for sentry_app"}
                 )
             if attrs.get("sentry_app_config"):
-                if attrs.get("sentry_app_installation_uuid") is None:
+                if sentry_app_installation_uuid is None:
                     raise serializers.ValidationError(
                         {"sentry_app": "Missing parameter: sentry_app_installation_uuid"}
                     )
 
                 try:
-                    install = SentryAppInstallation.objects.get(
-                        uuid=attrs.get("sentry_app_installation_uuid")
-                    )
+                    install = SentryAppInstallation.objects.get(uuid=sentry_app_installation_uuid)
                 except SentryAppInstallation.DoesNotExist:
                     raise serializers.ValidationError(
                         {"sentry_app": "The installation does not exist."}
@@ -147,8 +147,6 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
 
                 if not result["success"]:
                     raise serializers.ValidationError({"sentry_app": result["message"]})
-
-                del attrs["sentry_app_installation_uuid"]
 
         attrs["use_async_lookup"] = self.context.get("use_async_lookup")
         attrs["input_channel_id"] = self.context.get("input_channel_id")

--- a/tests/js/spec/views/alerts/issueRuleEditor/ruleNode.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/ruleNode.spec.jsx
@@ -52,7 +52,7 @@ describe('RuleNode', function () {
       },
       //   TODO: Add these fields and test if they implement correctly
       //   exampleMailActionField: {type: 'mailAction'},
-      //   exampleAssigneeield: {type: 'assignee'},
+      //   exampleAssigneeField: {type: 'assignee'},
     },
   });
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -116,7 +116,6 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
         )
         self.rule = self.create_alert_rule()
         trigger = self.create_alert_rule_trigger(self.rule, "hi", 1000)
-        print(trigger)
         self.create_alert_rule_trigger_action(
             alert_rule_trigger=trigger,
             target_identifier=self.sentry_app.id,


### PR DESCRIPTION
Ok this is a weird problem. It looks like when we're asynchronously updating the `input_channel_id` for a _Slack_ `AlertRuleTriggerAction`, we're seeing serialization errors in other parts of the AlertRule.

This PR will fix the problem in this case by always removing the `sentry_app_installation_uuid` field during validation, but a longer term fix would be to prevent a `AlertRuleTriggerAction` of type `SentryApp` from being incorrectly saved without `sentry_app_config`.

Fixes [SENTRY-TMD](https://sentry.io/organizations/sentry/issues/3144468587).