### PR TITLE
feat(dashboards): Widget Viewer reuse series results from widget card on first render

### DIFF
--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -43,6 +43,7 @@ type Props = {
   selection: PageFilters;
   widget: Widget;
   isFirstPage?: boolean;
+  onHeaderClick?: () => void;
   tableData?: TableDataWithTitle;
 };
 
@@ -82,7 +83,7 @@ export const renderIssueGridHeaderCell =
   };
 
 export const renderDiscoverGridHeaderCell =
-  ({location, selection, widget, tableData, organization}: Props) =>
+  ({location, selection, widget, tableData, organization, onHeaderClick}: Props) =>
   (column: TableColumn<keyof TableDataRow>, _columnIndex: number): React.ReactNode => {
     const eventView = eventViewFromWidget(
       widget.title,
@@ -126,6 +127,7 @@ export const renderDiscoverGridHeaderCell =
         canSort={canSort}
         generateSortLink={generateSortLink}
         onClick={() => {
+          onHeaderClick?.();
           trackAdvancedAnalyticsEvent('dashboards_views.widget_viewer.sort', {
             organization,
             widget_type: widget.widgetType ?? WidgetType.DISCOVER,

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -17,6 +17,8 @@ import {t} from 'sentry/locale';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
+import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
@@ -55,7 +57,10 @@ type Props = WithRouterProps & {
   windowWidth?: number;
 };
 
-class WidgetCard extends React.Component<Props> {
+type State = {seriesData?: Series[]; tableData?: TableDataWithTitle[]};
+
+class WidgetCard extends React.Component<Props, State> {
+  state: State = {};
   renderToolbar() {
     const {
       onEdit,
@@ -131,6 +136,8 @@ class WidgetCard extends React.Component<Props> {
       index,
     } = this.props;
 
+    const {seriesData, tableData} = this.state;
+
     if (isEditing) {
       return null;
     }
@@ -150,9 +157,21 @@ class WidgetCard extends React.Component<Props> {
         router={router}
         location={location}
         index={index}
+        seriesData={seriesData}
+        tableData={tableData}
       />
     );
   }
+
+  setData = ({
+    tableResults,
+    timeseriesResults,
+  }: {
+    tableResults?: TableDataWithTitle[];
+    timeseriesResults?: Series[];
+  }) => {
+    this.setState({seriesData: timeseriesResults, tableData: tableResults});
+  };
 
   render() {
     const {
@@ -187,6 +206,7 @@ class WidgetCard extends React.Component<Props> {
               renderErrorMessage={renderErrorMessage}
               tableItemLimit={tableItemLimit}
               windowWidth={windowWidth}
+              onDataFetched={this.setData}
             />
           ) : (
             <LazyLoad once resize height={200}>
@@ -199,6 +219,7 @@ class WidgetCard extends React.Component<Props> {
                 renderErrorMessage={renderErrorMessage}
                 tableItemLimit={tableItemLimit}
                 windowWidth={windowWidth}
+                onDataFetched={this.setData}
               />
             </LazyLoad>
           )}

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -12,7 +12,7 @@ import Placeholder from 'sentry/components/placeholder';
 import {IconWarning} from 'sentry/icons';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
-import {EChartDataZoomHandler, EChartEventHandler} from 'sentry/types/echarts';
+import {EChartDataZoomHandler, EChartEventHandler, Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import {getIssueFieldRenderer} from 'sentry/utils/dashboards/issueFieldRenderers';
 import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
@@ -40,6 +40,7 @@ type Props = WithRouterProps & {
   expandNumbers?: boolean;
   isMobile?: boolean;
   legendOptions?: LegendComponentOption;
+  onDataFetched?: (results: {timeseriesResults?: Series[]}) => void;
   onLegendSelectChanged?: EChartEventHandler<{
     name: string;
     selected: Record<string, boolean>;
@@ -66,6 +67,7 @@ export function WidgetCardChartContainer({
   onLegendSelectChanged,
   legendOptions,
   expandNumbers,
+  onDataFetched,
 }: Props) {
   function issueTableResultComponent({
     loading,
@@ -179,6 +181,7 @@ export function WidgetCardChartContainer({
         widget={widget}
         selection={selection}
         limit={tableItemLimit}
+        onDataFetched={onDataFetched}
       >
         {({tableResults, timeseriesResults, errorMessage, loading}) => {
           return (

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -12,10 +12,13 @@ import {IconEllipsis, IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {getWidgetDiscoverUrl, getWidgetIssueUrl} from 'sentry/views/dashboardsV2/utils';
 
 import {Widget, WidgetType} from '../types';
+import {WidgetViewerContext} from '../widgetViewer/widgetViewerContext';
 
 type Props = {
   location: Location;
@@ -29,8 +32,10 @@ type Props = {
   onDelete?: () => void;
   onDuplicate?: () => void;
   onEdit?: () => void;
+  seriesData?: Series[];
   showContextMenu?: boolean;
   showWidgetViewerButton?: boolean;
+  tableData?: TableDataWithTitle[];
 };
 
 function WidgetCardContextMenu({
@@ -47,6 +52,8 @@ function WidgetCardContextMenu({
   router,
   location,
   index,
+  seriesData,
+  tableData,
 }: Props) {
   if (!showContextMenu) {
     return null;
@@ -68,34 +75,43 @@ function WidgetCardContextMenu({
 
   if (isPreview) {
     return (
-      <ContextWrapper>
-        <StyledDropdownMenuControlV2
-          items={[
-            {
-              key: 'preview',
-              label: t('This is a preview only. To edit, you must add this dashboard.'),
-            },
-          ]}
-          triggerProps={{
-            'aria-label': t('Widget actions'),
-            size: 'xsmall',
-            borderless: true,
-            showChevron: false,
-            icon: <IconEllipsis direction="down" size="sm" />,
-          }}
-          placement="bottom right"
-          disabledKeys={['preview']}
-        />
-        {showWidgetViewerButton && (
-          <OpenWidgetViewerButton
-            aria-label={t('Open Widget Viewer')}
-            priority="link"
-            size="zero"
-            icon={<IconExpand size="xs" />}
-            onClick={() => openWidgetViewerPath(index)}
-          />
+      <WidgetViewerContext.Consumer>
+        {({setData}) => (
+          <ContextWrapper>
+            <StyledDropdownMenuControlV2
+              items={[
+                {
+                  key: 'preview',
+                  label: t(
+                    'This is a preview only. To edit, you must add this dashboard.'
+                  ),
+                },
+              ]}
+              triggerProps={{
+                'aria-label': t('Widget actions'),
+                size: 'xsmall',
+                borderless: true,
+                showChevron: false,
+                icon: <IconEllipsis direction="down" size="sm" />,
+              }}
+              placement="bottom right"
+              disabledKeys={['preview']}
+            />
+            {showWidgetViewerButton && (
+              <OpenWidgetViewerButton
+                aria-label={t('Open Widget Viewer')}
+                priority="link"
+                size="zero"
+                icon={<IconExpand size="xs" />}
+                onClick={() => {
+                  (seriesData || tableData) && setData({seriesData, tableData});
+                  openWidgetViewerPath(index);
+                }}
+              />
+            )}
+          </ContextWrapper>
         )}
-      </ContextWrapper>
+      </WidgetViewerContext.Consumer>
     );
   }
 
@@ -172,29 +188,36 @@ function WidgetCardContextMenu({
   }
 
   return (
-    <ContextWrapper>
-      <StyledDropdownMenuControlV2
-        items={menuOptions}
-        triggerProps={{
-          'aria-label': t('Widget actions'),
-          size: 'xsmall',
-          borderless: true,
-          showChevron: false,
-          icon: <IconEllipsis direction="down" size="sm" />,
-        }}
-        placement="bottom right"
-        disabledKeys={disabledKeys}
-      />
-      {showWidgetViewerButton && (
-        <OpenWidgetViewerButton
-          aria-label={t('Open Widget Viewer')}
-          priority="link"
-          size="zero"
-          icon={<IconExpand size="xs" />}
-          onClick={() => openWidgetViewerPath(widget.id ?? index)}
-        />
+    <WidgetViewerContext.Consumer>
+      {({setData}) => (
+        <ContextWrapper>
+          <StyledDropdownMenuControlV2
+            items={menuOptions}
+            triggerProps={{
+              'aria-label': t('Widget actions'),
+              size: 'xsmall',
+              borderless: true,
+              showChevron: false,
+              icon: <IconEllipsis direction="down" size="sm" />,
+            }}
+            placement="bottom right"
+            disabledKeys={disabledKeys}
+          />
+          {showWidgetViewerButton && (
+            <OpenWidgetViewerButton
+              aria-label={t('Open Widget Viewer')}
+              priority="link"
+              size="zero"
+              icon={<IconExpand size="xs" />}
+              onClick={() => {
+                (seriesData || tableData) && setData({seriesData, tableData});
+                openWidgetViewerPath(widget.id ?? index);
+              }}
+            />
+          )}
+        </ContextWrapper>
       )}
-    </ContextWrapper>
+    </WidgetViewerContext.Consumer>
   );
 }
 

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -140,6 +140,10 @@ type Props = {
   widget: Widget;
   cursor?: string;
   limit?: number;
+  onDataFetched?: (results: {
+    tableResults?: TableDataWithTitle[];
+    timeseriesResults?: Series[];
+  }) => void;
   pagination?: boolean;
 };
 
@@ -253,7 +257,16 @@ class WidgetQueries extends React.Component<Props, State> {
   private _isMounted: boolean = false;
 
   fetchEventData(queryFetchID: symbol) {
-    const {selection, api, organization, widget, limit, cursor, pagination} = this.props;
+    const {
+      selection,
+      api,
+      organization,
+      widget,
+      limit,
+      cursor,
+      pagination,
+      onDataFetched,
+    } = this.props;
 
     let tableResults: TableDataWithTitle[] = [];
     // Table, world map, and stat widgets use table results and need
@@ -306,6 +319,8 @@ class WidgetQueries extends React.Component<Props, State> {
           return;
         }
 
+        onDataFetched?.({tableResults});
+
         this.setState(prevState => {
           if (prevState.queryFetchID !== queryFetchID) {
             // invariant: a different request was initiated after this request
@@ -342,7 +357,7 @@ class WidgetQueries extends React.Component<Props, State> {
   }
 
   fetchTimeseriesData(queryFetchID: symbol, displayType: DisplayType) {
-    const {selection, api, organization, widget} = this.props;
+    const {selection, api, organization, widget, onDataFetched} = this.props;
     const widgetBuilderNewDesign = organization.features.includes(
       'new-widget-builder-experience-design'
     );
@@ -439,6 +454,8 @@ class WidgetQueries extends React.Component<Props, State> {
 
           const rawResultsClone = cloneDeep(prevState.rawResults ?? []);
           rawResultsClone[requestIndex] = rawResults;
+
+          onDataFetched?.({timeseriesResults});
 
           return {
             ...prevState,

--- a/static/app/views/dashboardsV2/widgetViewer/widgetViewerContext.tsx
+++ b/static/app/views/dashboardsV2/widgetViewer/widgetViewerContext.tsx
@@ -1,0 +1,16 @@
+import {createContext} from 'react';
+
+import {Series} from 'sentry/types/echarts';
+import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+
+export type WidgetViewerContextProps = {
+  setData: (data: {seriesData?: Series[]; tableData?: TableDataWithTitle[]}) => void;
+  seriesData?: Series[];
+  tableData?: TableDataWithTitle[];
+};
+
+export const WidgetViewerContext = createContext<WidgetViewerContextProps>({
+  setData: () => undefined,
+  seriesData: undefined,
+  tableData: undefined,
+});

--- a/static/app/views/dashboardsV2/widgetViewer/widgetViewerContext.tsx
+++ b/static/app/views/dashboardsV2/widgetViewer/widgetViewerContext.tsx
@@ -11,6 +11,4 @@ export type WidgetViewerContextProps = {
 
 export const WidgetViewerContext = createContext<WidgetViewerContextProps>({
   setData: () => undefined,
-  seriesData: undefined,
-  tableData: undefined,
 });

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -7,6 +7,8 @@ import {ModalRenderProps} from 'sentry/actionCreators/modal';
 import WidgetViewerModal from 'sentry/components/modals/widgetViewerModal';
 import MemberListStore from 'sentry/stores/memberListStore';
 import space from 'sentry/styles/space';
+import {Series} from 'sentry/types/echarts';
+import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {DisplayType, WidgetType} from 'sentry/views/dashboardsV2/types';
 
 jest.mock('echarts-for-react/lib/core', () => {
@@ -31,7 +33,17 @@ const waitForMetaToHaveBeenCalled = async () => {
   });
 };
 
-async function renderModal({initialData: {organization, routerContext}, widget}) {
+async function renderModal({
+  initialData: {organization, routerContext},
+  widget,
+  seriesData,
+  tableData,
+}: {
+  initialData: any;
+  widget: any;
+  seriesData?: Series[];
+  tableData?: TableDataWithTitle[];
+}) {
   const rendered = render(
     <div style={{padding: space(4)}}>
       <WidgetViewerModal
@@ -43,6 +55,8 @@ async function renderModal({initialData: {organization, routerContext}, widget})
         organization={organization}
         widget={widget}
         onEdit={() => undefined}
+        seriesData={seriesData}
+        tableData={tableData}
       />
     </div>,
     {
@@ -468,10 +482,27 @@ describe('Modals -> WidgetViewerModal', function () {
       await waitForMetaToHaveBeenCalled();
       expect(await screen.findByText('Next Page Test Error')).toBeInTheDocument();
     });
+
+    it('uses provided seriesData and does not make an events-stats requests', async function () {
+      await renderModal({initialData, widget: mockWidget, seriesData: []});
+      expect(eventsStatsMock).not.toHaveBeenCalled();
+    });
+
+    it('makes events-stats requests when table is sorted', async function () {
+      await renderModal({
+        initialData,
+        widget: mockWidget,
+        seriesData: [],
+      });
+      expect(eventsStatsMock).not.toHaveBeenCalled();
+      userEvent.click(screen.getByText('count()'));
+      await waitForMetaToHaveBeenCalled();
+      expect(eventsStatsMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Discover World Map Chart Widget', function () {
-    let eventsMock;
+    let eventsMock, eventsGeoMock;
     const mockQuery = {
       conditions: 'title:/organizations/:orgId/performance/summary/',
       fields: ['p75(measurements.lcp)'],
@@ -513,7 +544,7 @@ describe('Modals -> WidgetViewerModal', function () {
         url: '/organizations/org-slug/eventsv2/',
         body: eventsBody,
       });
-      MockApiClient.addMockResponse({
+      eventsGeoMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/events-geo/',
         body: eventsBody,
       });
@@ -535,6 +566,11 @@ describe('Modals -> WidgetViewerModal', function () {
     it('renders Discover topn chart widget viewer', async function () {
       const {container} = await renderModal({initialData, widget: mockWidget});
       expect(container).toSnapshot();
+    });
+
+    it('uses provided tableData and does not make an eventsv2 requests', async function () {
+      await renderModal({initialData, widget: mockWidget, tableData: []});
+      expect(eventsGeoMock).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Updates the widget viewer to reuse the `events-stats` series results from the widget card on the first render instead of making a new `events-stats` request. 

Using `React.Context` to allow `WidgetViewerContextMenu` to call `setData` (which updates the series results state) so that `DashboardDetail` knows what series to render, without having to pass down props from `DashboardDetail` all the way down to `WidgetViewerContextMenu`. This is not exactly the intended use for `React.Context` so I wonder if I should just bite the bullet and update to passing down props.