### PR TITLE
feat(dashboards): Temporarily restrict the number of RH lines plotted

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/metricsWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/metricsWidgetQueries.tsx
@@ -121,7 +121,11 @@ class MetricsWidgetQueries extends React.Component<Props, State> {
         return {
           ...prevState,
           timeseriesResults: prevState.rawResults?.flatMap((rawResult, index) =>
-            transformSessionsResponseToSeries(rawResult, widget.queries[index].name)
+            transformSessionsResponseToSeries(
+              rawResult,
+              limit,
+              widget.queries[index].name
+            )
           ),
         };
       });
@@ -229,6 +233,7 @@ class MetricsWidgetQueries extends React.Component<Props, State> {
           const timeseriesResults = [...(prevState.timeseriesResults ?? [])];
           const transformedResult = transformSessionsResponseToSeries(
             data,
+            this.limit,
             widget.queries[requestIndex].name
           );
 

--- a/static/app/views/dashboardsV2/widgetCard/transformSessionsResponseToSeries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/transformSessionsResponseToSeries.tsx
@@ -3,21 +3,27 @@ import {Series} from 'sentry/types/echarts';
 
 export function transformSessionsResponseToSeries(
   response: SessionApiResponse | null,
+  limit?: number,
   queryAlias?: string
 ): Series[] {
-  return (
-    response?.groups.flatMap(group =>
-      Object.keys(group.series).map(field => ({
-        seriesName: `${queryAlias ? `${queryAlias}: ` : ''}${field}${Object.entries(
-          group.by
-        )
-          .map(([key, value]) => `|${key}:${value}`)
-          .join('')}`,
-        data: response.intervals.map((interval, index) => ({
-          name: interval,
-          value: group.series[field][index] ?? 0,
-        })),
-      }))
-    ) ?? []
+  if (response === null) {
+    return [];
+  }
+  // Temporarily restrict the number of lines we plot on grouped queries
+  const groups: SessionApiResponse['groups'] = limit
+    ? response.groups.slice(0, limit)
+    : response.groups;
+  return groups.flatMap(group =>
+    Object.keys(group.series).map(field => ({
+      seriesName: `${queryAlias ? `${queryAlias}: ` : ''}${field}${Object.entries(
+        group.by
+      )
+        .map(([key, value]) => `|${key}:${value}`)
+        .join('')}`,
+      data: response.intervals.map((interval, index) => ({
+        name: interval,
+        value: group.series[field][index] ?? 0,
+      })),
+    }))
   );
 }

--- a/tests/js/spec/views/dashboardsV2/widgetCard/transformSessionsResponseToSeries.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard/transformSessionsResponseToSeries.spec.tsx
@@ -320,6 +320,7 @@ describe('transformSessionsResponseToSeries', function () {
     expect(
       transformSessionsResponseToSeries(
         TestStubs.MetricsSessionUserCountByStatusByRelease(),
+        undefined,
         'Lorem'
       )[0]
     ).toEqual(
@@ -328,5 +329,23 @@ describe('transformSessionsResponseToSeries', function () {
           'Lorem: sum(sentry.sessions.session)|session.status:crashed|release:1',
       })
     );
+  });
+  it('returns correct number of series if limit is set', () => {
+    expect(
+      transformSessionsResponseToSeries(
+        TestStubs.MetricsSessionUserCountByStatusByRelease(),
+        undefined,
+        'Lorem'
+      ).length
+    ).toEqual(16);
+
+    // limit = 3 returns 6 series, 3 for count_unique and 3 for sum
+    expect(
+      transformSessionsResponseToSeries(
+        TestStubs.MetricsSessionUserCountByStatusByRelease(),
+        3,
+        'Lorem'
+      ).length
+    ).toEqual(6);
   });
 });


### PR DESCRIPTION
Grouping by releases plots > 100 lines, restricting this in the FE
based on the selected chart limit since limit cannot
currently be passed as a param to the API request.

Before:
![Screen Shot 2022-04-19 at 8 24 33 AM](https://user-images.githubusercontent.com/63818634/164002960-257c185c-00d4-4971-b549-6932f436c904.png)


After:
![Screen Shot 2022-04-19 at 8 23 27 AM](https://user-images.githubusercontent.com/63818634/164002971-5ba140a3-8f2b-4ed9-8141-4144cf5238a9.png)

