### PR TITLE
fix(performance): updates trace error message to use error.message

### DIFF
--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -181,7 +181,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
                   <ErrorLabel>
                     {tct(
                       'The trace cannot be shown when all events are errors. An error occurred when attempting to fetch these error events: [error]',
-                      {error}
+                      {error: error.message}
                     )}
                   </ErrorLabel>
                 </Alert>


### PR DESCRIPTION
error used to be a string but now it's a QueryError so we need to use the message attribute instead