### PR TITLE
fix(issue-owners): Proper handling of issue owner rules for (release, user, dist) tags

### DIFF
--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -9,6 +9,7 @@ from parsimonious.exceptions import ParseError  # noqa
 from parsimonious.grammar import Grammar, NodeVisitor
 from rest_framework.serializers import ValidationError
 
+from sentry.eventstore.models import EventSubjectTemplateData
 from sentry.models import ActorTuple
 from sentry.utils.glob import glob_match
 from sentry.utils.safe import get_path
@@ -132,8 +133,26 @@ class Matcher(namedtuple("Matcher", "type pattern")):
 
     def test_tag(self, data):
         tag = self.type[5:]
+
+        # inspect the event-payload User interface first before checking tags.user
+        if tag and tag.startswith("user"):
+            for k, v in (get_path(data, "user", filter=True) or {}).items():
+                if isinstance(v, str) and glob_match(v, self.pattern):
+                    return True
+                # user interface supports different fields in the payload, any other fields present gets put into the
+                # 'data' dict
+                # we look one more level deep to see if the pattern matches
+                elif k == "data":
+                    for data_k, data_v in (v or {}).items():
+                        if isinstance(data_v, str) and glob_match(data_v, self.pattern):
+                            return True
+
         for k, v in get_path(data, "tags", filter=True) or ():
             if k == tag and glob_match(v, self.pattern):
+                return True
+            elif k in set(EventSubjectTemplateData.tag_aliases.values()) and glob_match(
+                v, self.pattern
+            ):
                 return True
         return False
 

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1,5 +1,6 @@
 from collections import Counter
 from datetime import datetime
+from typing import Mapping, Sequence
 from unittest import mock
 
 import pytz
@@ -22,6 +23,7 @@ from sentry.models import (
     Organization,
     OrganizationMember,
     OrganizationMemberTeam,
+    Project,
     ProjectOption,
     ProjectOwnership,
     Repository,
@@ -54,6 +56,18 @@ class BaseMailAdapterTest(TestCase):
     @fixture
     def adapter(self):
         return mail_adapter
+
+    def assert_notify(
+        self,
+        event,
+        emails_sent_to,
+        target_type=ActionTargetType.ISSUE_OWNERS,
+        target_identifier=None,
+    ):
+        mail.outbox = []
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
+            self.adapter.notify(Notification(event=event), target_type, target_identifier)
+        assert sorted(email.to[0] for email in mail.outbox) == sorted(emails_sent_to)
 
 
 class MailAdapterGetSendableUsersTest(BaseMailAdapterTest):
@@ -424,19 +438,25 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             not in msg.alternatives[0][0]
         )
 
-    def assert_notify(
-        self,
-        event,
-        emails_sent_to,
-        target_type=ActionTargetType.ISSUE_OWNERS,
-        target_identifier=None,
-    ):
-        mail.outbox = []
-        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
-            self.adapter.notify(Notification(event=event), target_type, target_identifier)
-        assert sorted(email.to[0] for email in mail.outbox) == sorted(emails_sent_to)
+    def test_notify_team_members(self):
+        """Test that each member of a team is notified"""
 
-    def test_notify_users_with_owners(self):
+        user = self.create_user(email="foo@example.com", is_active=True)
+        user2 = self.create_user(email="baz@example.com", is_active=True)
+        team = self.create_team(organization=self.organization, members=[user, user2])
+        project = self.create_project(teams=[team])
+        event = self.store_event(data=make_event_data("foo.py"), project_id=project.id)
+        self.assert_notify(event, [user.email, user2.email], ActionTargetType.TEAM, str(team.id))
+
+    def test_notify_user(self):
+        user = self.create_user(email="foo@example.com", is_active=True)
+        self.create_team(organization=self.organization, members=[user])
+        event = self.store_event(data=make_event_data("foo.py"), project_id=self.project.id)
+        self.assert_notify(event, [user.email], ActionTargetType.MEMBER, str(user.id))
+
+
+class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
+    def test_notify_with_path(self):
         user = self.create_user(email="foo@example.com", is_active=True)
         user2 = self.create_user(email="baz@example.com", is_active=True)
 
@@ -496,21 +516,280 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             )
             self.assert_notify(event_all_users, [user.email])
 
-    def test_notify_team_members(self):
-        """Test that each member of a team is notified"""
+    def test_notify_with_release_tag(self):
+        owner = self.create_user(email="theboss@example.com", is_active=True)
+        organization = self.create_organization(owner=owner)
+        team = self.create_team(organization=organization, name="awesome")
+        team2 = self.create_team(organization=organization, name="sauce")
+        project = self.create_project(name="Test", teams=[team, team2])
 
         user = self.create_user(email="foo@example.com", is_active=True)
         user2 = self.create_user(email="baz@example.com", is_active=True)
-        team = self.create_team(organization=self.organization, members=[user, user2])
-        project = self.create_project(teams=[team])
-        event = self.store_event(data=make_event_data("foo.py"), project_id=project.id)
-        self.assert_notify(event, [user.email, user2.email], ActionTargetType.TEAM, str(team.id))
 
-    def test_notify_user(self):
+        user3 = self.create_user(email="one@example.com", is_active=True)
+        user4 = self.create_user(email="two@example.com", is_active=True)
+        user5 = self.create_user(email="three@example.com", is_active=True)
+
+        [self.create_member(user=u, organization=organization, teams=[team]) for u in [user, user2]]
+        [
+            self.create_member(user=u, organization=organization, teams=[team2])
+            for u in [user3, user4, user5]
+        ]
+
+        ProjectOwnership.objects.create(
+            project_id=project.id,
+            schema=dump_schema(
+                [
+                    grammar.Rule(
+                        Matcher("tags.release", "*"),
+                        [Owner("user", user.email)],
+                    ),
+                    grammar.Rule(
+                        Matcher("tags.release", "1"),
+                        [Owner("user", user2.email)],
+                    ),
+                    grammar.Rule(
+                        Matcher("tags.release", "2"),
+                        [Owner("team", team2.slug)],
+                    ),
+                ]
+            ),
+            fallthrough=False,
+        )
+        with self.feature("organizations:notification-all-recipients"):
+            event_all_users = self.store_event(data={"release": "1"}, project_id=project.id)
+            self.assert_notify(event_all_users, [user.email, user2.email])
+
+        with self.feature("organizations:notification-all-recipients"):
+            event_all_users = self.store_event(data={"release": "2"}, project_id=project.id)
+            self.assert_notify(event_all_users, [user.email, user3.email, user4.email, user5.email])
+
+    def test_notify_with_dist_tag(self):
+        owner = self.create_user(email="theboss@example.com", is_active=True)
+        organization = self.create_organization(owner=owner)
+        team = self.create_team(organization=organization, name="awesome")
+        team2 = self.create_team(organization=organization, name="sauce")
+        project = self.create_project(name="Test", teams=[team, team2])
+
         user = self.create_user(email="foo@example.com", is_active=True)
-        self.create_team(organization=self.organization, members=[user])
-        event = self.store_event(data=make_event_data("foo.py"), project_id=self.project.id)
-        self.assert_notify(event, [user.email], ActionTargetType.MEMBER, str(user.id))
+        user2 = self.create_user(email="baz@example.com", is_active=True)
+
+        user3 = self.create_user(email="one@example.com", is_active=True)
+        user4 = self.create_user(email="two@example.com", is_active=True)
+        user5 = self.create_user(email="three@example.com", is_active=True)
+
+        [self.create_member(user=u, organization=organization, teams=[team]) for u in [user, user2]]
+        [
+            self.create_member(user=u, organization=organization, teams=[team2])
+            for u in [user3, user4, user5]
+        ]
+
+        ProjectOwnership.objects.create(
+            project_id=project.id,
+            schema=dump_schema(
+                [
+                    grammar.Rule(
+                        Matcher("tags.dist", "*"),
+                        [Owner("user", user.email)],
+                    ),
+                    grammar.Rule(
+                        Matcher("tags.dist", "rc1"),
+                        [Owner("user", user2.email)],
+                    ),
+                    grammar.Rule(
+                        Matcher("tags.dist", "lenny"),
+                        [Owner("team", team2.slug)],
+                    ),
+                ]
+            ),
+            fallthrough=False,
+        )
+        with self.feature("organizations:notification-all-recipients"):
+            event_all_users = self.store_event(
+                data={"dist": "rc1", "release": "1"}, project_id=project.id
+            )
+            self.assert_notify(event_all_users, [user.email, user2.email])
+
+        with self.feature("organizations:notification-all-recipients"):
+            event_all_users = self.store_event(
+                data={"dist": "lenny", "release": "1"}, project_id=project.id
+            )
+            self.assert_notify(event_all_users, [user.email, user3.email, user4.email, user5.email])
+
+    def test_notify_with_user_tag(self):
+        owner = self.create_user(email="theboss@example.com", is_active=True)
+        organization = self.create_organization(owner=owner)
+        team = self.create_team(organization=organization, name="sentry")
+        project = self.create_project(name="Test", teams=[team])
+
+        user_by_id = self.create_user(email="one@example.com", is_active=True)
+        user_by_username = self.create_user(email="two@example.com", is_active=True)
+        user_by_email = self.create_user(email="three@example.com", is_active=True)
+        user_by_ip = self.create_user(email="four@example.com", is_active=True)
+        user_by_sub = self.create_user(email="five@example.com", is_active=True)
+        user_by_extra = self.create_user(email="six@example.com", is_active=True)
+        [
+            self.create_member(user=u, organization=organization, teams=[team])
+            for u in [
+                user_by_id,
+                user_by_username,
+                user_by_email,
+                user_by_ip,
+                user_by_sub,
+                user_by_extra,
+            ]
+        ]
+
+        ProjectOwnership.objects.create(
+            project_id=project.id,
+            schema=dump_schema(
+                [
+                    grammar.Rule(
+                        Matcher("tags.user:id", "unique_id"),
+                        [Owner("user", user_by_id.email)],
+                    ),
+                    grammar.Rule(
+                        Matcher("tags.user:username", "my_user"),
+                        [Owner("user", user_by_username.email)],
+                    ),
+                    grammar.Rule(
+                        Matcher("tags.user:email", "foo@example.com"),
+                        [Owner("user", user_by_email.email)],
+                    ),
+                    grammar.Rule(
+                        Matcher("tags.user:ip_address", "127.0.0.1"),
+                        [Owner("user", user_by_ip.email)],
+                    ),
+                    grammar.Rule(
+                        Matcher("tags.user:subscription", "basic"),
+                        [Owner("user", user_by_sub.email)],
+                    ),
+                    grammar.Rule(
+                        Matcher("tags.user:extra", "detail"),
+                        [Owner("user", user_by_extra.email)],
+                    ),
+                ]
+            ),
+            fallthrough=False,
+        )
+
+        event_all_users = self.store_event(
+            data={
+                "user": {
+                    "id": "unique_id",
+                    "username": "my_user",
+                    "email": "foo@example.com",
+                    "ip_address": "127.0.0.1",
+                    "subscription": "basic",
+                    "extra": "detail",
+                }
+            },
+            project_id=project.id,
+        )
+
+        with self.feature("organizations:notification-all-recipients"):
+            self.assert_notify(
+                event_all_users,
+                [
+                    user_by_id.email,
+                    user_by_username.email,
+                    user_by_email.email,
+                    user_by_ip.email,
+                    user_by_sub.email,
+                    user_by_extra.email,
+                ],
+            )
+
+    def test_notify_with_user_tag_edge_cases(self):
+        owner = self.create_user(email="theboss@example.com", is_active=True)
+        organization = self.create_organization(owner=owner)
+        team = self.create_team(organization=organization, name="sentry")
+        project = self.create_project(name="Test", teams=[team])
+
+        user = self.create_user(email="sentryuser@example.com", is_active=True)
+        user_star = self.create_user(email="user_star@example.com", is_active=True)
+        user_username = self.create_user(email="user_username@example.com", is_active=True)
+        user_username_star = self.create_user(
+            email="user_username_star@example.com", is_active=True
+        )
+        [
+            self.create_member(user=u, organization=organization, teams=[team])
+            for u in [user, user_star, user_username, user_username_star]
+        ]
+
+        def create_test_delete_rule(
+            proj: Project, rule: grammar.Rule, data: Mapping, asserted_emails_fired: Sequence[str]
+        ):
+            po = ProjectOwnership.objects.create(
+                project_id=proj.id, schema=dump_schema([rule]), fallthrough=False
+            )
+            self.assert_notify(
+                self.store_event(data=data, project_id=proj.id),
+                asserted_emails_fired,
+            )
+            po.delete()
+
+        """
+            tags.user:username:someemail@example.com sentryuser@example.com
+            tags.user:someemail@example.com sentryuser@example.com
+
+            tags.user:* sentryuser@example.com
+
+            tags.user.username:* sentryuser@example.com
+            tags.user:username sentryuser@example.com
+
+            tags.user:*someemail* #sentry
+        """
+        with self.feature("organizations:notification-all-recipients"):
+            dat = {"user": {"username": "someemail@example.com"}}
+            create_test_delete_rule(
+                project,
+                grammar.Rule(
+                    Matcher("tags.user:username", "someemail@example.com"),
+                    [Owner("user", user_username.email)],
+                ),
+                dat,
+                [user_username.email],
+            )
+
+            create_test_delete_rule(
+                project,
+                grammar.Rule(
+                    Matcher("tags.user", "someemail@example.com"), [Owner("user", user.email)]
+                ),
+                dat,
+                [user.email],
+            )
+
+            create_test_delete_rule(
+                project,
+                grammar.Rule(Matcher("tags.user", "*"), [Owner("user", user_star.email)]),
+                dat,
+                [user_star.email],
+            )
+
+            create_test_delete_rule(
+                project,
+                grammar.Rule(
+                    Matcher("tags.user.username", "*"), [Owner("user", user_username_star.email)]
+                ),
+                dat,
+                [user_username_star.email],
+            )
+
+            create_test_delete_rule(
+                project,
+                grammar.Rule(Matcher("tags.user", "username"), [Owner("user", user.email)]),
+                dat,
+                [],
+            )
+
+            create_test_delete_rule(
+                project,
+                grammar.Rule(Matcher("tags.user", "*someemail*"), [Owner("team", team.slug)]),
+                dat,
+                [u.email for u in [user, user_star, user_username, user_username_star]],
+            )
 
 
 class MailAdapterGetDigestSubjectTest(BaseMailAdapterTest):

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -87,6 +87,23 @@ def test_load_schema():
     )
 
 
+def test_load_tag_schema():
+    assert (
+        load_schema(
+            {
+                "$version": 1,
+                "rules": [
+                    {
+                        "matcher": {"type": "tags.release", "pattern": "*"},
+                        "owners": [{"type": "user", "identifier": "test@sentry.io"}],
+                    }
+                ],
+            }
+        )
+        == [Rule(Matcher("tags.release", "*"), [Owner("user", "test@sentry.io")])]
+    )
+
+
 def test_matcher_test_url():
     data = {"request": {"url": "http://example.com/foo.js"}}
 


### PR DESCRIPTION
Special/reserved tags(sentry:release, sentry:dist, sentry:user) didn't work properly when creating new Issue ownership rules. The Issue Notifications would not fire even with `*` patterns. 

Add special handling for these particular cases.

More info:
https://github.com/getsentry/sentry/issues/23617

WOR-733