### PR TITLE
ref(mep): Introduce dataset parameter

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -21,12 +21,19 @@ from sentry.models.group import Group
 from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
 from sentry.search.events.fields import get_function_alias
 from sentry.search.events.filter import get_filter
-from sentry.snuba import discover
+from sentry.snuba import discover, metrics_enhanced_performance
 from sentry.utils import snuba
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import get_interval_from_range, get_rollup_from_request, parse_stats_period
 from sentry.utils.http import absolute_uri
 from sentry.utils.snuba import MAX_FIELDS, SnubaTSResult
+
+# Doesn't map 1:1 with real datasets, but rather what we present to users
+# ie. metricsEnhanced is not a real dataset
+DATASET_OPTIONS = {
+    "discover": discover,
+    "metricsEnhanced": metrics_enhanced_performance,
+}
 
 
 def resolve_axis_column(column: str, index: int = 0) -> str:
@@ -59,6 +66,12 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):  # type: ignore
             teams = Team.objects.get_for_user(organization, request.user)
 
         return [team.id for team in teams]
+
+    def get_dataset(self, request: Request) -> Any:
+        dataset_label = request.GET.get("dataset", "discover")
+        if dataset_label not in DATASET_OPTIONS:
+            raise ParseError(detail=f"dataset must be one of: {', '.join(DATASET_OPTIONS.keys())}")
+        return DATASET_OPTIONS[dataset_label]
 
     def get_snuba_params(
         self, request: Request, organization: Organization, check_global_views: bool = True

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -59,7 +59,15 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
         performance_dry_run_mep = features.has(
             "organizations:performance-dry-run-mep", organization=organization, actor=request.user
         )
-        metrics_enhanced = request.GET.get("metricsEnhanced") == "1" and performance_use_metrics
+
+        # This param will be deprecated in favour of dataset
+        if "metricsEnhanced" in request.GET:
+            metrics_enhanced = request.GET.get("metricsEnhanced") == "1" and performance_use_metrics
+            dataset = discover if not metrics_enhanced else metrics_enhanced_performance
+        else:
+            dataset = self.get_dataset(request) if performance_use_metrics else discover
+            metrics_enhanced = dataset != discover
+
         sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
         referrer = (
@@ -67,7 +75,6 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
         )
 
         def data_fn(offset, limit):
-            dataset = discover if not metrics_enhanced else metrics_enhanced_performance
             query_details = {
                 "selected_columns": self.get_field_list(organization, request),
                 "query": request.GET.get("query"),

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -146,7 +146,16 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
                 "organizations:performance-dry-run-mep", False
             )
 
-            metrics_enhanced = request.GET.get("metricsEnhanced") == "1" and performance_use_metrics
+            # This param will be deprecated in favour of dataset
+            if "metricsEnhanced" in request.GET:
+                metrics_enhanced = (
+                    request.GET.get("metricsEnhanced") == "1" and performance_use_metrics
+                )
+                dataset = discover if not metrics_enhanced else metrics_enhanced_performance
+            else:
+                dataset = self.get_dataset(request) if performance_use_metrics else discover
+                metrics_enhanced = dataset != discover
+
             allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
 
@@ -175,7 +184,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
                     include_other=include_other,
                     use_snql=discover_snql,
                 )
-            dataset = discover if not metrics_enhanced else metrics_enhanced_performance
             query_details = {
                 "selected_columns": query_columns,
                 "query": query,

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -5001,11 +5001,22 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
     def test_no_projects(self):
         response = self.do_request(
             {
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
             }
         )
 
         assert response.status_code == 200, response.content
+
+    def test_invalid_dataset(self):
+        response = self.do_request(
+            {
+                "dataset": "aFakeDataset",
+                "project": self.project.id,
+            }
+        )
+
+        assert response.status_code == 400, response.content
+        assert response.data["detail"] == "dataset must be one of: discover, metricsEnhanced"
 
     def test_out_of_retention(self):
         self.create_project()
@@ -5016,7 +5027,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "query": "event.type:transaction",
                 "start": iso_format(before_now(days=20)),
                 "end": iso_format(before_now(days=15)),
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
             }
             response = self.do_request(query)
         assert response.status_code == 400, response.content
@@ -5028,7 +5039,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "field": ["epm()"],
                 "query": "hi \n there",
                 "project": self.project.id,
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
             }
         )
         assert response.status_code == 400, response.content
@@ -5048,7 +5059,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": ["project.name", "environment", "epm()"],
                 "query": "event.type:transaction",
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
                 "per_page": 50,
             }
         )
@@ -5078,7 +5089,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": ["title", "p50()"],
                 "query": "event.type:transaction",
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
                 "per_page": 50,
             }
         )
@@ -5111,7 +5122,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": ["transaction", "project", "p50(transaction.duration)"],
                 "query": "event.type:transaction p50(transaction.duration):<50",
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
                 "per_page": 50,
             }
         )
@@ -5145,7 +5156,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": ["transaction", "project", "p50(transaction.duration)"],
                 "query": "event.type:transaction p50(transaction.duration):<50",
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
                 "preventMetricAggregates": "1",
                 "per_page": 50,
             }
@@ -5176,7 +5187,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": ["transaction", "project", "p50(transaction.duration)"],
                 "query": "event.type:transaction p75(transaction.duration):<50",
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
                 "per_page": 50,
             }
         )
@@ -5205,7 +5216,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": ["test", "p50(transaction.duration)"],
                 "query": "event.type:transaction",
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
                 "per_page": 50,
             }
         )
@@ -5269,7 +5280,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                     "user_misery()",
                 ],
                 "query": "event.type:transaction",
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
                 "per_page": 50,
             }
         )
@@ -5318,7 +5329,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "p95()",
             ],
             "per_page": 50,
-            "metricsEnhanced": "1",
+            "dataset": "metricsEnhanced",
         }
         response = self.do_request(query)
 
@@ -5373,7 +5384,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "p95()",
             ],
             "per_page": 50,
-            "metricsEnhanced": "1",
+            "dataset": "metricsEnhanced",
         }
 
         query["orderby"] = ["team_key_transaction", "p95()"]
@@ -5407,7 +5418,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "p95()",
             ],
             "per_page": 50,
-            "metricsEnhanced": "1",
+            "dataset": "metricsEnhanced",
         }
 
         query["orderby"] = ["team_key_transaction", "p95()"]
@@ -5463,7 +5474,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "p95()",
             ],
             "per_page": 50,
-            "metricsEnhanced": "1",
+            "dataset": "metricsEnhanced",
         }
 
         # test ascending order
@@ -5541,7 +5552,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "p95()",
             ],
             "per_page": 50,
-            "metricsEnhanced": "1",
+            "dataset": "metricsEnhanced",
         }
 
         # key transactions
@@ -5649,7 +5660,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                     "failure_rate()",
                     "p95()",
                 ],
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
                 "per_page": 50,
             }
 
@@ -5708,7 +5719,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                     "count_web_vitals(measurements.cls, good)",
                 ],
                 "query": "event.type:transaction",
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
                 "per_page": 50,
             }
         )
@@ -5742,7 +5753,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": ["transaction", "count_web_vitals(measurements.lcp, poor)"],
                 "query": "event.type:transaction",
-                "metricsEnhanced": "1",
+                "dataset": "metricsEnhanced",
                 "per_page": 50,
             }
         )
@@ -5762,7 +5773,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "count_web_vitals(measurements.foo, poor)",
             ],
             "project": [self.project.id],
-            "metricsEnhanced": "1",
+            "dataset": "metricsEnhanced",
         }
         response = self.do_request(query)
         assert response.status_code == 400, response.content
@@ -5772,7 +5783,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "count_web_vitals(tags[lcp], poor)",
             ],
             "project": [self.project.id],
-            "metricsEnhanced": "1",
+            "dataset": "metricsEnhanced",
         }
         response = self.do_request(query)
         assert response.status_code == 400, response.content
@@ -5782,7 +5793,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "count_web_vitals(transaction.duration, poor)",
             ],
             "project": [self.project.id],
-            "metricsEnhanced": "1",
+            "dataset": "metricsEnhanced",
         }
         response = self.do_request(query)
         assert response.status_code == 400, response.content
@@ -5792,7 +5803,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "count_web_vitals(measurements.lcp, bad)",
             ],
             "project": [self.project.id],
-            "metricsEnhanced": "1",
+            "dataset": "metricsEnhanced",
         }
         response = self.do_request(query)
         assert response.status_code == 400, response.content


### PR DESCRIPTION
- This introduces a dataset parameter, so that we can eventually explicitly state we want to back the results with metrics and error for incompatible queries instead of the implicit fallback we have today
