### PR TITLE
fix(releasemonitor): Log query timeouts as errors instead of info.

### DIFF
--- a/src/sentry/tasks/releasemonitor.py
+++ b/src/sentry/tasks/releasemonitor.py
@@ -82,9 +82,8 @@ def monitor_release_adoption(**kwargs):
                 break
 
         else:
-            logger.info(
+            logger.error(
                 "monitor_release_adoption.loop_timeout",
-                sample_rate=1.0,
                 extra={"offset": offset},
             )
     with metrics.timer(
@@ -180,7 +179,7 @@ def sum_sessions_and_releases(org_id, project_ids):
             if not more_results:
                 break
         else:
-            logger.info(
+            logger.error(
                 "process_projects_with_sessions.loop_timeout",
                 extra={"org_id": org_id, "project_ids": project_ids},
             )


### PR DESCRIPTION
If we get timeouts while scheduling or calculating release stages for a given task we should log
these as errors, since it means the task isn't finishing all of its work.