### PR TITLE
ref(page-filters): Remove unnecessary alignDropdowns

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -633,7 +633,7 @@ class DashboardDetail extends Component<Props, State> {
             </StyledPageHeader>
             <DashboardPageFilterBar condensed>
               <ProjectPageFilter />
-              <EnvironmentPageFilter alignDropdown="left" />
+              <EnvironmentPageFilter />
               <DatePageFilter alignDropdown="left" />
             </DashboardPageFilterBar>
             <HookHeader organization={organization} />
@@ -738,7 +738,7 @@ class DashboardDetail extends Component<Props, State> {
                 <Layout.Main fullWidth>
                   <DashboardPageFilterBar condensed>
                     <ProjectPageFilter />
-                    <EnvironmentPageFilter alignDropdown="left" />
+                    <EnvironmentPageFilter />
                     <DatePageFilter alignDropdown="left" />
                   </DashboardPageFilterBar>
                   <WidgetViewerContext.Provider value={{seriesData, setData}}>

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -47,7 +47,7 @@ function IssueListFilters({
         {hasPageFilters && (
           <PageFilterBar>
             <ProjectPageFilter />
-            <EnvironmentPageFilter alignDropdown="left" />
+            <EnvironmentPageFilter />
             <DatePageFilter alignDropdown="left" />
           </PageFilterBar>
         )}


### PR DESCRIPTION
aligning to the left is default for the project page filter and the environment page filter, so it doesn't need to be set here.