### PR TITLE
ref(sdkUpdateAlert): Pass class names down to Alert

### DIFF
--- a/static/app/components/globalSdkUpdateAlert.tsx
+++ b/static/app/components/globalSdkUpdateAlert.tsx
@@ -17,6 +17,7 @@ import {SidebarPanelKey} from './sidebar/types';
 import Button from './button';
 
 interface InnerGlobalSdkSuggestionsProps extends AlertProps {
+  className?: string;
   sdkUpdates?: ProjectSdkUpdates[] | null;
   selection?: PageFilters;
 }
@@ -90,6 +91,7 @@ function InnerGlobalSdkUpdateAlert(
     <Alert
       type="info"
       showIcon
+      className={props.className}
       trailingItems={
         <Fragment>
           <Button


### PR DESCRIPTION
Right now in `GlobalSdkUpdateAlert` we don't pass class names  to the alert component. This means any additional styles, like the ones in Project Details for removing the redundant margin bottom, won't be correctly applied.

**Before:**
<img width="1501" alt="Screen Shot 2022-04-21 at 11 44 29 AM" src="https://user-images.githubusercontent.com/44172267/164532305-da04eded-9371-48e1-9076-286cdd920dbc.png">

**After:**
<img width="1501" alt="Screen Shot 2022-04-21 at 11 47 58 AM" src="https://user-images.githubusercontent.com/44172267/164532310-2738331e-dd5e-4cf2-a0ce-4c93d8ef6063.png">

