### PR TITLE
fix(page-filters): Align discover page filters

### DIFF
--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -510,7 +510,7 @@ class Results extends React.Component<Props, State> {
                   <StyledPageFilterBar>
                     <ProjectPageFilter />
                     <EnvironmentPageFilter />
-                    <DatePageFilter />
+                    <DatePageFilter alignDropdown="left" />
                   </StyledPageFilterBar>
                 )}
                 <StyledSearchBar


### PR DESCRIPTION
Prevents the date page filter from overflowing into the sidebar