### PR TITLE
fix(alertWizard): Fix style of chart header

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -12,6 +12,7 @@ import {fetchOrganizationTags} from 'sentry/actionCreators/tags';
 import Access from 'sentry/components/acl/access';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import Button from 'sentry/components/button';
+import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import CircleIndicator from 'sentry/components/circleIndicator';
 import Confirm from 'sentry/components/confirm';
 import Form from 'sentry/components/forms/form';
@@ -850,14 +851,12 @@ const AlertListItem = styled(StyledListItem)`
 `;
 
 const ChartHeader = styled('div')`
-  padding: ${space(3)} ${space(3)} 0 ${space(3)};
+  padding: ${space(2)} ${space(3)} 0 ${space(3)};
   margin-bottom: -${space(1.5)};
 `;
 
-const AlertName = styled('div')`
-  font-size: ${p => p.theme.fontSizeExtraLarge};
-  font-weight: normal;
-  color: ${p => p.theme.textColor};
+const AlertName = styled(HeaderTitleLegend)`
+  position: relative;
 `;
 
 const AlertInfo = styled('div')`


### PR DESCRIPTION
Fix style of chart header when creating a new metric alert to match the chart header on the Transaction Summary page.

[FIXES WOR-1695](https://getsentry.atlassian.net/browse/WOR-1695)

# Before
<img width="194" alt="Screen Shot 2022-04-04 at 11 17 36 AM" src="https://user-images.githubusercontent.com/20312973/161607074-52452fdb-2275-4333-9622-236baaf47f1f.png">

# After
<img width="204" alt="Screen Shot 2022-04-04 at 11 06 47 AM" src="https://user-images.githubusercontent.com/20312973/161607105-34fa2753-29ef-49de-aecb-8731b180c3b8.png">


