### PR TITLE
ref(perf): Move long-tasks to app-wide

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -8,6 +8,7 @@ import {_browserPerformanceTimeOriginMode} from '@sentry/utils';
 import {DISABLE_RR_WEB, SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
 import {Config} from 'sentry/types';
 import {init as initApiSentryClient} from 'sentry/utils/apiSentryClient';
+import {LongTaskObserver} from 'sentry/utils/performanceForSentry';
 
 /**
  * We accept a routes argument here because importing `static/routes`
@@ -109,4 +110,6 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
     Sentry.setTag('sentry_version', window.__SENTRY__VERSION);
   }
   Sentry.setTag('rrweb.active', hasReplays ? 'yes' : 'no');
+
+  LongTaskObserver.startPerformanceObserver();
 }

--- a/static/app/components/events/interfaces/spans/traceView.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.tsx
@@ -4,7 +4,7 @@ import {Observer} from 'mobx-react';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
-import {ProfilerWithTasks} from 'sentry/utils/performanceForSentry';
+import {CustomerProfiler} from 'sentry/utils/performanceForSentry';
 
 import * as CursorGuideHandler from './cursorGuideHandler';
 import * as DividerHandlerManager from './dividerHandlerManager';
@@ -93,7 +93,7 @@ class TraceView extends PureComponent<Props> {
                             <Observer>
                               {() => {
                                 return (
-                                  <ProfilerWithTasks id="SpanTree">
+                                  <CustomerProfiler id="SpanTree">
                                     <SpanTree
                                       traceViewRef={this.traceViewRef}
                                       dragProps={dragProps}
@@ -110,7 +110,7 @@ class TraceView extends PureComponent<Props> {
                                         )
                                       )}
                                     />
-                                  </ProfilerWithTasks>
+                                  </CustomerProfiler>
                                 );
                               }}
                             </Observer>

--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -60,7 +60,6 @@ export class PerformanceInteraction {
       const currentIdleTransaction = getCurrentSentryReactTransaction();
       if (currentIdleTransaction) {
         // If interaction is started while idle still exists.
-        LongTaskObserver.setLongTaskTags(currentIdleTransaction);
         currentIdleTransaction.setTag('finishReason', 'sentry.interactionStarted'); // Override finish reason so we can capture if this has effects on idle timeout.
         currentIdleTransaction.finish();
       }
@@ -96,8 +95,6 @@ export class PerformanceInteraction {
       }
       clearTimeout(PerformanceInteraction.interactionTimeoutId);
 
-      LongTaskObserver.setLongTaskTags(PerformanceInteraction.interactionTransaction);
-
       if (immediate) {
         PerformanceInteraction.interactionTransaction?.finish();
         PerformanceInteraction.interactionTransaction = null;
@@ -116,11 +113,10 @@ export class PerformanceInteraction {
   }
 }
 
-class LongTaskObserver {
+export class LongTaskObserver {
   private static observer: PerformanceObserver;
   private static longTaskCount = 0;
   private static lastTransaction: IdleTransaction | Transaction | undefined;
-  private static currentId: string;
 
   static setLongTaskTags(t: IdleTransaction | Transaction) {
     t.setTag('ui.longTaskCount', LongTaskObserver.longTaskCount);
@@ -131,9 +127,8 @@ class LongTaskObserver {
     t.setTag('ui.longTaskCount.grouped', group < 1001 ? `<=${group}` : `>1000`);
   }
 
-  static getPerformanceObserver(id: string): PerformanceObserver | null {
+  static startPerformanceObserver(): PerformanceObserver | null {
     try {
-      LongTaskObserver.currentId = id;
       if (LongTaskObserver.observer) {
         LongTaskObserver.observer.disconnect();
         try {
@@ -171,7 +166,7 @@ class LongTaskObserver {
             const startSeconds = timeOrigin + entry.startTime / 1000;
             LongTaskObserver.longTaskCount++;
             transaction.startChild({
-              description: `Long Task - ${LongTaskObserver.currentId}`,
+              description: `Long Task`,
               op: `ui.sentry.long-task`,
               startTimestamp: startSeconds,
               endTimestamp: startSeconds + entry.duration / 1000,
@@ -202,25 +197,7 @@ class LongTaskObserver {
   }
 }
 
-export const ProfilerWithTasks = ({id, children}: {children: ReactNode; id: string}) => {
-  useEffect(() => {
-    let observer;
-    try {
-      if (!window.PerformanceObserver || !browserPerformanceTimeOrigin) {
-        return () => {};
-      }
-      observer = LongTaskObserver.getPerformanceObserver(id);
-    } catch (e) {
-      captureException(e);
-      // Defensive since this is auxiliary code.
-    }
-    return () => {
-      if (observer && observer.disconnect) {
-        observer.disconnect();
-      }
-    };
-  }, []);
-
+export const CustomerProfiler = ({id, children}: {children: ReactNode; id: string}) => {
   return (
     <Profiler id={id} onRender={onRenderCallback}>
       {children}
@@ -247,7 +224,7 @@ export const VisuallyCompleteWithData = ({
       if (!window.PerformanceObserver || !browserPerformanceTimeOrigin) {
         return () => {};
       }
-      observer = LongTaskObserver.getPerformanceObserver(id);
+      observer = LongTaskObserver.startPerformanceObserver();
     } catch (_) {
       // Defensive since this is auxiliary code.
     }

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -26,7 +26,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import {TraceFullDetailed} from 'sentry/utils/performance/quickTrace/types';
 import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
-import {ProfilerWithTasks} from 'sentry/utils/performanceForSentry';
+import {CustomerProfiler} from 'sentry/utils/performanceForSentry';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 import {Row, Tags, TransactionDetails, TransactionDetailsContainer} from './styles';
@@ -228,7 +228,7 @@ class TransactionDetail extends Component<Props> {
 
   render() {
     return (
-      <ProfilerWithTasks id="TransactionDetail">
+      <CustomerProfiler id="TransactionDetail">
         <TransactionDetailsContainer
           onClick={event => {
             // prevent toggling the transaction detail
@@ -238,7 +238,7 @@ class TransactionDetail extends Component<Props> {
           {this.renderTransactionErrors()}
           {this.renderTransactionDetail()}
         </TransactionDetailsContainer>
-      </ProfilerWithTasks>
+      </CustomerProfiler>
     );
   }
 }


### PR DESCRIPTION
### Summary
Part 2 of a previous PR to show long tasks vs. interactions, this moves long-tasks to be app-wide now that they've been tested on prod on a slice of the app (event view). Long tasks should cover catching any rendering or frontend performance issues generically, since anything that is a long task means that the user is likely seeing jank or worse, is CPU bound, which makes these a great entry point for profiling in the future.

#### Screenshots
![Screen Shot 2022-04-14 at 12 04 48 PM](https://user-images.githubusercontent.com/6111995/163429297-517a84f3-4229-4ea2-9fd0-3b93c6c76414.png)

