### PR TITLE
fix(new-widget-builder-experience): TopN should open with TopN display

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -261,16 +261,12 @@ function WidgetBuilder({
 
     if (isEditing && isValidWidgetIndex) {
       const widgetFromDashboard = dashboard.widgets[widgetIndexNum];
-      const visualization =
-        widgetBuilderNewDesign && widgetFromDashboard.displayType === DisplayType.TOP_N
-          ? DisplayType.TABLE
-          : widgetFromDashboard.displayType;
       setState({
         title: widgetFromDashboard.title,
-        displayType: visualization,
+        displayType: widgetFromDashboard.displayType,
         interval: widgetFromDashboard.interval,
         queries: normalizeQueries({
-          displayType: visualization,
+          displayType: widgetFromDashboard.displayType,
           queries: widgetFromDashboard.queries,
           widgetType: widgetFromDashboard.widgetType ?? WidgetType.DISCOVER,
           widgetBuilderNewDesign,

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1653,6 +1653,43 @@ describe('WidgetBuilder', function () {
     });
   });
 
+  it('opens top-N widgets as top-N display', async function () {
+    const widget: Widget = {
+      id: '1',
+      title: 'Errors over time',
+      interval: '5m',
+      displayType: DisplayType.TOP_N,
+      queries: [
+        {
+          name: '',
+          conditions: '',
+          fields: ['count()', 'count_unique(id)'],
+          aggregates: ['count()', 'count_unique(id)'],
+          columns: [],
+          orderby: '-count',
+        },
+      ],
+    };
+
+    const dashboard: DashboardDetails = {
+      id: '1',
+      title: 'Dashboard',
+      createdBy: undefined,
+      dateCreated: '2020-01-01T00:00:00.000Z',
+      widgets: [widget],
+    };
+
+    renderTestComponent({
+      orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
+      dashboard,
+      params: {
+        widgetIndex: '0',
+      },
+    });
+
+    expect(await screen.findByText('Top 5 Events')).toBeInTheDocument();
+  });
+
   // Disabling for CI, but should run locally when making changes
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('Update table header values (field alias)', async function () {


### PR DESCRIPTION
Small fix to keep opening TopN as a Top 5 Events chart.
In the future this will change to a stacked area chart but
for now, keep using the Top 5 Events visualization