### PR TITLE
fix(ui): linked issue flex fix

### DIFF
--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -96,6 +96,10 @@ class IssueSyncListElement extends React.Component<Props> {
                 display: flex;
                 align-items: center;
                 min-width: 0; /* flex-box overflow workaround */
+
+                svg {
+                  flex-shrink: 0;
+                }
               `}
               header={this.props.hoverCardHeader}
               body={this.props.hoverCardBody}

--- a/static/app/components/sentryAppComponentIcon.tsx
+++ b/static/app/components/sentryAppComponentIcon.tsx
@@ -31,4 +31,5 @@ const SentryAppAvatarWrapper = styled('span')<{isDark: boolean; isDefault: boole
   color: ${({isDark}) => (isDark ? 'white' : 'black')};
   filter: ${p => (p.isDark && !p.isDefault ? 'invert(1)' : 'invert(0)')};
   line-height: 0;
+  flex-shrink: 0;
 `;


### PR DESCRIPTION
On the Issue Details page, when the linked issue name gets really long then the SVG is squished by flexbox. So I’m adding `flex-shrink: 0` to the icon. 

![CleanShot 2022-04-06 at 11 16 03](https://user-images.githubusercontent.com/1900676/162044125-f0a2177d-7546-4c0b-986c-6dfe03b32f02.png)
 