### PR TITLE
fix(profiling): Change flamegraph tooltip background color

### DIFF
--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -127,7 +127,7 @@ function BoundTooltip({
 }
 
 const Tooltip = styled('div')`
-  background: #fff;
+  background: ${p => p.theme.background};
   position: absolute;
   white-space: nowrap;
   text-overflow: ellipsis;


### PR DESCRIPTION
Use the background color defined by the theme for the flamegraph tooltip.