### PR TITLE
fix(workflow): Handle correct group ID using event ID 

### DIFF
--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -509,7 +509,7 @@ class GroupDetails extends Component<Props, State> {
     };
 
     if (currentTab === Tab.DETAILS) {
-      if (group.id !== event?.groupID) {
+      if (group.id !== event?.groupID && !eventError) {
         // if user pastes only the event id into the url, but it's from another group, redirect to correct group/event
         const redirectUrl = `/organizations/${organization.slug}/issues/${event?.groupID}/events/${event?.id}/`;
         this.props.router.push(redirectUrl);

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -496,7 +496,7 @@ class GroupDetails extends Component<Props, State> {
   }
 
   renderContent(project: AvatarProject, group: Group) {
-    const {children, environments} = this.props;
+    const {children, environments, organization} = this.props;
     const {loadingEvent, eventError, event} = this.state;
 
     const {currentTab, baseUrl} = this.getCurrentRouteInfo(group);
@@ -509,14 +509,20 @@ class GroupDetails extends Component<Props, State> {
     };
 
     if (currentTab === Tab.DETAILS) {
-      childProps = {
-        ...childProps,
-        event,
-        loadingEvent,
-        eventError,
-        groupReprocessingStatus,
-        onRetry: () => this.remountComponent(),
-      };
+      if (group.id !== event?.groupID) {
+        // if user pastes only the event id into the url, but it's from another group, redirect to correct group/event
+        const redirectUrl = `/organizations/${organization.slug}/issues/${event?.groupID}/events/${event?.id}/`;
+        this.props.router.push(redirectUrl);
+      } else {
+        childProps = {
+          ...childProps,
+          event,
+          loadingEvent,
+          eventError,
+          groupReprocessingStatus,
+          onRetry: () => this.remountComponent(),
+        };
+      }
     }
 
     if (currentTab === Tab.TAGS) {


### PR DESCRIPTION
Previously, if pasting an event ID into the url from another issue, the details with that event ID would display, but error title/message/issue #, event count, users, etc would still display from the previous issue. This will now handle that case and redirect to the correct issue the event was originally from.

[FIXES ISSUE-1377](https://getsentry.atlassian.net/browse/ISSUE-1377)

Reproducible steps:

- Navigate to an issue
https://sentry.io/organizations/sentry-test/issues/2303727688/?query=is%3Aunresolved
- Click the event ID at the top to get the URL to change to the event-specific format:
https://sentry.io/organizations/sentry-test/issues/2303727688/events/d27f753babd443ac8c6ec8edd355f189/?project=5270453
- Replace the event ID in that URL with an event ID from a different issue:
https://sentry.io/organizations/sentry-test/issues/2303727688/events/28a22dc739864bf09b1bd450103da519/?project=5270453

You can see that it's showing a different error event in that issue than the first link even though event `28a22dc739864bf09b1bd450103da519` belongs to issue `2967165531` (`APP-FRONTEND-2EC`) and not `2303727688` (`APP-FRONTEND-12A`).