### PR TITLE
ref(access logs): Add group to access logs

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.ratelimits.utils import get_rate_limit_config
 
 from . import is_frontend_request
@@ -67,17 +68,21 @@ def _create_api_access_log(
     Create a log entry to be used for api metrics gathering
     """
     try:
-        resolver_match = request.resolver_match
-        try:
-            view = resolver_match._func_path
-        except AttributeError:
-            view = "Unknown"
-
+        resolver_match = getattr(request, "resolver_match", None)
+        view = (
+            getattr(resolver_match, "_func_path", "Unknown")
+            if resolver_match is not None
+            else "Unknown"
+        )
+        group = (
+            get_rate_limit_config(resolver_match.func.view_class).group
+            if resolver_match
+            else RateLimitConfig().group
+        )
         request_user = getattr(request, "user", None)
         user_id = getattr(request_user, "id", None)
         is_app = getattr(request_user, "is_sentry_app", None)
         org_id = getattr(getattr(request, "organization", None), "id", None)
-        group = get_rate_limit_config(resolver_match.func.view_class).group
         request_auth = _get_request_auth(request)
         auth_id = getattr(request_auth, "id", None)
         status_code = response.status_code if response else 500

--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -67,8 +67,9 @@ def _create_api_access_log(
     Create a log entry to be used for api metrics gathering
     """
     try:
+        resolver_match = request.resolver_match
         try:
-            view = request.resolver_match._func_path
+            view = resolver_match._func_path
         except AttributeError:
             view = "Unknown"
 
@@ -76,7 +77,7 @@ def _create_api_access_log(
         user_id = getattr(request_user, "id", None)
         is_app = getattr(request_user, "is_sentry_app", None)
         org_id = getattr(getattr(request, "organization", None), "id", None)
-        group = get_rate_limit_config(request.resolver_match.func.view_class).group
+        group = get_rate_limit_config(resolver_match.func.view_class).group
         request_auth = _get_request_auth(request)
         auth_id = getattr(request_auth, "id", None)
         status_code = response.status_code if response else 500

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -70,6 +70,7 @@ access_log_fields = (
     "response",
     "user_id",
     "is_app",
+    "group",
     "token_type",
     "organization_id",
     "auth_id",
@@ -140,6 +141,7 @@ class TestAccessLogRateLimited(LogCaptureAPITestCase):
         assert self.captured_logs[0].token_type == "None"
         assert self.captured_logs[0].limit == "0"
         assert self.captured_logs[0].remaining == "0"
+        assert self.captured_logs[0].group == RateLimitedEndpoint.rate_limits.group
 
 
 class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
@@ -155,6 +157,7 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
         self.assert_access_log_recorded()
         for i in range(10):
             assert self.captured_logs[i].token_type == "None"
+            assert self.captured_logs[i].group == ConcurrentRateLimitedEndpoint.rate_limits.group
             assert self.captured_logs[i].concurrent_requests == "1"
             assert self.captured_logs[i].concurrent_limit == "1"
             assert self.captured_logs[i].rate_limit_type == "RateLimitType.NOT_LIMITED"


### PR DESCRIPTION
Add the `RateLimitConfig` group to the API access logs. Right now the only value is `default` but as the project continues endpoints can define their own groups. 