### PR TITLE
fix(perf): Display page filters for Performance onboarding state

### DIFF
--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -129,6 +129,20 @@ export function PerformanceLanding(props: Props) {
     );
   };
 
+  let pageFilters: React.ReactNode = organization.features.includes(
+    'selection-filters-v2'
+  ) ? (
+    <PageFilterBar condensed>
+      <ProjectPageFilter />
+      <EnvironmentPageFilter />
+      <DatePageFilter alignDropdown="left" />
+    </PageFilterBar>
+  ) : null;
+
+  if (showOnboarding) {
+    pageFilters = <SearchContainerWithFilter>{pageFilters}</SearchContainerWithFilter>;
+  }
+
   return (
     <StyledPageContent data-test-id="performance-landing-v3">
       <PageErrorProvider>
@@ -185,28 +199,25 @@ export function PerformanceLanding(props: Props) {
             <GlobalSdkUpdateAlert />
             <PageErrorAlert />
             {showOnboarding ? (
-              <Onboarding
-                organization={organization}
-                project={
-                  props.selection.projects.length > 0
-                    ? // If some projects selected, use the first selection
-                      projects.find(
-                        project => props.selection.projects[0].toString() === project.id
-                      ) || projects[0]
-                    : // Otherwise, use the first project in the org
-                      projects[0]
-                }
-              />
+              <Fragment>
+                {pageFilters}
+                <Onboarding
+                  organization={organization}
+                  project={
+                    props.selection.projects.length > 0
+                      ? // If some projects selected, use the first selection
+                        projects.find(
+                          project => props.selection.projects[0].toString() === project.id
+                        ) || projects[0]
+                      : // Otherwise, use the first project in the org
+                        projects[0]
+                  }
+                />
+              </Fragment>
             ) : (
               <Fragment>
                 <SearchContainerWithFilter>
-                  {organization.features.includes('selection-filters-v2') && (
-                    <PageFilterBar condensed>
-                      <ProjectPageFilter />
-                      <EnvironmentPageFilter />
-                      <DatePageFilter alignDropdown="left" />
-                    </PageFilterBar>
-                  )}
+                  {pageFilters}
                   <SearchBar
                     searchSource="performance_landing"
                     organization={organization}


### PR DESCRIPTION
The page filters component was missing on the Performance on-boarding state. I've added it in this pull request: 

<img width="1358" alt="Screen Shot 2022-04-25 at 3 48 32 PM" src="https://user-images.githubusercontent.com/139499/165163478-14f6af33-2c7f-4cd8-8e7f-2f1976f01eb5.png">
