### PR TITLE
ref(assistant): Backend GUIDES can just be a key -> id mapping

### DIFF
--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -52,17 +52,12 @@ class AssistantEndpoint(Endpoint):
 
     def get(self, request: Request) -> Response:
         """Return all the guides with a 'seen' attribute if it has been 'viewed' or 'dismissed'."""
-        guides = deepcopy(manager.all())
+        guide_map = deepcopy(manager.all())
         seen_ids = set(
             AssistantActivity.objects.filter(user=request.user).values_list("guide_id", flat=True)
         )
 
-        for key, value in guides.items():
-            value["seen"] = value["id"] in seen_ids
-
-        if "v2" in request.GET:
-            guides = [{"guide": key, "seen": value["seen"]} for key, value in guides.items()]
-        return Response(guides)
+        return Response([{"guide": key, "seen": id in seen_ids} for key, id in guide_map.items()])
 
     def put(self, request: Request):
         """Mark a guide as viewed or dismissed.

--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -1,61 +1,37 @@
 from django.conf import settings
 
-# Guide Schema
-# id (text, required): unique id
-# required_targets (list): An empty list will cause the guide to be shown regardless
-#                          of page/targets presence.
-# steps (list): List of steps
+# Guide definitions
+#
+# The id of each guide should be unique and immutable, as it is stored in the
+# AssistantActivity model to record when the guide was seen / dismissed.
+#
+# Guide UI elements are configured on the frontend in `getGuideContent.tsx`.
 
-# Step Schema
-# title (text, required): Title text. Tone should be active.
-# message (text, optional): Message text. Should help illustrate how to do a task, not
-#                           just literally what the button does.
-# target (text, optional): step is tied to an anchor target. If the anchor doesn't exist,
-#                          the step will not be shown. if the anchor exists but is of type
-#                         "invisible", it will not be pinged but will be scrolled to.
-#                          otherwise the anchor will be pinged and scrolled to. If you'd like
-#                          your step to show always or have a step is not tied to a specific
-#                          element but you'd still like it to be shown, set this as None.
 
 GUIDES = {
-    "issue": {"id": 1, "required_targets": ["issue_title", "exception"]},
-    "issue_stream": {"id": 3, "required_targets": ["issue_stream"]},
-    "alerts_write_member": {"id": 10, "required_targets": ["alerts_write_member"]},
-    "alerts_write_owner": {"id": 11, "required_targets": ["alerts_write_owner"]},
-    "trace_view": {
-        "id": 16,
-        "required_targets": ["trace_view_guide_row", "trace_view_guide_row_details"],
-    },
-    "span_op_breakdowns_and_tag_explorer": {
-        "id": 17,
-        "required_targets": [
-            "span_op_breakdowns_filter",
-            "span_op_relative_breakdowns",
-            "tag_explorer",
-        ],
-    },
-    "team_key_transactions": {"id": 18, "required_targets": ["team_key_transaction_header"]},
-    "project_transaction_threshold": {
-        "id": 19,
-        "required_targets": ["project_transaction_threshold"],
-    },
-    "project_transaction_threshold_override": {
-        "id": 20,
-        "required_targets": ["project_transaction_threshold_override"],
-    },
-    "semver": {"id": 22, "required_targets": ["releases_search"]},
-    "release_stages": {"id": 23, "required_targets": ["release_stages"]},
+    "issue": 1,
+    "issue_stream": 3,
+    "alerts_write_member": 10,
+    "alerts_write_owner": 11,
+    "trace_view": 16,
+    "span_op_breakdowns_and_tag_explorer": 17,
+    "team_key_transactions": 18,
+    "project_transaction_threshold": 19,
+    "project_transaction_threshold_override": 20,
+    "semver": 22,
+    "release_stages": 23,
+    "new_page_filters": 24,
 }
 
 # demo mode has different guides
 if settings.DEMO_MODE:
     GUIDES = {
-        "sidebar": {"id": 20, "required_targets": ["projects"]},
-        "issue_stream_v2": {"id": 21, "required_targets": ["issue_title"]},
-        "issue_v2": {"id": 22, "required_targets": ["issue_details"]},
-        "releases": {"id": 23, "required_targets": ["release_version"]},
-        "release_details": {"id": 24, "required_targets": ["release_chart"]},
-        "discover_landing": {"id": 25, "required_targets": ["discover_landing_header"]},
-        "discover_event_view": {"id": 26, "required_targets": ["create_alert_from_discover"]},
-        "transaction_details": {"id": 27, "required_targets": ["span_tree"]},
+        "sidebar": 20,
+        "issue_stream_v2": 21,
+        "issue_v2": 22,
+        "releases": 23,
+        "release_details": 24,
+        "discover_landing": 25,
+        "discover_event_view": 26,
+        "transaction_details": 27,
     }

--- a/src/sentry/assistant/manager.py
+++ b/src/sentry/assistant/manager.py
@@ -3,16 +3,14 @@ class AssistantManager:
         self._guides = {}
 
     def add(self, guides):
-        for k, v in guides.items():
-            self._guides[k] = v
+        for guide_key, id in guides.items():
+            self._guides[guide_key] = id
 
     def get_valid_ids(self):
-        return list(v["id"] for k, v in self._guides.items())
+        return list(self._guides.values())
 
     def get_guide_id(self, guide):
-        guide = self._guides.get(guide)
-        if guide:
-            return guide.get("id")
+        return self._guides.get(guide)
 
     def all(self):
         return self._guides


### PR DESCRIPTION
The required_targets weren't actually used anywhere, this can just be a mapping like this. Everything else is configured in the frontend