### PR TITLE
fix(quotas): Use correct key in Redis

### DIFF
--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -46,14 +46,8 @@ class RedisQuota(Quota):
             return self.cluster.get_local_client_for_key(routing_key)
 
     def __get_redis_key(self, quota, timestamp, shift, organization_id):
-        if self.is_redis_cluster:
-            scope_id = quota.scope_id or "" if quota.scope != QuotaScope.ORGANIZATION else ""
-            # new style redis cluster format which always has the organization id in
-            local_key = f"{quota.id}{{{organization_id}}}{scope_id}"
-        else:
-            # legacy key format
-            local_key = f"{quota.id}:{quota.scope_id or organization_id}"
-
+        scope_id = quota.scope_id or "" if quota.scope != QuotaScope.ORGANIZATION else ""
+        local_key = f"{quota.id}{{{organization_id}}}{scope_id}"
         interval = quota.window
         return f"{self.namespace}:{local_key}:{int((timestamp - shift) // interval)}"
 


### PR DESCRIPTION
Since introducing Redis Cluster support for rate limiting, Sentry has
known two key formats: the legacy format, and the new format including
an organization ID for the use in Redis Cluster. During the initial
migration period, the new key was only used when RedisCluster had been
configured.

Relay only ever supported the new key format, irrespective of whether it
is configured with redis cluster or a single redis node. In self-hosted
and Single Tenant deployments, this created disparity between Relay and
Sentry, which appears in "Delete & Discard": The refund key assumed by
Relay doesn't match the one Sentry uses.

To fix this, we this PR now fully migrates to the new key format for
Redis quotas.