### PR TITLE
fix(tests): Don't assert order

### DIFF
--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -19,12 +19,10 @@ class PostgresIndexerTest(TestCase):
         org_id = self.organization.id
         org_strings = {org_id: {"hello", "hey", "hi"}}
         results = PGStringIndexer().bulk_record(org_strings=org_strings)
-        obj_ids = list(
-            MetricsKeyIndexer.objects.filter(string__in=["hello", "hey", "hi"]).values_list(
-                "id", flat=True
-            )
+        obj_ids = MetricsKeyIndexer.objects.filter(string__in=["hello", "hey", "hi"]).values_list(
+            "id", flat=True
         )
-        assert list(results.values()) == obj_ids
+        assert set(results.values()) == set(obj_ids)
 
         # test resolve and reverse_resolve
         obj = MetricsKeyIndexer.objects.get(string="hello")


### PR DESCRIPTION
This test failed once so I'm comparing sets instead of lists so that we don't assert order.