### PR TITLE
feat(metrics): Add transaction satisfaction count derived metric [INGEST-981]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -45,6 +45,7 @@ from sentry.snuba.metrics.fields.snql import (
     errored_preaggr_sessions,
     failure_count_transaction,
     percentage,
+    satisfaction_count_transaction,
     session_duration_filters,
     sessions_errored_set,
     subtraction,
@@ -908,6 +909,14 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             unit="transactions",
             snql=lambda failure_count, tx_count, org_id, metric_ids, alias=None: division_float(
                 failure_count, tx_count, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
+            metric_name=TransactionMRI.SATISFIED.value,
+            metrics=[TransactionMRI.DURATION.value],
+            unit="transactions",
+            snql=lambda *_, org_id, metric_ids, alias=None: satisfaction_count_transaction(
+                org_id=org_id, metric_ids=metric_ids, alias=alias
             ),
         ),
     ]

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -79,3 +79,4 @@ class TransactionMRI(Enum):
     ALL = "e:transactions/all@none"
     FAILURE_COUNT = "e:transactions/failure_count@none"
     FAILURE_RATE = "e:transaction/failure_rate@ratio"
+    SATISFIED = "e:transactions/satisfied@none"

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -14,6 +14,7 @@ __all__ = (
     "TransactionMetricKey",
     "TransactionTagsKey",
     "TransactionStatusTagValue",
+    "TransactionSatisfactionTagValue",
 )
 
 from enum import Enum
@@ -77,6 +78,7 @@ class TransactionTagsKey(Enum):
     """Identifier for a transaction-related tag."""
 
     TRANSACTION_STATUS = "transaction.status"
+    TRANSACTION_SATISFACTION = "satisfaction"
 
 
 class TransactionStatusTagValue(Enum):
@@ -90,3 +92,11 @@ class TransactionStatusTagValue(Enum):
     CANCELLED = "cancelled"
     UNKNOWN = "unknown"
     ABORTED = "aborted"
+
+
+class TransactionSatisfactionTagValue(Enum):
+    """Identifier value for the satisfaction of a transaction."""
+
+    SATISFIED = "satisfied"
+    TOLERATED = "tolerated"
+    FRUSTRATED = "frustrated"

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -74,6 +74,8 @@ class TransactionMetricKey(Enum):
     FAILURE_RATE = "transaction.failure_rate"
 
 
+# TODO: these tag keys and values below probably don't belong here, and should
+# be moved to another more private file.
 class TransactionTagsKey(Enum):
     """Identifier for a transaction-related tag."""
 


### PR DESCRIPTION
Add a new metric to count the satisfying transaction, according to [apdex](https://docs.sentry.io/product/performance/metrics/#apdex). Intended for internal use.