### PR TITLE
fix(new-widget-builder-experience): Unnecessary dashboard visit requests

### DIFF
--- a/static/app/views/dashboardsV2/view.tsx
+++ b/static/app/views/dashboardsV2/view.tsx
@@ -42,7 +42,9 @@ function ViewEditDashboard(props: Props) {
     if (dashboardId && dashboardId !== 'default-overview') {
       updateDashboardVisit(api, orgSlug, dashboardId);
     }
+  }, [api, orgSlug, dashboardId]);
 
+  useEffect(() => {
     const constructedWidget = constructWidgetFromQuery(location.query);
     setNewWidget(constructedWidget);
     // Clean up url after constructing widget from query string, only allow GHS params
@@ -53,7 +55,7 @@ function ViewEditDashboard(props: Props) {
         query: pick(location.query, ALLOWED_PARAMS),
       });
     }
-  }, [api, orgSlug, dashboardId, location.pathname]);
+  }, [location.pathname]);
 
   return (
     <DashboardBasicFeature organization={organization}>


### PR DESCRIPTION
Because the side effects of triggering a visit and checking the URL for a new widget were in one `useEffect`, we were unnecessarily recording dashboard visits. This separates the two effects so they're independent and we only trigger the dashboard visit request once, even when navigating between the builder and dashboard.