### PR TITLE
ref(ts): Avoid importing popper.js things

### DIFF
--- a/static/app/components/performance/teamKeyTransaction.tsx
+++ b/static/app/components/performance/teamKeyTransaction.tsx
@@ -1,8 +1,7 @@
 import {Component, Fragment} from 'react';
 import {createPortal} from 'react-dom';
-import {Manager, Popper, Reference} from 'react-popper';
+import {Manager, Popper, PopperProps, Reference} from 'react-popper';
 import styled from '@emotion/styled';
-import * as PopperJS from 'popper.js';
 
 import MenuHeader from 'sentry/components/actions/menuHeader';
 import CheckboxFancy from 'sentry/components/checkboxFancy/checkboxFancy';
@@ -208,7 +207,7 @@ class TeamKeyTransaction extends Component<Props, State> {
       return null;
     }
 
-    const modifiers: PopperJS.Modifiers = {
+    const modifiers: PopperProps['modifiers'] = {
       hide: {
         enabled: false,
       },

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -12,7 +12,6 @@ import {Manager, Popper, PopperArrowProps, PopperProps, Reference} from 'react-p
 import {SerializedStyles, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion, MotionProps, MotionStyle} from 'framer-motion';
-import * as PopperJS from 'popper.js';
 
 import {IS_ACCEPTANCE_TEST} from 'sentry/constants/index';
 import space from 'sentry/styles/space';
@@ -89,7 +88,7 @@ export interface InternalTooltipProps {
   /**
    * Position for the tooltip.
    */
-  position?: PopperJS.Placement;
+  position?: PopperProps['placement'];
 
   /**
    * Only display the tooltip only if the content overflows
@@ -202,7 +201,7 @@ export function DO_NOT_USE_TOOLTIP({
 
   // Tracks the triggering element
   const triggerRef = useRef<HTMLElement | null>(null);
-  const modifiers: PopperJS.Modifiers = useMemo(() => {
+  const modifiers: PopperProps['modifiers'] = useMemo(() => {
     return {
       hide: {enabled: false},
       preventOverflow: {

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import {createPortal} from 'react-dom';
-import {Manager, Popper, Reference} from 'react-popper';
+import {Manager, Popper, PopperProps, Reference} from 'react-popper';
 import styled from '@emotion/styled';
 import color from 'color';
-import * as PopperJS from 'popper.js';
 
 import {IconEllipsis} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -364,7 +363,7 @@ class CellAction extends React.Component<Props, State> {
       return null;
     }
 
-    const modifiers: PopperJS.Modifiers = {
+    const modifiers: PopperProps['modifiers'] = {
       hide: {
         enabled: false,
       },

--- a/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
@@ -1,10 +1,9 @@
 import {Component} from 'react';
 import {createPortal} from 'react-dom';
-import {Manager, Popper, Reference} from 'react-popper';
+import {Manager, Popper, PopperProps, Reference} from 'react-popper';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location, LocationDescriptorObject} from 'history';
-import * as PopperJS from 'popper.js';
 
 import {GetActorPropsFn} from 'sentry/components/dropdownMenu';
 import MenuItem from 'sentry/components/menuItem';
@@ -129,7 +128,7 @@ class OperationSort extends Component<Props, State> {
   }
 
   renderMenu() {
-    const modifiers: PopperJS.Modifiers = {
+    const modifiers: PopperProps['modifiers'] = {
       hide: {
         enabled: false,
       },


### PR DESCRIPTION
We can just use PopperProps since that's typically what we're using it for