### PR TITLE
feat(top-events): Support excluding other from topEvents query

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -126,6 +126,8 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
             # the start of the bucket does not align with the rollup.
             allow_partial_buckets = request.GET.get("partial") == "1"
 
+            include_other = request.GET.get("includeOther") != "0"
+
             referrer = request.GET.get("referrer")
             referrer = (
                 referrer
@@ -170,7 +172,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
                     referrer=referrer + ".find-topn",
                     allow_empty=False,
                     zerofill_results=zerofill_results,
-                    include_other=True,
+                    include_other=include_other,
                     use_snql=discover_snql,
                 )
             dataset = discover if not metrics_enhanced else metrics_enhanced_performance

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -126,7 +126,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
             # the start of the bucket does not align with the rollup.
             allow_partial_buckets = request.GET.get("partial") == "1"
 
-            include_other = request.GET.get("includeOther") != "0"
+            include_other = request.GET.get("excludeOther") != "1"
 
             referrer = request.GET.get("referrer")
             referrer = (

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -2370,6 +2370,29 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         assert other["order"] == 5
         assert [{"count": 4}] in [attrs for _, attrs in other["data"]]
 
+    def test_top_events_can_exclude_other_series(self):
+        with self.feature(self.enabled_features):
+            response = self.client.get(
+                self.url,
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=2)),
+                    "interval": "1h",
+                    "yAxis": "count()",
+                    "orderby": ["count()"],
+                    "field": ["count()", "message"],
+                    "topEvents": 5,
+                    "includeOther": "0",
+                },
+                format="json",
+            )
+
+        data = response.data
+        assert response.status_code == 200, response.content
+        assert len(data) == 5
+
+        assert "Other" not in response.data
+
 
 class OrganizationEventsStatsTopNEventsWithSnql(OrganizationEventsStatsTopNEvents):
     def setUp(self):

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -2382,7 +2382,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "orderby": ["count()"],
                     "field": ["count()", "message"],
                     "topEvents": 5,
-                    "includeOther": "0",
+                    "excludeOther": "1",
                 },
                 format="json",
             )


### PR DESCRIPTION
This supports excluding the `Other` series returned from the `event-stats` endpoint when conducting a topEvents query. We agreed to add this in this [meeting/notion doc](https://www.notion.so/sentry/Meeting-API-Pain-Points-2022-04-12-dfdf5bbe67d14f089af802f176fdf68d#ba9554b82dd84016bbfe3d98351cae07) because we only want to show `Other` in the case of 1 query, 1 y-axis, like it would be shown in a Top-N query.

~I chose to compare `!= '0'` to keep other uses where it's undefined to return `True`, the default behaviour prior to this PR~

Updated to use `excludeOther` because the default behaviour is to include.