### PR TITLE
fix: Upgrade progressbar2 to avoid `collections.abc` warnings

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -36,7 +36,7 @@ parsimonious==0.8.0
 petname==2.6
 phonenumberslite==8.12.0
 Pillow==9.0.1
-progressbar2==3.32.0
+progressbar2==3.41.0
 python-rapidjson==1.4
 psycopg2-binary==2.8.6
 PyJWT==2.1.0


### PR DESCRIPTION
against 3.32.0:

```console
$ python3 -Werror -c 'import progressbar.bar'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/progressbar/__init__.py", line 27, in <module>
    from .bar import (
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/progressbar/bar.py", line 41, in <module>
    class ProgressBarBase(collections.Iterable, ProgressBarMixinBase):
  File "/Users/asottile/.pyenv/versions/3.8.13/lib/python3.8/collections/__init__.py", line 49, in __getattr__
    warnings.warn("Using or importing the ABCs from 'collections' instead "
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```

against 3.41.0:

```console
$ python3 -Werror -c 'import progressbar.bar'
$
```

this was fixed in https://github.com/WoLpH/python-progressbar/commit/9af4d70e5e73fc1aa78f23bc808126ebe361580d (which claims to be released in 3.40.0 -- however that appears to be missing on pypi)