### PR TITLE
fix(ci): Export frontend_components_modified_lintable in files-changed

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,6 +15,8 @@ jobs:
     outputs:
       eslint_config: ${{ steps.changes.outputs.eslint_config }}
       frontend: ${{ steps.changes.outputs.frontend }}
+      frontend_components_modified_lintable: ${{ steps.changes.outputs.frontend_components_modified_lintable }}
+      frontend_components_modified_lintable_files: ${{ steps.changes.outputs.frontend_components_modified_lintable_files }}
       frontend_modified_lintable_files: ${{ steps.changes.outputs.frontend_modified_lintable_files }}
       yarn_lockfile: ${{ steps.changes.outputs.yarn_lockfile }}
     steps:


### PR DESCRIPTION
In #33455, we changed how files-changed are determined for frontend jobs. `frontend_components_modified_lintable` was missed, thus, evaluating for it would return `null`.

This caused the introduction of a regression. See #33787 for fix.