### PR TITLE
fix(ui): fix the grid gap property

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -184,7 +184,7 @@ const AddGroupButton = styled(Button)`
 const SortableQueryFields = styled('div')`
   display: grid;
   grid-auto-flow: row;
-  grid-gap: ${space(1)};
+  gap: ${space(1)};
 `;
 
 const Ghost = styled('div')`


### PR DESCRIPTION
Updating `grid-gap` -> `gap` as the linter seems to complain and error is thrown