### PR TITLE
fix(ui): Remove hack to trigger a full app re-render

### DIFF
--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -17,7 +17,6 @@ import {DEPLOY_PREVIEW_CONFIG, EXPERIMENTAL_SPA} from 'sentry/constants';
 import ConfigStore from 'sentry/stores/configStore';
 import HookStore from 'sentry/stores/hookStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
-import OrganizationStore from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {onRenderCallback} from 'sentry/utils/performanceForSentry';
 import useApi from 'sentry/utils/useApi';
@@ -37,9 +36,6 @@ const NewsletterConsent = lazy(() => import('sentry/views/newsletterConsent'));
 function App({children}: Props) {
   const api = useApi();
   const config = useLegacyStore(ConfigStore);
-
-  // XXX(epurkhiser): Soemthing weird is going on
-  const {organization: _unused} = useLegacyStore(OrganizationStore);
 
   // Command palette global-shortcut
   useHotkeys('command+shift+p, command+k, ctrl+shift+p, ctrl+k', e => {


### PR DESCRIPTION
This is no longer needed now that we've identified and fixed the root of
this incident in https://github.com/getsentry/sentry/pull/33191