### PR TITLE
fix: cache pre-commit hook environments

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -161,6 +161,12 @@ jobs:
           # Note this uses a different cache key than other backend-based workflows because this workflows dependencies are different
           cache-files-hash: ${{ hashFiles('requirements-pre-commit.txt') }}
 
+      - uses: actions/cache@v3
+        if: needs.files-changed.outputs.backend == 'true'
+        with:
+          path: ~/.cache/pre-commit
+          key: cache-epoch-1|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
       - name: Setup pre-commit
         if: needs.files-changed.outputs.backend == 'true'
         env:


### PR DESCRIPTION
this appears to save ~23 seconds on the backend lint job