### PR TITLE
fix(tests): Ticket Rules Futures Flakey Test

### DIFF
--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -19,7 +19,6 @@ class JiraCreateTicketAction(TicketEventAction):
     ticket_type = "a Jira issue"
     link = "https://docs.sentry.io/product/integrations/issue-tracking/jira/#issue-sync"
     provider = "jira"
-    integration_key = "integration"
 
     def clean(self) -> dict[str, Any] | None:
         cleaned_data = super().clean()

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -9,7 +9,6 @@ from django.utils.translation import ugettext_lazy as _
 from sentry.models import Integration
 from sentry.rules.actions.base import TicketEventAction
 from sentry.utils.http import absolute_uri
-from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger("sentry.rules")
 
@@ -52,8 +51,3 @@ class JiraCreateTicketAction(TicketEventAction):
     def translate_integration(self, integration):
         name = integration.metadata.get("domain_name", integration.name)
         return name.replace(".atlassian.net", "")
-
-    @transaction_start("JiraCreateTicketAction.after")
-    def after(self, event, state):
-        self.fix_data_for_issue()
-        yield super().after(event, state)  # type: ignore

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -1,12 +1,7 @@
 import logging
-from typing import Generator
 
-from sentry.eventstore.models import Event
-from sentry.rules import EventState
 from sentry.rules.actions.base import TicketEventAction
-from sentry.rules.base import CallbackFuture
 from sentry.utils.http import absolute_uri
-from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger("sentry.rules")
 
@@ -25,7 +20,3 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
             self.rule.label,  # type: ignore
             absolute_uri(rule_url),
         )
-
-    @transaction_start("AzureDevopsCreateTicketAction.after")
-    def after(self, event: Event, state: EventState) -> Generator[CallbackFuture, None, None]:
-        yield super().after(event, state)  # type: ignore

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -12,7 +12,6 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
     ticket_type = "an Azure DevOps work item"
     link = "https://docs.sentry.io/product/integrations/source-code-mgmt/azure-devops/#issue-sync"
     provider = "vsts"
-    integration_key = "integration"
 
     def generate_footer(self, rule_url: str) -> str:
         return "\nThis work item was automatically created by Sentry via [{}]({})".format(

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -290,8 +290,7 @@ class TicketEventAction(IntegrationEventAction, abc.ABC):
     def after(self, event: Event, state: EventState) -> Generator[CallbackFuture, None, None]:
         integration_id = self.get_integration_id()
         key = f"{self.provider}:{integration_id}"
-        # TODO(mgaeta): Bug: Inheriting functions all _yield_ not return.
-        return self.future(  # type: ignore
+        yield self.future(
             create_issue,
             key=key,
             data=self.data,

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -223,6 +223,7 @@ class TicketEventAction(IntegrationEventAction, abc.ABC):
     """Shared ticket actions"""
 
     form_cls = IntegrationNotifyServiceForm
+    integration_key = "integration"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(IntegrationEventAction, self).__init__(*args, **kwargs)


### PR DESCRIPTION
My current theory is that we're seeing flakey tests because of the inconsistent way we're using generators in python. This PR removes the need to override the parent `after()` definition.

Also I noticed a weird thing where we accidentally put the Jira Ticket Rules validator in the wrong class so I fixed that.