### PR TITLE
ref(timeSince): Add tooltip underlines

### DIFF
--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -280,7 +280,7 @@ function getTipDirection(
 }
 
 const Trigger = styled('span')<{showUnderline?: boolean}>`
-  ${p => p.showUnderline && p.theme.tooltipUnderline};
+  ${p => p.showUnderline && p.theme.tooltipUnderline()};
 `;
 
 const HovercardContainer = styled('div')`

--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -7,6 +7,7 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {getDuration} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import {ColorOrAlias} from 'sentry/utils/theme';
 
 import Tooltip from './tooltip';
 
@@ -46,6 +47,8 @@ interface Props extends DefaultProps, React.TimeHTMLAttributes<HTMLTimeElement> 
   shorten?: boolean;
 
   tooltipTitle?: React.ReactNode;
+
+  tooltipUnderlineColor?: ColorOrAlias;
 }
 
 type State = {
@@ -106,6 +109,7 @@ class TimeSince extends React.PureComponent<Props, State> {
       disabledAbsoluteTooltip,
       className,
       tooltipTitle,
+      tooltipUnderlineColor,
       shorten: _shorten,
       extraShort: _extraShort,
       ...props
@@ -124,6 +128,8 @@ class TimeSince extends React.PureComponent<Props, State> {
     return (
       <Tooltip
         disabled={disabledAbsoluteTooltip}
+        underlineColor={tooltipUnderlineColor}
+        showUnderline
         title={
           <div>
             <div>{tooltipTitle}</div>

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -17,6 +17,7 @@ import {IS_ACCEPTANCE_TEST} from 'sentry/constants/index';
 import space from 'sentry/styles/space';
 import domId from 'sentry/utils/domId';
 import testableTransition from 'sentry/utils/testableTransition';
+import {ColorOrAlias} from 'sentry/utils/theme';
 
 import {AcceptanceTestTooltip} from './acceptanceTestTooltip';
 
@@ -105,6 +106,11 @@ export interface InternalTooltipProps {
    * If child node supports ref forwarding, you can skip apply a wrapper
    */
   skipWrapper?: boolean;
+
+  /**
+   * Color of the dotted underline, if available. See also: showUnderline.
+   */
+  underlineColor?: ColorOrAlias;
 }
 
 /**
@@ -143,6 +149,7 @@ export function DO_NOT_USE_TOOLTIP({
   isHoverable,
   popperStyle,
   showUnderline,
+  underlineColor,
   showOnlyOnOverflow,
   skipWrapper,
   title,
@@ -245,7 +252,7 @@ export function DO_NOT_USE_TOOLTIP({
         ...containerProps,
         style: {
           ...triggerChildren.props.style,
-          ...(showUnderline && theme.tooltipUnderline),
+          ...(showUnderline && theme.tooltipUnderline(underlineColor)),
         },
         ref: setRef,
       });
@@ -256,7 +263,7 @@ export function DO_NOT_USE_TOOLTIP({
     return (
       <Container
         {...containerProps}
-        style={showUnderline ? theme.tooltipUnderline : undefined}
+        style={showUnderline ? theme.tooltipUnderline(underlineColor) : undefined}
         className={className}
         ref={setRef}
       >

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -14,7 +14,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
   }
 
   abbr {
-    ${theme.tooltipUnderline};
+    ${theme.tooltipUnderline()};
   }
 
   a {

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -564,12 +564,14 @@ const generateButtonTheme = (colors: BaseColors, alias: Aliases) => ({
   },
 });
 
-const generateUtils = (colors: BaseColors) => ({
-  tooltipUnderline: {
-    textDecoration: `underline dotted ${colors.gray300}`,
+const generateUtils = (colors: BaseColors, aliases: Aliases) => ({
+  tooltipUnderline: (underlineColor: ColorOrAlias = 'gray300') => ({
+    textDecoration: `underline dotted ${
+      colors[underlineColor] ?? aliases[underlineColor]
+    }`,
     textDecorationThickness: '0.75px',
     textUnderlineOffset: '1.25px',
-  },
+  }),
 });
 
 const iconSizes = {
@@ -820,7 +822,7 @@ export const lightTheme = {
     ...darkColors,
     ...darkAliases,
   },
-  ...generateUtils(lightColors),
+  ...generateUtils(lightColors, lightAliases),
   alert: generateAlertTheme(lightColors, lightAliases),
   badge: generateBadgeTheme(lightColors),
   button: generateButtonTheme(lightColors, lightAliases),
@@ -843,7 +845,7 @@ export const darkTheme: Theme = {
     ...lightColors,
     ...lightAliases,
   },
-  ...generateUtils(darkColors),
+  ...generateUtils(darkColors, lightAliases),
   alert: generateAlertTheme(darkColors, darkAliases),
   badge: generateBadgeTheme(darkColors),
   button: generateButtonTheme(darkColors, darkAliases),
@@ -858,9 +860,9 @@ export const darkTheme: Theme = {
 };
 
 export type Theme = typeof lightTheme;
-export type Aliases = typeof lightAliases;
-
 export type Color = keyof typeof lightColors;
+export type Aliases = typeof lightAliases;
+export type ColorOrAlias = keyof Aliases | Color;
 export type IconSize = keyof typeof iconSizes;
 
 export default commonTheme;

--- a/static/app/views/dashboardsV2/manage/dashboardCard.tsx
+++ b/static/app/views/dashboardsV2/manage/dashboardCard.tsx
@@ -134,7 +134,7 @@ const DateSelected = styled('div')`
 `;
 
 const DateStatus = styled('span')`
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.subText};
   padding-left: ${space(1)};
 `;
 

--- a/static/app/views/eventsV2/querycard.tsx
+++ b/static/app/views/eventsV2/querycard.tsx
@@ -140,7 +140,7 @@ const DateSelected = styled('div')`
 `;
 
 const DateStatus = styled('span')`
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.subText};
   padding-left: ${space(1)};
 `;
 

--- a/static/app/views/projectDetail/projectLatestAlerts.tsx
+++ b/static/app/views/projectDetail/projectLatestAlerts.tsx
@@ -15,7 +15,6 @@ import {t, tct} from 'sentry/locale';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
-import {Theme} from 'sentry/utils/theme';
 
 import {Incident, IncidentStatus} from '../alerts/types';
 
@@ -163,7 +162,14 @@ class ProjectLatestAlerts extends AsyncComponent<Props, State> {
               ? tct('Resolved [date]', {
                   date: dateClosed ? <TimeSince date={dateClosed} /> : null,
                 })
-              : tct('Triggered [date]', {date: <TimeSince date={dateStarted} />})}
+              : tct('Triggered [date]', {
+                  date: (
+                    <TimeSince
+                      date={dateStarted}
+                      tooltipUnderlineColor={getStatusColor(statusProps)}
+                    />
+                  ),
+                })}
           </AlertDate>
         </AlertDetails>
       </AlertRowLink>
@@ -241,12 +247,8 @@ type StatusColorProps = {
   isWarning: boolean;
 };
 
-const getStatusColor = ({
-  theme,
-  isResolved,
-  isWarning,
-}: {theme: Theme} & StatusColorProps) =>
-  isResolved ? theme.green300 : isWarning ? theme.yellow300 : theme.red300;
+const getStatusColor = ({isResolved, isWarning}: StatusColorProps) =>
+  isResolved ? 'green300' : isWarning ? 'yellow300' : 'red300';
 
 const AlertBadgeWrapper = styled('div')<{icon: React.ReactNode} & StatusColorProps>`
   display: flex;
@@ -271,7 +273,7 @@ const AlertTitle = styled('div')`
 `;
 
 const AlertDate = styled('span')<StatusColorProps>`
-  color: ${p => getStatusColor(p)};
+  color: ${p => p.theme[getStatusColor(p)]};
 `;
 
 const StyledEmptyStateWarning = styled(EmptyStateWarning)`


### PR DESCRIPTION
Add tooltip underlines to `timeSince`, to better indicate that the component is hoverable.

**Before:**
<img width="185" alt="Screen Shot 2022-04-21 at 11 38 26 AM" src="https://user-images.githubusercontent.com/44172267/164530732-cdcf1ac0-df83-409f-86a0-a0843f6e7ec5.png">
<img width="225" alt="Screen Shot 2022-04-21 at 11 40 37 AM" src="https://user-images.githubusercontent.com/44172267/164531030-22697160-44a9-4d48-9391-acadf45cf77b.png">

**After:**
<img width="185" alt="Screen Shot 2022-04-21 at 11 38 42 AM" src="https://user-images.githubusercontent.com/44172267/164530769-c57c1a48-54ea-4073-bae0-b4754d4a2023.png">
<img width="225" alt="Screen Shot 2022-04-21 at 11 40 46 AM" src="https://user-images.githubusercontent.com/44172267/164531056-065f30bf-d950-43ba-801c-c901e6b1151a.png">

