### PR TITLE
fix(perf): Fix choice of project for Performance onboarding

### DIFF
--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -43,6 +43,8 @@ function PerformanceContent({selection, location, demoMode}: Props) {
 
   const [state, setState] = useState<State>({error: undefined});
 
+  const eventView = generatePerformanceEventView(location, projects);
+
   function getOnboardingProject(): Project | undefined {
     // XXX used by getsentry to bypass onboarding for the upsell demo state.
     if (demoMode) {
@@ -120,8 +122,6 @@ function PerformanceContent({selection, location, demoMode}: Props) {
       },
     });
   }
-
-  const eventView = generatePerformanceEventView(location, projects);
 
   return (
     <SentryDocumentTitle title={t('Performance')} orgSlug={organization.slug}>

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -76,13 +76,13 @@ function PerformanceContent({selection, location, demoMode}: Props) {
     return undefined;
   }
 
-  const onBoardingProject = getOnboardingProject();
+  const onboardingProject = getOnboardingProject();
 
   useEffect(() => {
     if (!mounted.current) {
       trackAdvancedAnalyticsEvent('performance_views.overview.view', {
         organization,
-        show_onboarding: onBoardingProject !== undefined,
+        show_onboarding: onboardingProject !== undefined,
       });
       loadOrganizationTags(api, organization.slug, selection);
       addRoutePerformanceContext(selection);
@@ -143,7 +143,7 @@ function PerformanceContent({selection, location, demoMode}: Props) {
               setError={setError}
               handleSearch={handleSearch}
               handleTrendsClick={() => handleTrendsClick({location, organization})}
-              onBoardingProject={onBoardingProject}
+              onboardingProject={onboardingProject}
               organization={organization}
               location={location}
               projects={projects}

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -52,6 +52,7 @@ import {
 
 type Props = {
   eventView: EventView;
+  getOnboardingProject: () => Project | undefined;
   handleSearch: (searchQuery: string) => void;
   handleTrendsClick: () => void;
   location: Location;
@@ -59,7 +60,6 @@ type Props = {
   projects: Project[];
   selection: PageFilters;
   setError: (msg: string | undefined) => void;
-  shouldShowOnboarding: boolean;
 };
 
 const fieldToViewMap: Record<LandingDisplayField, FC<Props>> = {
@@ -78,7 +78,7 @@ export function PerformanceLanding(props: Props) {
     projects,
     handleSearch,
     handleTrendsClick,
-    shouldShowOnboarding,
+    getOnboardingProject,
   } = props;
 
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
@@ -90,6 +90,8 @@ export function PerformanceLanding(props: Props) {
     eventView
   );
   const landingDisplay = paramLandingDisplay ?? defaultLandingDisplayForProjects;
+  const onBoardingProject = getOnboardingProject();
+  const showOnboarding = onBoardingProject !== undefined;
 
   useEffect(() => {
     if (hasMounted.current) {
@@ -108,8 +110,6 @@ export function PerformanceLanding(props: Props) {
   }, []);
 
   const filterString = getTransactionSearchQuery(location, eventView.query);
-
-  const showOnboarding = shouldShowOnboarding;
 
   const ViewComponent = fieldToViewMap[landingDisplay.field];
 
@@ -201,18 +201,7 @@ export function PerformanceLanding(props: Props) {
             {showOnboarding ? (
               <Fragment>
                 {pageFilters}
-                <Onboarding
-                  organization={organization}
-                  project={
-                    props.selection.projects.length > 0
-                      ? // If some projects selected, use the first selection
-                        projects.find(
-                          project => props.selection.projects[0].toString() === project.id
-                        ) || projects[0]
-                      : // Otherwise, use the first project in the org
-                        projects[0]
-                  }
-                />
+                <Onboarding organization={organization} project={onBoardingProject} />
               </Fragment>
             ) : (
               <Fragment>

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -55,7 +55,7 @@ type Props = {
   handleSearch: (searchQuery: string) => void;
   handleTrendsClick: () => void;
   location: Location;
-  onBoardingProject: Project | undefined;
+  onboardingProject: Project | undefined;
   organization: Organization;
   projects: Project[];
   selection: PageFilters;
@@ -78,7 +78,7 @@ export function PerformanceLanding(props: Props) {
     projects,
     handleSearch,
     handleTrendsClick,
-    onBoardingProject,
+    onboardingProject,
   } = props;
 
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
@@ -90,7 +90,7 @@ export function PerformanceLanding(props: Props) {
     eventView
   );
   const landingDisplay = paramLandingDisplay ?? defaultLandingDisplayForProjects;
-  const showOnboarding = onBoardingProject !== undefined;
+  const showOnboarding = onboardingProject !== undefined;
 
   useEffect(() => {
     if (hasMounted.current) {
@@ -200,7 +200,7 @@ export function PerformanceLanding(props: Props) {
             {showOnboarding ? (
               <Fragment>
                 {pageFilters}
-                <Onboarding organization={organization} project={onBoardingProject} />
+                <Onboarding organization={organization} project={onboardingProject} />
               </Fragment>
             ) : (
               <Fragment>

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -52,10 +52,10 @@ import {
 
 type Props = {
   eventView: EventView;
-  getOnboardingProject: () => Project | undefined;
   handleSearch: (searchQuery: string) => void;
   handleTrendsClick: () => void;
   location: Location;
+  onBoardingProject: Project | undefined;
   organization: Organization;
   projects: Project[];
   selection: PageFilters;
@@ -78,7 +78,7 @@ export function PerformanceLanding(props: Props) {
     projects,
     handleSearch,
     handleTrendsClick,
-    getOnboardingProject,
+    onBoardingProject,
   } = props;
 
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
@@ -90,7 +90,6 @@ export function PerformanceLanding(props: Props) {
     eventView
   );
   const landingDisplay = paramLandingDisplay ?? defaultLandingDisplayForProjects;
-  const onBoardingProject = getOnboardingProject();
   const showOnboarding = onBoardingProject !== undefined;
 
   useEffect(() => {

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -26,7 +26,7 @@ const WrappedComponent = ({data}) => {
           eventView={eventView}
           projects={data.projects}
           selection={eventView.getPageFilters()}
-          shouldShowOnboarding={false}
+          getOnboardingProject={() => undefined}
           handleSearch={() => {}}
           handleTrendsClick={() => {}}
           setError={() => {}}

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -26,7 +26,7 @@ const WrappedComponent = ({data}) => {
           eventView={eventView}
           projects={data.projects}
           selection={eventView.getPageFilters()}
-          getOnboardingProject={() => undefined}
+          onBoardingProject={undefined}
           handleSearch={() => {}}
           handleTrendsClick={() => {}}
           setError={() => {}}

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -26,7 +26,7 @@ const WrappedComponent = ({data}) => {
           eventView={eventView}
           projects={data.projects}
           selection={eventView.getPageFilters()}
-          onBoardingProject={undefined}
+          onboardingProject={undefined}
           handleSearch={() => {}}
           handleTrendsClick={() => {}}
           setError={() => {}}


### PR DESCRIPTION
This pull request cleans up, and centralizes the source of truth of filtered projects we perform to determine if the onboarding view should be display on the Performance homepage.