### PR TITLE
fix(jira): Prevent KeyError on signed_params

### DIFF
--- a/src/sentry/integrations/jira/views/extension_configuration.py
+++ b/src/sentry/integrations/jira/views/extension_configuration.py
@@ -12,11 +12,10 @@ class JiraExtensionConfigurationView(IntegrationExtensionConfigurationView):
     provider = "jira"
     external_provider_key = "jira"
 
-    def map_params_to_state(self, params):
+    def map_params_to_state(self, original_params):
         # decode the signed params and add them to whatever params we have
-        params = params.copy()
-        signed_params = params["signed_params"]
-        del params["signed_params"]
+        params = original_params.copy()
+        signed_params = params.pop("signed_params", {})
         params.update(
             unsign(
                 signed_params,


### PR DESCRIPTION


<!-- Describe your PR here. -->

Fixes [SENTRY-TVX](https://sentry.io/organizations/sentry/issues/3216159247/?project=1&referrer=slack)

Avoids the KeyError and also changes a parameter name to be a bit more transparent.

<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
