### PR TITLE
feat(metrics): Add transaction tolerated count derived metric [INGEST-981]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -49,6 +49,7 @@ from sentry.snuba.metrics.fields.snql import (
     session_duration_filters,
     sessions_errored_set,
     subtraction,
+    tolerated_count_transaction,
 )
 from sentry.snuba.metrics.naming_layer.mapping import get_public_name_from_mri
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI, TransactionMRI
@@ -916,6 +917,14 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metrics=[TransactionMRI.DURATION.value],
             unit="transactions",
             snql=lambda *_, org_id, metric_ids, alias=None: satisfaction_count_transaction(
+                org_id=org_id, metric_ids=metric_ids, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
+            metric_name=TransactionMRI.TOLERATED.value,
+            metrics=[TransactionMRI.DURATION.value],
+            unit="transactions",
+            snql=lambda *_, org_id, metric_ids, alias=None: tolerated_count_transaction(
                 org_id=org_id, metric_ids=metric_ids, alias=alias
             ),
         ),

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -227,6 +227,12 @@ def satisfaction_count_transaction(org_id, metric_ids, alias=None):
     )
 
 
+def tolerated_count_transaction(org_id, metric_ids, alias=None):
+    return _dist_count_aggregation_on_tx_satisfaction_factory(
+        org_id, TransactionSatisfactionTagValue.TOLERATED.value, metric_ids, alias
+    )
+
+
 def percentage(arg1_snql, arg2_snql, alias=None):
     return Function("minus", [1, Function("divide", [arg1_snql, arg2_snql])], alias)
 

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -80,3 +80,4 @@ class TransactionMRI(Enum):
     FAILURE_COUNT = "e:transactions/failure_count@none"
     FAILURE_RATE = "e:transaction/failure_rate@ratio"
     SATISFIED = "e:transactions/satisfied@none"
+    TOLERATED = "e:transactions/tolerated@none"


### PR DESCRIPTION
Add a new metric to count the tolerated transactions, according to [apdex](https://docs.sentry.io/product/performance/metrics/#apdex). Intended for internal use.