### PR TITLE
feat(replays): replaced the global header with the new filter components on the replays index.

### DIFF
--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -10,39 +10,23 @@ import space from 'sentry/styles/space';
 function ReplaysFilters() {
   return (
     <FilterContainer>
-      <SearchContainer>
-        <PageFilterBar>
-          <ProjectPageFilter />
-          <EnvironmentPageFilter alignDropdown="left" />
-          <DatePageFilter alignDropdown="left" />
-        </PageFilterBar>
-      </SearchContainer>
+      <PageFilterBar>
+        <ProjectPageFilter />
+        <EnvironmentPageFilter alignDropdown="left" />
+        <DatePageFilter alignDropdown="left" />
+      </PageFilterBar>
     </FilterContainer>
   );
 }
 
 const FilterContainer = styled('div')`
-  display: grid;
-  gap: ${space(1)};
-  margin-bottom: ${space(1)};
-`;
-
-const SearchContainer = styled('div')<{
-  hasPageFilters?: boolean;
-}>`
-  display: inline-grid;
-  gap: ${space(1)};
-  width: 100%;
+  width: max-content;
+  max-width: 100%;
   margin-bottom: ${space(1)};
 
-  ${p =>
-    p.hasPageFilters
-      ? `grid-template-columns: minmax(0, max-content) minmax(20rem, 1fr);`
-      : `
-    @media (min-width: ${p.theme.breakpoints[0]}) {
-      grid-template-columns: 1fr auto;
-    }
-  }`}
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: 1fr auto;
+  }
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: minmax(0, 1fr);

--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -9,28 +9,18 @@ import space from 'sentry/styles/space';
 
 function ReplaysFilters() {
   return (
-    <FilterContainer>
-      <PageFilterBar>
-        <ProjectPageFilter />
-        <EnvironmentPageFilter alignDropdown="left" />
-        <DatePageFilter alignDropdown="left" />
-      </PageFilterBar>
-    </FilterContainer>
+    <StyledPageFilterBar>
+      <ProjectPageFilter />
+      <EnvironmentPageFilter />
+      <DatePageFilter />
+    </StyledPageFilterBar>
   );
 }
 
-const FilterContainer = styled('div')`
+const StyledPageFilterBar = styled(PageFilterBar)`
   width: max-content;
   max-width: 100%;
   margin-bottom: ${space(1)};
-
-  @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    grid-template-columns: 1fr auto;
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    grid-template-columns: minmax(0, 1fr);
-  }
 `;
 
 export default ReplaysFilters;

--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+
+import DatePageFilter from 'sentry/components/datePageFilter';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import ProjectPageFilter from 'sentry/components/projectPageFilter';
+import space from 'sentry/styles/space';
+
+function ReplaysFilters() {
+  return (
+    <FilterContainer>
+      <SearchContainer>
+        <PageFilterBar>
+          <ProjectPageFilter />
+          <EnvironmentPageFilter alignDropdown="left" />
+          <DatePageFilter alignDropdown="left" />
+        </PageFilterBar>
+      </SearchContainer>
+    </FilterContainer>
+  );
+}
+
+const FilterContainer = styled('div')`
+  display: grid;
+  gap: ${space(1)};
+  margin-bottom: ${space(1)};
+`;
+
+const SearchContainer = styled('div')<{
+  hasPageFilters?: boolean;
+}>`
+  display: inline-grid;
+  gap: ${space(1)};
+  width: 100%;
+  margin-bottom: ${space(1)};
+
+  ${p =>
+    p.hasPageFilters
+      ? `grid-template-columns: minmax(0, max-content) minmax(20rem, 1fr);`
+      : `
+    @media (min-width: ${p.theme.breakpoints[0]}) {
+      grid-template-columns: 1fr auto;
+    }
+  }`}
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+`;
+
+export default ReplaysFilters;

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -93,44 +93,56 @@ class Replays extends React.Component<Props> {
   render() {
     const {organization} = this.props;
     return (
-      <PageFiltersContainer hideGlobalHeader resetParamsOnChange={['cursor']}>
-        <PageContent>
-          <PageHeader>
-            <HeaderTitle>
-              <div>
-                {t('Replays')} <FeatureBadge type="alpha" />
-              </div>
-            </HeaderTitle>
-          </PageHeader>
-
-          <DiscoverQuery
-            eventView={this.getEventView()}
-            location={this.props.location}
-            orgSlug={organization.slug}
-          >
-            {data => {
-              return (
-                <React.Fragment>
-                  <ReplaysFilters />
-                  <PanelTable
-                    isLoading={data.isLoading}
-                    isEmpty={data.tableData?.data.length === 0}
-                    headers={[t('Session'), t('Timestamp')]}
-                  >
-                    {data.tableData
-                      ? this.renderTable(data.tableData.data as Replay[])
-                      : null}
-                  </PanelTable>
-                  <Pagination pageLinks={data.pageLinks} />
-                </React.Fragment>
-              );
-            }}
-          </DiscoverQuery>
-        </PageContent>
-      </PageFiltersContainer>
+      <React.Fragment>
+        <StyledPageHeader>
+          <HeaderTitle>
+            <div>
+              {t('Replays')} <FeatureBadge type="alpha" />
+            </div>
+          </HeaderTitle>
+        </StyledPageHeader>
+        <PageFiltersContainer hideGlobalHeader resetParamsOnChange={['cursor']}>
+          <StyledPageContent>
+            <DiscoverQuery
+              eventView={this.getEventView()}
+              location={this.props.location}
+              orgSlug={organization.slug}
+            >
+              {data => {
+                return (
+                  <React.Fragment>
+                    <ReplaysFilters />
+                    <PanelTable
+                      isLoading={data.isLoading}
+                      isEmpty={data.tableData?.data.length === 0}
+                      headers={[t('Session'), t('Timestamp')]}
+                    >
+                      {data.tableData
+                        ? this.renderTable(data.tableData.data as Replay[])
+                        : null}
+                    </PanelTable>
+                    <Pagination pageLinks={data.pageLinks} />
+                  </React.Fragment>
+                );
+              }}
+            </DiscoverQuery>
+          </StyledPageContent>
+        </PageFiltersContainer>
+      </React.Fragment>
     );
   }
 }
+
+const StyledPageHeader = styled(PageHeader)`
+  background-color: ${p => p.theme.surface100};
+  margin-top: 10px;
+  margin-left: 30px;
+`;
+
+const StyledPageContent = styled(PageContent)`
+  box-shadow: 0px 0px 1px ${p => p.theme.gray200};
+  background-color: ${p => p.theme.white};
+`;
 
 const HeaderTitle = styled(PageHeading)`
   display: flex;

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -22,6 +22,7 @@ import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import AsyncView from 'sentry/views/asyncView';
 
+import ReplaysFilters from './filters';
 import {Replay} from './types';
 
 type Props = AsyncView['props'] &
@@ -92,10 +93,7 @@ class Replays extends React.Component<Props> {
   render() {
     const {organization} = this.props;
     return (
-      <PageFiltersContainer
-        showEnvironmentSelector={false}
-        resetParamsOnChange={['cursor']}
-      >
+      <PageFiltersContainer hideGlobalHeader resetParamsOnChange={['cursor']}>
         <PageContent>
           <PageHeader>
             <HeaderTitle>
@@ -113,6 +111,7 @@ class Replays extends React.Component<Props> {
             {data => {
               return (
                 <React.Fragment>
+                  <ReplaysFilters />
                   <PanelTable
                     isLoading={data.isLoading}
                     isEmpty={data.tableData?.data.length === 0}

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -135,8 +135,8 @@ class Replays extends React.Component<Props> {
 
 const StyledPageHeader = styled(PageHeader)`
   background-color: ${p => p.theme.surface100};
-  margin-top: 10px;
-  margin-left: 30px;
+  margin-top: ${space(1.5)};
+  margin-left: ${space(4)};
 `;
 
 const StyledPageContent = styled(PageContent)`


### PR DESCRIPTION
# Description
#33270 
- Replaced the global header with the new filter components on the replays index.

# Screenshots
<img width="1405" alt="image" src="https://user-images.githubusercontent.com/7014871/163596066-4836dd0e-98bf-4195-ad1b-b7f628e02665.png">
<img width="445" alt="image" src="https://user-images.githubusercontent.com/7014871/163595755-ded5574a-5847-4ce6-aedf-472354acb553.png">




# Known Gotchas
- Search is part of this header but that's part of the work within ticket #33271, so if it's better to have that available along with this let me know and I can close this PR and add in search.