### PR TITLE
ref(reflux): remove index signature

### DIFF
--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -13,6 +13,8 @@ import {Group, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
+import {CommonStoreDefinition} from './types';
+
 // Between 0-100
 const MIN_SCORE = 0.6;
 
@@ -114,7 +116,10 @@ type InternalDefinition = {
   api: Client;
 };
 
-interface GroupingStoreDefinition extends StoreDefinition, InternalDefinition {
+interface GroupingStoreDefinition
+  extends StoreDefinition,
+    CommonStoreDefinition<State>,
+    InternalDefinition {
   getInitialState(): State;
   init(): void;
   isAllUnmergedSelected(): boolean;
@@ -614,6 +619,10 @@ const storeConfig: GroupingStoreDefinition = {
     const state = pick(this, ['mergeDisabled', 'mergeState', 'mergeList']);
     this.trigger(state);
     return state;
+  },
+
+  getState(): State {
+    return this.state;
   },
 };
 

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -1,5 +1,5 @@
 import pick from 'lodash/pick';
-import {createStore, StoreDefinition} from 'reflux';
+import {createStore} from 'reflux';
 
 import {mergeGroups} from 'sentry/actionCreators/group';
 import {
@@ -117,8 +117,7 @@ type InternalDefinition = {
 };
 
 interface GroupingStoreDefinition
-  extends StoreDefinition,
-    CommonStoreDefinition<State>,
+  extends CommonStoreDefinition<State>,
     InternalDefinition {
   getInitialState(): State;
   init(): void;

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -76,12 +76,14 @@ const defaultState: GuideStoreState = {
 interface GuideStoreDefinition extends StoreDefinition {
   browserHistoryListener: null | (() => void);
 
+  closeGuide(dismissed?: boolean): void;
   fetchSucceeded(data: GuidesServerData): void;
   nextStep(): void;
   recordCue(guide: string): void;
   registerAnchor(target: string): void;
   setForceHide(forceHide: boolean): void;
   state: GuideStoreState;
+  toStep(step: number): void;
   unregisterAnchor(target: string): void;
   updatePrevGuide(nextGuide: Guide | null): void;
 }

--- a/static/app/types/reflux.d.ts
+++ b/static/app/types/reflux.d.ts
@@ -4,8 +4,12 @@ import type {
 } from 'sentry/utils/makeSafeRefluxStore';
 import type {Store, StoreDefinition} from 'reflux';
 
+type RemoveIndex<T> = {
+  [P in keyof T as string extends P ? never : P]: T[P];
+};
+
 declare module 'reflux' {
   function createStore<T extends SafeStoreDefinition | StoreDefinition>(
     storeDefinition: T
-  ): Store & T;
+  ): RemoveIndex<Store & T>;
 }

--- a/static/app/views/organizationGroupDetails/groupMerged/mergedToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/groupMerged/mergedToolbar.tsx
@@ -31,7 +31,7 @@ class MergedToolbar extends React.Component<Props, State> {
 
   getInitialState() {
     const {unmergeList, unmergeLastCollapsed, unmergeDisabled, enableFingerprintCompare} =
-      GroupingStore;
+      GroupingStore.getState();
 
     return {
       enableFingerprintCompare,

--- a/static/app/views/organizationGroupDetails/groupMerged/mergedToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/groupMerged/mergedToolbar.tsx
@@ -30,8 +30,9 @@ class MergedToolbar extends React.Component<Props, State> {
   state: State = this.getInitialState();
 
   getInitialState() {
+    // @ts-ignore GroupingStore types are not correct, store.init dinamically sets these
     const {unmergeList, unmergeLastCollapsed, unmergeDisabled, enableFingerprintCompare} =
-      GroupingStore.getState();
+      GroupingStore;
 
     return {
       enableFingerprintCompare,

--- a/tests/js/spec/views/organizationGroupDetails/groupMergedView.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupMergedView.spec.jsx
@@ -3,6 +3,7 @@ import * as PropTypes from 'prop-types';
 import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {Client} from 'sentry/api';
+import GroupingStore from 'sentry/stores/groupingStore';
 import {GroupMergedView} from 'sentry/views/organizationGroupDetails/groupMerged';
 
 jest.mock('sentry/api');
@@ -37,6 +38,12 @@ describe('Issues -> Merged View', function () {
     });
   });
 
+  beforeEach(() => {
+    GroupingStore.init();
+  });
+  afterEach(() => {
+    GroupingStore.teardown();
+  });
   it('renders initially with loading component', function () {
     const wrapper = mountWithTheme(
       <GroupMergedView


### PR DESCRIPTION
Update reflux StoreDefinition type to omit `[key: string]: any` and fixes the MergedToolbar component ts error (possibly runtime error too)

Requires https://github.com/getsentry/getsentry/pull/7301 to be merged first