### PR TITLE
chore: Update navigateTo to support :project route parameter

### DIFF
--- a/static/app/actionCreators/navigation.tsx
+++ b/static/app/actionCreators/navigation.tsx
@@ -4,6 +4,7 @@ import {Location} from 'history';
 import {openModal} from 'sentry/actionCreators/modal';
 import ContextPickerModal from 'sentry/components/contextPickerModal';
 import ProjectsStore from 'sentry/stores/projectsStore';
+import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 
 // TODO(ts): figure out better typing for react-router here
 export function navigateTo(
@@ -12,8 +13,8 @@ export function navigateTo(
   configUrl?: string
 ) {
   // Check for placeholder params
-  const needOrg = to.indexOf(':orgId') > -1;
-  const needProject = to.indexOf(':projectId') > -1;
+  const needOrg = to.includes(':orgId');
+  const needProject = to.includes(':projectId') || to.includes(':project');
   const comingFromProjectId = router?.location?.query?.project;
   const needProjectId = !comingFromProjectId || Array.isArray(comingFromProjectId);
 
@@ -40,8 +41,12 @@ export function navigateTo(
       {}
     );
   } else {
-    projectById
-      ? router.push(to.replace(':projectId', projectById.slug))
-      : router.push(to);
+    if (projectById) {
+      to = replaceRouterParams(to, {
+        projectId: projectById.slug,
+        project: projectById.id,
+      });
+    }
+    router.push(to);
   }
 }

--- a/tests/js/spec/actionCreators/navigation.spec.jsx
+++ b/tests/js/spec/actionCreators/navigation.spec.jsx
@@ -33,6 +33,34 @@ describe('navigation ActionCreator', () => {
     expect(router.push).toHaveBeenCalledWith('/settings/project-slug/alert');
   });
 
+  it('should get project id from query parameters', () => {
+    router.location.query.project = '2';
+    expect(
+      navigateTo(
+        '/organizations/albertos-apples/performance/?project=:project#performance-sidequest',
+        router
+      )
+    ).toBe();
+    expect(openModal).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledWith(
+      '/organizations/albertos-apples/performance/?project=2#performance-sidequest'
+    );
+  });
+
+  it('should get project and project id from query parameters', () => {
+    router.location.query.project = '2';
+    expect(
+      navigateTo(
+        '/settings/:projectId/alert?project=:project#performance-sidequest',
+        router
+      )
+    ).toBe();
+    expect(openModal).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledWith(
+      '/settings/project-slug/alert?project=2#performance-sidequest'
+    );
+  });
+
   it('should open modal if the store is somehow missing selected projectId', () => {
     router.location.query.project = '911';
     expect(navigateTo('/settings/:projectId/alert', router)).toBe();

--- a/tests/js/spec/actionCreators/navigation.spec.jsx
+++ b/tests/js/spec/actionCreators/navigation.spec.jsx
@@ -72,6 +72,16 @@ describe('navigation ActionCreator', () => {
     expect(openModal).toHaveBeenCalled();
   });
 
+  it('should open modal when no project id is selected', () => {
+    expect(
+      navigateTo(
+        '/organizations/albertos-apples/performance/?project=:project#performance-sidequest',
+        router
+      )
+    ).toBe();
+    expect(openModal).toHaveBeenCalled();
+  });
+
   it('should open modal if more than one project is selected', () => {
     router.location.query.project = ['1', '2', '3'];
     expect(navigateTo('/settings/:projectId/alert', router)).toBe();


### PR DESCRIPTION
This is split from https://github.com/getsentry/sentry/pull/33852.

I'd like to be able to add router param replacement rule to `navigateTo()` such that `:project` are replaced with project ids.

My usecase is that I'd like to be able to do this:

```js
      navigateTo(
        `/organizations/${organization.slug}/performance/?project=:project#performance-sidequest`,
        router
      )
```
