### PR TITLE
fix(dashboards): Flatten error should handle strings too

### DIFF
--- a/static/app/views/dashboardsV2/utils.tsx
+++ b/static/app/views/dashboardsV2/utils.tsx
@@ -279,25 +279,29 @@ export function getWidgetIssueUrl(
 }
 
 export function flattenErrors(
-  data: ValidationError,
+  data: ValidationError | string,
   update: FlatValidationError
 ): FlatValidationError {
-  Object.keys(data).forEach((key: string) => {
-    const value = data[key];
-    if (typeof value === 'string') {
-      update[key] = value;
-      return;
-    }
-    // Recurse into nested objects.
-    if (Array.isArray(value) && typeof value[0] === 'string') {
-      update[key] = value[0];
-      return;
-    }
-    if (Array.isArray(value) && typeof value[0] === 'object') {
-      (value as ValidationError[]).map(item => flattenErrors(item, update));
-    } else {
-      flattenErrors(value as ValidationError, update);
-    }
-  });
+  if (typeof data === 'string') {
+    update.error = data;
+  } else {
+    Object.keys(data).forEach((key: string) => {
+      const value = data[key];
+      if (typeof value === 'string') {
+        update[key] = value;
+        return;
+      }
+      // Recurse into nested objects.
+      if (Array.isArray(value) && typeof value[0] === 'string') {
+        update[key] = value[0];
+        return;
+      }
+      if (Array.isArray(value) && typeof value[0] === 'object') {
+        (value as ValidationError[]).map(item => flattenErrors(item, update));
+      } else {
+        flattenErrors(value as ValidationError, update);
+      }
+    });
+  }
   return update;
 }

--- a/tests/js/spec/views/dashboardsV2/utils.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/utils.spec.tsx
@@ -2,6 +2,7 @@ import {DisplayType, WidgetType} from 'sentry/views/dashboardsV2/types';
 import {
   constructWidgetFromQuery,
   eventViewFromWidget,
+  flattenErrors,
   getFieldsFromEquations,
   getWidgetDiscoverUrl,
   getWidgetIssueUrl,
@@ -227,6 +228,26 @@ describe('Dashboards util', () => {
       expect(url).toEqual(
         '/organizations/org-slug/issues/?query=is%3Aunresolved&sort=date&statsPeriod=7d'
       );
+    });
+  });
+  describe('flattenErrors', function () {
+    it('flattens nested errors', () => {
+      const errorResponse = {
+        widgets: [
+          {
+            title: ['Ensure this field has no more than 3 characters.'],
+          },
+        ],
+      };
+      expect(flattenErrors(errorResponse, {})).toEqual({
+        title: 'Ensure this field has no more than 3 characters.',
+      });
+    });
+    it('does not spread error strings', () => {
+      const errorResponse = 'Dashboard title already taken.';
+      expect(flattenErrors(errorResponse, {})).toEqual({
+        error: 'Dashboard title already taken.',
+      });
     });
   });
 });


### PR DESCRIPTION
Right now when the error response is just a string, the
add error message just displays the first character of the
error because flattenError cannot handle strings.
