### PR TITLE
test(acceptance): Disable duplicate issue details mobile screenshots

### DIFF
--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -62,12 +62,12 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         event = self.create_sample_event(platform="python-rawbody")
         self.page.visit_issue(self.org.slug, event.group.id)
         self.browser.move_to('[data-test-id="rich-http-content-body-section-pre"]')
-        self.browser.snapshot("issue details python raw body")
+        self.browser.snapshot("issue details python raw body", desktop_only=True)
 
     def test_python_formdata_event(self):
         event = self.create_sample_event(platform="python-formdata")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details python formdata")
+        self.browser.snapshot("issue details python formdata", desktop_only=True)
 
     def test_pii_tooltips(self):
         event = self.create_sample_event(platform="pii-tooltips")
@@ -77,70 +77,72 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
     def test_cocoa_event(self):
         event = self.create_sample_event(platform="cocoa")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details cocoa")
+        self.browser.snapshot("issue details cocoa", desktop_only=True)
 
     def test_cocoa_event_frame_line_hover(self):
         event = self.create_sample_event(platform="cocoa")
         self.page.visit_issue(self.org.slug, event.group.id)
         self.browser.wait_until_not(".loading")
         self.browser.move_to(".traceback li:nth-child(2)")
-        self.browser.snapshot("issue details cocoa frame line hover")
+        self.browser.snapshot("issue details cocoa frame line hover", desktop_only=True)
 
     def test_unity_event(self):
         event = self.create_sample_event(default="unity", platform="csharp")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details unity")
+        self.browser.snapshot("issue details unity", desktop_only=True)
 
     def test_android_event(self):
         event = self.create_sample_event(platform="android")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details android")
+        self.browser.snapshot("issue details android", desktop_only=True)
 
     def test_android_ndk_event(self):
         event = self.create_sample_event(default="android-ndk", platform="android-ndk")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details android-ndk")
+        self.browser.snapshot("issue details android-ndk", desktop_only=True)
 
     def test_aspnetcore_event(self):
         event = self.create_sample_event(default="aspnetcore", platform="csharp")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details aspnetcore")
+        self.browser.snapshot("issue details aspnetcore", desktop_only=True)
 
     def test_javascript_specific_event(self):
         event = self.create_sample_event(platform="javascript")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details javascript - event details")
+        self.browser.snapshot("issue details javascript - event details", desktop_only=True)
 
         self.browser.click('[aria-label="curl"]')
-        self.browser.snapshot("issue details javascript - event details - curl command")
+        self.browser.snapshot(
+            "issue details javascript - event details - curl command", desktop_only=True
+        )
 
     def test_rust_event(self):
         # TODO: This should become its own "rust" platform type
         event = self.create_sample_event(platform="native", sample_name="Rust")
         self.page.visit_issue(self.org.slug, event.group.id)
 
-        self.browser.snapshot("issue details rust")
+        self.browser.snapshot("issue details rust", desktop_only=True)
 
     def test_cordova_event(self):
         event = self.create_sample_event(platform="cordova")
         self.page.visit_issue(self.org.slug, event.group.id)
 
-        self.browser.snapshot("issue details cordova")
+        self.browser.snapshot("issue details cordova", desktop_only=True)
 
     def test_stripped_event(self):
         event = self.create_sample_event(platform="pii")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details pii stripped")
+        self.browser.snapshot("issue details pii stripped", desktop_only=True)
 
     def test_empty_exception(self):
         event = self.create_sample_event(platform="empty-exception")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details empty exception")
+        self.browser.snapshot("issue details empty exception", desktop_only=True)
 
     def test_empty_stacktrace(self):
         event = self.create_sample_event(platform="empty-stacktrace")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details empty stacktrace")
+        self.browser.snapshot("issue details empty stacktrace", desktop_only=True)
 
     def test_invalid_interfaces(self):
         event = self.create_sample_event(platform="invalid-interfaces")
@@ -148,7 +150,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
 
         self.browser.click('[data-test-id="event-error-alert"]')
         self.browser.wait_until_test_id("event-error-details")
-        self.browser.snapshot("issue details invalid interfaces")
+        self.browser.snapshot("issue details invalid interfaces", desktop_only=True)
 
     def test_activity_page(self):
         event = self.create_sample_event(platform="python")
@@ -157,26 +159,26 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
 
         self.browser.wait_until_test_id("activity-item")
         self.browser.blur()
-        self.browser.snapshot("issue activity python")
+        self.browser.snapshot("issue activity python", desktop_only=True)
 
     def test_resolved(self):
         event = self.create_sample_event(platform="python")
         self.page.visit_issue(self.org.slug, event.group.id)
         self.page.resolve_issue()
 
-        self.browser.snapshot("issue details resolved")
+        self.browser.snapshot("issue details resolved", desktop_only=True)
 
     def test_ignored(self):
         event = self.create_sample_event(platform="python")
         self.page.visit_issue(self.org.slug, event.group.id)
         self.page.ignore_issue()
 
-        self.browser.snapshot("issue details ignored")
+        self.browser.snapshot("issue details ignored", desktop_only=True)
 
     def test_exception_and_no_threads_event(self):
         event = self.create_sample_event(platform="exceptions-and-no-threads")
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details exceptions and no threads")
+        self.browser.snapshot("issue details exceptions and no threads", desktop_only=True)
 
     def test_exception_with_stack_trace_and_crashed_thread_without_stack_trace_event(self):
         event = self.create_sample_event(
@@ -184,7 +186,8 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         )
         self.page.visit_issue(self.org.slug, event.group.id)
         self.browser.snapshot(
-            "issue details exception with stack trace and crashed thread without stack trace"
+            "issue details exception with stack trace and crashed thread without stack trace",
+            desktop_only=True,
         )
 
     def test_exception_without_stack_trace_and_crashed_thread_with_stack_trace_event(self):
@@ -193,7 +196,8 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         )
         self.page.visit_issue(self.org.slug, event.group.id)
         self.browser.snapshot(
-            "issue details exception without stack trace and crashed thread with stack trace"
+            "issue details exception without stack trace and crashed thread with stack trace",
+            desktop_only=True,
         )
 
     def test_exception_with_stack_trace_and_crashed_thread_with_stack_trace_event(self):
@@ -202,7 +206,8 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         )
         self.page.visit_issue(self.org.slug, event.group.id)
         self.browser.snapshot(
-            "issue details exception with stack trace and crashed thread with stack trace"
+            "issue details exception with stack trace and crashed thread with stack trace",
+            desktop_only=True,
         )
 
     def test_python_invalid_json_error(self):
@@ -215,4 +220,4 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
             default="exception-with-address-instruction", platform="cocoa"
         )
         self.page.visit_issue(self.org.slug, event.group.id)
-        self.browser.snapshot("issue details exception with address instruction")
+        self.browser.snapshot("issue details exception with address instruction", desktop_only=True)


### PR DESCRIPTION
Keeps the python mobile error stack, disables others
