### PR TITLE
feat(dashboards): Disable sorting as an option when session.status is selected as a column

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/index.tsx
@@ -41,6 +41,23 @@ export function SortByStep({
   limit,
   onLimitChange,
 }: Props) {
+  const fields = queries[0].columns;
+
+  let disabledSort = false;
+  let disabledSortDirection = false;
+  let disabledReason: string | undefined = undefined;
+
+  if (widgetType === WidgetType.METRICS && fields.includes('session.status')) {
+    disabledSort = true;
+    disabledSortDirection = true;
+    disabledReason = t('Sorting currently not supported with session.status');
+  }
+
+  if (widgetType === WidgetType.ISSUE) {
+    disabledSortDirection = true;
+    disabledReason = t('Issues dataset does not yet support descending order');
+  }
+
   const orderBy = queries[0].orderby;
   const maxLimit = getResultsLimit(queries.length, queries[0].aggregates.length);
 
@@ -88,6 +105,9 @@ export function SortByStep({
             )}
           <SortBySelectors
             widgetType={widgetType}
+            disabledReason={disabledReason}
+            disabledSort={disabledSort}
+            disabledSortDirection={disabledSortDirection}
             sortByOptions={
               dataSet === DataSet.ISSUES
                 ? generateIssueWidgetOrderOptions(

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -42,6 +42,7 @@ export function SortBySelectors({
         >
           <SelectControl
             name="sortDirection"
+            aria-label="Sort direction"
             menuPlacement="auto"
             disabled={disabledSortDirection}
             options={Object.keys(sortDirections).map(value => ({
@@ -63,6 +64,7 @@ export function SortBySelectors({
         >
           <SelectControl
             name="sortBy"
+            aria-label="Sort by"
             menuPlacement="auto"
             disabled={disabledSort}
             placeholder={`${t('Select a column')}\u{2026}`}

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -20,50 +20,64 @@ interface Props {
   sortByOptions: SelectValue<string>[];
   values: Values;
   widgetType: WidgetType;
+  disabledReason?: string;
+  disabledSort?: boolean;
+  disabledSortDirection?: boolean;
 }
 
-export function SortBySelectors({values, sortByOptions, widgetType, onChange}: Props) {
+export function SortBySelectors({
+  values,
+  sortByOptions,
+  onChange,
+  disabledReason,
+  disabledSort,
+  disabledSortDirection,
+}: Props) {
   return (
-    <Wrapper>
-      <Tooltip
-        title={
-          widgetType === WidgetType.ISSUE
-            ? t('Issues dataset does not yet support descending order')
-            : undefined
-        }
-        disabled={widgetType !== WidgetType.ISSUE}
-      >
-        <SelectControl
-          name="sortDirection"
-          menuPlacement="auto"
-          disabled={widgetType === WidgetType.ISSUE}
-          options={Object.keys(sortDirections).map(value => ({
-            label: sortDirections[value],
-            value,
-          }))}
-          value={values.sortDirection}
-          onChange={(option: SelectValue<SortDirection>) => {
-            onChange({
-              sortBy: values.sortBy,
-              sortDirection: option.value,
-            });
-          }}
-        />
-      </Tooltip>
-      <SelectControl
-        name="sortBy"
-        menuPlacement="auto"
-        placeholder={`${t('Select a column')}\u{2026}`}
-        value={values.sortBy}
-        options={uniqBy(sortByOptions, ({value}) => value)}
-        onChange={(option: SelectValue<string>) => {
-          onChange({
-            sortBy: option.value,
-            sortDirection: values.sortDirection,
-          });
-        }}
-      />
-    </Wrapper>
+    <Tooltip title={disabledReason} disabled={!(disabledSortDirection && disabledSort)}>
+      <Wrapper>
+        <Tooltip
+          title={disabledReason}
+          disabled={!disabledSortDirection || (disabledSortDirection && disabledSort)}
+        >
+          <SelectControl
+            name="sortDirection"
+            menuPlacement="auto"
+            disabled={disabledSortDirection}
+            options={Object.keys(sortDirections).map(value => ({
+              label: sortDirections[value],
+              value,
+            }))}
+            value={values.sortDirection}
+            onChange={(option: SelectValue<SortDirection>) => {
+              onChange({
+                sortBy: values.sortBy,
+                sortDirection: option.value,
+              });
+            }}
+          />
+        </Tooltip>
+        <Tooltip
+          title={disabledReason}
+          disabled={!disabledSort || (disabledSortDirection && disabledSort)}
+        >
+          <SelectControl
+            name="sortBy"
+            menuPlacement="auto"
+            disabled={disabledSort}
+            placeholder={`${t('Select a column')}\u{2026}`}
+            value={values.sortBy}
+            options={uniqBy(sortByOptions, ({value}) => value)}
+            onChange={(option: SelectValue<string>) => {
+              onChange({
+                sortBy: option.value,
+                sortDirection: values.sortDirection,
+              });
+            }}
+          />
+        </Tooltip>
+      </Wrapper>
+    </Tooltip>
   );
 }
 

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -537,6 +537,7 @@ function WidgetBuilder({
     isColumn = false
   ) {
     const fieldStrings = newFields.map(generateFieldAsString);
+
     const aggregateAliasFieldStrings =
       state.dataSet === DataSet.RELEASE
         ? fieldStrings.map(stripDerivedMetricsPrefix)
@@ -548,6 +549,9 @@ function WidgetBuilder({
 
     const newState = cloneDeep(state);
 
+    const disableSortBy =
+      widgetType === WidgetType.METRICS && fieldStrings.includes('session.status');
+
     const newQueries = state.queries.map(query => {
       const isDescending = query.orderby.startsWith('-');
       const orderbyAggregateAliasField = query.orderby.replace('-', '');
@@ -557,6 +561,10 @@ function WidgetBuilder({
           : getAggregateAlias(aggregate)
       );
       const newQuery = cloneDeep(query);
+
+      if (disableSortBy) {
+        newQuery.orderby = '';
+      }
 
       if (isColumn) {
         newQuery.fields = fieldStrings;

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2012,6 +2012,27 @@ describe('WidgetBuilder', function () {
       expect(screen.queryByText('session.status')).not.toBeInTheDocument();
     });
 
+    it('does not allow sort by when session.status is selected', async function () {
+      renderTestComponent({
+        orgFeatures: releaseHealthFeatureFlags,
+      });
+
+      expect(
+        await screen.findByText('Releases (sessions, crash rates)')
+      ).toBeInTheDocument();
+
+      userEvent.click(screen.getByLabelText(/releases/i));
+
+      expect(screen.getByText('High to low')).toBeEnabled();
+      expect(screen.getByText('sum(session)')).toBeInTheDocument();
+
+      userEvent.click(screen.getByLabelText('Add a Column'));
+      await selectEvent.select(screen.getByText('(Required)'), 'session.status');
+
+      expect(screen.getByRole('textbox', {name: 'Sort direction'})).toBeDisabled();
+      expect(screen.getByRole('textbox', {name: 'Sort by'})).toBeDisabled();
+    });
+
     it('makes the appropriate sessions call', async function () {
       renderTestComponent({
         orgFeatures: releaseHealthFeatureFlags,


### PR DESCRIPTION
Disable sorting as an option when session.status is selected as a column
because the sessions_v2 endpoint does not currently support this
functionality.