### PR TITLE
feat(workflow): Add team selector to projects page

### DIFF
--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -127,57 +127,60 @@ function Dashboard({teams, params, organization, loadingTeams, error}: Props) {
               </Button>
             </ButtonContainer>
           </ProjectsHeader>
-          <StyledTeamSelector
-            name="select-team"
-            inFieldLabel={t('Team: ')}
-            placeholder={t('My Teams')}
-            value={currentTeam}
-            onChange={choice => handleChange(choice)}
-            teamFilter={isSuperuser ? undefined : filterTeam => filterTeam.isMember}
-            useId
-            clearable
-            styles={{
-              placeholder: (provided: any) => ({
-                ...provided,
-                paddingLeft: space(0.5),
-                ':before': {
-                  ...provided[':before'],
-                  color: theme.textColor,
-                },
-              }),
-              singleValue(provided: any) {
-                const custom = {
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  fontSize: theme.fontSizeMedium,
+          {hasProjectRedesign && (
+            <StyledTeamSelector
+              name="select-team"
+              aria-label="select-team"
+              inFieldLabel={t('Team: ')}
+              placeholder={t('My Teams')}
+              value={currentTeam}
+              onChange={choice => handleChange(choice)}
+              teamFilter={isSuperuser ? undefined : filterTeam => filterTeam.isMember}
+              useId
+              clearable
+              styles={{
+                placeholder: (provided: any) => ({
+                  ...provided,
+                  paddingLeft: space(0.5),
                   ':before': {
                     ...provided[':before'],
                     color: theme.textColor,
-                    marginRight: space(1.5),
-                    marginLeft: space(0.5),
                   },
-                };
-                return {...provided, ...custom};
-              },
-              input: (provided: any, state: any) => ({
-                ...provided,
-                display: 'grid',
-                gridTemplateColumns: 'max-content 1fr',
-                alignItems: 'center',
-                marginRight: space(0.25),
-                gridGap: space(1.5),
-                ':before': {
-                  backgroundColor: state.theme.backgroundSecondary,
-                  height: 24,
-                  width: 38,
-                  borderRadius: 3,
-                  content: '""',
-                  display: 'block',
+                }),
+                singleValue(provided: any) {
+                  const custom = {
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    fontSize: theme.fontSizeMedium,
+                    ':before': {
+                      ...provided[':before'],
+                      color: theme.textColor,
+                      marginRight: space(1.5),
+                      marginLeft: space(0.5),
+                    },
+                  };
+                  return {...provided, ...custom};
                 },
-              }),
-            }}
-          />
+                input: (provided: any, state: any) => ({
+                  ...provided,
+                  display: 'grid',
+                  gridTemplateColumns: 'max-content 1fr',
+                  alignItems: 'center',
+                  marginRight: space(0.25),
+                  gridGap: space(1.5),
+                  ':before': {
+                    backgroundColor: state.theme.backgroundSecondary,
+                    height: 24,
+                    width: 38,
+                    borderRadius: 3,
+                    content: '""',
+                    display: 'block',
+                  },
+                }),
+              }}
+            />
+          )}
         </Fragment>
       )}
 

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -1,6 +1,7 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import LazyLoad from 'react-lazyload';
 import {RouteComponentProps} from 'react-router';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {withProfiler} from '@sentry/react';
 import flatten from 'lodash/flatten';
@@ -8,6 +9,7 @@ import uniqBy from 'lodash/uniqBy';
 
 import {Client} from 'sentry/api';
 import Button from 'sentry/components/button';
+import TeamSelector from 'sentry/components/forms/teamSelector';
 import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
 import LoadingError from 'sentry/components/loadingError';
@@ -21,6 +23,7 @@ import ProjectsStatsStore from 'sentry/stores/projectsStatsStore';
 import space from 'sentry/styles/space';
 import {Organization, TeamWithProjects} from 'sentry/types';
 import {sortProjects} from 'sentry/utils';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withTeamsForUser from 'sentry/utils/withTeamsForUser';
@@ -43,6 +46,7 @@ function Dashboard({teams, params, organization, loadingTeams, error}: Props) {
       ProjectsStatsStore.reset();
     };
   }, []);
+  const [currentTeam, setCurrentTeam] = useState<string>();
 
   if (loadingTeams) {
     return <LoadingIndicator />;
@@ -52,10 +56,14 @@ function Dashboard({teams, params, organization, loadingTeams, error}: Props) {
     return <LoadingError message={t('An error occurred while fetching your projects')} />;
   }
 
+  const theme = useTheme();
+  const isSuperuser = isActiveSuperuser();
+
   const filteredTeams = teams.filter(team => team.projects.length);
   filteredTeams.sort((team1, team2) => team1.slug.localeCompare(team2.slug));
 
   const projects = uniqBy(flatten(teams.map(teamObj => teamObj.projects)), 'id');
+  const currentProjects = filteredTeams.find(team => team.id === currentTeam)?.projects;
   const favorites = projects.filter(project => project.isBookmarked);
 
   const canCreateProjects = organization.access.includes('project:admin');
@@ -66,6 +74,11 @@ function Dashboard({teams, params, organization, loadingTeams, error}: Props) {
 
   const showEmptyMessage = projects.length === 0 && favorites.length === 0;
   const showResources = projects.length === 1 && !projects[0].firstEvent;
+
+  function handleChange(newValue) {
+    const updatedTeam = newValue ? newValue.actor.id : '';
+    setCurrentTeam(updatedTeam);
+  }
 
   if (showEmptyMessage) {
     return (
@@ -114,6 +127,57 @@ function Dashboard({teams, params, organization, loadingTeams, error}: Props) {
               </Button>
             </ButtonContainer>
           </ProjectsHeader>
+          <StyledTeamSelector
+            name="select-team"
+            inFieldLabel={t('Team: ')}
+            placeholder={t('My Teams')}
+            value={currentTeam}
+            onChange={choice => handleChange(choice)}
+            teamFilter={isSuperuser ? undefined : filterTeam => filterTeam.isMember}
+            useId
+            clearable
+            styles={{
+              placeholder: (provided: any) => ({
+                ...provided,
+                paddingLeft: space(0.5),
+                ':before': {
+                  ...provided[':before'],
+                  color: theme.textColor,
+                },
+              }),
+              singleValue(provided: any) {
+                const custom = {
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  fontSize: theme.fontSizeMedium,
+                  ':before': {
+                    ...provided[':before'],
+                    color: theme.textColor,
+                    marginRight: space(1.5),
+                    marginLeft: space(0.5),
+                  },
+                };
+                return {...provided, ...custom};
+              },
+              input: (provided: any, state: any) => ({
+                ...provided,
+                display: 'grid',
+                gridTemplateColumns: 'max-content 1fr',
+                alignItems: 'center',
+                marginRight: space(0.25),
+                gridGap: space(1.5),
+                ':before': {
+                  backgroundColor: state.theme.backgroundSecondary,
+                  height: 24,
+                  width: 38,
+                  borderRadius: 3,
+                  content: '""',
+                  display: 'block',
+                },
+              }),
+            }}
+          />
         </Fragment>
       )}
 
@@ -121,7 +185,7 @@ function Dashboard({teams, params, organization, loadingTeams, error}: Props) {
         <LazyLoad once debounce={50} height={300} offset={300}>
           <ProjectCardsContainer>
             <ProjectCards>
-              {projects.map(project => (
+              {(currentProjects ?? projects).map(project => (
                 <ProjectCard
                   data-test-id={project.slug}
                   key={project.slug}
@@ -182,8 +246,14 @@ const ButtonContainer = styled('div')`
   gap: ${space(1)};
 `;
 
+const StyledTeamSelector = styled(TeamSelector)`
+  margin: ${space(2)} 30px 0 0;
+  width: 300px;
+  margin-left: auto;
+`;
+
 const ProjectCardsContainer = styled('div')`
-  padding: 20px 30px 0 30px;
+  padding: ${space(2)} 30px ${space(2)} 30px;
 `;
 
 const ProjectCards = styled('div')`

--- a/tests/js/spec/views/projectsDashboard/index.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/index.spec.jsx
@@ -144,6 +144,7 @@ describe('ProjectsDashboard', function () {
 
       expect(screen.getByTestId('join-team')).toBeInTheDocument();
       expect(screen.getByTestId('create-project')).toBeInTheDocument();
+      expect(screen.getByText('My Teams')).toBeInTheDocument();
       expect(screen.queryByTestId('team')).not.toBeInTheDocument();
       expect(screen.queryByText('Resources')).not.toBeInTheDocument();
     });


### PR DESCRIPTION
Add team selector to the projects page.

[FIXES WOR-1757](https://getsentry.atlassian.net/browse/WOR-1757)

# Before
<img width="1221" alt="Screen Shot 2022-04-06 at 6 14 15 PM" src="https://user-images.githubusercontent.com/20312973/162100515-4a940b28-ce76-458c-8d7b-14a90313f16a.png">

# After

**All projects for teams the user is on**
<img width="1220" alt="Screen Shot 2022-04-06 at 6 06 56 PM" src="https://user-images.githubusercontent.com/20312973/162100440-920dfcce-0e9b-410d-b8c6-113052fe6345.png">

**One team selected**
<img width="1220" alt="Screen Shot 2022-04-06 at 6 07 31 PM 1" src="https://user-images.githubusercontent.com/20312973/162100455-21aa5040-2c9e-4c6c-97d9-5eaec1a4be17.png">
