### PR TITLE
fix(jira): Add trailing slash to UI hook URLs

### DIFF
--- a/src/sentry/integrations/jira/webhooks/descriptor.py
+++ b/src/sentry/integrations/jira/webhooks/descriptor.py
@@ -38,12 +38,12 @@ class JiraDescriptorEndpoint(Endpoint):
                 "apiVersion": 1,
                 "modules": {
                     "postInstallPage": {
-                        "url": "/extensions/jira/ui-hook",
+                        "url": "/extensions/jira/ui-hook/",
                         "name": {"value": "Configure Sentry Add-on"},
                         "key": "post-install-sentry",
                     },
                     "configurePage": {
-                        "url": "/extensions/jira/ui-hook",
+                        "url": "/extensions/jira/ui-hook/",
                         "name": {"value": "Configure Sentry Add-on"},
                         "key": "configure-sentry",
                     },


### PR DESCRIPTION
Users cannot install Jira following the merging of [this change](https://github.com/getsentry/sentry/pull/33079). This PR hardcodes the trailing slash to the UI hook URLs to fix the issue. 