### PR TITLE
feat(replays): Add a faux replay event with merged spans

### DIFF
--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -109,7 +109,7 @@ function ReplayLoader(props: ReplayLoaderProps) {
   const {
     fetchError,
     fetching,
-    breadcrumbEvent,
+    breadcrumbEntry,
     event,
     replayEvents,
     rrwebEvents,
@@ -138,13 +138,13 @@ function ReplayLoader(props: ReplayLoaderProps) {
       <React.Fragment>
         <BaseRRWebReplayer events={rrwebEvents} />
 
-        {breadcrumbEvent && (
+        {breadcrumbEntry && (
           <EventEntry
             projectSlug={getProjectSlug(event)}
             // group={group}
             organization={props.organization}
             event={event}
-            entry={breadcrumbEvent}
+            entry={breadcrumbEntry}
             route={props.route}
             router={props.router}
           />

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -16,12 +16,11 @@ import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
-import {Entry, EntryType, Event} from 'sentry/types/event';
+import {Event} from 'sentry/types/event';
 import {getMessage} from 'sentry/utils/events';
 import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 
-import mergeBreadcrumbsEntries from './utils/mergeBreadcrumbsEntries';
 import useReplayEvent from './utils/useReplayEvent';
 
 type Props = AsyncView['props'] &
@@ -104,23 +103,38 @@ function getProjectSlug(event: Event) {
   return event.projectSlug || event['project.name']; // seems janky
 }
 
-function isReplayEventEntity(entry: Entry) {
-  // Starting with an allowlist, might be better to block only a few types (like Tags)
-  switch (entry.type) {
-    case EntryType.SPANS:
-      return true;
-    default:
-      return false;
-  }
-}
+// function isReplayEventEntity(entry: Entry) {
+// // Starting with an allowlist, might be better to block only a few types (like Tags)
+// switch (entry.type) {
+// case EntryType.SPANS:
+// return true;
+// default:
+// return false;
+// }
+// }
 
 function ReplayLoader(props: ReplayLoaderProps) {
   const orgSlug = props.orgId;
 
-  const {fetchError, fetching, event, replayEvents, rrwebEvents} = useReplayEvent(props);
+  const {
+    fetchError,
+    fetching,
+    breadcrumbEvent,
+    event,
+    replayEvents,
+    rrwebEvents,
+    mergedReplayEvent,
+  } = useReplayEvent(props);
 
   /* eslint-disable-next-line no-console */
-  console.log({fetchError, fetching, event, replayEvents, rrwebEvents});
+  console.log({
+    fetchError,
+    fetching,
+    event,
+    replayEvents,
+    rrwebEvents,
+    mergedReplayEvent,
+  });
 
   const renderMain = () => {
     if (fetching) {
@@ -130,39 +144,34 @@ function ReplayLoader(props: ReplayLoaderProps) {
       return <NotFound />;
     }
 
-    const breadcrumbs = mergeBreadcrumbsEntries(replayEvents || []);
-
     return (
       <React.Fragment>
         <BaseRRWebReplayer events={rrwebEvents} />
 
-        <EventEntry
-          projectSlug={getProjectSlug(event)}
-          // group={group}
-          organization={props.organization}
-          event={event}
-          entry={breadcrumbs}
-          route={props.route}
-          router={props.router}
-        />
+        {breadcrumbEvent && (
+          <EventEntry
+            projectSlug={getProjectSlug(event)}
+            // group={group}
+            organization={props.organization}
+            event={event}
+            entry={breadcrumbEvent}
+            route={props.route}
+            router={props.router}
+          />
+        )}
 
-        {replayEvents?.map(replayEvent => (
-          <React.Fragment key={replayEvent.id}>
-            <TitleWrapper>ReplayEvent: {replayEvent.id}</TitleWrapper>
-            {replayEvent.entries.filter(isReplayEventEntity).map(entry => (
-              <EventEntry
-                key={`${replayEvent.id}+${entry.type}`}
-                projectSlug={getProjectSlug(replayEvent)}
-                // group={group}
-                organization={props.organization}
-                event={replayEvent}
-                entry={entry}
-                route={props.route}
-                router={props.router}
-              />
-            ))}
-          </React.Fragment>
-        ))}
+        {mergedReplayEvent && (
+          <EventEntry
+            key={`${mergedReplayEvent.id}`}
+            projectSlug={getProjectSlug(mergedReplayEvent)}
+            // group={group}
+            organization={props.organization}
+            event={mergedReplayEvent}
+            entry={mergedReplayEvent.entries[0]}
+            route={props.route}
+            router={props.router}
+          />
+        )}
       </React.Fragment>
     );
   };

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -103,16 +103,6 @@ function getProjectSlug(event: Event) {
   return event.projectSlug || event['project.name']; // seems janky
 }
 
-// function isReplayEventEntity(entry: Entry) {
-// // Starting with an allowlist, might be better to block only a few types (like Tags)
-// switch (entry.type) {
-// case EntryType.SPANS:
-// return true;
-// default:
-// return false;
-// }
-// }
-
 function ReplayLoader(props: ReplayLoaderProps) {
   const orgSlug = props.orgId;
 

--- a/static/app/views/replays/utils/useReplayEvent.tsx
+++ b/static/app/views/replays/utils/useReplayEvent.tsx
@@ -174,6 +174,7 @@ function useReplayEvent({eventSlug, location, orgId}: Options): Result {
       // endTimestamp by using the timestamp of the final span
       const mergedReplayEvent = {
         ...replayEvents[0],
+        breakdowns: null,
         entries: [{type: EntryType.SPANS, data: spans}],
         // This is probably better than taking the end timestamp of the last `replayEvent`
         endTimestamp: spans[spans.length - 1]?.timestamp,

--- a/static/app/views/replays/utils/useReplayEvent.tsx
+++ b/static/app/views/replays/utils/useReplayEvent.tsx
@@ -23,7 +23,7 @@ type State = {
   /**
    * List of breadcrumbs
    */
-  breadcrumbEvent: undefined | Entry;
+  breadcrumbEntry: undefined | Entry;
 
   /**
    * The root replay event
@@ -85,7 +85,7 @@ function useReplayEvent({eventSlug, location, orgId}: Options): Result {
   const [state, setState] = useState<State>({
     fetchError: undefined,
     fetching: true,
-    breadcrumbEvent: undefined,
+    breadcrumbEntry: undefined,
     event: undefined,
     replayEvents: undefined,
     rrwebEvents: undefined,
@@ -150,7 +150,7 @@ function useReplayEvent({eventSlug, location, orgId}: Options): Result {
       fetchError: undefined,
       fetching: true,
 
-      breadcrumbEvent: undefined,
+      breadcrumbEntry: undefined,
       event: undefined,
       replayEvents: undefined,
       rrwebEvents: undefined,
@@ -163,7 +163,7 @@ function useReplayEvent({eventSlug, location, orgId}: Options): Result {
         fetchReplayEvents(),
       ]);
 
-      const breadcrumbEvent = mergeBreadcrumbsEntries(replayEvents || []);
+      const breadcrumbEntry = mergeBreadcrumbsEntries(replayEvents || []);
 
       // Get a merged list of all spans from all replay events
       const spans = replayEvents.flatMap(
@@ -188,14 +188,14 @@ function useReplayEvent({eventSlug, location, orgId}: Options): Result {
         mergedReplayEvent,
         replayEvents,
         rrwebEvents,
-        breadcrumbEvent,
+        breadcrumbEntry,
       });
     } catch (error) {
       setState({
         fetchError: error,
         fetching: false,
 
-        breadcrumbEvent: undefined,
+        breadcrumbEntry: undefined,
         event: undefined,
         replayEvents: undefined,
         rrwebEvents: undefined,
@@ -210,7 +210,7 @@ function useReplayEvent({eventSlug, location, orgId}: Options): Result {
     fetchError: state.fetchError,
     fetching: state.fetching,
 
-    breadcrumbEvent: state.breadcrumbEvent,
+    breadcrumbEntry: state.breadcrumbEntry,
     event: state.event,
     replayEvents: state.replayEvents,
     rrwebEvents: state.rrwebEvents,


### PR DESCRIPTION
Move merged breadcrumbs into `useReplayEvent` and create a "merged spans"
replay event as well.