### PR TITLE
fix(new-widget-builder-experience): Add queries to handleBlur dependency list

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -73,17 +73,20 @@ export function FilterResultsStep({
     };
   }, []);
 
-  const handleBlur = useCallback((queryIndex: number) => {
-    return (field: string) => {
-      if (!blurTimeoutRef.current) {
-        const newQuery: WidgetQuery = {
-          ...queries[queryIndex],
-          conditions: field,
-        };
-        onQueryChange(queryIndex, newQuery);
-      }
-    };
-  }, []);
+  const handleBlur = useCallback(
+    (queryIndex: number) => {
+      return (field: string) => {
+        if (!blurTimeoutRef.current) {
+          const newQuery: WidgetQuery = {
+            ...queries[queryIndex],
+            conditions: field,
+          };
+          onQueryChange(queryIndex, newQuery);
+        }
+      };
+    },
+    [queries]
+  );
 
   return (
     <BuildStep


### PR DESCRIPTION
The handleBlur has a dependency on queries, which was not updating
when the query length would change. This stale data meant that there
could be an indexing issue that malforms our query structure, leading to
a validation bug

The problem is that the `useCallback` hook doesn't update the `queries` list properly when it updates (either when the widget builder re-renders and fills with data, or when starting fresh and adding fields), leading to the `queries[queryIndex]` index to return undefined, which wipes out a bunch of expected fields. The solution is to pass `queries` to `useCallback` so it updates.

Fixes #33236