### PR TITLE
ref(assistant): Disable superuser guides in acceptance tests

### DIFF
--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -5,7 +5,7 @@ import GuideActions from 'sentry/actions/guideActions';
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import getGuidesContent from 'sentry/components/assistant/getGuidesContent';
 import {Guide, GuidesContent, GuidesServerData} from 'sentry/components/assistant/types';
-import { IS_ACCEPTANCE_TEST } from 'sentry/constants';
+import {IS_ACCEPTANCE_TEST} from 'sentry/constants';
 import ConfigStore from 'sentry/stores/configStore';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import {

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -5,6 +5,7 @@ import GuideActions from 'sentry/actions/guideActions';
 import OrganizationsActions from 'sentry/actions/organizationsActions';
 import getGuidesContent from 'sentry/components/assistant/getGuidesContent';
 import {Guide, GuidesContent, GuidesServerData} from 'sentry/components/assistant/types';
+import { IS_ACCEPTANCE_TEST } from 'sentry/constants';
 import ConfigStore from 'sentry/stores/configStore';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import {
@@ -255,7 +256,7 @@ const storeConfig: GuideStoreDefinition = {
         if (seen) {
           return false;
         }
-        if (user?.isSuperuser) {
+        if (user?.isSuperuser && !IS_ACCEPTANCE_TEST) {
           return true;
         }
         if (dateThreshold) {


### PR DESCRIPTION
Generally we don't want to render guides in acceptance tests JUST because the user is a superuser.