### PR TITLE
fix(profiling): Sync x axis for chrome trace

### DIFF
--- a/static/app/components/profiling/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph.tsx
@@ -19,7 +19,9 @@ import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
 
 function getTransactionConfigSpace(profiles: Profile[]): Rect {
-  return new Rect(0, 0, Math.max(...profiles.map(p => p.endedAt)), 0);
+  const startedAt = Math.min(...profiles.map(p => p.startedAt));
+  const endedAt = Math.max(...profiles.map(p => p.endedAt));
+  return new Rect(startedAt, 0, endedAt - startedAt, 0);
 }
 interface FlamegraphProps {
   profiles: ProfileGroup;

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -50,8 +50,8 @@ export class Flamegraph {
 
     // If a custom config space is provided, use it and draw the chart in it
     this.frames = leftHeavy
-      ? this.buildLeftHeavyGraph(profile, configSpace ? this.profile.startedAt : 0)
-      : this.buildCallOrderGraph(profile, configSpace ? this.profile.startedAt : 0);
+      ? this.buildLeftHeavyGraph(profile, configSpace ? configSpace.x : 0)
+      : this.buildCallOrderGraph(profile, configSpace ? configSpace.x : 0);
 
     this.formatter = makeFormatter(profile.unit);
 
@@ -70,9 +70,9 @@ export class Flamegraph {
 
     if (this.profile.duration) {
       this.configSpace = new Rect(
+        configSpace ? configSpace.x : this.profile.startedAt,
         0,
-        0,
-        configSpace ? configSpace.width : this.profile.endedAt,
+        configSpace ? configSpace.width : this.profile.duration,
         this.depth
       );
     }

--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -138,15 +138,20 @@ function buildProfile(
   }
 
   const firstTimestamp = beginQueue[beginQueue.length - 1].ts;
+  const lastTimestamp = endQueue[0].ts;
 
   if (typeof firstTimestamp !== 'number') {
     throw new Error('First begin event contains no timestamp');
   }
 
+  if (typeof lastTimestamp !== 'number') {
+    throw new Error('Last end event contains no timestamp');
+  }
+
   const profile = new ChromeTraceProfile(
-    0,
-    0,
-    0,
+    lastTimestamp - firstTimestamp,
+    firstTimestamp,
+    lastTimestamp,
     `${processName}: ${threadName}`,
     'microseconds' // the trace event format provides timestamps in microseconds
   );

--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -138,7 +138,7 @@ function buildProfile(
   }
 
   const firstTimestamp = beginQueue[beginQueue.length - 1].ts;
-  const lastTimestamp = endQueue[0].ts;
+  const lastTimestamp = endQueue[0]?.ts ?? beginQueue[0].ts;
 
   if (typeof firstTimestamp !== 'number') {
     throw new Error('First begin event contains no timestamp');

--- a/static/app/views/profiling/flamegraph.tsx
+++ b/static/app/views/profiling/flamegraph.tsx
@@ -64,9 +64,9 @@ function FlamegraphView(props: FlamegraphViewProps): React.ReactElement {
 
   useEffect(() => {
     if (!props.params.eventId || !props.params.projectId) {
-      return;
+      return undefined;
     }
-    api.clear();
+
     setRequestState('loading');
 
     fetchFlamegraphs(api, props.params.eventId, props.params.projectId, organization)
@@ -75,6 +75,10 @@ function FlamegraphView(props: FlamegraphViewProps): React.ReactElement {
         setRequestState('resolved');
       })
       .catch(() => setRequestState('errored'));
+
+    return () => {
+      api.clear();
+    };
   }, [props.params.eventId, props.params.projectId, api, organization]);
 
   return (

--- a/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
@@ -122,7 +122,7 @@ describe('parseChromeTraceArrayFormat', () => {
       [
         {
           ph: 'B',
-          ts: 0,
+          ts: 1000,
           cat: 'program',
           pid: 0,
           tid: 0,
@@ -131,7 +131,7 @@ describe('parseChromeTraceArrayFormat', () => {
         },
         {
           ph: 'E',
-          ts: 1000,
+          ts: 2000,
           cat: 'program',
           pid: 0,
           tid: 0,
@@ -142,6 +142,8 @@ describe('parseChromeTraceArrayFormat', () => {
       ''
     );
 
+    expect(trace.profiles[0].startedAt).toBe(1000);
+    expect(trace.profiles[0].endedAt).toBe(2000);
     expect(trace.profiles[0].duration).toBe(1000);
     expect(trace.profiles[0].appendOrderTree.children[0].totalWeight).toBe(1000);
   });


### PR DESCRIPTION
The sync x axis option for chrome traces were broken because chrome traces were
not properly initializing a start/end/duration.