### PR TITLE
feat(metrics): Add `failure_rate` derived metric [INGEST-982]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -46,6 +46,7 @@ from sentry.snuba.metrics.fields.snql import (
     errored_all_users,
     errored_preaggr_sessions,
     failure_count_transaction,
+    failure_rate_transaction,
     percentage,
     session_duration_filters,
     sessions_errored_set,
@@ -759,6 +760,7 @@ class DerivedMetricKey(Enum):
 
     TRANSACTION_ALL = "transaction.all"
     TRANSACTION_FAILURE_COUNT = "transaction.failure_count"
+    TRANSACTION_FAILURE_RATE = "transaction.failure_rate"
 
 
 # ToDo(ahmed): Investigate dealing with derived metric keys as Enum objects rather than string
@@ -920,6 +922,17 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             unit="transactions",
             snql=lambda *_, org_id, metric_ids, alias=None: failure_count_transaction(
                 org_id, metric_ids=metric_ids, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
+            metric_name=DerivedMetricKey.TRANSACTION_FAILURE_RATE.value,
+            metrics=[
+                DerivedMetricKey.TRANSACTION_FAILURE_COUNT.value,
+                DerivedMetricKey.TRANSACTION_ALL.value,
+            ],
+            unit="transactions",
+            snql=lambda *args, org_id, metric_ids, alias=None: failure_rate_transaction(
+                *args, alias=alias
             ),
         ),
     ]

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -183,16 +183,10 @@ def failure_count_transaction(org_id, metric_ids, alias=None):
 
 def failure_rate_transaction(failure_count_snql, tx_count_snql, alias=None):
     return Function(
-        "multiply",
-        [
-            Function(
-                "divide",
-                # Clickhouse can manage divisions by 0, see:
-                # https://clickhouse.com/docs/en/sql-reference/functions/arithmetic-functions/#dividea-b-a-b-operator
-                [failure_count_snql, tx_count_snql],
-            ),
-            100,
-        ],
+        "divide",
+        # Clickhouse can manage divisions by 0, see:
+        # https://clickhouse.com/docs/en/sql-reference/functions/arithmetic-functions/#dividea-b-a-b-operator
+        [failure_count_snql, tx_count_snql],
         alias=alias,
     )
 

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -171,6 +171,7 @@ def failure_count_transaction(org_id, metric_ids, alias=None):
     return _dist_count_aggregation_on_tx_status_factory(
         org_id,
         exclude_tx_statuses=[
+            # See statuses in https://docs.sentry.io/product/performance/metrics/#failure-rate
             TransactionStatusTagValue.OK.value,
             TransactionStatusTagValue.CANCELLED.value,
             TransactionStatusTagValue.UNKNOWN.value,

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -181,7 +181,7 @@ def failure_count_transaction(org_id, metric_ids, alias=None):
     )
 
 
-def failure_rate_transaction(failure_num_snql, tx_num_snql, alias=None):
+def failure_rate_transaction(failure_count_snql, tx_count_snql, alias=None):
     return Function(
         "multiply",
         [
@@ -189,7 +189,7 @@ def failure_rate_transaction(failure_num_snql, tx_num_snql, alias=None):
                 "divide",
                 # Clickhouse can manage divisions by 0, see:
                 # https://clickhouse.com/docs/en/sql-reference/functions/arithmetic-functions/#dividea-b-a-b-operator
-                [failure_num_snql, tx_num_snql],
+                [failure_count_snql, tx_count_snql],
             ),
             100,
         ],

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -180,6 +180,22 @@ def failure_count_transaction(org_id, metric_ids, alias=None):
     )
 
 
+def failure_rate_transaction(failure_num_snql, tx_num_snql, alias=None):
+    return Function(
+        "multiply",
+        [
+            Function(
+                "divide",
+                # Clickhouse can manage divisions by 0, see:
+                # https://clickhouse.com/docs/en/sql-reference/functions/arithmetic-functions/#dividea-b-a-b-operator
+                [failure_num_snql, tx_num_snql],
+            ),
+            100,
+        ],
+        alias=alias,
+    )
+
+
 def percentage(arg1_snql, arg2_snql, alias=None):
     return Function("minus", [1, Function("divide", [arg1_snql, arg2_snql])], alias)
 

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1978,6 +1978,111 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["totals"] == {"transaction.failure_count": 1}
         assert group["series"] == {"transaction.failure_count": [1]}
 
+    def test_failure_rate_transaction(self):
+        user_ts = time.time()
+        self._send_buckets(
+            [
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": self.tx_metric,
+                    "timestamp": user_ts,
+                    "tags": {
+                        self.tx_status: indexer.record(
+                            self.organization.id, TransactionStatusTagValue.OK.value
+                        ),
+                    },
+                    "type": "d",
+                    "value": [3.4],
+                    "retention_days": 90,
+                },
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": self.tx_metric,
+                    "timestamp": user_ts,
+                    "tags": {
+                        self.tx_status: indexer.record(
+                            self.organization.id, TransactionStatusTagValue.CANCELLED.value
+                        ),
+                    },
+                    "type": "d",
+                    "value": [0.3],
+                    "retention_days": 90,
+                },
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": self.tx_metric,
+                    "timestamp": user_ts,
+                    "tags": {
+                        self.tx_status: indexer.record(
+                            self.organization.id, TransactionStatusTagValue.UNKNOWN.value
+                        ),
+                    },
+                    "type": "d",
+                    "value": [2.3],
+                    "retention_days": 90,
+                },
+                {
+                    "org_id": self.organization.id,
+                    "project_id": self.project.id,
+                    "metric_id": self.tx_metric,
+                    "timestamp": user_ts,
+                    "tags": {
+                        self.tx_status: indexer.record(
+                            self.organization.id, TransactionStatusTagValue.ABORTED.value
+                        ),
+                    },
+                    "type": "d",
+                    "value": [0.5],
+                    "retention_days": 90,
+                },
+            ],
+            entity="metrics_distributions",
+        )
+        response = self.get_success_response(
+            self.organization.slug,
+            field=["transaction.failure_rate"],
+            statsPeriod="1m",
+            interval="1m",
+        )
+
+        assert len(response.data["groups"]) == 1
+        group = response.data["groups"][0]
+        assert group["by"] == {}
+        assert group["totals"] == {"transaction.failure_rate": 25.0}
+        assert group["series"] == {"transaction.failure_rate": [25.0]}
+
+    def test_failure_rate_without_transactions(self):
+        """
+        Ensures the absence of transactions isn't an issue to calculate the rate.
+
+        The `nan` a division by 0 may produce must not be in the response, yet
+        they are an issue in javascript:
+        ```
+        $ node
+        Welcome to Node.js v16.13.1.
+        Type ".help" for more information.
+        > JSON.parse('NaN')
+        Uncaught SyntaxError: Unexpected token N in JSON at position 0
+        > JSON.parse('nan')
+        Uncaught SyntaxError: Unexpected token a in JSON at position 1
+        ```
+        """
+        # Not sending buckets means no project is created automatically. We need
+        # a project without transaction data, so create one:
+        self.project
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field=["transaction.failure_rate"],
+            statsPeriod="1m",
+            interval="1m",
+        )
+
+        assert response.data["groups"] == []
+
     def test_request_private_derived_metric(self):
         for private_name in [
             "session.crashed_and_abnormal_user",

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -2051,8 +2051,8 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert len(response.data["groups"]) == 1
         group = response.data["groups"][0]
         assert group["by"] == {}
-        assert group["totals"] == {"transaction.failure_rate": 25.0}
-        assert group["series"] == {"transaction.failure_rate": [25.0]}
+        assert group["totals"] == {"transaction.failure_rate": 0.25}
+        assert group["series"] == {"transaction.failure_rate": [0.25]}
 
     def test_failure_rate_without_transactions(self):
         """

--- a/tests/sentry/snuba/metrics/test_snql.py
+++ b/tests/sentry/snuba/metrics/test_snql.py
@@ -160,17 +160,10 @@ class DerivedMetricSnQLTestCase(TestCase):
             all_transactions(org_id, self.metric_ids, "transactions.all"),
             alias="transactions.failure_rate",
         ) == Function(
-            "multiply",
+            "divide",
             [
-                Function(
-                    "divide",
-                    [
-                        expected_failed_txs,
-                        expected_all_txs,
-                    ],
-                    alias=None,
-                ),
-                100,
+                expected_failed_txs,
+                expected_all_txs,
             ],
             alias="transactions.failure_rate",
         )

--- a/tests/sentry/snuba/metrics/test_snql.py
+++ b/tests/sentry/snuba/metrics/test_snql.py
@@ -18,7 +18,7 @@ from sentry.snuba.metrics import (
     sessions_errored_set,
     subtraction,
 )
-from sentry.snuba.metrics.fields.snql import failure_count_transaction
+from sentry.snuba.metrics.fields.snql import failure_count_transaction, failure_rate_transaction
 from sentry.testutils import TestCase
 
 
@@ -104,7 +104,7 @@ class DerivedMetricSnQLTestCase(TestCase):
     def test_dist_count_aggregation_on_tx_status(self):
         org_id = 1985
 
-        assert all_transactions(org_id, self.metric_ids, "transactions.all") == Function(
+        expected_all_txs = Function(
             "countIf",
             [
                 Column("value"),
@@ -119,10 +119,9 @@ class DerivedMetricSnQLTestCase(TestCase):
             ],
             alias="transactions.all",
         )
+        assert all_transactions(org_id, self.metric_ids, "transactions.all") == expected_all_txs
 
-        assert failure_count_transaction(
-            org_id, self.metric_ids, "transactions.failed"
-        ) == Function(
+        expected_failed_txs = Function(
             "countIf",
             [
                 Column("value"),
@@ -150,6 +149,30 @@ class DerivedMetricSnQLTestCase(TestCase):
                 ),
             ],
             alias="transactions.failed",
+        )
+        assert (
+            failure_count_transaction(org_id, self.metric_ids, "transactions.failed")
+            == expected_failed_txs
+        )
+
+        assert failure_rate_transaction(
+            failure_count_transaction(org_id, self.metric_ids, "transactions.failed"),
+            all_transactions(org_id, self.metric_ids, "transactions.all"),
+            alias="transactions.failure_rate",
+        ) == Function(
+            "multiply",
+            [
+                Function(
+                    "divide",
+                    [
+                        expected_failed_txs,
+                        expected_all_txs,
+                    ],
+                    alias=None,
+                ),
+                100,
+            ],
+            alias="transactions.failure_rate",
         )
 
     def test_percentage_in_snql(self):


### PR DESCRIPTION
Adds a `transaction.failure_rate` derived metric, returning the rate of failed transactions. See https://docs.sentry.io/product/performance/metrics/#failure-rate.