### PR TITLE
ref(perf): Add interaction for using drag handles

### DIFF
--- a/static/app/components/events/interfaces/spans/dragManager.tsx
+++ b/static/app/components/events/interfaces/spans/dragManager.tsx
@@ -109,6 +109,8 @@ class DragManager extends React.Component<DragManagerProps, DragManagerState> {
         return;
       }
 
+      PerformanceInteraction.startInteraction('SpanTreeDrag');
+
       // prevent the user from selecting things outside the minimap when dragging
       // the mouse cursor outside the minimap
 
@@ -190,6 +192,8 @@ class DragManager extends React.Component<DragManagerProps, DragManagerState> {
     ) {
       return;
     }
+
+    PerformanceInteraction.finishInteraction();
 
     // remove listeners that were attached in onDragStart
 

--- a/static/app/components/events/interfaces/spans/dragManager.tsx
+++ b/static/app/components/events/interfaces/spans/dragManager.tsx
@@ -109,7 +109,7 @@ class DragManager extends React.Component<DragManagerProps, DragManagerState> {
         return;
       }
 
-      PerformanceInteraction.startInteraction('SpanTreeDrag');
+      PerformanceInteraction.startInteraction('SpanTreeHandleDrag');
 
       // prevent the user from selecting things outside the minimap when dragging
       // the mouse cursor outside the minimap


### PR DESCRIPTION
### Summary
This adds an interaction to the drag manager to also monitor using the handles instead of just selecting with the mouse inside the minimap. This should capture more events with users modifying the span window.