### PR TITLE
fix(onboarding): Client state default state

### DIFF
--- a/static/app/stores/persistedStore.tsx
+++ b/static/app/stores/persistedStore.tsx
@@ -54,17 +54,25 @@ export function PersistedStoreProvider(props: {children: React.ReactNode}) {
 
   useEffect(() => {
     if (!organization) {
-      return;
+      return undefined;
     }
 
+    let shouldCancelRequest = false;
     api
       .requestPromise(`/organizations/${organization.slug}/client-state/`)
       .then((response: PersistedStore) => {
+        if (shouldCancelRequest) {
+          return;
+        }
         setState({...DefaultLoadedPersistedStore, ...response});
       })
       .catch(() => {
         setState(DefaultPersistedStore);
       });
+
+    return () => {
+      shouldCancelRequest = true;
+    };
   }, [organization]);
 
   return (

--- a/static/app/stores/persistedStore.tsx
+++ b/static/app/stores/persistedStore.tsx
@@ -108,7 +108,7 @@ export function usePersistedStoreCategory<C extends keyof PersistedStore>(
   );
 
   const stableState: UsePersistedCategory<PersistedStore[C]> = useMemo(() => {
-    return [state[category] ?? null, setCategoryState];
+    return [state[category] ?? {}, setCategoryState];
   }, [state[category], setCategoryState]);
 
   return stableState;

--- a/static/app/stores/persistedStore.tsx
+++ b/static/app/stores/persistedStore.tsx
@@ -22,7 +22,7 @@ export const DefaultPersistedStore: PersistedStore = {
   onboarding: null,
 };
 
-const DefaultLoadedPersistedStore: PersistedStore = {
+export const DefaultLoadedPersistedStore: PersistedStore = {
   onboarding: {},
 };
 
@@ -61,6 +61,9 @@ export function PersistedStoreProvider(props: {children: React.ReactNode}) {
       .requestPromise(`/organizations/${organization.slug}/client-state/`)
       .then((response: PersistedStore) => {
         setState({...DefaultLoadedPersistedStore, ...response});
+      })
+      .catch(() => {
+        setState(DefaultPersistedStore);
       });
   }, [organization]);
 

--- a/tests/js/spec/stores/persistedStore.spec.tsx
+++ b/tests/js/spec/stores/persistedStore.spec.tsx
@@ -4,6 +4,7 @@ import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
 import OrganizationStore from 'sentry/stores/organizationStore';
 import {
+  DefaultLoadedPersistedStore,
   DefaultPersistedStore,
   PersistedStoreProvider,
   usePersistedStoreCategory,
@@ -99,16 +100,31 @@ describe('PersistedStore', function () {
       })
     );
   });
-  it('returns default when state fails to load', async function () {
+  it('returns default when state is empty', async function () {
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/client-state/`,
-      status: 500,
+      body: {},
     });
     const {result, waitForNextUpdate} = reactHooks.renderHook(
       () => usePersistedStoreCategory('onboarding'),
       {wrapper}
     );
+    const [state] = result.current;
+    expect(state).toBe(DefaultPersistedStore.onboarding);
     await waitForNextUpdate();
+    const [state2] = result.current;
+    expect(state2).toBe(DefaultLoadedPersistedStore.onboarding);
+  });
+
+  it('returns default when state fails to load', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/client-state/`,
+      statusCode: 500,
+    });
+    const {result} = reactHooks.renderHook(
+      () => usePersistedStoreCategory('onboarding'),
+      {wrapper}
+    );
     const [state] = result.current;
     expect(state).toBe(DefaultPersistedStore.onboarding);
   });


### PR DESCRIPTION
- Return an empty object (instead of null) when the category was loaded but not initialized. This allows us to distinguish between the two cases.
- Remove `shouldCancelRequest` because `useApi` cancels requests for you. https://github.com/getsentry/sentry/pull/33489#discussion_r848933906
- Added a test for this particular case.