### PR TITLE
fix: Do not suggest SDK patch updates

### DIFF
--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -409,7 +409,7 @@ def _get_suggested_updates_step(setup_state, index_state, ignore_patch_version):
 
 
 def get_suggested_updates(
-    setup_state, index_state=None, parent_suggestions=None, ignore_patch_version=False
+    setup_state, index_state=None, parent_suggestions=None, ignore_patch_version=True
 ):
     if index_state is None:
         index_state = SdkIndexState()

--- a/tests/sentry/api/endpoints/test_organization_sdk_updates.py
+++ b/tests/sentry/api/endpoints/test_organization_sdk_updates.py
@@ -50,6 +50,30 @@ class OrganizationSdkUpdates(APITestCase, SnubaTestCase):
             "enables": [],
         }
 
+    @mock.patch(
+        "sentry.api.endpoints.organization_sdk_updates.SdkIndexState",
+        return_value=SdkIndexState(sdk_versions={"example.sdk": "1.0.1"}),
+    )
+    def test_ignores_patch(self, mock_index_state):
+        min_ago = iso_format(before_now(minutes=1))
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "oh no",
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+                "sdk": {"name": "example.sdk", "version": "1.0.0"},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+
+        with self.feature(self.features):
+            response = self.client.get(self.url)
+
+        update_suggestions = response.data
+        assert len(update_suggestions) == 0
+
     def test_no_projects(self):
         org = self.create_organization()
         self.create_member(user=self.user, organization=org)

--- a/tests/sentry/test_sdk_updates.py
+++ b/tests/sentry/test_sdk_updates.py
@@ -40,6 +40,13 @@ def test_ignore_patch_version():
     setup = SdkSetupState(
         sdk_name="sentry.python", sdk_version="0.9.0", integrations=[], modules={}
     )
+    assert len(list(get_suggested_updates(setup, PYTHON_INDEX_STATE))) == 0
+
+
+def test_ignore_patch_version_explicit():
+    setup = SdkSetupState(
+        sdk_name="sentry.python", sdk_version="0.9.0", integrations=[], modules={}
+    )
     assert (
         len(list(get_suggested_updates(setup, PYTHON_INDEX_STATE, ignore_patch_version=True))) == 0
     )


### PR DESCRIPTION
This pull request changes how we suggest SDK updates such that we do not suggest users should update to new patch versions.

Fixes https://github.com/getsentry/sentry-javascript/issues/4883.