### PR TITLE
fix(workflow): Handle superuser in team selector.

### DIFF
--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -13,6 +13,7 @@ import {IconAdd, IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project, Team} from 'sentry/types';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import useApi from 'sentry/utils/useApi';
 import useTeams from 'sentry/utils/useTeams';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -215,7 +216,12 @@ function TeamSelector(props: Props) {
   }
 
   function getOptions() {
-    const filteredTeams = teamFilter ? teams.filter(teamFilter) : teams;
+    const isSuperuser = isActiveSuperuser();
+    const filteredTeams = isSuperuser
+      ? teams
+      : teamFilter
+      ? teams.filter(teamFilter)
+      : teams;
 
     if (project) {
       const teamsInProjectIdSet = new Set(project.teams.map(team => team.id));


### PR DESCRIPTION
Handle superuser in team selector. Previously, there was a bug, when logged in as a superuser and on the create alert rule page, the Team would default to a team, possibly a team you're not on, (but is part of the project). When you select another team, the defaulted team does not display anymore.

[FIXES WOR-1745](https://getsentry.atlassian.net/browse/WOR-1745)

Repro steps:
- Be logged in as a Superuser
- Have a team that is part of a project you're going to create an alert for, but you're not a member of the team
- Go to the Create Alert page
- Notice the Team selector is defaulted to a team you're not on
- Click the team selector to select another team, then select the team
- Click the team selector again to notice the defaulted team is no longer there

# Before
![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/20312973/163072046-2b16037e-6171-4209-abaf-207493674727.gif)

# After
![ezgif com-gif-maker (10)](https://user-images.githubusercontent.com/20312973/163072072-8050c43c-a12d-45db-b5ac-f12cfcd0fd77.gif)