### PR TITLE
feat(events) - add partition override kill switches

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -120,20 +120,13 @@ ALL_KILLSWITCH_OPTIONS = {
         """,
         fields={"project_id": "A project ID to filter those messages by."},
     ),
-    "kafka.send-project-errors-to-random-partitions": KillswitchInfo(
+    "kafka.send-project-events-to-random-partitions": KillswitchInfo(
         description="""
         Send error messages from a project to random partitions, to avoid overloading a single partition
         """,
         fields={
-            "project_ids": "A set of project IDs to randomly assign partitions for event messages"
-        },
-    ),
-    "kafka.send-project-transactions-to-random-partitions": KillswitchInfo(
-        description="""
-        Send transactions messages from a project to random partitions, to avoid overloading a single partition
-        """,
-        fields={
-            "project_ids": "A set of project IDs to randomly assign partitions for event messages"
+            "project_id": "project ID to randomly assign partitions for event messages",
+            "message_type": "message type to randomly partition",
         },
     ),
 }

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -120,6 +120,22 @@ ALL_KILLSWITCH_OPTIONS = {
         """,
         fields={"project_id": "A project ID to filter those messages by."},
     ),
+    "kafka.send-project-errors-to-random-partitions": KillswitchInfo(
+        description="""
+        Send error messages from a project to random partitions, to avoid overloading a single partition
+        """,
+        fields={
+            "project_ids": "A set of project IDs to randomly assign partitions for event messages"
+        },
+    ),
+    "kafka.send-project-transactions-to-random-partitions": KillswitchInfo(
+        description="""
+        Send transactions messages from a project to random partitions, to avoid overloading a single partition
+        """,
+        fields={
+            "project_ids": "A set of project IDs to randomly assign partitions for event messages"
+        },
+    ),
 }
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -386,5 +386,6 @@ register("store.save-transactions-ingest-consumer-rate", default=0.0)
 register("reprocessing2.drop-delete-old-primary-hash", default=[])
 
 # Send event messages for specific project IDs to random partitions in Kafka
-register("kafka.send-project-transactions-to-random-partitions", default={})
-register("kafka.send-project-errors-to-random-partitions", default={})
+# contents are a list of project IDs to message types to be randomly assigned
+# e.g. [{"project_id": 2, "message_type": "error"}, {"project_id": 3, "message_type": "transaction"}]
+register("kafka.send-project-events-to-random-partitions", default=[])

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -384,3 +384,7 @@ register("store.save-transactions-ingest-consumer-rate", default=0.0)
 
 # Drop delete_old_primary_hash messages for a particular project.
 register("reprocessing2.drop-delete-old-primary-hash", default=[])
+
+# Send event messages for specific project IDs to random partitions in Kafka
+register("kafka.send-project-transactions-to-random-partitions", default={})
+register("kafka.send-project-errors-to-random-partitions", default={})


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-1311

Add a kill switch to distribute traffic across Kafka partitions for projects that are sending events at a very high rate