### PR TITLE
ref(vercel): Show error message to user

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -263,7 +263,15 @@ class VercelIntegration(IntegrationInstallation):
             return client.create_env_variable(vercel_project_id, data)
         except ApiError as e:
             if e.json and e.json.get("error", {}).get("code") == "ENV_ALREADY_EXISTS":
-                return self.update_env_variable(client, vercel_project_id, data)
+                try:
+                    return self.update_env_variable(client, vercel_project_id, data)
+                except ApiError as e:
+                    error_message = (
+                        e.json.get("error", {}).get("message")
+                        if e.json
+                        else f"Could not update environment variable {key}."
+                    )
+                    raise ValidationError({"project_mappings": [error_message]})
             raise
 
     def update_env_variable(self, client, vercel_project_id, data):


### PR DESCRIPTION
Surface the exact error message to the front end when a Vercel project fails to connect with a Sentry project.

**Before**
![failedtosave](https://user-images.githubusercontent.com/29959063/161827942-80829698-ab90-443e-8050-13de4a82f159.png)

**After**
<img width="970" alt="Screen Shot 2022-04-05 at 11 45 33 AM" src="https://user-images.githubusercontent.com/29959063/161827884-ebc04a63-088f-4351-93ee-0c1d58aba223.png">

It's worth noting that I can't actually reproduce [this error](https://sentry.io/organizations/sentry/issues/2967955043/events/f15d9b15c4d1440fa2059b50087af459/?project=1&statsPeriod=14d). If we find that the environment variable we are trying to create already exists (see the code [here](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/vercel/integration.py#L265-L266)) we will [make a PATCH request](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/vercel/client.py#L79-L80) and update it. This always works for me locally even if I already manually set environment variables in Vercel before connecting the projects. 
