### PR TITLE
feat(theme): Add tooltipUnderline (dotted underline) utility

### DIFF
--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -167,7 +167,6 @@ const SectionHeader = styled('div')<{isCentered?: boolean}>`
   }
   & small > span {
     color: ${p => p.theme.textColor};
-    border-bottom: 1px dotted ${p => p.theme.border};
     font-weight: normal;
   }
 

--- a/static/app/components/events/interfaces/crashHeader/crashTitle.tsx
+++ b/static/app/components/events/interfaces/crashHeader/crashTitle.tsx
@@ -34,7 +34,7 @@ const CrashTitle = ({
           {title}
         </GuideAnchor>
         {onChange && (
-          <Tooltip title={t('Toggle stack trace order')}>
+          <Tooltip showIndicator title={t('Toggle stack trace order')}>
             <small>
               (
               <span onClick={handleToggleOrder}>

--- a/static/app/components/events/interfaces/crashHeader/crashTitle.tsx
+++ b/static/app/components/events/interfaces/crashHeader/crashTitle.tsx
@@ -34,7 +34,7 @@ const CrashTitle = ({
           {title}
         </GuideAnchor>
         {onChange && (
-          <Tooltip showIndicator title={t('Toggle stack trace order')}>
+          <Tooltip showUnderline title={t('Toggle stack trace order')}>
             <small>
               (
               <span onClick={handleToggleOrder}>

--- a/static/app/components/group/seenInfo.tsx
+++ b/static/app/components/group/seenInfo.tsx
@@ -48,7 +48,7 @@ class SeenInfo extends React.Component<Props> {
     return (
       <HovercardWrapper>
         <StyledHovercard
-          showIndicator
+          showUnderline
           header={
             <div>
               <TimeSinceWrapper>

--- a/static/app/components/group/seenInfo.tsx
+++ b/static/app/components/group/seenInfo.tsx
@@ -48,6 +48,7 @@ class SeenInfo extends React.Component<Props> {
     return (
       <HovercardWrapper>
         <StyledHovercard
+          showIndicator
           header={
             <div>
               <TimeSinceWrapper>

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -70,7 +70,7 @@ interface HovercardProps {
    * Whether to add a dotted underline to the trigger element, to indicate the
    * presence of a tooltip.
    */
-  showIndicator?: boolean;
+  showUnderline?: boolean;
   /**
    * Color of the arrow tip border
    */
@@ -158,7 +158,7 @@ function Hovercard(props: HovercardProps): React.ReactElement {
             ref={ref}
             aria-describedby={tooltipId}
             className={props.containerClassName}
-            showIndicator={props.showIndicator}
+            showUnderline={props.showUnderline}
             {...hoverProps}
           >
             {props.children}
@@ -279,8 +279,8 @@ function getTipDirection(
   return (prefix || 'top') as 'top' | 'bottom' | 'left' | 'right';
 }
 
-const Trigger = styled('span')<{showIndicator?: boolean}>`
-  ${p => p.showIndicator && p.theme.tooltipUnderline};
+const Trigger = styled('span')<{showUnderline?: boolean}>`
+  ${p => p.showUnderline && p.theme.tooltipUnderline};
 `;
 
 const HovercardContainer = styled('div')`

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -67,6 +67,11 @@ interface HovercardProps {
    */
   show?: boolean;
   /**
+   * Whether to add a dotted underline to the trigger element, to indicate the
+   * presence of a tooltip.
+   */
+  showIndicator?: boolean;
+  /**
    * Color of the arrow tip border
    */
   tipBorderColor?: string;
@@ -149,14 +154,15 @@ function Hovercard(props: HovercardProps): React.ReactElement {
     <Manager>
       <Reference>
         {({ref}) => (
-          <span
+          <Trigger
             ref={ref}
             aria-describedby={tooltipId}
             className={props.containerClassName}
+            showIndicator={props.showIndicator}
             {...hoverProps}
           >
             {props.children}
-          </span>
+          </Trigger>
         )}
       </Reference>
       {createPortal(
@@ -272,6 +278,10 @@ function getTipDirection(
 
   return (prefix || 'top') as 'top' | 'bottom' | 'left' | 'right';
 }
+
+const Trigger = styled('span')<{showIndicator?: boolean}>`
+  ${p => p.showIndicator && p.theme.tooltipUnderline};
+`;
 
 const HovercardContainer = styled('div')`
   /* Some hovercards overlap the toplevel header and sidebar, and we need to appear on top */

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -92,15 +92,15 @@ export interface InternalTooltipProps {
   position?: PopperJS.Placement;
 
   /**
-   * Whether to add a dotted underline to the trigger element, to indicate the
-   * presence of a tooltip.
-   */
-  showIndicator?: boolean;
-
-  /**
    * Only display the tooltip only if the content overflows
    */
   showOnlyOnOverflow?: boolean;
+
+  /**
+   * Whether to add a dotted underline to the trigger element, to indicate the
+   * presence of a tooltip.
+   */
+  showUnderline?: boolean;
 
   /**
    * If child node supports ref forwarding, you can skip apply a wrapper
@@ -143,7 +143,7 @@ export function DO_NOT_USE_TOOLTIP({
   forceVisible,
   isHoverable,
   popperStyle,
-  showIndicator,
+  showUnderline,
   showOnlyOnOverflow,
   skipWrapper,
   title,
@@ -248,7 +248,7 @@ export function DO_NOT_USE_TOOLTIP({
             cloneElement(triggerChildren, {
               ...containerProps,
               className: cx(
-                showIndicator && css(theme.tooltipUnderline),
+                showUnderline && css(theme.tooltipUnderline),
                 triggerChildren.props.className
               ),
               ref: setRef,
@@ -263,7 +263,7 @@ export function DO_NOT_USE_TOOLTIP({
     return (
       <Container
         {...containerProps}
-        css={showIndicator && theme.tooltipUnderline}
+        css={showUnderline && theme.tooltipUnderline}
         className={className}
         ref={setRef}
       >

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -247,7 +247,10 @@ export function DO_NOT_USE_TOOLTIP({
           {({cx, css}) =>
             cloneElement(triggerChildren, {
               ...containerProps,
-              className: cx(showIndicator && css(theme.tooltipUnderline)),
+              className: cx(
+                showIndicator && css(theme.tooltipUnderline),
+                triggerChildren.props.className
+              ),
               ref: setRef,
             })
           }
@@ -258,17 +261,14 @@ export function DO_NOT_USE_TOOLTIP({
     containerProps.containerDisplayMode = containerDisplayMode;
 
     return (
-      <ClassNames>
-        {({cx, css}) => (
-          <Container
-            {...containerProps}
-            className={cx(className, showIndicator && css(theme.tooltipUnderline))}
-            ref={setRef}
-          >
-            {triggerChildren}
-          </Container>
-        )}
-      </ClassNames>
+      <Container
+        {...containerProps}
+        css={showIndicator && theme.tooltipUnderline}
+        className={className}
+        ref={setRef}
+      >
+        {triggerChildren}
+      </Container>
     );
   }
 
@@ -319,7 +319,9 @@ export function DO_NOT_USE_TOOLTIP({
 
 // Using an inline-block solves the container being smaller
 // than the elements it is wrapping
-const Container = styled('span')<{containerDisplayMode?: React.CSSProperties['display']}>`
+const Container = styled('span')<{
+  containerDisplayMode?: React.CSSProperties['display'];
+}>`
   ${p => p.containerDisplayMode && `display: ${p.containerDisplayMode}`};
   max-width: 100%;
 `;

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import {createPortal} from 'react-dom';
 import {Manager, Popper, PopperArrowProps, PopperProps, Reference} from 'react-popper';
-import {SerializedStyles} from '@emotion/react';
+import {ClassNames, SerializedStyles, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion, MotionProps, MotionStyle} from 'framer-motion';
 import * as PopperJS from 'popper.js';
@@ -92,6 +92,12 @@ export interface InternalTooltipProps {
   position?: PopperJS.Placement;
 
   /**
+   * Whether to add a dotted underline to the trigger element, to indicate the
+   * presence of a tooltip.
+   */
+  showIndicator?: boolean;
+
+  /**
    * Only display the tooltip only if the content overflows
    */
   showOnlyOnOverflow?: boolean;
@@ -137,6 +143,7 @@ export function DO_NOT_USE_TOOLTIP({
   forceVisible,
   isHoverable,
   popperStyle,
+  showIndicator,
   showOnlyOnOverflow,
   skipWrapper,
   title,
@@ -146,6 +153,7 @@ export function DO_NOT_USE_TOOLTIP({
 }: InternalTooltipProps) {
   const [visible, setVisible] = useState(false);
   const tooltipId = useMemo(() => domId('tooltip-'), []);
+  const theme = useTheme();
 
   // Delayed open and close time handles
   const delayOpenTimeoutRef = useRef<number | undefined>(undefined);
@@ -234,15 +242,33 @@ export function DO_NOT_USE_TOOLTIP({
       (skipWrapper || typeof triggerChildren.type === 'string')
     ) {
       // Basic DOM nodes can be cloned and have more props applied.
-      return cloneElement(triggerChildren, {...containerProps, ref: setRef});
+      return (
+        <ClassNames>
+          {({cx, css}) =>
+            cloneElement(triggerChildren, {
+              ...containerProps,
+              className: cx(showIndicator && css(theme.tooltipUnderline)),
+              ref: setRef,
+            })
+          }
+        </ClassNames>
+      );
     }
 
     containerProps.containerDisplayMode = containerDisplayMode;
 
     return (
-      <Container {...containerProps} className={className} ref={setRef}>
-        {triggerChildren}
-      </Container>
+      <ClassNames>
+        {({cx, css}) => (
+          <Container
+            {...containerProps}
+            className={cx(className, showIndicator && css(theme.tooltipUnderline))}
+            ref={setRef}
+          >
+            {triggerChildren}
+          </Container>
+        )}
+      </ClassNames>
     );
   }
 
@@ -293,9 +319,7 @@ export function DO_NOT_USE_TOOLTIP({
 
 // Using an inline-block solves the container being smaller
 // than the elements it is wrapping
-const Container = styled('span')<{
-  containerDisplayMode?: React.CSSProperties['display'];
-}>`
+const Container = styled('span')<{containerDisplayMode?: React.CSSProperties['display']}>`
   ${p => p.containerDisplayMode && `display: ${p.containerDisplayMode}`};
   max-width: 100%;
 `;

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -257,7 +257,7 @@ export function DO_NOT_USE_TOOLTIP({
     return (
       <Container
         {...containerProps}
-        {...(showUnderline && {style: theme.tooltipUnderline})}
+        style={showUnderline ? theme.tooltipUnderline : undefined}
         className={className}
         ref={setRef}
       >

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import {createPortal} from 'react-dom';
 import {Manager, Popper, PopperArrowProps, PopperProps, Reference} from 'react-popper';
-import {ClassNames, SerializedStyles, useTheme} from '@emotion/react';
+import {SerializedStyles, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion, MotionProps, MotionStyle} from 'framer-motion';
 import * as PopperJS from 'popper.js';
@@ -242,20 +242,14 @@ export function DO_NOT_USE_TOOLTIP({
       (skipWrapper || typeof triggerChildren.type === 'string')
     ) {
       // Basic DOM nodes can be cloned and have more props applied.
-      return (
-        <ClassNames>
-          {({cx, css}) =>
-            cloneElement(triggerChildren, {
-              ...containerProps,
-              className: cx(
-                showUnderline && css(theme.tooltipUnderline),
-                triggerChildren.props.className
-              ),
-              ref: setRef,
-            })
-          }
-        </ClassNames>
-      );
+      return cloneElement(triggerChildren, {
+        ...containerProps,
+        style: {
+          ...triggerChildren.props.style,
+          ...(showUnderline && theme.tooltipUnderline),
+        },
+        ref: setRef,
+      });
     }
 
     containerProps.containerDisplayMode = containerDisplayMode;
@@ -263,7 +257,7 @@ export function DO_NOT_USE_TOOLTIP({
     return (
       <Container
         {...containerProps}
-        css={showUnderline && theme.tooltipUnderline}
+        {...(showUnderline && {style: theme.tooltipUnderline})}
         className={className}
         ref={setRef}
       >

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -14,7 +14,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
   }
 
   abbr {
-    ${theme.tooltipIndicator};
+    ${theme.tooltipUnderline};
   }
 
   a {

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -14,7 +14,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
   }
 
   abbr {
-    border-bottom: 1px dotted ${theme.gray300};
+    ${theme.tooltipIndicator};
   }
 
   a {

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -1,4 +1,4 @@
-import {css} from '@emotion/react';
+import '@emotion/react';
 
 import color from 'color';
 
@@ -565,11 +565,11 @@ const generateButtonTheme = (colors: BaseColors, alias: Aliases) => ({
 });
 
 const generateUtils = (colors: BaseColors) => ({
-  tooltipUnderline: css({
+  tooltipUnderline: {
     textDecoration: `underline dotted ${colors.gray300}`,
     textDecorationThickness: '0.75px',
     textUnderlineOffset: '1.25px',
-  }),
+  },
 });
 
 const iconSizes = {

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -565,14 +565,6 @@ const generateButtonTheme = (colors: BaseColors, alias: Aliases) => ({
 });
 
 const generateUtils = (colors: BaseColors) => ({
-  linkUnderline: css({
-    textDecoration: `underline ${colors.translucentGray200}`,
-    textDecorationThickness: '1px',
-    textUnderlineOffset: '1px',
-    '&:hover': {
-      textDecorationColor: colors.gray300,
-    },
-  }),
   tooltipUnderline: css({
     textDecoration: `underline dotted ${colors.gray300}`,
     textDecorationThickness: '0.75px',

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -1,4 +1,4 @@
-import '@emotion/react';
+import {css} from '@emotion/react';
 
 import color from 'color';
 
@@ -564,6 +564,22 @@ const generateButtonTheme = (colors: BaseColors, alias: Aliases) => ({
   },
 });
 
+const generateUtils = (colors: BaseColors) => ({
+  linkUnderline: css({
+    textDecoration: `underline ${colors.translucentGray200}`,
+    textDecorationThickness: '1px',
+    textUnderlineOffset: '1px',
+    '&:hover': {
+      textDecorationColor: colors.gray300,
+    },
+  }),
+  tooltipUnderline: css({
+    textDecoration: `underline dotted ${colors.gray300}`,
+    textDecorationThickness: '0.75px',
+    textUnderlineOffset: '1.25px',
+  }),
+});
+
 const iconSizes = {
   xs: '12px',
   sm: '16px',
@@ -812,6 +828,7 @@ export const lightTheme = {
     ...darkColors,
     ...darkAliases,
   },
+  ...generateUtils(lightColors),
   alert: generateAlertTheme(lightColors, lightAliases),
   badge: generateBadgeTheme(lightColors),
   button: generateButtonTheme(lightColors, lightAliases),
@@ -834,6 +851,7 @@ export const darkTheme: Theme = {
     ...lightColors,
     ...lightAliases,
   },
+  ...generateUtils(darkColors),
   alert: generateAlertTheme(darkColors, darkAliases),
   badge: generateBadgeTheme(darkColors),
   button: generateButtonTheme(darkColors, darkAliases),

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -138,7 +138,7 @@ class GroupEventToolbar extends Component<Props> {
             </ExternalLink>
           </LinkContainer>
         </Heading>
-        <Tooltip title={this.getDateTooltip()} showIndicator disableForVisualTest>
+        <Tooltip title={this.getDateTooltip()} showUnderline disableForVisualTest>
           <StyledDateTime
             format={is24Hours ? 'MMM D, YYYY HH:mm:ss zz' : 'll LTS z'}
             date={getDynamicText({

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -138,7 +138,7 @@ class GroupEventToolbar extends Component<Props> {
             </ExternalLink>
           </LinkContainer>
         </Heading>
-        <Tooltip title={this.getDateTooltip()} disableForVisualTest>
+        <Tooltip title={this.getDateTooltip()} showIndicator disableForVisualTest>
           <StyledDateTime
             format={is24Hours ? 'MMM D, YYYY HH:mm:ss zz' : 'll LTS z'}
             date={getDynamicText({
@@ -198,7 +198,6 @@ const StyledIconWarning = styled(IconWarning)`
 `;
 
 const StyledDateTime = styled(DateTime)`
-  border-bottom: 1px dotted #dfe3ea;
   color: ${p => p.theme.subText};
 `;
 

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -198,6 +198,7 @@ class GroupHeader extends React.Component<Props, State> {
                       <h6 className="nav-header">
                         <Tooltip
                           className="help-link"
+                          showIndicator
                           title={t(
                             'This identifier is unique across your organization, and can be used to reference an issue in various places, like commit messages.'
                           )}

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -198,7 +198,7 @@ class GroupHeader extends React.Component<Props, State> {
                       <h6 className="nav-header">
                         <Tooltip
                           className="help-link"
-                          showIndicator
+                          showUnderline
                           title={t(
                             'This identifier is unique across your organization, and can be used to reference an issue in various places, like commit messages.'
                           )}

--- a/static/less/shared-components.less
+++ b/static/less/shared-components.less
@@ -1074,7 +1074,6 @@ header + .alert {
   a.help-link,
   span.help-link a {
     color: inherit;
-    border-bottom: 1px dotted @gray-light;
   }
 
   .view-more {


### PR DESCRIPTION
Add a new utility object in theme called `tooltipUnderline`, which contains styles for a dotted underline meant for indicating which elements have tooltips available for hover.

<img width="166" alt="Screen Shot 2022-04-19 at 11 48 59 AM" src="https://user-images.githubusercontent.com/44172267/164074577-12b53b0d-5747-4bbf-a65b-3f9aa826845f.png">

We already have this dotted underline pattern in a few places in-app. Moving the styles to the theme object standardizes it across components.