### PR TITLE
fix(perf): Fix registerCallback being called on null

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -66,7 +66,11 @@ class LongTaskObserver {
           });
         });
       });
-      transaction.registerBeforeFinishCallback(t => {
+
+      if (!transaction) {
+        return null;
+      }
+      transaction?.registerBeforeFinishCallback?.(t => {
         if (!browserPerformanceTimeOrigin) {
           return;
         }


### PR DESCRIPTION
### Summary 
Missed this check since any cast was needed to get at unexposed ts

Refs JAVASCRIPT-26P0