### PR TITLE
ref(access logs): Add rate limit group

### DIFF
--- a/src/sentry/middleware/access_log.py
+++ b/src/sentry/middleware/access_log.py
@@ -10,7 +10,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.utils import metrics
-from sentry.ratelimits.config import RateLimitConfig
 
 from . import is_frontend_request
 
@@ -48,6 +47,7 @@ def _get_rate_limit_stats_dict(request: Request) -> dict[str, str]:
         "concurrent_limit": str(None),
         "concurrent_requests": str(None),
         "reset_time": str(None),
+        "group": str(None),
         "limit": str(None),
         "remaining": str(None),
     }
@@ -77,7 +77,6 @@ def _create_api_access_log(
         user_id = getattr(request_user, "id", None)
         is_app = getattr(request_user, "is_sentry_app", None)
         org_id = getattr(getattr(request, "organization", None), "id", None)
-        rate_limit_group = getattr(request, "rate_limit_group", RateLimitConfig().group)
         request_auth = _get_request_auth(request)
         auth_id = getattr(request_auth, "id", None)
         status_code = getattr(response, "status_code", 500)
@@ -95,7 +94,6 @@ def _create_api_access_log(
             caller_ip=str(request.META.get("REMOTE_ADDR")),
             user_agent=str(request.META.get("HTTP_USER_AGENT")),
             rate_limited=str(getattr(request, "will_be_rate_limited", False)),
-            rate_limit_group=str(rate_limit_group),
             rate_limit_category=str(getattr(request, "rate_limit_category", None)),
             request_duration_seconds=access_log_metadata.get_request_duration(),
             **_get_rate_limit_stats_dict(request),

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -59,7 +59,9 @@ class RatelimitMiddleware:
                 rate_limit_group = (
                     rate_limit_config.group if rate_limit_config else RateLimitConfig().group
                 )
-                request.rate_limit_key = get_rate_limit_key(view_func, request, rate_limit_config)
+                request.rate_limit_key = get_rate_limit_key(
+                    view_func, request, rate_limit_group, rate_limit_config
+                )
                 if request.rate_limit_key is None:
                     return
 

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -53,7 +53,8 @@ class RatelimitMiddleware:
                 request.rate_limit_category = None
                 request.rate_limit_uid = uuid.uuid4().hex
                 view_class = getattr(view_func, "view_class", None)
-                rate_limit_config = get_rate_limit_config(view_class)
+                if view_class:
+                    rate_limit_config = get_rate_limit_config(view_class)
                 request.rate_limit_group = (
                     rate_limit_config.group if rate_limit_config else RateLimitConfig().group
                 )

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -16,7 +16,7 @@ from sentry.ratelimits import (
     get_rate_limit_key,
     get_rate_limit_value,
 )
-from sentry.ratelimits.config import ENFORCE_CONCURRENT_RATE_LIMITS, RateLimitConfig
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimitCategory, RateLimitMeta, RateLimitType
 from sentry.utils import json, metrics
 

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -70,7 +70,6 @@ class RatelimitMiddleware:
 
                 rate_limit = get_rate_limit_value(
                     http_method=request.method,
-                    endpoint=view_class,
                     category=RateLimitCategory(category_str),
                     rate_limit_config=rate_limit_config,
                 )

--- a/src/sentry/ratelimits/__init__.py
+++ b/src/sentry/ratelimits/__init__.py
@@ -5,6 +5,7 @@ from sentry.utils.services import LazyServiceWrapper
 __all__ = (
     "for_organization_member_invite",
     "above_rate_limit_check",
+    "get_rate_limit_config",
     "get_rate_limit_key",
     "get_rate_limit_value",
     "finish_request",
@@ -22,6 +23,7 @@ from .utils import (
     above_rate_limit_check,
     finish_request,
     for_organization_member_invite,
+    get_rate_limit_config,
     get_rate_limit_key,
     get_rate_limit_value,
 )

--- a/src/sentry/ratelimits/__init__.py
+++ b/src/sentry/ratelimits/__init__.py
@@ -10,7 +10,6 @@ __all__ = (
     "get_rate_limit_value",
     "finish_request",
     "RateLimiter",
-    "RateLimitConfig",
 )
 
 from .base import RateLimiter
@@ -21,7 +20,6 @@ backend = LazyServiceWrapper(
 backend.expose(locals())
 
 from .utils import (
-    RateLimitConfig,
     above_rate_limit_check,
     finish_request,
     for_organization_member_invite,

--- a/src/sentry/ratelimits/__init__.py
+++ b/src/sentry/ratelimits/__init__.py
@@ -10,6 +10,7 @@ __all__ = (
     "get_rate_limit_value",
     "finish_request",
     "RateLimiter",
+    "RateLimitConfig",
 )
 
 from .base import RateLimiter
@@ -20,6 +21,7 @@ backend = LazyServiceWrapper(
 backend.expose(locals())
 
 from .utils import (
+    RateLimitConfig,
     above_rate_limit_check,
     finish_request,
     for_organization_member_invite,

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -94,7 +94,9 @@ def get_rate_limit_key(
     # If IP address doesn't exist, skip ratelimiting for now
     else:
         return None
-    group = rate_limit_config.group if rate_limit_config else RateLimitConfig().group
+
+    group = rate_limit_config.group
+
     if rate_limit_config and rate_limit_config.has_custom_limit():
         # if there is a custom rate limit on the endpoint, we add view to the key
         # otherwise we just use what's default for the group
@@ -133,7 +135,9 @@ def get_rate_limit_value(
     return rate_limit_config.get_rate_limit(http_method, category)
 
 
-def above_rate_limit_check(key: str, rate_limit: RateLimit, request_uid: str) -> RateLimitMeta:
+def above_rate_limit_check(
+    key: str, rate_limit: RateLimit, request_uid: str, group: str
+) -> RateLimitMeta:
     # TODO: This is not as performant as it could be. The roundtrip betwwen the server and redis
     # is doubled because the fixd window limit and concurrent limit are two separate things with different
     # paths. Ideally there is just one lua script that does both and just says what kind of limit was hit
@@ -162,6 +166,7 @@ def above_rate_limit_check(key: str, rate_limit: RateLimit, request_uid: str) ->
         current=current,
         limit=rate_limit.limit,
         window=rate_limit.window,
+        group=group,
         reset_time=reset_time,
         remaining=remaining,
         concurrent_limit=rate_limit.concurrent_limit,

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -125,12 +125,10 @@ def get_rate_limit_config(endpoint: Type[object]) -> RateLimitConfig | None:
 
 def get_rate_limit_value(
     http_method: str,
-    endpoint: Type[object],
     category: RateLimitCategory,
     rate_limit_config: RateLimitConfig | None,
 ) -> RateLimit | None:
     """Read the rate limit from the view function to be used for the rate limit check."""
-    # types are hashable in python, the type checker disagrees though
     if not rate_limit_config:
         return None
     return rate_limit_config.get_rate_limit(http_method, category)

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -39,7 +39,10 @@ def concurrent_limiter() -> ConcurrentRateLimiter:
 
 
 def get_rate_limit_key(
-    view_func: EndpointFunction, request: Request, rate_limit_config: RateLimitConfig | None = None
+    view_func: EndpointFunction,
+    request: Request,
+    rate_limit_group: str,
+    rate_limit_config: RateLimitConfig | None = None,
 ) -> str | None:
     """Construct a consistent global rate limit key using the arguments provided"""
     if not hasattr(view_func, "view_class") or request.path_info.startswith(
@@ -95,14 +98,12 @@ def get_rate_limit_key(
     else:
         return None
 
-    group = rate_limit_config.group
-
     if rate_limit_config and rate_limit_config.has_custom_limit():
         # if there is a custom rate limit on the endpoint, we add view to the key
         # otherwise we just use what's default for the group
-        return f"{category}:{group}:{view}:{http_method}:{id}"
+        return f"{category}:{rate_limit_group}:{view}:{http_method}:{id}"
     else:
-        return f"{category}:{group}:{http_method}:{id}"
+        return f"{category}:{rate_limit_group}:{http_method}:{id}"
 
 
 def get_organization_id_from_token(token_id: str) -> int | None:

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -53,6 +53,7 @@ class RateLimitMeta:
     remaining: int
     limit: int
     window: int
+    group: str
     reset_time: int
     concurrent_limit: int | None
     concurrent_requests: int | None

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -79,7 +79,7 @@ access_log_fields = (
     "rate_limited",
     "rate_limit_category",
     "request_duration_seconds",
-    "rate_limit_group",
+    "group",
     "rate_limit_type",
     "concurrent_limit",
     "concurrent_requests",
@@ -142,7 +142,7 @@ class TestAccessLogRateLimited(LogCaptureAPITestCase):
         assert self.captured_logs[0].token_type == "None"
         assert self.captured_logs[0].limit == "0"
         assert self.captured_logs[0].remaining == "0"
-        assert self.captured_logs[0].rate_limit_group == RateLimitedEndpoint.rate_limits.group
+        assert self.captured_logs[0].group == RateLimitedEndpoint.rate_limits.group
 
 
 @override_settings(SENTRY_SELF_HOSTED=False)
@@ -159,7 +159,7 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
         self.assert_access_log_recorded()
         for i in range(10):
             assert self.captured_logs[i].token_type == "None"
-            assert self.captured_logs[0].rate_limit_group == RateLimitedEndpoint.rate_limits.group
+            assert self.captured_logs[0].group == RateLimitedEndpoint.rate_limits.group
             assert self.captured_logs[i].concurrent_requests == "1"
             assert self.captured_logs[i].concurrent_limit == "1"
             assert self.captured_logs[i].rate_limit_type == "RateLimitType.NOT_LIMITED"

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -79,6 +79,7 @@ access_log_fields = (
     "rate_limited",
     "rate_limit_category",
     "request_duration_seconds",
+    "rate_limit_group",
     "rate_limit_type",
     "concurrent_limit",
     "concurrent_requests",
@@ -141,6 +142,7 @@ class TestAccessLogRateLimited(LogCaptureAPITestCase):
         assert self.captured_logs[0].token_type == "None"
         assert self.captured_logs[0].limit == "0"
         assert self.captured_logs[0].remaining == "0"
+        assert self.captured_logs[0].rate_limit_group == RateLimitedEndpoint.rate_limits.group
 
 
 @override_settings(SENTRY_SELF_HOSTED=False)
@@ -157,6 +159,7 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
         self.assert_access_log_recorded()
         for i in range(10):
             assert self.captured_logs[i].token_type == "None"
+            assert self.captured_logs[0].rate_limit_group == RateLimitedEndpoint.rate_limits.group
             assert self.captured_logs[i].concurrent_requests == "1"
             assert self.captured_logs[i].concurrent_limit == "1"
             assert self.captured_logs[i].rate_limit_type == "RateLimitType.NOT_LIMITED"

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -223,13 +223,13 @@ class TestGetRateLimitValue(TestCase):
         rate_limit_config = get_rate_limit_config(view.view_class)
 
         assert get_rate_limit_value(
-            "GET", TestEndpoint, "ip", rate_limit_config
+            "GET", "ip", rate_limit_config
         ) == get_default_rate_limits_for_group("default", RateLimitCategory.IP)
         assert get_rate_limit_value(
-            "POST", TestEndpoint, "org", rate_limit_config
+            "POST", "org", rate_limit_config
         ) == get_default_rate_limits_for_group("default", RateLimitCategory.ORGANIZATION)
         assert get_rate_limit_value(
-            "DELETE", TestEndpoint, "user", rate_limit_config
+            "DELETE", "user", rate_limit_config
         ) == get_default_rate_limits_for_group("default", RateLimitCategory.USER)
 
     def test_override_rate_limit(self):
@@ -244,20 +244,16 @@ class TestGetRateLimitValue(TestCase):
         view = TestEndpoint.as_view()
         rate_limit_config = get_rate_limit_config(view.view_class)
 
-        assert get_rate_limit_value("GET", TestEndpoint, "ip", rate_limit_config) == RateLimit(
-            100, 5
-        )
+        assert get_rate_limit_value("GET", "ip", rate_limit_config) == RateLimit(100, 5)
         # get is not overriddent for user, hence we use the default
         assert get_rate_limit_value(
-            "GET", TestEndpoint, "user", rate_limit_config
+            "GET", "user", rate_limit_config
         ) == get_default_rate_limits_for_group("default", category=RateLimitCategory.USER)
         # get is not overriddent for IP, hence we use the default
         assert get_rate_limit_value(
-            "POST", TestEndpoint, "ip", rate_limit_config
+            "POST", "ip", rate_limit_config
         ) == get_default_rate_limits_for_group("default", category=RateLimitCategory.IP)
-        assert get_rate_limit_value("POST", TestEndpoint, "user", rate_limit_config) == RateLimit(
-            20, 4
-        )
+        assert get_rate_limit_value("POST", "user", rate_limit_config) == RateLimit(20, 4)
 
 
 class RateLimitHeaderTestEndpoint(Endpoint):

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -5,32 +5,40 @@ from unittest import TestCase
 
 from freezegun import freeze_time
 
-from sentry.ratelimits import above_rate_limit_check, finish_request
+from sentry.ratelimits import RateLimitConfig, above_rate_limit_check, finish_request
 from sentry.types.ratelimit import RateLimit, RateLimitMeta, RateLimitType
 
 
 class RatelimitMiddlewareTest(TestCase):
+    group = RateLimitConfig().group
+
     def test_above_rate_limit_check(self):
         with freeze_time("2000-01-01"):
             expected_reset_time = int(time() + 100)
-            return_val = above_rate_limit_check("foo", RateLimit(10, 100), "request_uid")
+            return_val = above_rate_limit_check(
+                "foo", RateLimit(10, 100), "request_uid", self.group
+            )
             assert return_val == RateLimitMeta(
                 rate_limit_type=RateLimitType.NOT_LIMITED,
                 current=1,
                 limit=10,
                 window=100,
+                group=self.group,
                 reset_time=expected_reset_time,
                 remaining=9,
                 concurrent_limit=None,
                 concurrent_requests=None,
             )
             for i in range(10):
-                return_val = above_rate_limit_check("foo", RateLimit(10, 100), f"request_uid{i}")
+                return_val = above_rate_limit_check(
+                    "foo", RateLimit(10, 100), f"request_uid{i}", self.group
+                )
             assert return_val == RateLimitMeta(
                 rate_limit_type=RateLimitType.FIXED_WINDOW,
                 current=11,
                 limit=10,
                 window=100,
+                group=self.group,
                 reset_time=expected_reset_time,
                 remaining=0,
                 concurrent_limit=None,
@@ -39,13 +47,14 @@ class RatelimitMiddlewareTest(TestCase):
 
             for i in range(10):
                 return_val = above_rate_limit_check(
-                    "bar", RateLimit(120, 100, 9), f"request_uid{i}"
+                    "bar", RateLimit(120, 100, 9), f"request_uid{i}", self.group
                 )
             assert return_val == RateLimitMeta(
                 rate_limit_type=RateLimitType.CONCURRENT,
                 current=10,
                 limit=120,
                 window=100,
+                group=self.group,
                 reset_time=expected_reset_time,
                 remaining=110,
                 concurrent_limit=9,
@@ -55,7 +64,7 @@ class RatelimitMiddlewareTest(TestCase):
     def test_concurrent(self):
         def do_request():
             uid = uuid.uuid4().hex
-            meta = above_rate_limit_check("foo", RateLimit(10, 1, 3), uid)
+            meta = above_rate_limit_check("foo", RateLimit(10, 1, 3), uid, self.group)
             sleep(0.2)
             finish_request("foo", uid)
             return meta
@@ -72,6 +81,6 @@ class RatelimitMiddlewareTest(TestCase):
     def test_window_and_concurrent_limit(self):
         """Test that if there is a window limit and a concurrent limit, the
         FIXED_WINDOW limit takes precedence"""
-        return_val = above_rate_limit_check("xar", RateLimit(0, 100, 0), "request_uid")
+        return_val = above_rate_limit_check("xar", RateLimit(0, 100, 0), "request_uid", self.group)
         assert return_val.rate_limit_type == RateLimitType.FIXED_WINDOW
         assert return_val.concurrent_remaining is None

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -5,7 +5,8 @@ from unittest import TestCase
 
 from freezegun import freeze_time
 
-from sentry.ratelimits import RateLimitConfig, above_rate_limit_check, finish_request
+from sentry.ratelimits import above_rate_limit_check, finish_request
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitMeta, RateLimitType
 
 

--- a/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
+++ b/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
@@ -17,13 +17,13 @@ class TestGetRateLimitValue(TestCase):
         rate_limit_config = get_rate_limit_config(_test_endpoint.view_class)
 
         assert get_rate_limit_value(
-            "GET", TestEndpoint, RateLimitCategory.IP, rate_limit_config
+            "GET", RateLimitCategory.IP, rate_limit_config
         ) == get_default_rate_limits_for_group("default", RateLimitCategory.IP)
         assert get_rate_limit_value(
-            "POST", TestEndpoint, RateLimitCategory.ORGANIZATION, rate_limit_config
+            "POST", RateLimitCategory.ORGANIZATION, rate_limit_config
         ) == get_default_rate_limits_for_group("default", RateLimitCategory.ORGANIZATION)
         assert get_rate_limit_value(
-            "DELETE", TestEndpoint, RateLimitCategory.USER, rate_limit_config
+            "DELETE", RateLimitCategory.USER, rate_limit_config
         ) == get_default_rate_limits_for_group("default", RateLimitCategory.USER)
 
     def test_override_rate_limit(self):
@@ -38,18 +38,18 @@ class TestGetRateLimitValue(TestCase):
         _test_endpoint = TestEndpoint.as_view()
         rate_limit_config = get_rate_limit_config(_test_endpoint.view_class)
 
+        assert get_rate_limit_value("GET", RateLimitCategory.IP, rate_limit_config) == RateLimit(
+            100, 5
+        )
         assert get_rate_limit_value(
-            "GET", TestEndpoint, RateLimitCategory.IP, rate_limit_config
-        ) == RateLimit(100, 5)
-        assert get_rate_limit_value(
-            "GET", TestEndpoint, RateLimitCategory.USER, rate_limit_config
+            "GET", RateLimitCategory.USER, rate_limit_config
         ) == get_default_rate_limits_for_group("default", RateLimitCategory.USER)
         assert get_rate_limit_value(
-            "POST", TestEndpoint, RateLimitCategory.IP, rate_limit_config
+            "POST", RateLimitCategory.IP, rate_limit_config
         ) == get_default_rate_limits_for_group("default", RateLimitCategory.IP)
-        assert get_rate_limit_value(
-            "POST", TestEndpoint, RateLimitCategory.USER, rate_limit_config
-        ) == RateLimit(20, 4)
+        assert get_rate_limit_value("POST", RateLimitCategory.USER, rate_limit_config) == RateLimit(
+            20, 4
+        )
 
     def test_inherit(self):
         class ParentEndpoint(Endpoint):
@@ -64,7 +64,7 @@ class TestGetRateLimitValue(TestCase):
         rate_limit_config = get_rate_limit_config(_child_endpoint.view_class)
 
         assert get_rate_limit_value(
-            "GET", ChildEndpoint, RateLimitCategory.IP, rate_limit_config
+            "GET", RateLimitCategory.IP, rate_limit_config
         ) == get_default_rate_limits_for_group("foo", RateLimitCategory.IP)
 
     def test_multiple_inheritance(self):
@@ -86,9 +86,9 @@ class TestGetRateLimitValue(TestCase):
         _child_endpoint_reverse = ChildEndpointReverse.as_view()
         rate_limit_config_reverse = get_rate_limit_config(_child_endpoint_reverse.view_class)
 
+        assert get_rate_limit_value("GET", RateLimitCategory.IP, rate_limit_config) == RateLimit(
+            100, 5
+        )
         assert get_rate_limit_value(
-            "GET", ChildEndpoint, RateLimitCategory.IP, rate_limit_config
-        ) == RateLimit(100, 5)
-        assert get_rate_limit_value(
-            "GET", ChildEndpointReverse, RateLimitCategory.IP, rate_limit_config_reverse
+            "GET", RateLimitCategory.IP, rate_limit_config_reverse
         ) == RateLimit(2, 4)

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -6,7 +6,7 @@ from sentry.api.endpoints.organization_group_index import OrganizationGroupIndex
 from sentry.auth.system import SystemToken
 from sentry.mediators.token_exchange import GrantExchanger
 from sentry.models import User
-from sentry.ratelimits import get_rate_limit_key
+from sentry.ratelimits import get_rate_limit_config, get_rate_limit_key
 from sentry.testutils.cases import TestCase
 
 
@@ -14,34 +14,35 @@ class GetRateLimitKeyTest(TestCase):
     def setUp(self) -> None:
         self.view = OrganizationGroupIndexEndpoint.as_view()
         self.request = RequestFactory().get("/")
+        self.rate_limit_config = get_rate_limit_config(self.view.view_class)
 
     def test_default_ip(self):
         assert (
-            get_rate_limit_key(self.view, self.request)
+            get_rate_limit_key(self.view, self.request, self.rate_limit_config)
             == "ip:default:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
         )
 
     def test_ip_address_missing(self):
         self.request.META["REMOTE_ADDR"] = None
-        assert get_rate_limit_key(self.view, self.request) is None
+        assert get_rate_limit_key(self.view, self.request, self.rate_limit_config) is None
 
     def test_ipv6(self):
         self.request.META["REMOTE_ADDR"] = "684D:1111:222:3333:4444:5555:6:77"
         assert (
-            get_rate_limit_key(self.view, self.request)
+            get_rate_limit_key(self.view, self.request, self.rate_limit_config)
             == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
     def test_system_token(self):
         self.request.auth = SystemToken()
-        assert get_rate_limit_key(self.view, self.request) is None
+        assert get_rate_limit_key(self.view, self.request, self.rate_limit_config) is None
 
     def test_users(self):
         user = User(id=1)
         self.request.session = {}
         self.request.user = user
         assert (
-            get_rate_limit_key(self.view, self.request)
+            get_rate_limit_key(self.view, self.request, self.rate_limit_config)
             == f"user:default:OrganizationGroupIndexEndpoint:GET:{user.id}"
         )
 
@@ -66,7 +67,7 @@ class GetRateLimitKeyTest(TestCase):
         self.request.auth = api_token
 
         assert (
-            get_rate_limit_key(self.view, self.request)
+            get_rate_limit_key(self.view, self.request, self.rate_limit_config)
             == f"org:default:OrganizationGroupIndexEndpoint:GET:{install.organization_id}"
         )
 
@@ -79,9 +80,13 @@ class TestDefaultToGroup(TestCase):
     def setUp(self) -> None:
         self.view = DummyEndpoint.as_view()
         self.request = RequestFactory().get("/")
+        self.rate_limit_config = get_rate_limit_config(self.view.view_class)
 
     def test_group_key(self):
         user = User(id=1)
         self.request.session = {}
         self.request.user = user
-        assert get_rate_limit_key(self.view, self.request) == f"user:default:GET:{user.id}"
+        assert (
+            get_rate_limit_key(self.view, self.request, self.rate_limit_config)
+            == f"user:default:GET:{user.id}"
+        )

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -16,33 +16,43 @@ class GetRateLimitKeyTest(TestCase):
         self.view = OrganizationGroupIndexEndpoint.as_view()
         self.request = RequestFactory().get("/")
         self.rate_limit_config = get_rate_limit_config(self.view.view_class)
-        self.group = (
+        self.rate_limit_group = (
             self.rate_limit_config.group if self.rate_limit_config else RateLimitConfig().group
         )
 
     def test_default_ip(self):
         assert (
-            get_rate_limit_key(self.view, self.request, self.group, self.rate_limit_config)
+            get_rate_limit_key(
+                self.view, self.request, self.rate_limit_group, self.rate_limit_config
+            )
             == "ip:default:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
         )
 
     def test_ip_address_missing(self):
         self.request.META["REMOTE_ADDR"] = None
         assert (
-            get_rate_limit_key(self.view, self.request, self.group, self.rate_limit_config) is None
+            get_rate_limit_key(
+                self.view, self.request, self.rate_limit_group, self.rate_limit_config
+            )
+            is None
         )
 
     def test_ipv6(self):
         self.request.META["REMOTE_ADDR"] = "684D:1111:222:3333:4444:5555:6:77"
         assert (
-            get_rate_limit_key(self.view, self.request, self.group, self.rate_limit_config)
+            get_rate_limit_key(
+                self.view, self.request, self.rate_limit_group, self.rate_limit_config
+            )
             == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
     def test_system_token(self):
         self.request.auth = SystemToken()
         assert (
-            get_rate_limit_key(self.view, self.request, self.group, self.rate_limit_config) is None
+            get_rate_limit_key(
+                self.view, self.request, self.rate_limit_group, self.rate_limit_config
+            )
+            is None
         )
 
     def test_users(self):
@@ -50,7 +60,9 @@ class GetRateLimitKeyTest(TestCase):
         self.request.session = {}
         self.request.user = user
         assert (
-            get_rate_limit_key(self.view, self.request, self.group, self.rate_limit_config)
+            get_rate_limit_key(
+                self.view, self.request, self.rate_limit_group, self.rate_limit_config
+            )
             == f"user:default:OrganizationGroupIndexEndpoint:GET:{user.id}"
         )
 
@@ -75,7 +87,9 @@ class GetRateLimitKeyTest(TestCase):
         self.request.auth = api_token
 
         assert (
-            get_rate_limit_key(self.view, self.request, self.group, self.rate_limit_config)
+            get_rate_limit_key(
+                self.view, self.request, self.rate_limit_group, self.rate_limit_config
+            )
             == f"org:default:OrganizationGroupIndexEndpoint:GET:{install.organization_id}"
         )
 
@@ -89,12 +103,17 @@ class TestDefaultToGroup(TestCase):
         self.view = DummyEndpoint.as_view()
         self.request = RequestFactory().get("/")
         self.rate_limit_config = get_rate_limit_config(self.view.view_class)
+        self.rate_limit_group = (
+            self.rate_limit_config.group if self.rate_limit_config else RateLimitConfig().group
+        )
 
     def test_group_key(self):
         user = User(id=1)
         self.request.session = {}
         self.request.user = user
         assert (
-            get_rate_limit_key(self.view, self.request, self.group, self.rate_limit_config)
+            get_rate_limit_key(
+                self.view, self.request, self.rate_limit_group, self.rate_limit_config
+            )
             == f"user:default:GET:{user.id}"
         )


### PR DESCRIPTION
Add the `RateLimitConfig` group to the API access logs. Right now the only value is "default", but as the project continues endpoints may define their own groups. To accomplish this I moved some things around - `get_rate_limit_key` and `get_rate_limit_value` were each calling `get_rate_limit_config` , so I instead pass the value of `get_rate_limit_config` to both functions and only calculate it once, as well as put it on the request object so that it can be accessed in the API access log middleware. 

This is a redo of https://github.com/getsentry/sentry/pull/33476 - I had initially panic reverted it in https://github.com/getsentry/sentry/pull/33516 because it was causing [SENTRY-TP9](https://sentry.io/organizations/sentry/issues/3184564140/?project=1), but have since dug into it and realized I didn't actually break _all_ access logs, just ones that didn't have a view. This PR also approaches the change in a different and hopefully better way.