### PR TITLE
fix(integrations): Check for oauth token

### DIFF
--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -54,8 +54,6 @@ class BitbucketServerSetupClient(ApiClient):
         Step 2 of the oauth flow.
         Get a URL that the user can verify our request token at.
         """
-        if not request_token.get("oauth_token"):
-            raise ApiError("Missing oauth_token")
         return self.authorize_url.format(self.base_url, request_token["oauth_token"])
 
     def get_access_token(self, request_token, verifier):

--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -54,6 +54,8 @@ class BitbucketServerSetupClient(ApiClient):
         Step 2 of the oauth flow.
         Get a URL that the user can verify our request token at.
         """
+        if not request_token.get("oauth_token"):
+            raise ApiError("Missing oauth_token")
         return self.authorize_url.format(self.base_url, request_token["oauth_token"])
 
     def get_access_token(self, request_token, verifier):

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -169,16 +169,24 @@ class OAuthLoginView(PipelineView):
 
         try:
             request_token = client.get_request_token()
-            pipeline.bind_state("request_token", request_token)
-            authorize_url = client.get_authorize_url(request_token)
-
-            return self.redirect(authorize_url)
         except ApiError as error:
             logger.info(
                 "identity.bitbucket-server.request-token",
                 extra={"url": config.get("url"), "error": error},
             )
             return pipeline.error(f"Could not fetch a request token from Bitbucket. {error}")
+
+        pipeline.bind_state("request_token", request_token)
+        if not request_token.get("oauth_token"):
+            logger.info(
+                "identity.bitbucket-server.oauth-token",
+                extra={"url": config.get("url")},
+            )
+            return pipeline.error("Missing oauth_token")
+
+        authorize_url = client.get_authorize_url(request_token)
+
+        return self.redirect(authorize_url)
 
 
 class OAuthCallbackView(PipelineView):

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -170,6 +170,8 @@ class OAuthLoginView(PipelineView):
         try:
             request_token = client.get_request_token()
             pipeline.bind_state("request_token", request_token)
+            if not request_token.get("oauth_token"):
+                raise ApiError("Missing oauth_token")
             authorize_url = client.get_authorize_url(request_token)
 
             return self.redirect(authorize_url)

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -170,8 +170,6 @@ class OAuthLoginView(PipelineView):
         try:
             request_token = client.get_request_token()
             pipeline.bind_state("request_token", request_token)
-            if not request_token.get("oauth_token"):
-                raise ApiError("Missing oauth_token")
             authorize_url = client.get_authorize_url(request_token)
 
             return self.redirect(authorize_url)

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -185,7 +185,7 @@ class OAuthLoginView(PipelineView):
         pipeline.bind_state("request_token", request_token)
         if not request_token.get("oauth_token"):
             logger.info(
-                "identity.bitbucket-server.oauth-token",
+                "identity.jira-server.oauth-token",
                 extra={"url": config.get("url")},
             )
             return pipeline.error("Missing oauth_token")

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -175,16 +175,24 @@ class OAuthLoginView(PipelineView):
         )
         try:
             request_token = client.get_request_token()
-            pipeline.bind_state("request_token", request_token)
-            authorize_url = client.get_authorize_url(request_token)
-
-            return self.redirect(authorize_url)
         except ApiError as error:
             logger.info(
                 "identity.jira-server.request-token",
                 extra={"url": config.get("url"), "error": error},
             )
             return pipeline.error(f"Could not fetch a request token from Jira. {error}")
+
+        pipeline.bind_state("request_token", request_token)
+        if not request_token.get("oauth_token"):
+            logger.info(
+                "identity.bitbucket-server.oauth-token",
+                extra={"url": config.get("url")},
+            )
+            return pipeline.error("Missing oauth_token")
+
+        authorize_url = client.get_authorize_url(request_token)
+
+        return self.redirect(authorize_url)
 
 
 class OAuthCallbackView(PipelineView):


### PR DESCRIPTION
Use `.get()` to check if the `request_token` has an `oauth_token`.

Handles [SENTRY-TK9](https://sentry.io/organizations/sentry/issues/3127582437/?project=1&referrer=jira_integration) 