### PR TITLE
ref(assistant): Backend GUIDES does not need required_targets

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -1,61 +1,44 @@
 from django.conf import settings
 
-# Guide Schema
-# id (text, required): unique id
-# required_targets (list): An empty list will cause the guide to be shown regardless
-#                          of page/targets presence.
-# steps (list): List of steps
+# Guide definitions
+#
+# The id of each guide should be unique and immutable, as it is stored in the
+# AssistantActivity model to record when the guide was seen / dismissed.
+#
+# Guide UI elements are configured on the frontend in `getGuideContent.tsx`.
 
-# Step Schema
-# title (text, required): Title text. Tone should be active.
-# message (text, optional): Message text. Should help illustrate how to do a task, not
-#                           just literally what the button does.
-# target (text, optional): step is tied to an anchor target. If the anchor doesn't exist,
-#                          the step will not be shown. if the anchor exists but is of type
-#                         "invisible", it will not be pinged but will be scrolled to.
-#                          otherwise the anchor will be pinged and scrolled to. If you'd like
-#                          your step to show always or have a step is not tied to a specific
-#                          element but you'd still like it to be shown, set this as None.
 
 GUIDES = {
-    "issue": {"id": 1, "required_targets": ["issue_title", "exception"]},
-    "issue_stream": {"id": 3, "required_targets": ["issue_stream"]},
-    "alerts_write_member": {"id": 10, "required_targets": ["alerts_write_member"]},
-    "alerts_write_owner": {"id": 11, "required_targets": ["alerts_write_owner"]},
+    "issue": {"id": 1},
+    "issue_stream": {"id": 3},
+    "alerts_write_member": {"id": 10},
+    "alerts_write_owner": {"id": 11},
     "trace_view": {
         "id": 16,
-        "required_targets": ["trace_view_guide_row", "trace_view_guide_row_details"],
     },
     "span_op_breakdowns_and_tag_explorer": {
         "id": 17,
-        "required_targets": [
-            "span_op_breakdowns_filter",
-            "span_op_relative_breakdowns",
-            "tag_explorer",
-        ],
     },
-    "team_key_transactions": {"id": 18, "required_targets": ["team_key_transaction_header"]},
+    "team_key_transactions": {"id": 18},
     "project_transaction_threshold": {
         "id": 19,
-        "required_targets": ["project_transaction_threshold"],
     },
     "project_transaction_threshold_override": {
         "id": 20,
-        "required_targets": ["project_transaction_threshold_override"],
     },
-    "semver": {"id": 22, "required_targets": ["releases_search"]},
-    "release_stages": {"id": 23, "required_targets": ["release_stages"]},
+    "semver": {"id": 22},
+    "release_stages": {"id": 23},
 }
 
 # demo mode has different guides
 if settings.DEMO_MODE:
     GUIDES = {
-        "sidebar": {"id": 20, "required_targets": ["projects"]},
-        "issue_stream_v2": {"id": 21, "required_targets": ["issue_title"]},
-        "issue_v2": {"id": 22, "required_targets": ["issue_details"]},
-        "releases": {"id": 23, "required_targets": ["release_version"]},
-        "release_details": {"id": 24, "required_targets": ["release_chart"]},
-        "discover_landing": {"id": 25, "required_targets": ["discover_landing_header"]},
-        "discover_event_view": {"id": 26, "required_targets": ["create_alert_from_discover"]},
-        "transaction_details": {"id": 27, "required_targets": ["span_tree"]},
+        "sidebar": {"id": 20},
+        "issue_stream_v2": {"id": 21},
+        "issue_v2": {"id": 22},
+        "releases": {"id": 23},
+        "release_details": {"id": 24},
+        "discover_landing": {"id": 25},
+        "discover_event_view": {"id": 26},
+        "transaction_details": {"id": 27},
     }


### PR DESCRIPTION
These aren't actually used anywhere, all assistant related things, other
than the IDs, are configured on the frontend