### PR TITLE
fix(workflow): Remove copy with link from Alerts empty state

### DIFF
--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -6,14 +6,13 @@ import flatten from 'lodash/flatten';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import * as Layout from 'sentry/components/layouts/thirds';
-import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconArrow} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {Organization, PageFilters, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import Projects from 'sentry/utils/projects';
@@ -26,8 +25,6 @@ import {AlertRuleType, CombinedMetricIssueAlerts} from '../types';
 import {getTeamParams, isIssueAlert} from '../utils';
 
 import RuleListRow from './row';
-
-const DOCS_URL = 'https://docs.sentry.io/product/alerts-notifications/metric-alerts/';
 
 type Props = RouteComponentProps<{orgId: string}, {}> & {
   organization: Organization;
@@ -218,13 +215,6 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
                 isLoading={loading || !loadedTeams}
                 isEmpty={ruleList?.length === 0}
                 emptyMessage={t('No alert rules found for the current query.')}
-                emptyAction={
-                  <EmptyStateAction>
-                    {tct('Learn more about [link:Alerts]', {
-                      link: <ExternalLink href={DOCS_URL} />,
-                    })}
-                  </EmptyStateAction>
-                }
               >
                 <Projects orgId={orgId} slugs={Array.from(allProjectsFromIncidents)}>
                   {({initiallyLoaded, projects}) =>
@@ -336,8 +326,4 @@ const StyledPanelTable = styled(PanelTable)`
   grid-template-columns: 4fr auto 140px 60px 110px auto;
   white-space: nowrap;
   font-size: ${p => p.theme.fontSizeMedium};
-`;
-
-const EmptyStateAction = styled('p')`
-  font-size: ${p => p.theme.fontSizeLarge};
 `;


### PR DESCRIPTION
Remove copy with link to docs from the Alerts empty state.

[FIXES WOR-1759](https://getsentry.atlassian.net/browse/WOR-1759)