### PR TITLE
feat(replay): Allow <Breadcrumbs> to render narrowly in the sidebar

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/index.tsx
@@ -25,6 +25,7 @@ type Props = Pick<React.ComponentProps<typeof Data>, 'route' | 'router'> & {
   searchTerm: string;
   style: React.CSSProperties;
   height?: string;
+  narrow?: boolean;
 };
 
 const Breadcrumb = memo(function Breadcrumb({
@@ -40,12 +41,14 @@ const Breadcrumb = memo(function Breadcrumb({
   route,
   router,
   ['data-test-id']: dataTestId,
+  narrow = false,
 }: Props) {
   const {type, description, color, level, category, timestamp} = breadcrumb;
   const error = breadcrumb.type === BreadcrumbType.ERROR;
 
   return (
     <Wrapper
+      narrow={narrow}
       style={style}
       error={error}
       onLoad={onLoad}
@@ -77,7 +80,45 @@ const Breadcrumb = memo(function Breadcrumb({
 
 export default Breadcrumb;
 
-const Wrapper = styled('div')<{error: boolean; scrollbarSize: number}>`
+const stackedWrapper = `
+grid-template-rows: repeat(2, auto);
+grid-template-columns: max-content 1fr 74px 82px ${p => p.scrollbarSize}px;
+
+> * {
+  padding: ${space(1)};
+
+  /* Type */
+  :nth-child(5n-4) {
+    grid-row: 1/-1;
+    padding-right: 0;
+    padding-left: 0;
+    margin-left: ${space(2)};
+    margin-right: ${space(1)};
+  }
+
+  /* Data */
+  :nth-child(5n-2) {
+    grid-row: 2/2;
+    grid-column: 2/-1;
+    padding-top: 0;
+    padding-right: ${space(2)};
+  }
+
+  /* Level */
+  :nth-child(5n-1) {
+    padding-right: 0;
+    display: flex;
+    justify-content: flex-end;
+    align-items: flex-start;
+  }
+
+  /* Time */
+  :nth-child(5n) {
+    padding: ${space(1)} ${space(2)};
+  }
+}`;
+
+const Wrapper = styled('div')<{error: boolean; narrow: boolean; scrollbarSize: number}>`
   display: grid;
   grid-template-columns: 64px 140px 1fr 106px 100px ${p => p.scrollbarSize}px;
 
@@ -85,44 +126,13 @@ const Wrapper = styled('div')<{error: boolean; scrollbarSize: number}>`
     padding: ${space(1)} ${space(2)};
   }
 
-  @media (max-width: ${props => props.theme.breakpoints[0]}) {
-    grid-template-rows: repeat(2, auto);
-    grid-template-columns: max-content 1fr 74px 82px ${p => p.scrollbarSize}px;
-
-    > * {
-      padding: ${space(1)};
-
-      /* Type */
-      :nth-child(5n-4) {
-        grid-row: 1/-1;
-        padding-right: 0;
-        padding-left: 0;
-        margin-left: ${space(2)};
-        margin-right: ${space(1)};
-      }
-
-      /* Data */
-      :nth-child(5n-2) {
-        grid-row: 2/2;
-        grid-column: 2/-1;
-        padding-top: 0;
-        padding-right: ${space(2)};
-      }
-
-      /* Level */
-      :nth-child(5n-1) {
-        padding-right: 0;
-        display: flex;
-        justify-content: flex-end;
-        align-items: flex-start;
-      }
-
-      /* Time */
-      :nth-child(5n) {
-        padding: ${space(1)} ${space(2)};
-      }
-    }
-  }
+  ${p =>
+    p.narrow
+      ? stackedWrapper
+      : `
+    @media (max-width: ${p.theme.breakpoints[0]}) {
+      ${stackedWrapper}
+    }`}
 
   word-break: break-all;
   white-space: pre-wrap;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -40,19 +40,21 @@ type Props = Pick<
     'emptyMessage' | 'emptyAction'
   >;
   onSwitchTimeFormat: () => void;
+  narrow?: boolean;
 };
 
 function Breadcrumbs({
   breadcrumbs,
   displayRelativeTime,
+  emptyMessage,
+  event,
+  narrow = false,
   onSwitchTimeFormat,
   organization,
-  searchTerm,
-  event,
   relativeTime,
-  emptyMessage,
   route,
   router,
+  searchTerm,
 }: Props) {
   const [scrollToIndex, setScrollToIndex] = useState<number | undefined>(undefined);
   const [scrollbarSize, setScrollbarSize] = useState(0);
@@ -109,6 +111,7 @@ function Breadcrumbs({
             event={event}
             relativeTime={relativeTime}
             displayRelativeTime={displayRelativeTime}
+            narrow={narrow}
             height={height ? String(height) : undefined}
             scrollbarSize={
               (contentRef?.current?.offsetHeight ?? 0) < PANEL_MAX_HEIGHT
@@ -125,6 +128,7 @@ function Breadcrumbs({
 
   return (
     <StyledPanelTable
+      narrow={narrow}
       scrollbarSize={scrollbarSize}
       headers={[
         t('Type'),
@@ -176,7 +180,26 @@ function Breadcrumbs({
 
 export default Breadcrumbs;
 
-const StyledPanelTable = styled(PanelTable)<{scrollbarSize: number}>`
+const hiddenPanelTableHeadings = `> * {
+  :nth-child(-n + 6) {
+    /* Type, Category & Level */
+    :nth-child(6n-5),
+    :nth-child(6n-4),
+    :nth-child(6n-2) {
+      color: transparent;
+    }
+
+    /* Description & Scrollbar */
+    :nth-child(6n-3) {
+      display: none;
+    }
+  }
+}`;
+
+const StyledPanelTable = styled(PanelTable)<{
+  narrow: boolean;
+  scrollbarSize: number;
+}>`
   display: grid;
   grid-template-columns: 64px 140px 1fr 106px 100px ${p => `${p.scrollbarSize}px`};
 
@@ -204,24 +227,18 @@ const StyledPanelTable = styled(PanelTable)<{scrollbarSize: number}>`
     }
   }
 
-  @media (max-width: ${props => props.theme.breakpoints[0]}) {
-    grid-template-columns: 48px 1fr 74px 82px ${p => `${p.scrollbarSize}px`};
-    > * {
-      :nth-child(-n + 6) {
-        /* Type, Category & Level */
-        :nth-child(6n-5),
-        :nth-child(6n-4),
-        :nth-child(6n-2) {
-          color: transparent;
-        }
-
-        /* Description & Scrollbar */
-        :nth-child(6n-3) {
-          display: none;
-        }
+  ${p =>
+    p.narrow
+      ? `
+      grid-template-columns: 48px 1fr 74px 82px ${`${p.scrollbarSize}px`};
+      ${hiddenPanelTableHeadings}
+      `
+      : `
+      @media (max-width: ${props => props.theme.breakpoints[0]}) {
+        grid-template-columns: 48px 1fr 74px 82px ${`${p.scrollbarSize}px`};
+        ${hiddenPanelTableHeadings}
       }
-    }
-  }
+    `}
 
   overflow: hidden;
 `;

--- a/static/app/components/replays/replayBreadcrumbs.tsx
+++ b/static/app/components/replays/replayBreadcrumbs.tsx
@@ -1,0 +1,50 @@
+import React, {useState} from 'react';
+
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import Breadcrumb from 'sentry/components/events/interfaces/breadcrumbs/breadcrumbs';
+import {transformCrumbs} from 'sentry/components/events/interfaces/breadcrumbs/utils';
+import {t} from 'sentry/locale';
+import {Entry} from 'sentry/types/event';
+
+interface Props
+  extends Pick<
+    React.ComponentProps<typeof Breadcrumb>,
+    'event' | 'organization' | 'router' | 'route'
+  > {
+  entry: Entry;
+}
+
+function getEmptyMessage() {
+  return {
+    emptyMessage: t('There are no breadcrumbs to be displayed'),
+  };
+}
+
+function Breadcrumbs({entry, event, organization, route, router}: Props) {
+  const [displayRelativeTime, setDisplayRelativeTime] = useState(false);
+
+  const transformedCrumbs = transformCrumbs(entry.data.values);
+  const relativeTime = transformedCrumbs[transformedCrumbs.length - 1]?.timestamp;
+
+  return (
+    <React.Fragment>
+      <ErrorBoundary>
+        <Breadcrumb
+          narrow
+          router={router}
+          route={route}
+          emptyMessage={getEmptyMessage()}
+          breadcrumbs={transformedCrumbs}
+          event={event}
+          organization={organization}
+          onSwitchTimeFormat={() => setDisplayRelativeTime(!displayRelativeTime)}
+          displayRelativeTime={displayRelativeTime}
+          searchTerm=""
+          relativeTime={relativeTime!} // relativeTime has to be always available, as the last item timestamp is the event created time
+        />
+      </ErrorBoundary>
+    </React.Fragment>
+  );
+}
+
+export default Breadcrumbs;

--- a/static/app/components/replays/replayBreadcrumbs.tsx
+++ b/static/app/components/replays/replayBreadcrumbs.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import {useState} from 'react';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Breadcrumb from 'sentry/components/events/interfaces/breadcrumbs/breadcrumbs';
@@ -14,12 +14,6 @@ interface Props
   entry: Entry;
 }
 
-function getEmptyMessage() {
-  return {
-    emptyMessage: t('There are no breadcrumbs to be displayed'),
-  };
-}
-
 function Breadcrumbs({entry, event, organization, route, router}: Props) {
   const [displayRelativeTime, setDisplayRelativeTime] = useState(false);
 
@@ -27,23 +21,21 @@ function Breadcrumbs({entry, event, organization, route, router}: Props) {
   const relativeTime = transformedCrumbs[transformedCrumbs.length - 1]?.timestamp;
 
   return (
-    <React.Fragment>
-      <ErrorBoundary>
-        <Breadcrumb
-          narrow
-          router={router}
-          route={route}
-          emptyMessage={getEmptyMessage()}
-          breadcrumbs={transformedCrumbs}
-          event={event}
-          organization={organization}
-          onSwitchTimeFormat={() => setDisplayRelativeTime(!displayRelativeTime)}
-          displayRelativeTime={displayRelativeTime}
-          searchTerm=""
-          relativeTime={relativeTime!} // relativeTime has to be always available, as the last item timestamp is the event created time
-        />
-      </ErrorBoundary>
-    </React.Fragment>
+    <ErrorBoundary>
+      <Breadcrumb
+        narrow
+        router={router}
+        route={route}
+        emptyMessage={{emptyMessage: t('There are no breadcrumbs to be displayed')}}
+        breadcrumbs={transformedCrumbs}
+        event={event}
+        organization={organization}
+        onSwitchTimeFormat={() => setDisplayRelativeTime(!displayRelativeTime)}
+        displayRelativeTime={displayRelativeTime}
+        searchTerm=""
+        relativeTime={relativeTime!} // relativeTime has to be always available, as the last item timestamp is the event created time
+      />
+    </ErrorBoundary>
   );
 }
 

--- a/static/app/components/replays/replayHeader.tsx
+++ b/static/app/components/replays/replayHeader.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
+import EventMessage from 'sentry/components/events/eventMessage';
+import FeatureBadge from 'sentry/components/featureBadge';
+import space from 'sentry/styles/space';
+import {Event} from 'sentry/types/event';
+import {getMessage} from 'sentry/utils/events';
+
+const ReplayHeader = ({event}: {event: Event}) => {
+  const message = getMessage(event);
+  return (
+    <EventHeaderContainer data-test-id="event-header">
+      <TitleWrapper>
+        <EventOrGroupTitle data={event} /> <FeatureBadge type="alpha" />
+      </TitleWrapper>
+      {message && (
+        <MessageWrapper>
+          <EventMessage message={message} />
+        </MessageWrapper>
+      )}
+    </EventHeaderContainer>
+  );
+};
+
+const EventHeaderContainer = styled('div')`
+  max-width: ${p => p.theme.breakpoints[0]};
+`;
+
+const TitleWrapper = styled('div')`
+  font-size: ${p => p.theme.headerFontSize};
+  margin-top: 20px;
+`;
+
+const MessageWrapper = styled('div')`
+  margin-top: ${space(1)};
+`;
+
+export default ReplayHeader;

--- a/static/app/components/replays/replayHeader.tsx
+++ b/static/app/components/replays/replayHeader.tsx
@@ -8,7 +8,11 @@ import space from 'sentry/styles/space';
 import {Event} from 'sentry/types/event';
 import {getMessage} from 'sentry/utils/events';
 
-const ReplayHeader = ({event}: {event: Event}) => {
+type Props = {
+  event: Event;
+};
+
+const ReplayHeader = ({event}: Props) => {
   const message = getMessage(event);
   return (
     <EventHeaderContainer data-test-id="event-header">

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -5,23 +5,20 @@ import styled from '@emotion/styled';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import DetailedError from 'sentry/components/errors/detailedError';
 import NotFound from 'sentry/components/errors/notFound';
-import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
 import EventEntry from 'sentry/components/events/eventEntry';
-import EventMessage from 'sentry/components/events/eventMessage';
-import FeatureBadge from 'sentry/components/featureBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import ReplayBreadcrumbs from 'sentry/components/replays/replayBreadcrumbs';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
+import ReplayHeader from 'sentry/components/replays/replayHeader';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import useFullscreen from 'sentry/components/replays/useFullscreen';
 import TagsTable from 'sentry/components/tagsTable';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
-import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {getMessage} from 'sentry/utils/events';
 import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 
@@ -46,22 +43,6 @@ type ReplayLoaderProps = {
 };
 
 type State = AsyncView['state'];
-
-const EventHeader = ({event}: {event: Event}) => {
-  const message = getMessage(event);
-  return (
-    <EventHeaderContainer data-test-id="event-header">
-      <TitleWrapper>
-        <EventOrGroupTitle data={event} /> <FeatureBadge type="alpha" />
-      </TitleWrapper>
-      {message && (
-        <MessageWrapper>
-          <EventMessage message={message} />
-        </MessageWrapper>
-      )}
-    </EventHeaderContainer>
-  );
-};
 
 class ReplayDetails extends AsyncView<Props, State> {
   state: State = {
@@ -181,18 +162,6 @@ function ReplayLoader(props: ReplayLoaderProps) {
           </FullscreenWrapper>
         </ReplayContextProvider>
 
-        {breadcrumbEntry && (
-          <EventEntry
-            projectSlug={getProjectSlug(event)}
-            // group={group}
-            organization={props.organization}
-            event={event}
-            entry={breadcrumbEntry}
-            route={props.route}
-            router={props.router}
-          />
-        )}
-
         {mergedReplayEvent && (
           <EventEntry
             key={`${mergedReplayEvent.id}`}
@@ -211,7 +180,20 @@ function ReplayLoader(props: ReplayLoaderProps) {
 
   const renderSide = () => {
     if (event) {
-      return <TagsTable generateUrl={() => ''} event={event} query="" />;
+      return (
+        <React.Fragment>
+          {breadcrumbEntry && (
+            <ReplayBreadcrumbs
+              entry={breadcrumbEntry}
+              event={event}
+              organization={props.organization}
+              route={props.route}
+              router={props.router}
+            />
+          )}
+          <TagsTable generateUrl={() => ''} event={event} query="" />
+        </React.Fragment>
+      );
     }
     return null;
   };
@@ -229,7 +211,7 @@ function ReplayLoader(props: ReplayLoaderProps) {
               {label: t('Replay Details')}, // TODO(replay): put replay ID or something here
             ]}
           />
-          {event ? <EventHeader event={event} /> : null}
+          {event ? <ReplayHeader event={event} /> : null}
         </Layout.HeaderContent>
       </Layout.Header>
       <Layout.Body>
@@ -239,19 +221,6 @@ function ReplayLoader(props: ReplayLoaderProps) {
     </NoPaddingContent>
   );
 }
-
-const EventHeaderContainer = styled('div')`
-  max-width: ${p => p.theme.breakpoints[0]};
-`;
-
-const TitleWrapper = styled('div')`
-  font-size: ${p => p.theme.headerFontSize};
-  margin-top: 20px;
-`;
-
-const MessageWrapper = styled('div')`
-  margin-top: ${space(1)};
-`;
 
 const NoPaddingContent = styled(PageContent)`
   padding: 0;


### PR DESCRIPTION
[events/interfaces/breadcrumbs/breadcrumb/index.tsx](https://github.com/getsentry/sentry/pull/33636/files#diff-4c67b861c17806121b3f65ae6b91ec30a5bd4b18eb9fb6557d3e8416792877af) is responsive to the window size, not the size of it's container. 

This adds some props so that `<Breadcrumb>` can render itself inside of skinny containers, and then sticks the breadcrumbs into the sidebar of the replay details page.

<img width="1515" alt="Screen Shot 2022-04-14 at 2 51 30 PM" src="https://user-images.githubusercontent.com/187460/163482629-e6738804-6bf7-4a01-b8ce-5ff907ab8b88.png">


Relates to #33668 