### PR TITLE
fix(span-tree): Undefined in sibling autogroup label

### DIFF
--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -55,16 +55,16 @@ export default function SpanSiblingGroupBar(props: Props) {
     const operation = spanGrouping[0].span.op;
     const description = spanGrouping[0].span.description;
 
-    if (!operation && !description) {
+    if (!description || !operation) {
+      if (description) {
+        return <strong>{`${t('Autogrouped')} \u2014 ${description}`}</strong>;
+      }
+
+      if (operation) {
+        return <strong>{`${t('Autogrouped')} \u2014 ${operation}`}</strong>;
+      }
+
       return <strong>{`${t('Autogrouped')} \u2014 ${t('siblings')}`}</strong>;
-    }
-
-    if (!operation) {
-      return <strong>{`${t('Autogrouped')} \u2014 ${description}`}</strong>;
-    }
-
-    if (!description) {
-      return <strong>{`${t('Autogrouped')} \u2014 ${operation}`}</strong>;
     }
 
     return (

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -60,16 +60,16 @@ export default function SpanSiblingGroupBar(props: Props) {
     }
 
     if (!operation) {
-      return <strong>{`${t('Autogrouped ')}\u2014 ${description}`}</strong>;
+      return <strong>{`${t('Autogrouped')} \u2014 ${description}`}</strong>;
     }
 
     if (!description) {
-      return <strong>{`${t('Autogrouped ')}\u2014 ${operation}`}</strong>;
+      return <strong>{`${t('Autogrouped')} \u2014 ${operation}`}</strong>;
     }
 
     return (
       <React.Fragment>
-        <strong>{`${t('Autogrouped ')}\u2014 ${operation} \u2014 `}</strong>
+        <strong>{`${t('Autogrouped')} \u2014 ${operation} \u2014 `}</strong>
         {description}
       </React.Fragment>
     );

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -55,12 +55,22 @@ export default function SpanSiblingGroupBar(props: Props) {
     const operation = spanGrouping[0].span.op;
     const description = spanGrouping[0].span.description;
 
+    if (!operation && !description) {
+      return <strong>{`${t('Autogrouped')} \u2014 ${t('siblings')}`}</strong>;
+    }
+
+    if (!operation) {
+      return <strong>{`${t('Autogrouped ')}\u2014 ${description}`}</strong>;
+    }
+
+    if (!description) {
+      return <strong>{`${t('Autogrouped ')}\u2014 ${operation}`}</strong>;
+    }
+
     return (
       <React.Fragment>
-        <strong>{`${t('Autogrouped ')}\u2014 ${operation} ${
-          description && '\u2014 '
-        }`}</strong>
-        {description && `${description}`}
+        <strong>{`${t('Autogrouped ')}\u2014 ${operation} \u2014 `}</strong>
+        {description}
       </React.Fragment>
     );
   }

--- a/tests/js/spec/components/events/interfaces/spans/traceView.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/traceView.spec.tsx
@@ -41,8 +41,8 @@ function generateSampleEvent(): EventTransaction {
 }
 
 function generateSampleSpan(
-  description: string,
-  op: string,
+  description: string | null,
+  op: string | null,
   span_id: string,
   parent_span_id: string,
   event: EventTransaction
@@ -222,5 +222,64 @@ describe('TraceView', () => {
     const secondRegroup = await screen.findByText('Regroup');
     userEvent.click(secondRegroup);
     expect(await screen.findAllByText('group me')).toHaveLength(2);
+  });
+
+  it('should correctly render sibling autogroup text when op and/or description is not provided', async () => {
+    const data = initializeData({
+      features: ['performance-autogroup-sibling-spans'],
+    });
+
+    const event1 = generateSampleEvent();
+    generateSampleSpan('group me', null, 'b000000000000000', 'a000000000000000', event1);
+    generateSampleSpan('group me', null, 'c000000000000000', 'a000000000000000', event1);
+    generateSampleSpan('group me', null, 'd000000000000000', 'a000000000000000', event1);
+    generateSampleSpan('group me', null, 'e000000000000000', 'a000000000000000', event1);
+    generateSampleSpan('group me', null, 'f000000000000000', 'a000000000000000', event1);
+
+    const {rerender} = render(
+      <TraceView
+        organization={data.organization}
+        waterfallModel={new WaterfallModel(event1)}
+      />
+    );
+    expect(await screen.findByTestId('span-row-2')).toHaveTextContent(
+      /Autogrouped — group me/
+    );
+
+    const event2 = generateSampleEvent();
+    generateSampleSpan(null, 'http', 'b000000000000000', 'a000000000000000', event2);
+    generateSampleSpan(null, 'http', 'c000000000000000', 'a000000000000000', event2);
+    generateSampleSpan(null, 'http', 'd000000000000000', 'a000000000000000', event2);
+    generateSampleSpan(null, 'http', 'e000000000000000', 'a000000000000000', event2);
+    generateSampleSpan(null, 'http', 'f000000000000000', 'a000000000000000', event2);
+
+    rerender(
+      <TraceView
+        organization={data.organization}
+        waterfallModel={new WaterfallModel(event2)}
+      />
+    );
+
+    expect(await screen.findByTestId('span-row-2')).toHaveTextContent(
+      /Autogrouped — http/
+    );
+
+    const event3 = generateSampleEvent();
+    generateSampleSpan(null, null, 'b000000000000000', 'a000000000000000', event3);
+    generateSampleSpan(null, null, 'c000000000000000', 'a000000000000000', event3);
+    generateSampleSpan(null, null, 'd000000000000000', 'a000000000000000', event3);
+    generateSampleSpan(null, null, 'e000000000000000', 'a000000000000000', event3);
+    generateSampleSpan(null, null, 'f000000000000000', 'a000000000000000', event3);
+
+    rerender(
+      <TraceView
+        organization={data.organization}
+        waterfallModel={new WaterfallModel(event3)}
+      />
+    );
+
+    expect(await screen.findByTestId('span-row-2')).toHaveTextContent(
+      /Autogrouped — siblings/
+    );
   });
 });


### PR DESCRIPTION
Sometimes if a sibling span group does not have a description or op provided, it will show up in the label as undefined.
This PR also makes the label more dynamic, so it can handle all cases, including when no op and no description is provided.

Fixes PERF-1522
