### PR TITLE
ref(ui): Import as type in type files

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/types.tsx
+++ b/static/app/components/events/interfaces/debugMeta/types.tsx
@@ -1,4 +1,4 @@
-import {combineStatus} from './utils';
+import type {combineStatus} from './utils';
 
 export type DebugStatus = ReturnType<typeof combineStatus>;
 

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -1,4 +1,4 @@
-import {Fuse} from 'sentry/utils/fuzzySearch';
+import type {Fuse} from 'sentry/utils/fuzzySearch';
 
 export type GapSpanType = {
   isOrphan: boolean;

--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -17,7 +17,7 @@ import RouteSource from 'sentry/components/search/sources/routeSource';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
-import {Fuse} from 'sentry/utils/fuzzySearch';
+import type {Fuse} from 'sentry/utils/fuzzySearch';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 
 import {Result} from './sources/types';

--- a/static/app/components/search/sources/index.tsx
+++ b/static/app/components/search/sources/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import flatten from 'lodash/flatten';
 
-import {Fuse} from 'sentry/utils/fuzzySearch';
+import type {Fuse} from 'sentry/utils/fuzzySearch';
 
 import {Result} from './types';
 

--- a/static/app/components/search/sources/types.tsx
+++ b/static/app/components/search/sources/types.tsx
@@ -1,4 +1,4 @@
-import {Fuse} from 'sentry/utils/fuzzySearch';
+import type {Fuse} from 'sentry/utils/fuzzySearch';
 
 /**
  * A result item that sources create.

--- a/static/app/components/search/sources/utils.tsx
+++ b/static/app/components/search/sources/utils.tsx
@@ -3,7 +3,7 @@
 // eslint-disable-next-line no-restricted-imports
 import get from 'lodash/get';
 
-import {Fuse} from 'sentry/utils/fuzzySearch';
+import type {Fuse} from 'sentry/utils/fuzzySearch';
 
 /**
  * A value getter for fuse that will ensure the result is a string.

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -1,5 +1,6 @@
-import {IssueConfigField} from 'sentry/types/index';
-import {SchemaFormConfig} from 'sentry/views/organizationIntegrations/sentryAppExternalForm';
+import type {SchemaFormConfig} from 'sentry/views/organizationIntegrations/sentryAppExternalForm';
+
+import type {IssueConfigField} from './integrations';
 
 type IssueAlertRuleFormField =
   | {

--- a/static/app/types/auth.tsx
+++ b/static/app/types/auth.tsx
@@ -1,8 +1,8 @@
-import u2f from 'u2f-api';
+import type u2f from 'u2f-api';
 
-import {Field} from 'sentry/components/forms/type';
+import type {Field} from 'sentry/components/forms/type';
 
-import {Organization} from './organization';
+import type {Organization} from './organization';
 
 export type AuthenticatorDevice = {
   authId: string;

--- a/static/app/types/breadcrumbs.tsx
+++ b/static/app/types/breadcrumbs.tsx
@@ -1,5 +1,5 @@
-import SvgIcon from 'sentry/icons/svgIcon';
-import {Color} from 'sentry/utils/theme';
+import type SvgIcon from 'sentry/icons/svgIcon';
+import type {Color} from 'sentry/utils/theme';
 
 export type IconProps = React.ComponentProps<typeof SvgIcon>;
 

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -4,8 +4,8 @@
  * Before a type is put here it should be required in multiple other types.
  * or used in multiple views.
  */
-import {getInterval} from 'sentry/components/charts/utils';
-import {API_ACCESS_SCOPES} from 'sentry/constants';
+import type {getInterval} from 'sentry/components/charts/utils';
+import type {API_ACCESS_SCOPES} from 'sentry/constants';
 
 /**
  * Visual representation of a project/team/organization/user

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -1,12 +1,12 @@
-import {DebugImage} from 'sentry/components/events/interfaces/debugMeta/types';
-import {TraceContextType} from 'sentry/components/events/interfaces/spans/types';
-import {SymbolicatorStatus} from 'sentry/components/events/interfaces/types';
-import {PlatformKey} from 'sentry/data/platformCategories';
+import type {DebugImage} from 'sentry/components/events/interfaces/debugMeta/types';
+import type {TraceContextType} from 'sentry/components/events/interfaces/spans/types';
+import type {SymbolicatorStatus} from 'sentry/components/events/interfaces/types';
+import type {PlatformKey} from 'sentry/data/platformCategories';
 
-import {RawCrumb} from './breadcrumbs';
-import {IssueAttachment} from './group';
-import {Release} from './release';
-import {RawStacktrace, StackTraceMechanism, StacktraceType} from './stacktrace';
+import type {RawCrumb} from './breadcrumbs';
+import type {IssueAttachment} from './group';
+import type {Release} from './release';
+import type {RawStacktrace, StackTraceMechanism, StacktraceType} from './stacktrace';
 
 // TODO(epurkhiser): objc and cocoa should almost definitely be moved into PlatformKey
 export type PlatformType = PlatformKey | 'objc' | 'cocoa';

--- a/static/app/types/experiments.tsx
+++ b/static/app/types/experiments.tsx
@@ -1,4 +1,4 @@
-import {experimentList, unassignedValue} from 'sentry/data/experimentConfig';
+import type {experimentList, unassignedValue} from 'sentry/data/experimentConfig';
 
 /**
  * The grouping of the experiment

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -1,12 +1,12 @@
 import {PlatformKey} from 'sentry/data/platformCategories';
 
-import {Actor, TimeseriesValue} from './core';
-import {Event, EventMetadata, EventOrGroupType, Level} from './event';
-import {Commit, PullRequest} from './integrations';
-import {Team} from './organization';
-import {Project} from './project';
-import {Release} from './release';
-import {AvatarUser, User} from './user';
+import type {Actor, TimeseriesValue} from './core';
+import type {Event, EventMetadata, EventOrGroupType, Level} from './event';
+import type {Commit, PullRequest} from './integrations';
+import type {Team} from './organization';
+import type {Project} from './project';
+import type {Release} from './release';
+import type {AvatarUser, User} from './user';
 
 export type EntryData = Record<string, any | Array<any>>;
 

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -1,4 +1,4 @@
-import {PlatformKey} from 'sentry/data/platformCategories';
+import type {PlatformKey} from 'sentry/data/platformCategories';
 
 import type {Actor, TimeseriesValue} from './core';
 import type {Event, EventMetadata, EventOrGroupType, Level} from './event';

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -1,19 +1,16 @@
-import {Route, RouteComponentProps} from 'react-router';
+import type {Route, RouteComponentProps} from 'react-router';
 
-import {ChildrenRenderFn} from 'sentry/components/acl/feature';
-import DateRange from 'sentry/components/organizations/timeRangeSelector/dateRange';
-import SelectorItems from 'sentry/components/organizations/timeRangeSelector/selectorItems';
-import SidebarItem from 'sentry/components/sidebar/sidebarItem';
-import {
-  Integration,
-  IntegrationProvider,
-  Member,
-  Organization,
-  Project,
-  User,
-} from 'sentry/types';
-import {ExperimentKey} from 'sentry/types/experiments';
-import {NavigationItem, NavigationSection} from 'sentry/views/settings/types';
+import type {ChildrenRenderFn} from 'sentry/components/acl/feature';
+import type DateRange from 'sentry/components/organizations/timeRangeSelector/dateRange';
+import type SelectorItems from 'sentry/components/organizations/timeRangeSelector/selectorItems';
+import type SidebarItem from 'sentry/components/sidebar/sidebarItem';
+import type {NavigationItem, NavigationSection} from 'sentry/views/settings/types';
+
+import type {ExperimentKey} from './experiments';
+import type {Integration, IntegrationProvider} from './integrations';
+import type {Member, Organization} from './organization';
+import type {Project} from './project';
+import type {User} from './user';
 
 // XXX(epurkhiser): A Note about `_`.
 //

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -1,16 +1,16 @@
-import Alert from 'sentry/components/alert';
-import {Field} from 'sentry/components/forms/type';
-import {PlatformKey} from 'sentry/data/platformCategories';
-import {
+import type Alert from 'sentry/components/alert';
+import type {Field} from 'sentry/components/forms/type';
+import type {PlatformKey} from 'sentry/data/platformCategories';
+import type {
   DISABLED as DISABLED_STATUS,
   INSTALLED,
   NOT_INSTALLED,
   PENDING,
 } from 'sentry/views/organizationIntegrations/constants';
 
-import {Avatar, Choices, ObjectStatus, Scope} from './core';
-import {BaseRelease} from './release';
-import {User} from './user';
+import type {Avatar, Choices, ObjectStatus, Scope} from './core';
+import type {BaseRelease} from './release';
+import type {User} from './user';
 
 export type PermissionValue = 'no-access' | 'read' | 'write' | 'admin';
 

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -1,4 +1,4 @@
-import {AvatarUser} from './user';
+import type {AvatarUser} from './user';
 
 export enum OnboardingTaskKey {
   FIRST_PROJECT = 'create_project',

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -1,9 +1,9 @@
-import {Actor, Avatar, ObjectStatus, Scope} from './core';
-import {OrgExperiments} from './experiments';
-import {ExternalTeam} from './integrations';
-import {OnboardingTaskStatus} from './onboarding';
-import {Relay} from './relay';
-import {User} from './user';
+import type {Actor, Avatar, ObjectStatus, Scope} from './core';
+import type {OrgExperiments} from './experiments';
+import type {ExternalTeam} from './integrations';
+import type {OnboardingTaskStatus} from './onboarding';
+import type {Relay} from './relay';
+import type {User} from './user';
 
 /**
  * Organization summaries are sent when you request a

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -1,11 +1,11 @@
-import {PlatformKey} from 'sentry/data/platformCategories';
+import type {PlatformKey} from 'sentry/data/platformCategories';
 
-import {TimeseriesValue} from './core';
-import {DynamicSamplingRules} from './dynamicSampling';
-import {SDKUpdatesSuggestion} from './event';
-import {Plugin} from './integrations';
-import {Organization, Team} from './organization';
-import {Deploy, Release} from './release';
+import type {TimeseriesValue} from './core';
+import type {DynamicSamplingRules} from './dynamicSampling';
+import type {SDKUpdatesSuggestion} from './event';
+import type {Plugin} from './integrations';
+import type {Organization, Team} from './organization';
+import type {Deploy, Release} from './release';
 
 // Minimal project representation for use with avatars.
 export type AvatarProject = {

--- a/static/app/types/react-router.d.ts
+++ b/static/app/types/react-router.d.ts
@@ -1,6 +1,6 @@
-import {ComponentClass, ComponentType, StatelessComponent} from 'react';
-import {InjectedRouter, PlainRoute, WithRouterProps} from 'react-router';
-import {Location} from 'history';
+import type {ComponentClass, ComponentType, StatelessComponent} from 'react';
+import type {InjectedRouter, PlainRoute, WithRouterProps} from 'react-router';
+import type {Location} from 'history';
 
 declare module 'react-router' {
   interface InjectedRouter<P = Record<string, string>, Q = any> {

--- a/static/app/types/reflux.d.ts
+++ b/static/app/types/reflux.d.ts
@@ -1,5 +1,8 @@
-import {SafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
-import {Store, StoreDefinition} from 'reflux';
+import type {
+  SafeRefluxStore,
+  SafeStoreDefinition,
+} from 'sentry/utils/makeSafeRefluxStore';
+import type {Store, StoreDefinition} from 'reflux';
 
 declare module 'reflux' {
   function createStore<T extends SafeStoreDefinition | StoreDefinition>(

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -1,8 +1,8 @@
-import {PlatformKey} from 'sentry/data/platformCategories';
+import type {PlatformKey} from 'sentry/data/platformCategories';
 
-import {TimeseriesValue} from './core';
-import {Commit} from './integrations';
-import {User} from './user';
+import type {TimeseriesValue} from './core';
+import type {Commit} from './integrations';
+import type {User} from './user';
 
 export enum ReleaseStatus {
   Active = 'open',

--- a/static/app/types/stacktrace.tsx
+++ b/static/app/types/stacktrace.tsx
@@ -1,4 +1,4 @@
-import {Frame} from 'sentry/types';
+import type {Frame} from './event';
 
 export enum STACK_VIEW {
   RAW = 'raw',

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -1,8 +1,8 @@
-import {FocusTrap} from 'focus-trap';
+import type {FocusTrap} from 'focus-trap';
 
-import exportGlobals from 'sentry/bootstrap/exportGlobals';
+import type exportGlobals from 'sentry/bootstrap/exportGlobals';
 
-import {User} from './user';
+import type {User} from './user';
 
 export enum SentryInitRenderReactComponent {
   INDICATORS = 'Indicators',

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -1,6 +1,6 @@
-import {Authenticator, EnrolledAuthenticator} from './auth';
-import {Avatar, Scope} from './core';
-import {UserExperiments} from './experiments';
+import type {Authenticator, EnrolledAuthenticator} from './auth';
+import type {Avatar, Scope} from './core';
+import type {UserExperiments} from './experiments';
 
 /**
  * Avatars are a more primitive version of User.

--- a/static/app/types/utils.tsx
+++ b/static/app/types/utils.tsx
@@ -1,4 +1,4 @@
-import {Organization, SharedViewOrganization} from 'sentry/types';
+import type {Organization, SharedViewOrganization} from './organization';
 
 // from:
 // - https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions

--- a/static/app/utils/highlightFuseMatches.tsx
+++ b/static/app/utils/highlightFuseMatches.tsx
@@ -1,4 +1,4 @@
-import {Fuse} from 'sentry/utils/fuzzySearch';
+import type {Fuse} from 'sentry/utils/fuzzySearch';
 
 type Match = Fuse.FuseResultMatch;
 

--- a/static/app/utils/parseHtmlMarks.tsx
+++ b/static/app/utils/parseHtmlMarks.tsx
@@ -1,4 +1,4 @@
-import {Fuse} from 'sentry/utils/fuzzySearch';
+import type {Fuse} from 'sentry/utils/fuzzySearch';
 
 type Options = {
   htmlString: string;


### PR DESCRIPTION
Babel can compile fewer files if we tell it that we're just importing the type, currently importing from sentry/types will compile lots of components

Removes some circular imports