### PR TITLE
feat(replay): Fix project filters on index page

### DIFF
--- a/static/app/views/replays/index.tsx
+++ b/static/app/views/replays/index.tsx
@@ -4,14 +4,12 @@ import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
-import {Organization, PageFilters} from 'sentry/types';
+import {Organization} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
-import withPageFilters from 'sentry/utils/withPageFilters';
 
 type Props = RouteComponentProps<{}, {}> & {
   children: React.ReactChildren;
   organization: Organization;
-  selection: PageFilters;
 };
 
 function ReplaysContainer({organization, children}: Props) {
@@ -34,4 +32,4 @@ function ReplaysContainer({organization, children}: Props) {
   );
 }
 
-export default withPageFilters(withOrganization(ReplaysContainer));
+export default withOrganization(ReplaysContainer);

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import FeatureBadge from 'sentry/components/featureBadge';
 import Link from 'sentry/components/links/link';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import PageHeading from 'sentry/components/pageHeading';
 import {Panel, PanelBody, PanelItem} from 'sentry/components/panels';
@@ -93,7 +94,7 @@ class Replays extends React.Component<Props> {
               >
                 {data => {
                   if (data.isLoading) {
-                    return <div>Loading</div>;
+                    return <LoadingIndicator />;
                   }
                   return this.renderTable(data.tableData.data);
                 }}

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -1,20 +1,21 @@
+import * as React from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
-import AsyncComponent from 'sentry/components/asyncComponent';
 import FeatureBadge from 'sentry/components/featureBadge';
 import Link from 'sentry/components/links/link';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import PageHeading from 'sentry/components/pageHeading';
-import Pagination from 'sentry/components/pagination';
 import {Panel, PanelBody, PanelItem} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
 import {PageContent, PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
-import {Organization} from 'sentry/types';
+import {NewQuery, Organization, PageFilters} from 'sentry/types';
+import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 import withOrganization from 'sentry/utils/withOrganization';
+import withPageFilters from 'sentry/utils/withPageFilters';
 import AsyncView from 'sentry/views/asyncView';
 
 import {Replay} from './types';
@@ -22,45 +23,54 @@ import {Replay} from './types';
 type Props = AsyncView['props'] &
   WithRouterProps<{orgId: string}> & {
     organization: Organization;
+    selection: PageFilters;
     statsPeriod?: string | undefined; // revisit i'm sure i'm doing statsperiod wrong
   };
 
-type State = AsyncView['state'] & {
-  replayList: Replay[] | null;
-};
+class Replays extends React.Component<Props> {
+  getEventView() {
+    const {location, selection} = this.props;
 
-class Replays extends AsyncView<Props, State> {
-  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {organization, statsPeriod, location} = this.props;
-
-    const eventView = EventView.fromSavedQuery({
+    const eventQueryParams: NewQuery = {
       id: '',
       name: '',
       version: 2,
       fields: ['eventID', 'timestamp', 'replayId'],
       orderby: '-timestamp',
-      projects: [],
-      range: statsPeriod,
+      environment: selection.environments,
+      projects: selection.projects,
       query: 'transaction:sentry-replay', // future: change to replay event
-    });
-    const apiPayload = eventView.getEventsAPIPayload(location);
-    return [
-      ['eventData', `/organizations/${organization.slug}/eventsv2/`, {query: apiPayload}],
-    ];
+    };
+
+    if (selection.datetime.period) {
+      eventQueryParams.range = selection.datetime.period;
+    }
+    return EventView.fromNewQueryWithLocation(eventQueryParams, location);
   }
+
   getTitle() {
     return `Replays - ${this.props.params.orgId}`;
   }
 
-  renderLoading() {
-    return <PageContent>{super.renderLoading()}</PageContent>;
+  renderTable(replayList: Array<Replay>) {
+    const {organization} = this.props;
+    return replayList?.map(replay => (
+      <PanelItemCentered key={replay.id}>
+        <Link
+          to={`/organizations/${organization.slug}/replays/${generateEventSlug({
+            project: replay['project.name'],
+            id: replay.id,
+          })}/`}
+        >
+          {replay.timestamp}
+        </Link>
+        {replay.replayId}
+      </PanelItemCentered>
+    ));
   }
 
-  renderBody() {
-    const {eventData, replayListPageLinks} = this.state;
+  render() {
     const {organization} = this.props;
-
-    const replayList = eventData.data;
     return (
       <PageFiltersContainer
         showEnvironmentSelector={false}
@@ -76,24 +86,20 @@ class Replays extends AsyncView<Props, State> {
           </PageHeader>
           <Panel>
             <PanelBody>
-              {replayList?.map(replay => (
-                <PanelItemCentered key={replay.id}>
-                  <Link
-                    to={`/organizations/${organization.slug}/replays/${generateEventSlug({
-                      project: replay['project.name'],
-                      id: replay.id,
-                    })}/`}
-                  >
-                    {replay.timestamp}
-                  </Link>
-                  {replay.replayId}
-                </PanelItemCentered>
-              ))}
+              <DiscoverQuery
+                eventView={this.getEventView()}
+                location={this.props.location}
+                orgSlug={organization.slug}
+              >
+                {data => {
+                  if (data.isLoading) {
+                    return <div>Loading</div>;
+                  }
+                  return this.renderTable(data.tableData.data);
+                }}
+              </DiscoverQuery>
             </PanelBody>
           </Panel>
-          {replayListPageLinks && (
-            <Pagination pageLinks={replayListPageLinks} {...this.props} />
-          )}
         </PageContent>
       </PageFiltersContainer>
     );
@@ -114,4 +120,4 @@ const PanelItemCentered = styled(PanelItem)`
   padding: ${space(2)};
 `;
 
-export default withRouter(withOrganization(Replays));
+export default withRouter(withPageFilters(withOrganization(Replays)));

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -1,7 +1,7 @@
 export type Replay = {
-  dateCreated: string;
-
   eventID: string;
   id: string;
   projectID: string;
+  replayId: string;
+  timestamp: string;
 };


### PR DESCRIPTION
Achieved primarily by refactoring from `AsyncComponent` to instead use the `DiscoverQuery` component.