### PR TITLE
feat(perf): Add min max exclusive time filters to span stats endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -126,6 +126,19 @@ class SpansPerformanceSerializer(serializers.Serializer):  # type: ignore
     spanGroup = ListField(
         child=serializers.CharField(), required=False, allow_null=True, max_length=4
     )
+    min_exclusive_time = serializers.FloatField(required=False)
+    max_exclusive_time = serializers.FloatField(required=False)
+
+    def validate(self, data):
+        if (
+            "min_exclusive_time" in data
+            and "max_exclusive_time" in data
+            and data["min_exclusive_time"] > data["max_exclusive_time"]
+        ):
+            raise serializers.ValidationError(
+                "min_exclusive_time cannot be greater than max_exclusive_time."
+            )
+        return data
 
     def validate_spanGroup(self, span_groups):
         for group in span_groups:
@@ -153,6 +166,8 @@ class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsSpansEndpoint
         query = serialized.get("query")
         span_ops = serialized.get("spanOp")
         span_groups = serialized.get("spanGroup")
+        min_exclusive_time = serialized.get("min_exclusive_time")
+        max_exclusive_time = serialized.get("max_exclusive_time")
 
         direction, orderby_column = self.get_orderby_column(request)
 
@@ -167,6 +182,8 @@ class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsSpansEndpoint
                 orderby_column,
                 limit,
                 offset,
+                min_exclusive_time,
+                max_exclusive_time,
             )
 
             return [suspect.serialize() for suspect in suspects]
@@ -440,6 +457,8 @@ def query_suspect_span_groups(
     orderby: str,
     limit: int,
     offset: int,
+    min_exclusive_time: Optional[float] = None,
+    max_exclusive_time: Optional[float] = None,
 ) -> List[SuspectSpan]:
     suspect_span_columns = SPAN_PERFORMANCE_COLUMNS[orderby]
 
@@ -491,6 +510,24 @@ def query_suspect_span_groups(
                 builder.resolve_function("array_join(spans_group)"),
                 Op.IN,
                 Function("tuple", span_groups),
+            )
+        )
+
+    if min_exclusive_time is not None:
+        extra_conditions.append(
+            Condition(
+                builder.resolve_function("array_join(spans_exclusive_time)"),
+                Op.GT,
+                min_exclusive_time,
+            )
+        )
+
+    if max_exclusive_time is not None:
+        extra_conditions.append(
+            Condition(
+                builder.resolve_function("array_join(spans_exclusive_time)"),
+                Op.LT,
+                max_exclusive_time,
             )
         )
 

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -73,7 +73,6 @@ from sentry.search.events.fields import (
     SnQLFieldColumn,
     SnQLFunction,
     SnQLStringArg,
-    StringArrayColumn,
     normalize_count_if_value,
     normalize_percentile_alias,
     reflective_result_type,
@@ -604,7 +603,7 @@ class DiscoverDatasetConfig(DatasetConfig):
                 ),
                 SnQLFunction(
                     "array_join",
-                    required_args=[StringArrayColumn("column")],
+                    required_args=[ColumnArg("column")],
                     snql_column=lambda args, alias: Function("arrayJoin", [args["column"]], alias),
                     default_result_type="string",
                     private=True,

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -895,12 +895,28 @@ class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndp
                 self.url,
                 data={
                     "project": self.project.id,
-                    "min_exclusive_time": 4,
+                    "min_exclusive_time": 3,
                 },
             )
 
+        expected_result = [
+            {
+                "op": "http.server",
+                "group": "abababababababab",
+                "description": "root transaction",
+                "frequency": None,
+                "count": None,
+                "avgOccurrences": None,
+                "sumExclusiveTime": 4.0,
+                "p50ExclusiveTime": None,
+                "p75ExclusiveTime": None,
+                "p95ExclusiveTime": None,
+                "p99ExclusiveTime": None,
+            },
+        ]
+
         assert response.status_code == 200, response.content
-        assert response.data == []
+        assert response.data == expected_result
 
     def test_max_exclusive_time_filter(self):
         self.create_event()
@@ -910,12 +926,27 @@ class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndp
                 self.url,
                 data={
                     "project": self.project.id,
-                    "max_exclusive_time": 1,
+                    "max_exclusive_time": 2,
                 },
             )
 
+        expected_result = [
+            {
+                "op": "django.view",
+                "group": "ef" * 8,
+                "description": "view span",
+                "frequency": None,
+                "count": None,
+                "avgOccurrences": None,
+                "sumExclusiveTime": 3.0,
+                "p50ExclusiveTime": None,
+                "p75ExclusiveTime": None,
+                "p95ExclusiveTime": None,
+                "p99ExclusiveTime": None,
+            }
+        ]
         assert response.status_code == 200, response.content
-        assert response.data == []
+        assert response.data == expected_result
 
     def test_min_max_exclusive_time_filter(self):
         self.create_event()
@@ -923,11 +954,27 @@ class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndp
         with self.feature(self.FEATURES):
             response = self.client.get(
                 self.url,
-                data={"project": self.project.id, "max_exclusive_time": 5, "min_exclusive_time": 4},
+                data={"project": self.project.id, "max_exclusive_time": 4, "min_exclusive_time": 2},
             )
 
+        expected_result = [
+            {
+                "op": "django.middleware",
+                "group": "cd" * 8,
+                "description": "middleware span",
+                "frequency": None,
+                "count": None,
+                "avgOccurrences": None,
+                "sumExclusiveTime": 6.0,
+                "p50ExclusiveTime": None,
+                "p75ExclusiveTime": None,
+                "p95ExclusiveTime": None,
+                "p99ExclusiveTime": None,
+            }
+        ]
+
         assert response.status_code == 200, response.content
-        assert response.data == []
+        assert response.data == expected_result
 
     @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
     def test_pagination_first_page(self, mock_raw_snql_query):

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -461,6 +461,57 @@ class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndp
             "detail": ErrorDetail("You must specify exactly 1 project.", code="parse_error"),
         }
 
+    def test_bad_params_reverse_min_max_exclusive_time(self):
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={
+                    "project": self.project.id,
+                    "min_exclusive_time": 7.0,
+                    "max_exclusive_time": 1.0,
+                },
+                format="json",
+            )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "non_field_errors": ["min_exclusive_time cannot be greater than max_exclusive_time."]
+        }
+
+    def test_bad_params_invalid_min_exclusive_time(self):
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={
+                    "project": self.project.id,
+                    "min_exclusive_time": "foo",
+                    "max_exclusive_time": 1.0,
+                },
+                format="json",
+            )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "min_exclusive_time": ["A valid number is required."]
+        }, "failing for min_exclusive_time"
+
+    def test_bad_params_invalid_max_exclusive_time(self):
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={
+                    "project": self.project.id,
+                    "min_exclusive_time": 100,
+                    "max_exclusive_time": "bar",
+                },
+                format="json",
+            )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "max_exclusive_time": ["A valid number is required."]
+        }, "failing for max_exclusive_time"
+
     def test_bad_sort(self):
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -835,6 +886,48 @@ class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndp
             )
             in mock_raw_snql_query.call_args_list[0][0][0].where
         )
+
+    def test_min_exclusive_time_filter(self):
+        self.create_event()
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={
+                    "project": self.project.id,
+                    "min_exclusive_time": 4,
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data == []
+
+    def test_max_exclusive_time_filter(self):
+        self.create_event()
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={
+                    "project": self.project.id,
+                    "max_exclusive_time": 1,
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data == []
+
+    def test_min_max_exclusive_time_filter(self):
+        self.create_event()
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={"project": self.project.id, "max_exclusive_time": 5, "min_exclusive_time": 4},
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data == []
 
     @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
     def test_pagination_first_page(self, mock_raw_snql_query):


### PR DESCRIPTION
This PR adds an ability to add extra filters, `min_exclusive_time` and `max_exclusive_time`, so that users are able to view span stats for the selected population. This supplements histogram zooming feature, so in the span details page users are able to view the stats specific to the selected population.

Fixes PERF-1520