### PR TITLE
chore(replay): Upgrade `rrweb-player` package

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4866,9 +4866,9 @@
     prop-types "^15.7.0"
 
 "@xstate/fsm@^1.4.0":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.6.1.tgz#c92972b835540c4e3c5e14277f40dbcbdaee9571"
-  integrity sha512-xYKDNuPR36/fUK+jmhM+oauBmbdUAfuJKnDjg3/7NbN+Pj03TX7e94LXnzkwGgAR+U/HWoMqM5UPTuGIYfIx9g==
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.6.5.tgz#f599e301997ad7e3c572a0b1ff0696898081bea5"
+  integrity sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -13713,29 +13713,29 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     inherits "^2.0.1"
 
 rrweb-player@^0.7.13:
-  version "0.7.13"
-  resolved "https://registry.yarnpkg.com/rrweb-player/-/rrweb-player-0.7.13.tgz#f78c31568aa2cb673a8e713b86989bda118e25fa"
-  integrity sha512-xdBpUNj0Q4LkYSlhLcOTNbpuCS/7lQon57DVqblZdJyDJl+h3OovvK2D0KWBCVkrnzXibxfWA1cDmRAVU+g3Ww==
+  version "0.7.14"
+  resolved "https://registry.yarnpkg.com/rrweb-player/-/rrweb-player-0.7.14.tgz#582840551cde5652dcadb7e41f957e652835287c"
+  integrity sha512-ehHgBWhWNVT8R5g6mWYdiT7rRVis5hCqEX7s8pzDeyUyfiBOyfXHIqsNFUL7875lryxkmuBQDCXfHhKtCYmbYg==
   dependencies:
     "@tsconfig/svelte" "^1.0.0"
-    rrweb "^1.1.2"
+    rrweb "^1.1.3"
 
-rrweb-snapshot@^1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.13.tgz#fc15adb7eb6354c859c8d594f57b09e1f5bccdd8"
-  integrity sha512-lv4vBSJ5orBcRoJnjLvtly6cSsctC+TNm5orVzYRL9SH3LmtSpQ+wI4bw7eh4AcyKoUf0x4pe1Bn632GggmKWQ==
+rrweb-snapshot@^1.1.14:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz#9d4d9be54a28a893373428ee4393ec7e5bd83fcc"
+  integrity sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ==
 
-rrweb@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.1.2.tgz#65279c8528dcfff7158bb31ed21323d3f26a741f"
-  integrity sha512-D1r3MdfYshY7rA8lN3R0cXqeY6fTtgHlkLQM4lxkU+TdKi023/hNQz6tvDJbXGX3HWGa4mRAmQs3S2uGho6Nsw==
+rrweb@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.1.3.tgz#4fbb3d473d71c79b6c30a54e585e5a01c8ac08bb"
+  integrity sha512-F2qp8LteJLyycsv+lCVJqtVpery63L3U+/ogqMA0da8R7Jx57o6gT+HpjrzdeeGMIBZR7kKNaKyJwDupTTu5KA==
   dependencies:
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"
     fflate "^0.4.4"
     mitt "^1.1.3"
-    rrweb-snapshot "^1.1.13"
+    rrweb-snapshot "^1.1.14"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
The upgraded package is: `rrweb-player` from 0.7.13 to 0.7.14
That package is a wrapper for `rrweb`, which adds play/pause buttons and a video scrobber. `rrweb` moved from 1.1.2 to 1.1.3.

Release notes: https://github.com/rrweb-io/rrweb/releases/tag/rrdom%400.1.2
Changes between versions: https://github.com/rrweb-io/rrweb/compare/rrdom%400.1.1...rrdom@0.1.2