### PR TITLE
ref(metrics): Update metrics names with enums in tests

### DIFF
--- a/src/sentry/sentry_metrics/transactions.py
+++ b/src/sentry/sentry_metrics/transactions.py
@@ -1,0 +1,34 @@
+""" Base module for transactions-related metrics """
+from enum import Enum
+
+
+class TransactionMetricKey(Enum):
+    """Identifier for a transaction-related metric
+
+    Values are metric names as submitted by Relay.
+    """
+
+    USER = "sentry.transactions.user"
+    DURATION = "sentry.transactions.transaction.duration"
+    MEASUREMENTS_FCP = "sentry.transactions.measurements.fcp"
+    MEASUREMENTS_LCP = "sentry.transactions.measurements.lcp"
+    MEASUREMENTS_APP_START_COLD = "sentry.transactions.measurements.app_start_cold"
+    MEASUREMENTS_APP_START_WARM = "sentry.transactions.measurements.app_start_warm"
+    MEASUREMENTS_CLS = "sentry.transactions.measurements.cls"
+    MEASUREMENTS_FID = "sentry.transactions.measurements.fid"
+    MEASUREMENTS_FP = "sentry.transactions.measurements.fp"
+    MEASUREMENTS_FRAMES_FROZEN = "sentry.transactions.measurements.frames_frozen"
+    MEASUREMENTS_FRAMES_FROZEN_RATE = "sentry.transactions.measurements.frames_frozen_rate"
+    MEASUREMENTS_FRAMES_SLOW = "sentry.transactions.measurements.frames_slow"
+    MEASUREMENTS_FRAMES_SLOW_RATE = "sentry.transactions.measurements.frames_slow_rate"
+    MEASUREMENTS_FRAMES_TOTAL = "sentry.transactions.measurements.frames_total"
+    MEASUREMENTS_STALL_COUNT = "sentry.transactions.measurements.stall_count"
+    MEASUREMENTS_STALL_LONGEST_TIME = "sentry.transactions.measurements.stall_longest_time"
+    MEASUREMENTS_STALL_PERCENTAGE = "sentry.transactions.measurements.stall_percentage"
+    MEASUREMENTS_STALL_TOTAL_TIME = "sentry.transactions.measurements.stall_total_time"
+    MEASUREMENTS_TTFB = "sentry.transactions.measurements.ttfb"
+    MEASUREMENTS_TTFB_REQUEST_TIME = "sentry.transactions.measurements.ttfb.requesttime"
+    BREAKDOWNS_HTTP = "sentry.transactions.breakdowns.span_ops.http"
+    BREAKDOWNS_DB = "sentry.transactions.breakdowns.span_ops.db"
+    BREAKDOWNS_BROWSER = "sentry.transactions.breakdowns.span_ops.browser"
+    BREAKDOWNS_RESOURCE = "sentry.transactions.breakdowns.span_ops.resource"

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -70,6 +70,7 @@ __all__ = (
     "SingularEntityDerivedMetric",
     "DERIVED_METRICS",
     "generate_bottom_up_dependency_tree_for_metrics",
+    "DerivedMetricKey",
 )
 
 

--- a/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tag_details.py
@@ -2,6 +2,7 @@ import time
 from unittest.mock import patch
 
 from sentry.sentry_metrics import indexer
+from sentry.snuba.metrics.fields.base import DerivedMetricKey
 from sentry.testutils.cases import OrganizationMetricMetaIntegrationTestCase
 from tests.sentry.api.endpoints.test_organization_metrics import MOCKED_DERIVED_METRICS
 
@@ -92,7 +93,10 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
         response = self.get_response(
             self.organization.slug,
             "release",
-            metric=["session.crash_free_rate", "session.all"],
+            metric=[
+                DerivedMetricKey.SESSION_CRASH_FREE_RATE.value,
+                DerivedMetricKey.SESSION_ALL.value,
+            ],
         )
         assert response.data == [{"key": "release", "value": "foobar"}]
 
@@ -107,10 +111,10 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
             )
         )
         for private_name in [
-            "session.crashed_and_abnormal_user",
-            "session.errored_preaggregated",
-            "session.errored_set",
-            "session.errored_user_all",
+            DerivedMetricKey.SESSION_CRASHED_AND_ABNORMAL_USER.value,
+            DerivedMetricKey.SESSION_ERRORED_PREAGGREGATED.value,
+            DerivedMetricKey.SESSION_ERRORED_SET.value,
+            DerivedMetricKey.SESSION_ERRORED_USER_ALL.value,
         ]:
             response = self.get_success_response(
                 self.organization.slug,
@@ -132,7 +136,7 @@ class OrganizationMetricsTagDetailsIntegrationTest(OrganizationMetricMetaIntegra
         response = self.get_success_response(
             self.organization.slug,
             "release",
-            metric=["session.healthy"],
+            metric=[DerivedMetricKey.SESSION_HEALTHY.value],
         )
         assert response.data == [{"key": "release", "value": "foobar@2.0"}]
 

--- a/tests/sentry/api/endpoints/test_organization_metric_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_tags.py
@@ -2,6 +2,7 @@ import time
 from unittest.mock import patch
 
 from sentry.sentry_metrics import indexer
+from sentry.snuba.metrics.fields.base import DerivedMetricKey
 from sentry.testutils.cases import OrganizationMetricMetaIntegrationTestCase
 from tests.sentry.api.endpoints.test_organization_metrics import MOCKED_DERIVED_METRICS
 
@@ -97,7 +98,10 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
 
         response = self.get_success_response(
             self.organization.slug,
-            metric=["session.crash_free_rate", "session.all"],
+            metric=[
+                DerivedMetricKey.SESSION_CRASH_FREE_RATE.value,
+                DerivedMetricKey.SESSION_ALL.value,
+            ],
         )
         assert response.data == [
             {"key": "environment"},
@@ -117,7 +121,7 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
             )
         response = self.get_success_response(
             self.organization.slug,
-            metric=["session.healthy"],
+            metric=[DerivedMetricKey.SESSION_HEALTHY.value],
         )
         assert response.data == [
             {"key": "environment"},
@@ -135,10 +139,10 @@ class OrganizationMetricsTagsIntegrationTest(OrganizationMetricMetaIntegrationTe
             )
         )
         for private_name in [
-            "session.crashed_and_abnormal_user",
-            "session.errored_preaggregated",
-            "session.errored_set",
-            "session.errored_user_all",
+            DerivedMetricKey.SESSION_CRASHED_AND_ABNORMAL_USER.value,
+            DerivedMetricKey.SESSION_ERRORED_PREAGGREGATED.value,
+            DerivedMetricKey.SESSION_ERRORED_SET.value,
+            DerivedMetricKey.SESSION_ERRORED_USER_ALL.value,
         ]:
             response = self.get_success_response(
                 self.organization.slug,

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from sentry.models import ApiToken
 from sentry.snuba.metrics.fields import DERIVED_METRICS, SingularEntityDerivedMetric
+from sentry.snuba.metrics.fields.base import DerivedMetricKey
 from sentry.snuba.metrics.fields.snql import percentage
 from sentry.testutils import APITestCase
 from sentry.testutils.cases import OrganizationMetricMetaIntegrationTestCase
@@ -16,7 +17,10 @@ MOCKED_DERIVED_METRICS.update(
     {
         "crash_free_fake": SingularEntityDerivedMetric(
             metric_name="crash_free_fake",
-            metrics=["session.crashed", "session.errored_set"],
+            metrics=[
+                DerivedMetricKey.SESSION_CRASHED.value,
+                DerivedMetricKey.SESSION_ERRORED_SET.value,
+            ],
             unit="percentage",
             snql=lambda *args, entity, metric_ids, alias=None: percentage(
                 *args, entity, metric_ids, alias="crash_free_fake"


### PR DESCRIPTION
Replaces metric names with enums as soon once we
introduce naming layer, these tests will probably
break otherwise