### PR TITLE
ref(profiling): Use vec2 over number array in flamegraph

### DIFF
--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -44,6 +44,8 @@ function FlamegraphZoomView({
   const [flamegraphState, dispatchFlamegraphState] = useFlamegraphState();
   const [canvasBounds, setCanvasBounds] = useState<Rect>(Rect.Empty());
   const [startPanVector, setStartPanVector] = useState<vec2 | null>(null);
+  const [selectedNode, setSelectedNode] = useState<FlamegraphFrame | null>(null);
+  const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
 
   const flamegraphRenderer = useMemoWithPrevious<FlamegraphRenderer | null>(
     previousRenderer => {
@@ -114,11 +116,6 @@ function FlamegraphZoomView({
     }
     return new SelectedFrameRenderer(flamegraphOverlayCanvasRef);
   }, [flamegraphOverlayCanvasRef, flamegraph, flamegraphTheme]);
-
-  const [selectedNode, setSelectedNode] = useState<FlamegraphFrame | null>(null);
-  const [configSpaceCursor, setConfigSpaceCursor] = useState<[number, number] | null>(
-    null
-  );
 
   const hoveredNode = useMemo(() => {
     if (!configSpaceCursor || !flamegraphRenderer) {
@@ -476,7 +473,7 @@ function FlamegraphZoomView({
         vec2.fromValues(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY)
       );
 
-      setConfigSpaceCursor([configSpaceMouse[0], configSpaceMouse[1]]);
+      setConfigSpaceCursor(configSpaceMouse);
 
       if (lastInteraction) {
         onMouseDrag(evt);

--- a/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
@@ -28,9 +28,7 @@ function FlamegraphZoomViewMinimap({
     useState<HTMLCanvasElement | null>(null);
   const [flamegraphMiniMapOverlayCanvasRef, setFlamegraphMiniMapOverlayCanvasRef] =
     useState<HTMLCanvasElement | null>(null);
-  const [configSpaceCursor, setConfigSpaceCursor] = useState<[number, number] | null>(
-    null
-  );
+  const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
 
   const scheduler = useMemo(() => new CanvasScheduler(), []);
 
@@ -292,7 +290,7 @@ function FlamegraphZoomViewMinimap({
         flamegraphMiniMapRenderer.configSpaceToPhysicalSpace
       );
 
-      setConfigSpaceCursor([configSpaceMouse[0], configSpaceMouse[1]]);
+      setConfigSpaceCursor(configSpaceMouse);
 
       if (lastDragVector) {
         onMouseDrag(evt);
@@ -403,11 +401,7 @@ function FlamegraphZoomViewMinimap({
         window.devicePixelRatio
       );
 
-      if (
-        flamegraphMiniMapRenderer.configView.contains(
-          vec2.fromValues(...configSpaceCursor)
-        )
-      ) {
+      if (flamegraphMiniMapRenderer.configView.contains(configSpaceCursor)) {
         setLastDragVector(physicalMousePos);
       } else {
         const startConfigSpaceCursor = flamegraphMiniMapRenderer.getConfigSpaceCursor(
@@ -456,9 +450,7 @@ function FlamegraphZoomViewMinimap({
         onMouseLeave={onMinimapCanvasMouseUp}
         cursor={
           configSpaceCursor &&
-          flamegraphMiniMapRenderer?.configView.contains(
-            vec2.fromValues(...configSpaceCursor)
-          )
+          flamegraphMiniMapRenderer?.configView.contains(configSpaceCursor)
             ? 'grab'
             : 'col-resize'
         }


### PR DESCRIPTION
The use of vec2 and [number, number] was inconsistent in the flamegraph. There
was no reason to convert between the two. So keep them all as vec2 everywhere.