### PR TITLE
ref(perf): Make parse arguments consistent everywhere

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -799,7 +799,9 @@ export function parseArguments(functionText: string, columnText: string): string
   // This function attempts to be identical with the similarly named parse_arguments
   // found in src/sentry/search/events/fields.py
   if (
-    (functionText !== 'to_other' && functionText !== 'count_if') ||
+    (functionText !== 'to_other' &&
+      functionText !== 'count_if' &&
+      functionText !== 'spans_histogram') ||
     columnText.length === 0
   ) {
     return columnText ? columnText.split(',').map(result => result.trim()) : [];


### PR DESCRIPTION
Mirror changes from https://github.com/getsentry/sentry/pull/32529/files/b5ae8855cf39e1d1a766dbfb66e90f307ee9d901#r826413115. `spans_op` might contains backslashes and quotes and needs to be parsed in a special way. In the frontend, I don't think `spans_histogram` is used anywhere but I thought I'd make two files consistent. I can also close this PR if the change is unnecessary 