### PR TITLE
fix(error-handling): Add default error message to addErrorMessage

### DIFF
--- a/static/app/actionCreators/indicator.tsx
+++ b/static/app/actionCreators/indicator.tsx
@@ -88,7 +88,7 @@ export function addErrorMessage(msg: React.ReactNode, options?: Options) {
   }
   return addMessageWithType('error')(
     t(
-      "It looks like you've hit an issue in our server API. It's likely we're already looking into this!"
+      "You've hit an issue, fortunately we use Sentry to monitor Sentry. So it's likely we're already looking into this!"
     ),
     options
   );

--- a/static/app/actionCreators/indicator.tsx
+++ b/static/app/actionCreators/indicator.tsx
@@ -87,7 +87,9 @@ export function addErrorMessage(msg: React.ReactNode, options?: Options) {
     return addMessageWithType('error')(msg, options);
   }
   return addMessageWithType('error')(
-    t('Oops, looks like something went wrong!'),
+    t(
+      "It looks like you've hit an issue in our server API. It's likely we're already looking into this!"
+    ),
     options
   );
 }

--- a/static/app/actionCreators/indicator.tsx
+++ b/static/app/actionCreators/indicator.tsx
@@ -83,7 +83,13 @@ export function addLoadingMessage(
 }
 
 export function addErrorMessage(msg: React.ReactNode, options?: Options) {
-  return addMessageWithType('error')(msg, options);
+  if (typeof msg === 'string' || React.isValidElement(msg)) {
+    return addMessageWithType('error')(msg, options);
+  }
+  return addMessageWithType('error')(
+    t('Oops, looks like something went wrong!'),
+    options
+  );
 }
 
 export function addSuccessMessage(msg: React.ReactNode, options?: Options) {

--- a/static/app/actionCreators/metrics.tsx
+++ b/static/app/actionCreators/metrics.tsx
@@ -15,7 +15,6 @@ import {
 } from 'sentry/types';
 import {defined} from 'sentry/utils';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
-import {flattenErrors} from 'sentry/views/dashboardsV2/utils';
 
 export type DoMetricsRequestOptions = {
   field: string[];
@@ -103,9 +102,9 @@ export function fetchMetricsTags(
   });
 
   promise.then(tagFetchSuccess).catch(response => {
-    const errorResponse = response?.responseJSON ?? t('Unable to fetch metric tags');
-    const errors = flattenErrors(errorResponse, {});
-    addErrorMessage(errors[Object.keys(errors)[0]]);
+    const errorResponse =
+      response?.responseJSON?.detail ?? t('Unable to fetch metric tags');
+    addErrorMessage(errorResponse);
     handleXhrErrorResponse(errorResponse)(response);
   });
 
@@ -133,9 +132,9 @@ export function fetchMetricsFields(
   );
 
   promise.then(metaFetchSuccess).catch(response => {
-    const errorResponse = response?.responseJSON ?? t('Unable to fetch metric fields');
-    const errors = flattenErrors(errorResponse, {});
-    addErrorMessage(errors[Object.keys(errors)[0]]);
+    const errorResponse =
+      response?.responseJSON?.detail ?? t('Unable to fetch metric fields');
+    addErrorMessage(errorResponse);
     handleXhrErrorResponse(errorResponse)(response);
   });
 

--- a/static/app/actionCreators/metrics.tsx
+++ b/static/app/actionCreators/metrics.tsx
@@ -15,6 +15,7 @@ import {
 } from 'sentry/types';
 import {defined} from 'sentry/utils';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import {flattenErrors} from 'sentry/views/dashboardsV2/utils';
 
 export type DoMetricsRequestOptions = {
   field: string[];
@@ -103,7 +104,8 @@ export function fetchMetricsTags(
 
   promise.then(tagFetchSuccess).catch(response => {
     const errorResponse = response?.responseJSON ?? t('Unable to fetch metric tags');
-    addErrorMessage(errorResponse);
+    const errors = flattenErrors(errorResponse, {});
+    addErrorMessage(errors[Object.keys(errors)[0]]);
     handleXhrErrorResponse(errorResponse)(response);
   });
 
@@ -132,7 +134,8 @@ export function fetchMetricsFields(
 
   promise.then(metaFetchSuccess).catch(response => {
     const errorResponse = response?.responseJSON ?? t('Unable to fetch metric fields');
-    addErrorMessage(errorResponse);
+    const errors = flattenErrors(errorResponse, {});
+    addErrorMessage(errors[Object.keys(errors)[0]]);
     handleXhrErrorResponse(errorResponse)(response);
   });
 


### PR DESCRIPTION
When non string, non-react element responses are passed, addErrorMessage
crashes the entire page because it falls outside any error
boundaries defined for the components on the page. Adding a fallback to prevent
page crashes.