### PR TITLE
ref(button): Remove success variant

### DIFF
--- a/docs-ui/stories/components/button.stories.js
+++ b/docs-ui/stories/components/button.stories.js
@@ -42,7 +42,7 @@ _Button.argTypes = {
   priority: {
     control: {
       type: 'select',
-      options: ['default', 'primary', 'danger', 'link', 'success', 'form'],
+      options: ['default', 'primary', 'danger', 'link', 'form'],
     },
   },
   size: {
@@ -65,11 +65,6 @@ export const Overview = ({busy}) => (
       <Item>
         <Button title="Tooltip" priority="primary" onClick={action('click primary')}>
           Primary Button
-        </Button>
-      </Item>
-      <Item>
-        <Button priority="success" onClick={action('click success')}>
-          Success Button
         </Button>
       </Item>
       <Item>

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -37,7 +37,7 @@ interface BaseButtonProps
   icon?: React.ReactNode;
   name?: string;
   onClick?: (e: React.MouseEvent) => void;
-  priority?: 'default' | 'primary' | 'danger' | 'link' | 'success' | 'form';
+  priority?: 'default' | 'primary' | 'danger' | 'link' | 'form';
   rel?: HTMLAnchorElement['rel'];
   size?: 'zero' | 'xsmall' | 'small';
   target?: HTMLAnchorElement['target'];
@@ -204,7 +204,6 @@ const getColors = ({
   const getFocusState = () => {
     switch (priority) {
       case 'primary':
-      case 'success':
       case 'danger':
         return `
           border-color: ${focusBorder};
@@ -224,7 +223,6 @@ const getColors = ({
   const getBackgroundColor = () => {
     switch (priority) {
       case 'primary':
-      case 'success':
       case 'danger':
         return `background-color: ${background};`;
       default:

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -507,17 +507,6 @@ const generateButtonTheme = (colors: BaseColors, alias: Aliases) => ({
     focusBorder: alias.focusBorder,
     focusShadow: alias.focus,
   },
-  success: {
-    color: colors.white,
-    colorActive: colors.white,
-    background: colors.green300,
-    backgroundActive: colors.green400,
-    border: colors.green300,
-    borderActive: colors.green300,
-    borderTranslucent: colors.green300,
-    focusBorder: colors.green300,
-    focusShadow: colors.green200,
-  },
   danger: {
     color: colors.white,
     colorActive: colors.white,


### PR DESCRIPTION
We don't use the success button variant anywhere in the app. The design team has already removed it from the design system.