### PR TITLE
ref(reflux): Remove SidebarPanelActions

### DIFF
--- a/static/app/actions/sidebarPanelActions.tsx
+++ b/static/app/actions/sidebarPanelActions.tsx
@@ -1,5 +1,0 @@
-import {createActions} from 'reflux';
-
-const SidebarPanelActions = createActions(['activatePanel', 'togglePanel', 'hidePanel']);
-
-export default SidebarPanelActions;

--- a/static/app/components/globalSdkUpdateAlert.tsx
+++ b/static/app/components/globalSdkUpdateAlert.tsx
@@ -1,10 +1,10 @@
 import {Fragment, useCallback, useEffect, useState} from 'react';
 
 import {promptsCheck, promptsUpdate} from 'sentry/actionCreators/prompts';
-import SidebarPanelActions from 'sentry/actions/sidebarPanelActions';
 import Alert, {AlertProps} from 'sentry/components/alert';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
+import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {PageFilters, ProjectSdkUpdates} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
@@ -41,7 +41,7 @@ function InnerGlobalSdkUpdateAlert(
   }, [api, organization]);
 
   const handleReviewUpdatesClick = useCallback(() => {
-    SidebarPanelActions.activatePanel(SidebarPanelKey.Broadcasts);
+    SidebarPanelStore.activatePanel(SidebarPanelKey.Broadcasts);
     trackAdvancedAnalyticsEvent('sdk_updates.clicked', {organization});
   }, []);
 

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -6,7 +6,6 @@ import {Location} from 'history';
 import * as qs from 'query-string';
 
 import {hideSidebar, showSidebar} from 'sentry/actionCreators/preferences';
-import SidebarPanelActions from 'sentry/actions/sidebarPanelActions';
 import Feature from 'sentry/components/acl/feature';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import HookOrDefault from 'sentry/components/hookOrDefault';
@@ -73,8 +72,8 @@ function Sidebar({location, organization}: Props) {
     action();
   };
 
-  const togglePanel = (panel: SidebarPanelKey) => SidebarPanelActions.togglePanel(panel);
-  const hidePanel = () => SidebarPanelActions.hidePanel();
+  const togglePanel = (panel: SidebarPanelKey) => SidebarPanelStore.togglePanel(panel);
+  const hidePanel = () => SidebarPanelStore.hidePanel();
 
   const bcl = document.body.classList;
 

--- a/static/app/components/sidebar/sidebarPanel.tsx
+++ b/static/app/components/sidebar/sidebarPanel.tsx
@@ -47,18 +47,16 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   title?: string;
 }
 
-/**
- * Get the container element of the sidebar that react portals into.
- */
-export const getSidebarPanelContainer = () =>
-  document.getElementById('sidebar-flyout-portal') as HTMLDivElement;
+const getSidebarPortal = () => {
+  let portal = document.getElementById('sidebar-flyout-portal');
 
-const makePortal = () => {
-  const portal = document.createElement('div');
-  portal.setAttribute('id', 'sidebar-flyout-portal');
-  document.body.appendChild(portal);
+  if (!portal) {
+    portal = document.createElement('div');
+    portal.setAttribute('id', 'sidebar-flyout-portal');
+    document.body.appendChild(portal);
+  }
 
-  return portal;
+  return portal as HTMLDivElement;
 };
 
 function SidebarPanel({
@@ -69,16 +67,14 @@ function SidebarPanel({
   children,
   ...props
 }: Props): React.ReactElement {
-  const portalEl = useRef<HTMLDivElement>(getSidebarPanelContainer() || makePortal());
+  const portalEl = useRef<HTMLDivElement>(getSidebarPortal());
 
   function panelCloseHandler(evt: MouseEvent) {
     if (!(evt.target instanceof Element)) {
       return;
     }
 
-    const panel = getSidebarPanelContainer();
-
-    if (panel?.contains(evt.target)) {
+    if (portalEl.current.contains(evt.target)) {
       return;
     }
 
@@ -86,7 +82,10 @@ function SidebarPanel({
   }
 
   useEffect(() => {
-    document.addEventListener('click', panelCloseHandler);
+    // Wait one tick to setup the click handler so we don't detect the click
+    // that is bubbling up from opening the panel itself
+    window.setTimeout(() => document.addEventListener('click', panelCloseHandler));
+
     return function cleanup() {
       document.removeEventListener('click', panelCloseHandler);
     };

--- a/static/app/stores/sidebarPanelStore.tsx
+++ b/static/app/stores/sidebarPanelStore.tsx
@@ -1,6 +1,5 @@
 import {createStore} from 'reflux';
 
-import SidebarPanelActions from 'sentry/actions/sidebarPanelActions';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
@@ -9,43 +8,31 @@ import {CommonStoreDefinition} from './types';
 type ActivePanelType = SidebarPanelKey | '';
 
 interface SidebarPanelStoreDefinition extends CommonStoreDefinition<ActivePanelType> {
-  activePanel: ActivePanelType;
+  activatePanel(panel: SidebarPanelKey): void;
 
-  onActivatePanel(panel: SidebarPanelKey): void;
-  onHidePanel(): void;
-  onTogglePanel(panel: SidebarPanelKey): void;
+  activePanel: ActivePanelType;
+  hidePanel(): void;
+  togglePanel(panel: SidebarPanelKey): void;
 }
 
 const storeConfig: SidebarPanelStoreDefinition = {
   activePanel: '',
   unsubscribeListeners: [],
 
-  init() {
-    this.unsubscribeListeners.push(
-      this.listenTo(SidebarPanelActions.activatePanel, this.onActivatePanel)
-    );
-    this.unsubscribeListeners.push(
-      this.listenTo(SidebarPanelActions.hidePanel, this.onHidePanel)
-    );
-    this.unsubscribeListeners.push(
-      this.listenTo(SidebarPanelActions.togglePanel, this.onTogglePanel)
-    );
-  },
-
-  onActivatePanel(panel: SidebarPanelKey) {
+  activatePanel(panel: SidebarPanelKey) {
     this.activePanel = panel;
     this.trigger(this.activePanel);
   },
 
-  onTogglePanel(panel: SidebarPanelKey) {
+  togglePanel(panel: SidebarPanelKey) {
     if (this.activePanel === panel) {
-      this.onHidePanel();
+      this.hidePanel();
     } else {
-      this.onActivatePanel(panel);
+      this.activatePanel(panel);
     }
   },
 
-  onHidePanel() {
+  hidePanel() {
     this.activePanel = '';
     this.trigger(this.activePanel);
   },

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -1,12 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {
-  act,
-  render,
-  screen,
-  userEvent,
-  waitFor,
-  waitForElementToBeRemoved,
-} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as incidentActions from 'sentry/actionCreators/serviceIncidents';
 import SidebarContainer from 'sentry/components/sidebar';
@@ -139,7 +132,7 @@ describe('Sidebar', function () {
 
       rerender(getElement({location: {...router.location, pathname: 'new-path-name'}}));
 
-      await waitForElementToBeRemoved(() => screen.queryByText("What's new in Sentry"));
+      expect(screen.queryByText("What's new in Sentry")).not.toBeInTheDocument();
     });
 
     it('can have onboarding feature', async function () {
@@ -173,7 +166,7 @@ describe('Sidebar', function () {
 
       // Close the sidebar
       userEvent.click(screen.getByText("What's new"));
-      await waitForElementToBeRemoved(() => screen.queryByText("What's new in Sentry"));
+      expect(screen.queryByText("What's new in Sentry")).not.toBeInTheDocument();
     });
 
     it('can display Broadcasts panel and mark as seen', async function () {
@@ -205,7 +198,7 @@ describe('Sidebar', function () {
 
       // Close the sidebar
       userEvent.click(screen.getByText("What's new"));
-      await waitForElementToBeRemoved(() => screen.queryByText("What's new in Sentry"));
+      expect(screen.queryByText("What's new in Sentry")).not.toBeInTheDocument();
     });
 
     it('can unmount Sidebar (and Broadcasts) and kills Broadcast timers', async function () {


### PR DESCRIPTION
In an effort to simplify our usage of Reflux, there are a number of
Actions that don't actually need to be actions. Here's one