### PR TITLE
ref(slack): Link directly to event in slack message

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -374,7 +374,7 @@ def build_group_attachment(
     identity: Identity | None = None,
     actions: Sequence[MessageAction] | None = None,
     rules: list[Rule] | None = None,
-    link_to_event: bool = False,
+    link_to_event: bool = True,
     issue_details: bool = False,
 ) -> SlackBody:
     """@deprecated"""


### PR DESCRIPTION
See: https://github.com/getsentry/sentry/issues/33678

Ticket: [API-2639](https://getsentry.atlassian.net/browse/API-2639)

Didn't know we had a variable to toggle this behaviour directly, but it seems like it should definitely be enabled by default. If slack messages are going out containing event information, we should definitely be linking directly to that event when users click through. 

