### PR TITLE
fix(Jira): Allow submitting multi user picker field

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -771,10 +771,11 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                         cleaned_data[field] = v
                         continue
                     if schema["type"] == "user" or schema.get("items") == "user":
-                        v = {user_id_field: v}
-                    elif schema.get("custom") == JIRA_CUSTOM_FIELD_TYPES.get("multiuserpicker"):
-                        # custom multi-picker
-                        v = [{user_id_field: v}]
+                        if schema.get("custom") == JIRA_CUSTOM_FIELD_TYPES.get("multiuserpicker"):
+                            # custom multi-picker
+                            v = [{user_id_field: user_id} for user_id in v]
+                        else:
+                            v = {user_id_field: v}
                     elif schema["type"] == "issuelink":  # used by Parent field
                         v = {"key": v}
                     elif schema.get("custom") == JIRA_CUSTOM_FIELD_TYPES["epic"]:


### PR DESCRIPTION
A user ran into an issue where when attempting to use the multi user picker [custom field](https://confluence.atlassian.com/adminjiracloud/custom-fields-types-in-company-managed-projects-972327807.html) they couldn't create a Jira ticket because the data was not in an array as expected by Jira. We actually already special cased the multi user picker field, but the code is very old (copied from the plugin, so at least 4 years old but probably more) so I'm not sure how it used to function. This PR puts the data in the correct format so that the form can be submitted like so: 
<img width="589" alt="Screen Shot 2022-03-31 at 4 10 32 PM" src="https://user-images.githubusercontent.com/29959063/161164341-7565a56c-5169-4792-89ce-3f89bcbbe059.png">

Note that this does not actually turn the field into a multi select - I attempted it but ultimately ran into front end bugs and was not convinced it was worth digging into right now. 
<img width="592" alt="Screen Shot 2022-03-31 at 4 09 37 PM" src="https://user-images.githubusercontent.com/29959063/161164338-ed726ec2-cdec-4a81-817b-e7ff6c290bef.png">
