### PR TITLE
fix(onboarding): A few fixes for the new onboarding flow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -351,3 +351,9 @@ build-utils/        @getsentry/owners-js-build
 /tests/sentry/snuba/metrics/                                          @getsentry/metrics
 
 ### End of Metrics ###
+
+### Growth ###
+
+/src/sentry/api/endpoints/client_state.py       @getsentry/growth
+
+### End of Growth ###

--- a/src/sentry/api/endpoints/client_state.py
+++ b/src/sentry/api/endpoints/client_state.py
@@ -12,7 +12,7 @@ from sentry.utils import json, redis
 STATE_CATEGORIES = {
     "onboarding": {
         "ttl": 30 * 24 * 60 * 60,  # the time in seconds that the state will be persisted
-        "scope": "member",  # Can be "org" or "member"
+        "scope": "org",  # Can be "org" or "member"
         "max_payload_size": 1024,
     }
 }

--- a/static/app/views/onboarding/targetedOnboarding/components/firstEventFooter.tsx
+++ b/static/app/views/onboarding/targetedOnboarding/components/firstEventFooter.tsx
@@ -138,7 +138,9 @@ const OnboardingButtonBar = styled(ButtonBar)`
   justify-self: end;
 `;
 
-const AnimatedText = styled(motion.div)<{errorReceived: boolean}>`
+const AnimatedText = styled(motion.div, {
+  shouldForwardProp: prop => prop !== 'errorReceived',
+})<{errorReceived: boolean}>`
   margin-left: ${space(1)};
   color: ${p =>
     p.errorReceived ? p.theme.successText : p.theme.charts.getColorPalette(5)[4]};

--- a/static/app/views/onboarding/targetedOnboarding/types.ts
+++ b/static/app/views/onboarding/targetedOnboarding/types.ts
@@ -39,7 +39,7 @@ export function fetchClientState(api: Client, orgSlug: string): Promise<ClientSt
     .requestPromise(`/organizations/${orgSlug}/client-state/onboarding/`)
     .then(lastState => {
       // Set default values
-      lastState.platform = lastState.platform || {};
+      lastState.platformToProjectIdMap = lastState.platformToProjectIdMap || {};
       lastState.selectedPlatforms = lastState.selectedPlatforms || [];
       return lastState;
     });


### PR DESCRIPTION
- The client-state scope should be org instead of member. Otherwise we may create projects for the same platform twice.
- Fix a problem with emotion styled component passing unwanted props down, causing problems.
- Fixed a variable naming problem