### PR TITLE
perf(metrics): Use bulk queries in metrics_sessions_v2 [INGEST-1180]

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -416,10 +416,7 @@ def _get_snuba_queries(
     columns: List[SelectableExpression],
     extra_conditions: Optional[List[Condition]] = None,
 ) -> Iterable[Tuple[MetricKey, _QueryType, Query]]:
-    """Get snuba queries required for this metric.
-    In case of the intial query, get the data right away, so other queries can use its
-    output as a filter.
-    """
+    """Get snuba queries required for this metric."""
 
     for query_type in (_QueryType.TOTALS, _QueryType.SERIES):
         snuba_query = _get_snuba_query(

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -672,7 +672,6 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
         expected = self.expected_duration_values
 
         groups = result_sorted(response.data)["groups"]
-        print(groups)
         assert len(groups) == 1, groups
         group = groups[0]
 

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -672,6 +672,7 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
         expected = self.expected_duration_values
 
         groups = result_sorted(response.data)["groups"]
+        print(groups)
         assert len(groups) == 1, groups
         group = groups[0]
 


### PR DESCRIPTION
The metrics implementation of sessions_v2 runs multiple snuba queries sequentially. With the change in this PR, we collect all queries before running them, so we can run some of them as a bulk query. This should improve end-to-end performance of the sessions v2 endpoint.

An additional benefit of this is that we can get rid of the `LimitState` class.