### PR TITLE
chore(profiling): Add setting to enable profiling backend

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1704,6 +1704,9 @@ SENTRY_USE_METRICS_DEV = False
 # This flags activates the Change Data Capture backend in the development environment
 SENTRY_USE_CDC_DEV = False
 
+# This flag activates profiling backend in the development environment
+SENTRY_USE_PROFILING = False
+
 # SENTRY_DEVSERVICES = {
 #     "service-name": lambda settings, options: (
 #         {
@@ -1862,6 +1865,7 @@ SENTRY_DEVSERVICES = {
                 "REDIS_PORT": "6379",
                 "REDIS_DB": "1",
                 "ENABLE_SENTRY_METRICS_DEV": "1" if settings.SENTRY_USE_METRICS_DEV else "",
+                "ENABLE_PROFILES_CONSUMER": "1" if settings.SENTRY_USE_PROFILING else "",
             },
             "only_if": "snuba" in settings.SENTRY_EVENTSTREAM
             or "kafka" in settings.SENTRY_EVENTSTREAM,

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -82,11 +82,6 @@ def _get_daemon(name, *args, **kwargs):
     default=False,
     help="This enables running sentry with pure separation of the frontend and backend",
 )
-@click.option(
-    "--ingest-profiles/--no-ingest-profiles",
-    default=False,
-    help="This enables ingesting profiles with the profiles consumer",
-)
 @click.argument(
     "bind", default=None, metavar="ADDRESS", envvar="SENTRY_DEVSERVER_BIND", required=False
 )
@@ -104,7 +99,6 @@ def devserver(
     environment,
     debug_server,
     bind,
-    ingest_profiles,
 ):
     "Starts a lightweight web server for development."
 
@@ -260,7 +254,7 @@ def devserver(
     if settings.SENTRY_USE_RELAY:
         daemons += [_get_daemon("ingest")]
 
-        if ingest_profiles or settings.SENTRY_USE_PROFILING:
+        if settings.SENTRY_USE_PROFILING:
             daemons += [_get_daemon("profiles")]
 
     if needs_https and has_https:

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -260,7 +260,7 @@ def devserver(
     if settings.SENTRY_USE_RELAY:
         daemons += [_get_daemon("ingest")]
 
-        if ingest_profiles:
+        if ingest_profiles or settings.SENTRY_USE_PROFILING:
             daemons += [_get_daemon("profiles")]
 
     if needs_https and has_https:


### PR DESCRIPTION
Adding `SENTRY_USE_PROFILING=True` to the server configs will now activate the
profiling backend so profiles can be ingested. You'll also want to run
`docker exec -it sentry_snuba snuba migrations run --group profiles --migration-id 0001_profiles`
to run the optional migration for the time being.