### PR TITLE
ref(page-filters): Move issues sort options inside table

### DIFF
--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -27,10 +27,12 @@ type Props = {
   groupIds: string[];
   onDelete: () => void;
   onSelectStatsPeriod: (period: string) => void;
+  onSortChange: (sort: string) => void;
   organization: Organization;
   query: string;
   queryCount: number;
   selection: PageFilters;
+  sort: string;
   statsPeriod: string;
   onActionTaken?: (itemIds: string[]) => void;
   onMarkReviewed?: (itemIds: string[]) => void;
@@ -268,6 +270,9 @@ class IssueListActions extends React.Component<Props, State> {
           </ActionsCheckbox>
           {!displayReprocessingActions && (
             <ActionSet
+              sort={this.props.sort}
+              onSortChange={this.props.onSortChange}
+              hasPageFilters={organization.features.includes('selection-filters-v2')}
               orgSlug={organization.slug}
               queryCount={queryCount}
               query={query}

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -5,8 +5,6 @@ import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
-import QueryCount from 'sentry/components/queryCount';
-import {tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, SavedSearch} from 'sentry/types';
 
@@ -22,9 +20,7 @@ type Props = {
   onSidebarToggle: (event: React.MouseEvent) => void;
   onSortChange: (sort: string) => void;
   organization: Organization;
-
   query: string;
-  queryCount: number;
   savedSearch: SavedSearch;
   sort: string;
   tagValueLoader: TagValueLoader;
@@ -35,7 +31,6 @@ function IssueListFilters({
   organization,
   savedSearch,
   query,
-  queryCount,
   isSearchDisabled,
   sort,
   onSidebarToggle,
@@ -74,24 +69,6 @@ function IssueListFilters({
           </DropdownsWrapper>
         )}
       </SearchContainer>
-      {hasPageFilters && (
-        <ResultsRow>
-          <QueryCountText>
-            {queryCount > 0 &&
-              tct('[queryCount] results found', {
-                queryCount: <QueryCount hideParens count={queryCount} max={1000} />,
-              })}
-          </QueryCountText>
-          <DisplayOptionsBar>
-            <IssueListSortOptions
-              sort={sort}
-              query={query}
-              onSelect={onSortChange}
-              hasPageFilters
-            />
-          </DisplayOptionsBar>
-        </ResultsRow>
-      )}
     </FilterContainer>
   );
 }
@@ -133,32 +110,6 @@ const DropdownsWrapper = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: 1fr;
   }
-`;
-
-const QueryCountText = styled('p')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  font-weight: 600;
-  color: ${p => p.theme.headingColor};
-  margin-bottom: 0;
-`;
-
-const DisplayOptionsBar = styled(PageFilterBar)`
-  height: auto;
-
-  /* make sure the border is on top of the trigger buttons */
-  &::after {
-    z-index: ${p => p.theme.zIndex.issuesList.displayOptions + 1};
-  }
-
-  button[aria-haspopup='listbox'] {
-    font-weight: 600;
-  }
-`;
-
-const ResultsRow = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
 `;
 
 export default IssueListFilters;

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1182,7 +1182,6 @@ class IssueListOverview extends React.Component<Props, State> {
               <IssueListFilters
                 organization={organization}
                 query={query}
-                queryCount={queryCount}
                 savedSearch={savedSearch}
                 sort={this.getSort()}
                 onSortChange={this.onSortChange}
@@ -1208,6 +1207,8 @@ class IssueListOverview extends React.Component<Props, State> {
                   groupIds={groupIds}
                   allResultsVisible={this.allResultsVisible()}
                   displayReprocessingActions={displayReprocessingActions}
+                  sort={this.getSort()}
+                  onSortChange={this.onSortChange}
                 />
                 <PanelBody>
                   <ProcessingIssueList

--- a/static/app/views/issueList/sortOptions.tsx
+++ b/static/app/views/issueList/sortOptions.tsx
@@ -56,12 +56,12 @@ const IssueListSortOptions = ({onSelect, sort, query, hasPageFilters}: Props) =>
       buttonProps={
         hasPageFilters
           ? {
-              borderless: true,
-              size: 'small',
-              icon: <IconSort />,
+              size: 'xsmall',
+              icon: <IconSort size="xs" />,
             }
           : {prefix: t('Sort by')}
       }
+      menuWidth={hasPageFilters ? '150px' : undefined}
       detached={hasPageFilters}
       label={getSortLabel(sortKey)}
     >
@@ -91,9 +91,5 @@ const StyledDropdownControl = styled(DropdownControl)`
 
   button {
     width: 100%;
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints[2]}) {
-    order: 2;
   }
 `;


### PR DESCRIPTION
Remove the second row in the search & filter area, and move the Sort dropdown inside the table.

**Before:**
<img width="1148" alt="Screen Shot 2022-04-13 at 10 09 55 AM" src="https://user-images.githubusercontent.com/44172267/163233865-f4c7edaf-bb22-43f5-8e23-a3ce5a4ac131.png">


**After:**
<img width="1148" alt="Screen Shot 2022-04-13 at 10 09 33 AM" src="https://user-images.githubusercontent.com/44172267/163233809-04abfa04-584a-4189-8d4e-9b0721a99aad.png">
