### PR TITLE
fix(ui): Add % to crash free sessions tooltip

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -270,6 +270,7 @@ class TeamStability extends AsyncComponent<Props, State> {
                       showTimeInTooltip
                       series={this.getMiniBarChartSeries(project, response)}
                       height={25}
+                      tooltipFormatter={(value: number) => `${value.toLocaleString()}%`}
                     />
                   )}
                 </div>


### PR DESCRIPTION
Previously, it wasn't clear the number in the tooltip was a percentage. Add % to crash free sessions tooltip.

[FIXES WOR-1749](https://getsentry.atlassian.net/browse/WOR-1749)

# Before
<img width="243" alt="Screen Shot 2022-04-14 at 12 34 22 PM" src="https://user-images.githubusercontent.com/20312973/163464271-3bec9f48-bad3-4773-9ef6-9803ed0d5593.png">

# After
<img width="261" alt="Screen Shot 2022-04-14 at 12 32 45 PM" src="https://user-images.githubusercontent.com/20312973/163464292-cca8615a-b4aa-46e3-8c38-8eb5438079cc.png">

