### PR TITLE
fix(rules): Surface errors from Sentry Apps + reformat slack errors

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -24,6 +24,7 @@ from sentry.signals import alert_rule_created
 from sentry.web.decorators import transaction_start
 
 
+# TODO(Leander): Move this method into a relevant abstract base class
 def trigger_alert_rule_action_creators(
     actions: Sequence[Mapping[str, str]],
 ) -> Optional[str]:

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.constants import MIGRATED_CONDITIONS, SCHEMA_FORM_ACTIONS, TICKET_ACTIONS
+from sentry.constants import MIGRATED_CONDITIONS, SENTRY_APP_ACTIONS, TICKET_ACTIONS
 from sentry.rules import rules
 
 
@@ -32,7 +32,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
             if not can_create_tickets and node.id in TICKET_ACTIONS:
                 continue
 
-            if node.id in SCHEMA_FORM_ACTIONS:
+            if node.id in SENTRY_APP_ACTIONS:
                 custom_actions = node.get_custom_actions(project)
                 if custom_actions:
                     action_list.extend(custom_actions)

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from sentry import features
 from sentry.api.fields.actor import ActorField
 from sentry.api.serializers.rest_framework.list import ListField
-from sentry.constants import MIGRATED_CONDITIONS, SCHEMA_FORM_ACTIONS, TICKET_ACTIONS
+from sentry.constants import MIGRATED_CONDITIONS, SENTRY_APP_ACTIONS, TICKET_ACTIONS
 from sentry.models import Environment
 from sentry.rules import rules
 
@@ -34,7 +34,7 @@ class RuleNodeField(serializers.Field):
         node = cls(self.context["project"], data)
 
         # Nodes with user-declared fields will manage their own validation
-        if node.id in SCHEMA_FORM_ACTIONS:
+        if node.id in SENTRY_APP_ACTIONS:
             if not data.get("hasSchemaFormConfig"):
                 raise ValidationError("Please configure your integration settings.")
             node.self_validate()

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -256,7 +256,7 @@ TICKET_ACTIONS = frozenset(
     ]
 )
 
-SCHEMA_FORM_ACTIONS = frozenset(
+SENTRY_APP_ACTIONS = frozenset(
     ["sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"]
 )
 

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -57,8 +57,8 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
         # in the task (integrations/slack/tasks.py) if the channel_id is found.
         self._pending_save = False
 
-    def _format_error_message(self, message: str) -> str:
-        return _(f"Slack Error: {message}")
+    def _format_error_message(self, message: str) -> Any:
+        return _(f"Slack: {message}")
 
     def clean(self) -> dict[str, Any] | None:
         channel_id = (

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -57,7 +57,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
         # in the task (integrations/slack/tasks.py) if the channel_id is found.
         self._pending_save = False
 
-    def _format_error_message(self, message: str) -> Any:
+    def _format_slack_error_message(self, message: str) -> Any:
         return _(f"Slack: {message}")
 
     def clean(self) -> dict[str, Any] | None:
@@ -76,7 +76,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
             )
             if not self.data.get("channel"):
                 raise forms.ValidationError(
-                    self._format_error_message("Channel name is a required field."),
+                    self._format_slack_error_message("Channel name is a required field."),
                     code="invalid",
                 )
             # default to "#" if they have the channel name without the prefix
@@ -97,7 +97,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
                 params = {"channel": self.data.get("channel"), "channel_id": channel_id}
                 raise forms.ValidationError(
                     # ValidationErrors contain a list of error messages, not just one.
-                    self._format_error_message("; ".join(e.messages)),
+                    self._format_slack_error_message("; ".join(e.messages)),
                     code="invalid",
                     params=params,
                 )
@@ -105,7 +105,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
             integration = Integration.objects.get(id=workspace)
         except Integration.DoesNotExist:
             raise forms.ValidationError(
-                self._format_error_message("Workspace is a required field."),
+                self._format_slack_error_message("Workspace is a required field."),
                 code="invalid",
             )
 
@@ -127,7 +127,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
                 params = {"channel": channel, "domain": domain}
 
                 raise forms.ValidationError(
-                    self._format_error_message(
+                    self._format_slack_error_message(
                         "Multiple users were found with display name '%(channel)s'. "
                         "Please use your username, found at %(domain)s/account/settings#username."
                     ),
@@ -136,7 +136,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
                 )
             except ApiRateLimitedError:
                 raise forms.ValidationError(
-                    self._format_error_message(SLACK_RATE_LIMITED_MESSAGE),
+                    self._format_slack_error_message(SLACK_RATE_LIMITED_MESSAGE),
                     code="invalid",
                 )
 
@@ -152,7 +152,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
                 "workspace": dict(self.fields["workspace"].choices).get(int(workspace)),
             }
             raise forms.ValidationError(
-                self._format_error_message(
+                self._format_slack_error_message(
                     'The resource "%(channel)s" does not exist or has not been granted access in the %(workspace)s Slack workspace.'
                 ),
                 code="invalid",

--- a/src/sentry/mediators/alert_rule_actions/creator.py
+++ b/src/sentry/mediators/alert_rule_actions/creator.py
@@ -1,5 +1,6 @@
 from sentry.coreapi import APIError
 from sentry.mediators import Mediator, Param, external_requests
+from sentry.mediators.external_requests.alert_rule_action_requester import AlertRuleActionResult
 from sentry.models import SentryAppComponent
 from sentry.utils.cache import memoize
 
@@ -8,7 +9,7 @@ class AlertRuleActionCreator(Mediator):
     install = Param("sentry.models.SentryAppInstallation")
     fields = Param(object, default=[])  # array of dicts
 
-    def call(self):
+    def call(self) -> AlertRuleActionResult:
         uri = self._fetch_sentry_app_uri()
         self._make_external_request(uri)
         return self.response

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -17,7 +17,7 @@ DEFAULT_SUCCESS_MESSAGE = "Success!"
 DEFAULT_ERROR_MESSAGE = "Something went wrong!"
 
 
-class AlertRuleActionRequesterResult(TypedDict):
+class AlertRuleActionResult(TypedDict):
     success: bool
     message: str
 
@@ -52,7 +52,7 @@ class AlertRuleActionRequester(Mediator):
             error_message = DEFAULT_ERROR_MESSAGE
         return error_message
 
-    def _make_request(self) -> AlertRuleActionRequesterResult:
+    def _make_request(self) -> AlertRuleActionResult:
         try:
             send_and_save_sentry_app_request(
                 self._build_url(),
@@ -75,9 +75,9 @@ class AlertRuleActionRequester(Mediator):
             )
             message = f"{self.sentry_app.name} Error: {self._get_error_message(e.response)}"
             # Bubble up error message from Sentry App to the UI for the user.
-            return AlertRuleActionRequesterResult(success=False, message=message)
+            return AlertRuleActionResult(success=False, message=message)
         # No messages are bubbled up from successful responses.
-        return AlertRuleActionRequesterResult(success=True, message=DEFAULT_SUCCESS_MESSAGE)
+        return AlertRuleActionResult(success=True, message=DEFAULT_SUCCESS_MESSAGE)
 
     def _build_headers(self):
         request_uuid = uuid4().hex

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -77,7 +77,8 @@ class AlertRuleActionRequester(Mediator):
             # Bubble up error message from Sentry App to the UI for the user.
             return AlertRuleActionResult(success=False, message=message)
         # No messages are bubbled up from successful responses.
-        return AlertRuleActionResult(success=True, message=DEFAULT_SUCCESS_MESSAGE)
+        message = f"{self.sentry_app.name}: {DEFAULT_SUCCESS_MESSAGE}"
+        return AlertRuleActionResult(success=True, message=message)
 
     def _build_headers(self):
         request_uuid = uuid4().hex

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -73,7 +73,7 @@ class AlertRuleActionRequester(Mediator):
                     "error_message": str(e),
                 },
             )
-            message = f"{self.sentry_app.name} Error: {self._get_error_message(e.response)}"
+            message = f"{self.sentry_app.name}: {self._get_error_message(e.response)}"
             # Bubble up error message from Sentry App to the UI for the user.
             return AlertRuleActionResult(success=False, message=message)
         # No messages are bubbled up from successful responses.

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Mapping, Union
+from typing import TypedDict
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
 from requests import RequestException
+from rest_framework.response import Response
 
-from sentry.http import safe_urlread
 from sentry.mediators import Mediator, Param
 from sentry.mediators.external_requests.util import send_and_save_sentry_app_request
 from sentry.utils import json
@@ -15,6 +15,11 @@ logger = logging.getLogger("sentry.mediators.external-requests")
 
 DEFAULT_SUCCESS_MESSAGE = "Success!"
 DEFAULT_ERROR_MESSAGE = "Something went wrong!"
+
+
+class AlertRuleActionRequesterResult(TypedDict):
+    success: bool
+    message: str
 
 
 class AlertRuleActionRequester(Mediator):
@@ -36,9 +41,20 @@ class AlertRuleActionRequester(Mediator):
         urlparts[2] = self.uri
         return urlunparse(urlparts)
 
-    def _make_request(self) -> Mapping[str, Union[bool, str]]:
+    def _get_error_message(self, response: Response) -> str:
+        """
+        Returns the error message from the response body, if in the expected location.
+        The location should be coordinated with the docs on Alert Rule Action UI Components.
+        """
         try:
-            request = send_and_save_sentry_app_request(
+            error_message = response.json().get("message", DEFAULT_ERROR_MESSAGE)
+        except Exception:
+            error_message = DEFAULT_ERROR_MESSAGE
+        return error_message
+
+    def _make_request(self) -> AlertRuleActionRequesterResult:
+        try:
+            send_and_save_sentry_app_request(
                 self._build_url(),
                 self.sentry_app,
                 self.install.organization_id,
@@ -57,16 +73,11 @@ class AlertRuleActionRequester(Mediator):
                     "error_message": str(e),
                 },
             )
-            # NOTE: bool(e.response) is always False because non-2xx responses are Falsey.
-            text = e.response.text if e.response is not None else None
-            message = f"{self.sentry_app.name}: {text or DEFAULT_ERROR_MESSAGE}"
+            message = f"{self.sentry_app.name} Error: {self._get_error_message(e.response)}"
             # Bubble up error message from Sentry App to the UI for the user.
-            return {"success": False, "message": message}
-
-        body_raw = safe_urlread(request)
-        body = body_raw.decode() if body_raw else None
-        message = f"{self.sentry_app.name}: {body or DEFAULT_SUCCESS_MESSAGE}"
-        return {"success": True, "message": message}
+            return AlertRuleActionRequesterResult(success=False, message=message)
+        # No messages are bubbled up from successful responses.
+        return AlertRuleActionRequesterResult(success=True, message=DEFAULT_SUCCESS_MESSAGE)
 
     def _build_headers(self):
         request_uuid = uuid4().hex

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -312,7 +312,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
         form = rule.get_form_instance()
         assert not form.is_valid()
-        assert ["Slack workspace is a required field."] in form.errors.values()
+        assert ["Slack: Workspace is a required field."] in form.errors.values()
 
     @responses.activate
     def test_display_name_conflict(self):
@@ -347,7 +347,7 @@ class SlackNotifyActionTest(RuleTestCase):
         form = rule.get_form_instance()
         assert not form.is_valid()
         assert [
-            'Multiple users were found with display name "@morty". Please use your username, found at sentry.slack.com/account/settings#username.'
+            "Slack: Multiple users were found with display name '@morty'. Please use your username, found at sentry.slack.com/account/settings#username."
         ] in form.errors.values()
 
     def test_disabled_org_integration(self):

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -1,6 +1,7 @@
 import responses
 
 from sentry.mediators.external_requests import AlertRuleActionRequester
+from sentry.mediators.external_requests.alert_rule_action_requester import DEFAULT_SUCCESS_MESSAGE
 from sentry.testutils import TestCase
 from sentry.utils import json
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
@@ -41,7 +42,6 @@ class TestAlertRuleActionRequester(TestCase):
             method=responses.POST,
             url="https://example.com/sentry/alert-rule",
             status=200,
-            json="Saved information",
         )
 
         result = AlertRuleActionRequester.run(
@@ -50,7 +50,7 @@ class TestAlertRuleActionRequester(TestCase):
             fields=self.fields,
         )
         assert result["success"]
-        assert result["message"] == 'foo: "Saved information"'
+        assert result["message"] == f"foo: {DEFAULT_SUCCESS_MESSAGE}"
         request = responses.calls[0].request
 
         data = {
@@ -85,7 +85,7 @@ class TestAlertRuleActionRequester(TestCase):
             method=responses.POST,
             url="https://example.com/sentry/alert-rule",
             status=401,
-            json="Channel not found!",
+            json={"message": "Channel not found!"},
         )
 
         result = AlertRuleActionRequester.run(
@@ -94,7 +94,7 @@ class TestAlertRuleActionRequester(TestCase):
             fields=self.fields,
         )
         assert not result["success"]
-        assert result["message"] == 'foo: "Channel not found!"'
+        assert result["message"] == "foo: Channel not found!"
         request = responses.calls[0].request
 
         data = {

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -1,7 +1,10 @@
 import responses
 
 from sentry.mediators.external_requests import AlertRuleActionRequester
-from sentry.mediators.external_requests.alert_rule_action_requester import DEFAULT_SUCCESS_MESSAGE
+from sentry.mediators.external_requests.alert_rule_action_requester import (
+    DEFAULT_ERROR_MESSAGE,
+    DEFAULT_SUCCESS_MESSAGE,
+)
 from sentry.testutils import TestCase
 from sentry.utils import json
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
@@ -34,6 +37,8 @@ class TestAlertRuleActionRequester(TestCase):
             {"name": "description", "value": "threshold reached"},
             {"name": "assignee_id", "value": "user-1"},
         ]
+        self.error_message = "Channel not found!"
+        self.success_message = "Created alert!"
 
     @responses.activate
     def test_makes_successful_request(self):
@@ -50,7 +55,7 @@ class TestAlertRuleActionRequester(TestCase):
             fields=self.fields,
         )
         assert result["success"]
-        assert result["message"] == f"foo: {DEFAULT_SUCCESS_MESSAGE}"
+        assert result["message"] == f"{self.sentry_app.name}: {DEFAULT_SUCCESS_MESSAGE}"
         request = responses.calls[0].request
 
         data = {
@@ -79,13 +84,45 @@ class TestAlertRuleActionRequester(TestCase):
         assert requests[0]["event_type"] == "alert_rule_action.requested"
 
     @responses.activate
+    def test_makes_successful_request_with_message(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=200,
+            json={"message": self.success_message},
+        )
+
+        result = AlertRuleActionRequester.run(
+            install=self.install,
+            uri="/sentry/alert-rule",
+            fields=self.fields,
+        )
+        assert result["success"]
+        assert result["message"] == f"{self.sentry_app.name}: {self.success_message}"
+
+    @responses.activate
+    def test_makes_successful_request_with_malformed_message(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=200,
+            body=bytes(self.success_message, encoding="utf-8"),
+        )
+        result = AlertRuleActionRequester.run(
+            install=self.install,
+            uri="/sentry/alert-rule",
+            fields=self.fields,
+        )
+        assert result["success"]
+        assert result["message"] == f"{self.sentry_app.name}: {DEFAULT_SUCCESS_MESSAGE}"
+
+    @responses.activate
     def test_makes_failed_request(self):
 
         responses.add(
             method=responses.POST,
             url="https://example.com/sentry/alert-rule",
             status=401,
-            json={"message": "Channel not found!"},
         )
 
         result = AlertRuleActionRequester.run(
@@ -94,7 +131,7 @@ class TestAlertRuleActionRequester(TestCase):
             fields=self.fields,
         )
         assert not result["success"]
-        assert result["message"] == "foo: Channel not found!"
+        assert result["message"] == f"{self.sentry_app.name}: {DEFAULT_ERROR_MESSAGE}"
         request = responses.calls[0].request
 
         data = {
@@ -123,12 +160,12 @@ class TestAlertRuleActionRequester(TestCase):
         assert requests[0]["event_type"] == "alert_rule_action.requested"
 
     @responses.activate
-    def test_makes_failed_request_returning_only_status(self):
-
+    def test_makes_failed_request_with_message(self):
         responses.add(
             method=responses.POST,
             url="https://example.com/sentry/alert-rule",
             status=401,
+            json={"message": self.error_message},
         )
 
         result = AlertRuleActionRequester.run(
@@ -137,30 +174,20 @@ class TestAlertRuleActionRequester(TestCase):
             fields=self.fields,
         )
         assert not result["success"]
-        assert result["message"] == "foo: Something went wrong!"
-        request = responses.calls[0].request
+        assert result["message"] == f"{self.sentry_app.name}: {self.error_message}"
 
-        data = {
-            "fields": [
-                {"name": "title", "value": "An Alert"},
-                {"name": "description", "value": "threshold reached"},
-                {
-                    "name": "assignee_id",
-                    "value": "user-1",
-                },
-            ],
-            "installationId": self.install.uuid,
-        }
-        payload = json.loads(request.body)
-        assert payload == data
-
-        assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
-            json.dumps(payload)
+    @responses.activate
+    def test_makes_failed_request_with_malformed_message(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=401,
+            body=bytes(self.error_message, encoding="utf-8"),
         )
-
-        buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
-        requests = buffer.get_requests()
-
-        assert len(requests) == 1
-        assert requests[0]["response_code"] == 401
-        assert requests[0]["event_type"] == "alert_rule_action.requested"
+        result = AlertRuleActionRequester.run(
+            install=self.install,
+            uri="/sentry/alert-rule",
+            fields=self.fields,
+        )
+        assert not result["success"]
+        assert result["message"] == f"{self.sentry_app.name}: {DEFAULT_ERROR_MESSAGE}"


### PR DESCRIPTION
See [API-2619](https://getsentry.atlassian.net/browse/API-2619)

This PR cleans up the errors that appear on the rules page for Sentry Apps and Slack.

I've also added a TODO to refactor the function that checks for Alert Rule Actions into a better wrapper, along with renaming one of the constants.

**New Slack Errors**:

<img width="831" alt="Screen Shot 2022-04-12 at 10 55 26 AM" src="https://user-images.githubusercontent.com/35509934/163071699-e1a89241-f60d-4fa4-8c47-fa120de1bbb4.png">

<img width="831" alt="Screen Shot 2022-04-12 at 10 55 17 AM" src="https://user-images.githubusercontent.com/35509934/163071696-770a381a-e46f-4047-b051-b1f7ab3cadd0.png">
 

**New Sentry App Errors**: 

<img width="774" alt="Screen Shot 2022-04-12 at 3 58 04 PM" src="https://user-images.githubusercontent.com/35509934/163071702-0f3c4722-6513-4ca7-9b22-9552d9e31032.png">

<img width="774" alt="Screen Shot 2022-04-12 at 4 01 12 PM" src="https://user-images.githubusercontent.com/35509934/163071700-63f31463-5c5b-4236-9791-0c8d111fa367.png">