### PR TITLE
feat(alerts): Alert wizard v3 project selector dropdown

### DIFF
--- a/static/app/views/alerts/builder/builderBreadCrumbs.tsx
+++ b/static/app/views/alerts/builder/builderBreadCrumbs.tsx
@@ -91,7 +91,7 @@ function BuilderBreadCrumbs({
       label: t('Alerts'),
       preservePageFilters: true,
     },
-    projectCrumb,
+    ...(hasAlertWizardV3 ? [] : [projectCrumb]),
     {
       label: title,
       ...(alertName

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import {Fragment} from 'react';
+import {InjectedRouter} from 'react-router';
+import {components} from 'react-select';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import {Location} from 'history';
 import pick from 'lodash/pick';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -10,15 +14,18 @@ import SearchBar from 'sentry/components/events/searchBar';
 import FormField from 'sentry/components/forms/formField';
 import SelectControl from 'sentry/components/forms/selectControl';
 import SelectField from 'sentry/components/forms/selectField';
+import SelectOption from 'sentry/components/forms/selectOption';
+import IdBadge from 'sentry/components/idBadge';
 import ListItem from 'sentry/components/list/listItem';
 import {Panel, PanelBody} from 'sentry/components/panels';
 import Tooltip from 'sentry/components/tooltip';
 import {IconQuestion} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Environment, Organization, SelectValue} from 'sentry/types';
+import {Environment, Organization, Project, SelectValue} from 'sentry/types';
 import {MobileVital, WebVital} from 'sentry/utils/discover/fields';
 import {getDisplayName} from 'sentry/utils/environment';
+import Projects from 'sentry/utils/projects';
 import WizardField from 'sentry/views/alerts/incidentRules/wizardField';
 import {
   convertDatasetEventTypesToSource,
@@ -55,11 +62,13 @@ type Props = {
   dataset: Dataset;
   disabled: boolean;
   hasAlertWizardV3: boolean;
+  location: Location;
   onComparisonDeltaChange: (value: number) => void;
   onFilterSearch: (query: string) => void;
   onTimeWindowChange: (value: number) => void;
   organization: Organization;
-  projectSlug: string;
+  project: Project;
+  router: InjectedRouter;
   thresholdChart: React.ReactNode;
   timeWindow: number;
   allowChangeEventTypes?: boolean;
@@ -85,11 +94,11 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   };
 
   async fetchData() {
-    const {api, organization, projectSlug} = this.props;
+    const {api, organization, project} = this.props;
 
     try {
       const environments = await api.requestPromise(
-        `/projects/${organization.slug}/${projectSlug}/environments/`,
+        `/projects/${organization.slug}/${project.slug}/environments/`,
         {
           query: {
             visibility: 'visible',
@@ -234,6 +243,61 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
     );
   }
 
+  renderProjectSelector() {
+    const {organization, project: selectedProject, location, router} = this.props;
+
+    return (
+      <Projects orgId={organization.slug} allProjects>
+        {({projects}) => (
+          <SelectControl
+            value={selectedProject.id}
+            styles={{
+              container: (provided: {[x: string]: string | number | boolean}) => ({
+                ...provided,
+                margin: `${space(0.5)}`,
+              }),
+            }}
+            options={projects.map(project => ({
+              label: project.slug, // replaced by leadingItems id badge
+              value: project.id,
+              leadingItems: (
+                <IdBadge
+                  project={project}
+                  avatarProps={{consistentWidth: true}}
+                  avatarSize={18}
+                  disableLink
+                  hideName
+                />
+              ),
+            }))}
+            onChange={({label}) => {
+              router.replace({
+                ...location,
+                query: {
+                  ...location.query,
+                  project: label,
+                },
+              });
+            }}
+            components={{
+              Option: optionProps => <SelectOption {...optionProps} />,
+              ValueContainer: containerProps => (
+                <components.ValueContainer {...containerProps}>
+                  <IdBadge
+                    project={selectedProject}
+                    avatarProps={{consistentWidth: true}}
+                    avatarSize={18}
+                    disableLink
+                  />
+                </components.ValueContainer>
+              ),
+            }}
+          />
+        )}
+      </Projects>
+    );
+  }
+
   renderInterval() {
     const {
       organization,
@@ -275,8 +339,6 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
               disabled={disabled}
               style={{
                 ...this.formElemBaseStyle,
-                padding: 0,
-                marginRight: space(1),
                 flex: 1,
               }}
               inline={false}
@@ -311,6 +373,10 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                 ...provided,
                 minWidth: hasAlertWizardV3 ? 200 : 130,
                 maxWidth: 300,
+              }),
+              container: (provided: {[x: string]: string | number | boolean}) => ({
+                ...provided,
+                margin: hasAlertWizardV3 ? `${space(0.5)}` : 0,
               }),
             }}
             options={this.timeWindowOptions}
@@ -396,8 +462,12 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
           <StyledPanelBody>{this.props.thresholdChart}</StyledPanelBody>
         </ChartPanel>
         {hasAlertWizardV3 && this.renderInterval()}
-        <StyledListItem>{t('Filter environments')}</StyledListItem>
-        <FormRow noMargin>
+        <StyledListItem>{t('Filter events')}</StyledListItem>
+        <FormRow
+          noMargin
+          columns={1 + (allowChangeEventTypes ? 1 : 0) + (hasAlertWizardV3 ? 1 : 0)}
+        >
+          {hasAlertWizardV3 && this.renderProjectSelector()}
           <SelectField
             name="environment"
             placeholder={t('All')}
@@ -520,12 +590,18 @@ const StyledListItem = styled(ListItem)`
   line-height: 1.3;
 `;
 
-const FormRow = styled('div')<{noMargin?: boolean}>`
+const FormRow = styled('div')<{columns?: number; noMargin?: boolean}>`
   display: flex;
   flex-direction: row;
   align-items: center;
   flex-wrap: wrap;
   margin-bottom: ${p => (p.noMargin ? 0 : space(4))};
+  ${p =>
+    p.columns !== undefined &&
+    css`
+      display: grid;
+      grid-template-columns: repeat(${p.columns}, auto);
+    `}
 `;
 
 const FormRowText = styled('div')`

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -663,6 +663,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       project,
       userTeamIds,
       isCustomMetric,
+      router,
+      location,
     } = this.props;
     const {
       query,
@@ -813,8 +815,10 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
             <List symbol="colored-numeric">
               <RuleConditionsForm
                 api={this.api}
-                projectSlug={project.slug}
+                project={project}
                 organization={organization}
+                router={router}
+                location={location}
                 disabled={!hasAccess || !canEdit}
                 thresholdChart={wizardBuilderChart}
                 onFilterSearch={this.handleFilterUpdate}

--- a/static/app/views/alerts/incidentRules/wizardField.tsx
+++ b/static/app/views/alerts/incidentRules/wizardField.tsx
@@ -162,12 +162,6 @@ function WizardField({
           <Container hideGap={gridColumns < 1}>
             <SelectControl
               value={selectedTemplate}
-              styles={{
-                container: (provided: {[x: string]: string | number | boolean}) => ({
-                  ...provided,
-                  margin: `${space(0.5)}`,
-                }),
-              }}
               options={menuOptions}
               onChange={(option: MenuOption) => {
                 const template = AlertWizardRuleTemplates[option.value];

--- a/static/app/views/alerts/incidentRules/wizardField.tsx
+++ b/static/app/views/alerts/incidentRules/wizardField.tsx
@@ -22,7 +22,7 @@ import {generateFieldOptions} from 'sentry/views/eventsV2/utils';
 
 import {getFieldOptionConfig} from './metricField';
 
-type MenuOption = {label: string; value: any};
+type MenuOption = {label: string; value: AlertType};
 
 type Props = Omit<FormField['props'], 'children'> & {
   location: Location;
@@ -169,8 +169,8 @@ function WizardField({
                 }),
               }}
               options={menuOptions}
-              onChange={args => {
-                const template = AlertWizardRuleTemplates[args.value];
+              onChange={(option: MenuOption) => {
+                const template = AlertWizardRuleTemplates[option.value];
 
                 model.setValue('aggregate', template.aggregate);
                 model.setValue('dataset', template.dataset);

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -25,6 +25,7 @@ import Button from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
 import Input from 'sentry/components/forms/controls/input';
 import Field from 'sentry/components/forms/field';
+import FieldHelp from 'sentry/components/forms/field/fieldHelp';
 import Form from 'sentry/components/forms/form';
 import SelectControl from 'sentry/components/forms/selectControl';
 import SelectField from 'sentry/components/forms/selectField';
@@ -653,7 +654,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
         help={
           hasAlertWizardV3
             ? null
-            : t('Perform the actions above once this often for an issue')
+            : t('Perform these actions once this often for an issue')
         }
         clearable={false}
         name="frequency"
@@ -1024,7 +1025,12 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                   </Step>
                 </PanelBody>
               </ConditionsPanel>
-              <StyledListItem>{t('Set action interval')}</StyledListItem>
+              <StyledListItem>
+                {t('Set action interval')}
+                <StyledFieldHelp>
+                  {t('Perform the actions above once this often for an issue')}
+                </StyledFieldHelp>
+              </StyledListItem>
               {hasAlertWizardV3 ? (
                 this.renderActionInterval(hasAccess, canEdit, hasAlertWizardV3)
               ) : (
@@ -1068,6 +1074,10 @@ const StyledAlert = styled(Alert)`
 const StyledListItem = styled(ListItem)`
   margin: ${space(2)} 0 ${space(1)} 0;
   font-size: ${p => p.theme.fontSizeExtraLarge};
+`;
+
+const StyledFieldHelp = styled(FieldHelp)`
+  margin-top: 0;
 `;
 
 const SetConditionsListItem = styled(StyledListItem)`

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -1,10 +1,5 @@
 import {ChangeEvent, Fragment, ReactNode} from 'react';
-import {
-  browserHistory,
-  RouteComponentProps,
-  withRouter,
-  WithRouterProps,
-} from 'react-router';
+import {browserHistory, RouteComponentProps} from 'react-router';
 import {components} from 'react-select';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
@@ -117,8 +112,7 @@ type Props = {
   userTeamIds: string[];
   loadingProjects?: boolean;
   onChangeTitle?: (data: string) => void;
-} & WithRouterProps &
-  RouteComponentProps<RouteParams, {}>;
+} & RouteComponentProps<RouteParams, {}>;
 
 type State = AsyncView['state'] & {
   configs: {
@@ -1055,7 +1049,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   }
 }
 
-export default withRouter(withOrganization(withProjects(IssueRuleEditor)));
+export default withOrganization(withProjects(IssueRuleEditor));
 
 // TODO(ts): Understand why styled is not correctly inheriting props here
 const StyledForm = styled(Form)<Form['props']>`


### PR DESCRIPTION
This adds the project selector dropdown to alert wizard for both metric and issue alerts. Modified the issue alert editor to reflect the most recent design. Removed project from the breadcrumbs. All changes are only applied if org has the `alert-wizard-v3` flag.

Design: [Figma](https://www.figma.com/file/yskaUlIaLj7raPo5RDR9aJ/Alert-Wizard-v4?node-id=6%3A5380)

Project selector dropdown:
<img width="778" alt="Screen Shot 2022-04-06 at 8 19 15 PM" src="https://user-images.githubusercontent.com/15015880/162113632-7c5a3d4c-d8e4-41df-8b46-38588cb373dc.png">

Issue alert wizard:
<img width="838" alt="Screen Shot 2022-04-06 at 8 19 24 PM" src="https://user-images.githubusercontent.com/15015880/162113646-c2c60677-09fd-470c-b8b7-c2bf6e83ee91.png">

Breadcrumbs:
<img width="330" alt="Screen Shot 2022-04-06 at 8 21 15 PM" src="https://user-images.githubusercontent.com/15015880/162113798-bddd7e5e-cebf-4965-8707-7d55f43cea48.png">
