### PR TITLE
fix(metrics): Auto-create kafka topic ingest-metrics

### DIFF
--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -33,7 +33,7 @@ from confluent_kafka import Producer
 from django.conf import settings
 
 from sentry.utils import json, kafka_config
-from sentry.utils.batching_kafka_consumer import auto_create_topics
+from sentry.utils.batching_kafka_consumer import create_topics
 
 DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000
 DEFAULT_QUEUED_MIN_MESSAGES = 100000
@@ -696,7 +696,7 @@ def get_streaming_metrics_consumer(
             commit_max_batch_time=commit_max_batch_time,
         )
 
-    auto_create_topics([topic])
+    create_topics([topic])
 
     return StreamProcessor(
         KafkaConsumer(get_config(topic, group_id, auto_offset_reset)),

--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -33,6 +33,7 @@ from confluent_kafka import Producer
 from django.conf import settings
 
 from sentry.utils import json, kafka_config
+from sentry.utils.batching_kafka_consumer import auto_create_topics
 
 DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000
 DEFAULT_QUEUED_MIN_MESSAGES = 100000
@@ -694,6 +695,8 @@ def get_streaming_metrics_consumer(
             commit_max_batch_size=commit_max_batch_size,
             commit_max_batch_time=commit_max_batch_time,
         )
+
+    auto_create_topics([topic])
 
     return StreamProcessor(
         KafkaConsumer(get_config(topic, group_id, auto_offset_reset)),

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -17,7 +17,7 @@ from sentry.snuba.json_schemas import SUBSCRIPTION_PAYLOAD_VERSIONS, SUBSCRIPTIO
 from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.snuba.tasks import _delete_from_snuba
 from sentry.utils import json, kafka_config, metrics
-from sentry.utils.batching_kafka_consumer import auto_create_topics
+from sentry.utils.batching_kafka_consumer import create_topics
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +159,7 @@ class QuerySubscriptionConsumer:
         self.consumer = Consumer(self.cluster_options)
         self.__shutdown_requested = False
 
-        auto_create_topics([self.topic])
+        create_topics([self.topic])
 
         self.consumer.subscribe([self.topic], on_assign=on_assign, on_revoke=on_revoke)
 

--- a/src/sentry/utils/batching_kafka_consumer.py
+++ b/src/sentry/utils/batching_kafka_consumer.py
@@ -57,6 +57,23 @@ def wait_for_topics(admin_client: AdminClient, topics: List[str], timeout: int =
                 )
 
 
+def auto_create_topics(topics: List[str]):
+    """If configured to do so, create topics and make sure that they exist
+
+    topics must be from the same cluster.
+    """
+    if settings.KAFKA_CONSUMER_AUTO_CREATE_TOPICS:
+        cluster_names = {settings.KAFKA_TOPICS[topic]["cluster"] for topic in topics}
+        assert len(cluster_names) == 1
+        # This is required for confluent-kafka>=1.5.0, otherwise the topics will
+        # not be automatically created.
+        conf = kafka_config.get_kafka_admin_cluster_options(
+            cluster_names.pop(), override_params={"allow.auto.create.topics": "true"}
+        )
+        admin_client = AdminClient(conf)
+        wait_for_topics(admin_client, topics)
+
+
 class KafkaConsumerFacade(abc.ABC):
     """
     Kafka consumer facade which defines the minimal set of methods to be implemented in order to be used as a consumer
@@ -292,14 +309,7 @@ class BatchingKafkaConsumer:
             },
         )
 
-        if settings.KAFKA_CONSUMER_AUTO_CREATE_TOPICS:
-            # This is required for confluent-kafka>=1.5.0, otherwise the topics will
-            # not be automatically created.
-            conf = kafka_config.get_kafka_admin_cluster_options(
-                cluster_name, override_params={"allow.auto.create.topics": "true"}
-            )
-            admin_client = AdminClient(conf)
-            wait_for_topics(admin_client, topics)
+        auto_create_topics(topics)
 
         consumer = Consumer(consumer_config)
 

--- a/src/sentry/utils/batching_kafka_consumer.py
+++ b/src/sentry/utils/batching_kafka_consumer.py
@@ -57,7 +57,7 @@ def wait_for_topics(admin_client: AdminClient, topics: List[str], timeout: int =
                 )
 
 
-def auto_create_topics(topics: List[str]):
+def create_topics(topics: List[str]):
     """If configured to do so, create topics and make sure that they exist
 
     topics must be from the same cluster.
@@ -309,7 +309,7 @@ class BatchingKafkaConsumer:
             },
         )
 
-        auto_create_topics(topics)
+        create_topics(topics)
 
         consumer = Consumer(consumer_config)
 


### PR DESCRIPTION
When setting up a fresh sentry dev environment with the following settings:

```python
# Required for writing metrics to Snuba
SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"

# Required to run the metrics consumer in Sentry
SENTRY_USE_METRICS_DEV = True
```

running `sentry devservices up --workers` would fail with

```
arroyo.errors.ConsumerError: KafkaError{code=UNKNOWN_TOPIC_OR_PART,val=3,str="Subscribed topic not available: ingest-metrics: Broker: Unknown topic or partition"}
```

because the necessary topic was not automatically created.
This PR solves the problem by calling `auto_create_topic` in `get_streaming_metrics_consumer`.