### PR TITLE
ref(reflux): Remove SdkUpdatesActions

### DIFF
--- a/static/app/actionCreators/sdkUpdates.tsx
+++ b/static/app/actionCreators/sdkUpdates.tsx
@@ -1,10 +1,10 @@
-import SdkUpdatesActions from 'sentry/actions/sdkUpdatesActions';
 import {Client} from 'sentry/api';
+import SdkUpdatesStore from 'sentry/stores/sdkUpdatesStore';
 
 /**
  * Load SDK Updates for a specific organization
  */
 export async function loadSdkUpdates(api: Client, orgSlug: string) {
   const updates = await api.requestPromise(`/organizations/${orgSlug}/sdk-updates/`);
-  SdkUpdatesActions.load(orgSlug, updates);
+  SdkUpdatesStore.loadSuccess(orgSlug, updates);
 }

--- a/static/app/actions/sdkUpdatesActions.tsx
+++ b/static/app/actions/sdkUpdatesActions.tsx
@@ -1,5 +1,0 @@
-import {createActions} from 'reflux';
-
-const SdkUpdatesActions = createActions(['load']);
-
-export default SdkUpdatesActions;

--- a/static/app/stores/sdkUpdatesStore.tsx
+++ b/static/app/stores/sdkUpdatesStore.tsx
@@ -1,6 +1,5 @@
 import {createStore, StoreDefinition} from 'reflux';
 
-import SdkUpdatesActions from 'sentry/actions/sdkUpdatesActions';
 import {ProjectSdkUpdates} from 'sentry/types';
 import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
@@ -14,20 +13,14 @@ type InternalDefinition = {
 interface SdkUpdatesStoreDefinition extends StoreDefinition, InternalDefinition {
   getUpdates(orgSlug: string): ProjectSdkUpdates[] | undefined;
   isSdkUpdatesLoaded(orgSlug: string): boolean;
-  onLoadSuccess(orgSlug: string, data: ProjectSdkUpdates[]): void;
+  loadSuccess(orgSlug: string, data: ProjectSdkUpdates[]): void;
 }
 
 const storeConfig: SdkUpdatesStoreDefinition = {
   orgSdkUpdates: new Map(),
   unsubscribeListeners: [],
 
-  init() {
-    this.unsubscribeListeners.push(
-      this.listenTo(SdkUpdatesActions.load, this.onLoadSuccess)
-    );
-  },
-
-  onLoadSuccess(orgSlug, data) {
+  loadSuccess(orgSlug, data) {
     this.orgSdkUpdates.set(orgSlug, data);
     this.trigger(this.orgSdkUpdates);
   },


### PR DESCRIPTION
In an effort to simplify our usage of Reflux, there are a number of
Actions that don't actually need to be actions. Here's one