### PR TITLE
fix(workflow): Handle issue count request fail

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -490,9 +490,7 @@ class IssueListOverview extends React.Component<Props, State> {
             };
           },
           error: () => {
-            this.setState({
-              issuesLoading: false,
-            });
+            this.setState({queryCounts: {}});
           },
           complete: () => {
             this._lastFetchCountsRequest = null;

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -489,9 +489,9 @@ class IssueListOverview extends React.Component<Props, State> {
               })),
             };
           },
-          error: err => {
+          error: () => {
             this.setState({
-              error: parseApiError(err),
+              issuesLoading: false,
             });
           },
           complete: () => {


### PR DESCRIPTION
Handle issue count request fail on the issue stream. Previously, if the request failed, it would show an error banner and not display the issue stream. We want to fail silently here to at least show the issue stream.

[FIXES WOR-1787
](https://getsentry.atlassian.net/browse/WOR-1787)
