### PR TITLE
chore(auth): add metric for login exits

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -833,19 +833,32 @@ class AuthHelper(Pipeline):
                 "sentry-organization-auth-settings", args=[self.organization.slug]
             )
 
-        # NOTE: Does NOT indicated a _login_ error specificallyl.
-        # Could potentially be error with registering, configuring the provider, etc
-        metrics.incr(
-            "sso.error",
-            tags={
-                "flow": self.state.flow,
-                "provider": self.provider.key,
-                "organization_id": self.organization.id,
-                "user_id": self.request.user.id,
-            },
-            skip_internal=False,
-            sample_rate=1.0,
-        )
+        if redirect_uri == "/":
+            metrics.incr(
+                "sso.exit",
+                tags={
+                    "flow": self.state.flow,
+                    "provider": self.provider.key,
+                    "organization_id": self.organization.id,
+                    "user_id": self.request.user.id,
+                },
+                skip_internal=False,
+                sample_rate=1.0,
+            )
+        else:
+            metrics.incr(
+                "sso.error",
+                tags={
+                    "flow": self.state.flow,
+                    "provider": self.provider.key,
+                    "organization_id": self.organization.id,
+                    "user_id": self.request.user.id,
+                },
+                skip_internal=False,
+                sample_rate=1.0,
+            )
+
+        # NOTE: Does NOT necessarily indicate a login _failure_
         logger.warning(
             "sso.login-pipeline.error",
             extra={

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -835,7 +835,7 @@ class AuthHelper(Pipeline):
 
         if redirect_uri == "/":
             metrics.incr(
-                "sso.exit",
+                "sso.error",
                 tags={
                     "flow": self.state.flow,
                     "provider": self.provider.key,
@@ -847,7 +847,7 @@ class AuthHelper(Pipeline):
             )
         else:
             metrics.incr(
-                "sso.error",
+                "sso.exit",
                 tags={
                     "flow": self.state.flow,
                     "provider": self.provider.key,


### PR DESCRIPTION


Create separate metric prompts for login flow redirects vs. errors



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
