### PR TITLE
fix(ui): Add more whitespace to options in roleSelectControl

### DIFF
--- a/static/app/components/roleSelectControl.tsx
+++ b/static/app/components/roleSelectControl.tsx
@@ -68,6 +68,7 @@ const RoleItem = styled('div')`
   display: grid;
   grid-template-columns: 80px 1fr;
   gap: ${space(1)};
+  margin-bottom: ${space(1)};
 
   h1,
   div {


### PR DESCRIPTION
### Before

<img width="394" alt="pr1-2" src="https://user-images.githubusercontent.com/1748388/163039161-d7cfc417-4043-4f3e-9d12-58c55219cbe2.png">

### After 

<img width="449" alt="pr1-1" src="https://user-images.githubusercontent.com/1748388/163039149-beaa0bc7-b5e6-4dc3-b5d8-c554d4663584.png">

