### PR TITLE
Better logo in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 <p align="center">
   <p align="center">
-    <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+    <a href="https://sentry.io/?utm_source=github&utm_medium=logo#gh-light-mode-only" target="_blank">
       <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" alt="Sentry" height="72">
+    </a>
+    <a href="https://sentry.io/?utm_source=github&utm_medium=logo#gh-dark-mode-only" target="_blank">
+      <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" alt="Sentry" height="72">
     </a>
   </p>
   <p align="center">


### PR DESCRIPTION
This uses Github's support for [specifying which theme an image should be shown to](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to).

### Before:

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/67560/164296843-05520248-2c9e-4146-8032-0062fc22569e.png">

### After:

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/67560/164296873-a69e82b2-37b0-4e35-9dd2-9c9b8d47525b.png">
