### PR TITLE
refs(release_monitor): Move logic for fetching organizations and projects with recent sessions into a backend

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1419,6 +1419,13 @@ SENTRY_METRICS_INDEXER_CACHE_TTL = 3600 * 2
 SENTRY_RELEASE_HEALTH = "sentry.release_health.sessions.SessionsReleaseHealthBackend"
 SENTRY_RELEASE_HEALTH_OPTIONS = {}
 
+# Release Monitor
+SENTRY_RELEASE_MONITOR = (
+    "sentry.release_health.release_monitor.sessions.SessionReleaseMonitorBackend"
+)
+SENTRY_RELEASE_MONITOR_OPTIONS = {}
+
+
 # Render charts on the backend. This uses the Chartcuterie external service.
 SENTRY_CHART_RENDERER = "sentry.charts.chartcuterie.Chartcuterie"
 SENTRY_CHART_RENDERER_OPTIONS = {}

--- a/src/sentry/release_health/release_monitor/__init__.py
+++ b/src/sentry/release_health/release_monitor/__init__.py
@@ -1,0 +1,20 @@
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+
+from sentry.utils.services import LazyServiceWrapper
+
+from .base import BaseReleaseMonitorBackend
+
+backend = LazyServiceWrapper(
+    BaseReleaseMonitorBackend,
+    settings.SENTRY_RELEASE_MONITOR,
+    settings.SENTRY_RELEASE_MONITOR_OPTIONS,
+)
+backend.expose(locals())
+
+if TYPE_CHECKING:
+    __release_monitor_backend__ = BaseReleaseMonitorBackend()
+    fetch_projects_with_recent_sessions = (
+        __release_monitor_backend__.fetch_projects_with_recent_sessions
+    )

--- a/src/sentry/release_health/release_monitor/base.py
+++ b/src/sentry/release_health/release_monitor/base.py
@@ -1,0 +1,17 @@
+from typing import Mapping, Sequence
+
+from sentry.utils.services import Service
+
+
+class BaseReleaseMonitorBackend(Service):
+    CHUNK_SIZE = 1000
+    MAX_SECONDS = 60
+
+    __all__ = ("fetch_projects_with_recent_sessions",)
+
+    def fetch_projects_with_recent_sessions(self) -> Mapping[int, Sequence[int]]:
+        """
+        Fetches all projects that have had session data in the last 6 hours, grouped by
+        organization_id. Returned as a dict in format {organization_id: <list of project ids>}.
+        """
+        raise NotImplementedError

--- a/src/sentry/release_health/release_monitor/sessions.py
+++ b/src/sentry/release_health/release_monitor/sessions.py
@@ -1,0 +1,69 @@
+import logging
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import Mapping, Sequence
+
+from snuba_sdk import Column, Condition, Direction, Entity, Granularity, Op, OrderBy, Query
+
+from sentry.release_health.release_monitor.base import BaseReleaseMonitorBackend
+from sentry.utils import metrics
+from sentry.utils.snuba import raw_snql_query
+
+logger = logging.getLogger(__name__)
+
+
+class SessionReleaseMonitorBackend(BaseReleaseMonitorBackend):
+    def fetch_projects_with_recent_sessions(self) -> Mapping[int, Sequence[int]]:
+        with metrics.timer(
+            "sentry.tasks.monitor_release_adoption.aggregate_projects.loop", sample_rate=1.0
+        ):
+            aggregated_projects = defaultdict(list)
+            start_time = time.time()
+            offset = 0
+            while (time.time() - start_time) < self.MAX_SECONDS:
+                query = (
+                    Query(
+                        dataset="sessions",
+                        match=Entity("org_sessions"),
+                        select=[
+                            Column("org_id"),
+                            Column("project_id"),
+                        ],
+                        groupby=[Column("org_id"), Column("project_id")],
+                        where=[
+                            Condition(
+                                Column("started"), Op.GTE, datetime.utcnow() - timedelta(hours=6)
+                            ),
+                            Condition(Column("started"), Op.LT, datetime.utcnow()),
+                        ],
+                        granularity=Granularity(3600),
+                        orderby=[
+                            OrderBy(Column("org_id"), Direction.ASC),
+                            OrderBy(Column("project_id"), Direction.ASC),
+                        ],
+                    )
+                    .set_limit(self.CHUNK_SIZE + 1)
+                    .set_offset(offset)
+                )
+                data = raw_snql_query(query, referrer="tasks.monitor_release_adoption")["data"]
+                count = len(data)
+                more_results = count > self.CHUNK_SIZE
+                offset += self.CHUNK_SIZE
+
+                if more_results:
+                    data = data[:-1]
+
+                for row in data:
+                    aggregated_projects[row["org_id"]].append(row["project_id"])
+
+                if not more_results:
+                    break
+
+            else:
+                logger.error(
+                    "monitor_release_adoption.loop_timeout",
+                    extra={"offset": offset},
+                )
+
+        return aggregated_projects

--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -19,6 +19,7 @@ from sentry.models import (
     ReleaseProjectEnvironment,
     ReleaseStatus,
 )
+from sentry.release_health import release_monitor
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics, snuba
 
@@ -36,62 +37,11 @@ logger = logging.getLogger("tasks.releasemonitor")
 )  # type: ignore
 def monitor_release_adoption(**kwargs) -> None:
     metrics.incr("sentry.tasks.monitor_release_adoption.start", sample_rate=1.0)
-    # 1. Query snuba for all project ids that have sessions.
-    with metrics.timer(
-        "sentry.tasks.monitor_release_adoption.aggregate_projects.loop", sample_rate=1.0
-    ):
-        aggregated_projects = defaultdict(list)
-        start_time = time.time()
-        offset = 0
-        while (time.time() - start_time) < MAX_SECONDS:
-            query = (
-                Query(
-                    dataset="sessions",
-                    match=Entity("org_sessions"),
-                    select=[
-                        Column("org_id"),
-                        Column("project_id"),
-                    ],
-                    groupby=[Column("org_id"), Column("project_id")],
-                    where=[
-                        Condition(
-                            Column("started"), Op.GTE, datetime.utcnow() - timedelta(hours=6)
-                        ),
-                        Condition(Column("started"), Op.LT, datetime.utcnow()),
-                    ],
-                    granularity=Granularity(3600),
-                    orderby=[
-                        OrderBy(Column("org_id"), Direction.ASC),
-                        OrderBy(Column("project_id"), Direction.ASC),
-                    ],
-                )
-                .set_limit(CHUNK_SIZE + 1)
-                .set_offset(offset)
-            )
-            data = snuba.raw_snql_query(query, referrer="tasks.monitor_release_adoption")["data"]
-            count = len(data)
-            more_results = count > CHUNK_SIZE
-            offset += CHUNK_SIZE
-
-            if more_results:
-                data = data[:-1]
-
-            for row in data:
-                aggregated_projects[row["org_id"]].append(row["project_id"])
-
-            if not more_results:
-                break
-
-        else:
-            logger.error(
-                "monitor_release_adoption.loop_timeout",
-                extra={"offset": offset},
-            )
     with metrics.timer(
         "sentry.tasks.monitor_release_adoption.process_projects_with_sessions", sample_rate=1.0
     ):
-        for org_id in aggregated_projects:
-            process_projects_with_sessions.delay(org_id, aggregated_projects[org_id])
+        for org_id, project_ids in release_monitor.fetch_projects_with_recent_sessions().items():
+            process_projects_with_sessions.delay(org_id, project_ids)
 
 
 @instrumented_task(

--- a/tests/sentry/release_health/release_monitor/test_sessions.py
+++ b/tests/sentry/release_health/release_monitor/test_sessions.py
@@ -1,0 +1,38 @@
+from sentry.release_health import release_monitor
+from sentry.testutils import SnubaTestCase, TestCase
+
+
+class TestFetchProjectsWithRecentSessions(TestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+        self.project1 = self.create_project()
+        self.project2 = self.create_project()
+        self.environment = self.create_environment(project=self.project2)
+
+    def test_monitor_release_adoption(self):
+        self.org2 = self.create_organization()
+        self.org2_project = self.create_project(organization=self.org2)
+        self.org2_release = self.create_release(project=self.org2_project, version="org@2.0.0")
+        self.org2_environment = self.create_environment(project=self.org2_project)
+        self.bulk_store_sessions(
+            [
+                self.build_session(
+                    org_id=self.org2,
+                    project_id=self.org2_project,
+                    release=self.org2_release,
+                    environment=self.org2_environment,
+                )
+                for _ in range(2)
+            ]
+            + [self.build_session(project_id=self.project1) for _ in range(3)]
+            + [
+                self.build_session(project_id=self.project2, environment=self.environment)
+                for _ in range(1)
+            ]
+        )
+        results = release_monitor.fetch_projects_with_recent_sessions()
+        assert results == {
+            self.organization.id: [self.project1.id, self.project2.id],
+            self.org2.id: [self.org2_project.id],
+        }


### PR DESCRIPTION
We want to start fetching this data from metrics soon. To allow us to switch over easily and support
sessions on ST/self-hosted we need to move this logic into backends, so that we can transition to
this over time.

This is the first step, and just move the scheduling query into a backend. This shouldn't result in
any changes, just moving around of code.