### PR TITLE
ref(rate limits): Use new style Django middleware

### DIFF
--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 import uuid
+from typing import Callable
 
 from django.http.response import HttpResponse
-from django.utils.deprecation import MiddlewareMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -23,8 +23,19 @@ DEFAULT_ERROR_MESSAGE = (
 )
 
 
-class RatelimitMiddleware(MiddlewareMixin):
-    """Middleware that applies a rate limit to every endpoint."""
+class RatelimitMiddleware:
+    """Middleware that applies a rate limit to every endpoint.
+    See: https://docs.djangoproject.com/en/4.0/topics/http/middleware/#writing-your-own-middleware
+    """
+
+    def __init__(self, get_response: Callable[[Request], Response]):
+        self.get_response = get_response
+
+    def __call__(self, request: Request) -> Response:
+        # process_view is automatically called by Django
+        response = self.get_response(request)
+        self.process_response(request, response)
+        return response
 
     def process_view(self, request: Request, view_func, view_args, view_kwargs) -> Response | None:
         """Check if the endpoint call will violate."""

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -26,7 +26,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class RatelimitMiddlewareTest(TestCase):
-    middleware = fixture(RatelimitMiddleware)
+    middleware = RatelimitMiddleware(None)
     factory = fixture(RequestFactory)
 
     class TestEndpoint(Endpoint):


### PR DESCRIPTION
Rewrite the rate limit middleware to not use the deprecated MiddlewareMixin - follows the pattern suggested in the Django docs [here](https://docs.djangoproject.com/en/4.0/topics/http/middleware/#writing-your-own-middleware).

This is a redo of https://github.com/getsentry/sentry/pull/32747 in which I follow the simpler rewrite from the first few commits rather than a larger rewrite which didn't work and needed to be reverted.