### PR TITLE
Revert "fix(cra): Change granularities for crash rate alerts over metrics (#33298)"

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -267,30 +267,19 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
         return [self.session_status]
 
     def get_granularity(self) -> int:
-        """
-        Both time_window and granularity are in seconds
-        Time windows <= 1h -> Granularity 10s
-        Time windows > 1h & <= 4h -> Granularity 60s
-        Time windows > 4h and <= 24h -> Granularity 1 hour
-        Time windows > 24h -> Granularity 1 day
-        """
-        # ToDo(ahmed): Uncomment this logic once we are through with the comparisons
-        # if self.time_window <= 3600:
-        #     granularity = 10
-        # elif self.time_window <= 4 * 3600:
-        #     granularity = 60
-        # elif 4 * 3600 < self.time_window <= 24 * 3600:
-        #     granularity = 3600
-        # else:
-        #     granularity = 24 * 3600
-
-        # ToDo(ahmed): Hack this out in favor of previous commented logic
-        # Adding this to enable sessions vs metrics crash rate alert comparisons as it only
-        # makes sense to compare against sessions crash rate alerts with these granularities
+        # Both time_window and granularity are in seconds
+        # Time windows <= 1h -> Granularity 10s
+        # Time windows > 1h & <= 4h -> Granularity 60s
+        # Time windows > 4h and <= 24h -> Granularity 1 hour
+        # Time windows > 24h -> Granularity 1 day
         if self.time_window <= 3600:
+            granularity = 10
+        elif self.time_window <= 4 * 3600:
             granularity = 60
-        else:
+        elif 4 * 3600 < self.time_window <= 24 * 3600:
             granularity = 3600
+        else:
+            granularity = 24 * 3600
         return granularity
 
     def build_snuba_filter(

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -105,7 +105,7 @@ class EntitySubscriptionTestCase(TestCase):
         assert entity_subscription.get_entity_extra_params() == {
             "organization": self.organization.id,
             "groupby": groupby,
-            "granularity": 60,
+            "granularity": 10,
         }
         assert entity_subscription.entity_key == EntityKey.MetricsSets
         assert entity_subscription.time_col == ENTITY_TIME_COLUMNS[EntityKey.MetricsSets]
@@ -137,7 +137,7 @@ class EntitySubscriptionTestCase(TestCase):
         assert entity_subscription.get_entity_extra_params() == {
             "organization": self.organization.id,
             "groupby": groupby,
-            "granularity": 60,
+            "granularity": 10,
         }
         assert entity_subscription.entity_key == EntityKey.MetricsCounters
         assert entity_subscription.time_col == ENTITY_TIME_COLUMNS[EntityKey.MetricsCounters]

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -160,10 +160,10 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
         for tag in [SessionMRI.SESSION.value, SessionMRI.USER.value, "session.status"]:
             indexer.record(self.organization.id, tag)
         for (time_window, expected_granularity) in [
-            (30, 60),
-            (90, 3600),
+            (30, 10),
+            (90, 60),
             (5 * 60, 3600),
-            (25 * 60, 3600),
+            (25 * 60, 3600 * 24),
         ]:
             for idx, aggregate in enumerate(["sessions", "users"]):
                 sub = self.create_subscription(


### PR DESCRIPTION
This reverts commit 851068582e44724cd3ff4ac35560178384fc5d59.

We're finished with these comparison tests, so reverting this change.