### PR TITLE
ref(page-filters): Team filter bar min width

### DIFF
--- a/static/app/views/alerts/rules/filter.tsx
+++ b/static/app/views/alerts/rules/filter.tsx
@@ -173,6 +173,7 @@ const Header = styled('div')`
 const StyledDropdownButton = styled(DropdownButton)`
   white-space: nowrap;
   max-width: 200px;
+  min-width: 180px;
 
   z-index: ${p => p.theme.zIndex.dropdown};
 `;


### PR DESCRIPTION
This is to avoid the bar from expanding when clicking multiple options and pushing the other elements to the right

![2022-04-01 10 07 41](https://user-images.githubusercontent.com/9372512/161353534-b5ca2b74-e165-4c0b-8fba-5bd14aacbe16.gif)

