### PR TITLE
fix(Superuser): Superuser access upon login 

### DIFF
--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -19,9 +19,8 @@ from django.core.signing import BadSignature
 from django.http import RawPostDataException
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare, get_random_string
-from rest_framework import serializers, status
+from rest_framework import serializers
 
-from sentry.api.exceptions import SentryAPIException
 from sentry.auth.system import is_system_auth
 from sentry.utils import json
 from sentry.utils.auth import has_completed_sso
@@ -67,12 +66,6 @@ def is_active_superuser(request):
 class SuperuserAccessSerializer(serializers.Serializer):
     superuserAccessCategory = serializers.ChoiceField(choices=SUPERUSER_ACCESS_CATEGORIES)
     superuserReason = serializers.CharField(min_length=4, max_length=128)
-
-
-class SuperuserAccessFormInvalidJson(SentryAPIException):
-    status_code = status.HTTP_400_BAD_REQUEST
-    code = "invalid-superuser-access-json"
-    message = "The request contains invalid json"
 
 
 class Superuser:

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.core.signing import BadSignature
+from django.http import RawPostDataException
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare, get_random_string
 from rest_framework import serializers, status
@@ -318,9 +319,7 @@ class Superuser:
         try:
             # need to use json loads as the data is no longer in request.data
             su_access_json = json.loads(request.body)
-        except json.JSONDecodeError:
-            raise SuperuserAccessFormInvalidJson()
-        except AttributeError:
+        except (AttributeError, json.JSONDecodeError, RawPostDataException):
             su_access_json = {}
 
         if "superuserAccessCategory" in su_access_json:

--- a/tests/sentry/auth/test_superuser.py
+++ b/tests/sentry/auth/test_superuser.py
@@ -17,7 +17,6 @@ from sentry.auth.superuser import (
     MAX_AGE,
     SESSION_KEY,
     Superuser,
-    SuperuserAccessFormInvalidJson,
     SuperuserAccessSerializer,
     is_active_superuser,
 )
@@ -188,16 +187,21 @@ class SuperuserTestCase(TestCase):
                 "superuser.logged-in", extra={"ip_address": "127.0.0.1", "user_id": 10}
             )
 
-    def test_su_access_invalid_request_body(self):
+    # modify test once https://github.com/getsentry/sentry/pull/32191 is merged
+    @mock.patch("sentry.auth.superuser.logger")
+    def test_su_access_invalid_request_body(self, logger):
         user = User(is_superuser=True, id=10, email="test@sentry.io")
         request = self.make_request(user=user, method="PUT")
         request._body = '{"invalid" "json"}'
 
         superuser = Superuser(request, org_id=None)
         with self.settings(VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON=True):
-            with self.assertRaises(SuperuserAccessFormInvalidJson):
-                superuser.set_logged_in(request.user)
-                assert superuser.is_active is False
+            superuser.set_logged_in(request.user)
+            assert superuser.is_active is True
+            assert logger.info.call_count == 1
+            logger.info.assert_any_call(
+                "superuser.logged-in", extra={"ip_address": "127.0.0.1", "user_id": 10}
+            )
 
     def test_login_saves_session(self):
         user = self.create_user("foo@example.com", is_superuser=True)


### PR DESCRIPTION
When `VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON` is turned on , this causes a problem with the login flow as the `request.body` contains ```b'csrfmiddlewaretoken=eDqITFi9GMl0f37TylhFLz6IiNvoYNMYqajKxWqT5Cel343vz6dua5GlGQd2RlMO&challenge=%7B%22webAuthnAuthenticationData%22%3A%22pGRycElkeBhyaWNoYXJkbWFzZW50cnkubmdyb2suaW9pY2hhbGxlbmdlWCBvH%2Bkq%2FPBJ70xAfVgf%2BeB%2B8xqMPrivKg7RA5fomCVxhGpleHRlbnNpb25zoWVhcHBpZHg3aHR0cHM6Ly9yaWNoYXJkbWFzZW50cnkubmdyb2suaW8vYXV0aC8yZmEvdTJmYXBwaWQuanNvbnBhbGxvd0NyZWRlbnRpYWxzgaJiaWRYQO7SKcWI3nPdZpYTqb5%2B5LntW0EXu1sd7gzV4kfqpwYj3Q77Uljvlgc6hos8dzCMRS9xVkT%2BmU4UgK6zF0IrOfhkdHlwZWpwdWJsaWMta2V5%22%7D&response=%7B%22keyHandle%22%3A%227tIpxYjec91mlhOpvn7kue1bQRe7Wx3uDNXiR-qnBiPdDvtSWO-WBzqGizx3MIxFL3FWRP6ZThSArrMXQis5-A%22%2C%22clientData%22%3A%22eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiYnhfcEt2endTZTlNUUgxWUhfbmdmdk1hakQ2NHJ5b08wUU9YNkpnbGNZUSIsIm9yaWdpbiI6Imh0dHBzOi8vcmljaGFyZG1hc2VudHJ5Lm5ncm9rLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ%22%2C%22signatureData%22%3A%22MEQCID1F0t0j9t7HGPVHz_bzh2qvwvfgcKLJu_UO6-tRdnFpAiAlkmjnbjHDiu-ZxqTLQmkGDTwzrVK4xdiJgaf8lXiCng%22%2C%22authenticatorData%22%3A%22dMsc6ARz46ITf5wcoxCGiLKiJRlmv2GeNJ635pkBOmUBAAAD3w%22%7D'```
which will cause the superuser class to raise an `SuperuserAccessFormInvalidJson`. This PR sets `su_access_json` to an empty dict instead of raising an error. Will be reverted once superuser access is disabled upon login.