### PR TITLE
fix: Fix integrity errors with EventUser.get_or_create

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -964,7 +964,7 @@ def _get_event_user_impl(project, data, metrics_tags):
         except IntegrityError:
             euser = EventUser.objects.get(
                 project_id=euser.project_id,
-                hash=euser.hash,
+                ident=euser.ident,
             )
             created = False
 


### PR DESCRIPTION
With high enough concurrency it is possible that the insert part of
get_or_create fails because the EvenUser with given project and hash was
created by other worker.

In such a case we will catch the IntegrityError and get the db record.

Fix SENTRY-TME