### PR TITLE
ref(auditlog): Add audit log event manager

### DIFF
--- a/src/sentry/audit_log/__init__.py
+++ b/src/sentry/audit_log/__init__.py
@@ -1,0 +1,1 @@
+from .manager import *  # NOQA

--- a/src/sentry/audit_log/manager.py
+++ b/src/sentry/audit_log/manager.py
@@ -3,6 +3,8 @@ from typing import Callable, List
 
 import sentry_sdk
 
+from sentry.models.auditlogentry import AuditLogEntry
+
 
 @dataclass
 class AuditLogEvent:
@@ -10,7 +12,7 @@ class AuditLogEvent:
     name: str
     api_name: str
     # render holds a function that will determine the message to be displayed in the audit log
-    render: Callable[..., str]
+    render: Callable[[AuditLogEntry], str]
 
 
 class AuditLogEventManager:

--- a/src/sentry/audit_log/manager.py
+++ b/src/sentry/audit_log/manager.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+import sentry_sdk
+
+from sentry.models.auditlogentry import AuditLogEntry
+
+
+@dataclass
+class AuditLogEvent:
+    event_id: int
+    name: str
+    api_name: str
+
+    # Use `template` OR `get_template` for each AuditLogEvent.
+
+    # For audit log events using one string format to display the log's message,
+    # use `temaplate`.
+    # Add any new variables to `template_variables` in `AuditLogEventManager.get_note`.
+    template: Optional[str] = None
+
+    # For audit log events that need a function to determine the log's message,
+    # use `get_template` to store that function.
+    get_template: Optional[Callable[["AuditLogEntry"], str]] = None
+
+
+class AuditLogEventManager:
+    _event_registry = {}
+    _event_id_lookup = {}
+
+    def add(self, audit_log_event: "AuditLogEvent"):
+        if (
+            audit_log_event.name in self._event_registry
+            or audit_log_event.event_id in self._event_id_lookup
+        ):
+            # TODO(mbauer404): raise exception once getsentry specific audit logs
+            # have been permanently moved from sentry into getsentry
+            with sentry_sdk.push_scope() as scope:
+                scope.level = "warning"
+                sentry_sdk.capture_message(
+                    f"Duplicate audit log: {audit_log_event.name} with ID {audit_log_event.event_id}"
+                )
+            return
+        if not audit_log_event.template and not audit_log_event.get_template:
+            raise Exception("AuditLogEvent must include either a `template` or `get_template`")
+
+        self._event_registry[audit_log_event.name] = audit_log_event
+        self._event_id_lookup[audit_log_event.event_id] = audit_log_event
+
+    def get(self, event_id: int) -> "AuditLogEvent":
+        if event_id not in self._event_id_lookup:
+            raise Exception("Event ID does not exist")
+        return self._event_id_lookup[event_id]
+
+    def get_event_id(self, name: str) -> int:
+        if name not in self._event_registry:
+            raise Exception("Event does not exist")
+        return self._event_registry[name].event_id
+
+    def get_api_names(self) -> List[str]:
+        # returns a list of all the api names
+        api_names: list = []
+        for audit_log_event in self._event_registry.values():
+            api_names.append(audit_log_event.api_name)
+        return api_names
+
+    def get_note(self, audit_log_entry: "AuditLogEntry") -> str:
+        # Takes an AuditLogEntry and returns the formatted log message to be displayed in the audit log.
+        audit_log_event = self.get(audit_log_entry.event)
+
+        if audit_log_event.get_template:
+            return audit_log_event.get_template(audit_log_entry)
+
+        if audit_log_event.template:
+            actor = audit_log_entry.actor if audit_log_entry.actor else None
+            target_user = audit_log_entry.target_user if audit_log_entry.target_user else None
+            target_user_display_name = target_user.get_display_name() if target_user else None
+
+            template_variables = {
+                **audit_log_entry.data,
+                "actor": actor,
+                "target_user": target_user,
+                "target_user_display_name": target_user_display_name,
+            }
+            return audit_log_event.template.format(**template_variables)
+        return ""
+
+
+audit_log_manager = AuditLogEventManager()

--- a/src/sentry/audit_log/manager.py
+++ b/src/sentry/audit_log/manager.py
@@ -1,9 +1,7 @@
 from dataclasses import dataclass
-from typing import Callable, List, Optional
+from typing import Callable, List
 
 import sentry_sdk
-
-from sentry.models.auditlogentry import AuditLogEntry
 
 
 @dataclass
@@ -11,24 +9,15 @@ class AuditLogEvent:
     event_id: int
     name: str
     api_name: str
-
-    # Use `template` OR `get_template` for each AuditLogEvent.
-
-    # For audit log events using one string format to display the log's message,
-    # use `temaplate`.
-    # Add any new variables to `template_variables` in `AuditLogEventManager.get_note`.
-    template: Optional[str] = None
-
-    # For audit log events that need a function to determine the log's message,
-    # use `get_template` to store that function.
-    get_template: Optional[Callable[["AuditLogEntry"], str]] = None
+    # render holds a function that will determine the message to be displayed in the audit log
+    render: Callable[..., str]
 
 
 class AuditLogEventManager:
     _event_registry = {}
     _event_id_lookup = {}
 
-    def add(self, audit_log_event: "AuditLogEvent"):
+    def add(self, audit_log_event: AuditLogEvent):
         if (
             audit_log_event.name in self._event_registry
             or audit_log_event.event_id in self._event_id_lookup
@@ -41,8 +30,6 @@ class AuditLogEventManager:
                     f"Duplicate audit log: {audit_log_event.name} with ID {audit_log_event.event_id}"
                 )
             return
-        if not audit_log_event.template and not audit_log_event.get_template:
-            raise Exception("AuditLogEvent must include either a `template` or `get_template`")
 
         self._event_registry[audit_log_event.name] = audit_log_event
         self._event_id_lookup[audit_log_event.event_id] = audit_log_event
@@ -63,27 +50,6 @@ class AuditLogEventManager:
         for audit_log_event in self._event_registry.values():
             api_names.append(audit_log_event.api_name)
         return api_names
-
-    def get_note(self, audit_log_entry: "AuditLogEntry") -> str:
-        # Takes an AuditLogEntry and returns the formatted log message to be displayed in the audit log.
-        audit_log_event = self.get(audit_log_entry.event)
-
-        if audit_log_event.get_template:
-            return audit_log_event.get_template(audit_log_entry)
-
-        if audit_log_event.template:
-            actor = audit_log_entry.actor if audit_log_entry.actor else None
-            target_user = audit_log_entry.target_user if audit_log_entry.target_user else None
-            target_user_display_name = target_user.get_display_name() if target_user else None
-
-            template_variables = {
-                **audit_log_entry.data,
-                "actor": actor,
-                "target_user": target_user,
-                "target_user_display_name": target_user_display_name,
-            }
-            return audit_log_event.template.format(**template_variables)
-        return ""
 
 
 audit_log_manager = AuditLogEventManager()

--- a/tests/sentry/audit_log/test_manager.py
+++ b/tests/sentry/audit_log/test_manager.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+from django.utils import timezone
+
+from sentry.audit_log import AuditLogEvent, audit_log_manager
+from sentry.models import AuditLogEntry, AuditLogEntryEvent
+from sentry.testutils import TestCase
+
+
+class AuditLogEventManagerTest(TestCase):
+    def test_audit_log_manager(self):
+        log_event = AuditLogEvent(
+            event_id=1,
+            name="member_invite",
+            api_name="member.invite",
+            template="invited member {email}",
+        )
+
+        log_entry = AuditLogEntry.objects.create(
+            organization=self.organization,
+            event=AuditLogEntryEvent.MEMBER_INVITE,
+            actor=self.user,
+            datetime=timezone.now(),
+            data={"email": "my_email@mail.com"},
+        )
+
+        audit_log_manager.add(log_event)
+
+        assert audit_log_manager.get(event_id=1) == log_event
+        assert audit_log_manager.get_event_id(name="member_invite") == 1
+        assert audit_log_manager.get_api_names() == ["member.invite"]
+        assert audit_log_manager.get_note(log_entry) == "invited member my_email@mail.com"
+
+    @mock.patch("sentry.audit_log.manager.sentry_sdk")
+    def test_for_duplicate_events(self, mock_sentry_sdk):
+        log_event = AuditLogEvent(
+            event_id=1,
+            name="member_invite",
+            api_name="member.invite",
+            template="invited member {email}",
+        )
+        log_event_duplicate_id = AuditLogEvent(
+            event_id=1,
+            name="member_add",
+            api_name="member.add",
+            template="invited member {email}",
+        )
+        audit_log_manager.add(log_event)
+        audit_log_manager.add(log_event_duplicate_id)
+
+        assert mock_sentry_sdk.capture_message.called


### PR DESCRIPTION
Creates a new AuditLogEventManager class to manage audit log events

- Adds an audit log manager interface to the sentry repo that stores registered AuditLogEvent instances
- Enables AuditLogEvent instances to be registered in memory in both sentry and getsentry repos