### PR TITLE
feat(sessions): sessions v2 order by [INGEST-1193 INGEST-1211]

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -378,9 +378,12 @@ def _get_filter_conditions(conditions: Sequence[Condition]) -> Any:
 
 
 def _parse_orderby(query: QueryDefinition) -> Optional[OrderBy]:
-    orderby = query.raw_orderby
-    if orderby is None:
+    orderbys = query.raw_orderby
+    if orderbys == []:
         return None
+    if len(orderbys) > 1:
+        raise InvalidParams("Cannot order by multiple fields")
+    orderby = orderbys[0]
 
     if "session.status" in query.raw_groupby:
         raise InvalidParams("Cannot use 'orderBy' when grouping by sessions.status")

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -358,6 +358,14 @@ def run_sessions_query(
     return cast(SessionsQueryResult, results)
 
 
+def _get_filter_conditions(conditions: Sequence[Condition]) -> Any:
+    """Translate given conditions to snql"""
+    dummy_entity = EntityKey.MetricsSets.value
+    return json_to_snql(
+        {"selected_columns": ["value"], "conditions": conditions}, entity=dummy_entity
+    ).where
+
+
 def _parse_orderby(query: QueryDefinition) -> Optional[OrderBy]:
     orderby = query.raw_orderby
     if orderby is None:
@@ -393,11 +401,3 @@ def _get_primary_field(fields: Sequence[Field], raw_groupby: Sequence[str]) -> M
 
     assert primary_metric_field
     return primary_metric_field
-
-
-def _get_filter_conditions(conditions: Sequence[Condition]) -> Any:
-    """Translate given conditions to snql"""
-    dummy_entity = EntityKey.MetricsSets.value
-    return json_to_snql(
-        {"selected_columns": ["value"], "conditions": conditions}, entity=dummy_entity
-    ).where

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -546,11 +546,7 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
                         ]
                     snuba_query = snuba_query.set_where(where)
 
-                    # Set the limit of the second query to be the provided limits multiplied by
-                    # the number of the metrics requested in the query in this specific entity
-                    snuba_query = snuba_query.set_limit(
-                        snuba_query.limit.limit * len(snuba_query.select)
-                    )
+                    # The initial query already selected the "page", so reset the offset
                     snuba_query = snuba_query.set_offset(0)
 
                     snuba_query_res = raw_snql_query(

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -668,7 +668,12 @@ class SingularEntityDerivedMetric(DerivedMetricExpression):
     def run_post_query_function(
         self, data: SnubaDataType, query_definition: QueryDefinition, idx: Optional[int] = None
     ) -> Any:
-        compute_func_args = [data[self.metric_mri] if idx is None else data[self.metric_mri][idx]]
+        try:
+            compute_func_args = [
+                data[self.metric_mri] if idx is None else data[self.metric_mri][idx]
+            ]
+        except KeyError:
+            compute_func_args = [self.generate_default_null_values()]
         result = self.post_query_func(*compute_func_args)
         if isinstance(result, tuple) and len(result) == 1:
             result = result[0]

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -257,6 +257,7 @@ class QueryDefinition:
         self.query = query.get("query", "")
         self.raw_fields = raw_fields = query.getlist("field", [])
         self.raw_groupby = raw_groupby = query.getlist("groupBy", [])
+        self.raw_orderby = query.get("orderBy")  # only respected by metrics implementation
 
         if len(raw_fields) == 0:
             raise InvalidField('Request is missing a "field"')

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -257,7 +257,7 @@ class QueryDefinition:
         self.query = query.get("query", "")
         self.raw_fields = raw_fields = query.getlist("field", [])
         self.raw_groupby = raw_groupby = query.getlist("groupBy", [])
-        self.raw_orderby = query.get("orderBy")  # only respected by metrics implementation
+        self.raw_orderby = query.getlist("orderBy")  # only respected by metrics implementation
 
         if len(raw_fields) == 0:
             raise InvalidField('Request is missing a "field"')

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -928,4 +928,145 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
 class OrganizationSessionsEndpointMetricsTest(
     SessionMetricsTestCase, OrganizationSessionsEndpointTest
 ):
-    """Repeat with metrics backend"""
+    """Repeat all tests with metrics backend"""
+
+    @freeze_time(MOCK_DATETIME)
+    def test_orderby(self):
+        response = self.do_request(
+            {
+                "project": [-1],
+                "statsPeriod": "2d",
+                "interval": "1d",
+                "field": ["sum(session)"],
+                "orderBy": "foobar",
+            }
+        )
+        assert response.status_code == 400
+        assert response.data == {"detail": "'orderBy' must be one of the provided 'fields'"}
+
+        response = self.do_request(
+            {
+                "project": [-1],
+                "statsPeriod": "2d",
+                "interval": "1d",
+                "field": ["sum(session)"],
+                "orderBy": "count_unique(user)",  # wrong field
+            }
+        )
+        assert response.status_code == 400
+        assert response.data == {"detail": "'orderBy' must be one of the provided 'fields'"}
+
+        response = self.do_request(
+            {
+                "project": [-1],
+                "statsPeriod": "2d",
+                "interval": "1d",
+                "field": ["sum(session)"],
+                "orderBy": "sum(session)",  # misses group by, but why not
+            }
+        )
+        assert response.status_code == 200
+
+        response = self.do_request(
+            {
+                "project": [-1],
+                "statsPeriod": "2d",
+                "interval": "1d",
+                "field": ["sum(session)"],
+                "orderBy": "sum(session)",
+                "groupBy": ["session.status"],
+            }
+        )
+        assert response.status_code == 400
+        assert response.data == {"detail": "Cannot use 'orderBy' when grouping by sessions.status"}
+
+        response = self.do_request(
+            {
+                "project": [self.project.id, self.project3.id],
+                "statsPeriod": "2d",
+                "interval": "1d",
+                "field": ["sum(session)", "p95(session.duration)"],
+                "orderBy": "p95(session.duration)",
+                "groupBy": ["project", "release", "environment"],
+            }
+        )
+
+        expected_groups = [
+            {
+                "by": {
+                    "project": self.project.id,
+                    "release": "foo@1.0.0",
+                    "environment": "production",
+                },
+                "totals": {"sum(session)": 3, "p95(session.duration)": 25000.0},
+                "series": {"sum(session)": [0, 3], "p95(session.duration)": [None, 25000.0]},
+            },
+            {
+                "by": {
+                    "project": self.project3.id,
+                    "release": "foo@1.2.0",
+                    "environment": "production",
+                },
+                "totals": {"sum(session)": 1, "p95(session.duration)": 37000.0},
+                "series": {"sum(session)": [0, 1], "p95(session.duration)": [None, 37000.0]},
+            },
+            {
+                "by": {
+                    "project": self.project.id,
+                    "release": "foo@1.1.0",
+                    "environment": "production",
+                },
+                "totals": {"sum(session)": 1, "p95(session.duration)": 49000.0},
+                "series": {"sum(session)": [0, 1], "p95(session.duration)": [None, 49000.0]},
+            },
+            {
+                "by": {
+                    "project": self.project3.id,
+                    "release": "foo@1.0.0",
+                    "environment": "production",
+                },
+                "totals": {"sum(session)": 2, "p95(session.duration)": 79400.0},
+                "series": {"sum(session)": [0, 2], "p95(session.duration)": [None, 79400.0]},
+            },
+        ]
+        print(response.data)
+
+        # Not using `result_sorted` here, because we want to verify the order
+        assert response.status_code == 200, response.data
+        assert response.data["groups"] == expected_groups
+
+        # Sort descending
+        response = self.do_request(
+            {
+                "project": [self.project.id, self.project3.id],
+                "statsPeriod": "2d",
+                "interval": "1d",
+                "field": ["sum(session)", "p95(session.duration)"],
+                "orderBy": "-p95(session.duration)",
+                "groupBy": ["project", "release", "environment"],
+            }
+        )
+
+        assert response.status_code == 200
+        assert response.data["groups"] == list(reversed(expected_groups))
+
+        # Add some more code coverage
+        all_fields = [
+            "sum(session)",
+            "count_unique(user)",
+            "avg(session.duration)",
+        ]
+        for field in all_fields:
+            assert (
+                self.do_request(
+                    {
+                        "project": [self.project.id, self.project3.id],
+                        "statsPeriod": "2d",
+                        "interval": "1d",
+                        "field": all_fields,
+                        "orderBy": field,
+                        "groupBy": ["project", "release", "environment"],
+                    }
+                ).status_code
+                == 200
+            )

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -932,6 +932,7 @@ class OrganizationSessionsEndpointMetricsTest(
 
     @freeze_time(MOCK_DATETIME)
     def test_orderby(self):
+
         response = self.do_request(
             {
                 "project": [-1],
@@ -955,6 +956,19 @@ class OrganizationSessionsEndpointMetricsTest(
         )
         assert response.status_code == 400
         assert response.data == {"detail": "'orderBy' must be one of the provided 'fields'"}
+
+        # Cannot sort by more than one field
+        response = self.do_request(
+            {
+                "project": [-1],
+                "statsPeriod": "2d",
+                "interval": "1d",
+                "field": ["sum(session)", "count_unique(user)"],
+                "orderBy": ["sum(session)", "count_unique(user)"],
+            }
+        )
+        assert response.status_code == 400
+        assert response.data == {"detail": "Cannot order by multiple fields"}
 
         response = self.do_request(
             {


### PR DESCRIPTION
Give the sessions API the ability to sort the returned groups by one of the `fields`, e.g.:

```
?field=sum(session)&groupBy=release&orderBy=-sum(session)  # descending
```

Caveats:
* You can only order by a single field (e.g. `sum(session)`), not by group by values such as `release` or `environment`.
* This only works with the `MetricsReleaseHealthBackend` configured.
* `orderBy` only works when `session.status` is not in `groupBy`.

Requires https://github.com/getsentry/sentry/pull/33827.