### PR TITLE
ref(discover): Add to Dashboard menu links

### DIFF
--- a/static/app/components/dropdownMenuItemV2.tsx
+++ b/static/app/components/dropdownMenuItemV2.tsx
@@ -6,6 +6,7 @@ import {useMenuItem} from '@react-aria/menu';
 import {mergeProps} from '@react-aria/utils';
 import {TreeState} from '@react-stately/tree';
 import {Node} from '@react-types/shared';
+import {LocationDescriptor} from 'history';
 
 import Link from 'sentry/components/links/link';
 import {IconChevron} from 'sentry/icons';
@@ -77,7 +78,7 @@ export type MenuItemProps = {
   /**
    * Destination if this menu item is a link. See also: `isExternalLink`.
    */
-  to?: string;
+  to?: LocationDescriptor;
   /*
    * Items to be added to the right of the label.
    */

--- a/static/app/components/dropdownMenuItemV2.tsx
+++ b/static/app/components/dropdownMenuItemV2.tsx
@@ -316,7 +316,7 @@ const InnerWrap = styled('div', {
   isDisabled: boolean;
   isFocused: boolean;
   priority?: Priority;
-  to?: string;
+  to?: LocationDescriptor;
 }>`
   display: flex;
   position: relative;

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -580,7 +580,7 @@ function eventViewToWidgetQuery({
     conditions: eventView.query,
     orderby: sort ? `${sort.kind === 'desc' ? '-' : ''}${sort.field}` : '',
   };
-  return {fields, widgetQuery};
+  return widgetQuery;
 }
 
 export function handleAddQueryToDashboard({
@@ -596,7 +596,7 @@ export function handleAddQueryToDashboard({
 }) {
   const displayType = displayModeToDisplayType(eventView.display as DisplayModes);
   const defaultTableFields = eventView.fields.map(({field}) => field);
-  const {widgetQuery: defaultWidgetQuery} = eventViewToWidgetQuery({
+  const defaultWidgetQuery = eventViewToWidgetQuery({
     eventView,
     displayType,
     yAxis,
@@ -631,7 +631,7 @@ export function constructAddQueryToDashboardLink({
 }) {
   const displayType = displayModeToDisplayType(eventView.display as DisplayModes);
   const defaultTableFields = eventView.fields.map(({field}) => field);
-  const {widgetQuery: defaultWidgetQuery} = eventViewToWidgetQuery({
+  const defaultWidgetQuery = eventViewToWidgetQuery({
     eventView,
     displayType,
     yAxis,

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -9,6 +9,7 @@ import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import {NewQuery, Organization, SelectValue} from 'sentry/types';
 import {Event} from 'sentry/types/event';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
@@ -613,6 +614,10 @@ export function handleAddQueryToDashboard({
     defaultTitle:
       query?.name ?? (eventView.name !== 'All Events' ? eventView.name : undefined),
     displayType,
+  });
+  trackAdvancedAnalyticsEvent('discover_views.add_to_dashboard.modal_open', {
+    organization,
+    saved_query: !!query,
   });
 }
 


### PR DESCRIPTION
refactors the discover Add to Dashboard button logic into `utils.tsx` and
updates buttons to use `to` prop if new widget builder experience flag
is enabled. 

This allows the Add to Dashboard buttons to open in another
tab when command clicked