### PR TITLE
fix(performance): Avoid overwriting the default event table title list

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -35,7 +35,7 @@ type Props = {
   webVital?: WebVital;
 };
 
-const transactionsListTitles: Readonly<string[]> = [
+const TRANSACTIONS_LIST_TITLES: Readonly<string[]> = [
   t('event id'),
   t('user'),
   t('operation duration'),
@@ -56,6 +56,7 @@ function EventsContent(props: Props) {
   } = props;
 
   const eventView = originalEventView.clone();
+  const transactionsListTitles = TRANSACTIONS_LIST_TITLES.slice();
 
   if (webVital) {
     transactionsListTitles.splice(3, 0, t(webVital));

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -35,7 +35,7 @@ type Props = {
   webVital?: WebVital;
 };
 
-const transactionsListTitles = [
+const transactionsListTitles: Readonly<string[]> = [
   t('event id'),
   t('user'),
   t('operation duration'),


### PR DESCRIPTION
This pull request fixes a regression introduced in https://github.com/getsentry/sentry/pull/28346

From the "Web Vitals" tab in a transaction summary, clicking on the "View All Events" button on any of the web vitals widget card will lead to an inconsistent state when the user re-sorts the events table:

![Kapture 2022-04-15 at 14 55 43](https://user-images.githubusercontent.com/139499/163890720-3f79a97d-d2a9-4e61-ae77-67584cb9beaf.gif)
gif courtesy of @doralchan

-----


`transactionsListTitles.splice(3, 0, t(webVital));` will **_modify_** the `transactionsListTitles` array ***in-place***. (See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice).

I've renamed `transactionsListTitles` to `TRANSACTIONS_LIST_TITLES` and defined its type as Readonly<string[]>. This results in a type error, and I've amended by cloning from `TRANSACTIONS_LIST_TITLES` directly. 

This should address the bug.