### PR TITLE
feat: added pagination on the replays page

### DIFF
--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -6,6 +6,7 @@ import FeatureBadge from 'sentry/components/featureBadge';
 import Link from 'sentry/components/links/link';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import PageHeading from 'sentry/components/pageHeading';
+import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCalendar} from 'sentry/icons';
@@ -32,7 +33,6 @@ type Props = AsyncView['props'] &
 class Replays extends React.Component<Props> {
   getEventView() {
     const {location, selection} = this.props;
-
     const eventQueryParams: NewQuery = {
       id: '',
       name: '',
@@ -102,15 +102,18 @@ class Replays extends React.Component<Props> {
           >
             {data => {
               return (
-                <PanelTable
-                  isLoading={data.isLoading}
-                  isEmpty={data.tableData?.data.length === 0}
-                  headers={['Replay ID', 'User', 'Timestamp']}
-                >
-                  {data.tableData
-                    ? this.renderTable(data.tableData.data as Replay[])
-                    : null}
-                </PanelTable>
+                <React.Fragment>
+                  <PanelTable
+                    isLoading={data.isLoading}
+                    isEmpty={data.tableData?.data.length === 0}
+                    headers={['Replay ID', 'User', 'Timestamp']}
+                  >
+                    {data.tableData
+                      ? this.renderTable(data.tableData.data as Replay[])
+                      : null}
+                  </PanelTable>
+                  <Pagination pageLinks={data.pageLinks} />
+                </React.Fragment>
               );
             }}
           </DiscoverQuery>


### PR DESCRIPTION
# Description
Issues: #33258  
- Adds pagination to the Replays page

# Screenshots
<img width="289" alt="image" src="https://user-images.githubusercontent.com/7014871/163262749-7d7f7c76-2540-4eff-9493-d0847636cdd5.png">

Noting it here: I paged ahead so the initial isn't disabled, but it does behave as expected.
<img width="1666" alt="image" src="https://user-images.githubusercontent.com/7014871/163263046-f06b151d-5a7c-4240-8aa4-f8eaae254bea.png">


# Known Gotchas
- None