### PR TITLE
ref(sessions): remove  > 90 days test

### DIFF
--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -12,7 +12,6 @@ from sentry.release_health.sessions import SessionsReleaseHealthBackend
 from sentry.snuba.sessions import _make_stats
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.cases import SessionMetricsTestCase
-from sentry.utils.dates import to_timestamp
 
 
 def parametrize_backend(cls):
@@ -131,62 +130,6 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
             [(self.project.id, self.session_release), (self.project.id, "dummy-release")]
         )
         assert data == {(self.project.id, self.session_release)}
-
-    def test_check_has_health_data_without_releases_should_exclude_sessions_gt_90_days(self):
-        """
-        Test that ensures that `check_has_health_data` returns a set of projects that has health
-        data within the last 90d if only a list of project ids is provided and that any project
-        with session data older than 90 days should be exluded
-        """
-        project2 = self.create_project(
-            name="Bar2",
-            slug="bar2",
-            teams=[self.team],
-            fire_project_created=True,
-            organization=self.organization,
-        )
-
-        date_100_days_ago = to_timestamp(
-            (datetime.utcnow() - timedelta(days=100)).replace(tzinfo=pytz.utc)
-        )
-        self.store_session(
-            self.build_session(
-                **{
-                    "started": date_100_days_ago // 60 * 60,
-                    "received": date_100_days_ago,
-                    "project_id": project2.id,
-                    "org_id": project2.organization_id,
-                    "status": "exited",
-                }
-            )
-        )
-        data = self.backend.check_has_health_data([self.project.id, project2.id])
-        assert data == {self.project.id}
-
-    def test_check_has_health_data_without_releases_should_include_sessions_lte_90_days(self):
-        """
-        Test that ensures that `check_has_health_data` returns a set of projects that has health
-        data within the last 90d if only a list of project ids is provided and any project with
-        session data earlier than 90 days should be included
-        """
-        project2 = self.create_project(
-            name="Bar2",
-            slug="bar2",
-            teams=[self.team],
-            fire_project_created=True,
-            organization=self.organization,
-        )
-        self.store_session(
-            self.build_session(
-                **{
-                    "project_id": project2.id,
-                    "org_id": project2.organization_id,
-                    "status": "exited",
-                }
-            )
-        )
-        data = self.backend.check_has_health_data([self.project.id, project2.id])
-        assert data == {self.project.id, project2.id}
 
     def test_check_has_health_data_does_not_crash_when_sending_projects_list_as_set(self):
         data = self.backend.check_has_health_data({self.project.id})


### PR DESCRIPTION
In snuba we want to start enforcing retention days for both session and metric data: https://github.com/getsentry/snuba/pull/2626. However, this change will break the `test_check_has_health_data_without_releases_should_exclude_sessions_gt_90_days` test because you are no longer allowed to create data that would be farther back in time than 90 days (it will raise `EventTooOld` in snuba).

I'm not sure what a better way around this test is besides just deleting it, but happy to take suggestions