### PR TITLE
fix(profiling): Flamegraph config space should use duration

### DIFF
--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -72,7 +72,7 @@ export class Flamegraph {
       this.configSpace = new Rect(
         0,
         0,
-        configSpace ? configSpace.width : this.profile.endedAt,
+        configSpace ? configSpace.width : this.profile.duration,
         this.depth
       );
     }
@@ -198,10 +198,5 @@ export class Flamegraph {
     }
     visit(profile.appendOrderTree, 0);
     return frames;
-  }
-
-  setConfigSpace(configSpace: Rect): Flamegraph {
-    this.configSpace = configSpace;
-    return this;
   }
 }

--- a/tests/js/spec/utils/profiling/flamegraph.spec.tsx
+++ b/tests/js/spec/utils/profiling/flamegraph.spec.tsx
@@ -314,12 +314,4 @@ describe('flamegraph', () => {
   it('Empty', () => {
     expect(Flamegraph.Empty().configSpace.equals(new Rect(0, 0, 1_000, 0))).toBe(true);
   });
-
-  it('setConfigSpace', () => {
-    expect(
-      Flamegraph.Empty()
-        .setConfigSpace(new Rect(0, 0, 10, 5))
-        .configSpace.equals(new Rect(0, 0, 10, 5))
-    ).toBe(true);
-  });
 });


### PR DESCRIPTION
When creating the config space for a flamegraph, the width should be the
duration and not the endedAt value.