### PR TITLE
fix(jira): Error message copy

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from collections import namedtuple
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Mapping, Optional, Sequence
+from typing import Any, Dict, FrozenSet, Mapping, MutableMapping, Optional, Sequence
 from urllib.request import Request
 
 from django.views import View
@@ -295,7 +295,7 @@ class IntegrationInstallation:
         """
         return []
 
-    def update_organization_config(self, data: Mapping[str, Any]) -> None:
+    def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
         """
         Update the configuration field for an organization integration.
         """

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import re
 from operator import attrgetter
@@ -835,8 +837,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
     def sync_assignee_outbound(
         self,
-        external_issue: "ExternalIssue",
-        user: Optional["User"],
+        external_issue: ExternalIssue,
+        user: Optional[User],
         assign: bool = True,
         **kwargs: Any,
     ) -> None:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -607,15 +607,15 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 },
             )
             raise IntegrationError(
-                "Could not fetch project list from Jira"
-                "Ensure that jira is available and your account is still active."
+                "Could not fetch project list from Jira. Ensure that Jira is"
+                " available and your account is still active."
             )
 
         meta = self.get_issue_create_meta(client, project_id, jira_projects)
         if not meta:
             raise IntegrationError(
-                "Could not fetch issue create metadata from Jira. "
-                "Ensure that the integration user has access to the requested project."
+                "Could not fetch issue create metadata from Jira. Ensure that"
+                " the integration user has access to the requested project."
             )
 
         # check if the issuetype was passed as a parameter


### PR DESCRIPTION
I noticed a problem with the error message on the Issues page. This PR adds a space between "jira" and "ensure".

Before:
![Screen Shot 2022-04-01 at 11 21 23 AM](https://user-images.githubusercontent.com/31750075/161320404-584bcccc-55a9-4830-be0c-ec5c2a93e1f2.png)
