### PR TITLE
fix(ci): Do not skip step for visual diffs on PRs or master

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -325,7 +325,9 @@ jobs:
         id: visual-snapshots-diff
         uses: getsentry/action-visual-snapshot@v2
         # Do not execute on forks or on master. Forks are handled in visual-diff.yml
-        if: github.head_repository.full_name == 'getsentry/sentry' && github.ref != 'refs/heads/master'
+        # Only execute this check when a PR is opened from the upstream repo rather than a fork
+        # event.pull_request is *only* available when run within a PR (use head_repository for workflow_run)
+        if: github.event.pull_request.head.repo.full_name == 'getsentry/sentry' && github.ref != 'refs/heads/master'
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           gcs-bucket: 'sentry-visual-snapshots'

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -324,10 +324,8 @@ jobs:
       - name: Diff snapshots
         id: visual-snapshots-diff
         uses: getsentry/action-visual-snapshot@v2
-        # Do not execute on forks or on master. Forks are handled in visual-diff.yml
-        # Only execute this check when a PR is opened from the upstream repo rather than a fork
-        # event.pull_request is *only* available when run within a PR (use head_repository for workflow_run)
-        if: github.event.pull_request.head.repo.full_name == 'getsentry/sentry' && github.ref != 'refs/heads/master'
+        # Do not execute on forks. Forks are handled in visual-diff.yml
+        if: github.event.pull_request.head.repo.full_name == 'getsentry/sentry' || github.ref == 'refs/heads/master'
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           gcs-bucket: 'sentry-visual-snapshots'

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   visual-diff:
-    # This is the opposite condition as acceptance.yml/visual-diff
-    if: github.head_repository.full_name != 'getsentry/sentry'
+    # Only execute this check when a PR is opened from a fork rather than the upstream repo
+    if: github.event.workflow_run.head_repository.full_name != 'getsentry/sentry'
     runs-on: ubuntu-20.04
     timeout-minutes: 20
 


### PR DESCRIPTION
This fixes a regression from https://github.com/getsentry/sentry/pull/33609 since `head_repository.full_name` is not part of the `github` context in PRs.

Visual Snapshots have not been running from acceptance/visual-diff for the last week. In the PR,
we missed that it did not get triggered:
https://github.com/getsentry/sentry/actions/runs/2167609568

The step (rather than the job) is being skipped on PRs:
https://github.com/getsentry/sentry/runs/6117835780?check_suite_focus=true

This has not been noticed because `visual-diff.yml` would still trigger Visual Snapshots for PRs:
https://github.com/getsentry/sentry/pull/33835/checks?check_run_id=6117841569