### PR TITLE
fix(workflow): Handle filtering release list by date

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -80,13 +80,17 @@ class ReleasesList extends AsyncView<Props, State> {
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {organization, location} = this.props;
-    const {statsPeriod} = location.query;
+    const {statsPeriod, start, end, utc} = location.query;
     const activeSort = this.getSort();
     const activeStatus = this.getStatus();
 
     const query = {
       ...pick(location.query, ['project', 'environment', 'cursor', 'query', 'sort']),
       summaryStatsPeriod: statsPeriod,
+      ...(statsPeriod && {statsPeriod}),
+      start,
+      end,
+      utc,
       per_page: 20,
       flatten: activeSort === ReleasesSortOption.DATE ? 0 : 1,
       adoptionStages: 1,

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -87,7 +87,7 @@ class ReleasesList extends AsyncView<Props, State> {
     const query = {
       ...pick(location.query, ['project', 'environment', 'cursor', 'query', 'sort']),
       summaryStatsPeriod: statsPeriod,
-      ...(statsPeriod && {statsPeriod}),
+      statsPeriod,
       start,
       end,
       utc,


### PR DESCRIPTION
Currently, the date picker on the releases list only changes the graph. This adds the ability to filter by date using the global selection header.

[FIXES WOR-1786](https://getsentry.atlassian.net/browse/WOR-1786)