### PR TITLE
chore(dashboards): Add dashboards-mep flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1047,6 +1047,8 @@ SENTRY_FEATURES = {
     "organizations:dashboards-edit": True,
     # Enable dashboard widget library
     "organizations:widget-library": False,
+    # Enable metrics enhanced performance in dashboards
+    "organizations:dashboards-mep": False,
     # Enable metrics in dashboards
     "organizations:dashboards-metrics": False,
     # Enable widget viewer modal in dashboards

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -59,6 +59,7 @@ default_manager.add("organizations:breadcrumb-linked-event", OrganizationFeature
 default_manager.add("organizations:crash-rate-alerts", OrganizationFeature, True)
 default_manager.add("organizations:custom-event-title", OrganizationFeature)
 default_manager.add("organizations:dashboard-grid-layout", OrganizationFeature, True)
+default_manager.add("organizations:dashboards-mep", OrganizationFeature, True)
 default_manager.add("organizations:dashboards-metrics", OrganizationFeature, True)
 default_manager.add("organizations:dashboards-template", OrganizationFeature, True)
 default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, True)


### PR DESCRIPTION
This flag will be used in an upcoming dashboards work where we will start calling /events API with the `metricsEnhanced=1` param. It will enable us to display performance widgets backed by metrics data.