### PR TITLE
fix(page-filters): Align time and environment dropdowns

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -625,8 +625,8 @@ class DashboardDetail extends Component<Props, State> {
             </StyledPageHeader>
             <DashboardPageFilterBar>
               <ProjectPageFilter />
-              <EnvironmentPageFilter alignDropdown="right" />
-              <DatePageFilter alignDropdown="right" />
+              <EnvironmentPageFilter alignDropdown="left" />
+              <DatePageFilter alignDropdown="left" />
             </DashboardPageFilterBar>
             <HookHeader organization={organization} />
             <Dashboard
@@ -730,8 +730,8 @@ class DashboardDetail extends Component<Props, State> {
                 <Layout.Main fullWidth>
                   <DashboardPageFilterBar>
                     <ProjectPageFilter />
-                    <EnvironmentPageFilter alignDropdown="right" />
-                    <DatePageFilter alignDropdown="right" />
+                    <EnvironmentPageFilter alignDropdown="left" />
+                    <DatePageFilter alignDropdown="left" />
                   </DashboardPageFilterBar>
                   <WidgetViewerContext.Provider value={{seriesData, setData}}>
                     <Dashboard

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -505,7 +505,7 @@ class ReleasesList extends AsyncView<Props, State> {
             <ReleasesPageFilterBar>
               <ProjectPageFilter />
               <EnvironmentPageFilter />
-              <DatePageFilter />
+              <DatePageFilter alignDropdown="left" />
             </ReleasesPageFilterBar>
 
             <SortAndFilterWrapper>


### PR DESCRIPTION
Before:
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/9372512/162534396-49caf039-925a-471f-8b90-71f441823b35.png">


After:
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/9372512/162534375-c4147ecd-3669-4d74-b3d1-a72da758a972.png">
