### PR TITLE
fix(ui): Padding matters for OrganizationMemberRow

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -247,6 +247,7 @@ const StyledPanelItem = styled(PanelItem)`
 // Force action button at the end to align to right
 const RightColumn = styled('div')`
   display: flex;
+  justify-content: flex-end;
 `;
 
 const Section = styled('div')`

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -172,7 +172,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
         </div>
 
         {showRemoveButton || showLeaveButton ? (
-          <div>
+          <RightColumn>
             {showRemoveButton && canRemoveMember && (
               <Confirm
                 message={tct('Are you sure you want to remove [name] from [orgName]?', {
@@ -228,7 +228,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                 {t('Leave')}
               </Button>
             )}
-          </div>
+          </RightColumn>
         ) : null}
       </StyledPanelItem>
     );
@@ -237,9 +237,16 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
 
 const StyledPanelItem = styled(PanelItem)`
   display: grid;
-  grid-template-columns: minmax(150px, 2fr) minmax(90px, 1fr) minmax(120px, 1fr) 90px;
+  grid-template-columns: minmax(150px, 4fr) minmax(90px, 2fr) minmax(120px, 2fr) minmax(
+      100px,
+      1fr
+    );
   gap: ${space(2)};
   align-items: center;
+`;
+// Force action button at the end to align to right
+const RightColumn = styled('div')`
+  display: flex;
 `;
 
 const Section = styled('div')`


### PR DESCRIPTION
### Before

<img width="1182" alt="pr2-1" src="https://user-images.githubusercontent.com/1748388/163039326-1b60ff17-3f1e-4be6-9d11-c0409447ef43.png">

### After

<img width="1183" alt="pr2-2" src="https://user-images.githubusercontent.com/1748388/163039343-367bafa1-7190-4a47-bceb-84674129914d.png">
