### PR TITLE
fix(profiling): Use microseconds for chrome trace array format

### DIFF
--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -148,7 +148,7 @@ function buildProfile(
     0,
     0,
     `${processName}: ${threadName}`,
-    'milliseconds'
+    'microseconds' // the trace event format provides timestamps in microseconds
   );
 
   const stack: ChromeTrace.Event[] = [];


### PR DESCRIPTION
The chrome trace array format actually gives timestamps in microseconds.