### PR TITLE
fix(workflow): Handle toISOString if date is null

### DIFF
--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -131,7 +131,7 @@ class TimeSince extends React.PureComponent<Props, State> {
           </div>
         }
       >
-        <time dateTime={dateObj.toISOString()} className={className} {...props}>
+        <time dateTime={dateObj?.toISOString()} className={className} {...props}>
           {this.state.relative}
         </time>
       </Tooltip>


### PR DESCRIPTION
Handle toISOString if date is null. Previously, this would error and display an error page that was not formatted.

[FIXES WOR-1739
](https://getsentry.atlassian.net/browse/WOR-1739)[FIXES JAVASCRIPT-24H9](https://sentry.io/organizations/sentry/issues/2390820831/?project=11276&statsPeriod=14d)

<img width="1255" alt="Screen Shot 2022-04-12 at 2 15 14 PM" src="https://user-images.githubusercontent.com/20312973/163057950-9ac72490-992c-42ce-b5ad-02e41d2909fe.png">

In the case of the hovercard date being `null`, the page will still load, but the hovercard should now show as:
<img width="140" alt="Screen Shot 2022-04-12 at 2 16 38 PM 1" src="https://user-images.githubusercontent.com/20312973/163058118-c36c27f1-112e-4297-8231-d8647f206f5c.png">
