### PR TITLE
feat(replays): Show pathname instead of url

### DIFF
--- a/static/app/utils/getUrlPathname.tsx
+++ b/static/app/utils/getUrlPathname.tsx
@@ -1,4 +1,4 @@
-export default function getURLPathname(url: string) {
+export default function getUrlPathname(url: string) {
   try {
     return new URL(url).pathname;
   } catch {

--- a/static/app/utils/getUrlPathname.tsx
+++ b/static/app/utils/getUrlPathname.tsx
@@ -1,0 +1,7 @@
+export default function getURLPathname(url: string) {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return undefined;
+  }
+}

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -19,6 +19,7 @@ import {NewQuery, Organization, PageFilters} from 'sentry/types';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
+import getUrlPathname from 'sentry/utils/getUrlPathname';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -109,7 +110,7 @@ function Replays(props: Props) {
               email: replay['user.display'],
             }}
             // this is the subheading for the avatar, so displayEmail in this case is a misnomer
-            displayEmail={replay.url?.split('?')[0] || ''}
+            displayEmail={getUrlPathname(replay.url) ?? ''}
           />
         </Link>
         <ProjectBadge


### PR DESCRIPTION
### Description

- Show pathname instead of url 

### Screenshots
<img width="772" alt="Screen Shot 2022-04-18 at 16 49 23" src="https://user-images.githubusercontent.com/14813235/163867885-3ab662fa-7f0b-44cf-8778-10495278ada0.png">

Closes https://github.com/getsentry/sentry/issues/33594