### PR TITLE
fix(workflow): Properly update project resources when transferring

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -21,7 +21,7 @@ Scheduling Deletions
 --------------------
 
 The entrypoint into deletions for the majority of application code is via the ``ScheduledDeletion``
-model. This model lets you creation deletion jobs that are run in the future.
+model. This model lets you create deletion jobs that are run in the future.
 
 >>> from sentry.models import ScheduledDeletion
 >>> ScheduledDeletion.schedule(organization, days=1, hours=2)
@@ -52,7 +52,7 @@ If you have scheduled a record for deletion and want to be able to cancel that d
 deletion task needs to implement the `should_proceed` hook.
 
 >>> def should_proceed(self, instance):
->>>     return instance.status in {ObjectStatus.PENDING_DELETION, ObjectStatus. DELETION_IN_PROGRESS}
+>>>     return instance.status in {ObjectStatus.PENDING_DELETION, ObjectStatus.DELETION_IN_PROGRESS}
 
 The above would only proceed with the deletion if the record's status was correct.  When a deletion
 is cancelled by this hook, the `ScheduledDeletion` row will be removed.
@@ -63,7 +63,7 @@ Using Deletions Manager Directly
 For example, let's say you want to delete an organization:
 
 >>> from sentry import deletions
->>> task = deletions.get(model=Organization)
+>>> task = deletions.get(model=Organization, query={})
 >>> work = True
 >>> while work:
 >>>    work = task.chunk()

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -342,9 +342,10 @@ class Project(Model, PendingDeletionMixin):
             if not is_member:
                 rule.update(owner=None)
 
-        # null out environment_id so when the org(and its associated resources) eventually gets deleted
-        # the to_org resources aren't referencing to-be-deleted DB objects, blocking the deletion process
-        # alertrule ->  snuba_query -> environmentId
+        # conditionally create a new environment associated to the new Org -> Project -> AlertRule -> SnubaQuery
+        # this should take care of any potentially dead references from SnubaQuery -> Environment when deleting
+        # the old org
+        # alertrule ->  snuba_query -> environment_id
         for snuba_id, environment_id in AlertRule.objects.fetch_for_project(self).values_list(
             "snuba_query_id", "snuba_query__environment__id"
         ):

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -198,11 +198,10 @@ class DeleteOrganizationTest(TestCase):
 
         alert_rule.refresh_from_db()
         assert AlertRule.objects.fetch_for_project(project).exists()
-        assert alert_rule.snuba_query.environment is not environment
-        assert alert_rule.snuba_query.environment is None
+        assert alert_rule.snuba_query.environment != environment
         assert Environment.objects.filter(organization_id=from_org.id).count() == 1
         assert (
-            Environment.objects.filter(organization_id=to_org.id).count() == 0
+            Environment.objects.filter(organization_id=to_org.id).count() == 1
         )  # env should stay with og org
 
         # block until its deleted
@@ -217,7 +216,11 @@ class DeleteOrganizationTest(TestCase):
         assert not Organization.objects.filter(name="from_org").exists()
         assert Organization.objects.filter(name="to_org").exists()
         assert AlertRule.objects.filter(id=alert_rule.id).exists()
-        assert SnubaQuery.objects.filter(id=alert_rule.snuba_query.id, environment_id=None).exists()
+        assert (
+            SnubaQuery.objects.filter(id=alert_rule.snuba_query.id)
+            .exclude(environment=None)
+            .exists()
+        )
 
 
 class ReattemptDeletionsTest(TestCase):

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -2,27 +2,21 @@ from datetime import timedelta
 from unittest.mock import Mock
 from uuid import uuid4
 
-from sentry import deletions, nodestore
+from sentry import nodestore
 from sentry.constants import ObjectStatus
-from sentry.deletions.defaults.organization import OrganizationDeletionTask
 from sentry.eventstore.models import Event
-from sentry.incidents.models import AlertRule
 from sentry.models import (
-    ActorTuple,
-    Environment,
     Group,
     GroupAssignee,
     GroupHash,
     GroupMeta,
     GroupRedirect,
     GroupStatus,
-    Organization,
     Repository,
     ScheduledDeletion,
     Team,
 )
 from sentry.signals import pending_delete
-from sentry.snuba.models import SnubaQuery
 from sentry.tasks.deletion import delete_groups, reattempt_deletions, run_scheduled_deletions
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -144,83 +138,6 @@ class RunScheduledDeletionTest(TestCase):
             run_scheduled_deletions()
 
         assert not ScheduledDeletion.objects.filter(id=schedule.id).exists()
-
-
-class DeleteOrganizationTest(TestCase):
-    def test_delete_org_simple(self):
-        name_filter = {"name": "test_delete_org_simple"}
-        org = self.create_organization(**name_filter)
-
-        assert Organization.objects.filter(**name_filter).count() == 1
-        assert ScheduledDeletion.objects.count() == 0
-
-        org_deletion_task: OrganizationDeletionTask = deletions.get(
-            model=Organization, query={"id": org.id}
-        )
-
-        # schedule the deletion
-        ScheduledDeletion.schedule(instance=org, days=0)
-        assert ScheduledDeletion.objects.count() == 1
-
-        # org should still exist and not deleted yet
-        assert Organization.objects.filter(**name_filter).count() == 1
-        # make progress on the deletion tasks
-        work = True
-        while work:
-            work = org_deletion_task.chunk()
-
-        assert Organization.objects.filter(**name_filter).count() == 0
-
-    def test_delete_org_after_project_transfer(self):
-        from_org = self.create_organization(name="from_org")
-        from_user = self.create_user()
-        self.create_member(user=from_user, role="member", organization=from_org)
-        from_team = self.create_team(organization=from_org)
-
-        to_org = self.create_organization(name="to_org")
-        self.create_team(organization=to_org)
-        to_user = self.create_user()
-        self.create_member(user=to_user, role="member", organization=to_org)
-        assert Organization.objects.filter(name="to_org").exists()
-
-        project = self.create_project(teams=[from_team])
-        environment = Environment.get_or_create(project, "production")
-
-        alert_rule: AlertRule = self.create_alert_rule(
-            organization=from_org,
-            projects=[project],
-            owner=ActorTuple.from_actor_identifier(f"team:{from_team.id}"),
-            environment=environment,
-        )
-
-        project.transfer_to(organization=to_org)
-        assert project.organization.id is to_org.id
-
-        alert_rule.refresh_from_db()
-        assert AlertRule.objects.fetch_for_project(project).exists()
-        assert alert_rule.snuba_query.environment != environment
-        assert Environment.objects.filter(organization_id=from_org.id).count() == 1
-        assert (
-            Environment.objects.filter(organization_id=to_org.id).count() == 1
-        )  # env should stay with og org
-
-        # block until its deleted
-        ScheduledDeletion.schedule(instance=from_org, days=0)
-        org_deletion_task: OrganizationDeletionTask = deletions.get(
-            model=Organization, query={"id": from_org.id}
-        )
-        work = True
-        while work:
-            work = org_deletion_task.chunk()
-
-        assert not Organization.objects.filter(name="from_org").exists()
-        assert Organization.objects.filter(name="to_org").exists()
-        assert AlertRule.objects.filter(id=alert_rule.id).exists()
-        assert (
-            SnubaQuery.objects.filter(id=alert_rule.snuba_query.id)
-            .exclude(environment=None)
-            .exists()
-        )
 
 
 class ReattemptDeletionsTest(TestCase):


### PR DESCRIPTION
* Conditionally create a new Environment by-name when transferring a project across orgs.
* Update SnubaQuery to reference the new Environment.

WOR-1663