### PR TITLE
feat(jira): Allow multiple Sentry Issues to be rendered on Jira Issue View

### DIFF
--- a/src/sentry/integrations/jira/views/issue_hook.py
+++ b/src/sentry/integrations/jira/views/issue_hook.py
@@ -119,7 +119,6 @@ class JiraIssueHookView(JiraBaseHook):
                 external_issue = ExternalIssue.objects.get(
                     integration_id=integration.id, key=issue_key
                 )
-                # TODO: handle multiple
                 group_link = GroupLink.objects.filter(
                     linked_type=GroupLink.LinkedType.issue,
                     linked_id=external_issue.id,
@@ -128,7 +127,12 @@ class JiraIssueHookView(JiraBaseHook):
                 if not group_link:
                     raise GroupLink.DoesNotExist()
                 group = Group.objects.get(id=group_link.group_id)
-            except (ExternalIssue.DoesNotExist, GroupLink.DoesNotExist, Group.DoesNotExist) as e:
+            except (
+                ExternalIssue.DoesNotExist,
+                GroupLink.DoesNotExist,
+                Group.DoesNotExist,
+                ExternalIssue.MultipleObjectsReturned,
+            ) as e:
                 scope.set_tag("failure", e.__class__.__name__)
                 set_badge(integration, issue_key, 0)
                 return self.get_response({"issue_not_linked": True})

--- a/src/sentry/integrations/jira/views/issue_hook.py
+++ b/src/sentry/integrations/jira/views/issue_hook.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from functools import reduce
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 from urllib.parse import quote
 
 from jwt import ExpiredSignatureError
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializer
 from sentry.integrations.utils import AtlassianConnectValidationError, get_integration_from_request
-from sentry.models import ExternalIssue, Group, GroupLink
+from sentry.models import ExternalIssue, Group
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 from sentry.utils.sdk import configure_scope
@@ -86,13 +86,19 @@ def build_context(group: Group) -> Mapping[str, Any]:
 class JiraIssueHookView(JiraBaseHook):
     html_file = "sentry/integrations/jira-issue.html"
 
-    def handle_group(self, group: Group) -> Response:
-        context = build_context(group)
+    def handle_groups(self, groups: Sequence[Group]) -> Response:
+        response_context = {"groups": []}
+        for group in groups:
+            context = build_context(group)
+            response_context["groups"].append(context)
+
         logger.info(
             "issue_hook.response",
-            extra={"type": context["type"], "title_url": context["title_url"]},
+            # TODO(PR Review): Backwards compatability with logs?
+            # extra={"type": context["type"], "title_url": context["title_url"]},
         )
-        return self.get_response(context)
+
+        return self.get_response(response_context)
 
     def dispatch(self, request: Request, *args, **kwargs) -> Response:
         try:
@@ -119,31 +125,25 @@ class JiraIssueHookView(JiraBaseHook):
                 external_issue = ExternalIssue.objects.get(
                     integration_id=integration.id, key=issue_key
                 )
-                # TODO(Ecosystem): Handle multiple group links appearing in Jira's Issue Hook View
-                group_link = GroupLink.objects.filter(
-                    linked_type=GroupLink.LinkedType.issue,
-                    linked_id=external_issue.id,
-                    relationship=GroupLink.Relationship.references,
+                organization = integration.organizations.filter(
+                    id=external_issue.organization_id
                 ).first()
-                if not group_link:
-                    raise GroupLink.DoesNotExist()
-                group = Group.objects.get(id=group_link.group_id)
+                groups = Group.objects.get_groups_by_external_issue(
+                    integration=integration,
+                    organizations=[organization],
+                    external_issue_key=issue_key,
+                )
             except (
                 ExternalIssue.DoesNotExist,
                 ExternalIssue.MultipleObjectsReturned,
-                GroupLink.DoesNotExist,
-                Group.DoesNotExist,
             ) as e:
                 scope.set_tag("failure", e.__class__.__name__)
                 set_badge(integration, issue_key, 0)
                 return self.get_response({"issue_not_linked": True})
 
-            scope.set_tag("organization.slug", group.organization.slug)
-            result = self.handle_group(group)
-            scope.set_tag("status_code", result.status_code)
+            scope.set_tag("organization.slug", organization.slug)
+            response = self.handle_groups(groups)
+            scope.set_tag("status_code", response.status_code)
 
-            # XXX(CEO): group_link_num is hardcoded as 1 now, but when we handle
-            #  displaying multiple linked issues this should be updated to the
-            #  actual count.
-            set_badge(integration, issue_key, 1)
-            return result
+            set_badge(integration, issue_key, len(groups))
+            return response

--- a/src/sentry/integrations/jira/views/issue_hook.py
+++ b/src/sentry/integrations/jira/views/issue_hook.py
@@ -129,9 +129,9 @@ class JiraIssueHookView(JiraBaseHook):
                 group = Group.objects.get(id=group_link.group_id)
             except (
                 ExternalIssue.DoesNotExist,
+                ExternalIssue.MultipleObjectsReturned,
                 GroupLink.DoesNotExist,
                 Group.DoesNotExist,
-                ExternalIssue.MultipleObjectsReturned,
             ) as e:
                 scope.set_tag("failure", e.__class__.__name__)
                 set_badge(integration, issue_key, 0)

--- a/src/sentry/integrations/jira/views/issue_hook.py
+++ b/src/sentry/integrations/jira/views/issue_hook.py
@@ -135,6 +135,9 @@ class JiraIssueHookView(JiraBaseHook):
                 )
             except (
                 ExternalIssue.DoesNotExist,
+                # Multiple ExternalIssues are returned if organizations share one integration.
+                # Since we cannot identify the organization from the request alone, for now, we just
+                # avoid crashing on the MultipleObjectsReturned error.
                 ExternalIssue.MultipleObjectsReturned,
             ) as e:
                 scope.set_tag("failure", e.__class__.__name__)

--- a/src/sentry/integrations/jira/views/issue_hook.py
+++ b/src/sentry/integrations/jira/views/issue_hook.py
@@ -119,6 +119,7 @@ class JiraIssueHookView(JiraBaseHook):
                 external_issue = ExternalIssue.objects.get(
                     integration_id=integration.id, key=issue_key
                 )
+                # TODO(Ecosystem): Handle multiple group links appearing in Jira's Issue Hook View
                 group_link = GroupLink.objects.filter(
                     linked_type=GroupLink.LinkedType.issue,
                     linked_id=external_issue.id,

--- a/src/sentry/templates/sentry/integrations/jira-issue.html
+++ b/src/sentry/templates/sentry/integrations/jira-issue.html
@@ -45,20 +45,29 @@
       </div>
       {% else %}
 
+      {% for group in groups %}
       <div>
-        <h2>{{ type }}</h2>
-        <p><a href="{{ title_url }}" target="_blank">{{title}}</a></p>
+        <h2>{{ group.type }}</h2>
+        <p><a href="{{ group.title_url }}" target="_blank">{{ group.title }}</a></p>
         <br />
+
+        <!-- EVENTS GROUP -->
         <div class="aui-group">
           <div class="aui-item">
-            <span>{% trans "Events last 24 hours:" %}</span>
-            <aui-badge>{{ stats_24hr }}</aui-badge>
+            <h4>{% trans "Events" %}</h4>
+          </div>
+        </div>
+
+        <div class="aui-group">
+          <div class="aui-item" >
+            <span>{% trans "Last 24 hours:" %}</span>
+            <aui-badge>{{ group.stats_24hr }}</aui-badge>
           </div>
         </div>
         <div class="aui-group">
           <div class="aui-item">
-            <span>{% trans "Events last 14 days:" %}</span>
-            <aui-badge>{{ stats_14d }}</aui-badge>
+            <span>{% trans "Last 14 days:" %}</span>
+            <aui-badge>{{ group.stats_14d }}</aui-badge>
           </div>
         </div>
       </div>
@@ -71,23 +80,23 @@
       </div>
 
       <div class="aui-group">
-        <div class="aui-item">
+        <div class="aui-item" style="width:75px;">
           <span class="left-grid">{% trans "Date:" %}</span>
         </div>
         <div class="aui-item">
-          <span class="right-grid">{{ first_seen }} UTC</span>
+          <span class="right-grid">{{ group.first_seen }} UTC</span>
         </div>
       </div>
 
       {% if first_release %}
       <div class="aui-group">
-        <div class="aui-item">
+        <div class="aui-item" style="width:75px;">
           <span class="left-grid">{% trans "Release:" %}</span>
         </div>
         <div class="aui-item">
-          <span class="right-grid"
-            ><a href="{{ first_release_url}}" target="_blank">{{first_release}}</a></span
-          >
+          <span class="right-grid">
+            <a href="{{ group.first_release_url }}" target="_blank">{{ group.first_release }}</a>
+          </span>
         </div>
       </div>
       {% endif %}
@@ -100,26 +109,34 @@
       </div>
 
       <div class="aui-group">
-        <div class="aui-item">
+        <div class="aui-item" style="width:75px;">
           <span class="left-grid">{% trans "Date:" %}</span>
         </div>
         <div class="aui-item">
-          <span class="right-grid">{{ last_seen }} UTC</span>
+          <span class="right-grid">{{ group.last_seen }} UTC</span>
         </div>
       </div>
 
       {% if last_release %}
       <div class="aui-group">
-        <div class="aui-item">
+        <div class="aui-item" style="width:75px;">
           <span class="left-grid">{% trans "Release:" %}</span>
         </div>
         <div class="aui-item">
-          <span class="right-grid"
-            ><a href="{{ last_release_url}}" target="_blank">{{last_release}}</a></span
-          >
+          <span class="right-grid">
+            <a href="{{ group.last_release_url }}" target="_blank">{{ group.last_release }}</a>
+          </span>
         </div>
       </div>
-      {% endif %} {% endif %}
+      {% endif %}
+
+      <br/>
+      {% if not forloop.last %}
+      <hr style="opacity:0.5;" />
+      {% endif %}
+
+      {% endfor %}
+      {% endif %}
     </div>
   </body>
 </html>

--- a/src/sentry/templates/sentry/integrations/jira-issue.html
+++ b/src/sentry/templates/sentry/integrations/jira-issue.html
@@ -88,7 +88,7 @@
         </div>
       </div>
 
-      {% if first_release %}
+      {% if group.first_release %}
       <div class="aui-group">
         <div class="aui-item" style="width:75px;">
           <span class="left-grid">{% trans "Release:" %}</span>
@@ -117,7 +117,7 @@
         </div>
       </div>
 
-      {% if last_release %}
+      {% if group.last_release %}
       <div class="aui-group">
         <div class="aui-item" style="width:75px;">
           <span class="left-grid">{% trans "Release:" %}</span>


### PR DESCRIPTION
<!-- Describe your PR here. -->

This originally was just a bug fix but for [SENTRY-TC6](https://sentry.io/organizations/sentry/issues/3023574964/?project=1&referrer=slack), but there was a todo that i figured would be a useful fix/feature.

This PR will allow for multiple sentry issues to be rendered with details in jira if they are all linked with one jira ticket.

## Current UI

<img width="453" alt="image" src="https://user-images.githubusercontent.com/35509934/164560223-8abf02c1-3985-4258-b166-9ea37508227c.png">


## In this PR

**Badge showing more than 1 issue**

<img width="499" alt="image" src="https://user-images.githubusercontent.com/35509934/164559256-66963556-f0ce-47c9-868d-990c92e20a19.png">

**Separator for showing more than 1 issue**

<img width="453" alt="image" src="https://user-images.githubusercontent.com/35509934/164562835-9d41d7ac-3222-4556-90a9-4116e4f999e9.png">

**Regular UI for only 1 issue**

<img width="453" alt="image" src="https://user-images.githubusercontent.com/35509934/164562866-5a7dd9b2-57db-47d1-af11-71681b4f4e47.png">


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
