### PR TITLE
debug(tests): Added some debugging for flakey ado test

### DIFF
--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -81,7 +81,6 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
 
         external_issue = ExternalIssue.objects.get(key="309")
         assert external_issue
-        forced_error = 1 / 0  # noqa: F841
 
     @responses.activate
     def test_doesnt_create_issue(self):

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -81,6 +81,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
 
         external_issue = ExternalIssue.objects.get(key="309")
         assert external_issue
+        forced_error = 1 / 0  # noqa: F841
 
     @responses.activate
     def test_doesnt_create_issue(self):


### PR DESCRIPTION
Occasionaly, we see the ado create issue test fail. I'm suspecting that the mock URL isn't getting added to the responses. I want to verify that as well as be able to see what individual values are in the issue.

This change will be reverted after debugging is complete