### PR TITLE
fix: sync click version between base and pre-commit requirements

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.7.1
 boto3==1.13.16
 botocore==1.16.16
 celery==4.4.7
-click==7.1.2
+click==8.0.4
 # See if we can remove CPATH from lib.sh
 # https://github.com/getsentry/sentry/pull/30094
 confluent-kafka==1.5.0; python_version == '3.8'


### PR DESCRIPTION
fixes this crash:

```
--> Applying migrations
INFO:The Sentry runner will report development issues to Sentry.io. Use SENTRY_DEVENV_NO_REPORT to avoid reporting issues.
!! Configuration error: ConfigurationError("DistributionNotFound: The 'click==7.1.2' distribution was not found and is required by sentry")
make: *** [apply-migrations] Error 1
```