### PR TITLE
fix(tests): Slack Notification Flakey Test

### DIFF
--- a/tests/sentry/integrations/slack/notifications/test_deploy.py
+++ b/tests/sentry/integrations/slack/notifications/test_deploy.py
@@ -52,7 +52,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest):
         )
 
         first_project = None
-        for i in range(2):
+        for i in range(len(projects)):
             project = SLUGS_TO_PROJECT[attachment["actions"][i]["text"]]
             if not first_project:
                 first_project = project


### PR DESCRIPTION
This test was making assertions about the order of Projects in a Slack notification. This failed occasionally. This PR breaks the dependency on order.