### PR TITLE
fix(new-widget-builder-experience): Modifying filter bar wipes columns

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -51,27 +51,30 @@ export function FilterResultsStep({
     };
   }, []);
 
-  const handleSearch = useCallback((queryIndex: number) => {
-    return (field: string) => {
-      // SearchBar will call handlers for both onSearch and onBlur
-      // when selecting a value from the autocomplete dropdown. This can
-      // cause state issues for the search bar in our use case. To prevent
-      // this, we set a timer in our onSearch handler to block our onBlur
-      // handler from firing if it is within 200ms, ie from clicking an
-      // autocomplete value.
-      window.clearTimeout(blurTimeoutRef.current);
-      blurTimeoutRef.current = window.setTimeout(() => {
-        blurTimeoutRef.current = undefined;
-      }, 200);
+  const handleSearch = useCallback(
+    (queryIndex: number) => {
+      return (field: string) => {
+        // SearchBar will call handlers for both onSearch and onBlur
+        // when selecting a value from the autocomplete dropdown. This can
+        // cause state issues for the search bar in our use case. To prevent
+        // this, we set a timer in our onSearch handler to block our onBlur
+        // handler from firing if it is within 200ms, ie from clicking an
+        // autocomplete value.
+        window.clearTimeout(blurTimeoutRef.current);
+        blurTimeoutRef.current = window.setTimeout(() => {
+          blurTimeoutRef.current = undefined;
+        }, 200);
 
-      const newQuery: WidgetQuery = {
-        ...queries[queryIndex],
-        conditions: field,
+        const newQuery: WidgetQuery = {
+          ...queries[queryIndex],
+          conditions: field,
+        };
+
+        onQueryChange(queryIndex, newQuery);
       };
-
-      onQueryChange(queryIndex, newQuery);
-    };
-  }, []);
+    },
+    [queries]
+  );
 
   const handleBlur = useCallback(
     (queryIndex: number) => {

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1143,6 +1143,28 @@ describe('WidgetBuilder', function () {
     });
   });
 
+  it('does not wipe column changes when filters are modified', async function () {
+    jest.useFakeTimers();
+
+    // widgetIndex: undefined means creating a new widget
+    renderTestComponent({params: {widgetIndex: undefined}});
+
+    userEvent.click(await screen.findByLabelText('Add a Column'));
+    await selectEvent.select(screen.getByText('(Required)'), /project/);
+
+    // Triggering the onBlur of the filter should not error
+    userEvent.click(
+      screen.getByPlaceholderText('Search for events, users, tags, and more')
+    );
+    userEvent.keyboard('{enter}');
+    act(() => {
+      // Run all timers because the handleBlur contains a setTimeout
+      jest.runAllTimers();
+    });
+
+    expect(await screen.findAllByText('project')).toHaveLength(2);
+  });
+
   describe('Sort by selectors', function () {
     it('renders', async function () {
       renderTestComponent({


### PR DESCRIPTION
Similar to #33260, the search callback wasn't updating to have the latest `queries`.

Priscila added this fix to #33241 but since I had some comments that she might want to address, I figured we could pull this out and do a separate test for it.