### PR TITLE
fix(span-tree): Fix autogrouped siblings connector bar issues

### DIFF
--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -98,20 +98,6 @@ export default function SpanSiblingGroupBar(props: Props) {
       );
     });
 
-    if (!isLastSibling) {
-      const depth: number = unwrapTreeDepth(spanTreeDepth - 1);
-      const left = ((spanTreeDepth - depth) * (TOGGLE_BORDER_BOX / 2) + 2) * -1;
-      connectorBars.push(
-        <ConnectorBar
-          style={{
-            left,
-          }}
-          key={`${span.description}-${depth}`}
-          orphanBranch={false}
-        />
-      );
-    }
-
     return (
       <TreeConnector isLast={isLastSibling} hasToggler orphanBranch={isOrphanSpan(span)}>
         {connectorBars}

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -534,7 +534,7 @@ class SpanTreeModel {
             type: 'span_group_siblings',
             span: this.span,
             treeDepth: treeDepth + 1,
-            continuingTreeDepths,
+            continuingTreeDepths: descendantContinuingTreeDepths,
             spanSiblingGrouping: wrappedSiblings,
             isLastSibling: groupIndex === groupedDescendants.length - 1,
             occurrence: occurrence ?? 0,


### PR DESCRIPTION
Sometimes there were missing or misplaced connector bars for autogrouped sibling spans in the span tree, this was due to the wrong variable being used for `continuingTreeDepths`.

### Before
<img width="395" alt="image" src="https://user-images.githubusercontent.com/16740047/164271009-83fe996e-2efd-443d-a74e-770b5257b98b.png">
<img width="398" alt="image" src="https://user-images.githubusercontent.com/16740047/164271475-c7df7ade-72dd-4ed3-9798-632996d21244.png">


### After
<img width="400" alt="image" src="https://user-images.githubusercontent.com/16740047/164271115-7cf4a735-4944-4afd-8e32-84a547a16418.png">
<img width="410" alt="image" src="https://user-images.githubusercontent.com/16740047/164271584-79b2cb5f-9955-4444-a23e-6cad95f0305f.png">



Fixes PERF-1521

