### PR TITLE
ref(reflux): Remove PreferencesActions

### DIFF
--- a/static/app/actionCreators/preferences.tsx
+++ b/static/app/actionCreators/preferences.tsx
@@ -1,24 +1,24 @@
 import Cookies from 'js-cookie';
 
-import PreferencesActions from '../actions/preferencesActions';
+import PreferenceStore from 'sentry/stores/preferencesStore';
 
 const SIDEBAR_COOKIE_KEY = 'sidebar_collapsed';
 const COOKIE_ENABLED = '1';
 const COOKIE_DISABLED = '0';
 
 export function hideSidebar() {
-  PreferencesActions.hideSidebar();
+  PreferenceStore.hideSidebar();
   Cookies.set(SIDEBAR_COOKIE_KEY, COOKIE_ENABLED);
 }
 
 export function showSidebar() {
-  PreferencesActions.showSidebar();
+  PreferenceStore.showSidebar();
   Cookies.set(SIDEBAR_COOKIE_KEY, COOKIE_DISABLED);
 }
 
 export function loadPreferencesState() {
   // Set initial "collapsed" state to true or false
-  PreferencesActions.loadInitialState({
+  PreferenceStore.loadInitialState({
     collapsed: Cookies.get(SIDEBAR_COOKIE_KEY) === COOKIE_ENABLED,
   });
 }

--- a/static/app/actions/preferencesActions.tsx
+++ b/static/app/actions/preferencesActions.tsx
@@ -1,9 +1,0 @@
-import {createActions} from 'reflux';
-
-const PreferencesActions = createActions([
-  'loadInitialState',
-  'hideSidebar',
-  'showSidebar',
-]);
-
-export default PreferencesActions;

--- a/static/app/stores/preferencesStore.tsx
+++ b/static/app/stores/preferencesStore.tsx
@@ -1,6 +1,5 @@
 import {createStore} from 'reflux';
 
-import PreferencesActions from 'sentry/actions/preferencesActions';
 import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreDefinition} from './types';
@@ -15,9 +14,11 @@ type Preferences = {
 interface PreferenceStoreDefinition extends CommonStoreDefinition<Preferences> {
   getInitialState(): Preferences;
 
+  hideSidebar(): void;
   loadInitialState(prefs: Preferences): void;
   prefs: Preferences;
   reset(): void;
+  showSidebar(): void;
 }
 
 const storeConfig: PreferenceStoreDefinition = {
@@ -26,16 +27,6 @@ const storeConfig: PreferenceStoreDefinition = {
 
   init() {
     this.reset();
-
-    this.unsubscribeListeners.push(
-      this.listenTo(PreferencesActions.hideSidebar, this.onHideSidebar)
-    );
-    this.unsubscribeListeners.push(
-      this.listenTo(PreferencesActions.showSidebar, this.onShowSidebar)
-    );
-    this.unsubscribeListeners.push(
-      this.listenTo(PreferencesActions.loadInitialState, this.loadInitialState)
-    );
   },
 
   getInitialState() {
@@ -46,17 +37,17 @@ const storeConfig: PreferenceStoreDefinition = {
     this.prefs = {collapsed: false};
   },
 
-  loadInitialState(prefs: Preferences) {
+  loadInitialState(prefs) {
     this.prefs = {...prefs};
     this.trigger(this.prefs);
   },
 
-  onHideSidebar() {
+  hideSidebar() {
     this.prefs = {...this.prefs, collapsed: true};
     this.trigger(this.prefs);
   },
 
-  onShowSidebar() {
+  showSidebar() {
     this.prefs = {...this.prefs, collapsed: false};
     this.trigger(this.prefs);
   },

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -250,7 +250,7 @@ describe('Sidebar', function () {
     userEvent.click(screen.getByTestId('sidebar-collapse'));
 
     // Check that the organization name is no longer visible
-    await waitForElementToBeRemoved(() => screen.queryByText(organization.name));
+    expect(screen.queryByText(organization.name)).not.toBeInTheDocument();
 
     // Un-collapse he sidebar and make sure the org name is visible again
     userEvent.click(screen.getByTestId('sidebar-collapse'));


### PR DESCRIPTION
In an effort to simplify our usage of Reflux, there are a number of
Actions that don't actually need to be actions. Here's one