### PR TITLE
fix(issue_alerts): Make sure we capture environment in the audit logs for editing issue alerts

### DIFF
--- a/src/sentry/models/rule.py
+++ b/src/sentry/models/rule.py
@@ -85,7 +85,12 @@ class Rule(Model):
         return rv
 
     def get_audit_log_data(self):
-        return {"label": self.label, "data": self.data, "status": self.status}
+        return {
+            "label": self.label,
+            "data": self.data,
+            "status": self.status,
+            "environment": self.environment_id,
+        }
 
 
 class RuleActivityType(Enum):


### PR DESCRIPTION
The audit logs are missing this info, which makes it hard to check on the history of some issue
alert rules.