### PR TITLE
fix(issues): Remove duplicate series on group stats

### DIFF
--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -8,8 +8,8 @@ import set from 'lodash/set';
 import {getFormattedDate} from 'sentry/utils/dates';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 
-import {BarChart, BarChartSeries} from './barChart';
-import BaseChart from './baseChart';
+import {BarChart, BarChartProps, BarChartSeries} from './barChart';
+import type BaseChart from './baseChart';
 import {truncationFormatter} from './utils';
 
 type Marker = {
@@ -21,9 +21,7 @@ type Marker = {
 
 type ChartProps = React.ComponentProps<typeof BaseChart>;
 
-type BarChartProps = React.ComponentProps<typeof BarChart>;
-
-type Props = Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'> & {
+interface Props extends Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'> {
   /**
    * Chart height
    */
@@ -81,7 +79,7 @@ type Props = Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'> & {
    * Whether timestamps are should be shown in UTC or local timezone.
    */
   utc?: boolean;
-};
+}
 
 function MiniBarChart({
   markers,
@@ -107,11 +105,11 @@ function MiniBarChart({
   // Ensure bars overlap and that empty values display as we're disabling the axis lines.
   if (!!series?.length) {
     chartSeries = series.map((original, i: number) => {
-      const updated = {
+      const updated: BarChartSeries = {
         ...original,
         cursor: 'normal',
         type: 'bar',
-      } as BarChartSeries;
+      };
 
       if (i === 0) {
         updated.barMinHeight = 1;

--- a/static/app/components/group/releaseChart.tsx
+++ b/static/app/components/group/releaseChart.tsx
@@ -17,18 +17,19 @@ type Markers = React.ComponentProps<typeof MiniBarChart>['markers'];
  */
 type StatsGroup = Record<string, TimeseriesValue[]>;
 
-type Props = {
+interface Props {
   group: Group;
   statsPeriod: string;
   title: string;
   className?: string;
   environment?: string;
+  environmentLabel?: string;
   environmentStats?: StatsGroup;
   firstSeen?: string;
   lastSeen?: string;
   release?: Release;
   releaseStats?: StatsGroup;
-};
+}
 
 function GroupReleaseChart(props: Props) {
   const {
@@ -40,33 +41,37 @@ function GroupReleaseChart(props: Props) {
     release,
     releaseStats,
     environment,
+    environmentLabel,
     environmentStats,
     title,
   } = props;
 
   const stats = group.stats[statsPeriod];
-  if (!stats || !stats.length) {
+  const environmentPeriodStats = environmentStats?.[statsPeriod];
+  if (!stats || !stats.length || !environmentPeriodStats) {
     return null;
   }
+
   const series: Series[] = [];
-  // Add all events.
+
+  if (environment) {
+    // Add all events.
+    series.push({
+      seriesName: t('Events'),
+      data: stats.map(point => ({name: point[0] * 1000, value: point[1]})),
+    });
+  }
+
   series.push({
-    seriesName: t('Events'),
-    data: stats.map(point => ({name: point[0] * 1000, value: point[1]})),
+    seriesName: t('Events in %s', environmentLabel),
+    data: environmentStats[statsPeriod].map(point => ({
+      name: point[0] * 1000,
+      value: point[1],
+    })),
   });
 
   // Get the timestamp of the first point.
   const firstTime = series[0].data[0].value;
-
-  if (environment && environmentStats) {
-    series.push({
-      seriesName: t('Events in %s', environment),
-      data: environmentStats[statsPeriod].map(point => ({
-        name: point[0] * 1000,
-        value: point[1],
-      })),
-    });
-  }
 
   if (release && releaseStats) {
     series.push({
@@ -114,6 +119,7 @@ function GroupReleaseChart(props: Props) {
         isGroupedByDate
         showTimeInTooltip
         height={42}
+        colors={environment ? undefined : [theme.purple300, theme.purple300]}
         series={series}
         markers={markers}
       />

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -31,10 +31,11 @@ const GroupReleaseStats = ({
   group,
   currentRelease,
 }: Props) => {
-  const environmentLabel =
+  const environment =
     environments.length > 0
       ? environments.map(env => env.displayName).join(', ')
-      : t('All Environments');
+      : undefined;
+  const environmentLabel = environment ? environment : t('All Environments');
 
   const shortEnvironmentLabel =
     environments.length > 1
@@ -57,7 +58,8 @@ const GroupReleaseStats = ({
           <GraphContainer>
             <GroupReleaseChart
               group={allEnvironments}
-              environment={environmentLabel}
+              environment={environment}
+              environmentLabel={environmentLabel}
               environmentStats={group.stats}
               release={currentRelease?.release}
               releaseStats={currentRelease?.stats}
@@ -70,7 +72,8 @@ const GroupReleaseStats = ({
           <GraphContainer>
             <GroupReleaseChart
               group={allEnvironments}
-              environment={environmentLabel}
+              environment={environment}
+              environmentLabel={environmentLabel}
               environmentStats={group.stats}
               release={currentRelease?.release}
               releaseStats={currentRelease?.stats}


### PR DESCRIPTION
Removes the duplicate "Events" series when no environment is selected, instead shows just environments

before
<img width="334" alt="Screen Shot 2022-04-08 at 4 30 35 PM" src="https://user-images.githubusercontent.com/1400464/162547102-70d7095d-00f7-43e9-874c-c283570ad751.png">


after
<img width="320" alt="Screen Shot 2022-04-08 at 4 30 03 PM" src="https://user-images.githubusercontent.com/1400464/162547067-49da5792-dd4b-43c8-8204-c5e95639bf78.png">

after - with environment selected
<img width="326" alt="Screen Shot 2022-04-08 at 4 30 18 PM" src="https://user-images.githubusercontent.com/1400464/162547109-ea633b8f-4255-4b2f-840d-8b950e3ffd7a.png">

