### PR TITLE
fix(ui): Handle Email dropdown in alert creator for Safari

### DIFF
--- a/static/app/views/alerts/incidentRules/types.tsx
+++ b/static/app/views/alerts/incidentRules/types.tsx
@@ -141,7 +141,9 @@ export enum ActionType {
 }
 
 export const ActionLabel = {
-  [ActionType.EMAIL]: t('Email'),
+  // \u200B is needed because Safari disregards autocomplete="off". It's seeing "Email" and
+  // opening up the browser autocomplete for email. https://github.com/JedWatson/react-select/issues/3500
+  [ActionType.EMAIL]: t('Emai\u200Bl'),
   [ActionType.SLACK]: t('Slack'),
   [ActionType.PAGERDUTY]: t('Pagerduty'),
   [ActionType.MSTEAMS]: t('MS Teams'),


### PR DESCRIPTION
Safari is disregarding `autoComplete='off'` and still showing the browser autocomplete for the select action field in the alerts creator. This is due to the first/default option being set as Email, so having an invisible character to break up the word seems to fix this. There's an open issue with react-select and the other solutions mentioned here don't work for Safari https://github.com/JedWatson/react-select/issues/3500.

[FIXES WOR-1779](https://getsentry.atlassian.net/browse/WOR-1779)

# Before
<img width="1014" alt="Screen Shot 2022-04-19 at 11 17 29 AM" src="https://user-images.githubusercontent.com/20312973/164069823-3bbb4a42-e2c5-4562-9e87-0c1f33b7e2df.png">

# After
<img width="1019" alt="Screen Shot 2022-04-19 at 11 16 19 AM" src="https://user-images.githubusercontent.com/20312973/164069841-68f16530-90f8-4b66-b346-86dc255b6202.png">

