### PR TITLE
feat(release_monitor): Add metric backend for release monitor

### DIFF
--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -24,7 +24,7 @@ from sentry.sentry_metrics.utils import resolve_tag_key
 from sentry.snuba.dataset import Dataset, EntityKey
 
 # from sentry.snuba.metrics import QueryDefinition, MetricField, get_series, OrderBy as MetricsOrderBy, MetricOperationType
-from sentry.snuba.metrics.naming_layer import SessionMRI
+from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.utils import metrics
 from sentry.utils.snuba import raw_snql_query
 

--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -4,11 +4,27 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Mapping, Sequence
 
-from snuba_sdk import Column, Condition, Direction, Entity, Granularity, Op, OrderBy, Query
+from snuba_sdk import (
+    Column,
+    Condition,
+    Direction,
+    Entity,
+    Function,
+    Granularity,
+    Op,
+    OrderBy,
+    Query,
+)
 
+# from sentry import release_health
 from sentry.release_health.release_monitor.base import BaseReleaseMonitorBackend, Totals
+from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.indexer.strings import SESSION_METRIC_NAMES
+from sentry.sentry_metrics.utils import resolve_tag_key
 from sentry.snuba.dataset import Dataset, EntityKey
+
+# from sentry.snuba.metrics import QueryDefinition, MetricField, get_series, OrderBy as MetricsOrderBy, MetricOperationType
+from sentry.snuba.metrics.naming_layer import SessionMRI
 from sentry.utils import metrics
 from sentry.utils.snuba import raw_snql_query
 
@@ -41,7 +57,7 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                             Condition(
                                 Column("metric_id"),
                                 Op.EQ,
-                                SESSION_METRIC_NAMES["c:sessions/session@none"],
+                                SESSION_METRIC_NAMES[SessionMRI.SESSION.value],
                             ),
                         ],
                         granularity=Granularity(3600),
@@ -85,48 +101,81 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
         totals: Totals = defaultdict(dict)
         with metrics.timer("release_monitor.fetch_project_release_health_totals.loop"):
             while (time.time() - start_time) < self.MAX_SECONDS:
-                with metrics.timer("release_monitor.fetch_project_release_health_totals.query"):
-                    query = (
-                        Query(
-                            dataset=Dataset.Metrics.value,
-                            match=Entity(EntityKey.MetricsCounters.value),
-                            select=[
-                                # TODO: What will this be? Sum of value?
-                                Column("sessions"),
-                            ],
-                            groupby=[
-                                Column("org_id"),
-                                Column("project_id"),
-                                Column("release"),
-                                Column("environment"),
-                            ],
-                            where=[
-                                Condition(
-                                    Column("timestamp"),
-                                    Op.GTE,
-                                    datetime.utcnow() - timedelta(hours=6),
-                                ),
-                                Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
-                                Condition(Column("org_id"), Op.EQ, org_id),
-                                Condition(Column("project_id"), Op.IN, project_ids),
-                                Condition(
-                                    Column("metric_id"),
-                                    Op.EQ,
-                                    SESSION_METRIC_NAMES["c:sessions/session@none"],
-                                ),
-                            ],
-                            granularity=Granularity(21600),
-                            orderby=[
-                                OrderBy(Column("org_id"), Direction.ASC),
-                                OrderBy(Column("project_id"), Direction.ASC),
-                            ],
-                        )
-                        .set_limit(self.CHUNK_SIZE + 1)
-                        .set_offset(offset)
+                # query = QueryDefinition(
+                #     org_id=org_id,
+                #     project_ids=project_ids,
+                #     select=[
+                #         MetricField("sum", "sentry.sessions.session"),
+                #         MetricField(None, "project_id"),
+                #         MetricField(None, "release"),
+                #         MetricField(None, "environment"),
+                #     ],
+                #     start=datetime.utcnow() - timedelta(hours=6),
+                #     end=datetime.utcnow(),
+                #     granularity=Granularity(21600),
+                #     where=[Condition(
+                #         Column("metric_id"),
+                #         Op.EQ,
+                #         indexer.resolve(org_id, SessionMRI.SESSION.value),
+                #     )],
+                #     groupby=[
+                #         Column("project_id"),
+                #         Column(resolve_tag_key(org_id, "release")),
+                #         Column(resolve_tag_key(org_id, "environment")),
+                #     ],
+                #     orderby=MetricsOrderBy(MetricField(None, "project_id"), Direction.ASC),
+                #     limit=self.CHUNK_SIZE + 1,
+                #     offset=offset,
+                # )
+                release_key = resolve_tag_key(org_id, "release")
+                release_col = Column(release_key)
+                env_key = resolve_tag_key(org_id, "environment")
+                env_col = Column(env_key)
+                query = (
+                    Query(
+                        dataset=Dataset.Metrics.value,
+                        match=Entity(EntityKey.MetricsCounters.value),
+                        select=[
+                            Function("sum", [Column("value")], "sessions"),
+                            Column("project_id"),
+                            release_col,
+                            env_col,
+                        ],
+                        groupby=[
+                            Column("project_id"),
+                            release_col,
+                            env_col,
+                        ],
+                        where=[
+                            Condition(
+                                Column("timestamp"),
+                                Op.GTE,
+                                datetime.utcnow() - timedelta(hours=6),
+                            ),
+                            Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                            Condition(Column("org_id"), Op.EQ, org_id),
+                            Condition(Column("project_id"), Op.IN, project_ids),
+                            Condition(
+                                Column("metric_id"),
+                                Op.EQ,
+                                indexer.resolve(org_id, SessionMRI.SESSION.value),
+                            ),
+                        ],
+                        granularity=Granularity(21600),
+                        orderby=[
+                            OrderBy(Column("project_id"), Direction.ASC),
+                            OrderBy(release_col, Direction.ASC),
+                            OrderBy(env_col, Direction.ASC),
+                        ],
                     )
+                    .set_limit(self.CHUNK_SIZE + 1)
+                    .set_offset(offset)
+                )
 
+                with metrics.timer("release_monitor.fetch_project_release_health_totals.query"):
+                    # data = get_series(project_ids, query)
                     data = raw_snql_query(
-                        query, referrer="release_monitor.fetch_project_release_health_totals"
+                        query, referrer="release_monitor.fetch_projects_with_recent_sessions"
                     )["data"]
                     count = len(data)
                     more_results = count > self.CHUNK_SIZE
@@ -136,11 +185,13 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                         data = data[:-1]
 
                     for row in data:
+                        env_name = indexer.reverse_resolve(row[env_key])
+                        release_name = indexer.reverse_resolve(row[release_key])
                         row_totals = totals[row["project_id"]].setdefault(
-                            row["environment"], {"total_sessions": 0, "releases": defaultdict(int)}
+                            env_name, {"total_sessions": 0, "releases": defaultdict(int)}
                         )
                         row_totals["total_sessions"] += row["sessions"]
-                        row_totals["releases"][row["release"]] += row["sessions"]
+                        row_totals["releases"][release_name] += row["sessions"]
 
                 if not more_results:
                     break

--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -1,0 +1,152 @@
+import logging
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import Mapping, Sequence
+
+from snuba_sdk import Column, Condition, Direction, Entity, Granularity, Op, OrderBy, Query
+
+from sentry.release_health.release_monitor.base import BaseReleaseMonitorBackend, Totals
+from sentry.sentry_metrics.indexer.strings import SESSION_METRIC_NAMES
+from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.utils import metrics
+from sentry.utils.snuba import raw_snql_query
+
+logger = logging.getLogger(__name__)
+
+
+class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
+    def fetch_projects_with_recent_sessions(self) -> Mapping[int, Sequence[int]]:
+        with metrics.timer(
+            "release_monitor.fetch_projects_with_recent_sessions.loop", sample_rate=1.0
+        ):
+            aggregated_projects = defaultdict(list)
+            start_time = time.time()
+            offset = 0
+            while (time.time() - start_time) < self.MAX_SECONDS:
+                query = (
+                    Query(
+                        dataset=Dataset.Metrics.value,
+                        match=Entity(EntityKey.OrgMetricsCounters.value),
+                        select=[
+                            Column("org_id"),
+                            Column("project_id"),
+                        ],
+                        groupby=[Column("org_id"), Column("project_id")],
+                        where=[
+                            Condition(
+                                Column("timestamp"), Op.GTE, datetime.utcnow() - timedelta(hours=6)
+                            ),
+                            Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                            Condition(
+                                Column("metric_id"),
+                                Op.EQ,
+                                SESSION_METRIC_NAMES["c:sessions/session@none"],
+                            ),
+                        ],
+                        granularity=Granularity(3600),
+                        orderby=[
+                            OrderBy(Column("org_id"), Direction.ASC),
+                            OrderBy(Column("project_id"), Direction.ASC),
+                        ],
+                    )
+                    .set_limit(self.CHUNK_SIZE + 1)
+                    .set_offset(offset)
+                )
+                data = raw_snql_query(
+                    query, referrer="release_monitor.fetch_projects_with_recent_sessions"
+                )["data"]
+                count = len(data)
+                more_results = count > self.CHUNK_SIZE
+                offset += self.CHUNK_SIZE
+
+                if more_results:
+                    data = data[:-1]
+
+                for row in data:
+                    aggregated_projects[row["org_id"]].append(row["project_id"])
+
+                if not more_results:
+                    break
+
+            else:
+                logger.error(
+                    "release_monitor.fetch_projects_with_recent_sessions.loop_timeout",
+                    extra={"offset": offset},
+                )
+
+        return aggregated_projects
+
+    def fetch_project_release_health_totals(
+        self, org_id: int, project_ids: Sequence[int]
+    ) -> Totals:
+        start_time = time.time()
+        offset = 0
+        totals: Totals = defaultdict(dict)
+        with metrics.timer("release_monitor.fetch_project_release_health_totals.loop"):
+            while (time.time() - start_time) < self.MAX_SECONDS:
+                with metrics.timer("release_monitor.fetch_project_release_health_totals.query"):
+                    query = (
+                        Query(
+                            dataset=Dataset.Metrics.value,
+                            match=Entity(EntityKey.MetricsCounters.value),
+                            select=[
+                                # TODO: What will this be? Sum of value?
+                                Column("sessions"),
+                            ],
+                            groupby=[
+                                Column("org_id"),
+                                Column("project_id"),
+                                Column("release"),
+                                Column("environment"),
+                            ],
+                            where=[
+                                Condition(
+                                    Column("timestamp"),
+                                    Op.GTE,
+                                    datetime.utcnow() - timedelta(hours=6),
+                                ),
+                                Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                                Condition(Column("org_id"), Op.EQ, org_id),
+                                Condition(Column("project_id"), Op.IN, project_ids),
+                                Condition(
+                                    Column("metric_id"),
+                                    Op.EQ,
+                                    SESSION_METRIC_NAMES["c:sessions/session@none"],
+                                ),
+                            ],
+                            granularity=Granularity(21600),
+                            orderby=[
+                                OrderBy(Column("org_id"), Direction.ASC),
+                                OrderBy(Column("project_id"), Direction.ASC),
+                            ],
+                        )
+                        .set_limit(self.CHUNK_SIZE + 1)
+                        .set_offset(offset)
+                    )
+
+                    data = raw_snql_query(
+                        query, referrer="release_monitor.fetch_project_release_health_totals"
+                    )["data"]
+                    count = len(data)
+                    more_results = count > self.CHUNK_SIZE
+                    offset += self.CHUNK_SIZE
+
+                    if more_results:
+                        data = data[:-1]
+
+                    for row in data:
+                        row_totals = totals[row["project_id"]].setdefault(
+                            row["environment"], {"total_sessions": 0, "releases": defaultdict(int)}
+                        )
+                        row_totals["total_sessions"] += row["sessions"]
+                        row_totals["releases"][row["release"]] += row["sessions"]
+
+                if not more_results:
+                    break
+            else:
+                logger.error(
+                    "fetch_project_release_health_totals.loop_timeout",
+                    extra={"org_id": org_id, "project_ids": project_ids},
+                )
+        return totals

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -19,4 +19,5 @@ class EntityKey(Enum):
     Transactions = "transactions"
     MetricsSets = "metrics_sets"
     MetricsCounters = "metrics_counters"
+    OrgMetricsCounters = "org_metrics_counters"
     MetricsDistributions = "metrics_distributions"

--- a/tests/sentry/release_health/release_monitor/__init__.py
+++ b/tests/sentry/release_health/release_monitor/__init__.py
@@ -1,0 +1,95 @@
+class BaseFetchProjectsWithRecentSessionsTest:
+    backend_class = None
+
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+        self.project1 = self.create_project()
+        self.project2 = self.create_project()
+        self.environment = self.create_environment(project=self.project2)
+        self.backend = self.backend_class()
+
+    def test_monitor_release_adoption(self):
+        self.org2 = self.create_organization()
+        self.org2_project = self.create_project(organization=self.org2)
+        self.org2_release = self.create_release(project=self.org2_project, version="org@2.0.0")
+        self.org2_environment = self.create_environment(project=self.org2_project)
+        self.bulk_store_sessions(
+            [
+                self.build_session(
+                    org_id=self.org2,
+                    project_id=self.org2_project,
+                    release=self.org2_release,
+                    environment=self.org2_environment,
+                )
+                for _ in range(2)
+            ]
+            + [self.build_session(project_id=self.project1) for _ in range(3)]
+            + [
+                self.build_session(project_id=self.project2, environment=self.environment)
+                for _ in range(1)
+            ]
+        )
+        results = self.backend.fetch_projects_with_recent_sessions()
+        assert results == {
+            self.organization.id: [self.project1.id, self.project2.id],
+            self.org2.id: [self.org2_project.id],
+        }
+
+
+class BaseFetchProjectReleaseHealthTotalsTest:
+    backend_class = None
+
+    def setUp(self):
+        self.project1 = self.create_project()
+        self.project2 = self.create_project()
+        self.environment1 = self.create_environment(project=self.project1)
+        self.environment2 = self.create_environment(project=self.project2)
+        self.release1 = self.create_release(project=self.project1)
+        self.release2 = self.create_release(project=self.project2)
+        self.backend = self.backend_class()
+
+    def test(self):
+        self.bulk_store_sessions(
+            [
+                self.build_session(
+                    project_id=self.project1,
+                    environment=self.environment1.name,
+                    release=self.release1.version,
+                )
+                for _ in range(5)
+            ]
+            + [
+                self.build_session(
+                    project_id=self.project2,
+                    environment=self.environment2.name,
+                    release=self.release2.version,
+                )
+            ]
+        )
+
+        totals = self.backend.fetch_project_release_health_totals(
+            self.organization.id,
+            [self.project.id, self.project1.id, self.project2.id],
+        )
+        assert totals == {
+            self.project1.id: {
+                self.environment1.name: {
+                    "total_sessions": 5,
+                    "releases": {self.release1.version: 5},
+                }
+            },
+            self.project2.id: {
+                self.environment2.name: {
+                    "total_sessions": 1,
+                    "releases": {self.release2.version: 1},
+                }
+            },
+        }, totals
+
+    def test_no_data(self):
+        totals = self.backend.fetch_project_release_health_totals(
+            self.organization.id,
+            [self.project.id, self.project1.id, self.project2.id],
+        )
+        assert totals == {}

--- a/tests/sentry/release_health/release_monitor/test_metrics.py
+++ b/tests/sentry/release_health/release_monitor/test_metrics.py
@@ -1,0 +1,18 @@
+from sentry.release_health.release_monitor.metrics import MetricReleaseMonitorBackend
+from sentry.testutils import SessionMetricsTestCase, TestCase
+from tests.sentry.release_health.release_monitor import (
+    BaseFetchProjectReleaseHealthTotalsTest,
+    BaseFetchProjectsWithRecentSessionsTest,
+)
+
+
+class MetricFetchProjectsWithRecentSessionsTest(
+    BaseFetchProjectsWithRecentSessionsTest, TestCase, SessionMetricsTestCase
+):
+    backend_class = MetricReleaseMonitorBackend
+
+
+class SessionFetchProjectReleaseHealthTotalsTest(
+    BaseFetchProjectReleaseHealthTotalsTest, TestCase, SessionMetricsTestCase
+):
+    backend_class = MetricReleaseMonitorBackend

--- a/tests/sentry/release_health/release_monitor/test_sessions.py
+++ b/tests/sentry/release_health/release_monitor/test_sessions.py
@@ -1,94 +1,18 @@
-from sentry.release_health import release_monitor
+from sentry.release_health.release_monitor.sessions import SessionReleaseMonitorBackend
 from sentry.testutils import SnubaTestCase, TestCase
+from tests.sentry.release_health.release_monitor import (
+    BaseFetchProjectReleaseHealthTotalsTest,
+    BaseFetchProjectsWithRecentSessionsTest,
+)
 
 
-class TestFetchProjectsWithRecentSessions(TestCase, SnubaTestCase):
-    def setUp(self):
-        super().setUp()
-        self.project = self.create_project()
-        self.project1 = self.create_project()
-        self.project2 = self.create_project()
-        self.environment = self.create_environment(project=self.project2)
-
-    def test_monitor_release_adoption(self):
-        self.org2 = self.create_organization()
-        self.org2_project = self.create_project(organization=self.org2)
-        self.org2_release = self.create_release(project=self.org2_project, version="org@2.0.0")
-        self.org2_environment = self.create_environment(project=self.org2_project)
-        self.bulk_store_sessions(
-            [
-                self.build_session(
-                    org_id=self.org2,
-                    project_id=self.org2_project,
-                    release=self.org2_release,
-                    environment=self.org2_environment,
-                )
-                for _ in range(2)
-            ]
-            + [self.build_session(project_id=self.project1) for _ in range(3)]
-            + [
-                self.build_session(project_id=self.project2, environment=self.environment)
-                for _ in range(1)
-            ]
-        )
-        results = release_monitor.fetch_projects_with_recent_sessions()
-        assert results == {
-            self.organization.id: [self.project1.id, self.project2.id],
-            self.org2.id: [self.org2_project.id],
-        }
+class SessionFetchProjectsWithRecentSessionsTest(
+    BaseFetchProjectsWithRecentSessionsTest, TestCase, SnubaTestCase
+):
+    backend_class = SessionReleaseMonitorBackend
 
 
-class TestFetchProjectReleaseHealthTotals(TestCase, SnubaTestCase):
-    def setUp(self):
-        self.project1 = self.create_project()
-        self.project2 = self.create_project()
-        self.environment1 = self.create_environment(project=self.project1)
-        self.environment2 = self.create_environment(project=self.project2)
-        self.release1 = self.create_release(project=self.project1)
-        self.release2 = self.create_release(project=self.project2)
-
-    def test(self):
-        self.bulk_store_sessions(
-            [
-                self.build_session(
-                    project_id=self.project1,
-                    environment=self.environment1.name,
-                    release=self.release1.version,
-                )
-                for _ in range(5)
-            ]
-            + [
-                self.build_session(
-                    project_id=self.project2,
-                    environment=self.environment2.name,
-                    release=self.release2.version,
-                )
-            ]
-        )
-
-        totals = release_monitor.fetch_project_release_health_totals(
-            self.organization.id,
-            [self.project.id, self.project1.id, self.project2.id],
-        )
-        assert totals == {
-            self.project1.id: {
-                self.environment1.name: {
-                    "total_sessions": 5,
-                    "releases": {self.release1.version: 5},
-                }
-            },
-            self.project2.id: {
-                self.environment2.name: {
-                    "total_sessions": 1,
-                    "releases": {self.release2.version: 1},
-                }
-            },
-        }
-
-    def test_no_data(self):
-
-        totals = release_monitor.fetch_project_release_health_totals(
-            self.organization.id,
-            [self.project.id, self.project1.id, self.project2.id],
-        )
-        assert totals == {}
+class SessionFetchProjectReleaseHealthTotalsTest(
+    BaseFetchProjectReleaseHealthTotalsTest, TestCase, SnubaTestCase
+):
+    backend_class = SessionReleaseMonitorBackend


### PR DESCRIPTION
This adds a metrics backend for release monitor. Ideally this would use our metrics query 
abstraction layer, but it doesn't support the queries we want to use yet.