### PR TITLE
feat(performance): Show project icon next to span/transaction summary title

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -7,10 +7,12 @@ import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
 import FeatureBadge from 'sentry/components/featureBadge';
+import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ListLink from 'sentry/components/links/listLink';
 import NavTabs from 'sentry/components/navTabs';
 import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
@@ -218,7 +220,8 @@ class TransactionHeader extends React.Component<Props> {
   }
 
   render() {
-    const {organization, location, projectId, transactionName, currentTab} = this.props;
+    const {organization, location, projectId, transactionName, currentTab, projects} =
+      this.props;
 
     const routeQuery = {
       orgSlug: organization.slug,
@@ -233,6 +236,8 @@ class TransactionHeader extends React.Component<Props> {
     const spansTarget = spansRouteWithQuery(routeQuery);
     const anomaliesTarget = anomaliesRouteWithQuery(routeQuery);
 
+    const project = projects.find(p => p.id === projectId);
+
     return (
       <Layout.Header>
         <Layout.HeaderContent>
@@ -245,7 +250,12 @@ class TransactionHeader extends React.Component<Props> {
             }}
             tab={currentTab}
           />
-          <Layout.Title>{transactionName}</Layout.Title>
+          <Layout.Title>
+            <TransactionName>
+              <IdBadge project={project} avatarSize={28} hideName />
+              {transactionName}
+            </TransactionName>
+          </Layout.Title>
         </Layout.HeaderContent>
         <Layout.HeaderActions>
           <ButtonBar gap={1}>
@@ -318,6 +328,13 @@ const StyledNavTabs = styled(NavTabs)`
   margin-bottom: 0;
   /* Makes sure the tabs are pushed into another row */
   width: 100%;
+`;
+
+const TransactionName = styled('div')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  grid-column-gap: ${space(1)};
+  align-items: center;
 `;
 
 export default TransactionHeader;

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -252,7 +252,14 @@ class TransactionHeader extends React.Component<Props> {
           />
           <Layout.Title>
             <TransactionName>
-              <IdBadge project={project} avatarSize={28} hideName />
+              {project && (
+                <IdBadge
+                  project={project}
+                  avatarSize={28}
+                  hideName
+                  avatarProps={{hasTooltip: true, tooltip: project.slug}}
+                />
+              )}
               {transactionName}
             </TransactionName>
           </Layout.Title>

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -62,7 +62,14 @@ export default function SpanDetailsContentWrapper(props: Props) {
           />
           <Layout.Title>
             <TransactionName>
-              <IdBadge project={project} avatarSize={28} hideName />
+              {project && (
+                <IdBadge
+                  project={project}
+                  avatarSize={28}
+                  hideName
+                  avatarProps={{hasTooltip: true, tooltip: project.slug}}
+                />
+              )}
               {transactionName}
             </TransactionName>
           </Layout.Title>

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 import Feature from 'sentry/components/acl/feature';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
+import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import space from 'sentry/styles/space';
@@ -59,7 +60,12 @@ export default function SpanDetailsContentWrapper(props: Props) {
             tab={Tab.Spans}
             spanSlug={spanSlug}
           />
-          <Layout.Title>{transactionName}</Layout.Title>
+          <Layout.Title>
+            <TransactionName>
+              <IdBadge project={project} avatarSize={28} hideName />
+              {transactionName}
+            </TransactionName>
+          </Layout.Title>
         </Layout.HeaderContent>
       </Layout.Header>
       <Layout.Body>
@@ -123,6 +129,13 @@ export default function SpanDetailsContentWrapper(props: Props) {
     </Fragment>
   );
 }
+
+const TransactionName = styled('div')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  grid-column-gap: ${space(1)};
+  align-items: center;
+`;
 
 type ContentProps = {
   eventView: EventView;


### PR DESCRIPTION
This will be more relevant when we migrate to page filters, since we won't retain the project selection in the global header

<img width="1426" alt="image" src="https://user-images.githubusercontent.com/9372512/164115129-e1a49b4e-8c04-431a-92bc-87ea9f68ee3d.png">
