### PR TITLE
ref: make --bind compatible with click 8.x

### DIFF
--- a/tests/sentry/runner/commands/test_run.py
+++ b/tests/sentry/runner/commands/test_run.py
@@ -1,0 +1,18 @@
+from unittest import mock
+
+import pytest
+
+from sentry.runner.commands import run
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    (
+        (None, (None, None)),
+        ("192.168.1.1", ("192.168.1.1", None)),
+        ("192.168.1.1:9001", ("192.168.1.1", 9001)),
+    ),
+)
+def test_address_validate(value, expected):
+    ctx, param = mock.Mock(), mock.Mock()
+    assert run._address_validate(ctx, param, value) == expected


### PR DESCRIPTION
this change in `click` causes custom `type=` to no longer apply to `default=None` -- https://github.com/pallets/click/pull/1687

this was leading to a stacktrace with click 8.x:

```console
$ sentry run web
...
Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/.venv/bin/sentry", line 33, in <module>
    sys.exit(load_entry_point('sentry', 'console_scripts', 'sentry')())
  File "/Users/asottile/workspace/sentry/src/sentry/runner/__init__.py", line 186, in main
    raise e
  File "/Users/asottile/workspace/sentry/src/sentry/runner/__init__.py", line 178, in main
    func(**kwargs)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/asottile/workspace/sentry/src/sentry/runner/decorators.py", line 69, in inner
    return ctx.invoke(f, *args, **kwargs)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/asottile/workspace/sentry/src/sentry/runner/decorators.py", line 29, in inner
    return ctx.invoke(f, *args, **kwargs)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/asottile/workspace/sentry/src/sentry/runner/commands/run.py", line 114, in web
    SentryHTTPServer(host=bind[0], port=bind[1], workers=workers).run()
TypeError: 'NoneType' object is not subscriptable
```

___

I added tests for the validator since there were none

I also checked all of the other callsites with:

```python
import ast
import sys

class NV(ast.NodeVisitor):
    def __init__(self, filename):
        self.filename = filename

    def visit_Call(self, node):
        if (
            isinstance(node.func, ast.Attribute) and
            node.func.attr == 'option' and
            isinstance(node.func.value, ast.Name) and
            node.func.value.id == 'click'
        ):
            has_default = False
            has_type = False
            args = {kw.arg for kw in node.keywords}
            if args >= {'default', 'type'}:
                print(f'+{node.lineno} {self.filename}')
        self.generic_visit(node)


def main() -> int:
    for filename in sys.argv[1:]:
        with open(filename) as f:
            NV(filename).visit(ast.parse(f.read(), filename=filename))

if __name__ == '__main__':
    raise SystemExit(main())
```

and

```bash
babi $(python3 t.py $(git ls-files -- '*.py'))
```
