### PR TITLE
fix(page-filters): Persist environments with projects

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -301,6 +301,9 @@ export function updateProjects(
   PageFiltersActions.updateProjects(projects, options?.environments);
   updateParams({project: projects, environment: options?.environments}, router, options);
   persistPageFilters('projects', options);
+  if (options?.environments) {
+    persistPageFilters('environments', options);
+  }
   updateDesyncedUrlState(router);
 }
 


### PR DESCRIPTION
Previously we wouldn't save the environments if they changed along with projects. This lead to some wonky behavior as seen here:


![Kapture 2022-04-25 at 15 57 53](https://user-images.githubusercontent.com/9372512/165188014-f5a3186e-2057-4bd7-afcd-6dc8cde86375.gif)

Basically when you select a new project we clear out the environment selection since environments are unique to each project. But this change is not propagated to local storage so if you are to navigate to a new page, we load in filters from local storage if the env filter is pinned and so we restore the previously selected environment which may not even exist in the new project.

Fixed by persisting environments when they are provided with projects.
