### PR TITLE
fix(widget-builder): Disable Stay in Discover button if new dashboard [DD-787]

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -54,6 +54,8 @@ export type AddToDashboardModalProps = {
 
 type Props = ModalRenderProps & AddToDashboardModalProps;
 
+const SELECT_DASHBOARD_MESSAGE = t('Select a dashboard');
+
 function AddToDashboardModal({
   Header,
   Body,
@@ -87,7 +89,7 @@ function AddToDashboardModal({
   }
 
   async function handleAddAndStayInDiscover() {
-    if (selectedDashboardId === null) {
+    if (selectedDashboardId === null || selectedDashboardId === NEW_DASHBOARD_ID) {
       return;
     }
 
@@ -177,8 +179,8 @@ function AddToDashboardModal({
         <StyledButtonBar gap={1.5}>
           <Button
             onClick={handleAddAndStayInDiscover}
-            disabled={!canSubmit}
-            title={canSubmit ? undefined : t('Select a dashboard')}
+            disabled={!canSubmit || selectedDashboardId === NEW_DASHBOARD_ID}
+            title={canSubmit ? undefined : SELECT_DASHBOARD_MESSAGE}
           >
             {t('Add + Stay in Discover')}
           </Button>
@@ -186,7 +188,7 @@ function AddToDashboardModal({
             priority="primary"
             onClick={handleGoToBuilder}
             disabled={!canSubmit}
-            title={canSubmit ? undefined : t('Select a dashboard')}
+            title={canSubmit ? undefined : SELECT_DASHBOARD_MESSAGE}
           >
             {t('Open in Widget Builder')}
           </Button>

--- a/tests/js/spec/components/modals/addToDashboardModal.spec.tsx
+++ b/tests/js/spec/components/modals/addToDashboardModal.spec.tsx
@@ -268,4 +268,32 @@ describe('add to dashboard modal', () => {
       );
     });
   });
+
+  it('disables Add + Stay in Discover when a new dashboard is selected', async () => {
+    render(
+      <AddToDashboardModal
+        Header={stubEl}
+        Footer={stubEl as ModalRenderProps['Footer']}
+        Body={stubEl as ModalRenderProps['Body']}
+        CloseButton={stubEl}
+        closeModal={() => undefined}
+        organization={initialData.organization}
+        widget={widget}
+        selection={defaultSelection}
+        router={initialData.router}
+        widgetAsQueryParams={mockWidgetAsQueryParams}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Select Dashboard')).toBeEnabled();
+    });
+    await selectEvent.select(
+      screen.getByText('Select Dashboard'),
+      '+ Create New Dashboard'
+    );
+
+    expect(screen.getByRole('button', {name: 'Add + Stay in Discover'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Open in Widget Builder'})).toBeEnabled();
+  });
 });


### PR DESCRIPTION
We have to disable the `Add + Stay in Discover` button when the user selects `+ Create New Dashboard` because it will error out. If a user wants to create a new dashboard, their flow should be to enter the builder and subsequently fill out the dashboard information (i.e. title) to make sure there aren't conflicts.