### PR TITLE
feat(replay): Flip the  icon to create a forward-10-seconds icon

### DIFF
--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -79,7 +79,7 @@ const ReplayControls = ({
             data-test-id="replay-forward-10s"
             size="xsmall"
             title={t('Go forward 10 seconds')}
-            icon={<IconRefresh color="gray500" size="sm" />}
+            icon={<IconClockwise color="gray500" size="sm" />}
             onClick={() => setCurrentTime(currentTime + 10 * SECOND)}
             aria-label={t('Go forward 10 seconds')}
           />
@@ -128,6 +128,10 @@ const ReplayControls = ({
 const Column = styled('div')`
   display: grid;
   flex-direction: column;
+`;
+
+const IconClockwise = styled(IconRefresh)`
+  transform: scaleX(-1);
 `;
 
 const ButtonGrid = styled('div')`


### PR DESCRIPTION
Now we have icons pointing clockwise and counter-clockwise
<img width="207" alt="Screen Shot 2022-04-12 at 9 52 14 AM" src="https://user-images.githubusercontent.com/187460/163014059-0306f22e-1dcb-455c-aa10-c7504a5a8649.png">

