### PR TITLE
build(codecov): Disable status checks for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,11 +6,13 @@ coverage:
     patch:
       default: false
       frontend:
-        target: 60%
+        # codecov should not fail status checks
+        target: 0%
         flags:
         - frontend
       backend:
-        target: 90%
+        # codecov should not fail status checks
+        target: 0%
         flags:
           - backend
   ignore:

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,12 +7,16 @@ coverage:
       default: false
       frontend:
         # codecov should not fail status checks
-        target: 0%
+        informational: true
+        only_pulls: true
+        target: 60%
         flags:
         - frontend
       backend:
         # codecov should not fail status checks
-        target: 0%
+        informational: true
+        only_pulls: true
+        target: 90%
         flags:
           - backend
   ignore:


### PR DESCRIPTION
As discussed codecov failing status checks is mostly an annoyance and not really actionable. Turns turns off the minimum threshold so we still get the report but not more red markers.