### PR TITLE
fix(tests): UserRole Flakey Test

### DIFF
--- a/tests/sentry/api/endpoints/test_user_role_details.py
+++ b/tests/sentry/api/endpoints/test_user_role_details.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sentry.models import UserRole
 from sentry.testutils import APITestCase
 
@@ -61,7 +59,6 @@ class UserUserRolesCreateTest(UserUserRolesTest, PermissionTestMixin):
         resp = self.get_response("me", "blah")
         assert resp.status_code == 404
 
-    @pytest.mark.xfail
     def test_existing_role(self):
         role = UserRole.objects.create(name="support", permissions=["broadcasts.admin"])
         role.users.add(self.user)


### PR DESCRIPTION
We were skipping this test because `role.users.add(user)` doesn't raise an error the way we want to. This PR just uses a `get_or_create()` on the cross table manually.
