### PR TITLE
feat(Superuser Modal): added superuser-access-category to type hooks

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -99,6 +99,7 @@ export type ComponentHooks = {
   'component:header-selector-items': () => React.ComponentType<SelectorItemsProps>;
   'component:member-list-header': () => React.ComponentType<MemberListHeaderProps>;
   'component:org-stats-banner': () => React.ComponentType<DashboardHeadersProps>;
+  'component:superuser-access-category': React.FC<any>;
 };
 
 /**


### PR DESCRIPTION
added so [this branch ](https://github.com/getsentry/getsentry/pull/7146) could be merged. Originally part of [this pr](https://github.com/getsentry/sentry/pull/32556) but it depends on the first pr linked