### PR TITLE
fix(new-widget-builder-experience): Fix field with one parameter not taking up the whole space

### DIFF
--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -635,7 +635,14 @@ class QueryField extends React.Component<Props> {
         fieldValue.kind === 'function' &&
         AGGREGATIONS[fieldValue.function[0]].parameters.length > 0
       ) {
-        gridColumnsQuantity = containerColumns;
+        if (
+          containerColumns === 3 &&
+          AGGREGATIONS[fieldValue.function[0]].parameters.length === 1
+        ) {
+          gridColumnsQuantity = 2;
+        } else {
+          gridColumnsQuantity = containerColumns;
+        }
       } else {
         gridColumnsQuantity = 1;
       }


### PR DESCRIPTION
**Before:**
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/29228205/161429708-fcc47250-c0e2-40fb-8a5d-761b81aa8ca9.png">


**After:**

<img width="999" alt="image" src="https://user-images.githubusercontent.com/29228205/161429670-69027d04-dbfd-4e4a-bee8-6762d1487ad0.png">
