### PR TITLE
fix(issues-details): Fix padding mismatch between DataSections and the header

### DIFF
--- a/static/app/components/events/styles.tsx
+++ b/static/app/components/events/styles.tsx
@@ -12,7 +12,7 @@ export const DataSection = styled('div')`
   /* Padding aligns with Layout.Body */
   padding: ${space(3)} ${space(2)} ${space(2)};
 
-  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
     padding: ${space(3)} ${space(4)} ${space(3)};
   }
 `;


### PR DESCRIPTION
In between `breakpoints[1]` and `breakpoints[2]`, there's a padding mismatch between the header and the body content:

<img width="248" alt="Screen Shot 2022-04-04 at 12 29 59 PM" src="https://user-images.githubusercontent.com/44172267/161617895-b72a87b6-da36-472e-afe5-fbc08323a53e.png">

This PR fixes that:
<img width="248" alt="Screen Shot 2022-04-04 at 12 31 29 PM" src="https://user-images.githubusercontent.com/44172267/161618124-00c748aa-d39b-406f-9e4b-420a818803fa.png">

