### PR TITLE
fix(timeRangeSelector): Allow menu to overflow container

### DIFF
--- a/static/app/components/pageTimeRangeSelector.tsx
+++ b/static/app/components/pageTimeRangeSelector.tsx
@@ -64,7 +64,7 @@ const DropdownDate = styled(Panel)<{hasCustomButton: boolean; isCalendarOpen: bo
     /* Menu that dropdowns from TimeRangeSelector */
     > div > div:last-child:not(:first-child) {
       /* Remove awkward 1px width difference on dropdown due to border */
-      width: calc(100% + 2px);
+      min-width: calc(100% + 2px);
       transform: translateX(-1px);
       right: auto;
     }


### PR DESCRIPTION
**Before:**
<img width="693" alt="Screen Shot 2022-04-13 at 12 02 46 PM" src="https://user-images.githubusercontent.com/44172267/163251811-d8e286b7-39e5-4cc3-b511-aa28b42e273c.png">


**After:**
<img width="693" alt="Screen Shot 2022-04-13 at 12 03 02 PM" src="https://user-images.githubusercontent.com/44172267/163251815-3393c289-da48-45f2-a2c5-0f9d43e5dd0c.png">
