### PR TITLE
fix: remove codecov from backend lint job

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -199,9 +199,6 @@ jobs:
         with:
           github-token: ${{ steps.token.outputs.token }}
 
-      - name: Handle artifacts
-        uses: ./.github/actions/artifacts
-
   migration:
     needs: files-changed
     name: check migration


### PR DESCRIPTION
as far as I can tell, no coverage artifacts are generated as part of `pre-commit` execution

this saves 1.5-2s per job execution