### PR TITLE
feat(devserver): Add allowlist for devserver logs

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2528,4 +2528,8 @@ SENTRY_ISSUE_ALERT_HISTORY_OPTIONS = {}
 # This is useful for testing SSO expiry flows
 SENTRY_SSO_EXPIRY_SECONDS = os.environ.get("SENTRY_SSO_EXPIRY_SECONDS", None)
 
+# Set to an iterable of strings matching services so only logs from those services show up
+# eg. DEVSERVER_LOGS_ALLOWLIST = {"server", "webpack", "worker"}
+DEVSERVER_LOGS_ALLOWLIST = None
+
 LOG_API_ACCESS = not IS_DEV or os.environ.get("SENTRY_LOG_API_ACCESS")

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -335,7 +335,7 @@ def devserver(
     for name, cmd in daemons:
         quiet = (
             name not in settings.DEVSERVER_LOGS_ALLOWLIST
-            if hasattr(settings, "DEVSERVER_LOGS_ALLOWLIST")
+            if settings.DEVSERVER_LOGS_ALLOWLIST is not None
             else False
         )
         manager.add_process(name, list2cmdline(cmd), quiet=quiet, cwd=cwd)

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -333,7 +333,12 @@ def devserver(
 
     manager = Manager(honcho_printer)
     for name, cmd in daemons:
-        manager.add_process(name, list2cmdline(cmd), quiet=False, cwd=cwd)
+        quiet = (
+            name not in settings.DEVSERVER_LOGS_ALLOWLIST
+            if hasattr(settings, "DEVSERVER_LOGS_ALLOWLIST")
+            else False
+        )
+        manager.add_process(name, list2cmdline(cmd), quiet=quiet, cwd=cwd)
 
     manager.loop()
     sys.exit(manager.returncode)


### PR DESCRIPTION
- This adds an allowlist to settings that when included will only show logs from those processes instead of everything
  - The intent here is that I run relay, post-process-forwarding etc. and they overwhelm my local logs making development more difficult
  
#### example usage
- Edit `/.sentry/sentry.conf.py` to have something like
```python
DEVSERVER_LOGS_ALLOWLIST = ["server", "worker", "webpack"]
```
- Which means we'll only have logs from those 3 services