### PR TITLE
fix(ui): moved discover button back

### DIFF
--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -23,6 +23,7 @@ import IgnoreActions from 'sentry/components/actions/ignore';
 import ResolveActions from 'sentry/components/actions/resolve';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Button from 'sentry/components/button';
+import DiscoverButton from 'sentry/components/discoverButton';
 import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
 import Tooltip from 'sentry/components/tooltip';
 import {IconEllipsis} from 'sentry/icons';
@@ -381,6 +382,13 @@ class Actions extends Component<Props, State> {
         >
           <ReviewAction onUpdate={this.onUpdate} disabled={!group.inbox || disabled} />
         </Tooltip>
+        <DiscoverButton
+          disabled={!hasDiscoverBasic}
+          onClick={this.onRedirectDiscover}
+          size="xsmall"
+        >
+          {t('Open in Discover')}
+        </DiscoverButton>
         {orgFeatures.has('shared-issues') && (
           <ShareIssue
             disabled={disabled}
@@ -396,7 +404,6 @@ class Actions extends Component<Props, State> {
           group={group}
           onClick={this.handleClick(disabled, this.onToggleSubscribe)}
         />
-
         <Access organization={organization} access={['event:admin']}>
           {({hasAccess}) => (
             <GuideAnchor target="open_in_discover">
@@ -413,12 +420,6 @@ class Actions extends Component<Props, State> {
                     label: bookmarkTitle,
                     hidden: false,
                     onAction: this.onToggleBookmark,
-                  },
-                  {
-                    key: 'open-in-discover',
-                    label: t('Open in Discover'),
-                    hidden: !hasDiscoverBasic,
-                    onAction: this.onRedirectDiscover,
                   },
                   {
                     key: 'reprocess',


### PR DESCRIPTION
Moved "Open in Discover" button out of `•••` on Issue Details page

![CleanShot 2022-03-31 at 19 06 13](https://user-images.githubusercontent.com/1900676/161180379-68ac366e-0797-439c-8296-9a881141b0e3.png)
.