### PR TITLE
feat(performance): Replace GSH with page filters

### DIFF
--- a/static/app/components/organizations/pageFilters/utils.tsx
+++ b/static/app/components/organizations/pageFilters/utils.tsx
@@ -88,6 +88,7 @@ export function doesPathHaveNewFilters(pathname: string, organization: Organizat
           'dashboard',
           'releases',
           'discover',
+          'performance',
         ]
       : ['user-feedback', 'alerts', 'monitors', 'projects', 'dashboards', 'releases']
   ).map(route => `/organizations/${organization.slug}/${route}/`);

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -130,6 +130,7 @@ function PerformanceContent({selection, location, demoMode}: Props) {
                 period: DEFAULT_STATS_PERIOD,
               },
             }}
+            hideGlobalHeader={organization.features.includes('selection-filters-v2')}
           >
             <PerformanceLanding
               eventView={eventView}

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -7,12 +7,16 @@ import {openModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
+import DatePageFilter from 'sentry/components/datePageFilter';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import {GlobalSdkUpdateAlert} from 'sentry/components/globalSdkUpdateAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageHeading from 'sentry/components/pageHeading';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
+import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -195,6 +199,13 @@ export function PerformanceLanding(props: Props) {
               />
             ) : (
               <Fragment>
+                {organization.features.includes('selection-filters-v2') && (
+                  <StyledPageFilterBar condensed>
+                    <ProjectPageFilter />
+                    <EnvironmentPageFilter />
+                    <DatePageFilter alignDropdown="left" />
+                  </StyledPageFilterBar>
+                )}
                 <SearchContainerWithFilter>
                   <SearchBar
                     searchSource="performance_landing"
@@ -250,4 +261,8 @@ const SearchContainerWithFilter = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: 1fr min-content;
   }
+`;
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(1)};
 `;

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -111,6 +111,7 @@ function PageLayout(props: Props) {
             showProjectSettingsLink
             relativeDateOptions={relativeDateOptions}
             maxPickableDays={maxPickableDays}
+            hideGlobalHeader={organization.features.includes('selection-filters-v2')}
           >
             <StyledPageContent>
               <NoProjectMessage organization={organization}>

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
@@ -7,8 +7,11 @@ import omit from 'lodash/omit';
 import MarkArea from 'sentry/components/charts/components/markArea';
 import MarkLine from 'sentry/components/charts/components/markLine';
 import {LineChartSeries} from 'sentry/components/charts/lineChart';
+import DatePageFilter from 'sentry/components/datePageFilter';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -272,6 +275,12 @@ function AnomaliesContent(props: Props) {
   }
   return (
     <Layout.Main fullWidth>
+      {organization.features.includes('selection-filters-v2') && (
+        <StyledPageFilterBar condensed>
+          <EnvironmentPageFilter />
+          <DatePageFilter alignDropdown="left" />
+        </StyledPageFilterBar>
+      )}
       <SearchBar
         organization={organization}
         projectIds={eventView.project}
@@ -305,6 +314,10 @@ function AnomaliesContent(props: Props) {
 
 const Container = styled('div')`
   margin-top: ${space(2)};
+`;
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(1)};
 `;
 
 export default AnomaliesContent;

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -4,9 +4,12 @@ import {Location} from 'history';
 import omit from 'lodash/omit';
 
 import Button from 'sentry/components/button';
+import DatePageFilter from 'sentry/components/datePageFilter';
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -74,6 +77,12 @@ function EventsContent(props: Props) {
 
   return (
     <Layout.Main fullWidth>
+      {organization.features.includes('selection-filters-v2') && (
+        <StyledPageFilterBar condensed>
+          <EnvironmentPageFilter />
+          <DatePageFilter alignDropdown="left" />
+        </StyledPageFilterBar>
+      )}
       <Search {...props} />
       <StyledTable>
         <EventsTable
@@ -88,6 +97,10 @@ function EventsContent(props: Props) {
     </Layout.Main>
   );
 }
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(1)};
+`;
 
 function Search(props: Props) {
   const {

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -5,11 +5,14 @@ import {Location} from 'history';
 import omit from 'lodash/omit';
 
 import Feature from 'sentry/components/acl/feature';
+import DatePageFilter from 'sentry/components/datePageFilter';
 import TransactionsList, {
   DropdownOption,
 } from 'sentry/components/discover/transactionsList';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -263,6 +266,12 @@ function SummaryContent({
   return (
     <React.Fragment>
       <Layout.Main>
+        {organization.features.includes('selection-filters-v2') && (
+          <StyledPageFilterBar condensed>
+            <EnvironmentPageFilter />
+            <DatePageFilter alignDropdown="left" />
+          </StyledPageFilterBar>
+        )}
         <Search>
           <Filter
             organization={organization}
@@ -458,6 +467,10 @@ function getTransactionsListSort(
   const selectedSort = sortOptions.find(opt => opt.value === urlParam) || sortOptions[0];
   return {selected: selectedSort, options: sortOptions};
 }
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(1)};
+`;
 
 const Search = styled('div')`
   display: flex;

--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -1,13 +1,18 @@
 import {Fragment} from 'react';
 import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
 import {Location} from 'history';
 import omit from 'lodash/omit';
 
+import DatePageFilter from 'sentry/components/datePageFilter';
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Pagination from 'sentry/components/pagination';
+import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
@@ -89,6 +94,12 @@ function SpansContent(props: Props) {
 
   return (
     <Layout.Main fullWidth>
+      {organization.features.includes('selection-filters-v2') && (
+        <StyledPageFilterBar condensed>
+          <EnvironmentPageFilter />
+          <DatePageFilter alignDropdown="left" />
+        </StyledPageFilterBar>
+      )}
       <Actions>
         <OpsFilter
           location={location}
@@ -160,6 +171,10 @@ function SpansContent(props: Props) {
     </Layout.Main>
   );
 }
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(1)};
+`;
 
 function getSpansEventView(eventView: EventView, sort: SpanSort): EventView {
   eventView = eventView.clone();

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -1,8 +1,13 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import Feature from 'sentry/components/acl/feature';
+import DatePageFilter from 'sentry/components/datePageFilter';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import * as Layout from 'sentry/components/layouts/thirds';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
@@ -149,6 +154,10 @@ function SpanDetailsContent(props: ContentProps) {
 
   return (
     <Fragment>
+      <StyledPageFilterBar condensed>
+        <EnvironmentPageFilter />
+        <DatePageFilter />
+      </StyledPageFilterBar>
       <SpanDetailsHeader
         spanSlug={spanSlug}
         totalCount={totalCount}
@@ -180,6 +189,10 @@ function SpanDetailsContent(props: ContentProps) {
     </Fragment>
   );
 }
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(1)};
+`;
 
 function getSpansEventView(eventView: EventView): EventView {
   // TODO: There is a bug where if the sort is not avg occurrence,

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
@@ -66,6 +66,7 @@ export default function SpanDetails(props: Props) {
           showProjectSettingsLink
           relativeDateOptions={SPAN_RELATIVE_PERIODS}
           maxPickableDays={SPAN_RETENTION_DAYS}
+          hideGlobalHeader={organization.features.includes('selection-filters-v2')}
         >
           <StyledPageContent>
             <NoProjectMessage organization={organization}>

--- a/static/app/views/performance/transactionSummary/transactionTags/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/content.tsx
@@ -4,9 +4,12 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
+import DatePageFilter from 'sentry/components/datePageFilter';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import Radio from 'sentry/components/radio';
@@ -153,6 +156,12 @@ const InnerContent = (
       />
       <StyledMain>
         <StyledActions>
+          {organization.features.includes('selection-filters-v2') && (
+            <StyledPageFilterBar condensed>
+              <EnvironmentPageFilter />
+              <DatePageFilter alignDropdown="left" />
+            </StyledPageFilterBar>
+          )}
           <StyledSearchBar
             organization={organization}
             projectIds={eventView.project}
@@ -293,6 +302,10 @@ const StyledSearchBar = styled(SearchBar)`
 `;
 
 const StyledActions = styled('div')`
+  margin-bottom: ${space(1)};
+`;
+
+const StyledPageFilterBar = styled(PageFilterBar)`
   margin-bottom: ${space(1)};
 `;
 

--- a/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
@@ -5,10 +5,13 @@ import {Location} from 'history';
 
 import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
+import DatePageFilter from 'sentry/components/datePageFilter';
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -85,6 +88,12 @@ function VitalsContent(props: Props) {
                     </Alert>
                   )}
 
+                  {organization.features.includes('selection-filters-v2') && (
+                    <StyledPageFilterBar condensed>
+                      <EnvironmentPageFilter />
+                      <DatePageFilter alignDropdown="left" />
+                    </StyledPageFilterBar>
+                  )}
                   <StyledActions>
                     <StyledSearchBar
                       organization={organization}
@@ -159,6 +168,10 @@ const StyledActions = styled('div')`
   grid-template-columns: auto max-content max-content;
   align-items: center;
   margin-bottom: ${space(3)};
+`;
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(1)};
 `;
 
 export default VitalsContent;

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -5,10 +5,14 @@ import {Location} from 'history';
 
 import Alert from 'sentry/components/alert';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
+import DatePageFilter from 'sentry/components/datePageFilter';
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -206,11 +210,14 @@ class TrendsContent extends React.Component<Props, State> {
     );
     const query = getTransactionSearchQuery(location);
 
+    const hasPageFilters = organization.features.includes('selection-filters-v2');
+
     return (
       <PageFiltersContainer
         defaultSelection={{
           datetime: defaultTrendsSelectionDate,
         }}
+        hideGlobalHeader={hasPageFilters}
       >
         <Layout.Header>
           <Layout.HeaderContent>
@@ -231,6 +238,13 @@ class TrendsContent extends React.Component<Props, State> {
         <Layout.Body>
           <Layout.Main fullWidth>
             <DefaultTrends location={location} eventView={eventView} projects={projects}>
+              {hasPageFilters && (
+                <StyledPageFilterBar condensed>
+                  <ProjectPageFilter />
+                  <EnvironmentPageFilter />
+                  <DatePageFilter />
+                </StyledPageFilterBar>
+              )}
               <StyledSearchContainer>
                 <StyledSearchBar
                   searchSource="trends"
@@ -345,6 +359,10 @@ class DefaultTrends extends React.Component<DefaultTrendsProps> {
     return null;
   }
 }
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(1)};
+`;
 
 const StyledSearchBar = styled(SearchBar)`
   flex-grow: 1;

--- a/static/app/views/performance/vitalDetail/index.tsx
+++ b/static/app/views/performance/vitalDetail/index.tsx
@@ -101,7 +101,9 @@ class VitalDetail extends Component<Props, State> {
     return (
       <SentryDocumentTitle title={this.getDocumentTitle()} orgSlug={organization.slug}>
         <PerformanceEventViewProvider value={{eventView: this.state.eventView}}>
-          <PageFiltersContainer>
+          <PageFiltersContainer
+            hideGlobalHeader={organization.features.includes('selection-filters-v2')}
+          >
             <StyledPageContent>
               <NoProjectMessage organization={organization}>
                 <VitalDetailContent

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -10,13 +10,17 @@ import Alert from 'sentry/components/alert';
 import ButtonBar from 'sentry/components/buttonBar';
 import {getInterval} from 'sentry/components/charts/utils';
 import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
+import DatePageFilter from 'sentry/components/datePageFilter';
 import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
 import {MenuItemProps} from 'sentry/components/dropdownMenuItemV2';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
+import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import {IconCheckmark, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -210,8 +214,17 @@ class VitalDetailContent extends Component<Props, State> {
     const filterString = getTransactionSearchQuery(location);
     const summaryConditions = getSummaryConditions(filterString);
 
+    const hasPageFilters = organization.features.includes('selection-filters-v2');
+
     return (
       <Fragment>
+        {hasPageFilters && (
+          <StyledPageFilterBar condensed>
+            <ProjectPageFilter />
+            <EnvironmentPageFilter />
+            <DatePageFilter />
+          </StyledPageFilterBar>
+        )}
         <StyledSearchBar
           searchSource="performance_vitals"
           organization={organization}
@@ -324,6 +337,10 @@ class VitalDetailContent extends Component<Props, State> {
 }
 
 export default withProjects(VitalDetailContent);
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(1)};
+`;
 
 const StyledDescription = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};


### PR DESCRIPTION
Replacing GSH with page filters on the performance pages (internal only). Now organizational-level filters (projects, env, date) exist alongside other filters on each performance page.

For many of these I put the page filters above the search bar because I didn't want to choke out the search bar but let me know if it makes more sense to be inline. 

Screenshots:
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/9372512/163920444-eaaf395a-6460-4898-95e7-8501dbc65221.png">

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/9372512/163920461-8f0dccb8-ca9d-41c3-afd3-f06ec6ac5896.png">

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/9372512/163920489-23af8887-7c72-4ec4-800b-2e39d38d13ee.png">

<img width="1421" alt="image" src="https://user-images.githubusercontent.com/9372512/163920648-585eb0b2-1d53-4321-b6d6-7b033856a425.png">
