### PR TITLE
feat(widget-builder): Allow saving raw equation in widget query orderby

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -186,7 +186,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
                 dataset=Dataset.Discover,
                 params=params,
                 equation_config={
-                    "auto_add": not is_table or is_equation(orderby.lstrip("-")),
+                    "auto_add": not is_table,
                     "aggregates_only": not is_table,
                 },
             )

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -185,7 +185,10 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
             builder = UnresolvedQuery(
                 dataset=Dataset.Discover,
                 params=params,
-                equation_config={"auto_add": not is_table, "aggregates_only": not is_table},
+                equation_config={
+                    "auto_add": not is_table or is_equation(orderby.lstrip("-")),
+                    "aggregates_only": not is_table,
+                },
             )
 
             builder.resolve_conditions(conditions, use_aggregate_conditions=True)
@@ -204,10 +207,11 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
             # error based on the Widget's type
             data["discover_query_error"] = {"fields": f"Invalid fields: {err}"}
 
-        try:
-            builder.resolve_orderby(orderby)
-        except (InvalidSearchQuery) as err:
-            data["discover_query_error"] = {"orderby": f"Invalid orderby: {err}"}
+        if not is_equation(orderby.lstrip("-")):
+            try:
+                builder.resolve_orderby(orderby)
+            except (InvalidSearchQuery) as err:
+                data["discover_query_error"] = {"orderby": f"Invalid orderby: {err}"}
 
         return data
 

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -272,3 +272,35 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert response.status_code == 400, response.data
         assert "queries" in response.data, response.data
         assert response.data["queries"][0]["conditions"], response.data
+
+    def test_raw_equation_in_orderby_is_valid(self):
+        data = {
+            "title": "Test Query",
+            "displayType": "table",
+            "widgetType": "discover",
+            "queries": [
+                {"name": "", "conditions": "", "fields": [], "orderby": "equation|count() * 2"}
+            ],
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 200, response.data
+
+    def test_raw_desc_equation_in_orderby_is_valid(self):
+        data = {
+            "title": "Test Query",
+            "displayType": "table",
+            "widgetType": "discover",
+            "queries": [
+                {"name": "", "conditions": "", "fields": [], "orderby": "-equation|count() * 2"}
+            ],
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 200, response.data

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -129,6 +129,68 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
         assert response.status_code == 200, response.data
 
+    def test_valid_orderby_equation_alias_line_widget(self):
+        data = {
+            "title": "Invalid query",
+            "displayType": "line",
+            "queries": [
+                {
+                    "name": "errors",
+                    "conditions": "event.type:error",
+                    "fields": ["equation|count() * 2"],
+                    "orderby": "equation[0]",
+                }
+            ],
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 200, response.data
+
+    def test_invalid_orderby_equation_alias_line_widget(self):
+        data = {
+            "title": "Invalid query",
+            "displayType": "line",
+            "queries": [
+                {
+                    "name": "errors",
+                    "conditions": "event.type:error",
+                    "fields": ["equation|count() * 2"],
+                    "orderby": "equation[999999]",
+                }
+            ],
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 400, response.data
+        assert "queries" in response.data, response.data
+
+    def test_missing_equation_for_orderby_equation_alias(self):
+        data = {
+            "title": "Invalid query",
+            "displayType": "line",
+            "queries": [
+                {
+                    "name": "errors",
+                    "conditions": "event.type:error",
+                    "fields": [""],
+                    "orderby": "equation[0]",
+                }
+            ],
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 400, response.data
+        assert "queries" in response.data, response.data
+
     def test_invalid_equation_table_widget(self):
         data = {
             "title": "Invalid query",
@@ -305,7 +367,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
         assert response.status_code == 200, response.data
 
-    def test_invalid_raw_equation_in_order_by_throws_error(self):
+    def test_invalid_raw_equation_in_orderby_throws_error(self):
         data = {
             "title": "Test Query",
             "displayType": "table",

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -304,3 +304,25 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             data=data,
         )
         assert response.status_code == 200, response.data
+
+    def test_invalid_raw_equation_in_order_by_throws_error(self):
+        data = {
+            "title": "Test Query",
+            "displayType": "table",
+            "widgetType": "discover",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "fields": [],
+                    "orderby": "-equation|thisIsNotARealEquation() * 42",
+                }
+            ],
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 400, response.data
+        assert "queries" in response.data, response.data


### PR DESCRIPTION
Update the dashboard widget validation to allow for saving a raw equation. This is so we can add a custom equation as a sorting field and use it for querying the events-stats endpoint.