### PR TITLE
fix(hovercard): Fix arrow position with non-default offset

### DIFF
--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -284,6 +284,7 @@ type StyledHovercardProps = {
 };
 
 const StyledHovercard = styled('div')<StyledHovercardProps>`
+  position: relative;
   border-radius: ${p => p.theme.borderRadius};
   text-align: left;
   padding: 0;
@@ -335,10 +336,10 @@ const HovercardArrow = styled('span')<HovercardArrowProps>`
   position: absolute;
   width: 20px;
   height: 20px;
-  right: ${p => (p.placement === 'left' ? '-3px' : 'auto')};
-  left: ${p => (p.placement === 'right' ? '-3px' : 'auto')};
-  bottom: ${p => (p.placement === 'top' ? '-3px' : 'auto')};
-  top: ${p => (p.placement === 'bottom' ? '-3px' : 'auto')};
+  right: ${p => (p.placement === 'left' ? '-20px' : 'auto')};
+  left: ${p => (p.placement === 'right' ? '-20px' : 'auto')};
+  bottom: ${p => (p.placement === 'top' ? '-20px' : 'auto')};
+  top: ${p => (p.placement === 'bottom' ? '-20px' : 'auto')};
 
   &::before,
   &::after {


### PR DESCRIPTION
The current positioning styles on hover card arrows doesn't account for when the `offset` prop's value is not the default (`16px`). We need to position the arrow _relative to the hover card content_, not the container.

**Before** - [Storybook sample](https://storybook.sentry.dev/?path=/story/components-tooltips-hovercard--hovercard&args=offset:30px)
<img width="347" alt="Screen Shot 2022-04-13 at 3 00 33 PM" src="https://user-images.githubusercontent.com/44172267/163277491-6b581765-8708-42d2-8bc5-f27f69610c77.png">

**After** - [Storybook sample](https://storybook-ad0imyxb4.sentry.dev/?path=/story/components-tooltips-hovercard--hovercard&args=offset:30px)
<img width="347" alt="Screen Shot 2022-04-13 at 2 59 09 PM" src="https://user-images.githubusercontent.com/44172267/163277506-c2b1ea81-57a6-471c-ba2c-51586cb56d44.png">

