### PR TITLE
ref(metrics): Rename `failure_rate` -> division

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -43,10 +43,10 @@ from sentry.snuba.metrics.fields.snql import (
     all_users,
     crashed_sessions,
     crashed_users,
+    division_float,
     errored_all_users,
     errored_preaggr_sessions,
     failure_count_transaction,
-    failure_rate_transaction,
     percentage,
     session_duration_filters,
     sessions_errored_set,
@@ -931,8 +931,8 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
                 DerivedMetricKey.TRANSACTION_ALL.value,
             ],
             unit="transactions",
-            snql=lambda *args, org_id, metric_ids, alias=None: failure_rate_transaction(
-                *args, alias=alias
+            snql=lambda failure_count, tx_count, org_id, metric_ids, alias=None: division_float(
+                failure_count, tx_count, alias=alias
             ),
         ),
     ]

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -181,16 +181,6 @@ def failure_count_transaction(org_id, metric_ids, alias=None):
     )
 
 
-def failure_rate_transaction(failure_count_snql, tx_count_snql, alias=None):
-    return Function(
-        "divide",
-        # Clickhouse can manage divisions by 0, see:
-        # https://clickhouse.com/docs/en/sql-reference/functions/arithmetic-functions/#dividea-b-a-b-operator
-        [failure_count_snql, tx_count_snql],
-        alias=alias,
-    )
-
-
 def percentage(arg1_snql, arg2_snql, alias=None):
     return Function("minus", [1, Function("divide", [arg1_snql, arg2_snql])], alias)
 
@@ -201,6 +191,16 @@ def subtraction(arg1_snql, arg2_snql, alias=None):
 
 def addition(arg1_snql, arg2_snql, alias=None):
     return Function("plus", [arg1_snql, arg2_snql], alias)
+
+
+def division_float(arg1_snql, arg2_snql, alias=None):
+    return Function(
+        "divide",
+        # Clickhouse can manage divisions by 0, see:
+        # https://clickhouse.com/docs/en/sql-reference/functions/arithmetic-functions/#dividea-b-a-b-operator
+        [arg1_snql, arg2_snql],
+        alias=alias,
+    )
 
 
 def session_duration_filters(org_id):


### PR DESCRIPTION
`failure_rate` is a metric resulting from a division. Making the
function more generalized allows its reusability in other places.

The function name is specifically `division_float`, to avoid confusion
with integer division.

Originally coming from https://github.com/getsentry/sentry/pull/33297#discussion_r843790780.