### PR TITLE
fix(ui) Fix tag bar segments having round corners.

### DIFF
--- a/static/app/components/tagDistributionMeter.tsx
+++ b/static/app/components/tagDistributionMeter.tsx
@@ -220,7 +220,7 @@ const TagSummary = styled('div')`
 const SegmentBar = styled('div')`
   display: flex;
   overflow: hidden;
-  border-radius: 2px;
+  border-radius: ${p => p.theme.borderRadius};
 `;
 
 const Title = styled('div')`
@@ -271,4 +271,5 @@ const Segment = styled(Link, {shouldForwardProp: isPropValid})<SegmentValue>`
   color: inherit;
   outline: none;
   background-color: ${p => COLORS[p.index]};
+  border-radius: 0;
 `;


### PR DESCRIPTION
An inadvertent side-effect of #33873 was that tag bar links were also rounded. This reverts the rounding on segments but retains the rounding on the outer bar shape.

![Screen Shot 2022-04-25 at 5 01 55 PM](https://user-images.githubusercontent.com/24086/165174366-ff1a6551-a1c0-4b40-a451-48073f6bc88e.png)



<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
