### PR TITLE
fix(alerts): Format total issue count

### DIFF
--- a/static/app/views/alerts/details/alertChart.tsx
+++ b/static/app/views/alerts/details/alertChart.tsx
@@ -147,7 +147,7 @@ class AlertChart extends AsyncComponent<Props, State> {
         </StyledPanelBody>
         <ChartFooter>
           <FooterHeader>{t('Total Alerts')}</FooterHeader>
-          <FooterValue>{totalAlertsTriggered}</FooterValue>
+          <FooterValue>{totalAlertsTriggered.toLocaleString()}</FooterValue>
         </ChartFooter>
       </Panel>
     );


### PR DESCRIPTION
just formatting the total alerts, we expected it to be small, but sometimes it may be in 1000s

<img width="780" alt="image" src="https://user-images.githubusercontent.com/1400464/164082762-53c9ea38-ef45-43bd-9b47-6889587e9a8c.png">
