### PR TITLE
fix(tests): Not waiting long enough for guide anchor to go away

### DIFF
--- a/tests/js/spec/components/assistant/guideAnchor.spec.jsx
+++ b/tests/js/spec/components/assistant/guideAnchor.spec.jsx
@@ -140,7 +140,7 @@ describe('GuideAnchor', function () {
     GuideActions.fetchSucceeded(serverGuide);
     expect(await screen.findByText("Let's Get This Over With")).toBeInTheDocument();
     GuideActions.setForceHide(true);
-    expect(await screen.findByText("Let's Get This Over With")).not.toBeInTheDocument();
+    await waitForElementToBeRemoved(() => screen.queryByText("Let's Get This Over With"));
     GuideActions.setForceHide(false);
     expect(await screen.findByText("Let's Get This Over With")).toBeInTheDocument();
   });


### PR DESCRIPTION
This is a guess but it's possible that the `await screen.findByText` returned
before the call to `setForceHide` had a chance to complete execution so the
guide anchor is still in the DOM at the time which caused the test to fail.