### PR TITLE
feat(alerts): Retain form when changing projects in the alert wizard

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -290,6 +290,20 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                 ),
               }))}
               onChange={({value}: {value: Project['id']}) => {
+                // if the current owner/team isn't part of project selected, update to the first available team
+                const nextSelectedProject = projects.find(({id}) => id === value);
+                const ownerId: String | undefined = model
+                  .getValue('owner')
+                  ?.split(':')[1];
+                if (
+                  ownerId &&
+                  nextSelectedProject &&
+                  nextSelectedProject.teams.find(({id}) => id === ownerId) ===
+                    undefined &&
+                  nextSelectedProject.teams.length
+                ) {
+                  model.setValue('owner', `team:${nextSelectedProject.teams[0].id}`);
+                }
                 onChange(value, {});
                 onBlur(value, {});
               }}

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -5,7 +5,6 @@ import {components} from 'react-select';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -91,7 +90,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (isEqual(prevProps.project, this.props.project)) {
+    if (prevProps.project.id === this.props.project.id) {
       return;
     }
 

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -291,13 +291,13 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
               }))}
               onChange={({value}: {value: Project['id']}) => {
                 // if the current owner/team isn't part of project selected, update to the first available team
-                const nextSelectedProject = projects.find(({id}) => id === value);
+                const nextSelectedProject =
+                  projects.find(({id}) => id === value) ?? selectedProject;
                 const ownerId: String | undefined = model
                   .getValue('owner')
                   ?.split(':')[1];
                 if (
                   ownerId &&
-                  nextSelectedProject &&
                   nextSelectedProject.teams.find(({id}) => id === ownerId) ===
                     undefined &&
                   nextSelectedProject.teams.length

--- a/static/app/views/alerts/incidentRules/ruleNameOwnerForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleNameOwnerForm.tsx
@@ -49,10 +49,7 @@ export default function RuleNameOwnerForm({disabled, project, hasAlertWizardV3}:
           <TeamSelector
             value={ownerId}
             project={project}
-            onChange={({value}) => {
-              const ownerValue = value && `team:${value}`;
-              model.setValue('owner', ownerValue);
-            }}
+            onChange={({value}) => model.setValue('owner', value && `team:${value}`)}
             teamFilter={(team: Team) => team.isMember || team.id === ownerId}
             useId
             includeUnassigned

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -178,7 +178,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       params: {ruleId, orgId},
     } = this.props;
     // project in state isn't initialized when getEndpoints is first called
-    const project = this.state.project ?? this.props.project;
+    const project = this.state?.project ?? this.props.project;
 
     const endpoints = [
       ['environments', `/projects/${orgId}/${project.slug}/environments/`],


### PR DESCRIPTION
This updates the project selector in metric and issue alert wizards to not change url parameters and refresh the page. Chart data is still refetched and owner selector updates to pick the first available owner if the currently selected owner isn't a part of the project.

Metric wizard:

https://user-images.githubusercontent.com/15015880/165369399-f2ddb9ca-9fe4-4b55-8335-5ba41af5e3fb.mov

Issue wizard:

https://user-images.githubusercontent.com/15015880/165369418-df40db44-31ee-4c55-80a8-005242ae8142.mov

Jira: [WOR-1777](https://getsentry.atlassian.net/browse/WOR-1777)


