### PR TITLE
fix(tests): Join Organization Request Flakey Test

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -132,10 +132,11 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest):
             "join_request.created", member_id=join_request.id, organization_id=self.organization.id
         )
 
+        users_able_to_approve_requests = {user1, user2}
         expected_subject = f"Access request to {self.organization.name}"
-        assert len(mail.outbox) == 2
+        assert len(mail.outbox) == len(users_able_to_approve_requests)
         for i in range(len(mail.outbox)):
-            assert mail.outbox[i].to in ([user.email] for user in (user1, user2))
+            assert mail.outbox[i].to in ([user.email] for user in users_able_to_approve_requests)
             assert mail.outbox[i].subject == expected_subject
 
     @responses.activate

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -132,13 +132,11 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest):
             "join_request.created", member_id=join_request.id, organization_id=self.organization.id
         )
 
-        assert len(mail.outbox) == 2
-
-        assert mail.outbox[0].to == ["manager@localhost"]
-        assert mail.outbox[1].to == ["owner@localhost"]
-
         expected_subject = f"Access request to {self.organization.name}"
-        assert mail.outbox[0].subject == expected_subject
+        assert len(mail.outbox) == 2
+        for i in range(len(mail.outbox)):
+            assert mail.outbox[i].to in ([user.email] for user in (user1, user2))
+            assert mail.outbox[i].subject == expected_subject
 
     @responses.activate
     def test_request_to_join_slack(self):


### PR DESCRIPTION
This test relies on emails hitting the Django inbox in order. This PR allows them to appear in any order.