### PR TITLE
ref: improve speed of `import sentry` by ~30%

### DIFF
--- a/src/sentry/__init__.py
+++ b/src/sentry/__init__.py
@@ -1,10 +1,11 @@
+import importlib.metadata
 import os
 import os.path
 from subprocess import check_output
 
 try:
-    VERSION = __import__("pkg_resources").get_distribution("sentry").version
-except Exception:
+    VERSION = importlib.metadata.version("sentry")
+except importlib.metadata.PackageNotFoundError:
     VERSION = "unknown"
 
 


### PR DESCRIPTION
```console
$ ./best-of -n 50 -- python3 -c 'import sentry'
..................................................
best of 50: 0.184s
$ git apply patch
$ ./best-of -n 50 -- python3 -c 'import sentry'
..................................................
best of 50: 0.135s
```

there's a few other references to `pkg_resources` elsewhere that I plan to clean up as well.

`importlib.metadata` was added to the standard library in python3.8 as a replacement for most of the parts of `pkg_resources` (which is unavoidably slow due to its design)

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
