### PR TITLE
fix(ui): Correctly cleanup outside-click panel close handler

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -59,6 +59,14 @@ type Props = {
   organization?: Organization;
 };
 
+function togglePanel(panel: SidebarPanelKey) {
+  SidebarPanelStore.togglePanel(panel);
+}
+
+function hidePanel() {
+  SidebarPanelStore.hidePanel();
+}
+
 function Sidebar({location, organization}: Props) {
   const config = useLegacyStore(ConfigStore);
   const preferences = useLegacyStore(PreferencesStore);
@@ -71,9 +79,6 @@ function Sidebar({location, organization}: Props) {
     const action = collapsed ? showSidebar : hideSidebar;
     action();
   };
-
-  const togglePanel = (panel: SidebarPanelKey) => SidebarPanelStore.togglePanel(panel);
-  const hidePanel = () => SidebarPanelStore.hidePanel();
 
   const bcl = document.body.classList;
 

--- a/static/app/components/sidebar/sidebarPanel.tsx
+++ b/static/app/components/sidebar/sidebarPanel.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -69,17 +69,20 @@ function SidebarPanel({
 }: Props): React.ReactElement {
   const portalEl = useRef<HTMLDivElement>(getSidebarPortal());
 
-  function panelCloseHandler(evt: MouseEvent) {
-    if (!(evt.target instanceof Element)) {
-      return;
-    }
+  const panelCloseHandler = useCallback(
+    (evt: MouseEvent) => {
+      if (!(evt.target instanceof Element)) {
+        return;
+      }
 
-    if (portalEl.current.contains(evt.target)) {
-      return;
-    }
+      if (portalEl.current.contains(evt.target)) {
+        return;
+      }
 
-    hidePanel();
-  }
+      hidePanel();
+    },
+    [hidePanel]
+  );
 
   useEffect(() => {
     // Wait one tick to setup the click handler so we don't detect the click
@@ -89,7 +92,7 @@ function SidebarPanel({
     return function cleanup() {
       document.removeEventListener('click', panelCloseHandler);
     };
-  }, []);
+  }, [panelCloseHandler]);
 
   return createPortal(
     <PanelContainer


### PR DESCRIPTION
This wasn't actually cleaning anything up