### PR TITLE
fix(perf): Render info alert when web vitals data is missing

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
@@ -22,7 +22,7 @@ import VitalsCardsDiscoverQuery from 'sentry/utils/performance/vitals/vitalsCard
 import {decodeScalar} from 'sentry/utils/queryString';
 
 import {VITAL_GROUPS, ZOOM_KEYS} from './constants';
-import {shouldDisplayMissingVitalsAlert} from './utils';
+import {isMissingVitalsData} from './utils';
 import VitalsPanel from './vitalsPanel';
 
 type Props = {
@@ -65,13 +65,12 @@ function VitalsContent(props: Props) {
             vitals={allVitals}
           >
             {results => {
-              const isMissingVitalsData =
-                !results.isLoading &&
-                shouldDisplayMissingVitalsAlert(results.vitalsData, allVitals);
+              const shouldDisplayMissingVitalsAlert =
+                !results.isLoading && isMissingVitalsData(results.vitalsData, allVitals);
 
               return (
                 <Fragment>
-                  {isMissingVitalsData && (
+                  {shouldDisplayMissingVitalsAlert && (
                     <Alert type="info" showIcon>
                       {tct(
                         'If this page is looking a little bare, keep in mind not all browsers support these vitals. [link]',

--- a/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
@@ -22,6 +22,7 @@ import VitalsCardsDiscoverQuery from 'sentry/utils/performance/vitals/vitalsCard
 import {decodeScalar} from 'sentry/utils/queryString';
 
 import {VITAL_GROUPS, ZOOM_KEYS} from './constants';
+import {shouldDisplayMissingVitalsAlert} from './utils';
 import VitalsPanel from './vitalsPanel';
 
 type Props = {
@@ -66,7 +67,7 @@ function VitalsContent(props: Props) {
             {results => {
               const isMissingVitalsData =
                 !results.isLoading &&
-                allVitals.some(vital => !results.vitalsData?.[vital]);
+                shouldDisplayMissingVitalsAlert(results.vitalsData, allVitals);
 
               return (
                 <Fragment>

--- a/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
@@ -162,22 +162,12 @@ export function isMissingVitalsData(
   vitalsData: VitalsData | null,
   allVitals: WebVital[]
 ): boolean {
-  if (!vitalsData) {
+  if (!vitalsData || allVitals.some(vital => !vitalsData[vital])) {
     return true;
   }
 
-  const isMissingVitalsMeasurement = allVitals.some(vital => !vitalsData[vital]);
-
-  const measurementsWithoutData = Object.keys(vitalsData).filter(key => {
-    const vitalObj = vitalsData[key];
-    const isVitalObjectEmpty = Object.keys(vitalObj).every(
-      measurement => vitalObj[measurement] === null || vitalObj[measurement] === 0
-    );
-
-    return isVitalObjectEmpty;
-  });
-
-  const hasEmptyVitalsMeasurement = measurementsWithoutData.length > 0;
-
-  return isMissingVitalsMeasurement || hasEmptyVitalsMeasurement;
+  const measurementsWithoutCounts = Object.values(vitalsData).filter(
+    vitalObj => vitalObj.total === 0
+  );
+  return measurementsWithoutCounts.length > 0;
 }

--- a/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
@@ -1,8 +1,10 @@
 import type {ECharts} from 'echarts';
 import {Query} from 'history';
 
+import {WebVital} from 'sentry/utils/discover/fields';
 import {HistogramData} from 'sentry/utils/performance/histogram/types';
 import {getBucketWidth} from 'sentry/utils/performance/histogram/utils';
+import {VitalsData} from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
 
 import {Point, Rectangle} from './types';
 
@@ -154,4 +156,28 @@ export function mapPoint(
     x: destRect.point1.x + (destRect.point2.x - destRect.point1.x) * xPercentage,
     y: destRect.point1.y + (destRect.point2.y - destRect.point1.y) * yPercentage,
   };
+}
+
+export function shouldDisplayMissingVitalsAlert(
+  vitalsData: VitalsData | null,
+  allVitals: WebVital[]
+): boolean {
+  if (!vitalsData) {
+    return true;
+  }
+
+  const isMissingVitalsMeasurement = allVitals.some(vital => !vitalsData?.[vital]);
+
+  const measurementsWithoutData = Object.keys(vitalsData).filter(key => {
+    const vitalObj = vitalsData[key];
+    const isVitalObjectEmpty = Object.keys(vitalObj).every(
+      measurement => vitalObj[measurement] === null || vitalObj[measurement] === 0
+    );
+
+    return isVitalObjectEmpty;
+  });
+
+  const hasEmptyVitalsMeasurement = measurementsWithoutData.length > 0;
+
+  return isMissingVitalsMeasurement || hasEmptyVitalsMeasurement;
 }

--- a/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
@@ -166,7 +166,7 @@ export function shouldDisplayMissingVitalsAlert(
     return true;
   }
 
-  const isMissingVitalsMeasurement = allVitals.some(vital => !vitalsData?.[vital]);
+  const isMissingVitalsMeasurement = allVitals.some(vital => !vitalsData[vital]);
 
   const measurementsWithoutData = Object.keys(vitalsData).filter(key => {
     const vitalObj = vitalsData[key];

--- a/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
@@ -158,7 +158,7 @@ export function mapPoint(
   };
 }
 
-export function shouldDisplayMissingVitalsAlert(
+export function isMissingVitalsData(
   vitalsData: VitalsData | null,
   allVitals: WebVital[]
 ): boolean {

--- a/tests/js/spec/views/performance/transactionVitals.spec.jsx
+++ b/tests/js/spec/views/performance/transactionVitals.spec.jsx
@@ -404,4 +404,37 @@ describe('Performance > Web Vitals', function () {
       expect(wrapper.find('Alert')).toHaveLength(0);
     });
   });
+
+  it('renders an info alert when some web vitals measurements has no data available', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-vitals/',
+      body: {
+        'measurements.cls': {poor: 1, meh: 2, good: 3, total: 6, p75: 4567},
+        'measurements.fcp': {poor: 1, meh: 2, good: 3, total: 6, p75: 4567},
+        'measurements.fid': {poor: 1, meh: 2, good: 3, total: 6, p75: 4567},
+        'measurements.fp': {poor: 1, meh: 2, good: 3, total: 6, p75: 1456},
+        'measurements.lcp': {poor: 0, meh: 0, good: 0, total: 0, p75: null},
+      },
+    });
+
+    const {organization, router, routerContext} = initialize({
+      query: {
+        lcpStart: '20',
+      },
+    });
+
+    const wrapper = mountWithTheme(
+      <WrappedComponent
+        organization={organization}
+        location={router.location}
+        router={router}
+      />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('Alert')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
In [#31764](https://github.com/getsentry/sentry/pull/31764), I had written some code that would display an info alert on the Web Vitals page for a transaction, if some of the web vitals data is missing. This alert would link to the docs to explain to users why they may not be seeing their web vitals data.

However, my check to determine if data was missing was not correct. This PR fixes this error by checking if some of the web vitals have a count of 0 for each measurement.

For example, the following object is missing LCP and CLS data, but that was not being recognized by the check in my previous PR.

```
{ 
  measurements.cls: {poor: 0, meh: 0, good: 0, total: 0, p75: null}
  measurements.fcp: {poor: 43, meh: 1728, good: 1565, total: 3336, p75: 1318.8501000404356}
  measurements.fid: {poor: 0, meh: 1, good: 16, total: 17, p75: 9.5}
  measurements.fp: {poor: 28, meh: 1648, good: 1568, total: 3244, p75: 1309.0912699699402}
  measurements.lcp: {poor: 0, meh: 0, good: 0, total: 0, p75: null}
}
```