### PR TITLE
fix(alertStatus): Handle alert details page when no project

### DIFF
--- a/static/app/views/alerts/details/ruleDetails.tsx
+++ b/static/app/views/alerts/details/ruleDetails.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 import moment from 'moment';
 
+import Alert from 'sentry/components/alert';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import Button from 'sentry/components/button';
@@ -188,6 +189,14 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
 
     if (!rule) {
       return <LoadingError message={t('There was an error loading the alert rule.')} />;
+    }
+
+    if (!project) {
+      return (
+        <Alert type="warning">
+          {t('The project you were looking for was not found.')}
+        </Alert>
+      );
     }
 
     return (


### PR DESCRIPTION
The page would error without any helpful information if trying to access the alert details page when there's no project. This can happen if a user changes the project name/slug and tries to reload a page using the old project name. This will now show an alert on the page that the project wasn't found.

[FIXES WOR-1765
](https://getsentry.atlassian.net/browse/WOR-1765)[FIXES JAVASCRIPT-26YF](https://sentry.io/organizations/sentry/issues/3171269203/?project=11276)

<img width="1225" alt="Screen Shot 2022-04-14 at 2 40 49 PM" src="https://user-images.githubusercontent.com/20312973/163481886-265a5061-ff46-4087-91f0-ee231a9a8f7b.png">

