### PR TITLE
fix(replay): Show a basic error when replays cannot be loaded

### DIFF
--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -3,6 +3,7 @@ import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import Breadcrumbs from 'sentry/components/breadcrumbs';
+import DetailedError from 'sentry/components/errors/detailedError';
 import NotFound from 'sentry/components/errors/notFound';
 import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
 import EventEntry from 'sentry/components/events/eventEntry';
@@ -111,6 +112,7 @@ function ReplayLoader(props: ReplayLoaderProps) {
   const {
     fetchError,
     fetching,
+    onRetry,
     breadcrumbEntry,
     event,
     replayEvents,
@@ -122,6 +124,7 @@ function ReplayLoader(props: ReplayLoaderProps) {
   console.log({
     fetchError,
     fetching,
+    onRetry,
     event,
     replayEvents,
     rrwebEvents,
@@ -136,9 +139,29 @@ function ReplayLoader(props: ReplayLoaderProps) {
       return <NotFound />;
     }
 
+    if (!rrwebEvents || rrwebEvents.length < 2) {
+      return (
+        <DetailedError
+          onRetry={onRetry}
+          hideSupportLinks
+          heading={t('Expected two or more replay events')}
+          message={
+            <React.Fragment>
+              <p>{t('This Replay may not have captured any user actions.')}</p>
+              <p>
+                {t(
+                  'Or there may be an issue loading the actions from the server, click to try loading the Replay again.'
+                )}
+              </p>
+            </React.Fragment>
+          }
+        />
+      );
+    }
+
     return (
       <React.Fragment>
-        <ReplayContextProvider events={rrwebEvents || []}>
+        <ReplayContextProvider events={rrwebEvents}>
           <ReplayPlayer />
           <ReplayController />
         </ReplayContextProvider>


### PR DESCRIPTION
There are some examples where a replay transaction doesn't have any attachments, so there are no rrweb events to display. 

Previously there was no guard, so the page would crash with an error like this:
<img width="511" alt="Screen Shot 2022-04-12 at 10 47 58 AM" src="https://user-images.githubusercontent.com/187460/163023780-74491a9d-ecc4-4aa3-897c-c938881f9082.png">

Now we have a simple error message with Retry button:

<img width="1359" alt="Screen Shot 2022-04-12 at 10 50 04 AM" src="https://user-images.githubusercontent.com/187460/163023481-11fdc3fe-050a-4c33-80f9-9421f4318dd6.png">


And when the transaction itself cannot be found or loaded we still get the usual 404 message:
<img width="1359" alt="Screen Shot 2022-04-12 at 10 35 32 AM" src="https://user-images.githubusercontent.com/187460/163021850-4acb9ee4-bbd8-4616-89cc-bbf17a6be757.png">
