### PR TITLE
ref(rate limits): Tag DD metric w/ rate limit type

### DIFF
--- a/src/sentry/middleware/stats.py
+++ b/src/sentry/middleware/stats.py
@@ -66,15 +66,21 @@ class RequestTimingMiddleware(MiddlewareMixin):
         if not view_path:
             return
 
+        rate_limit_type = getattr(
+            getattr(request, "rate_limit_metadata", None), "rate_limit_type", None
+        )
+
         tags = getattr(request, "_metric_tags", {})
         tags.update(
             {
                 "method": request.method,
                 "status_code": status_code,
                 "ui_request": is_frontend_request(request),
+                "rate_limit_type": getattr(rate_limit_type, "value", None)
+                if rate_limit_type
+                else None,
             }
         )
-
         metrics.incr("view.response", instance=view_path, tags=tags, skip_internal=False)
 
         start_time = getattr(request, "_start_time", None)

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -23,7 +23,12 @@ class RequestTimingMiddlewareTest(TestCase):
         incr.assert_called_with(
             "view.response",
             instance=request._view_path,
-            tags={"method": "GET", "status_code": 200, "ui_request": False},
+            tags={
+                "method": "GET",
+                "status_code": 200,
+                "ui_request": False,
+                "rate_limit_type": None,
+            },
             skip_internal=False,
         )
 
@@ -39,7 +44,7 @@ class RequestTimingMiddlewareTest(TestCase):
         incr.assert_called_with(
             "view.response",
             instance=request._view_path,
-            tags={"method": "GET", "status_code": 200, "ui_request": True},
+            tags={"method": "GET", "status_code": 200, "ui_request": True, "rate_limit_type": None},
             skip_internal=False,
         )
 
@@ -56,7 +61,13 @@ class RequestTimingMiddlewareTest(TestCase):
         incr.assert_called_with(
             "view.response",
             instance=request._view_path,
-            tags={"method": "GET", "status_code": 200, "ui_request": False, "a": "b"},
+            tags={
+                "method": "GET",
+                "status_code": 200,
+                "ui_request": False,
+                "a": "b",
+                "rate_limit_type": None,
+            },
             skip_internal=False,
         )
 
@@ -74,6 +85,12 @@ class RequestTimingMiddlewareTest(TestCase):
         incr.assert_called_with(
             "view.response",
             instance=request._view_path,
-            tags={"method": "GET", "status_code": 200, "ui_request": False, "foo": "bar"},
+            tags={
+                "method": "GET",
+                "status_code": 200,
+                "ui_request": False,
+                "foo": "bar",
+                "rate_limit_type": None,
+            },
             skip_internal=False,
         )

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -53,7 +53,7 @@ class RequestTimingMiddlewareTest(TestCase):
         test_endpoint = RateLimitedEndpoint.as_view()
         request = self.factory.get("/")
         request._view_path = "/"
-        response = Mock(status_code=200)
+        response = Mock(status_code=429)
 
         rate_limit_middleware.process_view(request, test_endpoint, [], {})
         self.middleware.process_response(request, response)
@@ -63,7 +63,7 @@ class RequestTimingMiddlewareTest(TestCase):
             instance=request._view_path,
             tags={
                 "method": "GET",
-                "status_code": 200,
+                "status_code": 429,
                 "ui_request": False,
                 "rate_limit_type": "fixed_window",
             },


### PR DESCRIPTION
Add a rate limit type tag to the Datadog `sentry.view.response` metrics. 