### PR TITLE
ref(access): Remove dead code from get_allowed_roles

### DIFF
--- a/src/sentry/api/endpoints/organization_member/__init__.py
+++ b/src/sentry/api/endpoints/organization_member/__init__.py
@@ -45,10 +45,6 @@ def get_allowed_roles(
             # token whose proxy user does not have an OrganizationMember object.
             return ()
 
-    if member and roles.get(acting_member.role).priority < roles.get(member.role).priority:
-        # Disallow the acting member from demoting another member who outranks them
-        return ()
-
     return acting_member.get_allowed_roles_to_invite()
 
 

--- a/src/sentry/api/endpoints/organization_member/__init__.py
+++ b/src/sentry/api/endpoints/organization_member/__init__.py
@@ -28,24 +28,27 @@ def get_allowed_roles(
     organization: Organization,
     member: OrganizationMember | None = None,
 ) -> Collection[Role]:
+    """Get the set of roles that the request is allowed to manage.
+
+    In order to change another member's role, the returned set must include both
+    the starting role and the new role. That is, the set contains the roles that
+    the request is allowed to promote someone to and to demote someone from.
+    """
+
     if is_active_superuser(request):
         return roles.get_all()
     if not request.access.has_scope("member:admin"):
         return ()
 
-    if member:
-        acting_member = member
-    else:
+    if member is None:
         try:
-            acting_member = OrganizationMember.objects.get(
-                user=request.user, organization=organization
-            )
+            member = OrganizationMember.objects.get(user=request.user, organization=organization)
         except OrganizationMember.DoesNotExist:
             # This can happen if the request was authorized by an app integration
             # token whose proxy user does not have an OrganizationMember object.
             return ()
 
-    return acting_member.get_allowed_roles_to_invite()
+    return member.get_allowed_roles_to_invite()
 
 
 from .details import OrganizationMemberDetailsEndpoint


### PR DESCRIPTION
The inside of this block should be completely unreachable:

https://github.com/getsentry/sentry/blob/73bd578967fa96b3085ccbf79bae747672393ff7/src/sentry/api/endpoints/organization_member/__init__.py#L48-L50

The value of `member` is always assigned to `acting_member` if `member` is non-null, and we look up an `acting_member` from the DB only if `member` is null. Therefore, `member` must be either null or equal to `acting_member`; it is impossible for them to be distinct values with unequal roles.

This block looks confusingly like it is doing something important, and (as discussed [in #33853](https://github.com/getsentry/sentry/pull/33853#issuecomment-1109064882)) there is a relevant test:

https://github.com/getsentry/sentry/blob/73bd578967fa96b3085ccbf79bae747672393ff7/tests/sentry/api/endpoints/test_organization_member_details.py#L364-L377

However, the actually working check doesn't live in this function and hasn't for at least some time.