### PR TITLE
ref(integrations): Exit task if the external issue doesn't exist

### DIFF
--- a/src/sentry/tasks/integrations/update_comment.py
+++ b/src/sentry/tasks/integrations/update_comment.py
@@ -12,9 +12,12 @@ from sentry.types.activity import ActivityType
     max_retries=5,
 )
 # TODO(jess): Add more retry exclusions once ApiClients have better error handling
-@retry(exclude=(ExternalIssue.DoesNotExist, Integration.DoesNotExist))
+@retry(exclude=(Integration.DoesNotExist))
 def update_comment(external_issue_id: int, user_id: int, group_note_id: int) -> None:
-    external_issue = ExternalIssue.objects.get(id=external_issue_id)
+    try:
+        external_issue = ExternalIssue.objects.get(id=external_issue_id)
+    except ExternalIssue.DoesNotExist:
+        return
     installation = external_issue.get_installation()
 
     if not should_comment_sync(installation, external_issue):


### PR DESCRIPTION
Fixes [SENTRY-SR6](https://sentry.io/organizations/sentry/issues/2797042873/events/e30cb483077f46c085c9c56455a0b831/?project=1)

Silence the error from the task crashing when unable to find an ExternalIssue.




<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
