### PR TITLE
ref(perf): Track chart display changes in span summary

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -41,7 +41,7 @@ export type PerformanceEventParameters = {
     show_onboarding: boolean;
   };
   'performance_views.span_summary.change_chart': {
-    selected_display: string;
+    change_to_display: string;
   };
   'performance_views.spans.change_op': {
     operation_name?: string;

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -40,6 +40,9 @@ export type PerformanceEventParameters = {
   'performance_views.overview.view': {
     show_onboarding: boolean;
   };
+  'performance_views.span_summary.change_chart': {
+    selected_display: string;
+  };
   'performance_views.spans.change_op': {
     operation_name?: string;
   };
@@ -70,6 +73,8 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.landingv3.batch_queries':
     'Performance Views: Landing Query Batching',
   'performance_views.landingv3.display_change': 'Performance Views: Switch Landing Tabs',
+  'performance_views.span_summary.change_chart':
+    'Performance Views: Span Summary displayed chart changed',
   'performance_views.spans.change_op': 'Performance Views: Change span operation name',
   'performance_views.spans.change_sort': 'Performance Views: Change span sort column',
   'performance_views.overview.view': 'Performance Views: Transaction overview view',

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/chart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/chart.tsx
@@ -15,6 +15,7 @@ import {Panel} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
 import {removeHistogramQueryStrings} from 'sentry/utils/performance/histogram';
 import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
@@ -50,6 +51,11 @@ function Chart(props: Props) {
   }
 
   function handleDisplayChange(value: string) {
+    trackAdvancedAnalyticsEvent('performance_views.span_summary.change_chart', {
+      organization: props.organization,
+      selected_display: value,
+    });
+
     browserHistory.push({
       pathname: location.pathname,
       query: {

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/chart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/chart.tsx
@@ -53,7 +53,7 @@ function Chart(props: Props) {
   function handleDisplayChange(value: string) {
     trackAdvancedAnalyticsEvent('performance_views.span_summary.change_chart', {
       organization: props.organization,
-      selected_display: value,
+      change_to_display: value,
     });
 
     browserHistory.push({


### PR DESCRIPTION
This PR adds new analytics to track when users change display chart type (`histogram` vs `timeseries`). The event has already been added to reload https://github.com/getsentry/reload/pull/257.

Fixes PERF-1418