### PR TITLE
feat(release_health): Move logic from `sum_sessions_and_releases` into `SessionReleaseMonitorBackend`

### DIFF
--- a/src/sentry/release_health/release_monitor/__init__.py
+++ b/src/sentry/release_health/release_monitor/__init__.py
@@ -18,3 +18,6 @@ if TYPE_CHECKING:
     fetch_projects_with_recent_sessions = (
         __release_monitor_backend__.fetch_projects_with_recent_sessions
     )
+    fetch_project_release_health_totals = (
+        __release_monitor_backend__.fetch_project_release_health_totals
+    )

--- a/src/sentry/release_health/release_monitor/base.py
+++ b/src/sentry/release_health/release_monitor/base.py
@@ -1,17 +1,34 @@
-from typing import Mapping, Sequence
+from typing import Dict, Mapping, Sequence, TypedDict
 
 from sentry.utils.services import Service
+
+
+class EnvironmentTotals(TypedDict):
+    total_sessions: int
+    releases: Dict[str, int]
+
+
+Totals = Dict[int, Dict[str, EnvironmentTotals]]
 
 
 class BaseReleaseMonitorBackend(Service):
     CHUNK_SIZE = 1000
     MAX_SECONDS = 60
 
-    __all__ = ("fetch_projects_with_recent_sessions",)
+    __all__ = ("fetch_projects_with_recent_sessions", "fetch_project_release_health_totals")
 
     def fetch_projects_with_recent_sessions(self) -> Mapping[int, Sequence[int]]:
         """
         Fetches all projects that have had session data in the last 6 hours, grouped by
         organization_id. Returned as a dict in format {organization_id: <list of project ids>}.
+        """
+        raise NotImplementedError
+
+    def fetch_project_release_health_totals(
+        self, org_id: int, project_ids: Sequence[int]
+    ) -> Totals:
+        """
+        Fetches release health totals for the passed project_ids, which must be related to the
+        passed org id.
         """
         raise NotImplementedError

--- a/src/sentry/release_health/release_monitor/sessions.py
+++ b/src/sentry/release_health/release_monitor/sessions.py
@@ -6,7 +6,7 @@ from typing import Mapping, Sequence
 
 from snuba_sdk import Column, Condition, Direction, Entity, Granularity, Op, OrderBy, Query
 
-from sentry.release_health.release_monitor.base import BaseReleaseMonitorBackend
+from sentry.release_health.release_monitor.base import BaseReleaseMonitorBackend, Totals
 from sentry.utils import metrics
 from sentry.utils.snuba import raw_snql_query
 
@@ -67,3 +67,75 @@ class SessionReleaseMonitorBackend(BaseReleaseMonitorBackend):
                 )
 
         return aggregated_projects
+
+    def fetch_project_release_health_totals(
+        self, org_id: int, project_ids: Sequence[int]
+    ) -> Totals:
+        start_time = time.time()
+        offset = 0
+        totals: Totals = defaultdict(dict)
+        with metrics.timer(
+            "sentry.tasks.monitor_release_adoption.process_projects_with_sessions.loop"
+        ):
+            while (time.time() - start_time) < self.MAX_SECONDS:
+                with metrics.timer(
+                    "sentry.tasks.monitor_release_adoption.process_projects_with_sessions.query"
+                ):
+                    query = (
+                        Query(
+                            dataset="sessions",
+                            match=Entity("sessions"),
+                            select=[
+                                Column("sessions"),
+                            ],
+                            groupby=[
+                                Column("org_id"),
+                                Column("project_id"),
+                                Column("release"),
+                                Column("environment"),
+                            ],
+                            where=[
+                                Condition(
+                                    Column("started"),
+                                    Op.GTE,
+                                    datetime.utcnow() - timedelta(hours=6),
+                                ),
+                                Condition(Column("started"), Op.LT, datetime.utcnow()),
+                                Condition(Column("org_id"), Op.EQ, org_id),
+                                Condition(Column("project_id"), Op.IN, project_ids),
+                            ],
+                            granularity=Granularity(21600),
+                            orderby=[
+                                OrderBy(Column("org_id"), Direction.ASC),
+                                OrderBy(Column("project_id"), Direction.ASC),
+                            ],
+                        )
+                        .set_limit(self.CHUNK_SIZE + 1)
+                        .set_offset(offset)
+                    )
+
+                    data = raw_snql_query(
+                        query, referrer="tasks.process_projects_with_sessions.session_count"
+                    )["data"]
+                    count = len(data)
+                    more_results = count > self.CHUNK_SIZE
+                    offset += self.CHUNK_SIZE
+
+                    if more_results:
+                        data = data[:-1]
+
+                    for row in data:
+                        row_totals = totals[row["project_id"]].setdefault(
+                            row["environment"], {"total_sessions": 0, "releases": defaultdict(int)}
+                        )
+                        row_totals["total_sessions"] += row["sessions"]
+                        row_totals["releases"][row["release"]] += row["sessions"]
+
+                if not more_results:
+                    break
+            else:
+                logger.error(
+                    "process_projects_with_sessions.loop_timeout",
+                    extra={"org_id": org_id, "project_ids": project_ids},
+                )
+        return totals

--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -1,14 +1,10 @@
 import logging
-import time
-from collections import defaultdict
-from datetime import datetime, timedelta
-from typing import Dict, Sequence, TypedDict
+from typing import Sequence
 
 from django.db import IntegrityError
 from django.db.models import F, Q
 from django.utils import timezone
 from sentry_sdk import capture_exception
-from snuba_sdk import Column, Condition, Direction, Entity, Granularity, Op, OrderBy, Query
 
 from sentry.models import (
     Environment,
@@ -20,8 +16,9 @@ from sentry.models import (
     ReleaseStatus,
 )
 from sentry.release_health import release_monitor
+from sentry.release_health.release_monitor.base import Totals
 from sentry.tasks.base import instrumented_task
-from sentry.utils import metrics, snuba
+from sentry.utils import metrics
 
 CHUNK_SIZE = 1000
 MAX_SECONDS = 60
@@ -61,88 +58,11 @@ def process_projects_with_sessions(org_id, project_ids) -> None:
             flags=F("flags").bitand(~Project.flags.has_sessions),
         ).update(flags=F("flags").bitor(Project.flags.has_sessions))
 
-        totals = sum_sessions_and_releases(org_id, project_ids)
+        totals = release_monitor.fetch_project_release_health_totals(org_id, project_ids)
 
         adopted_ids = adopt_releases(org_id, totals)
 
         cleanup_adopted_releases(project_ids, adopted_ids)
-
-
-class EnvironmentTotals(TypedDict):
-    total_sessions: int
-    releases: Dict[str, int]
-
-
-Totals = Dict[int, Dict[str, EnvironmentTotals]]
-
-
-def sum_sessions_and_releases(org_id: int, project_ids: Sequence[int]) -> Totals:
-    # Takes a single org id and a list of project ids
-    # returns counts of releases and sessions across all environments and passed project_ids for the last 6 hours
-    start_time = time.time()
-    offset = 0
-    totals: Totals = defaultdict(dict)
-    with metrics.timer("sentry.tasks.monitor_release_adoption.process_projects_with_sessions.loop"):
-        while (time.time() - start_time) < MAX_SECONDS:
-            with metrics.timer(
-                "sentry.tasks.monitor_release_adoption.process_projects_with_sessions.query"
-            ):
-                query = (
-                    Query(
-                        dataset="sessions",
-                        match=Entity("sessions"),
-                        select=[
-                            Column("sessions"),
-                        ],
-                        groupby=[
-                            Column("org_id"),
-                            Column("project_id"),
-                            Column("release"),
-                            Column("environment"),
-                        ],
-                        where=[
-                            Condition(
-                                Column("started"), Op.GTE, datetime.utcnow() - timedelta(hours=6)
-                            ),
-                            Condition(Column("started"), Op.LT, datetime.utcnow()),
-                            Condition(Column("org_id"), Op.EQ, org_id),
-                            Condition(Column("project_id"), Op.IN, project_ids),
-                        ],
-                        granularity=Granularity(21600),
-                        orderby=[
-                            OrderBy(Column("org_id"), Direction.ASC),
-                            OrderBy(Column("project_id"), Direction.ASC),
-                        ],
-                    )
-                    .set_limit(CHUNK_SIZE + 1)
-                    .set_offset(offset)
-                )
-
-                data = snuba.raw_snql_query(
-                    query, referrer="tasks.process_projects_with_sessions.session_count"
-                )["data"]
-                count = len(data)
-                more_results = count > CHUNK_SIZE
-                offset += CHUNK_SIZE
-
-                if more_results:
-                    data = data[:-1]
-
-                for row in data:
-                    row_totals = totals[row["project_id"]].setdefault(
-                        row["environment"], {"total_sessions": 0, "releases": defaultdict(int)}
-                    )
-                    row_totals["total_sessions"] += row["sessions"]
-                    row_totals["releases"][row["release"]] += row["sessions"]
-
-            if not more_results:
-                break
-        else:
-            logger.error(
-                "process_projects_with_sessions.loop_timeout",
-                extra={"org_id": org_id, "project_ids": project_ids},
-            )
-    return totals
 
 
 def adopt_releases(org_id: int, totals: Totals) -> Sequence[int]:


### PR DESCRIPTION
This moves the logic of fetching release health totals for a list of projects into our
ReleaseMonitorBackend. This allows us to convert it over to metrics and compare results.