### PR TITLE
fix(slack): Fix metric alert unfurls

### DIFF
--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -71,19 +71,21 @@ def incident_attachment_info(incident, new_status: IncidentStatus, metric_value=
 
     title = f"{status}: {alert_rule.name}"
 
-    title_link = absolute_uri(
-        reverse(
-            "sentry-metric-alert",
-            kwargs={
-                "organization_slug": incident.organization.slug,
-                "incident_id": incident.identifier,
-            },
-        )
-    )
     if unfurl:
         # this URL is needed for the Slack unfurl, but nothing else
         title_link = absolute_uri(
             f"organizations/{incident.organization.slug}/alerts/rules/details/{incident.identifier}"
+        )
+
+    else:
+        title_link = absolute_uri(
+            reverse(
+                "sentry-metric-alert",
+                kwargs={
+                    "organization_slug": incident.organization.slug,
+                    "incident_id": incident.identifier,
+                },
+            )
         )
 
     return {

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -45,7 +45,6 @@ def incident_attachment_info(incident, new_status: IncidentStatus, metric_value=
             end = incident_trigger.date_modified
         else:
             start, end = None, None
-        # this line is failing in the unfurl test, very annoying
         metric_value = get_incident_aggregates(incident=incident, start=start, end=end).get("count")
     time_window = alert_rule.snuba_query.time_window // 60
 

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
@@ -46,7 +45,7 @@ def incident_attachment_info(incident, new_status: IncidentStatus, metric_value=
             end = incident_trigger.date_modified
         else:
             start, end = None, None
-
+        # this line is failing in the unfurl test, very annoying
         metric_value = get_incident_aggregates(incident=incident, start=start, end=end).get("count")
     time_window = alert_rule.snuba_query.time_window // 60
 
@@ -72,13 +71,7 @@ def incident_attachment_info(incident, new_status: IncidentStatus, metric_value=
     title = f"{status}: {alert_rule.name}"
 
     title_link = absolute_uri(
-        reverse(
-            "sentry-metric-alert",
-            kwargs={
-                "organization_slug": incident.organization.slug,
-                "incident_id": incident.identifier,
-            },
-        )
+        f"organizations/{incident.organization.slug}/alerts/rules/details/{incident.identifier}"
     )
 
     return {

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -35,7 +35,9 @@ class SlackIncidentsMessageBuilder(SlackMessageBuilder):
         self.new_status = new_status
 
     def build(self) -> SlackBody:
-        data = incident_attachment_info(self.incident, self.new_status, self.metric_value)
+        data = incident_attachment_info(
+            self.incident, self.new_status, self.metric_value, unfurl=True
+        )
 
         return self._build(
             actions=[],

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -34,9 +34,9 @@ class SlackIncidentsMessageBuilder(SlackMessageBuilder):
         self.metric_value = metric_value
         self.new_status = new_status
 
-    def build(self) -> SlackBody:
+    def build(self, unfurl=False) -> SlackBody:
         data = incident_attachment_info(
-            self.incident, self.new_status, self.metric_value, unfurl=True
+            self.incident, self.new_status, self.metric_value, unfurl=unfurl
         )
 
         return self._build(
@@ -54,8 +54,9 @@ class SlackIncidentsMessageBuilder(SlackMessageBuilder):
 def build_incident_attachment(
     incident: Incident,
     metric_value: Optional[int] = None,
+    unfurl: bool = False,
 ) -> SlackBody:
     """@deprecated"""
     return SlackIncidentsMessageBuilder(
         incident, IncidentStatus(incident.status), metric_value
-    ).build()
+    ).build(unfurl=unfurl)

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -34,7 +34,7 @@ class SlackIncidentsMessageBuilder(SlackMessageBuilder):
         self.metric_value = metric_value
         self.new_status = new_status
 
-    def build(self, unfurl=False) -> SlackBody:
+    def build(self, unfurl: bool = False) -> SlackBody:
         data = incident_attachment_info(
             self.incident, self.new_status, self.metric_value, unfurl=unfurl
         )

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -36,6 +36,7 @@ class SlackIncidentsMessageBuilder(SlackMessageBuilder):
 
     def build(self) -> SlackBody:
         data = incident_attachment_info(self.incident, self.new_status, self.metric_value)
+
         return self._build(
             actions=[],
             color=INCIDENT_COLOR_MAPPING.get(data["status"]),

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -36,7 +36,6 @@ class SlackIncidentsMessageBuilder(SlackMessageBuilder):
 
     def build(self) -> SlackBody:
         data = incident_attachment_info(self.incident, self.new_status, self.metric_value)
-
         return self._build(
             actions=[],
             color=INCIDENT_COLOR_MAPPING.get(data["status"]),

--- a/src/sentry/integrations/slack/unfurl/incidents.py
+++ b/src/sentry/integrations/slack/unfurl/incidents.py
@@ -31,7 +31,6 @@ def unfurl_incidents(
         identifier = link.args["incident_id"]
         org_slug = link.args["org_slug"]
         filter_query |= Q(identifier=identifier, organization__slug=org_slug)
-
     results = {
         i.identifier: i
         for i in Incident.objects.filter(

--- a/src/sentry/integrations/slack/unfurl/incidents.py
+++ b/src/sentry/integrations/slack/unfurl/incidents.py
@@ -45,7 +45,7 @@ def unfurl_incidents(
         return {}
 
     return {
-        link.url: build_incident_attachment(results[link.args["incident_id"]])
+        link.url: build_incident_attachment(results[link.args["incident_id"]], unfurl=True)
         for link in links
         if link.args["incident_id"] in results
     }

--- a/src/sentry/integrations/slack/unfurl/incidents.py
+++ b/src/sentry/integrations/slack/unfurl/incidents.py
@@ -31,6 +31,7 @@ def unfurl_incidents(
         identifier = link.args["incident_id"]
         org_slug = link.args["org_slug"]
         filter_query |= Q(identifier=identifier, organization__slug=org_slug)
+
     results = {
         i.identifier: i
         for i in Incident.objects.filter(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -98,10 +98,9 @@ class UnfurlTest(TestCase):
             links[0].url
             == f"https://sentry.io/organizations/{self.organization.slug}/alerts/rules/details/{incident.identifier}/"
         )
-        assert (
-            unfurls[links[0].url]
-            == SlackIncidentsMessageBuilder(incident, IncidentStatus.CLOSED).build()
-        )
+        assert unfurls[links[0].url] == SlackIncidentsMessageBuilder(
+            incident, IncidentStatus.CLOSED
+        ).build(unfurl=True)
 
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
     def test_unfurl_discover(self, mock_generate_chart):

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -94,7 +94,10 @@ class UnfurlTest(TestCase):
             ),
         ]
         unfurls = link_handlers[LinkType.INCIDENTS].fn(self.request, self.integration, links)
-
+        assert (
+            unfurls[links[0].url]
+            == f"https://sentry.io/organizations/{self.organization.slug}/alerts/rules/details/{incident.identifier}/"
+        )
         assert (
             unfurls[links[0].url]
             == SlackIncidentsMessageBuilder(incident, IncidentStatus.CLOSED).build()

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -95,7 +95,7 @@ class UnfurlTest(TestCase):
         ]
         unfurls = link_handlers[LinkType.INCIDENTS].fn(self.request, self.integration, links)
         assert (
-            unfurls[links[0].url]
+            links[0].url
             == f"https://sentry.io/organizations/{self.organization.slug}/alerts/rules/details/{incident.identifier}/"
         )
         assert (


### PR DESCRIPTION
If you pasted a link to a metric alert in Slack, the unfurl link was going to the wrong URL - e.g. https://meowlificent.ngrok.io/organizations/sentry/alerts/rules/details/3/ instead of https://meowlificent.ngrok.io/organizations/sentry/alerts/rules/details/1/?alert=3 

This PR generates a link to the correct URL. 