### PR TITLE
feat(sourcemaps): Share SourceMapView across events [INGEST-1194]

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -108,6 +108,7 @@ default_manager.add("organizations:performance-use-snql", OrganizationFeature, T
 default_manager.add("organizations:performance-use-metrics", OrganizationFeature, True)
 default_manager.add("organizations:performance-dry-run-mep", OrganizationFeature, True)
 default_manager.add("organizations:trends-use-snql", OrganizationFeature, True)
+default_manager.add("organizations:processing-sourcemap-lru-cache", OrganizationFeature, True)
 default_manager.add("organizations:profiling", OrganizationFeature, True)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)
 default_manager.add("organizations:projects-page-redesign", OrganizationFeature, True)

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -1215,7 +1215,6 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                     fetch_sourcemap_fn = cached_fetch_sourcemap
                 else:
                     fetch_sourcemap_fn = fetch_sourcemap
-
                 sourcemap_view = fetch_sourcemap_fn(
                     sourcemap_url,
                     project=self.project,

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -844,6 +844,10 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             "sentry:scrape_javascript", True
         ) is not False and self.project.get_option("sentry:scrape_javascript", True)
 
+        self.use_sourcemap_lru_cache = features.has(
+            "organizations:processing-sourcemap-lru-cache", organization
+        )
+
         self.fetch_count = 0
         self.sourcemaps_touched = set()
 
@@ -1207,7 +1211,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 op="JavaScriptStacktraceProcessor.cache_source.fetch_sourcemap"
             ) as span:
                 span.set_data("sourcemap_url", sourcemap_url)
-                if features.has("organizations:processing-sourcemap-lru-cache"):
+                if self.use_sourcemap_lru_cache:
                     fetch_sourcemap_fn = cached_fetch_sourcemap
                 else:
                     fetch_sourcemap_fn = fetch_sourcemap

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -352,6 +352,11 @@ register("processing.release-archive-min-files", default=10)
 # Try to read release artifacts from zip archives
 register("processing.use-release-archives-sample-rate", default=0.0)  # unused
 
+# Max number of source maps in the process-wide source map cache.
+# The current default (10) only makes sense when the projects:per-process-sourcemap-cache
+# is enabled for a handful of projects.
+register("processing.sourcemap-lru-cache-limit", default=10)
+
 # All Relay options (statically authenticated Relays can be registered here)
 register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
 

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -1380,7 +1380,8 @@ class CacheSourceTest(TestCase):
         "sentry.lang.javascript.processor.discover_sourcemap",
         return_value="app:///../node_modules/some-package/index.js.map",
     )
-    def test_sourcemap_lru_cache_used(self, _):
+    @patch("sentry.lang.javascript.processor.fetch_sourcemap")
+    def test_sourcemap_lru_cache_used(self, _1, _2):
         """When the feature flag is on, lru cache is reused"""
 
         project = self.create_project()

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -33,6 +33,7 @@ from sentry.lang.javascript.processor import (
     trim_line,
 )
 from sentry.models import EventError, File, Release, ReleaseFile
+from sentry.models.project import Project
 from sentry.models.releasefile import ARTIFACT_INDEX_FILENAME, update_artifact_index
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
@@ -1392,9 +1393,11 @@ class CacheSourceTest(TestCase):
 
         for expected_cache_hits, expected_cache_misses in [(0, 1), (1, 1)]:
             processor = JavaScriptStacktraceProcessor(
-                data={"release": release.version}, stacktrace_infos=None, project=project
+                data={"release": release.version},
+                stacktrace_infos=None,
+                project=Project.objects.get(pk=project.id),
             )
-            processor.release = release
+            processor.release = Release.objects.get(pk=release.id)
 
             processor.cache_source(abs_path)
             cache_info = cached_fetch_sourcemap.cache_info()


### PR DESCRIPTION
Experimental implementation of an LRU cache on `fetch_sourcemap`.
The current implementation only makes sense if very few organizations have the corresponding feature flag enabled.