### PR TITLE
fix(rate limit): Format 429 response correctly

### DIFF
--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -76,8 +76,8 @@ class RatelimitMiddleware:
                         return HttpResponse(
                             json.dumps(
                                 DEFAULT_ERROR_MESSAGE.format(
-                                    limit=1,
-                                    window=5,
+                                    limit=request.rate_limit_metadata.limit,
+                                    window=request.rate_limit_metadata.window,
                                 )
                             ),
                             status=429,

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -16,7 +16,7 @@ from sentry.ratelimits import (
 )
 from sentry.ratelimits.config import ENFORCE_CONCURRENT_RATE_LIMITS
 from sentry.types.ratelimit import RateLimitCategory, RateLimitMeta, RateLimitType
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 
 DEFAULT_ERROR_MESSAGE = (
     "You are attempting to use this endpoint too frequently. Limit is "
@@ -74,12 +74,12 @@ class RatelimitMiddleware:
                     enforce_rate_limit = getattr(view_func.view_class, "enforce_rate_limit", False)
                     if enforce_rate_limit:
                         return HttpResponse(
-                            {
-                                "detail": DEFAULT_ERROR_MESSAGE.format(
-                                    limit=request.rate_limit_metadata.limit,
-                                    window=request.rate_limit_metadata.window,
+                            json.dumps(
+                                DEFAULT_ERROR_MESSAGE.format(
+                                    limit=1,
+                                    window=5,
                                 )
-                            },
+                            ),
                             status=429,
                         )
             except Exception:


### PR DESCRIPTION
Use `HttpResponse` correctly.

**Before**
<img width="640" alt="Screen Shot 2022-04-14 at 2 18 48 PM" src="https://user-images.githubusercontent.com/29959063/163478013-d9ee5f0c-d6f5-4f40-863f-461c87cb67b7.png">

**After**
<img width="930" alt="Screen Shot 2022-04-14 at 2 19 02 PM" src="https://user-images.githubusercontent.com/29959063/163478076-8240203f-866e-487f-b209-15815102f8f1.png">

