### PR TITLE
feat(replay): Show a 'buffering...' message when navigating a replay video

### DIFF
--- a/docs-ui/stories/components/replays/replayPlayer.stories.js
+++ b/docs-ui/stories/components/replays/replayPlayer.stories.js
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 
@@ -8,14 +10,32 @@ export default {
   component: ReplayPlayer,
 };
 
+const ManualResize = styled('div')`
+  resize: both;
+  overflow: auto;
+  width: 50%;
+`;
+
 export const ScaledReplayPlayer = () => (
   <ReplayContextProvider events={events}>
-    <ReplayPlayer />
+    <ManualResize>
+      <ReplayPlayer />
+    </ManualResize>
   </ReplayContextProvider>
 );
 
 export const FastForwardingReplayPlayer = () => (
   <ReplayContextProvider value={{fastForwardSpeed: 4}} events={events}>
-    <ReplayPlayer />
+    <ManualResize>
+      <ReplayPlayer />
+    </ManualResize>
+  </ReplayContextProvider>
+);
+
+export const BufferingReplayPlayer = () => (
+  <ReplayContextProvider value={{isBuffering: true}} events={events}>
+    <ManualResize>
+      <ReplayPlayer />
+    </ManualResize>
   </ReplayContextProvider>
 );

--- a/static/app/components/replays/player/bufferingOverlay.tsx
+++ b/static/app/components/replays/player/bufferingOverlay.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+
+import {IconClock} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+
+function BufferingOverlay() {
+  return (
+    <Overlay>
+      <Message>
+        <IconClock size="sm" />
+        {t('Buffering...')}
+      </Message>
+    </Overlay>
+  );
+}
+
+/* Position the badge in the corner */
+const Overlay = styled('div')`
+  display: grid;
+  place-items: center;
+`;
+
+/* Badge layout and style */
+const Message = styled('div')`
+  display: grid;
+  grid-template-columns: max-content max-content;
+  gap: ${space(0.75)};
+  place-items: center;
+
+  padding: ${space(3)};
+  background: ${p => p.theme.gray300};
+  border-radius: ${p => p.theme.borderRadius};
+  color: ${p => p.theme.white};
+  z-index: ${p => p.theme.zIndex.initial};
+`;
+
+export default BufferingOverlay;

--- a/static/app/components/replays/player/fastForwardBadge.tsx
+++ b/static/app/components/replays/player/fastForwardBadge.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+
+import Tooltip from 'sentry/components/tooltip';
+import {IconArrow} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+
+type Props = {
+  speed: number;
+};
+
+function FastForwardBadge({speed}: Props) {
+  return (
+    <Badge>
+      <FastForwardTooltip title={t('Fast forwarding')}>
+        <IconArrow size="sm" direction="right" />
+        {speed}x
+      </FastForwardTooltip>
+    </Badge>
+  );
+}
+
+/* Position the badge in the corner */
+const Badge = styled('div')`
+  display: grid;
+  align-items: end;
+  justify-items: start;
+`;
+
+/* Badge layout and style */
+const FastForwardTooltip = styled(Tooltip)`
+  display: grid;
+  grid-template-columns: max-content max-content;
+  gap: ${space(0.5)};
+  align-items: center;
+
+  background: ${p => p.theme.gray300};
+  color: ${p => p.theme.white};
+  padding: ${space(1.5)} ${space(2)};
+  border-bottom-left-radius: ${p => p.theme.borderRadius};
+  border-top-right-radius: ${p => p.theme.borderRadius};
+  z-index: ${p => p.theme.zIndex.initial};
+`;
+
+export default FastForwardBadge;

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -51,6 +51,11 @@ type ReplayPlayerContextProps = {
   initRoot: (root: RootElem) => void;
 
   /**
+   * Set to true while the library is reconstructing the DOM
+   */
+  isBuffering: boolean;
+
+  /**
    * Whether the video is currently playing
    */
   isPlaying: boolean;
@@ -97,6 +102,7 @@ const ReplayPlayerContext = React.createContext<ReplayPlayerContextProps>({
   events: [],
   fastForwardSpeed: 0,
   initRoot: () => {},
+  isBuffering: false,
   isPlaying: false,
   isSkippingInactive: false,
   setCurrentTime: () => {},
@@ -127,6 +133,8 @@ export function Provider({children, events, value = {}}: Props) {
   const [isSkippingInactive, setIsSkippingInactive] = useState(false);
   const [speed, setSpeedState] = useState(1);
   const [fastForwardSpeed, setFFSpeed] = useState(0);
+  const [buffer, setBufferTime] = useState({target: -1, previous: -1});
+  const playTimer = useRef<number | undefined>(undefined);
 
   const forceDimensions = (dimension: Dimensions) => {
     setDimensions(dimension);
@@ -211,14 +219,24 @@ export function Provider({children, events, value = {}}: Props) {
         return;
       }
 
+      // Sometimes rrweb doesn't get to the exact target time, as long as it has
+      // changed away from the previous time then we can hide then buffering message.
+      setBufferTime({target: time, previous: getCurrentTime()});
+
+      // Clear previous timers. Without this (but with the setTimeout) multiple
+      // requests to set the currentTime could finish out of order and cause jumping.
+      if (playTimer.current) {
+        window.clearTimeout(playTimer.current);
+      }
+
       // TODO: it might be nice to always just pause() here
       // Why? People can drag the scrobber, or click 'back 10s' and then be in a
       // paused state to inspect things.
       if (isPlaying) {
-        replayer.play(time);
+        playTimer.current = window.setTimeout(() => replayer.play(time), 0);
         setIsPlaying(true);
       } else {
-        replayer.pause(time);
+        playTimer.current = window.setTimeout(() => replayer.pause(time), 0);
         setIsPlaying(false);
       }
     },
@@ -274,7 +292,16 @@ export function Provider({children, events, value = {}}: Props) {
     [replayerRef.current]
   );
 
-  const currentTime = useCurrentTime(getCurrentTime);
+  const currentPlayerTime = useCurrentTime(getCurrentTime);
+
+  const [isBuffering, currentTime] =
+    buffer.target !== -1 && buffer.previous === currentPlayerTime
+      ? [true, buffer.target]
+      : [false, currentPlayerTime];
+
+  if (!isBuffering && buffer.target !== -1) {
+    setBufferTime({target: -1, previous: -1});
+  }
 
   return (
     <ReplayPlayerContext.Provider
@@ -285,6 +312,7 @@ export function Provider({children, events, value = {}}: Props) {
         events,
         fastForwardSpeed,
         initRoot,
+        isBuffering,
         isPlaying,
         isSkippingInactive,
         setCurrentTime,

--- a/static/app/components/replays/stackedContent.tsx
+++ b/static/app/components/replays/stackedContent.tsx
@@ -1,0 +1,45 @@
+import React, {useCallback, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import {useResizeObserver} from '@react-aria/utils';
+
+type Dimensions = {height: number; width: number};
+
+type Props = {
+  children: (props: Dimensions) => React.ReactElement | null;
+};
+
+/**
+ * Overlap rows of content on top of each other using grid.
+ * Similar to how `posisition: absolute;` could force content to be on-top of
+ * each other, but this does so without taking the content out of the page flow.
+ *
+ * Injest the width/height of the container, so children can adjust and expand
+ * to fill the whole area.
+ */
+function StackedContent({children}: Props) {
+  const el = useRef<HTMLDivElement>(null);
+
+  const [dimensions, setDimensions] = useState({height: 0, width: 0});
+
+  const onResize = useCallback(() => {
+    setDimensions({
+      height: el.current?.clientHeight || 0,
+      width: el.current?.clientWidth || 0,
+    });
+  }, [setDimensions]);
+
+  useResizeObserver({ref: el, onResize});
+
+  return <Stack ref={el}>{children(dimensions)}</Stack>;
+}
+
+const Stack = styled('div')`
+  height: 100%;
+  display: grid;
+  grid-template: 1 / 1;
+  > * {
+    grid-area: 1 /1;
+  }
+`;
+
+export default StackedContent;

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -176,7 +176,9 @@ function ReplayLoader(props: ReplayLoaderProps) {
       <React.Fragment>
         <ReplayContextProvider events={rrwebEvents}>
           <FullscreenWrapper isFullscreen={isFullscreen} ref={fullscreenRef}>
-            <ReplayPlayer />
+            {/* In fullscreen we need to consider the max-height that the player is able
+            to full up, on a page that scrolls we only consider the max-width. */}
+            <ReplayPlayer fixedHeight={isFullscreen} />
             <ReplayController toggleFullscreen={toggleFullscreen} />
           </FullscreenWrapper>
         </ReplayContextProvider>


### PR DESCRIPTION
This throws up a "Buffering..." message when you're clicking around on the timeline (or the forward/back 10 seconds buttons). 
With slow CPU's (read: most computers) it can take a while for rrweb to render certain page changes, presumably because it has to iterate over all the events and it's touching the DOM a lot.

Changes:
- Create the <BufferingOverlay> component and extract <FastForwardBadge> into their own files
- Update stories for the player, so we can see all the components and resizing working together
- Add the `isBuffering` flag to the ReplayPlayerContextProps with the internal state
- Quick refactor of `BasePlayerRoot` because we can just pass in `fixedHeight` instead of calling`useFullscreen()` again, makes storybook examples easier
- Added <StackedContent> which is the same as in #33926

Fixes #33730