### PR TITLE
fix(issues-index): Use <QueryCount /> in search results row

### DIFF
--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -5,6 +5,7 @@ import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
+import QueryCount from 'sentry/components/queryCount';
 import {tct} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import space from 'sentry/styles/space';
@@ -101,9 +102,12 @@ function IssueListFilters({
       </SearchContainer>
       {hasPageFilters && (
         <ResultsRow>
-          <QueryCount>
-            {queryCount > 0 && tct('[queryCount] results found', {queryCount})}
-          </QueryCount>
+          <QueryCountText>
+            {queryCount > 0 &&
+              tct('[queryCount] results found', {
+                queryCount: <QueryCount hideParens count={queryCount} max={1000} />,
+              })}
+          </QueryCountText>
           <DisplayOptionsBar>
             {hasIssuePercentDisplay && (
               <IssueListDisplayOptions
@@ -167,7 +171,7 @@ const DropdownsWrapper = styled('div')<{hasIssuePercentDisplay?: boolean}>`
   }
 `;
 
-const QueryCount = styled('p')`
+const QueryCountText = styled('p')`
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: 600;
   color: ${p => p.theme.headingColor};


### PR DESCRIPTION
Using `<QueryCount />` to automatically add a `+` when the count exceeds 1000.

**Before:**
<img width="848" alt="Screen Shot 2022-04-04 at 12 16 37 PM" src="https://user-images.githubusercontent.com/44172267/161615902-2dff9106-677e-4000-b298-dba310de29c2.png">

**After:**
<img width="848" alt="Screen Shot 2022-04-04 at 12 16 27 PM" src="https://user-images.githubusercontent.com/44172267/161615877-c2555415-dfd1-443a-bd1c-b57d96c1c1bf.png">

