### PR TITLE
test(performance): Add test to check if error events could not be fetched

### DIFF
--- a/tests/js/spec/views/performance/traceDetails/content.spec.tsx
+++ b/tests/js/spec/views/performance/traceDetails/content.spec.tsx
@@ -71,5 +71,45 @@ describe('TraceDetailsContent', () => {
         await within(errorList).findByText(SAMPLE_ERROR_DATA.data[1].level)
       ).toBeInTheDocument();
     });
+
+    it('should should display an error if the error events could not be fetched', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/eventsv2/',
+        statusCode: 404,
+        body: {detail: 'This is a test error'},
+      });
+
+      const initialData = initializeData();
+      const eventView = EventView.fromSavedQuery(DEFAULT_EVENT_VIEW);
+      const meta = {errors: 2, projects: 1, transactions: 0};
+
+      render(
+        <TraceDetailsContent
+          location={initialData.location}
+          organization={initialData.organization}
+          traceSlug="123"
+          params={{traceSlug: '123'}}
+          traceEventView={eventView}
+          dateSelected
+          isLoading={false}
+          error={null}
+          traces={null}
+          meta={meta}
+        />
+      );
+
+      const errorText = await screen.findByText(
+        'The trace cannot be shown when all events are errors. An error occurred when attempting to fetch these error events:'
+      );
+
+      const errorContainer = errorText.parentElement;
+      expect(errorContainer).not.toBeNull();
+
+      if (errorContainer) {
+        expect(
+          within(errorContainer).getByText('This is a test error')
+        ).toBeInTheDocument();
+      }
+    });
   });
 });

--- a/tests/js/spec/views/performance/traceDetails/content.spec.tsx
+++ b/tests/js/spec/views/performance/traceDetails/content.spec.tsx
@@ -105,11 +105,9 @@ describe('TraceDetailsContent', () => {
       const errorContainer = errorText.parentElement;
       expect(errorContainer).not.toBeNull();
 
-      if (errorContainer) {
-        expect(
-          within(errorContainer).getByText('This is a test error')
-        ).toBeInTheDocument();
-      }
+      expect(
+        within(errorContainer!).getByText('This is a test error')
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
This PR follows up on #33306 by adding a test to check for the case when error events were unable to be fetched on the trace view