### PR TITLE
fix(workflow): Format metric date to number from query params

### DIFF
--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -125,7 +125,7 @@ class Actions extends Component<Props, State> {
       action_type: action,
       // Alert properties track if the user came from email/slack alerts
       alert_date:
-        typeof alert_date === 'string' ? getUtcDateString(alert_date) : undefined,
+        typeof alert_date === 'string' ? getUtcDateString(Number(alert_date)) : undefined,
       alert_rule_id: typeof alert_rule_id === 'string' ? alert_rule_id : undefined,
       alert_type: typeof alert_type === 'string' ? alert_type : undefined,
     });

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -130,7 +130,7 @@ class GroupDetails extends Component<Props, State> {
       group_id: parseInt(params.groupId, 10),
       // Alert properties track if the user came from email/slack alerts
       alert_date:
-        typeof alert_date === 'string' ? getUtcDateString(alert_date) : undefined,
+        typeof alert_date === 'string' ? getUtcDateString(Number(alert_date)) : undefined,
       alert_rule_id: typeof alert_rule_id === 'string' ? alert_rule_id : undefined,
       alert_type: typeof alert_type === 'string' ? alert_type : undefined,
     });


### PR DESCRIPTION
Fixes an issue with metrics on alert date, before it was "invalid date" because it was a string instead of the unix time as a number