### PR TITLE
fix(codeowners): Start task after a delay and retry once on error

### DIFF
--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -54,7 +54,9 @@ def process_resource_change(instance, **kwargs):
 
     # CODEOWNERS file added or modified, trigger auto-sync
     if instance.filename in filepaths and instance.type in ["A", "M"]:
-        code_owners_auto_sync.delay(instance.commit_id)
+        code_owners_auto_sync.apply_async(
+            kwargs={"commit_id": instance.commit_id}, countdown=60 * 5
+        )
 
 
 post_save.connect(

--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -54,6 +54,7 @@ def process_resource_change(instance, **kwargs):
 
     # CODEOWNERS file added or modified, trigger auto-sync
     if instance.filename in filepaths and instance.type in ["A", "M"]:
+        # Trigger the task after 5min to make sure all records in the transactions has been saved.
         code_owners_auto_sync.apply_async(
             kwargs={"commit_id": instance.commit_id}, countdown=60 * 5
         )

--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -63,7 +63,7 @@ def code_owners_auto_sync(commit_id: int, **kwargs):
         except (NotImplementedError, NotFound):
             codeowner_contents = None
 
-        # If failed to fetch, the user can manually sync. We'll send them an email on failure.
+        # If we fail to fetch the codeowners file, the user can manually sync. We'll send them an email on failure.
         if not codeowner_contents:
             return AutoSyncNotification(code_mapping.project).send()
 

--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -1,25 +1,21 @@
 from rest_framework.exceptions import NotFound
 
+from sentry.models import Commit, ProjectCodeOwners, ProjectOwnership, RepositoryProjectPathConfig
 from sentry.notifications.notifications.codeowners_auto_sync import AutoSyncNotification
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 
 
 @instrumented_task(
     name="sentry.tasks.code_owners_auto_sync",
     queue="code_owners",
-    # If the task fails, the user can manually sync. We'll send them an email on failure.
-    max_retries=0,
+    default_retry_delay=60 * 5,
+    max_retries=1,
 )
+@retry(on=(Commit.DoesNotExist,))
 def code_owners_auto_sync(commit_id: int, **kwargs):
     from django.db.models import BooleanField, Case, Exists, OuterRef, Subquery, When
 
     from sentry.api.endpoints.organization_code_mapping_codeowners import get_codeowner_contents
-    from sentry.models import (
-        Commit,
-        ProjectCodeOwners,
-        ProjectOwnership,
-        RepositoryProjectPathConfig,
-    )
 
     commit = Commit.objects.get(id=commit_id)
 
@@ -67,6 +63,7 @@ def code_owners_auto_sync(commit_id: int, **kwargs):
         except (NotImplementedError, NotFound):
             codeowner_contents = None
 
+        # If failed to fetch, the user can manually sync. We'll send them an email on failure.
         if not codeowner_contents:
             return AutoSyncNotification(code_mapping.project).send()
 


### PR DESCRIPTION
## Objective:
Fixes [SENTRY-TH3](https://sentry.io/organizations/sentry/issues/3084878291/?project=1&referrer=jira_integration)

It looks like the task is failing to find the Commit before it has been saved. Since we do not make any realtime guarantees for this feature, I added a delay to when we start the task and 1 retry on Commit.DoesNotExist error. 
