### PR TITLE
fix(ui): Project dropdown selector shouldn't disable all projects for non-superuser

### DIFF
--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -295,7 +295,6 @@ class ContextPickerModal extends Component<Props> {
   renderProjectSelectOrMessage() {
     const {organization, projects, comingFromProjectId} = this.props;
     const [memberProjects, nonMemberProjects] = this.getMemberProjects();
-    const {isSuperuser} = ConfigStore.get('user') || {};
 
     const projectOptions = [
       {
@@ -311,7 +310,6 @@ class ContextPickerModal extends Component<Props> {
         options: nonMemberProjects.map(p => ({
           value: p.slug,
           label: t(`${p.slug}`),
-          isDisabled: isSuperuser ? false : true,
         })),
       },
     ];
@@ -365,7 +363,7 @@ class ContextPickerModal extends Component<Props> {
               <span>{config.domainName}</span>
             </StyledIntegrationItem>
           ),
-          isDisabled: isSuperuser ? false : true,
+          isDisabled: !isSuperuser,
         })),
       },
     ];


### PR DESCRIPTION
Per title says, project selector dropdown disabling projects isn't actually controlling for access rights. The releases page shouldn't return releases if project access is a concern

Fix for: [WOR-1665](https://getsentry.atlassian.net/browse/WOR-1665)