### PR TITLE
ref(page-filters): No desynced state on locked project page filter

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -255,7 +255,7 @@ export function initializeUrlState({
 
   const pinnedFilters = storedPageFilters?.pinnedFilters ?? new Set();
   PageFiltersActions.initializeUrlState(pageFilters, pinnedFilters);
-  updateDesyncedUrlState(router);
+  updateDesyncedUrlState(router, shouldForceProject);
 
   const newDatetime = {
     ...datetime,
@@ -409,7 +409,7 @@ async function persistPageFilters(filter: PinnedPageFilter | null, options?: Opt
  * Checks if the URL state has changed in synchronization from the local
  * storage state, and persists that check into the store.
  */
-async function updateDesyncedUrlState(router?: Router) {
+async function updateDesyncedUrlState(router?: Router, shouldForceProject?: boolean) {
   // Cannot compare URL state without the router
   if (!router) {
     return;
@@ -453,7 +453,8 @@ async function updateDesyncedUrlState(router?: Router) {
   if (
     pinnedFilters.has('projects') &&
     currentQuery.project !== null &&
-    !valueIsEqual(currentQuery.project, storedState.project)
+    !valueIsEqual(currentQuery.project, storedState.project) &&
+    !shouldForceProject
   ) {
     differingFilters.add('projects');
   }

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -408,6 +408,9 @@ async function persistPageFilters(filter: PinnedPageFilter | null, options?: Opt
 /**
  * Checks if the URL state has changed in synchronization from the local
  * storage state, and persists that check into the store.
+ *
+ * If shouldForceProject is enabled, then we do not record any url desync
+ * for the project.
  */
 async function updateDesyncedUrlState(router?: Router, shouldForceProject?: boolean) {
   // Cannot compare URL state without the router


### PR DESCRIPTION
Previously, when there was any diff at all between query params and the locked selection we would show an alert to the user. 

example:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/9372512/164782462-bc1fa836-c7f2-48e5-8b5d-2e72f6147758.png">

But in cases when the project is a locked selection the user can not do any action to change the project selection so there is no need to have a desynced state and show the alert.

