### PR TITLE
fix: fix flake8 lint errors

### DIFF
--- a/bin/lint-requirements
+++ b/bin/lint-requirements
@@ -13,7 +13,7 @@ def main():
     """
     with open("requirements-base.txt") as reqs_file:
         if any(not req.specifier for req in requirements.parse(reqs_file)):
-            print(
+            print(  # noqa: S002
                 "\n".join(
                     [
                         "You cannot use dependencies that are not on PyPI directly.",

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -14,7 +14,6 @@ from sentry.notifications.notifications.user_report import UserReportNotificatio
 from sentry.notifications.types import ActionTargetType
 from sentry.plugins.base.structs import Notification
 from sentry.tasks.digests import deliver_digest
-from sentry.types.rules import RuleFuture
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
not sure how these snuck through, but now `pre-commit run flake8 --all-files` passes




<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
