### PR TITLE
test(acceptance): Add `desktop_only` flaky mobile issue details

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -298,7 +298,7 @@ class Browser:
         """
         self.driver.implicitly_wait(duration)
 
-    def snapshot(self, name, mobile_only=False):
+    def snapshot(self, name, mobile_only=False, desktop_only=False):
         """
         Capture a screenshot of the current state of the page.
         """
@@ -346,14 +346,15 @@ class Browser:
                         "window.__closeAllTooltips && window.__closeAllTooltips()"
                     )
 
-        with self.mobile_viewport():
-            screenshot_path = f"{snapshot_dir}-mobile/{filename}.png"
-            self.driver.find_element_by_tag_name("body").screenshot(screenshot_path)
+        if not desktop_only:
+            with self.mobile_viewport():
+                screenshot_path = f"{snapshot_dir}-mobile/{filename}.png"
+                self.driver.find_element_by_tag_name("body").screenshot(screenshot_path)
 
-            if os.environ.get("SENTRY_SCREENSHOT"):
-                import click
+                if os.environ.get("SENTRY_SCREENSHOT"):
+                    import click
 
-                click.launch(screenshot_path)
+                    click.launch(screenshot_path)
 
         return self
 

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -72,7 +72,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
     def test_pii_tooltips(self):
         event = self.create_sample_event(platform="pii-tooltips")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details pii tooltips")
+        self.browser.snapshot("issue details pii tooltips", desktop_only=True)
 
     def test_cocoa_event(self):
         event = self.create_sample_event(platform="cocoa")
@@ -208,7 +208,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
     def test_python_invalid_json_error(self):
         event = self.create_sample_event(default="python-invalid-json-error", platform="native")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details invalid json error exception")
+        self.browser.snapshot("issue details invalid json error exception", desktop_only=True)
 
     def test_exception_with_address_instruction(self):
         event = self.create_sample_event(


### PR DESCRIPTION
We're seeing some flakes from mobile issue details https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/eca8543829f6075300a762314461c13155a803fa/index.html
