### PR TITLE
ref: clean up sentry flake8 plugin 

### DIFF
--- a/bin/find-good-catalogs
+++ b/bin/find-good-catalogs
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-import json  # noqa: b317
+import json  # noqa: S003
 import os
 
 import click

--- a/conftest.py
+++ b/conftest.py
@@ -82,7 +82,7 @@ def pytest_runtest_makereport(item, call):
         except AttributeError:
             pass
 
-        print(_error_workflow_command(filesystempath, lineno, longrepr))  # noqa: B314
+        print(_error_workflow_command(filesystempath, lineno, longrepr))  # noqa: S002
 
 
 def _error_workflow_command(filesystempath, lineno, longrepr):

--- a/scripts/appconnect_cli.py
+++ b/scripts/appconnect_cli.py
@@ -39,7 +39,7 @@ def main(argv):
     elif argv[0] == "dump-db":
         # Dumps (part of) the AppConnectBuild table.
         for build in AppConnectBuild.objects.all():
-            print(  # noqa: B314
+            print(  # noqa: S002
                 f"{build!r} app_id={build.app_id} bundle_id={build.bundle_id} platform={build.platform} version={build.bundle_short_version} build={build.bundle_version} fetched={build.fetched}"
             )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,12 +2,16 @@
 # File filtering is taken care of in pre-commit.
 # E203 false positive, see https://github.com/PyCQA/pycodestyle/issues/373
 # B011 We don't use PYTHONOPTIMIZE.
-ignore = F999,E203,E501,E128,E124,E402,W503,W504,E731,C901,B007,B009,B010,B011
 
 # XXX: E501 is ignored, which disables line length checking.
 # Currently, the black formatter doesn't wrap long strings: https://github.com/psf/black/issues/182#issuecomment-385325274
 # We already have a lot of E501's - these are lines black didn't wrap.
 # But rather than append # noqa: E501 to all of them, we just ignore E501 for now.
+extend-ignore = E203,E501,E402,E731,B007,B009,B010,B011
+
+per-file-ignores =
+    # allow prints in tests
+    tests/*: S002
 
 [flake8:local-plugins]
 paths = .

--- a/src/sentry/api/serializers/rest_framework/list.py
+++ b/src/sentry/api/serializers/rest_framework/list.py
@@ -1,4 +1,4 @@
-from rest_framework.serializers import ListField  # NOQA
+from rest_framework.serializers import ListField
 
 
 class EmptyListField(ListField):

--- a/src/sentry/app.py
+++ b/src/sentry/app.py
@@ -23,6 +23,6 @@ from .nodestore import backend as nodestore  # NOQA
 from .quotas import backend as quotas  # NOQA
 from .ratelimits import backend as ratelimiter  # NOQA
 
-raven = client = RavenShim()  # NOQA
+raven = client = RavenShim()
 
 locks = LockManager(RedisLockBackend(redis.clusters.get("default")))

--- a/src/sentry/audit_log/__init__.py
+++ b/src/sentry/audit_log/__init__.py
@@ -1,5 +1,5 @@
 from sentry.audit_log.manager import *  # NOQA
-from sentry.audit_log.register import default_manager  # NOQA
+from sentry.audit_log.register import default_manager
 
 # expose public api
 

--- a/src/sentry/buffer/__init__.py
+++ b/src/sentry/buffer/__init__.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
 
-from .base import Buffer  # NOQA
+from .base import Buffer
 
 backend = LazyServiceWrapper(Buffer, settings.SENTRY_BUFFER, settings.SENTRY_BUFFER_OPTIONS)
 backend.expose(locals())

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -296,7 +296,7 @@ class RedisBuffer(Buffer):
             # XXX(py3): Note that ``import_string`` explicitly wants a str in
             # python2, so we'll decode (for python3) and then translate back to
             # a byte string (in python2) for import_string.
-            model = import_string(str(values.pop("m").decode("utf-8")))  # NOQA
+            model = import_string(str(values.pop("m").decode("utf-8")))
 
             if values["f"].startswith(b"{"):
                 filters = self._load_values(json.loads(values.pop("f").decode("utf-8")))

--- a/src/sentry/charts/__init__.py
+++ b/src/sentry/charts/__init__.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
 
-from .base import ChartRenderer  # NOQA
+from .base import ChartRenderer
 
 # The charts module provides a service to interface with the external
 # Chartcuterie service, which produces charts as images.

--- a/src/sentry/debug/utils/packages.py
+++ b/src/sentry/debug/utils/packages.py
@@ -5,7 +5,7 @@ from sentry.utils.compat import map
 try:
     import pkg_resources
 except ImportError:
-    pkg_resources = None  # NOQA
+    pkg_resources = None
 
 
 def get_package_version(module_name, app):

--- a/src/sentry/digests/__init__.py
+++ b/src/sentry/digests/__init__.py
@@ -12,8 +12,8 @@ from sentry.utils.services import LazyServiceWrapper
 if TYPE_CHECKING:
     from sentry.models import Rule, Group
 
-from .backends.base import Backend  # NOQA
-from .backends.dummy import DummyBackend  # NOQA
+from .backends.base import Backend
+from .backends.dummy import DummyBackend
 
 backend = LazyServiceWrapper(
     Backend, settings.SENTRY_DIGESTS, settings.SENTRY_DIGESTS_OPTIONS, (DummyBackend,)

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -141,7 +141,7 @@ class EventStorage(Service):
         orderby=None,
         limit=100,
         offset=0,
-        referrer="eventstore.get_events",  # NOQA
+        referrer="eventstore.get_events",
     ):
         """
         Fetches a list of events given a set of criteria.
@@ -164,7 +164,7 @@ class EventStorage(Service):
         orderby=None,
         limit=100,
         offset=0,
-        referrer="eventstore.get_unfetched_events",  # NOQA
+        referrer="eventstore.get_unfetched_events",
     ):
         """
         Same as get_events but returns events without their node datas loaded.
@@ -197,7 +197,7 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_next_event_id(self, event, snuba_filter):  # NOQA
+    def get_next_event_id(self, event, snuba_filter):
         """
         Gets the next event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -208,7 +208,7 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_prev_event_id(self, event, snuba_filter):  # NOQA
+    def get_prev_event_id(self, event, snuba_filter):
         """
         Gets the previous event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -219,7 +219,7 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_earliest_event_id(self, event, snuba_filter):  # NOQA
+    def get_earliest_event_id(self, event, snuba_filter):
         """
         Gets the earliest event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -230,7 +230,7 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_latest_event_id(self, event, snuba_filter):  # NOQA
+    def get_latest_event_id(self, event, snuba_filter):
         """
         Gets the latest event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -48,7 +48,7 @@ class SnubaEventStorage(EventStorage):
 
     def get_events(
         self,
-        filter,  # NOQA
+        filter,
         orderby=None,
         limit=DEFAULT_LIMIT,
         offset=DEFAULT_OFFSET,
@@ -59,7 +59,7 @@ class SnubaEventStorage(EventStorage):
         """
         with sentry_sdk.start_span(op="eventstore.snuba.get_events"):
             return self.__get_events(
-                filter,  # NOQA
+                filter,
                 orderby=orderby,
                 limit=limit,
                 offset=offset,
@@ -69,7 +69,7 @@ class SnubaEventStorage(EventStorage):
 
     def get_unfetched_events(
         self,
-        filter,  # NOQA
+        filter,
         orderby=None,
         limit=DEFAULT_LIMIT,
         offset=DEFAULT_OFFSET,
@@ -79,7 +79,7 @@ class SnubaEventStorage(EventStorage):
         Get events from Snuba, without node data loaded.
         """
         return self.__get_events(
-            filter,  # NOQA
+            filter,
             orderby=orderby,
             limit=limit,
             offset=offset,
@@ -89,14 +89,14 @@ class SnubaEventStorage(EventStorage):
 
     def __get_events(
         self,
-        filter,  # NOQA
+        filter,
         orderby=None,
         limit=DEFAULT_LIMIT,
         offset=DEFAULT_OFFSET,
         referrer=None,
         should_bind_nodes=False,
     ):
-        assert filter, "You must provide a filter"  # NOQA
+        assert filter, "You must provide a filter"
         cols = self.__get_columns()
         orderby = orderby or DESC_ORDERING
 
@@ -238,60 +238,60 @@ class SnubaEventStorage(EventStorage):
 
         return event
 
-    def get_earliest_event_id(self, event, filter):  # NOQA
-        filter = deepcopy(filter)  # NOQA
+    def get_earliest_event_id(self, event, filter):
+        filter = deepcopy(filter)
         filter.conditions = filter.conditions or []
         filter.conditions.extend(get_before_event_condition(event))
         filter.end = event.datetime
 
-        return self.__get_event_id_from_filter(filter=filter, orderby=ASC_ORDERING)  # NOQA
+        return self.__get_event_id_from_filter(filter=filter, orderby=ASC_ORDERING)
 
-    def get_latest_event_id(self, event, filter):  # NOQA
-        filter = deepcopy(filter)  # NOQA
+    def get_latest_event_id(self, event, filter):
+        filter = deepcopy(filter)
         filter.conditions = filter.conditions or []
         filter.conditions.extend(get_after_event_condition(event))
         filter.start = event.datetime
 
-        return self.__get_event_id_from_filter(filter=filter, orderby=DESC_ORDERING)  # NOQA
+        return self.__get_event_id_from_filter(filter=filter, orderby=DESC_ORDERING)
 
-    def get_next_event_id(self, event, filter):  # NOQA
+    def get_next_event_id(self, event, filter):
         """
         Returns (project_id, event_id) of a next event given a current event
         and any filters/conditions. Returns None if no next event is found.
         """
-        assert filter, "You must provide a filter"  # NOQA
+        assert filter, "You must provide a filter"
 
         if not event:
             return None
 
-        filter = deepcopy(filter)  # NOQA
+        filter = deepcopy(filter)
         filter.conditions = filter.conditions or []
         filter.conditions.extend(get_after_event_condition(event))
         filter.start = event.datetime
 
-        return self.__get_event_id_from_filter(filter=filter, orderby=ASC_ORDERING)  # NOQA
+        return self.__get_event_id_from_filter(filter=filter, orderby=ASC_ORDERING)
 
-    def get_prev_event_id(self, event, filter):  # NOQA
+    def get_prev_event_id(self, event, filter):
         """
         Returns (project_id, event_id) of a previous event given a current event
         and a filter. Returns None if no previous event is found.
         """
-        assert filter, "You must provide a filter"  # NOQA
+        assert filter, "You must provide a filter"
 
         if not event:
             return None
 
-        filter = deepcopy(filter)  # NOQA
+        filter = deepcopy(filter)
         filter.conditions = filter.conditions or []
         filter.conditions.extend(get_before_event_condition(event))
         filter.end = event.datetime
 
-        return self.__get_event_id_from_filter(filter=filter, orderby=DESC_ORDERING)  # NOQA
+        return self.__get_event_id_from_filter(filter=filter, orderby=DESC_ORDERING)
 
     def __get_columns(self):
         return [col.value.event_name for col in EventStorage.minimal_columns]
 
-    def __get_event_id_from_filter(self, filter=None, orderby=None):  # NOQA
+    def __get_event_id_from_filter(self, filter=None, orderby=None):
         columns = [Columns.EVENT_ID.value.alias, Columns.PROJECT_ID.value.alias]
 
         try:

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -117,7 +117,7 @@ default_manager.add("organizations:release-health-check-metrics", OrganizationFe
 default_manager.add("organizations:release-health-check-metrics-report", OrganizationFeature, True)
 default_manager.add("organizations:release-health-return-metrics", OrganizationFeature, True)
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature)
-default_manager.add("organizations:required-email-verification", OrganizationFeature, True)  # NOQA
+default_manager.add("organizations:required-email-verification", OrganizationFeature, True)
 default_manager.add("organizations:rule-page", OrganizationFeature)
 default_manager.add("organizations:selection-filters-v2", OrganizationFeature, True)
 default_manager.add("organizations:session-replay", OrganizationFeature, True)

--- a/src/sentry/identity/__init__.py
+++ b/src/sentry/identity/__init__.py
@@ -4,7 +4,7 @@ from .github import *  # NOQA
 from .github_enterprise import *  # NOQA
 from .gitlab import *  # NOQA
 from .google import *  # NOQA
-from .manager import IdentityManager  # NOQA
+from .manager import IdentityManager
 from .oauth2 import *  # NOQA
 from .slack import *  # NOQA
 from .vercel import *  # NOQA

--- a/src/sentry/incidents/serializers/__init__.py
+++ b/src/sentry/incidents/serializers/__init__.py
@@ -36,6 +36,6 @@ UNSUPPORTED_QUERIES = {"release:latest"}
 CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS = [30, 60, 120, 240, 720, 1440]
 
 
-from .alert_rule import AlertRuleSerializer  # NOQA
-from .alert_rule_trigger import AlertRuleTriggerSerializer  # NOQA
-from .alert_rule_trigger_action import AlertRuleTriggerActionSerializer  # NOQA
+from .alert_rule import AlertRuleSerializer
+from .alert_rule_trigger import AlertRuleTriggerSerializer
+from .alert_rule_trigger_action import AlertRuleTriggerActionSerializer

--- a/src/sentry/management/commands/makemigrations.py
+++ b/src/sentry/management/commands/makemigrations.py
@@ -29,7 +29,7 @@ def validate(migrations_filepath, latest_migration_by_app):
 
     for app_label, name in sorted(latest_migration_by_app.items()):
         if infile[app_label] != name:
-            print(  # noqa: B314
+            print(  # noqa: S002
                 f"ERROR: The latest migration does not match the one in the lockfile -> `{app_label}` app: {name} vs {infile[app_label]}"
             )
             # makemigrations.Command --check exits with 1 if a migration needs to be generated

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -86,9 +86,7 @@ def get_group_with_redirect(id_or_qualified_short_id, queryset=None, organizatio
             queryset = queryset.filter(project__organization=organization)
         getter = queryset.get
 
-    if not (
-        isinstance(id_or_qualified_short_id, int) or id_or_qualified_short_id.isdigit()  # noqa
-    ):  # NOQA
+    if not (isinstance(id_or_qualified_short_id, int) or id_or_qualified_short_id.isdigit()):
         short_id = parse_short_id(id_or_qualified_short_id)
         if not short_id or not organization:
             raise Group.DoesNotExist()

--- a/src/sentry/monkey/__init__.py
+++ b/src/sentry/monkey/__init__.py
@@ -2,7 +2,7 @@ from .pickle import patch_pickle_loaders
 
 
 def register_scheme(name):
-    from urllib import parse as urlparse  # NOQA
+    from urllib import parse as urlparse
 
     uses = urlparse.uses_netloc, urlparse.uses_query, urlparse.uses_relative, urlparse.uses_fragment
     for use in uses:

--- a/src/sentry/newsletter/__init__.py
+++ b/src/sentry/newsletter/__init__.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
 
-from .base import Newsletter  # NOQA
+from .base import Newsletter
 
 backend = LazyServiceWrapper(
     Newsletter, settings.SENTRY_NEWSLETTER, settings.SENTRY_NEWSLETTER_OPTIONS

--- a/src/sentry/nodestore/__init__.py
+++ b/src/sentry/nodestore/__init__.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
 
-from .base import NodeStorage  # NOQA
+from .base import NodeStorage
 
 backend = LazyServiceWrapper(
     NodeStorage,

--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -25,7 +25,7 @@ set = default_manager.set
 delete = default_manager.delete
 register = default_manager.register
 all = default_manager.all
-filter = default_manager.filter  # NOQA
+filter = default_manager.filter
 isset = default_manager.isset
 lookup_key = default_manager.lookup_key
 

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from django.db.models import Q
-from parsimonious.exceptions import ParseError  # noqa
+from parsimonious.exceptions import ParseError
 from parsimonious.grammar import Grammar, NodeVisitor
 from parsimonious.nodes import Node
 from rest_framework.serializers import ValidationError

--- a/src/sentry/quotas/__init__.py
+++ b/src/sentry/quotas/__init__.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
 
-from .base import Quota  # NOQA
+from .base import Quota
 
 backend = LazyServiceWrapper(Quota, settings.SENTRY_QUOTAS, settings.SENTRY_QUOTA_OPTIONS)
 backend.expose(locals())

--- a/src/sentry/ratelimits/__init__.py
+++ b/src/sentry/ratelimits/__init__.py
@@ -11,7 +11,7 @@ __all__ = (
     "RateLimiter",
 )
 
-from .base import RateLimiter  # NOQA
+from .base import RateLimiter
 
 backend = LazyServiceWrapper(
     RateLimiter, settings.SENTRY_RATELIMITER, settings.SENTRY_RATELIMITER_OPTIONS

--- a/src/sentry/search/__init__.py
+++ b/src/sentry/search/__init__.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
 
-from .base import SearchBackend  # NOQA
+from .base import SearchBackend
 
 LazyServiceWrapper(SearchBackend, settings.SENTRY_SEARCH, settings.SENTRY_SEARCH_OPTIONS).expose(
     locals()

--- a/src/sentry/similarity/encoder.py
+++ b/src/sentry/similarity/encoder.py
@@ -5,7 +5,7 @@ from sentry.utils.compat import map
 
 class Encoder:
     try:
-        number_types = (int, long, float)  # noqa
+        number_types = (int, long, float)
     except NameError:
         number_types = (int, float)
 

--- a/src/sentry/status_checks/__init__.py
+++ b/src/sentry/status_checks/__init__.py
@@ -2,7 +2,7 @@ __all__ = ("check_all", "sort_by_severity", "Problem", "StatusCheck")
 
 from sentry.utils.warnings import seen_warnings
 
-from .base import Problem, StatusCheck, sort_by_severity  # NOQA
+from .base import Problem, StatusCheck, sort_by_severity
 from .celery_alive import CeleryAliveCheck
 from .celery_app_version import CeleryAppVersionCheck
 from .warnings import WarningStatusCheck

--- a/src/sentry/testutils/relay.py
+++ b/src/sentry/testutils/relay.py
@@ -31,7 +31,7 @@ def ensure_relay_is_registered():
             )
     except:  # NOQA
         # relay already registered  probably the first test (registration happened at Relay handshake time)
-        pass  # NOQA
+        pass
 
 
 class RelayStoreHelper:
@@ -170,9 +170,9 @@ class RelayStoreHelper:
         )
 
         self.settings = settings
-        self.get_relay_store_url = get_relay_store_url  # noqa
-        self.get_relay_minidump_url = get_relay_minidump_url  # noqa
-        self.get_relay_unreal_url = get_relay_unreal_url  # noqa
-        self.get_relay_security_url = get_relay_security_url  # noqa
-        self.get_relay_attachments_url = get_relay_attachments_url  # noqa
-        self.wait_for_ingest_consumer = wait_for_ingest_consumer(settings)  # noqa
+        self.get_relay_store_url = get_relay_store_url
+        self.get_relay_minidump_url = get_relay_minidump_url
+        self.get_relay_unreal_url = get_relay_unreal_url
+        self.get_relay_security_url = get_relay_security_url
+        self.get_relay_attachments_url = get_relay_attachments_url
+        self.wait_for_ingest_consumer = wait_for_ingest_consumer(settings)

--- a/src/sentry/tsdb/__init__.py
+++ b/src/sentry/tsdb/__init__.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
 
-from .base import BaseTSDB  # NOQA
+from .base import BaseTSDB
 from .dummy import DummyTSDB
 
 LazyServiceWrapper(

--- a/src/sentry/utils/fernet_encrypt.py
+++ b/src/sentry/utils/fernet_encrypt.py
@@ -34,7 +34,7 @@ def encrypt_object(obj: IntoJsonObject, key: str) -> str:
     key = key.encode("utf-8")
     try:
         f = Fernet(key)
-    except Exception as e:  # NOQA
+    except Exception as e:
         raise ValueError("Invalid encryption key") from e
     json_str = json.dumps(obj)
     json_bytes = json_str.encode("utf-8")
@@ -52,7 +52,7 @@ def decrypt_object(encrypted: str, key: str) -> IntoJsonObject:
     key = key.encode("utf-8")
     try:
         f = Fernet(key)
-    except Exception as e:  # NOQA
+    except Exception as e:
         raise ValueError("Invalid encryption Key") from e
     encrypted = encrypted.encode("utf-8")
     decrypted_bytes = f.decrypt(encrypted)

--- a/src/sentry/utils/pytest/kafka.py
+++ b/src/sentry/utils/pytest/kafka.py
@@ -36,7 +36,7 @@ class _KafkaAdminWrapper:
         try:
             futures_dict = self.admin_client.delete_topics([topic_name])
             self._sync_wait_on_result(futures_dict)
-        except Exception:  # noqa
+        except Exception:
             _log.warning("Could not delete topic %s", topic_name)
 
     def _sync_wait_on_result(self, futures_dict):
@@ -219,7 +219,7 @@ def wait_for_ingest_consumer(session_ingest_consumer, task_runner):
             start_wait = time.time()
             with task_runner():
                 while time.time() - start_wait < max_time:
-                    consumer._run_once()  # noqa
+                    consumer._run_once()
                     # check if the condition is satisfied
                     val = exit_predicate()
                     if val is not None:

--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -12,7 +12,7 @@ class InvalidQuerySetError(ValueError):
     pass
 
 
-def celery_run_batch_query(filter, batch_size, referrer, state=None, fetch_events=True):  # noqa
+def celery_run_batch_query(filter, batch_size, referrer, state=None, fetch_events=True):
     """
     A tool for batched queries similar in purpose to RangeQuerySetWrapper that
     is used for celery tasks in issue merge/unmerge/reprocessing.
@@ -46,7 +46,7 @@ def celery_run_batch_query(filter, batch_size, referrer, state=None, fetch_event
 
     events = list(
         method(
-            filter=filter,  # noqa
+            filter=filter,
             limit=batch_size,
             referrer=referrer,
             orderby=["-timestamp", "-event_id"],

--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -313,7 +313,7 @@ class OAuthAuthorizeView(AuthLoginView):
                     "expires_in": int((timezone.now() - token.expires_at).total_seconds()),
                     "expires_at": token.expires_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     "token_type": "bearer",
-                    "scope": " ".join(token.get_scopes()),  # NOQA
+                    "scope": " ".join(token.get_scopes()),
                     "state": params["state"],
                 },
             )

--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -116,7 +116,7 @@ class OAuthTokenView(View):
                     else None,
                     "expires_at": token.expires_at,
                     "token_type": "bearer",
-                    "scope": " ".join(token.get_scopes()),  # NOQA
+                    "scope": " ".join(token.get_scopes()),
                     "user": {
                         "id": str(token.user.id),
                         # we might need these to become scope based

--- a/src/sentry_plugins/trello/plugin.py
+++ b/src/sentry_plugins/trello/plugin.py
@@ -11,7 +11,7 @@ from sentry_plugins.base import CorePluginMixin
 
 from .client import TrelloApiClient
 
-SETUP_URL = "https://github.com/getsentry/sentry/blob/master/src/sentry_plugins/trello/Trello_Instructions.md"  # NOQA
+SETUP_URL = "https://github.com/getsentry/sentry/blob/master/src/sentry_plugins/trello/Trello_Instructions.md"
 
 LABLEX_REGEX = re.compile(r"\w+/https://trello\.com/")
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -27,7 +27,7 @@ def pytest_configure(config):
             last_built = int(time.time()) - data["built"]
 
             if last_built <= 3600:
-                print(  # noqa: B314
+                print(
                     """
 ###################
 #
@@ -45,7 +45,7 @@ def pytest_configure(config):
     except Exception:
         pass
 
-    print(  # noqa: B314
+    print(
         """
 ###################
 #

--- a/tests/sentry/similarity/test_encoder.py
+++ b/tests/sentry/similarity/test_encoder.py
@@ -19,7 +19,7 @@ def test_builtin_types():
     ]
 
     try:
-        values.append(long(1))  # noqa
+        values.append(long(1))
     except NameError:
         pass
 

--- a/tests/sentry/sudo/test_views.py
+++ b/tests/sentry/sudo/test_views.py
@@ -64,8 +64,7 @@ class SudoViewTestCase(BaseTestCase):
         response = sudo(self.request)
         self.assertEqual(response["Location"], REDIRECT_URL)
         self.request.GET = {
-            REDIRECT_FIELD_NAME: "http://%s\\@mattrobenolt.com"
-            % self.request.get_host(),  # noqa: W605
+            REDIRECT_FIELD_NAME: "http://%s\\@mattrobenolt.com" % self.request.get_host(),
         }
         response = sudo(self.request)
         self.assertEqual(response["Location"], REDIRECT_URL)
@@ -119,7 +118,7 @@ class SudoViewTestCase(BaseTestCase):
         self.assertEqual(response["Location"], REDIRECT_URL)
         self.assertFalse("redirect_to" in self.request.session)
         self.request.session[REDIRECT_TO_FIELD_NAME] = (
-            "http://%s\\@mattrobenolt.com" % self.request.get_host()  # noqa: W605
+            "http://%s\\@mattrobenolt.com" % self.request.get_host()
         )
         response = sudo(self.request)
         self.assertEqual(response["Location"], REDIRECT_URL)

--- a/tests/tools/flake8_plugin_test.py
+++ b/tests/tools/flake8_plugin_test.py
@@ -4,9 +4,8 @@ from tools.flake8_plugin import S001, S002, SentryCheck
 
 
 def _run(src):
-    lines = src.splitlines(True)
     tree = ast.parse(src)
-    return list(SentryCheck(filename="example.py", tree=tree, lines=lines).run())
+    return list(SentryCheck(tree=tree).run())
 
 
 def _errors(*errors):


### PR DESCRIPTION
- remove S005: pyupgrade handles this for us
- remove `pycodestyle` handling: flake8 does this natively
- clean up the ignore list and use extend-ignore

the "noqa" commit is entirely automated using https://github.com/asottile/yesqa

validated via:

```console
$ pre-commit run flake8 --all-files
flake8...................................................................Passed
```

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
