### PR TITLE
ref(perf): Add new profiler with long tasks for TraceView

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -20,7 +20,7 @@ import {
   ParsedTraceType,
   SpanType,
 } from './types';
-import {getSpanID, getSpanOperation} from './utils';
+import {getSpanID, getSpanOperation, setSpansOnTransaction} from './utils';
 import WaterfallModel from './waterfallModel';
 
 type PropType = ScrollbarManagerChildrenProps & {
@@ -33,6 +33,10 @@ type PropType = ScrollbarManagerChildrenProps & {
 };
 
 class SpanTree extends React.Component<PropType> {
+  componentDidMount() {
+    setSpansOnTransaction(this.props.spans.length);
+  }
+
   shouldComponentUpdate(nextProps: PropType) {
     if (
       this.props.dragProps.isDragging !== nextProps.dragProps.isDragging ||

--- a/static/app/components/events/interfaces/spans/traceView.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.tsx
@@ -4,6 +4,7 @@ import {Observer} from 'mobx-react';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
+import {ProfilerWithTasks} from 'sentry/utils/performanceForSentry';
 
 import * as CursorGuideHandler from './cursorGuideHandler';
 import * as DividerHandlerManager from './dividerHandlerManager';
@@ -92,22 +93,24 @@ class TraceView extends PureComponent<Props> {
                             <Observer>
                               {() => {
                                 return (
-                                  <SpanTree
-                                    traceViewRef={this.traceViewRef}
-                                    dragProps={dragProps}
-                                    organization={organization}
-                                    waterfallModel={waterfallModel}
-                                    filterSpans={waterfallModel.filterSpans}
-                                    spans={waterfallModel.getWaterfall(
-                                      {
-                                        viewStart: dragProps.viewWindowStart,
-                                        viewEnd: dragProps.viewWindowEnd,
-                                      },
-                                      organization.features.includes(
-                                        'performance-autogroup-sibling-spans'
-                                      )
-                                    )}
-                                  />
+                                  <ProfilerWithTasks id="SpanTree">
+                                    <SpanTree
+                                      traceViewRef={this.traceViewRef}
+                                      dragProps={dragProps}
+                                      organization={organization}
+                                      waterfallModel={waterfallModel}
+                                      filterSpans={waterfallModel.filterSpans}
+                                      spans={waterfallModel.getWaterfall(
+                                        {
+                                          viewStart: dragProps.viewWindowStart,
+                                          viewEnd: dragProps.viewWindowEnd,
+                                        },
+                                        organization.features.includes(
+                                          'performance-autogroup-sibling-spans'
+                                        )
+                                      )}
+                                    />
+                                  </ProfilerWithTasks>
                                 );
                               }}
                             </Observer>

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -7,6 +7,7 @@ import moment from 'moment';
 
 import {EntryType, EventTransaction} from 'sentry/types/event';
 import {assert} from 'sentry/types/utils';
+import getCurrentSentryReactTransaction from 'sentry/utils/getCurrentSentryReactTransaction';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 
 import {
@@ -25,6 +26,20 @@ import {
 
 export const isValidSpanID = (maybeSpanID: any) =>
   isString(maybeSpanID) && maybeSpanID.length > 0;
+
+export const setSpansOnTransaction = (spanCount: number) => {
+  const transaction = getCurrentSentryReactTransaction();
+
+  if (!transaction || spanCount === 0) {
+    return;
+  }
+
+  const spanCountGroups = [10, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1001];
+  const spanGroup = spanCountGroups.find(g => g <= spanCount) || -1;
+
+  transaction.setTag('ui.spanCount', spanCount);
+  transaction.setTag('ui.spanCount.grouped', `<=${spanGroup}`);
+};
 
 export type SpanBoundsType = {endTimestamp: number; startTimestamp: number};
 export type SpanGeneratedBoundsType =

--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -4,7 +4,7 @@ import {browserPerformanceTimeOrigin, timestampWithMs} from '@sentry/utils';
 
 import getCurrentSentryReactTransaction from './getCurrentSentryReactTransaction';
 
-const MIN_UPDATE_SPAN_TIME = 16; // Frame boundary @ 60fps
+const MIN_UPDATE_SPAN_TIME = 5; // Frame boundary @ 60fps
 
 /**
  * Callback for React Profiler https://reactjs.org/docs/profiler.html

--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -1,4 +1,5 @@
 import {Fragment, Profiler, ReactNode, useEffect, useRef} from 'react';
+import {captureException} from '@sentry/react';
 import {browserPerformanceTimeOrigin, timestampWithMs} from '@sentry/utils';
 
 import getCurrentSentryReactTransaction from './getCurrentSentryReactTransaction';
@@ -29,6 +30,89 @@ export function onRenderCallback(
   }
 }
 
+class LongTaskObserver {
+  private static observer: PerformanceObserver;
+  private static longTaskCount = 0;
+  private static currentId: string;
+  static getPerformanceObserver(id: string): PerformanceObserver | null {
+    try {
+      LongTaskObserver.currentId = id;
+      if (LongTaskObserver.observer) {
+        return LongTaskObserver.observer;
+      }
+      if (!window.PerformanceObserver || !browserPerformanceTimeOrigin) {
+        return null;
+      }
+      const transaction: any = getCurrentSentryReactTransaction();
+
+      const timeOrigin = browserPerformanceTimeOrigin / 1000;
+
+      const observer = new PerformanceObserver(function (list) {
+        const perfEntries = list.getEntries();
+
+        if (!transaction) {
+          return;
+        }
+        perfEntries.forEach(entry => {
+          const startSeconds = timeOrigin + entry.startTime / 1000;
+          LongTaskObserver.longTaskCount++;
+          transaction.startChild({
+            description: `Long Task - ${LongTaskObserver.currentId}`,
+            op: `ui.sentry.long-task`,
+            startTimestamp: startSeconds,
+            endTimestamp: startSeconds + entry.duration / 1000,
+          });
+        });
+      });
+      transaction.registerBeforeFinishCallback(t => {
+        if (!browserPerformanceTimeOrigin) {
+          return;
+        }
+
+        t.setTag('longTaskCount', LongTaskObserver.longTaskCount);
+      });
+
+      if (!observer || !observer.observe) {
+        return null;
+      }
+      LongTaskObserver.observer = observer;
+      LongTaskObserver.observer.observe({entryTypes: ['longtask']});
+
+      return LongTaskObserver.observer;
+    } catch (e) {
+      captureException(e);
+      // Defensive try catch.
+    }
+    return null;
+  }
+}
+
+export const ProfilerWithTasks = ({id, children}: {children: ReactNode; id: string}) => {
+  useEffect(() => {
+    let observer;
+    try {
+      if (!window.PerformanceObserver || !browserPerformanceTimeOrigin) {
+        return () => {};
+      }
+      observer = LongTaskObserver.getPerformanceObserver(id);
+    } catch (e) {
+      captureException(e);
+      // Defensive since this is auxiliary code.
+    }
+    return () => {
+      if (observer && observer.disconnect) {
+        observer.disconnect();
+      }
+    };
+  }, []);
+
+  return (
+    <Profiler id={id} onRender={onRenderCallback}>
+      {children}
+    </Profiler>
+  );
+};
+
 export const VisuallyCompleteWithData = ({
   id,
   hasData,
@@ -48,29 +132,7 @@ export const VisuallyCompleteWithData = ({
       if (!window.PerformanceObserver || !browserPerformanceTimeOrigin) {
         return () => {};
       }
-      const timeOrigin = browserPerformanceTimeOrigin / 1000;
-
-      observer = new PerformanceObserver(function (list) {
-        const perfEntries = list.getEntries();
-
-        const transaction = getCurrentSentryReactTransaction();
-        if (!transaction) {
-          return;
-        }
-        perfEntries.forEach(entry => {
-          const startSeconds = timeOrigin + entry.startTime / 1000;
-          longTaskCount.current++;
-          transaction.startChild({
-            description: `Long Task - ${id}`,
-            op: `ui.long-task`,
-            startTimestamp: startSeconds,
-            endTimestamp: startSeconds + entry.duration / 1000,
-          });
-        });
-      });
-      if (observer && observer.observe) {
-        observer.observe({entryTypes: ['longtask']});
-      }
+      observer = LongTaskObserver.getPerformanceObserver(id);
     } catch (_) {
       // Defensive since this is auxiliary code.
     }

--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -38,6 +38,8 @@ class LongTaskObserver {
     try {
       LongTaskObserver.currentId = id;
       if (LongTaskObserver.observer) {
+        LongTaskObserver.observer.disconnect();
+        LongTaskObserver.observer.observe({entryTypes: ['longtask']});
         return LongTaskObserver.observer;
       }
       if (!window.PerformanceObserver || !browserPerformanceTimeOrigin) {

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -26,6 +26,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import {TraceFullDetailed} from 'sentry/utils/performance/quickTrace/types';
 import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
+import {ProfilerWithTasks} from 'sentry/utils/performanceForSentry';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 import {Row, Tags, TransactionDetails, TransactionDetailsContainer} from './styles';
@@ -227,15 +228,17 @@ class TransactionDetail extends Component<Props> {
 
   render() {
     return (
-      <TransactionDetailsContainer
-        onClick={event => {
-          // prevent toggling the transaction detail
-          event.stopPropagation();
-        }}
-      >
-        {this.renderTransactionErrors()}
-        {this.renderTransactionDetail()}
-      </TransactionDetailsContainer>
+      <ProfilerWithTasks id="TransactionDetail">
+        <TransactionDetailsContainer
+          onClick={event => {
+            // prevent toggling the transaction detail
+            event.stopPropagation();
+          }}
+        >
+          {this.renderTransactionErrors()}
+          {this.renderTransactionDetail()}
+        </TransactionDetailsContainer>
+      </ProfilerWithTasks>
     );
   }
 }


### PR DESCRIPTION
### Summary
This adds a profiler wrapper that also observes long tasks, so you can confirm if the suspect component is causing the majority of the render time.

#### Other
- Using static members in a class since observe may or may not be safe to call multiple times, there seems to be some browser variability with it, so we'll see in practice. Most issues should be caught by the defensive try/catch since this is non critical code.

#### Screenshots
![Screen Shot 2022-04-06 at 12 43 58 PM](https://user-images.githubusercontent.com/6111995/162025967-53d367ad-fff6-43c8-baa2-0f65bfc699ec.png)

