### PR TITLE
fix(dashboards): Update widget validation to use query builder

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -194,9 +194,6 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
             data["discover_query_error"] = {"conditions": [f"Invalid conditions: {err}"]}
             return data
 
-        if orderby:
-            builder.resolve_orderby(orderby)
-
         # TODO(dam): Add validation for metrics fields/queries
         try:
             builder.resolve_select(fields, equations)
@@ -206,6 +203,11 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
             # Widget serializer to decide if whether or not to raise this
             # error based on the Widget's type
             data["discover_query_error"] = {"fields": f"Invalid fields: {err}"}
+
+        try:
+            builder.resolve_orderby(orderby)
+        except (InvalidSearchQuery) as err:
+            data["discover_query_error"] = {"orderby": f"Invalid orderby: {err}"}
 
         return data
 

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -7,7 +7,7 @@ from rest_framework import serializers
 from sentry.api.issue_search import parse_search_query
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
-from sentry.discover.arithmetic import ArithmeticError, categorize_columns, resolve_equation_list
+from sentry.discover.arithmetic import ArithmeticError, categorize_columns
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import (
     Dashboard,
@@ -16,8 +16,8 @@ from sentry.models import (
     DashboardWidgetQuery,
     DashboardWidgetTypes,
 )
-from sentry.search.events.fields import get_function_alias, resolve_field_list
-from sentry.search.events.filter import get_filter
+from sentry.search.events.builder import UnresolvedQuery
+from sentry.snuba.dataset import Dataset
 from sentry.utils.dates import parse_stats_period
 
 AGGREGATE_PATTERN = r"^(\w+)\((.*)?\)$"
@@ -161,19 +161,6 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
             data["columns"] = columns
             data["aggregates"] = aggregates
 
-        if equations is not None:
-            try:
-                resolved_equations, _, _ = resolve_equation_list(
-                    equations,
-                    fields,
-                    auto_add=not is_table,
-                    aggregates_only=not is_table,
-                )
-            except (InvalidSearchQuery, ArithmeticError) as err:
-                raise serializers.ValidationError({"fields": f"Invalid fields: {err}"})
-        else:
-            resolved_equations = []
-
         try:
             parse_search_query(conditions)
         except InvalidSearchQuery as err:
@@ -195,18 +182,25 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
                 "organization_id": self.context.get("organization").id,
             }
 
-            snuba_filter = get_filter(conditions, params=params)
+            builder = UnresolvedQuery(
+                dataset=Dataset.Discover,
+                params=params,
+                equation_config={"auto_add": not is_table, "aggregates_only": not is_table},
+            )
+
+            builder.resolve_conditions(conditions, use_aggregate_conditions=True)
+            builder.resolve_params()
         except InvalidSearchQuery as err:
             data["discover_query_error"] = {"conditions": [f"Invalid conditions: {err}"]}
             return data
 
         if orderby:
-            snuba_filter.orderby = get_function_alias(orderby)
+            builder.resolve_orderby(orderby)
 
         # TODO(dam): Add validation for metrics fields/queries
         try:
-            resolve_field_list(fields, snuba_filter, resolved_equations=resolved_equations)
-        except InvalidSearchQuery as err:
+            builder.resolve_select(fields, equations)
+        except (InvalidSearchQuery, ArithmeticError) as err:
             # We don't know if the widget that this query belongs to is an
             # Issue widget or Discover widget. Pass the error back to the
             # Widget serializer to decide if whether or not to raise this

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -16,7 +16,12 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             "title": "Errors over time",
             "displayType": "line",
             "queries": [
-                {"name": "errors", "conditions": "event.type:error", "fields": ["count()"]}
+                {"name": "errors", "conditions": "event.type:error", "fields": ["count()"]},
+                {
+                    "name": "errors",
+                    "conditions": "(level:error OR title:*Error*) !release:latest",
+                    "fields": ["count()"],
+                },
             ],
         }
         response = self.do_request(


### PR DESCRIPTION
Some widget validation was failing on release filters eventhough
it was a valid condition, possibly because the get_filter
code is getting stale. Switched over to use Query Builder to
validate widgets instead

![Screen Shot 2022-04-01 at 11 49 58 AM](https://user-images.githubusercontent.com/63818634/161298286-b942411c-7b5b-4537-a32f-8d0e3b6c7a9c.png)
.