### PR TITLE
ref(ts): [POC] Generic store provider

### DIFF
--- a/static/app/stores/configStore.tsx
+++ b/static/app/stores/configStore.tsx
@@ -10,7 +10,7 @@ interface InternalConfigStore {
   config: Config;
 }
 
-interface ConfigStoreDefinition
+export interface ConfigStoreDefinition
   extends CommonStoreDefinition<Config>,
     InternalConfigStore {
   get<K extends keyof Config>(key: K): Config[K];

--- a/static/app/stores/configStore/configProvider.tsx
+++ b/static/app/stores/configStore/configProvider.tsx
@@ -1,0 +1,18 @@
+import LegacyConfigStore, {ConfigStoreDefinition} from 'sentry/stores/configStore';
+
+import {createStoreProvider} from '../providers/createStoreProvider';
+
+const actions = {
+  set: LegacyConfigStore.set,
+  updateTheme: LegacyConfigStore.updateTheme,
+};
+
+export const [ConfigProvider, useConfigStore] = createStoreProvider<
+  ConfigStoreDefinition['config'],
+  typeof LegacyConfigStore,
+  typeof actions
+>({
+  name: 'ConfigStore',
+  store: LegacyConfigStore,
+  actions,
+});

--- a/static/app/stores/configStore/withConfig.tsx
+++ b/static/app/stores/configStore/withConfig.tsx
@@ -1,0 +1,20 @@
+import {Config} from 'sentry/types';
+import getDisplayName from 'sentry/utils/getDisplayName';
+
+import {useConfigStore} from './configProvider';
+
+interface WithConfigProps {
+  config: Config;
+}
+
+export function withConfig<P extends WithConfigProps>(
+  WrappedComponent: React.ComponentType<P>
+) {
+  const Wrapper: React.FC<Omit<P, keyof WithConfigProps>> = props => {
+    const config = useConfigStore();
+    return <WrappedComponent {...(props as unknown as P)} config={config} />;
+  };
+
+  Wrapper.displayName = `withConfig(${getDisplayName(WrappedComponent)})`;
+  return Wrapper;
+}

--- a/static/app/stores/providers/createStoreProvider.tsx
+++ b/static/app/stores/providers/createStoreProvider.tsx
@@ -1,0 +1,52 @@
+import React, {FunctionComponent, ReactNode, useEffect, useState} from 'react';
+import {Store} from 'reflux';
+
+import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
+
+import {CommonStoreDefinition} from '../types';
+
+type Actions<T> = Partial<T>;
+type GenericContext<S, SS, A extends Actions<S>> = {
+  actions: A;
+  state: Readonly<SS>;
+};
+
+export const createStoreProvider = <
+  State,
+  LegacyStore extends CommonStoreDefinition<State> & Store,
+  A
+>({
+  name,
+  store,
+  actions,
+}: {
+  actions: A;
+  name: string;
+  store: LegacyStore;
+}): [
+  FunctionComponent,
+  () => GenericContext<LegacyStore, State, A>,
+  React.Context<GenericContext<LegacyStore, State, A>>
+] => {
+  const [_StoreProvider, _useStore, Context] = createDefinedContext<
+    GenericContext<LegacyStore, State, A>
+  >({
+    name,
+  });
+
+  const StoreProvider = ({children}: {children?: ReactNode}) => {
+    const [_signal, setSignal] = useState({});
+    useEffect(() => {
+      const unsubscribe = store.listen(() => setSignal({}), this as any);
+      return () => unsubscribe();
+    });
+    return (
+      <_StoreProvider value={{state: Object.freeze(store.getState()), actions}}>
+        {children}
+      </_StoreProvider>
+    );
+  };
+  const useStore = _useStore;
+
+  return [StoreProvider, useStore, Context];
+};


### PR DESCRIPTION
### Summary
Somewhat similar to the other approaches, just showing how we might make the store generic and only use one source of truth.

Basically just elaborating on #33393 and finishing my thoughts from https://github.com/getsentry/sentry/pull/33332#discussion_r844473183

#### Notes (in no particular order)
- Using Object.freeze to basically force anything modifying the existing store states to go through actions,
- Just pick off actions directly from the store functions since they are nicely typed that way (instead of dispatch w/ more generics and intermediate strings)
- Made a 'legacy store provider' create function since we should take the same general approach for all stores

#### Rough (example) Migration Plan
- Use these to wrap all existing stores, keep them reflux but start porting all call-sites to use these providers instead.
- Start removing reflux and leave the `store.getState` as a singleton class (or static methods) and for those ported, switch this provider to wrap all actions with a state update instead of `listen`
- We would then be left with singleton classes + provider wrappers, which is functional enough to remove reflux and we can clean these up behaviourally on a case-by-case basis.