### PR TITLE
feat(alerts): Move "event is captured" in issue alert sidebar

### DIFF
--- a/static/app/views/alerts/details/sidebar.tsx
+++ b/static/app/views/alerts/details/sidebar.tsx
@@ -24,14 +24,14 @@ class Sidebar extends PureComponent<Props> {
       ? rule.conditions.map(condition => (
           <ConditionsBadge key={condition.id}>{condition.name}</ConditionsBadge>
         ))
-      : '';
+      : null;
     const filters = rule.filters.length
       ? rule.filters.map(filter => (
           <ConditionsBadge key={filter.id}>
             {filter.time ? filter.name + '(s)' : filter.name}
           </ConditionsBadge>
         ))
-      : '';
+      : null;
     const actions = rule.actions.length ? (
       rule.actions.map(action => {
         let name = action.name;
@@ -59,12 +59,11 @@ class Sidebar extends PureComponent<Props> {
             </ChevronContainer>
             <StepContent>
               <StepLead>
-                {tct('[when:When] [selector] of the following happens', {
+                {tct('[when:When] an event is captured [selector]', {
                   when: <Badge />,
-                  selector: rule.actionMatch,
+                  selector: conditions?.length ? t('and %s...', rule.actionMatch) : '',
                 })}
               </StepLead>
-              <ConditionsBadge>{t('An event is captured')}</ConditionsBadge>
               {conditions}
             </StepContent>
           </StepContainer>


### PR DESCRIPTION
Attempting to reduce confusion between the issue alert details page and issue alert editing

before w/ items
<img width="302" alt="Screen Shot 2022-04-22 at 4 05 42 PM" src="https://user-images.githubusercontent.com/1400464/164836272-b886d32d-be80-45d4-8da0-cf47773e6273.png">


after w/ items
<img width="315" alt="Screen Shot 2022-04-22 at 4 05 22 PM" src="https://user-images.githubusercontent.com/1400464/164836260-c90ed864-2f13-44cd-9e53-30e1e2e26fee.png">


before without items
<img width="289" alt="Screen Shot 2022-04-22 at 5 02 52 PM" src="https://user-images.githubusercontent.com/1400464/164836308-a554ae19-911c-4700-beee-d8be710f2848.png">

after without items
<img width="312" alt="Screen Shot 2022-04-22 at 5 03 09 PM" src="https://user-images.githubusercontent.com/1400464/164836322-cdbaf1c8-9bf4-4cb6-af52-986819a9d1f3.png">

