### PR TITLE
ref(event-errors): Use Alert instead of BannerSummary

### DIFF
--- a/static/app/components/alert.tsx
+++ b/static/app/components/alert.tsx
@@ -73,6 +73,11 @@ const alertStyles = ({
       text-decoration-style: solid;
     }
 
+    pre {
+      background: ${alertColors.backgroundLight};
+      margin: ${space(0.5)} 0 0;
+    }
+
     ${IconWrapper} {
       color: ${alertColors.iconColor};
     }

--- a/static/app/components/events/errorItem.tsx
+++ b/static/app/components/events/errorItem.tsx
@@ -50,7 +50,9 @@ class ErrorItem extends React.Component<Props, State> {
     return this.state.isOpen !== nextState.isOpen;
   }
 
-  handleToggle = () => {
+  handleToggle = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
     this.setState({isOpen: !this.state.isOpen});
   };
 

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -146,7 +146,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         event = self.create_sample_event(platform="invalid-interfaces")
         self.page.visit_issue(self.org.slug, event.group.id)
 
-        self.browser.click('[data-test-id="event-error-toggle"]')
+        self.browser.click('[data-test-id="event-error-alert"]')
         self.browser.wait_until_test_id("event-error-details")
         self.browser.snapshot("issue details invalid interfaces")
 

--- a/tests/js/spec/views/organizationGroupDetails/groupEventEntries.spec.tsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventEntries.spec.tsx
@@ -30,23 +30,17 @@ async function renderComponent(event: Event, errors?: Array<Error>) {
 
   const eventErrors = wrapper.find('Errors');
 
-  const bannerSummary = eventErrors.find('BannerSummary');
-  const bannerSummaryInfo = bannerSummary.find(
-    'span[data-test-id="errors-banner-summary-info"]'
-  );
+  const alert = eventErrors.find('StyledAlert');
+  const alertSummaryInfo = alert.find('span[data-test-id="alert-summary-info"]');
 
-  const toggleButton = bannerSummary
-    .find('[data-test-id="event-error-toggle"]')
-    .hostNodes();
-
-  toggleButton.simulate('click');
+  alert.simulate('click');
 
   await tick();
   wrapper.update();
 
   const errorItem = wrapper.find('ErrorItem');
 
-  return {bannerSummaryInfoText: bannerSummaryInfo.text(), errorItem};
+  return {alertSummaryInfoText: alertSummaryInfo.text(), errorItem};
 }
 
 describe('GroupEventEntries', function () {
@@ -82,9 +76,9 @@ describe('GroupEventEntries', function () {
         },
       ];
 
-      const {bannerSummaryInfoText, errorItem} = await renderComponent(event, errors);
+      const {alertSummaryInfoText, errorItem} = await renderComponent(event, errors);
 
-      expect(bannerSummaryInfoText).toEqual(
+      expect(alertSummaryInfoText).toEqual(
         `There were ${errors.length} problems processing this event`
       );
       expect(errorItem.length).toBe(2);
@@ -110,9 +104,9 @@ describe('GroupEventEntries', function () {
         };
 
         await act(async () => {
-          const {errorItem, bannerSummaryInfoText} = await renderComponent(newEvent);
+          const {errorItem, alertSummaryInfoText} = await renderComponent(newEvent);
 
-          expect(bannerSummaryInfoText).toEqual(
+          expect(alertSummaryInfoText).toEqual(
             'There was 1 problem processing this event'
           );
 
@@ -146,11 +140,9 @@ describe('GroupEventEntries', function () {
           ],
         };
 
-        const {bannerSummaryInfoText, errorItem} = await renderComponent(newEvent);
+        const {alertSummaryInfoText, errorItem} = await renderComponent(newEvent);
 
-        expect(bannerSummaryInfoText).toEqual(
-          'There was 1 problem processing this event'
-        );
+        expect(alertSummaryInfoText).toEqual('There was 1 problem processing this event');
 
         expect(errorItem.length).toBe(1);
         expect(errorItem.at(0).props().error).toEqual({
@@ -200,9 +192,9 @@ describe('GroupEventEntries', function () {
             ],
           };
 
-          const {bannerSummaryInfoText, errorItem} = await renderComponent(newEvent);
+          const {alertSummaryInfoText, errorItem} = await renderComponent(newEvent);
 
-          expect(bannerSummaryInfoText).toEqual(
+          expect(alertSummaryInfoText).toEqual(
             'There was 1 problem processing this event'
           );
 
@@ -274,9 +266,9 @@ describe('GroupEventEntries', function () {
             ],
           };
 
-          const {bannerSummaryInfoText, errorItem} = await renderComponent(newEvent);
+          const {alertSummaryInfoText, errorItem} = await renderComponent(newEvent);
 
-          expect(bannerSummaryInfoText).toEqual(
+          expect(alertSummaryInfoText).toEqual(
             'There was 1 problem processing this event'
           );
 


### PR DESCRIPTION
Use the `<Alert />` component for event errors, instead of `BannerSummary` which mimics the Alert style.

**Before:**
<img width="1091" alt="Screen Shot 2022-04-04 at 10 44 17 AM" src="https://user-images.githubusercontent.com/44172267/161609549-705c6968-68fc-4639-972e-6a61e65b70c4.png">
<img width="1091" alt="Screen Shot 2022-04-04 at 10 44 23 AM" src="https://user-images.githubusercontent.com/44172267/161609554-643c51f8-10a7-4369-bb2a-e2d710f6e9b1.png">

**After:**
<img width="1091" alt="Screen Shot 2022-04-04 at 10 43 21 AM" src="https://user-images.githubusercontent.com/44172267/161609577-4d096460-4815-40e4-96c7-60c8fbee5775.png">
<img width="1091" alt="Screen Shot 2022-04-04 at 10 43 28 AM" src="https://user-images.githubusercontent.com/44172267/161609583-f9111ca2-f5ba-4539-9e2a-e7537e869ccd.png">

