### PR TITLE
fix(perf): Do not trigger histogram call on table cursor update

### DIFF
--- a/static/app/utils/performance/histogram/spanHistogramQuery.tsx
+++ b/static/app/utils/performance/histogram/spanHistogramQuery.tsx
@@ -45,6 +45,7 @@ function getHistogramRequestPayload(props: RequestProps) {
   const additionalApiPayload = omit(eventView.getEventsAPIPayload(location), [
     'sort',
     'per_page',
+    'cursor',
   ]);
   const apiPayload = {...baseApiPayload, ...additionalApiPayload};
   return apiPayload;


### PR DESCRIPTION
Histogram query should not refire when users click through example events table. The histogram covers the selected population while table is capped at 10 results, so it makes sense not to tie the table cursor to the histogram query.

Fixes PERF-1516