### PR TITLE
fix(events-search): Return helpful error message on semver filter

### DIFF
--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1516,10 +1516,14 @@ class DiscoverDatasetConfig(DatasetConfig):
         build: str = search_filter.value.raw_value
 
         operator, negated = handle_operator_negation(search_filter.operator)
+        try:
+            django_op = OPERATOR_TO_DJANGO[operator]
+        except KeyError:
+            raise InvalidSearchQuery("Invalid operation 'IN' for semantic version filter.")
         versions = list(
             Release.objects.filter_by_semver_build(
                 organization_id,
-                OPERATOR_TO_DJANGO[operator],
+                django_op,
                 build,
                 project_ids=project_ids,
                 negated=negated,

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -2109,3 +2109,12 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             query="transaction:foo_transaction",
             allow_metric_aggregates=False,
         )
+
+    def test_invalid_semver_filter(self):
+        with self.assertRaises(InvalidSearchQuery):
+            QueryBuilder(
+                Dataset.Discover,
+                self.params,
+                "user.email:foo@example.com release.build:[1.2.1]",
+                ["user.email", "release"],
+            )

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -1793,6 +1793,12 @@ class SemverBuildFilterConverterTest(BaseSemverConverterTest, TestCase):
         with pytest.raises(ValueError, match="organization_id is a required param"):
             _semver_filter_converter(filter, key, {"something": 1})
 
+        filter = SearchFilter(SearchKey(key), "IN", SearchValue("sentry"))
+        with pytest.raises(
+            InvalidSearchQuery, match="Invalid operation 'IN' for semantic version filter."
+        ):
+            _semver_filter_converter(filter, key, {"organization_id": 1})
+
     def test_empty(self):
         self.run_test("=", "test", "IN", [SEMVER_EMPTY_RELEASE])
 
@@ -1822,6 +1828,11 @@ class ParseSemverTest(unittest.TestCase):
             match=INVALID_SEMVER_MESSAGE,
         ):
             assert parse_semver("hello", ">") is None
+        with pytest.raises(
+            InvalidSearchQuery,
+            match="Invalid operation 'IN' for semantic version filter.",
+        ):
+            assert parse_semver("1.2.3.4", "IN") is None
 
     def test_normal(self):
         self.run_test("1", ">", SemverFilter("gt", [1, 0, 0, 0, 1, ""]))


### PR DESCRIPTION
'IN' type queries currently raise an unhandled KeyError, raising an
InvalidSearchQuery instead.
![Screen Shot 2022-04-20 at 10 49 07 AM](https://user-images.githubusercontent.com/63818634/164258385-c8e668ee-f9d5-4a16-99bf-59bdb95bcfb9.png)


Fixes SENTRY-RYC