### PR TITLE
ref(integrations): Keep icon same size regardless of text length

### DIFF
--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import capitalize from 'lodash/capitalize';
 import * as qs from 'query-string';
 
@@ -201,19 +202,19 @@ export const getIntegrationIcon = (integrationType?: string, size?: string) => {
   const iconSize = size || 'md';
   switch (integrationType) {
     case 'bitbucket':
-      return <IconBitbucket size={iconSize} />;
+      return <StyledBitbucket size={iconSize} />;
     case 'gitlab':
-      return <IconGitlab size={iconSize} />;
+      return <StyledGitlab size={iconSize} />;
     case 'github':
     case 'github_enterprise':
-      return <IconGithub size={iconSize} />;
+      return <StyledGithub size={iconSize} />;
     case 'jira':
     case 'jira_server':
-      return <IconJira size={iconSize} />;
+      return <StyledJira size={iconSize} />;
     case 'vsts':
-      return <IconVsts size={iconSize} />;
+      return <StyledVsts size={iconSize} />;
     default:
-      return <IconGeneric size={iconSize} />;
+      return <StyledGeneric size={iconSize} />;
   }
 };
 
@@ -260,3 +261,27 @@ export const sentryNameToOption = ({id, name}): Result => ({
   value: id,
   label: name,
 });
+
+const StyledJira = styled(IconJira)`
+  flex-shrink: 0;
+`;
+
+const StyledBitbucket = styled(IconBitbucket)`
+  flex-shrink: 0;
+`;
+
+const StyledGitlab = styled(IconGitlab)`
+  flex-shrink: 0;
+`;
+
+const StyledGithub = styled(IconGithub)`
+  flex-shrink: 0;
+`;
+
+const StyledVsts = styled(IconVsts)`
+  flex-shrink: 0;
+`;
+
+const StyledGeneric = styled(IconGeneric)`
+  flex-shrink: 0;
+`;


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/33331#discussion_r843982268 to keep the external issue icon the same size regardless of the length of the text that follows it.

**Before**
<img width="348" alt="Screen Shot 2022-04-06 at 10 33 51 AM" src="https://user-images.githubusercontent.com/29959063/162036451-694300c4-eb3d-42c6-a931-779125e75704.png">

**After**
<img width="355" alt="Screen Shot 2022-04-06 at 10 41 04 AM" src="https://user-images.githubusercontent.com/29959063/162036458-afe3261a-0ee9-4417-8f4b-7af1a95a2303.png">
