### PR TITLE
fix(widget-builder): Pass along equation alias on column changes [DD-803]

### DIFF
--- a/static/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/static/app/views/eventsV2/table/columnEditCollection.tsx
@@ -213,6 +213,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
         newColumns[i] = {
           kind: 'equation',
           field: newEquation,
+          alias: newColumns[i].alias,
         };
       }
     }

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1690,9 +1690,7 @@ describe('WidgetBuilder', function () {
     expect(await screen.findByText('Top 5 Events')).toBeInTheDocument();
   });
 
-  // Disabling for CI, but should run locally when making changes
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('Update table header values (field alias)', async function () {
+  it('Update table header values (field alias)', async function () {
     const handleSave = jest.fn();
 
     renderTestComponent({
@@ -1702,11 +1700,11 @@ describe('WidgetBuilder', function () {
 
     await screen.findByText('Table');
 
-    userEvent.type(screen.getByPlaceholderText('Alias'), 'First Alias{enter}');
+    userEvent.paste(screen.getByPlaceholderText('Alias'), 'First Alias');
 
     userEvent.click(screen.getByLabelText('Add a Column'));
 
-    userEvent.type(screen.getAllByPlaceholderText('Alias')[1], 'Second Alias{enter}');
+    userEvent.paste(screen.getAllByPlaceholderText('Alias')[1], 'Second Alias');
 
     userEvent.click(screen.getByText('Add Widget'));
 
@@ -1719,6 +1717,35 @@ describe('WidgetBuilder', function () {
         }),
       ]);
     });
+  });
+
+  it('does not wipe equation aliases when a column alias is updated', async function () {
+    renderTestComponent({
+      orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
+    });
+
+    await screen.findByText('Table');
+
+    userEvent.click(screen.getByText('Add an Equation'));
+    userEvent.paste(screen.getAllByPlaceholderText('Alias')[1], 'This should persist');
+    userEvent.type(screen.getAllByPlaceholderText('Alias')[0], 'A');
+
+    expect(screen.getByText('This should persist')).toBeInTheDocument();
+  });
+
+  it('does not wipe equation aliases when a column selection is made', async function () {
+    renderTestComponent({
+      orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
+    });
+
+    await screen.findByText('Table');
+
+    userEvent.click(screen.getByText('Add an Equation'));
+    userEvent.paste(screen.getAllByPlaceholderText('Alias')[1], 'This should persist');
+
+    await selectEvent.select(screen.getAllByText('count()')[1], /count_unique/);
+
+    expect(screen.getByText('This should persist')).toBeInTheDocument();
   });
 
   describe('Issue Widgets', function () {


### PR DESCRIPTION
When a column is updated, it triggers a check for updating other
equations. This update method was not passing along the alias
so it resulted in wiping out the aliases for equations