### PR TITLE
chore(vscode): Don't specify the .eslintrc.* file in vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,10 +16,6 @@
   "files.trimFinalNewlines": true,
   "files.insertFinalNewline": true,
 
-  "eslint.options": {
-    "configFile": ".eslintrc.js"
-  },
-
   "files.associations": {
     "*.jsx": "javascriptreact"
   },


### PR DESCRIPTION
I saw seeing an error in the `vscode-eslint` plugin that:
```
Error: Invalid Options:
- Unknown options: configFile
- 'configFile' has been removed. Please use the 'overrideConfigFile' option instead.
```