### PR TITLE
fix(dashboards): Template Toggle in Safari

### DIFF
--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -284,7 +284,7 @@ class ManageDashboards extends AsyncView<Props, State> {
             <NoProjectMessage organization={organization}>
               <PageContent>
                 <StyledPageHeader>
-                  <Title>{t('Dashboards')}</Title>
+                  <StyledTitle>{t('Dashboards')}</StyledTitle>
                   <ButtonBar gap={1.5}>
                     <Feature
                       organization={organization}
@@ -323,6 +323,10 @@ class ManageDashboards extends AsyncView<Props, State> {
     );
   }
 }
+
+const StyledTitle = styled(Title)`
+  width: auto;
+`;
 
 const StyledPageContent = styled(PageContent)`
   padding: 0;


### PR DESCRIPTION
- This fixes the template toggle in safari so it no longer overlaps with
  the add dashboard button

### Preview
#### Before
<img width="1226" alt="image" src="https://user-images.githubusercontent.com/4205004/161306832-e502f82c-bbc6-428b-96cd-03f219319a6e.png">


#### After
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/4205004/161306783-33f3cef9-77f0-48b4-a43f-c8c7584c7b21.png">
