### PR TITLE
fix(test): Remove usage of `done` callback (jest/no-done-callback)

### DIFF
--- a/tests/js/spec/views/passwordForm.spec.jsx
+++ b/tests/js/spec/views/passwordForm.spec.jsx
@@ -60,7 +60,7 @@ describe('PasswordForm', function () {
     expect(putMock).not.toHaveBeenCalled();
   });
 
-  it('calls API when all fields are validated and clears form on success', function (done) {
+  it('calls API when all fields are validated and clears form on success', async function () {
     wrapper.find('input[name="password"]').simulate('change', {target: {value: 'test'}});
     wrapper
       .find('input[name="passwordNew"]')
@@ -81,11 +81,9 @@ describe('PasswordForm', function () {
       })
     );
 
-    setTimeout(() => {
-      wrapper.update();
-      expect(wrapper.find('input[name="password"]').prop('value')).toBe('');
-      done();
-    }, 1);
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('input[name="password"]').prop('value')).toBe('');
   });
 
   it('validates mismatched passwords and remvoes validation on match', function () {

--- a/tests/js/spec/views/projectPluginDetails.spec.jsx
+++ b/tests/js/spec/views/projectPluginDetails.spec.jsx
@@ -82,20 +82,14 @@ describe('ProjectPluginDetails', function () {
     expect(wrapper.state().pluginDetails.config[0].value).toBe('default');
   });
 
-  it('enables/disables plugin', function (done) {
+  it('enables/disables plugin', async function () {
     const btn = component.find('button').first();
     expect(btn.text()).toBe('Enable Plugin');
 
     btn.simulate('click');
+    await tick();
 
-    setTimeout(() => {
-      try {
-        component.update();
-        expect(btn.text()).toBe('Disable Plugin');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    }, 1);
+    component.update();
+    expect(btn.text()).toBe('Disable Plugin');
   });
 });

--- a/tests/js/spec/views/settings/auditLogView.spec.jsx
+++ b/tests/js/spec/views/settings/auditLogView.spec.jsx
@@ -15,17 +15,16 @@ describe('OrganizationAuditLog', function () {
     });
   });
 
-  it('renders', function (done) {
+  it('renders', async function () {
     const wrapper = mountWithTheme(
       <OrganizationAuditLog location={{query: ''}} params={{orgId: org.slug}} />
     );
     wrapper.setState({loading: false});
     wrapper.update();
-    setTimeout(() => {
-      wrapper.update();
-      expect(wrapper).toSnapshot();
-      done();
-    });
+    await tick();
+
+    wrapper.update();
+    expect(wrapper).toSnapshot();
   });
 
   it('displays whether an action was done by a superuser', function () {

--- a/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
+++ b/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
@@ -19,7 +19,7 @@ describe('OrganizationSettingsForm', function () {
     onSave.mockReset();
   });
 
-  it('can change a form field', function (done) {
+  it('can change a form field', async function () {
     putMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,
       method: 'PUT',
@@ -54,12 +54,12 @@ describe('OrganizationSettingsForm', function () {
       })
     );
 
-    saveOnBlurUndoMessage.mockImplementationOnce(async function (
-      change,
-      model,
-      fieldName
-    ) {
-      try {
+    await new Promise(resolve => {
+      saveOnBlurUndoMessage.mockImplementationOnce(async function (
+        change,
+        model,
+        fieldName
+      ) {
         expect(fieldName).toBe('name');
         expect(change.old).toBe('Organization Name');
         expect(change.new).toBe('New Name');
@@ -79,10 +79,8 @@ describe('OrganizationSettingsForm', function () {
         // Blurring the name field again should NOT trigger a save
         input.simulate('blur');
         expect(putMock).not.toHaveBeenCalled();
-        done();
-      } catch (err) {
-        done(err);
-      }
+        resolve();
+      });
     });
   });
 


### PR DESCRIPTION
updating the eslint-pulgin-jest package adds this rule, seems like a
good one