### PR TITLE
fix: use .get instead of bracket for google oauth provider

### DIFF
--- a/src/sentry/identity/google/provider.py
+++ b/src/sentry/identity/google/provider.py
@@ -29,7 +29,7 @@ class GoogleIdentityProvider(OAuth2Provider):
         return options.get("auth-google.client-secret")
 
     def build_identity(self, state):
-        data = state["data"]
+        data = state.get("data", {})
 
         try:
             id_token = data["id_token"]


### PR DESCRIPTION
SENTRY-TVK 
https://sentry.io/organizations/sentry/issues/3206941359/?project=1&referrer=slack