### PR TITLE
fix(js): Fix unbound variable

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -962,16 +962,15 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 )
                 source = self.get_sourceview(abs_path)
 
-            if source is None:
-                errors = cache.get_errors(abs_path)
-                if errors:
-                    all_errors.extend(errors)
-                else:
-                    all_errors.append(
-                        {"type": EventError.JS_MISSING_SOURCE, "url": http.expose_url(abs_path)}
-                    )
+                if source is None:
+                    errors = cache.get_errors(abs_path)
+                    if errors:
+                        all_errors.extend(errors)
+                    else:
+                        all_errors.append(
+                            {"type": EventError.JS_MISSING_SOURCE, "url": http.expose_url(abs_path)}
+                        )
 
-            if token is not None:
                 # the tokens are zero indexed, so offset correctly
                 new_frame["lineno"] = token.src_line + 1
                 new_frame["colno"] = token.src_col + 1


### PR DESCRIPTION
The [pyright commit hook](https://github.com/getsentry/sentry/runs/5814068167?check_suite_focus=true#step:8:94) prevents modifications to `javascript/processor.py` because `abs_path` can be unbound.