### PR TITLE
fix(workflow): Handle open in discover issue column when transaction dataset

### DIFF
--- a/static/app/views/alerts/incidentRules/incidentRulePresets.tsx
+++ b/static/app/views/alerts/incidentRules/incidentRulePresets.tsx
@@ -49,6 +49,8 @@ export function makeDefaultCta({
     };
   }
 
+  const transactionFields = ['title', 'count()', 'count_unique(user)'];
+
   const extraQueryParams = {
     display: DisplayModes.TOP5,
   };
@@ -63,7 +65,7 @@ export function makeDefaultCta({
       start,
       end,
       extraQueryParams,
-      fields,
+      fields: eventType === 'event.type:transaction' ? transactionFields : fields,
     }),
   };
 }

--- a/static/app/views/alerts/incidentRules/incidentRulePresets.tsx
+++ b/static/app/views/alerts/incidentRules/incidentRulePresets.tsx
@@ -49,8 +49,6 @@ export function makeDefaultCta({
     };
   }
 
-  const transactionFields = ['title', 'count()', 'count_unique(user)'];
-
   const extraQueryParams = {
     display: DisplayModes.TOP5,
   };
@@ -65,7 +63,7 @@ export function makeDefaultCta({
       start,
       end,
       extraQueryParams,
-      fields: eventType === 'event.type:transaction' ? transactionFields : fields,
+      fields,
     }),
   };
 }

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -299,6 +299,9 @@ class MetricChart extends React.PureComponent<Props, State> {
     warningDuration: number
   ) {
     const {rule, orgId, project, timePeriod, query} = this.props;
+    const transactionFields = ['title', 'count()', 'count_unique(user)'];
+    const errorFields = ['issue', 'title', 'count()', 'count_unique(user)'];
+
     const ctaOpts = {
       orgSlug: orgId,
       projects: [project],
@@ -306,7 +309,7 @@ class MetricChart extends React.PureComponent<Props, State> {
       eventType: query,
       start: timePeriod.start,
       end: timePeriod.end,
-      fields: ['issue', 'title', 'count()', 'count_unique(user)'],
+      fields: rule.dataset === 'transactions' ? transactionFields : errorFields,
     };
 
     const {buttonText, ...props} = makeDefaultCta(ctaOpts);


### PR DESCRIPTION
Previously, the Open in Discover button on a metric alert details page would link to a discover page with an Issue column for both error and transaction datasets. This PR checks if the eventType is transaction, and if it is, does not include the issue field.

[FIXES WOR-1738](https://getsentry.atlassian.net/browse/WOR-1738)

# Before
<img width="1180" alt="Screen Shot 2022-04-04 at 11 54 54 AM" src="https://user-images.githubusercontent.com/20312973/161613704-2e684605-7b3a-4522-b7f2-038db6810009.png">

# After
<img width="1183" alt="Screen Shot 2022-04-04 at 11 55 45 AM" src="https://user-images.githubusercontent.com/20312973/161613728-a774177e-047c-4036-a72f-01470a811098.png">


