### PR TITLE
poc(config): test out an alternative poc with manual dispatch wrapping

### DIFF
--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -6,11 +6,53 @@ import routes from 'sentry/routes';
 import LegacyConfigStore from 'sentry/stores/configStore';
 
 import {ConfigProvider} from './stores/configStore/configProvider';
+import {useConfig} from './stores/configStore/useConfig';
+import Button from 'sentry/components/button';
+import {useLegacyStore} from './stores/useLegacyStore';
+
+const ReactContext = () => {
+  const [config, dispatch] = useConfig();
+
+  return (
+    <span>
+      React Theme: {config.theme}{' '}
+      <Button
+        onClick={() =>
+          dispatch({
+            type: 'set theme',
+            payload: config.theme === 'dark' ? 'light' : 'dark',
+          })
+        }
+      >
+        Switch to {config.theme === 'dark' ? 'light' : 'dark'}
+      </Button>
+    </span>
+  );
+};
+
+const LegacyContext = () => {
+  const store = useLegacyStore(LegacyConfigStore);
+
+  return (
+    <span>
+      Reflux Theme: {store.theme}{' '}
+      <Button
+        onClick={() =>
+          LegacyConfigStore.set('theme', store.theme === 'dark' ? 'light' : 'dark')
+        }
+      >
+        Switch to {store.theme === 'dark' ? 'light' : 'dark'}
+      </Button>
+    </span>
+  );
+};
 
 function Main() {
   return (
-    <ConfigProvider initialValue={LegacyConfigStore.config} bridgeReflux>
+    <ConfigProvider initialValue={LegacyConfigStore.config}>
       <ThemeAndStyleProvider>
+        <ReactContext />
+        <LegacyContext />
         {LegacyConfigStore.get('demoMode') && <DemoHeader />}
         <Router history={browserHistory}>{routes()}</Router>
       </ThemeAndStyleProvider>

--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -6,53 +6,11 @@ import routes from 'sentry/routes';
 import LegacyConfigStore from 'sentry/stores/configStore';
 
 import {ConfigProvider} from './stores/configStore/configProvider';
-import {useConfig} from './stores/configStore/useConfig';
-import Button from 'sentry/components/button';
-import {useLegacyStore} from './stores/useLegacyStore';
-
-const ReactContext = () => {
-  const [config, dispatch] = useConfig();
-
-  return (
-    <span>
-      React Theme: {config.theme}{' '}
-      <Button
-        onClick={() =>
-          dispatch({
-            type: 'set theme',
-            payload: config.theme === 'dark' ? 'light' : 'dark',
-          })
-        }
-      >
-        Switch to {config.theme === 'dark' ? 'light' : 'dark'}
-      </Button>
-    </span>
-  );
-};
-
-const LegacyContext = () => {
-  const store = useLegacyStore(LegacyConfigStore);
-
-  return (
-    <span>
-      Reflux Theme: {store.theme}{' '}
-      <Button
-        onClick={() =>
-          LegacyConfigStore.set('theme', store.theme === 'dark' ? 'light' : 'dark')
-        }
-      >
-        Switch to {store.theme === 'dark' ? 'light' : 'dark'}
-      </Button>
-    </span>
-  );
-};
 
 function Main() {
   return (
     <ConfigProvider initialValue={LegacyConfigStore.config}>
       <ThemeAndStyleProvider>
-        <ReactContext />
-        <LegacyContext />
         {LegacyConfigStore.get('demoMode') && <DemoHeader />}
         <Router history={browserHistory}>{routes()}</Router>
       </ThemeAndStyleProvider>

--- a/static/app/stores/configStore.tsx
+++ b/static/app/stores/configStore.tsx
@@ -47,9 +47,9 @@ const storeConfig: ConfigStoreDefinition = {
    * the auto switching of color schemes without affecting manual toggle
    */
   updateTheme(theme) {
-    if (this.config.user?.options.theme !== 'system') {
-      return;
-    }
+    // if (this.config.user?.options.theme !== 'system') {
+    //   return;
+    // }
 
     this.set('theme', theme);
   },

--- a/static/app/stores/configStore/configContext.tsx
+++ b/static/app/stores/configStore/configContext.tsx
@@ -2,6 +2,9 @@ import {createContext} from 'react';
 
 import {ConfigAction, ConfigState} from './configReducer';
 
-export const ConfigContext = createContext<
-  [ConfigState, React.Dispatch<ConfigAction<keyof ConfigState>>] | null
->(null);
+export type ConfigContextValue = [
+  ConfigState,
+  React.Dispatch<ConfigAction<keyof ConfigState>>
+];
+
+export const ConfigContext = createContext<ConfigContextValue | null>(null);

--- a/static/app/stores/configStore/configReducer.tsx
+++ b/static/app/stores/configStore/configReducer.tsx
@@ -30,28 +30,13 @@ export type ConfigState = Config;
 
 export function configReducer<K extends keyof Config>(
   state: ConfigState,
-  action: ConfigAction<K>,
-  bridgeReflux?: boolean
+  action: ConfigAction<K>
 ): ConfigState {
   switch (action.type) {
     case 'set config value': {
-      // XXX: side effect that bridges reflux and reducer, keeping the two stores in sync
-      if (bridgeReflux) {
-        // We need to escape the React lifecycle update or this will result in an "calling setState inside setState error"
-        window.setTimeout(() => {
-          LegacyConfigStore.set(action.payload.key, action.payload.value);
-        });
-      }
       return {...state, [action.payload.key]: action.payload.value};
     }
     case 'set theme': {
-      // XXX: side effect that bridges reflux and reducer, keeping the two stores in sync
-      if (bridgeReflux) {
-        // We need to escape the React lifecycle update or this will result in an "calling setState inside setState error"
-        window.setTimeout(() => {
-          LegacyConfigStore.updateTheme(action.payload);
-        });
-      }
       return {...state, theme: action.payload};
     }
     case 'patch': {
@@ -64,23 +49,4 @@ export function configReducer<K extends keyof Config>(
       return state;
     }
   }
-}
-type BridgableReducer<S, A, F extends boolean> = (state: S, action: A, flag: F) => S;
-
-type BridgableReducerState<R extends BridgableReducer<any, any, boolean>> =
-  R extends BridgableReducer<infer S, any, any> ? S : never;
-
-type BridgableReducerAction<R extends BridgableReducer<any, any, boolean>> =
-  R extends BridgableReducer<any, infer A, any> ? A : never;
-
-export function makeBridgableReducer<T extends BridgableReducer<any, any, boolean>>(
-  reducer: T,
-  flag: boolean
-): (
-  state: BridgableReducerState<T>,
-  action: BridgableReducerAction<T>
-) => BridgableReducerState<T> {
-  return (state: BridgableReducerState<T>, action: BridgableReducerAction<T>) => {
-    return reducer(state, action, flag);
-  };
 }


### PR DESCRIPTION
An alternative approach to the reflux problem. This one does not require setTimeout, but it does require us to wrap the dispatch method. The pros of this approach is that we can start relying early on our react state and progressively migrate by action. The legacy mechanism that is required to keep stores in sync is decoupled from the reducer, which may make it more prone to errors, but we can decide to throw in that default switch statement with an error and that should help during migrations.

![CleanShot 2022-04-07 at 07 54 17](https://user-images.githubusercontent.com/9317857/162192887-af59acfe-0540-49e1-b990-7ee8e8536186.gif)
 