### PR TITLE
feat(ci): Add backend and frontend workflow placeholders

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -25,7 +25,7 @@ jobs:
   # This check is the only required Github check
   backend-required-check:
     needs: files-changed
-    if: ${{ needs.changes.outputs.backend_or_backend == 'true' }}
+    if: ${{ needs.changes.outputs.backend == 'true' }}
     name: Backend
     runs-on: ubuntu-20.04
     steps:
@@ -37,7 +37,7 @@ jobs:
   # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
   fake-backend-required-check:
     needs: files-changed
-    if: ${{ needs.changes.outputs.backend_or_backend != 'true' }}
+    if: ${{ needs.changes.outputs.backend != 'true' }}
     name: Backend
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,44 @@
+name: Backend
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  files-changed:
+    name: detect what files changed
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check for backend file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+  # This check runs once all dependant jobs have passed
+  # It symbolizes that all required Backend checks have succesfully passed
+  # This check is the only required Github check
+  backend-required-check:
+    needs: files-changed
+    if: ${{ needs.changes.outputs.backend_or_backend == 'true' }}
+    name: Backend
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "All required checks have passed and we meet the requirements." '
+
+  # If there are no backend checks, we still want the required check to be satisfied
+  # In order to do this, we need to pretend that the real check run but hijacking the name
+  # This is the recommended approach by Github:
+  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+  fake-backend-required-check:
+    needs: files-changed
+    if: ${{ needs.changes.outputs.backend_or_backend != 'true' }}
+    name: Backend
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "The changed files do not require running the checks in this workflow." '

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -25,7 +25,7 @@ jobs:
   # This check is the only required Github check
   frontend-required-check:
     needs: files-changed
-    if: ${{ needs.changes.outputs.backend_or_frontend == 'true' }}
+    if: ${{ needs.changes.outputs.frontend == 'true' }}
     name: Frontend
     runs-on: ubuntu-20.04
     steps:
@@ -37,7 +37,7 @@ jobs:
   # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
   fake-frontend-required-check:
     needs: files-changed
-    if: ${{ needs.changes.outputs.backend_or_frontend != 'true' }}
+    if: ${{ needs.changes.outputs.frontend != 'true' }}
     name: Frontend
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,44 @@
+name: Frontend
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  files-changed:
+    name: detect what files changed
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check for frontend file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+  # This check runs once all dependant jobs have passed
+  # It symbolizes that all required Frontend checks have succesfully passed
+  # This check is the only required Github check
+  frontend-required-check:
+    needs: files-changed
+    if: ${{ needs.changes.outputs.backend_or_frontend == 'true' }}
+    name: Frontend
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "All required checks have passed and we meet the requirements." '
+
+  # If there are no frontend checks, we still want the required check to be satisfied
+  # In order to do this, we need to pretend that the real check run but hijacking the name
+  # This is the recommended approach by Github:
+  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+  fake-frontend-required-check:
+    needs: files-changed
+    if: ${{ needs.changes.outputs.backend_or_frontend != 'true' }}
+    name: Frontend
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "The changed files do not require running the checks in this workflow." '


### PR DESCRIPTION
These two new workflows are where most other checks will move to (see issue for details).

Landing this ahead of time will enable engineers to have these checks show up in their PRs before we make them required. This will save them having to update their PRs.

This is step 2 of #33408.