### PR TITLE
feat(alerts): Alert wizard v3 pre-project selector projectId route parameter

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1082,6 +1082,18 @@ function buildRoutes() {
         </Route>
       </Route>
       <Route
+        path="new/"
+        name={t('New Alert Rule')}
+        component={SafeLazyLoad}
+        componentPromise={() => import('sentry/views/alerts/builder/projectProvider')}
+      >
+        <Route
+          path=":alertType/"
+          component={SafeLazyLoad}
+          componentPromise={() => import('sentry/views/alerts/create')}
+        />
+      </Route>
+      <Route
         path=":alertId/"
         componentPromise={() => import('sentry/views/alerts/incidentRedirect')}
         component={SafeLazyLoad}

--- a/static/app/views/alerts/builder/builderBreadCrumbs.tsx
+++ b/static/app/views/alerts/builder/builderBreadCrumbs.tsx
@@ -6,6 +6,7 @@ import Breadcrumbs, {Crumb, CrumbDropdown} from 'sentry/components/breadcrumbs';
 import IdBadge from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import useProjects from 'sentry/utils/useProjects';
@@ -14,43 +15,49 @@ import type {RouteWithName} from 'sentry/views/settings/components/settingsBread
 
 interface Props {
   location: Location;
-  orgSlug: string;
+  organization: Organization;
   projectSlug: string;
   routes: RouteWithName[];
   title: string;
   alertName?: string;
+  alertType?: string;
   canChangeProject?: boolean;
 }
 
 function BuilderBreadCrumbs({
-  orgSlug,
   title,
   alertName,
   projectSlug,
   routes,
   canChangeProject,
   location,
+  organization,
+  alertType,
 }: Props) {
   const {projects} = useProjects();
   const isSuperuser = isActiveSuperuser();
   const project = projects.find(({slug}) => projectSlug === slug);
+  const hasAlertWizardV3 = organization.features.includes('alert-wizard-v3');
 
   const label = (
     <IdBadge project={project ?? {slug: projectSlug}} avatarSize={18} disableLink />
   );
 
   const projectCrumbLink: Crumb = {
-    to: `/organizations/${orgSlug}/alerts/rules/?project=${project?.id}`,
+    to: `/organizations/${organization.slug}/alerts/rules/?project=${project?.id}`,
     label,
   };
 
   function getProjectDropdownCrumb(): CrumbDropdown {
     return {
-      onSelect: ({value}) => {
+      onSelect: ({value: projectId}) => {
+        // TODO(taylangocmen): recreating route doesn't update query, don't edit recreateRoute will add project selector for alert-wizard-v3
         browserHistory.push(
           recreateRoute('', {
             routes,
-            params: {orgId: orgSlug, projectId: value},
+            params: hasAlertWizardV3
+              ? {orgId: organization.slug, alertType}
+              : {orgId: organization.slug, projectId},
             location,
           })
         );
@@ -80,7 +87,7 @@ function BuilderBreadCrumbs({
 
   const crumbs: (Crumb | CrumbDropdown)[] = [
     {
-      to: `/organizations/${orgSlug}/alerts/rules/`,
+      to: `/organizations/${organization.slug}/alerts/rules/`,
       label: t('Alerts'),
       preservePageFilters: true,
     },
@@ -89,7 +96,7 @@ function BuilderBreadCrumbs({
       label: title,
       ...(alertName
         ? {
-            to: `/organizations/${orgSlug}/alerts/${projectSlug}/wizard`,
+            to: `/organizations/${organization.slug}/alerts/${projectSlug}/wizard`,
             preservePageFilters: true,
           }
         : {}),

--- a/static/app/views/alerts/builder/projectProvider.tsx
+++ b/static/app/views/alerts/builder/projectProvider.tsx
@@ -17,7 +17,7 @@ type Props = RouteComponentProps<RouteParams, {}> & {
 };
 
 type RouteParams = {
-  projectId: string;
+  projectId?: string;
 };
 
 function AlertBuilderProjectProvider(props: Props) {
@@ -25,7 +25,7 @@ function AlertBuilderProjectProvider(props: Props) {
   useScrollToTop({location: props.location});
 
   const {children, params, organization, ...other} = props;
-  const {projectId} = params;
+  const projectId = params.projectId || props.location.query.project;
   const {projects, initiallyLoaded, fetching, fetchError} = useProjects({
     slugs: [projectId],
   });

--- a/static/app/views/alerts/edit.tsx
+++ b/static/app/views/alerts/edit.tsx
@@ -12,6 +12,7 @@ import Teams from 'sentry/utils/teams';
 import BuilderBreadCrumbs from 'sentry/views/alerts/builder/builderBreadCrumbs';
 import IncidentRulesDetails from 'sentry/views/alerts/incidentRules/details';
 import IssueEditor from 'sentry/views/alerts/issueRuleEditor';
+import {AlertRuleType} from 'sentry/views/alerts/types';
 
 type RouteParams = {
   orgId: string;
@@ -52,8 +53,10 @@ class ProjectAlertsEditor extends Component<Props, State> {
     return `${ruleName}`;
   }
 
-  getAlertType(): 'metric' | 'issue' {
-    return location.pathname.includes('/alerts/metric-rules/') ? 'metric' : 'issue';
+  getAlertType(): AlertRuleType {
+    return location.pathname.includes('/alerts/metric-rules/')
+      ? AlertRuleType.METRIC
+      : AlertRuleType.ISSUE;
   }
 
   render() {
@@ -70,7 +73,7 @@ class ProjectAlertsEditor extends Component<Props, State> {
         <Layout.Header>
           <Layout.HeaderContent>
             <BuilderBreadCrumbs
-              orgSlug={organization.slug}
+              organization={organization}
               title={t('Edit Alert Rule')}
               projectSlug={project.slug}
               routes={routes}
@@ -93,7 +96,7 @@ class ProjectAlertsEditor extends Component<Props, State> {
                         userTeamIds={teams.map(({id}) => id)}
                       />
                     )}
-                    {hasMetricAlerts && alertType === 'metric' && (
+                    {hasMetricAlerts && alertType === AlertRuleType.METRIC && (
                       <IncidentRulesDetails
                         {...this.props}
                         project={project}

--- a/static/app/views/alerts/incidentRules/create.tsx
+++ b/static/app/views/alerts/incidentRules/create.tsx
@@ -14,7 +14,7 @@ import RuleForm from './ruleForm';
 
 type RouteParams = {
   orgId: string;
-  projectId: string;
+  projectId?: string;
   ruleId?: string;
 };
 

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -98,12 +98,14 @@ type RuleTaskResponse = {
   rule?: IssueAlertRule;
 };
 
+type RouteParams = {orgId: string; projectId?: string; ruleId?: string};
+
 type Props = {
   organization: Organization;
   project: Project;
   userTeamIds: string[];
   onChangeTitle?: (data: string) => void;
-} & RouteComponentProps<{orgId: string; projectId: string; ruleId?: string}, {}>;
+} & RouteComponentProps<RouteParams, {}>;
 
 type State = AsyncView['state'] & {
   configs: {
@@ -162,15 +164,18 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {ruleId, projectId, orgId} = this.props.params;
+    const {
+      project,
+      params: {ruleId, orgId},
+    } = this.props;
 
     const endpoints = [
-      ['environments', `/projects/${orgId}/${projectId}/environments/`],
-      ['configs', `/projects/${orgId}/${projectId}/rules/configuration/`],
+      ['environments', `/projects/${orgId}/${project.slug}/environments/`],
+      ['configs', `/projects/${orgId}/${project.slug}/rules/configuration/`],
     ];
 
     if (ruleId) {
-      endpoints.push(['rule', `/projects/${orgId}/${projectId}/rules/${ruleId}/`]);
+      endpoints.push(['rule', `/projects/${orgId}/${project.slug}/rules/${ruleId}/`]);
     }
 
     return endpoints as [string, string][];

--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -22,7 +22,7 @@ import withPageFilters from 'sentry/utils/withPageFilters';
 
 import FilterBar from '../filterBar';
 import AlertHeader from '../list/header';
-import {CombinedMetricIssueAlerts} from '../types';
+import {AlertRuleType, CombinedMetricIssueAlerts} from '../types';
 import {getTeamParams, isIssueAlert} from '../utils';
 
 import RuleListRow from './row';
@@ -231,7 +231,9 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
                     ruleList.map(rule => (
                       <RuleListRow
                         // Metric and issue alerts can have the same id
-                        key={`${isIssueAlert(rule) ? 'metric' : 'issue'}-${rule.id}`}
+                        key={`${
+                          isIssueAlert(rule) ? AlertRuleType.METRIC : AlertRuleType.ISSUE
+                        }-${rule.id}`}
                         projectsLoaded={initiallyLoaded}
                         projects={projects as Project[]}
                         rule={rule}

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -4,6 +4,11 @@ import {IncidentRule} from 'sentry/views/alerts/incidentRules/types';
 
 type Data = [number, {count: number}[]][];
 
+export enum AlertRuleType {
+  METRIC = 'metric',
+  ISSUE = 'issue',
+}
+
 export type Incident = {
   alertRule: IncidentRule;
   dateClosed: string | null;

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -295,6 +295,8 @@ export const AlertWizardRuleTemplates: Record<
   },
 };
 
+export const DEFAULT_WIZARD_TEMPLATE = AlertWizardRuleTemplates.num_errors;
+
 export const hidePrimarySelectorSet = new Set<AlertType>([
   'num_errors',
   'users_experiencing_errors',

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -1,4 +1,3 @@
-import {browserHistory} from 'react-router';
 import selectEvent from 'react-select-event';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -88,9 +87,9 @@ describe('ProjectAlertsCreate', function () {
 
   it('redirects to wizard', function () {
     const location = {query: {}};
-    createWrapper(undefined, location);
+    const wrapper = createWrapper(undefined, location);
 
-    expect(browserHistory.replace).toHaveBeenCalledWith(
+    expect(wrapper.router.replace).toHaveBeenCalledWith(
       '/organizations/org-slug/alerts/project-slug/wizard'
     );
   });


### PR DESCRIPTION
This makes no visual changes but updates the alert wizard routes so that `projectId` in the route params can also be passed as url param and still point to the same page and work.