### PR TITLE
ref(github): Avoid KeyError on external_id generation

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -50,9 +50,9 @@ class Webhook:
         raise NotImplementedError
 
     def __call__(self, event: Mapping[str, Any], host: str | None = None) -> None:
-        external_id = event["installation"]["id"]
+        external_id = event.get("installation", {}).get("id")
         if host:
-            external_id = "{}:{}".format(host, event["installation"]["id"])
+            external_id = f"{host}:{external_id}"
 
         try:
             integration = Integration.objects.get(external_id=external_id, provider=self.provider)


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fixes [SENTRY-S3J](https://sentry.io/organizations/sentry/issues/2621428939/?project=1&referrer=slack)

Small refactor to avoid a KeyError. In the case that it's not found, the Integration.DoesNotExist error will trigger and be logged/handled appropriately (see L58)

<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
