### PR TITLE
fix(ui): Fix breadcrumbs when empty

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -100,7 +100,7 @@ function BreadcrumbsContainer({
 
     setState({
       ...state,
-      relativeTime: transformedCrumbs[transformedCrumbs.length - 1].timestamp,
+      relativeTime: transformedCrumbs[transformedCrumbs.length - 1]?.timestamp,
       breadcrumbs: transformedCrumbs,
       filteredByFilter: transformedCrumbs,
       filteredBySearch: transformedCrumbs,


### PR DESCRIPTION
Breadcrumbs cause a crash if there are no breadcrumbs to display.

Fixes JAVASCRIPT-25VQ