### PR TITLE
ref(sentryapps): Put action creator function into separate module

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -3,7 +3,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.rule import RuleEndpoint
-from sentry.api.endpoints.project_rules import trigger_alert_rule_action_creators
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer
 from sentry.api.serializers.rest_framework.rule import RuleSerializer as DrfRuleSerializer
@@ -19,6 +18,7 @@ from sentry.models import (
     Team,
     User,
 )
+from sentry.rules.actions.base import trigger_alert_rule_action_creators
 from sentry.signals import alert_rule_edited
 from sentry.web.decorators import transaction_start
 

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -18,7 +18,7 @@ from sentry.models import (
     Team,
     User,
 )
-from sentry.rules.actions.base import trigger_alert_rule_action_creators
+from sentry.rules.actions.base import trigger_sentry_app_action_creators_for_issues
 from sentry.signals import alert_rule_edited
 from sentry.web.decorators import transaction_start
 
@@ -128,7 +128,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 context = {"uuid": client.uuid}
                 return Response(context, status=202)
 
-            trigger_alert_rule_action_creators(kwargs.get("actions"))
+            trigger_sentry_app_action_creators_for_issues(kwargs.get("actions"))
 
             updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -24,6 +24,7 @@ from sentry.signals import alert_rule_created
 from sentry.web.decorators import transaction_start
 
 
+# TODO(Leander): Move this method into a relevant abstract base class
 def trigger_alert_rule_action_creators(
     actions: Sequence[Mapping[str, str]],
 ) -> Optional[str]:

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -1,6 +1,4 @@
-from typing import Mapping, Optional, Sequence
-
-from rest_framework import serializers, status
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -8,42 +6,19 @@ from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import RuleSerializer
 from sentry.integrations.slack import tasks
-from sentry.mediators import alert_rule_actions, project_rules
-from sentry.mediators.external_requests.alert_rule_action_requester import AlertRuleActionResult
+from sentry.mediators import project_rules
 from sentry.models import (
     AuditLogEntryEvent,
     Rule,
     RuleActivity,
     RuleActivityType,
     RuleStatus,
-    SentryAppInstallation,
     Team,
     User,
 )
+from sentry.rules.actions.base import trigger_alert_rule_action_creators
 from sentry.signals import alert_rule_created
 from sentry.web.decorators import transaction_start
-
-
-# TODO(Leander): Move this method into a relevant abstract base class
-def trigger_alert_rule_action_creators(
-    actions: Sequence[Mapping[str, str]],
-) -> Optional[str]:
-    created = None
-    for action in actions:
-        # Only call creator for Sentry Apps with UI Components for alert rules.
-        if not action.get("hasSchemaFormConfig"):
-            continue
-
-        install = SentryAppInstallation.objects.get(uuid=action.get("sentryAppInstallationUuid"))
-        result: AlertRuleActionResult = alert_rule_actions.AlertRuleActionCreator.run(
-            install=install,
-            fields=action.get("settings"),
-        )
-        # Bubble up errors from Sentry App to the UI
-        if not result["success"]:
-            raise serializers.ValidationError({"actions": [result["message"]]})
-        created = "alert-rule-action"
-    return created
 
 
 class ProjectRulesEndpoint(ProjectEndpoint):

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -16,7 +16,7 @@ from sentry.models import (
     Team,
     User,
 )
-from sentry.rules.actions.base import trigger_alert_rule_action_creators
+from sentry.rules.actions.base import trigger_sentry_app_action_creators_for_issues
 from sentry.signals import alert_rule_created
 from sentry.web.decorators import transaction_start
 
@@ -103,7 +103,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 tasks.find_channel_id_for_rule.apply_async(kwargs=kwargs)
                 return Response(uuid_context, status=202)
 
-            created_alert_rule_ui_component = trigger_alert_rule_action_creators(
+            created_alert_rule_ui_component = trigger_sentry_app_action_creators_for_issues(
                 kwargs.get("actions")
             )
             rule = project_rules.Creator.run(request=request, **kwargs)

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.constants import MIGRATED_CONDITIONS, SCHEMA_FORM_ACTIONS, TICKET_ACTIONS
+from sentry.constants import MIGRATED_CONDITIONS, SENTRY_APP_ACTIONS, TICKET_ACTIONS
 from sentry.rules import rules
 
 
@@ -32,7 +32,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
             if not can_create_tickets and node.id in TICKET_ACTIONS:
                 continue
 
-            if node.id in SCHEMA_FORM_ACTIONS:
+            if node.id in SENTRY_APP_ACTIONS:
                 custom_actions = node.get_custom_actions(project)
                 if custom_actions:
                     action_list.extend(custom_actions)

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from sentry import features
 from sentry.api.fields.actor import ActorField
 from sentry.api.serializers.rest_framework.list import ListField
-from sentry.constants import MIGRATED_CONDITIONS, SCHEMA_FORM_ACTIONS, TICKET_ACTIONS
+from sentry.constants import MIGRATED_CONDITIONS, SENTRY_APP_ACTIONS, TICKET_ACTIONS
 from sentry.models import Environment
 from sentry.rules import rules
 
@@ -34,7 +34,7 @@ class RuleNodeField(serializers.Field):
         node = cls(self.context["project"], data)
 
         # Nodes with user-declared fields will manage their own validation
-        if node.id in SCHEMA_FORM_ACTIONS:
+        if node.id in SENTRY_APP_ACTIONS:
             if not data.get("hasSchemaFormConfig"):
                 raise ValidationError("Please configure your integration settings.")
             node.self_validate()

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -256,7 +256,7 @@ TICKET_ACTIONS = frozenset(
     ]
 )
 
-SCHEMA_FORM_ACTIONS = frozenset(
+SENTRY_APP_ACTIONS = frozenset(
     ["sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"]
 )
 

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -9,7 +9,7 @@ from sentry.incidents.logic import (
     AlreadyDeletedError,
     delete_alert_rule,
     get_slack_actions_with_async_lookups,
-    tell_sentry_apps,
+    validate_sentry_app_trigger_actions,
 )
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.integrations.slack import tasks
@@ -38,6 +38,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
             partial=True,
         )
         if serializer.is_valid():
+            validate_sentry_app_trigger_actions(serializer.validated_data)
             if get_slack_actions_with_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()
@@ -51,7 +52,6 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
                 tasks.find_channel_id_for_alert_rule.apply_async(kwargs=task_args)
                 return Response({"uuid": client.uuid}, status=202)
             else:
-                tell_sentry_apps(serializer.validated_data)
                 alert_rule = serializer.save()
                 return Response(serialize(alert_rule, request.user), status=status.HTTP_200_OK)
 

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -9,6 +9,7 @@ from sentry.incidents.logic import (
     AlreadyDeletedError,
     delete_alert_rule,
     get_slack_actions_with_async_lookups,
+    tell_sentry_apps,
 )
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.integrations.slack import tasks
@@ -50,6 +51,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
                 tasks.find_channel_id_for_alert_rule.apply_async(kwargs=task_args)
                 return Response({"uuid": client.uuid}, status=202)
             else:
+                tell_sentry_apps(serializer.validated_data)
                 alert_rule = serializer.save()
                 return Response(serialize(alert_rule, request.user), status=status.HTTP_200_OK)
 

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -9,7 +9,7 @@ from sentry.incidents.logic import (
     AlreadyDeletedError,
     delete_alert_rule,
     get_slack_actions_with_async_lookups,
-    validate_sentry_app_trigger_actions,
+    trigger_sentry_app_action_creators_for_incidents,
 )
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.integrations.slack import tasks
@@ -38,7 +38,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
             partial=True,
         )
         if serializer.is_valid():
-            validate_sentry_app_trigger_actions(serializer.validated_data)
+            trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
             if get_slack_actions_with_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -13,7 +13,10 @@ from sentry.api.paginator import (
     OffsetPaginator,
 )
 from sentry.api.serializers import CombinedRuleSerializer, serialize
-from sentry.incidents.logic import get_slack_actions_with_async_lookups
+from sentry.incidents.logic import (
+    get_slack_actions_with_async_lookups,
+    validate_sentry_app_trigger_actions,
+)
 from sentry.incidents.models import AlertRule
 from sentry.incidents.serializers import AlertRuleSerializer
 from sentry.integrations.slack import tasks
@@ -93,6 +96,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
             data=data,
         )
         if serializer.is_valid():
+            validate_sentry_app_trigger_actions(serializer.validated_data)
             if get_slack_actions_with_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -15,7 +15,7 @@ from sentry.api.paginator import (
 from sentry.api.serializers import CombinedRuleSerializer, serialize
 from sentry.incidents.logic import (
     get_slack_actions_with_async_lookups,
-    validate_sentry_app_trigger_actions,
+    trigger_sentry_app_action_creators_for_incidents,
 )
 from sentry.incidents.models import AlertRule
 from sentry.incidents.serializers import AlertRuleSerializer
@@ -96,7 +96,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
             data=data,
         )
         if serializer.is_valid():
-            validate_sentry_app_trigger_actions(serializer.validated_data)
+            trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
             if get_slack_actions_with_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1389,13 +1389,14 @@ def translate_aggregate_field(aggregate, reverse=False):
     return aggregate
 
 
-def tell_sentry_apps(data):
+def validate_sentry_app_trigger_actions(validated_alert_rule_data):
     from rest_framework import serializers
 
     from sentry.mediators import alert_rule_actions
 
     sentry_app_actions = get_filtered_actions(
-        validated_alert_rule_data=data, action_type=AlertRuleTriggerAction.Type.SENTRY_APP
+        validated_alert_rule_data=validated_alert_rule_data,
+        action_type=AlertRuleTriggerAction.Type.SENTRY_APP,
     )
     for action in sentry_app_actions:
         install = SentryAppInstallation.objects.get(uuid=action.get("sentry_app_installation_uuid"))

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1389,7 +1389,7 @@ def translate_aggregate_field(aggregate, reverse=False):
     return aggregate
 
 
-def validate_sentry_app_trigger_actions(validated_alert_rule_data):
+def trigger_sentry_app_action_creators_for_incidents(validated_alert_rule_data):
     from rest_framework import serializers
 
     from sentry.mediators import alert_rule_actions

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1480,8 +1480,8 @@ def get_filtered_actions(validated_alert_rule_data, action_type: AlertRuleTrigge
     from sentry.incidents.serializers import STRING_TO_ACTION_TYPE
 
     filtered_actions = []
-    for trigger in validated_alert_rule_data["triggers"]:
-        for action in trigger["actions"]:
-            if STRING_TO_ACTION_TYPE[action["type"]] == action_type:
+    for trigger in validated_alert_rule_data.get("triggers", []):
+        for action in trigger.get("actions", []):
+            if STRING_TO_ACTION_TYPE.get(action.get("type")) == action_type:
                 filtered_actions.append(rewrite_trigger_action_fields(action))
     return filtered_actions

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -15,7 +15,6 @@ from sentry.incidents.serializers import (
     STRING_TO_ACTION_TYPE,
 )
 from sentry.integrations.slack.utils import validate_channel_id
-from sentry.mediators import alert_rule_actions
 from sentry.models import OrganizationMember, SentryAppInstallation, Team, User
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
 
@@ -134,19 +133,14 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                     )
 
                 try:
-                    install = SentryAppInstallation.objects.get(uuid=sentry_app_installation_uuid)
+                    SentryAppInstallation.objects.get(uuid=sentry_app_installation_uuid)
                 except SentryAppInstallation.DoesNotExist:
                     raise serializers.ValidationError(
                         {"sentry_app": "The installation does not exist."}
                     )
-                # Check response from creator and bubble up errors from providers as a ValidationError
-                result = alert_rule_actions.AlertRuleActionCreator.run(
-                    install=install,
-                    fields=attrs.get("sentry_app_config"),
-                )
 
-                if not result["success"]:
-                    raise serializers.ValidationError({"sentry_app": result["message"]})
+                # TODO(Ecosystem): Validate that all fields as part of the config
+                # See NotifyEventSentryAppAction for more details
 
         attrs["use_async_lookup"] = self.context.get("use_async_lookup")
         attrs["input_channel_id"] = self.context.get("input_channel_id")

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -57,8 +57,8 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
         # in the task (integrations/slack/tasks.py) if the channel_id is found.
         self._pending_save = False
 
-    def _format_error_message(self, message: str) -> str:
-        return _(f"Slack Error: {message}")
+    def _format_error_message(self, message: str) -> Any:
+        return _(f"Slack: {message}")
 
     def clean(self) -> dict[str, Any] | None:
         channel_id = (

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -57,7 +57,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
         # in the task (integrations/slack/tasks.py) if the channel_id is found.
         self._pending_save = False
 
-    def _format_error_message(self, message: str) -> Any:
+    def _format_slack_error_message(self, message: str) -> Any:
         return _(f"Slack: {message}")
 
     def clean(self) -> dict[str, Any] | None:
@@ -76,7 +76,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
             )
             if not self.data.get("channel"):
                 raise forms.ValidationError(
-                    self._format_error_message("Channel name is a required field."),
+                    self._format_slack_error_message("Channel name is a required field."),
                     code="invalid",
                 )
             # default to "#" if they have the channel name without the prefix
@@ -97,7 +97,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
                 params = {"channel": self.data.get("channel"), "channel_id": channel_id}
                 raise forms.ValidationError(
                     # ValidationErrors contain a list of error messages, not just one.
-                    self._format_error_message("; ".join(e.messages)),
+                    self._format_slack_error_message("; ".join(e.messages)),
                     code="invalid",
                     params=params,
                 )
@@ -105,7 +105,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
             integration = Integration.objects.get(id=workspace)
         except Integration.DoesNotExist:
             raise forms.ValidationError(
-                self._format_error_message("Workspace is a required field."),
+                self._format_slack_error_message("Workspace is a required field."),
                 code="invalid",
             )
 
@@ -127,7 +127,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
                 params = {"channel": channel, "domain": domain}
 
                 raise forms.ValidationError(
-                    self._format_error_message(
+                    self._format_slack_error_message(
                         "Multiple users were found with display name '%(channel)s'. "
                         "Please use your username, found at %(domain)s/account/settings#username."
                     ),
@@ -136,7 +136,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
                 )
             except ApiRateLimitedError:
                 raise forms.ValidationError(
-                    self._format_error_message(SLACK_RATE_LIMITED_MESSAGE),
+                    self._format_slack_error_message(SLACK_RATE_LIMITED_MESSAGE),
                     code="invalid",
                 )
 
@@ -152,7 +152,7 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
                 "workspace": dict(self.fields["workspace"].choices).get(int(workspace)),
             }
             raise forms.ValidationError(
-                self._format_error_message(
+                self._format_slack_error_message(
                     'The resource "%(channel)s" does not exist or has not been granted access in the %(workspace)s Slack workspace.'
                 ),
                 code="invalid",

--- a/src/sentry/mediators/alert_rule_actions/creator.py
+++ b/src/sentry/mediators/alert_rule_actions/creator.py
@@ -1,5 +1,6 @@
 from sentry.coreapi import APIError
 from sentry.mediators import Mediator, Param, external_requests
+from sentry.mediators.external_requests.alert_rule_action_requester import AlertRuleActionResult
 from sentry.models import SentryAppComponent
 from sentry.utils.cache import memoize
 
@@ -8,7 +9,7 @@ class AlertRuleActionCreator(Mediator):
     install = Param("sentry.models.SentryAppInstallation")
     fields = Param(object, default=[])  # array of dicts
 
-    def call(self):
+    def call(self) -> AlertRuleActionResult:
         uri = self._fetch_sentry_app_uri()
         self._make_external_request(uri)
         return self.response

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -17,7 +17,7 @@ DEFAULT_SUCCESS_MESSAGE = "Success!"
 DEFAULT_ERROR_MESSAGE = "Something went wrong!"
 
 
-class AlertRuleActionRequesterResult(TypedDict):
+class AlertRuleActionResult(TypedDict):
     success: bool
     message: str
 
@@ -52,7 +52,7 @@ class AlertRuleActionRequester(Mediator):
             error_message = DEFAULT_ERROR_MESSAGE
         return error_message
 
-    def _make_request(self) -> AlertRuleActionRequesterResult:
+    def _make_request(self) -> AlertRuleActionResult:
         try:
             send_and_save_sentry_app_request(
                 self._build_url(),
@@ -75,9 +75,9 @@ class AlertRuleActionRequester(Mediator):
             )
             message = f"{self.sentry_app.name} Error: {self._get_error_message(e.response)}"
             # Bubble up error message from Sentry App to the UI for the user.
-            return AlertRuleActionRequesterResult(success=False, message=message)
+            return AlertRuleActionResult(success=False, message=message)
         # No messages are bubbled up from successful responses.
-        return AlertRuleActionRequesterResult(success=True, message=DEFAULT_SUCCESS_MESSAGE)
+        return AlertRuleActionResult(success=True, message=DEFAULT_SUCCESS_MESSAGE)
 
     def _build_headers(self):
         request_uuid = uuid4().hex

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -77,7 +77,8 @@ class AlertRuleActionRequester(Mediator):
             # Bubble up error message from Sentry App to the UI for the user.
             return AlertRuleActionResult(success=False, message=message)
         # No messages are bubbled up from successful responses.
-        return AlertRuleActionResult(success=True, message=DEFAULT_SUCCESS_MESSAGE)
+        message = f"{self.sentry_app.name}: {DEFAULT_SUCCESS_MESSAGE}"
+        return AlertRuleActionResult(success=True, message=message)
 
     def _build_headers(self):
         request_uuid = uuid4().hex

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -73,7 +73,7 @@ class AlertRuleActionRequester(Mediator):
                     "error_message": str(e),
                 },
             )
-            message = f"{self.sentry_app.name} Error: {self._get_error_message(e.response)}"
+            message = f"{self.sentry_app.name}: {self._get_error_message(e.response)}"
             # Bubble up error message from Sentry App to the UI for the user.
             return AlertRuleActionResult(success=False, message=message)
         # No messages are bubbled up from successful responses.

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Mapping, Union
+from typing import TypedDict
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
 from requests import RequestException
+from rest_framework.response import Response
 
-from sentry.http import safe_urlread
 from sentry.mediators import Mediator, Param
 from sentry.mediators.external_requests.util import send_and_save_sentry_app_request
 from sentry.utils import json
@@ -15,6 +15,11 @@ logger = logging.getLogger("sentry.mediators.external-requests")
 
 DEFAULT_SUCCESS_MESSAGE = "Success!"
 DEFAULT_ERROR_MESSAGE = "Something went wrong!"
+
+
+class AlertRuleActionRequesterResult(TypedDict):
+    success: bool
+    message: str
 
 
 class AlertRuleActionRequester(Mediator):
@@ -36,9 +41,20 @@ class AlertRuleActionRequester(Mediator):
         urlparts[2] = self.uri
         return urlunparse(urlparts)
 
-    def _make_request(self) -> Mapping[str, Union[bool, str]]:
+    def _get_error_message(self, response: Response) -> str:
+        """
+        Returns the error message from the response body, if in the expected location.
+        The location should be coordinated with the docs on Alert Rule Action UI Components.
+        """
         try:
-            request = send_and_save_sentry_app_request(
+            error_message = response.json().get("message", DEFAULT_ERROR_MESSAGE)
+        except Exception:
+            error_message = DEFAULT_ERROR_MESSAGE
+        return error_message
+
+    def _make_request(self) -> AlertRuleActionRequesterResult:
+        try:
+            send_and_save_sentry_app_request(
                 self._build_url(),
                 self.sentry_app,
                 self.install.organization_id,
@@ -57,16 +73,11 @@ class AlertRuleActionRequester(Mediator):
                     "error_message": str(e),
                 },
             )
-            # NOTE: bool(e.response) is always False because non-2xx responses are Falsey.
-            text = e.response.text if e.response is not None else None
-            message = f"{self.sentry_app.name}: {text or DEFAULT_ERROR_MESSAGE}"
+            message = f"{self.sentry_app.name} Error: {self._get_error_message(e.response)}"
             # Bubble up error message from Sentry App to the UI for the user.
-            return {"success": False, "message": message}
-
-        body_raw = safe_urlread(request)
-        body = body_raw.decode() if body_raw else None
-        message = f"{self.sentry_app.name}: {body or DEFAULT_SUCCESS_MESSAGE}"
-        return {"success": True, "message": message}
+            return AlertRuleActionRequesterResult(success=False, message=message)
+        # No messages are bubbled up from successful responses.
+        return AlertRuleActionRequesterResult(success=True, message=DEFAULT_SUCCESS_MESSAGE)
 
     def _build_headers(self):
         request_uuid = uuid4().hex

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -75,7 +75,7 @@ class SentryAppEventAction(EventAction, abc.ABC):
         raise NotImplementedError()
 
 
-def trigger_alert_rule_action_creators(actions: Sequence[Mapping[str, str]]):
+def trigger_alert_rule_action_creators(actions: Sequence[Mapping[str, str]]) -> str | None:
     created = None
     for action in actions:
         # Only call creator for Sentry Apps with UI Components for alert rules.

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -75,7 +75,9 @@ class SentryAppEventAction(EventAction, abc.ABC):
         raise NotImplementedError()
 
 
-def trigger_alert_rule_action_creators(actions: Sequence[Mapping[str, str]]) -> str | None:
+def trigger_sentry_app_action_creators_for_issues(
+    actions: Sequence[Mapping[str, str]]
+) -> str | None:
     created = None
     for action in actions:
         # Only call creator for Sentry Apps with UI Components for alert rules.

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -129,6 +129,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
             assert alert_rule.snuba_query.aggregate == "count_unique(tags[sentry:user])"
 
 
+# TODO(Leander): Test validate_sentry_app_trigger_actions on PUT
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
     method = "put"
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import responses
 from exam import fixture
 
 from sentry.api.serializers import serialize
@@ -17,6 +18,20 @@ from sentry.testutils import APITestCase
 
 class AlertRuleDetailsBase:
     endpoint = "sentry-api-0-project-alert-rule-details"
+
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        self.owner_user = self.create_user()
+        self.member_user = self.create_user()
+        self.alert_rule = self.create_alert_rule(name="hello")
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.create_member(
+            user=self.member_user, organization=self.organization, role="member", teams=[self.team]
+        )
 
     @fixture
     def valid_params(self):
@@ -43,7 +58,11 @@ class AlertRuleDetailsBase:
                     "alertThreshold": 150,
                     "actions": [
                         {"type": "email", "targetType": "team", "targetIdentifier": self.team.id},
-                        {"type": "email", "targetType": "user", "targetIdentifier": self.user.id},
+                        {
+                            "type": "email",
+                            "targetType": "user",
+                            "targetIdentifier": self.owner_user.id,
+                        },
                     ],
                 },
             ],
@@ -63,34 +82,14 @@ class AlertRuleDetailsBase:
         self.method = original_method
         return serialized_alert_rule
 
-    @fixture
-    def organization(self):
-        return self.create_organization()
-
-    @fixture
-    def project(self):
-        return self.create_project(organization=self.organization)
-
-    @fixture
-    def user(self):
-        return self.create_user()
-
-    @fixture
-    def alert_rule(self):
-        return self.create_alert_rule(name="hello")
-
     def test_invalid_rule_id(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
+        self.login_as(self.owner_user)
         with self.feature("organizations:incidents"):
             resp = self.get_response(self.organization.slug, self.project.slug, 1234)
 
         assert resp.status_code == 404
 
     def test_permissions(self):
-        self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.create_user())
         with self.feature("organizations:incidents"):
             resp = self.get_response(self.organization.slug, self.project.slug, self.alert_rule.id)
@@ -98,18 +97,14 @@ class AlertRuleDetailsBase:
         assert resp.status_code == 403
 
     def test_no_feature(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
+        self.login_as(self.owner_user)
         resp = self.get_response(self.organization.slug, self.project.slug, self.alert_rule.id)
         assert resp.status_code == 404
 
 
 class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
     def test_simple(self):
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
+        self.login_as(self.member_user)
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id
@@ -118,10 +113,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data == serialize(self.alert_rule)
 
     def test_aggregate_translation(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
+        self.login_as(self.owner_user)
         alert_rule = self.create_alert_rule(aggregate="count_unique(tags[sentry:user])")
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(self.organization.slug, self.project.slug, alert_rule.id)
@@ -129,20 +121,18 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
             assert alert_rule.snuba_query.aggregate == "count_unique(tags[sentry:user])"
 
 
-# TODO(Leander): Test validate_sentry_app_trigger_actions on PUT
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
     method = "put"
 
-    def test_simple(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.owner_user)
 
+    def test_simple(self):
         test_params = self.valid_params.copy()
         test_params["resolve_threshold"] = self.alert_rule.resolve_threshold
         test_params.update({"name": "what"})
 
-        self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
@@ -164,11 +154,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         test_params["resolve_threshold"] = self.alert_rule.resolve_threshold
         test_params["aggregate"] = self.alert_rule.snuba_query.aggregate
 
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-
-        self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
@@ -185,10 +170,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert updated_sub.subscription_id == existing_sub.subscription_id
 
     def test_update_snapshot(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         alert_rule = self.alert_rule
         # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
         serialized_alert_rule = self.get_serialized_alert_rule()
@@ -216,10 +197,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
     ):
         mock_uuid4.return_value = self.get_mock_uuid()
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         self.integration = Integration.objects.create(
             provider="slack",
             name="Team A",
@@ -255,7 +232,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             "uuid": "abc123",
             "alert_rule_id": self.alert_rule.id,
             "data": test_params,
-            "user_id": self.user.id,
+            "user_id": self.owner_user.id,
         }
         mock_find_channel_id_for_alert_rule.assert_called_once_with(kwargs=kwargs)
 
@@ -266,11 +243,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
     @patch("sentry.integrations.slack.tasks.uuid4")
     def test_async_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):
         mock_uuid4.return_value = self.get_mock_uuid()
-
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         self.integration = Integration.objects.create(
             provider="slack",
             name="Team A",
@@ -400,12 +372,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         )  # Did not increment from the last assertion because we early out on the validation error
 
     def test_no_owner(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-
-        self.login_as(self.user)
-
         alert_rule = self.alert_rule
         alert_rule.owner = self.user.actor
         alert_rule.save()
@@ -425,15 +391,124 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data == serialize(alert_rule, self.user)
         assert resp.data["owner"] is None
 
+    @responses.activate
+    def test_success_response_from_sentry_app(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=202,
+        )
+
+        sentry_app = self.create_sentry_app(
+            name="foo",
+            organization=self.organization,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
+        )
+        install = self.create_sentry_app_installation(
+            slug="foo", organization=self.organization, user=self.user
+        )
+
+        sentry_app_settings = [
+            {"name": "title", "value": "test title"},
+            {"name": "description", "value": "test description"},
+        ]
+
+        test_params = self.valid_params.copy()
+        test_params["triggers"] = [
+            {
+                "actions": [
+                    {
+                        "type": "sentry_app",
+                        "targetType": "sentry_app",
+                        "targetIdentifier": sentry_app.id,
+                        "hasSchemaFormConfig": True,
+                        "sentryAppId": sentry_app.id,
+                        "sentryAppInstallationUuid": install.uuid,
+                        "settings": sentry_app_settings,
+                    }
+                ],
+                "alertThreshold": 300,
+                "label": "critical",
+            }
+        ]
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            self.get_valid_response(
+                self.organization.slug,
+                self.project.slug,
+                self.alert_rule.id,
+                status_code=200,
+                **test_params,
+            )
+
+    @responses.activate
+    def test_error_response_from_sentry_app(self):
+        error_message = "Everything is broken!"
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=500,
+            json={"message": error_message},
+        )
+
+        sentry_app = self.create_sentry_app(
+            name="foo",
+            organization=self.organization,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
+        )
+        install = self.create_sentry_app_installation(
+            slug="foo", organization=self.organization, user=self.user
+        )
+
+        sentry_app_settings = [
+            {"name": "title", "value": "test title"},
+            {"name": "description", "value": "test description"},
+        ]
+
+        test_params = self.valid_params.copy()
+        test_params["triggers"] = [
+            {
+                "actions": [
+                    {
+                        "type": "sentry_app",
+                        "targetType": "sentry_app",
+                        "targetIdentifier": sentry_app.id,
+                        "hasSchemaFormConfig": True,
+                        "sentryAppId": sentry_app.id,
+                        "sentryAppInstallationUuid": install.uuid,
+                        "settings": sentry_app_settings,
+                    }
+                ],
+                "alertThreshold": 300,
+                "label": "critical",
+            }
+        ]
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_response(
+                self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
+            )
+
+        assert resp.status_code == 400
+        assert error_message in resp.data["sentry_app"]
+
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
     method = "delete"
 
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.owner_user)
+
     def test_simple(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         with self.feature("organizations:incidents"):
             self.get_valid_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, status_code=204
@@ -450,11 +525,6 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
 
     def test_snapshot_and_create_new_with_same_name(self):
         with self.tasks():
-            self.create_member(
-                user=self.user, organization=self.organization, role="owner", teams=[self.team]
-            )
-            self.login_as(self.user)
-
             # We attach the rule to an incident so the rule is snapshotted instead of deleted.
             incident = self.create_incident(alert_rule=self.alert_rule)
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import responses
-from exam import fixture
 
 from sentry.api.serializers import serialize
 from sentry.incidents.models import (
@@ -23,19 +22,18 @@ class AlertRuleDetailsBase:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
-        self.owner_user = self.create_user()
-        self.member_user = self.create_user()
         self.alert_rule = self.create_alert_rule(name="hello")
+        self.owner_user = self.create_user()
         self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+            user=self.owner_user, organization=self.organization, role="owner", teams=[self.team]
         )
+        # Default to the 'owner' user
+        self.user = self.owner_user
+        self.member_user = self.create_user()
         self.create_member(
             user=self.member_user, organization=self.organization, role="member", teams=[self.team]
         )
-
-    @fixture
-    def valid_params(self):
-        return {
+        self.valid_params = {
             "name": "hello",
             "time_window": 10,
             "query": "level:error",

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -66,6 +66,7 @@ class AlertRuleListEndpointTest(APITestCase):
         assert resp.status_code == 404
 
 
+# TODO(Leander): Test validate_sentry_app_trigger_actions on POST
 @freeze_time()
 class AlertRuleCreateEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-alert-rules"

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -67,7 +67,6 @@ class AlertRuleListEndpointTest(APITestCase):
         assert resp.status_code == 404
 
 
-# TODO(Leander): Test validate_sentry_app_trigger_actions on POST
 @freeze_time()
 class AlertRuleCreateEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-alert-rules"

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -104,7 +104,6 @@ class AlertRuleCreateEndpointTest(APITestCase):
             "projects": [self.project.slug],
             "owner": self.user.id,
             "name": "JustAValidTestRule",
-            "comparisonDelta": 60,
         }
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -996,35 +996,6 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
         )
 
     @responses.activate
-    def test_sentry_app_action_creator_fails(self):
-        error_message = "Invalid channel."
-        responses.add(
-            method=responses.POST,
-            url="https://example.com/sentry/alert-rule",
-            status=400,
-            json={"message": error_message},
-        )
-
-        serializer = AlertRuleTriggerActionSerializer(
-            context=self.context,
-            data={
-                "type": AlertRuleTriggerAction.get_registered_type(
-                    AlertRuleTriggerAction.Type.SENTRY_APP
-                ).slug,
-                "target_type": ACTION_TARGET_TYPE_TO_STRING[
-                    AlertRuleTriggerAction.TargetType.SENTRY_APP
-                ],
-                "target_identifier": "1",
-                "sentry_app": self.sentry_app.id,
-                "sentry_app_config": {"channel": "#santry"},
-                "sentry_app_installation_uuid": self.sentry_app_installation.uuid,
-            },
-        )
-        assert not serializer.is_valid()
-        error = serializer.errors.get("sentryApp")[0]
-        assert str(error) == f"Super Awesome App: {error_message}"
-
-    @responses.activate
     def test_create_and_update_sentry_app_action_success(self):
         responses.add(
             method=responses.POST,

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -995,15 +995,7 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
             {"sentryApp": ["Missing parameter: sentry_app_installation_uuid"]},
         )
 
-    @responses.activate
     def test_create_and_update_sentry_app_action_success(self):
-        responses.add(
-            method=responses.POST,
-            url="https://example.com/sentry/alert-rule",
-            status=200,
-            json={},
-        )
-
         serializer = AlertRuleTriggerActionSerializer(
             context=self.context,
             data={

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -312,7 +312,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
         form = rule.get_form_instance()
         assert not form.is_valid()
-        assert ["Slack workspace is a required field."] in form.errors.values()
+        assert ["Slack: Workspace is a required field."] in form.errors.values()
 
     @responses.activate
     def test_display_name_conflict(self):
@@ -347,7 +347,7 @@ class SlackNotifyActionTest(RuleTestCase):
         form = rule.get_form_instance()
         assert not form.is_valid()
         assert [
-            'Multiple users were found with display name "@morty". Please use your username, found at sentry.slack.com/account/settings#username.'
+            "Slack: Multiple users were found with display name '@morty'. Please use your username, found at sentry.slack.com/account/settings#username."
         ] in form.errors.values()
 
     def test_disabled_org_integration(self):

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -1,6 +1,7 @@
 import responses
 
 from sentry.mediators.external_requests import AlertRuleActionRequester
+from sentry.mediators.external_requests.alert_rule_action_requester import DEFAULT_SUCCESS_MESSAGE
 from sentry.testutils import TestCase
 from sentry.utils import json
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
@@ -41,7 +42,6 @@ class TestAlertRuleActionRequester(TestCase):
             method=responses.POST,
             url="https://example.com/sentry/alert-rule",
             status=200,
-            json="Saved information",
         )
 
         result = AlertRuleActionRequester.run(
@@ -50,7 +50,7 @@ class TestAlertRuleActionRequester(TestCase):
             fields=self.fields,
         )
         assert result["success"]
-        assert result["message"] == 'foo: "Saved information"'
+        assert result["message"] == f"foo: {DEFAULT_SUCCESS_MESSAGE}"
         request = responses.calls[0].request
 
         data = {
@@ -85,7 +85,7 @@ class TestAlertRuleActionRequester(TestCase):
             method=responses.POST,
             url="https://example.com/sentry/alert-rule",
             status=401,
-            json="Channel not found!",
+            json={"message": "Channel not found!"},
         )
 
         result = AlertRuleActionRequester.run(
@@ -94,7 +94,7 @@ class TestAlertRuleActionRequester(TestCase):
             fields=self.fields,
         )
         assert not result["success"]
-        assert result["message"] == 'foo: "Channel not found!"'
+        assert result["message"] == "foo: Channel not found!"
         request = responses.calls[0].request
 
         data = {

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -1,7 +1,10 @@
 import responses
 
 from sentry.mediators.external_requests import AlertRuleActionRequester
-from sentry.mediators.external_requests.alert_rule_action_requester import DEFAULT_SUCCESS_MESSAGE
+from sentry.mediators.external_requests.alert_rule_action_requester import (
+    DEFAULT_ERROR_MESSAGE,
+    DEFAULT_SUCCESS_MESSAGE,
+)
 from sentry.testutils import TestCase
 from sentry.utils import json
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
@@ -34,6 +37,8 @@ class TestAlertRuleActionRequester(TestCase):
             {"name": "description", "value": "threshold reached"},
             {"name": "assignee_id", "value": "user-1"},
         ]
+        self.error_message = "Channel not found!"
+        self.success_message = "Created alert!"
 
     @responses.activate
     def test_makes_successful_request(self):
@@ -50,7 +55,7 @@ class TestAlertRuleActionRequester(TestCase):
             fields=self.fields,
         )
         assert result["success"]
-        assert result["message"] == f"foo: {DEFAULT_SUCCESS_MESSAGE}"
+        assert result["message"] == f"{self.sentry_app.name}: {DEFAULT_SUCCESS_MESSAGE}"
         request = responses.calls[0].request
 
         data = {
@@ -79,13 +84,45 @@ class TestAlertRuleActionRequester(TestCase):
         assert requests[0]["event_type"] == "alert_rule_action.requested"
 
     @responses.activate
+    def test_makes_successful_request_with_message(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=200,
+            json={"message": self.success_message},
+        )
+
+        result = AlertRuleActionRequester.run(
+            install=self.install,
+            uri="/sentry/alert-rule",
+            fields=self.fields,
+        )
+        assert result["success"]
+        assert result["message"] == f"{self.sentry_app.name}: {self.success_message}"
+
+    @responses.activate
+    def test_makes_successful_request_with_malformed_message(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=200,
+            body=bytes(self.success_message, encoding="utf-8"),
+        )
+        result = AlertRuleActionRequester.run(
+            install=self.install,
+            uri="/sentry/alert-rule",
+            fields=self.fields,
+        )
+        assert result["success"]
+        assert result["message"] == f"{self.sentry_app.name}: {DEFAULT_SUCCESS_MESSAGE}"
+
+    @responses.activate
     def test_makes_failed_request(self):
 
         responses.add(
             method=responses.POST,
             url="https://example.com/sentry/alert-rule",
             status=401,
-            json={"message": "Channel not found!"},
         )
 
         result = AlertRuleActionRequester.run(
@@ -94,7 +131,7 @@ class TestAlertRuleActionRequester(TestCase):
             fields=self.fields,
         )
         assert not result["success"]
-        assert result["message"] == "foo: Channel not found!"
+        assert result["message"] == f"{self.sentry_app.name}: {DEFAULT_ERROR_MESSAGE}"
         request = responses.calls[0].request
 
         data = {
@@ -123,12 +160,12 @@ class TestAlertRuleActionRequester(TestCase):
         assert requests[0]["event_type"] == "alert_rule_action.requested"
 
     @responses.activate
-    def test_makes_failed_request_returning_only_status(self):
-
+    def test_makes_failed_request_with_message(self):
         responses.add(
             method=responses.POST,
             url="https://example.com/sentry/alert-rule",
             status=401,
+            json={"message": self.error_message},
         )
 
         result = AlertRuleActionRequester.run(
@@ -137,30 +174,20 @@ class TestAlertRuleActionRequester(TestCase):
             fields=self.fields,
         )
         assert not result["success"]
-        assert result["message"] == "foo: Something went wrong!"
-        request = responses.calls[0].request
+        assert result["message"] == f"{self.sentry_app.name}: {self.error_message}"
 
-        data = {
-            "fields": [
-                {"name": "title", "value": "An Alert"},
-                {"name": "description", "value": "threshold reached"},
-                {
-                    "name": "assignee_id",
-                    "value": "user-1",
-                },
-            ],
-            "installationId": self.install.uuid,
-        }
-        payload = json.loads(request.body)
-        assert payload == data
-
-        assert request.headers["Sentry-App-Signature"] == self.sentry_app.build_signature(
-            json.dumps(payload)
+    @responses.activate
+    def test_makes_failed_request_with_malformed_message(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=401,
+            body=bytes(self.error_message, encoding="utf-8"),
         )
-
-        buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
-        requests = buffer.get_requests()
-
-        assert len(requests) == 1
-        assert requests[0]["response_code"] == 401
-        assert requests[0]["event_type"] == "alert_rule_action.requested"
+        result = AlertRuleActionRequester.run(
+            install=self.install,
+            uri="/sentry/alert-rule",
+            fields=self.fields,
+        )
+        assert not result["success"]
+        assert result["message"] == f"{self.sentry_app.name}: {DEFAULT_ERROR_MESSAGE}"


### PR DESCRIPTION
Blocked by https://github.com/getsentry/sentry/pull/33571

The function which would trigger the action creators for Sentry App Alert Rules was located in the generic ProjectRules endpoint, which is messy and difficult to trace. This moves it to the base file which already contains similar one off functionality for Ticket Rules.

I also introduced an abstract base class for SENTRY_APP_RULES to lend from, since in code we assumed those methods exist as the SENTRY_APP_RULES constant only references one module. If in the future someone adds a new action to SENTRY_APP_RULES, they can extend the base class to ensure they have all the methods required by these actions.