### PR TITLE
chore(logs): Forgot to fix logs before merging

### DIFF
--- a/src/sentry/integrations/jira/views/issue_hook.py
+++ b/src/sentry/integrations/jira/views/issue_hook.py
@@ -94,8 +94,7 @@ class JiraIssueHookView(JiraBaseHook):
 
         logger.info(
             "issue_hook.response",
-            # TODO(PR Review): Backwards compatability with logs?
-            # extra={"type": context["type"], "title_url": context["title_url"]},
+            extra={"issue_count": len(groups)},
         )
 
         return self.get_response(response_context)


### PR DESCRIPTION
Refer to https://github.com/getsentry/sentry/pull/33842

Made the PR late last week and merged on a Monday. Forgot there was one step to do prior to merging.
This changes the logging to be more useful since we don't actually need to know what type of issues customers are linking, since the amount is more critical to our understanding of the usage of the feature.


<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
