### PR TITLE
fix(profiling): Center loading indicator on flamegraph

### DIFF
--- a/static/app/views/profiling/flamegraph.tsx
+++ b/static/app/views/profiling/flamegraph.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
+import styled from '@emotion/styled';
 
 import {Client} from 'sentry/api';
 import Alert from 'sentry/components/alert';
@@ -88,7 +89,9 @@ function FlamegraphView(props: FlamegraphViewProps): React.ReactElement {
             ) : requestState === 'loading' ? (
               <Fragment>
                 <Flamegraph profiles={LoadingGroup} />
-                <LoadingIndicator />
+                <LoadingIndicatorContainer>
+                  <LoadingIndicator />
+                </LoadingIndicatorContainer>
               </Fragment>
             ) : requestState === 'resolved' && profiles ? (
               <Flamegraph profiles={profiles} />
@@ -99,5 +102,14 @@ function FlamegraphView(props: FlamegraphViewProps): React.ReactElement {
     </SentryDocumentTitle>
   );
 }
+
+const LoadingIndicatorContainer = styled('div')`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+`;
 
 export default FlamegraphView;


### PR DESCRIPTION
This extra loading flamegraph is pushing the loading spinner down to the bottom
of the page. Make sure the loading indicator is centered on the flamegraph.

![image](https://user-images.githubusercontent.com/10239353/162248257-baf72678-caef-47fd-84c2-9afc41b3ce5f.png)
