### PR TITLE
ref(discover): Move stopEventPropagation above defaultProps

### DIFF
--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -125,17 +125,6 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
     };
   }
 
-  static defaultProps: DefaultProps = {
-    disabled: false,
-  };
-
-  state: State = {
-    isNewQuery: true,
-    isEditingQuery: false,
-
-    queryName: '',
-  };
-
   /**
    * Stop propagation for the input and container so people can interact with
    * the inputs in the dropdown.
@@ -150,6 +139,17 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
       event.preventDefault();
       event.stopPropagation();
     }
+  };
+
+  static defaultProps: DefaultProps = {
+    disabled: false,
+  };
+
+  state: State = {
+    isNewQuery: true,
+    isEditingQuery: false,
+
+    queryName: '',
   };
 
   onBlurInput = (event: React.FormEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Noticed an eslint warning when developing:
```
/Users/nsaynorath/workspace/sentry/static/app/views/eventsV2/savedQuery/index.tsx
  143:3  warning  stopEventPropagation should be placed before defaultProps  react/sort-comp
```

So I just moved the method before defaultProps