### PR TITLE
Revert "fix(dev): Do not export SENTRY_DSN in .envrc"

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -59,8 +59,7 @@ report_to_sentry() {
         curl -sL https://sentry.io/get-cli/ | bash
     fi
     # Report to sentry-dev-env project
-    SENTRY_DSN="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503" \
-        sentry-cli send-event -m "$error_message" --logfile "$_SENTRY_LOG_FILE" --level $log_level
+    sentry-cli send-event -m "$error_message" --logfile "$_SENTRY_LOG_FILE" --level $log_level
     rm "$_SENTRY_LOG_FILE"
 }
 
@@ -143,6 +142,8 @@ fi
 if [ -n "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
     debug "No development environment errors will be reported (since you've defined SENTRY_DEVENV_NO_REPORT)."
 else
+    # This is necessary for the bash-hook in lib.sh to work
+    export SENTRY_DSN="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503"
     # Since direnv traps the EXIT signal we place the temp file under /tmp for the odd time
     # the script will use the EXIT path
     _SENTRY_LOG_FILE=$(mktemp /tmp/sentry.envrc.$$.out || mktemp /tmp/sentry.envrc.XXXXXXXX.out)

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -16,8 +16,8 @@ if sys.version_info.major < 3:
 try:
     import sentry_sdk
 
-    if not os.environ.get("SENTRY_DEVENV_NO_REPORT"):
-        sentry_sdk.init(dsn="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503")
+    if os.environ.get("SENTRY_DSN"):
+        sentry_sdk.init(dsn=os.environ["SENTRY_DSN"])
     else:
         sys.stdout.write(
             "WARNING: Errors in this file will not be reported to Sentry since SENTRY_DSN is not set.\n"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -14,19 +14,6 @@ if [ -z "${CI+x}" ]; then
     green="$(tput setaf 2)"
     yellow="$(tput setaf 3)"
     reset="$(tput sgr0)"
-    if [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
-        sentry_cli_major_version="$(sentry-cli --version | awk '{print $2}' | sed 's/\([0-9]*\).*/\1/')"
-        # XXX: Until we support version 2.x
-        if [ $sentry_cli_major_version -lt 2 ]; then
-            # sentry-dev-env project
-            export SENTRY_DSN="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503"
-            eval "$(sentry-cli bash-hook)"
-        else
-            echo "You are using the latest major release of sentry-cli."
-            echo "${yellow}Please remove it and we will install the correct version: rm $(which sentry-cli)${reset}"
-            exit 1
-        fi
-    fi
 fi
 
 venv_name=".venv"
@@ -45,6 +32,15 @@ configure-sentry-cli() {
         if ! require sentry-cli; then
             # XXX: Temporary install version 1.74.3 until we upgrade to version 2.x
             curl -sL https://gist.githubusercontent.com/armenzg/96481b0b653ecf807900373f5af09816/raw/caf5695e0eb6c214ec84f9fc217965aec928acc0/get-cli.sh | bash
+        fi
+        sentry_cli_major_version="$(sentry-cli --version | awk '{print $2}' | sed 's/\([0-9]*\).*/\1/')"
+        # XXX: Until we support version 2.x
+        if [ $sentry_cli_major_version -lt 2 ]; then
+            eval "$(sentry-cli bash-hook)"
+        else
+            echo "You are using the latest major release of sentry-cli."
+            echo "${yellow}Please remove it and we will install the correct version: rm $(which sentry-cli)${reset}"
+            exit 1
         fi
     fi
 }


### PR DESCRIPTION
Reverts getsentry/sentry#33802

this appears to be breaking direnv for me (and others):

```console
$ git branch
  asottile-stylelint-fix
  asottile-warn-docker-memory
  asottile-yesqa
* master
$ git rev-parse HEAD
0399f61e6d209605fa7c11e4ee289748cb4b9b4a
$ cd -
/Users/asottile/workspace
direnv: unloading
$ cd -
/Users/asottile/workspace/sentry
direnv: loading ~/workspace/sentry/.envrc
SUCCESS!
$ which python
$ 
```