### PR TITLE
feat(su_modal): Reload after su modal closes in flow where user is restricted

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -42,6 +42,7 @@ export function closeModal() {
 
 type OpenSudoModalOptions = {
   isSuperuser?: boolean;
+  needsReload?: boolean;
   onClose?: () => void;
   retryRequest?: () => Promise<any>;
   sudo?: boolean;

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -28,6 +28,7 @@ type Props = WithRouterProps &
      * User is a superuser without an active su session
      */
     isSuperuser?: boolean;
+    needsReload?: boolean;
     /**
      * expects a function that returns a Promise
      */
@@ -79,7 +80,8 @@ class SudoModal extends React.Component<Props, State> {
   };
 
   handleSuccess = () => {
-    const {closeModal, isSuperuser, location, router, retryRequest} = this.props;
+    const {closeModal, isSuperuser, location, needsReload, router, retryRequest} =
+      this.props;
 
     if (!retryRequest) {
       closeModal();
@@ -88,6 +90,9 @@ class SudoModal extends React.Component<Props, State> {
 
     if (isSuperuser) {
       router.replace({pathname: location.pathname, state: {forceUpdate: new Date()}});
+      if (needsReload) {
+        window.location.reload();
+      }
       return;
     }
 

--- a/static/app/views/organizationContextContainer.tsx
+++ b/static/app/views/organizationContextContainer.tsx
@@ -261,6 +261,7 @@ class OrganizationContextContainer extends React.Component<Props, State> {
         openSudo({
           retryRequest: () => Promise.resolve(this.fetchData()),
           isSuperuser: true,
+          needsReload: true,
         });
       }
     }


### PR DESCRIPTION
Reload page when superuser modal is closed only during privileged access while not having permission. Based off of this comment

Additional super user modal feedback - typically the support team navigates directly to a view that requires the access (whereas in Richards’s example today the modal was brought up, authentication happened and then he navigated away). Is it possible that submitting the form will trigger the navigation action again? When in this view:
![Uploading image.png…]()
