### PR TITLE
fix(issue-link): Exclude choices that do not conform to our API

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -63,6 +63,16 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 del action["_sentry_app_installation"]
                 del action["_sentry_app_component"]
 
+            # TODO(nisanthan): This is a temporary fix. We need to save both the label and value of the selected choice and not save all the choices.
+            if action.get("id") == "sentry.integrations.jira.notify_action.JiraCreateTicketAction":
+                for field in action.get("dynamic_form_fields", []):
+                    if field.get("choices"):
+                        field["choices"] = [
+                            p
+                            for p in field.get("choices", [])
+                            if isinstance(p[0], str) and isinstance(p[1], str)
+                        ]
+
         if len(errors):
             serialized_rule["errors"] = errors
 


### PR DESCRIPTION
## Objective:
In `sentry_rule.data` we have saved select field `choices` that do not conform to our API of `Array<string, string>`. This causes our frontend to crash when trying to render the form. Instead we will filter out those choices and if the saved value for the field was in the excluded choices set, we will ask the user to reselect for that field.

![reselect for choice](https://user-images.githubusercontent.com/10491193/162866825-38c9ea96-4012-4aa7-90df-854963aff89b.png)
