### PR TITLE
fix(tests): Fix migration test to return to latest migration after running.

### DIFF
--- a/src/sentry/migrations/0269_alertrule_remove_unique_name.py
+++ b/src/sentry/migrations/0269_alertrule_remove_unique_name.py
@@ -38,6 +38,7 @@ class Migration(CheckedMigration):
             database_operations=[
                 migrations.RunSQL(
                     "DROP INDEX CONCURRENTLY IF EXISTS sentry_alertrule_status_active;",
+                    reverse_sql="CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS sentry_alertrule_status_active ON sentry_alertrule USING btree (organization_id, name, status)  WHERE status = 0;",
                     hints={"tables": ["sentry_alertrule"]},
                 )
             ],

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1546,7 +1546,7 @@ class TestMigrations(TransactionTestCase):
 
         executor = MigrationExecutor(connection)
         self.current_migration = [
-            max(m for m in executor.loader.applied_migrations if m[0] == self.app)
+            max(filter(lambda m: m[0] == self.app, executor.loader.applied_migrations))
         ]
         old_apps = executor.loader.project_state(self.migrate_from).apps
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1525,6 +1525,9 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
 class TestMigrations(TransactionTestCase):
     """
     From https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
+
+    Note that when running these tests locally you will need to set the `MIGRATIONS_TEST_MIGRATE=1`
+    environmental variable for these to pass.
     """
 
     @property

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1522,7 +1522,7 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
         self.login_as(self.user)
 
 
-class TestMigrations(TestCase):
+class TestMigrations(TransactionTestCase):
     """
     From https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
     """
@@ -1535,6 +1535,7 @@ class TestMigrations(TestCase):
     migrate_to = None
 
     def setUp(self):
+        super().setUp()
         assert (
             self.migrate_from and self.migrate_to
         ), "TestCase '{}' must define migrate_from and migrate_to properties".format(
@@ -1542,7 +1543,11 @@ class TestMigrations(TestCase):
         )
         self.migrate_from = [(self.app, self.migrate_from)]
         self.migrate_to = [(self.app, self.migrate_to)]
+
         executor = MigrationExecutor(connection)
+        self.current_migration = [
+            max(m for m in executor.loader.applied_migrations if m[0] == self.app)
+        ]
         old_apps = executor.loader.project_state(self.migrate_from).apps
 
         # Reverse to the original migration
@@ -1556,6 +1561,12 @@ class TestMigrations(TestCase):
         executor.migrate(self.migrate_to)
 
         self.apps = executor.loader.project_state(self.migrate_to).apps
+
+    def tearDown(self):
+        super().tearDown()
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()  # reload.
+        executor.migrate(self.current_migration)
 
     def setup_before_migration(self, apps):
         pass

--- a/tests/sentry/migrations/test_0223_semver_backfill_2.py
+++ b/tests/sentry/migrations/test_0223_semver_backfill_2.py
@@ -1,135 +1,130 @@
-# TODO: Re-enable this once we can get `TestMigrations` to work correctly with
-# `TransactionTestCase`. Currently, if we use `TestCase` then it rolls back
-# migrations using atomic, which breaks anything using `CONCURRENTLY`. If we
-# use `TransactionTestCase` then the migration state isn't restored afterwards,
-# since Django just flushes the database instead of rolling back a transaction.
-# from unittest import mock
-#
-# from psycopg2.extras import execute_values
-#
-# from sentry.testutils.cases import TestMigrations
-#
-#
-# class TestBackfill(TestMigrations):
-#     migrate_from = "0222_add_datetime_index_to_auditlogentry"
-#     migrate_to = "0223_semver_backfill_2"
-#
-#     def setup_before_migration(self, apps):
-#         Release = apps.get_model("sentry", "Release")
-#         self.expected_none_ids = [
-#             Release.objects.create(
-#                 organization_id=self.organization.id,
-#                 version="test@1cdbeafkj",
-#                 package="test",
-#                 major=1,
-#                 minor=0,
-#                 patch=0,
-#                 revision=0,
-#                 prerelease="cdbeafkj",
-#                 build_code="",
-#             ).id,
-#             Release.objects.create(
-#                 organization_id=self.organization.id,
-#                 version="1.2.3",
-#                 package="sentry",
-#                 major=1,
-#                 minor=2,
-#                 patch=3,
-#                 revision=0,
-#                 prerelease="",
-#                 build_code="",
-#             ).id,
-#         ]
-#         self.expected_semver = [
-#             (
-#                 Release.objects.create(
-#                     organization_id=self.organization.id,
-#                     version="test@1.2.3",
-#                     package="sentry",
-#                 ).id,
-#                 ["test", 1, 2, 3, 0, "", None],
-#             ),
-#         ]
-#         self.expected_not_updated = {
-#             Release.objects.create(
-#                 organization_id=self.organization.id,
-#                 version="abc123",
-#             ).id,
-#             Release.objects.create(
-#                 organization_id=self.organization.id,
-#                 version="test@1.2.4",
-#                 package="test",
-#                 major=1,
-#                 minor=2,
-#                 patch=4,
-#                 revision=0,
-#                 prerelease="",
-#             ).id,
-#             Release.objects.create(
-#                 organization_id=self.organization.id,
-#                 version="test@1.2.5-hi",
-#                 package="test",
-#                 major=1,
-#                 minor=2,
-#                 patch=5,
-#                 revision=0,
-#                 prerelease="hi",
-#             ).id,
-#             Release.objects.create(
-#                 organization_id=self.organization.id,
-#                 version="test@1.2.6-hi+1234",
-#                 package="test",
-#                 major=1,
-#                 minor=2,
-#                 patch=6,
-#                 revision=0,
-#                 prerelease="hi",
-#                 build_code="1234",
-#                 build_number=1234,
-#             ).id,
-#             Release.objects.create(
-#                 organization_id=self.organization.id,
-#                 version="test@1.2.7-hi+abc123",
-#                 package="test",
-#                 major=1,
-#                 minor=2,
-#                 patch=7,
-#                 revision=0,
-#                 prerelease="hi",
-#                 build_code="abc123",
-#             ).id,
-#         }
-#         self.execute_values_patcher = mock.patch(
-#             "sentry.migrations.0223_semver_backfill_2.execute_values", side_effect=execute_values
-#         )
-#         self.execute_values_mock = self.execute_values_patcher.start()
-#
-#     def tearDown(self):
-#         super().tearDown()
-#         self.execute_values_patcher.stop()
-#
-#     def test(self):
-#         Release = self.apps.get_model("sentry", "Release")
-#         none_releases = Release.objects.filter(id__in=self.expected_none_ids)
-#         expected_fields = (
-#             "package",
-#             "major",
-#             "minor",
-#             "patch",
-#             "revision",
-#             "prerelease",
-#             "build_code",
-#         )
-#         for release in none_releases:
-#             assert all(getattr(release, field) is None for field in expected_fields)
-#
-#         expected_semver_releases = Release.objects.filter(
-#             id__in=[expected[0] for expected in self.expected_semver]
-#         )
-#         for release, expected in zip(
-#             expected_semver_releases, [expected[1] for expected in self.expected_semver]
-#         ):
-#             assert [getattr(release, field) for field in expected_fields] == expected
-#
-#         updated_release_ids = {item[0] for item in self.execute_values_mock.call_args[0][2]}
-#         assert updated_release_ids & self.expected_not_updated == set()
+from unittest import mock
+
+from psycopg2.extras import execute_values
+
+from sentry.testutils.cases import TestMigrations
+
+
+class TestBackfill(TestMigrations):
+    migrate_from = "0222_add_datetime_index_to_auditlogentry"
+    migrate_to = "0223_semver_backfill_2"
+
+    def setup_before_migration(self, apps):
+        Release = apps.get_model("sentry", "Release")
+        self.expected_none_ids = [
+            Release.objects.create(
+                organization_id=self.organization.id,
+                version="test@1cdbeafkj",
+                package="test",
+                major=1,
+                minor=0,
+                patch=0,
+                revision=0,
+                prerelease="cdbeafkj",
+                build_code="",
+            ).id,
+            Release.objects.create(
+                organization_id=self.organization.id,
+                version="1.2.3",
+                package="sentry",
+                major=1,
+                minor=2,
+                patch=3,
+                revision=0,
+                prerelease="",
+                build_code="",
+            ).id,
+        ]
+        self.expected_semver = [
+            (
+                Release.objects.create(
+                    organization_id=self.organization.id,
+                    version="test@1.2.3",
+                    package="sentry",
+                ).id,
+                ["test", 1, 2, 3, 0, "", None],
+            ),
+        ]
+        self.expected_not_updated = {
+            Release.objects.create(
+                organization_id=self.organization.id,
+                version="abc123",
+            ).id,
+            Release.objects.create(
+                organization_id=self.organization.id,
+                version="test@1.2.4",
+                package="test",
+                major=1,
+                minor=2,
+                patch=4,
+                revision=0,
+                prerelease="",
+            ).id,
+            Release.objects.create(
+                organization_id=self.organization.id,
+                version="test@1.2.5-hi",
+                package="test",
+                major=1,
+                minor=2,
+                patch=5,
+                revision=0,
+                prerelease="hi",
+            ).id,
+            Release.objects.create(
+                organization_id=self.organization.id,
+                version="test@1.2.6-hi+1234",
+                package="test",
+                major=1,
+                minor=2,
+                patch=6,
+                revision=0,
+                prerelease="hi",
+                build_code="1234",
+                build_number=1234,
+            ).id,
+            Release.objects.create(
+                organization_id=self.organization.id,
+                version="test@1.2.7-hi+abc123",
+                package="test",
+                major=1,
+                minor=2,
+                patch=7,
+                revision=0,
+                prerelease="hi",
+                build_code="abc123",
+            ).id,
+        }
+        self.execute_values_patcher = mock.patch(
+            "sentry.migrations.0223_semver_backfill_2.execute_values", side_effect=execute_values
+        )
+        self.execute_values_mock = self.execute_values_patcher.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self.execute_values_patcher.stop()
+
+    def test(self):
+        Release = self.apps.get_model("sentry", "Release")
+        none_releases = Release.objects.filter(id__in=self.expected_none_ids)
+        expected_fields = (
+            "package",
+            "major",
+            "minor",
+            "patch",
+            "revision",
+            "prerelease",
+            "build_code",
+        )
+        for release in none_releases:
+            assert all(getattr(release, field) is None for field in expected_fields)
+
+        expected_semver_releases = Release.objects.filter(
+            id__in=[expected[0] for expected in self.expected_semver]
+        )
+        for release, expected in zip(
+            expected_semver_releases, [expected[1] for expected in self.expected_semver]
+        ):
+            assert [getattr(release, field) for field in expected_fields] == expected
+
+        updated_release_ids = {item[0] for item in self.execute_values_mock.call_args[0][2]}
+        assert updated_release_ids & self.expected_not_updated == set()

--- a/tests/sentry/migrations/test_0286_backfill_alertrule_organization.py
+++ b/tests/sentry/migrations/test_0286_backfill_alertrule_organization.py
@@ -1,32 +1,32 @@
-# from sentry.testutils.cases import TestMigrations
-#
-#
-# class TestBackfill(TestMigrations):
-#     migrate_from = "0285_add_organization_member_team_role"
-#     migrate_to = "0286_backfill_alertrule_organization"
-#
-#     def setup_before_migration(self, apps):
-#         AlertRule = apps.get_model("sentry", "AlertRule")
-#
-#         # typical case
-#         self.alert_rule = self.create_alert_rule(
-#             organization=self.organization, projects=[self.project]
-#         )
-#
-#         ar = AlertRule.objects_with_snapshots.get(id=self.alert_rule.id)
-#         ar.organization_id = self.create_organization(name="diff_org").id
-#         ar.save()
-#
-#         # somehow alert rule org got nulled out
-#         self.alert_rule_no_org = self.create_alert_rule(
-#             organization=self.create_organization(), projects=[self.create_project()]
-#         )
-#         self.alert_rule_no_org.organization_id = None
-#         self.alert_rule_no_org.save()
-#
-#     def tearDown(self):
-#         super().tearDown()
-#
-#     def test(self):
-#         assert self.alert_rule.organization_id == self.project.organization.id
-#         assert not self.alert_rule_no_org.organization_id
+from sentry.testutils.cases import TestMigrations
+
+
+class TestBackfill(TestMigrations):
+    migrate_from = "0285_add_organization_member_team_role"
+    migrate_to = "0286_backfill_alertrule_organization"
+
+    def setup_before_migration(self, apps):
+        AlertRule = apps.get_model("sentry", "AlertRule")
+
+        # typical case
+        self.alert_rule = self.create_alert_rule(
+            organization=self.organization, projects=[self.project]
+        )
+
+        ar = AlertRule.objects_with_snapshots.get(id=self.alert_rule.id)
+        ar.organization_id = self.create_organization(name="diff_org").id
+        ar.save()
+
+        # somehow alert rule org got nulled out
+        self.alert_rule_no_org = self.create_alert_rule(
+            organization=self.create_organization(), projects=[self.create_project()]
+        )
+        self.alert_rule_no_org.organization_id = None
+        self.alert_rule_no_org.save()
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test(self):
+        assert self.alert_rule.organization_id == self.project.organization.id
+        assert not self.alert_rule_no_org.organization_id

--- a/tests/sentry/migrations/test_0287_backfill_snubaquery_environment.py
+++ b/tests/sentry/migrations/test_0287_backfill_snubaquery_environment.py
@@ -1,62 +1,62 @@
-# from sentry.testutils.cases import TestMigrations
-#
-#
-# class TestBackfill(TestMigrations):
-#     migrate_from = "0286_backfill_alertrule_organization"
-#     migrate_to = "0287_backfill_snubaquery_environment"
-#
-#     def setup_before_migration(self, apps):
-#         SnubaQuery = apps.get_model("sentry", "SnubaQuery")
-#
-#         # the case when environments exists for both orgs that map nicely
-#         self.to_org = self.create_organization(name="to_org")
-#         self.transferred_project = self.create_project(
-#             organization=self.to_org, name="migrate_transfer"
-#         )
-#         self.from_env = self.create_environment(
-#             organization=self.create_organization(name="from_org"), name="production"
-#         )
-#         self.to_env = self.create_environment(
-#             organization=self.to_org, project=self.transferred_project, name="production"
-#         )
-#         self.alert_rule = self.create_alert_rule(
-#             organization=self.to_org, projects=[self.transferred_project], environment=self.to_env
-#         )
-#
-#         self.snuba_query = SnubaQuery.objects.get(id=self.alert_rule.snuba_query_id)
-#         self.snuba_query.environment_id = self.from_env.id
-#         self.snuba_query.save()
-#
-#         # the case when an environment exists in the previous org, but not in the new org - need to create an org
-#         self.create_to_org = self.create_organization(name="to_org")
-#         self.create_transferred_project = self.create_project(
-#             organization=self.create_to_org, name="create_migrate_transfer"
-#         )
-#         self.create_from_env = self.create_environment(
-#             organization=self.create_organization(name="create_from_org"), name="production"
-#         )
-#         self.create_alert_rule = self.create_alert_rule(
-#             organization=self.create_to_org,
-#             projects=[self.create_transferred_project],
-#         )
-#
-#         self.create_snuba_query = SnubaQuery.objects.get(id=self.create_alert_rule.snuba_query_id)
-#         self.create_snuba_query.environment_id = self.create_from_env.id
-#         self.create_snuba_query.save()
-#
-#     def tearDown(self):
-#         super().tearDown()
-#
-#     def test(self):
-#         # normal scenario
-#         self.snuba_query.refresh_from_db()
-#         self.alert_rule.refresh_from_db()
-#         assert self.alert_rule.organization_id == self.to_org.id
-#         assert self.snuba_query.environment_id == self.to_env.id
-#
-#         # when env needs to be created
-#         self.create_snuba_query.refresh_from_db()
-#         self.create_alert_rule.refresh_from_db()
-#         assert self.create_alert_rule.organization_id == self.create_to_org.id
-#         assert self.create_snuba_query.environment_id != self.create_from_env.id
-#         assert self.create_snuba_query.environment.name == self.create_from_env.name
+from sentry.testutils.cases import TestMigrations
+
+
+class TestBackfill(TestMigrations):
+    migrate_from = "0286_backfill_alertrule_organization"
+    migrate_to = "0287_backfill_snubaquery_environment"
+
+    def setup_before_migration(self, apps):
+        SnubaQuery = apps.get_model("sentry", "SnubaQuery")
+
+        # the case when environments exists for both orgs that map nicely
+        self.to_org = self.create_organization(name="to_org")
+        self.transferred_project = self.create_project(
+            organization=self.to_org, name="migrate_transfer"
+        )
+        self.from_env = self.create_environment(
+            organization=self.create_organization(name="from_org"), name="production"
+        )
+        self.to_env = self.create_environment(
+            organization=self.to_org, project=self.transferred_project, name="production"
+        )
+        self.alert_rule = self.create_alert_rule(
+            organization=self.to_org, projects=[self.transferred_project], environment=self.to_env
+        )
+
+        self.snuba_query = SnubaQuery.objects.get(id=self.alert_rule.snuba_query_id)
+        self.snuba_query.environment_id = self.from_env.id
+        self.snuba_query.save()
+
+        # the case when an environment exists in the previous org, but not in the new org - need to create an org
+        self.create_to_org = self.create_organization(name="to_org")
+        self.create_transferred_project = self.create_project(
+            organization=self.create_to_org, name="create_migrate_transfer"
+        )
+        self.create_from_env = self.create_environment(
+            organization=self.create_organization(name="create_from_org"), name="production"
+        )
+        self.create_alert_rule = self.create_alert_rule(
+            organization=self.create_to_org,
+            projects=[self.create_transferred_project],
+        )
+
+        self.create_snuba_query = SnubaQuery.objects.get(id=self.create_alert_rule.snuba_query_id)
+        self.create_snuba_query.environment_id = self.create_from_env.id
+        self.create_snuba_query.save()
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test(self):
+        # normal scenario
+        self.snuba_query.refresh_from_db()
+        self.alert_rule.refresh_from_db()
+        assert self.alert_rule.organization_id == self.to_org.id
+        assert self.snuba_query.environment_id == self.to_env.id
+
+        # when env needs to be created
+        self.create_snuba_query.refresh_from_db()
+        self.create_alert_rule.refresh_from_db()
+        assert self.create_alert_rule.organization_id == self.create_to_org.id
+        assert self.create_snuba_query.environment_id != self.create_from_env.id
+        assert self.create_snuba_query.environment.name == self.create_from_env.name


### PR DESCRIPTION
This fixes our automated migration tests. Using a normal `TestCase` doesn't work, since many of our
migrations use `CONCURRENTLY`, which can't run inside of a transaction. `TransactionTestCase` also
was failing, since it just resets data by flushing the database and restoring fixtures, but this
doesn't undo the changes from the migrations.

To fix this, we use `TransactionTestCase` and explicitly migrate back to the latest migration in
tearDown.