### PR TITLE
feat(ratelimits): Add RPS values to access log

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -44,6 +44,9 @@ def _get_rate_limit_stats_dict(request: Request) -> dict[str, str]:
         "rate_limit_type": "DNE",
         "concurrent_limit": str(None),
         "concurrent_requests": str(None),
+        "reset_time": str(None),
+        "limit": str(None),
+        "remaining": str(None),
     }
 
     rate_limit_metadata = getattr(request, "rate_limit_metadata", None)

--- a/src/sentry/ratelimits/concurrent.py
+++ b/src/sentry/ratelimits/concurrent.py
@@ -52,17 +52,17 @@ class ConcurrentRateLimiter:
                 "Could not start request", dict(key=redis_key, limit=limit, request_uid=request_uid)
             )
             return ConcurrentLimitInfo(limit, -1, False)
-
-        logger.info(
-            "Cleaned up concurrent executions: %s",
-            cleaned_up_requests,
-            extra={
-                "cleaned_up_requests": cleaned_up_requests,
-                "key": key,
-                "limit": limit,
-                "request_uid": request_uid,
-            },
-        )
+        if cleaned_up_requests != 0:
+            logger.info(
+                "Cleaned up concurrent executions: %s",
+                cleaned_up_requests,
+                extra={
+                    "cleaned_up_requests": cleaned_up_requests,
+                    "key": key,
+                    "limit": limit,
+                    "request_uid": request_uid,
+                },
+            )
         return ConcurrentLimitInfo(limit, int(current_executions), not bool(request_allowed))
 
     def get_concurrent_requests(self, key: str) -> int:

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -82,6 +82,9 @@ access_log_fields = (
     "rate_limit_type",
     "concurrent_limit",
     "concurrent_requests",
+    "reset_time",
+    "limit",
+    "remaining",
 )
 
 
@@ -135,6 +138,8 @@ class TestAccessLogRateLimited(LogCaptureAPITestCase):
         self.assert_access_log_recorded()
         # no token because the endpoint was not hit
         assert self.captured_logs[0].token_type == "None"
+        assert self.captured_logs[0].limit == "0"
+        assert self.captured_logs[0].remaining == "0"
 
 
 class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
@@ -143,19 +148,21 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
 
     def test_concurrent_request_finishes(self):
         self._caplog.set_level(logging.INFO, logger="api.access")
-        self.get_success_response()
+        for i in range(10):
+            self.get_success_response()
         # these requests were done in succession, so we should not have any
         # rate limiting
         self.assert_access_log_recorded()
-        assert self.captured_logs[0].token_type == "None"
-        assert self.captured_logs[0].concurrent_requests == "1"
-        assert self.captured_logs[0].concurrent_limit == "1"
-        assert self.captured_logs[0].rate_limit_type == "RateLimitType.NOT_LIMITED"
-        self.get_success_response()
-        assert self.captured_logs[1].token_type == "None"
-        assert self.captured_logs[1].concurrent_requests == "1"
-        assert self.captured_logs[1].concurrent_limit == "1"
-        assert self.captured_logs[1].rate_limit_type == "RateLimitType.NOT_LIMITED"
+        for i in range(10):
+            assert self.captured_logs[i].token_type == "None"
+            assert self.captured_logs[i].concurrent_requests == "1"
+            assert self.captured_logs[i].concurrent_limit == "1"
+            assert self.captured_logs[i].rate_limit_type == "RateLimitType.NOT_LIMITED"
+            assert self.captured_logs[i].limit == "20"
+            # we cannot assert on the exact amount of remaining requests because
+            # we may be crossing a second boundary during our test. That would make things
+            # flaky.
+            assert int(self.captured_logs[i].remaining) < 20
 
 
 class TestAccessLogSuccess(LogCaptureAPITestCase):


### PR DESCRIPTION
Currently RPS has been calculating by tallying the amount of requests in the access logs. After further analysis it may be the case that the logs are not capturing every API request. In order to have reliable RPS data, log the RPS rate limiter's values.