### PR TITLE
fix(dashboard): Drop validation on project slug converter

### DIFF
--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -1,5 +1,5 @@
 from functools import reduce
-from typing import List, Mapping, Optional
+from typing import Mapping, Optional
 
 from snuba_sdk import Condition, Op
 
@@ -74,11 +74,6 @@ def project_slug_converter(
     project_slugs: Mapping[str, int] = {
         slug: project_id for slug, project_id in builder.project_slugs.items() if slug in slugs
     }
-    missing: List[str] = [slug for slug in slugs if slug not in project_slugs]
-    if missing and search_filter.operator in constants.EQUALITY_OPERATORS:
-        raise InvalidSearchQuery(
-            f"Invalid query. Project(s) {', '.join(missing)} do not exist or are not actively selected."
-        )
     # Sorted for consistent query results
     project_ids = list(sorted(project_slugs.values()))
     if project_ids:

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -272,3 +272,19 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert response.status_code == 400, response.data
         assert "queries" in response.data, response.data
         assert response.data["queries"][0]["conditions"], response.data
+
+    def test_project_doesnt_exist_should_not_error(self):
+        data = {
+            "title": "Unresolved Issues",
+            "displayType": "table",
+            "widgetType": "discover",
+            "queries": [
+                {"name": "unresolved", "conditions": "project:this-doesnt-exist", "fields": []}
+            ],
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 200, response.data


### PR DESCRIPTION
Until we have saved page filters for dashboards, it doesn't make sense
for users to have to select projects just to save and update

This fixes an issue where if widgets were referencing unselected or non-existent
projects (i.e. a user has a query condition for a project they don't belong to), they
would see an error due to this validation when updating a widget, updating a dashboard, etc.