### PR TITLE
feat(pageFilters): Add guide to page filters

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -20,6 +20,7 @@ GUIDES = {
     "project_transaction_threshold_override": 20,
     "semver": 22,
     "release_stages": 23,
+    "new_page_filters": 24,
 }
 
 # demo mode has different guides

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -274,6 +274,29 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
         },
       ],
     },
+    {
+      guide: 'new_page_filters',
+      requiredTargets: ['new_page_filter_button'],
+      expectedTargets: ['new_page_filter_pin'],
+      dateThreshold: new Date('2022-04-05'),
+      steps: [
+        {
+          title: t('Selection Filters have moved!'),
+          target: 'new_page_filter_button',
+          description: t(
+            'Selection filters have teleported from the top of the page to live closer to the content they are filtering on!'
+          ),
+          nextText: t('Tell me more'),
+        },
+        {
+          title: t('Explicit memory'),
+          target: 'new_page_filter_pin',
+          description: t(
+            'Selection filters will no longer be implicitly be remembered between sessions. You can now "Pin" a filter to remember it'
+          ),
+        },
+      ],
+    },
   ];
 }
 

--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -2,6 +2,7 @@ import {Fragment, useRef} from 'react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Button from 'sentry/components/button';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
 import PageFilterPinButton from 'sentry/components/organizations/pageFilters/pageFilterPinButton';
@@ -217,7 +218,11 @@ const ProjectSelector = ({
           >
             {showPin ? '' : t('Project')}
           </AddButton>
-          {showPin && <PageFilterPinButton size="xsmall" filter="projects" />}
+          {showPin && (
+            <GuideAnchor target="new_page_filter_pin" position="bottom">
+              <PageFilterPinButton size="xsmall" filter="projects" />
+            </GuideAnchor>
+          )}
         </InputActions>
       }
       menuFooter={renderProps => {

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -5,6 +5,7 @@ import isEqual from 'lodash/isEqual';
 import partition from 'lodash/partition';
 
 import {updateProjects} from 'sentry/actionCreators/pageFilters';
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Badge from 'sentry/components/badge';
 import MultipleProjectSelector from 'sentry/components/organizations/multipleProjectSelector';
 import PageFilterDropdownButton from 'sentry/components/organizations/pageFilters/pageFilterDropdownButton';
@@ -117,6 +118,7 @@ export function ProjectPageFilter({
   const nonMemberProjects = isSuperuser || isOrgAdmin ? otherProjects : [];
 
   const customProjectDropdown: MultipleProjectSelectorProps['customDropdownButton'] = ({
+    actions,
     selectedProjects,
     isOpen,
   }) => {
@@ -146,20 +148,26 @@ export function ProjectPageFilter({
     );
 
     return (
-      <PageFilterDropdownButton
-        detached
-        hideBottomBorder={false}
-        isOpen={isOpen}
-        highlighted={desyncedFilters.has('projects')}
+      <GuideAnchor
+        target="new_page_filter_button"
+        position="bottom"
+        onStepComplete={actions.open}
       >
-        <DropdownTitle>
-          {icon}
-          <TitleContainer>{title}</TitleContainer>
-          {selectedProjects.length > projectsToShow.length && (
-            <StyledBadge text={`+${selectedProjects.length - projectsToShow.length}`} />
-          )}
-        </DropdownTitle>
-      </PageFilterDropdownButton>
+        <PageFilterDropdownButton
+          detached
+          hideBottomBorder={false}
+          isOpen={isOpen}
+          highlighted={desyncedFilters.has('projects')}
+        >
+          <DropdownTitle>
+            {icon}
+            <TitleContainer>{title}</TitleContainer>
+            {selectedProjects.length > projectsToShow.length && (
+              <StyledBadge text={`+${selectedProjects.length - projectsToShow.length}`} />
+            )}
+          </DropdownTitle>
+        </PageFilterDropdownButton>
+      </GuideAnchor>
     );
   };
 

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -51,6 +51,20 @@ describe('GuideStore', function () {
     expect(GuideStore.state.currentGuide).toEqual(null);
   });
 
+  it('should expect anchors to appear in expectedTargets', function () {
+    data = [{guide: 'new_page_filters', seen: false}];
+
+    GuideStore.onRegisterAnchor('new_page_filter_button');
+    GuideStore.onFetchSucceeded(data);
+    expect(GuideStore.state.currentStep).toEqual(0);
+    expect(GuideStore.state.currentGuide.guide).toEqual('new_page_filters');
+
+    GuideStore.onRegisterAnchor('new_page_filter_button');
+
+    // Will not prune steps that don't have anchors
+    expect(GuideStore.state.currentGuide.steps).toHaveLength(2);
+  });
+
   it('should force show a guide with #assistant', function () {
     data = [
       {


### PR DESCRIPTION
This adds a new guide that shows up on the new page filters letting
users know that the page filters have moved.

See video below

https://user-images.githubusercontent.com/1421724/162097648-a3013112-8be2-4402-9216-eafb5744100e.mov



