### PR TITLE
feat(superuser): Added button to let COPS and CSM not fill out the form

### DIFF
--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -58,6 +58,21 @@ class SudoModal extends React.Component<Props, State> {
     this.getAuthenticators();
   }
 
+  handleSubmit = async () => {
+    const {api, isSuperuser} = this.props;
+    const data = {
+      isSuperuserModal: isSuperuser,
+      superuserAccessCategory: 'cops_csm',
+      superuserReason: 'COPS and CSM use',
+    };
+    try {
+      await api.requestPromise('/auth/', {method: 'PUT', data});
+      this.handleSuccess();
+    } catch (err) {
+      this.handleError(err);
+    }
+  };
+
   handleSuccess = () => {
     const {closeModal, isSuperuser, location, needsReload, router, retryRequest} =
       this.props;
@@ -161,6 +176,11 @@ class SudoModal extends React.Component<Props, State> {
               onSubmitSuccess={this.handleSuccess}
               onSubmitError={this.handleError}
               initialData={{isSuperuserModal: isSuperuser}}
+              extraButton={
+                <BackWrapper>
+                  <Button onClick={this.handleSubmit}>{t('COPS/CSM')}</Button>
+                </BackWrapper>
+              }
               resetOnError
             >
               {!isSelfHosted && <Hook name="component:superuser-access-category" />}
@@ -249,4 +269,9 @@ const StyledInputField = styled(InputField)`
 
 const StyledAlert = styled(Alert)`
   margin-bottom: 0;
+`;
+
+const BackWrapper = styled('div')`
+  width: 100%;
+  margin-left: ${space(4)};
 `;

--- a/static/app/components/superuserAccessForm.tsx
+++ b/static/app/components/superuserAccessForm.tsx
@@ -1,22 +1,46 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
 
+import {Client} from 'sentry/api';
 import Alert from 'sentry/components/alert';
 import Form from 'sentry/components/forms/form';
 import Hook from 'sentry/components/hook';
 import ThemeAndStyleProvider from 'sentry/components/themeAndStyleProvider';
 import {ErrorCodes} from 'sentry/constants/superuserAccessErrors';
 import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import withApi from 'sentry/utils/withApi';
+
+import Button from './button';
+
+type Props = {
+  api: Client;
+};
 
 type State = {
   error: boolean;
   errorType: string;
 };
 
-class SuperuserAccessForm extends Component<State> {
+class SuperuserAccessForm extends Component<Props, State> {
   state: State = {
     error: false,
     errorType: '',
+  };
+
+  handleSubmit = async () => {
+    const {api} = this.props;
+    const data = {
+      isSuperuserModal: true,
+      superuserAccessCategory: 'cops_csm',
+      superuserReason: 'COPS and CSM use',
+    };
+    try {
+      await api.requestPromise('/auth/', {method: 'PUT', data});
+      this.handleSuccess();
+    } catch (err) {
+      this.handleError(err);
+    }
   };
 
   handleSuccess = () => {
@@ -51,6 +75,11 @@ class SuperuserAccessForm extends Component<State> {
           onSubmitSuccess={this.handleSuccess}
           onSubmitError={this.handleError}
           initialData={{isSuperuserModal: true}}
+          extraButton={
+            <BackWrapper>
+              <Button onClick={this.handleSubmit}>{t('COPS/CSM')}</Button>
+            </BackWrapper>
+          }
           resetOnError
         >
           {error && (
@@ -69,4 +98,9 @@ const StyledAlert = styled(Alert)`
   margin-bottom: 0;
 `;
 
-export default SuperuserAccessForm;
+const BackWrapper = styled('div')`
+  width: 100%;
+  margin-left: ${space(4)};
+`;
+
+export default withApi(SuperuserAccessForm);


### PR DESCRIPTION
Based on the discussion with Misty, Tom and Armin, there will now be a button that allows COPS and CSM to not fill out the superuser access form. 

The changes:
Added a button that grants superuser to COPS and CSM without having to fill out the form

<img width="581" alt="image" src="https://user-images.githubusercontent.com/22259802/164338770-73260cfc-aff7-4902-ae60-8a5d46867916.png">
