### PR TITLE
fix(ui): removed old feedback alert

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -15,7 +15,6 @@ import {
   NotificationSettingsByProviderObject,
   NotificationSettingsObject,
 } from 'sentry/views/settings/account/notifications/constants';
-import FeedbackAlert from 'sentry/views/settings/account/notifications/feedbackAlert';
 import {ACCOUNT_NOTIFICATION_FIELDS} from 'sentry/views/settings/account/notifications/fields';
 import {
   NOTIFICATION_SETTING_FIELDS,
@@ -321,7 +320,6 @@ class NotificationSettingsByType extends AsyncComponent<Props, State> {
         {hasSlack && unlinkedOrgs.length > 0 && (
           <UnlinkedAlert organizations={unlinkedOrgs} />
         )}
-        <FeedbackAlert />
         <Form
           saveOnBlur
           apiMethod="PUT"

--- a/tests/js/spec/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/tests/js/spec/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -79,7 +79,7 @@ describe('NotificationSettingsByType', function () {
       [TestStubs.OrganizationIntegrations()]
     );
     const alert = wrapper.find('StyledAlert');
-    expect(alert).toHaveLength(2);
+    expect(alert).toHaveLength(1);
     const organizationSlugs = alert.at(0).find('li');
     expect(organizationSlugs).toHaveLength(1);
     expect(organizationSlugs.at(0).text()).toEqual(org.slug);
@@ -95,6 +95,6 @@ describe('NotificationSettingsByType', function () {
       [TestStubs.OrganizationIntegrations({organizationId: org.id})]
     );
     const alert = wrapper.find('StyledAlert');
-    expect(alert).toHaveLength(1);
+    expect(alert).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Removing the feedback alert below on Notification detail pages because it should be a temporary thing.

![CleanShot 2022-04-06 at 10 20 44](https://user-images.githubusercontent.com/1900676/162031950-9ff139d6-e84c-4d1e-ba0d-b61d501baae5.png)
