### PR TITLE
fix(test): Fix crash rate alert tests failing 1% of the time.

### DIFF
--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1595,7 +1595,7 @@ class CrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass):
                         "data": [
                             {
                                 CRASH_RATE_ALERT_AGGREGATE_ALIAS: value,
-                                CRASH_RATE_ALERT_SESSION_COUNT_ALIAS: randint(0, 100)
+                                CRASH_RATE_ALERT_SESSION_COUNT_ALIAS: randint(1, 100)
                                 if count is EMPTY
                                 else count,
                             }


### PR DESCRIPTION
If the session count is 0 then these tests will fail. Changed the random generator to exclude values
of 0.

Specifically fixing a flake I saw for `test_multiple_threshold_trigger_is_reset_when_count_is_lower_than_min_threshold`, 
but this probably happens with other tests here.