### PR TITLE
ref(metric-alerts): Prevent AlertRuleActionRequester from firing on serialization.

### DIFF
--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -9,6 +9,7 @@ from sentry.incidents.logic import (
     AlreadyDeletedError,
     delete_alert_rule,
     get_slack_actions_with_async_lookups,
+    trigger_sentry_app_action_creators_for_incidents,
 )
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.integrations.slack import tasks
@@ -37,6 +38,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
             partial=True,
         )
         if serializer.is_valid():
+            trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
             if get_slack_actions_with_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -9,9 +9,9 @@ from sentry.incidents.logic import (
     AlreadyDeletedError,
     delete_alert_rule,
     get_slack_actions_with_async_lookups,
-    trigger_sentry_app_action_creators_for_incidents,
 )
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
+from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
 from sentry.integrations.slack import tasks
 
 

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -13,12 +13,10 @@ from sentry.api.paginator import (
     OffsetPaginator,
 )
 from sentry.api.serializers import CombinedRuleSerializer, serialize
-from sentry.incidents.logic import (
-    get_slack_actions_with_async_lookups,
-    trigger_sentry_app_action_creators_for_incidents,
-)
+from sentry.incidents.logic import get_slack_actions_with_async_lookups
 from sentry.incidents.models import AlertRule
 from sentry.incidents.serializers import AlertRuleSerializer
+from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
 from sentry.integrations.slack import tasks
 from sentry.models import Rule, RuleStatus
 from sentry.signals import alert_rule_created

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -13,7 +13,10 @@ from sentry.api.paginator import (
     OffsetPaginator,
 )
 from sentry.api.serializers import CombinedRuleSerializer, serialize
-from sentry.incidents.logic import get_slack_actions_with_async_lookups
+from sentry.incidents.logic import (
+    get_slack_actions_with_async_lookups,
+    trigger_sentry_app_action_creators_for_incidents,
+)
 from sentry.incidents.models import AlertRule
 from sentry.incidents.serializers import AlertRuleSerializer
 from sentry.integrations.slack import tasks
@@ -93,6 +96,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
             data=data,
         )
         if serializer.is_valid():
+            trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
             if get_slack_actions_with_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1458,5 +1458,5 @@ def get_filtered_actions(
         rewrite_trigger_action_fields(action)
         for trigger in validated_alert_rule_data.get("triggers", [])
         for action in trigger.get("actions", [])
-        if STRING_TO_ACTION_TYPE[action["type"]] == action_type
+        if STRING_TO_ACTION_TYPE.get(action.get("type")) == action_type
     ]

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -32,7 +32,14 @@ from sentry.incidents.models import (
     IncidentTrigger,
     TriggerStatus,
 )
-from sentry.models import AuditLogEntryEvent, Integration, PagerDutyService, Project, SentryApp
+from sentry.models import (
+    AuditLogEntryEvent,
+    Integration,
+    PagerDutyService,
+    Project,
+    SentryApp,
+    SentryAppInstallation,
+)
 from sentry.search.events.fields import resolve_field
 from sentry.search.events.filter import get_filter
 from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
@@ -1382,6 +1389,27 @@ def translate_aggregate_field(aggregate, reverse=False):
     return aggregate
 
 
+def trigger_sentry_app_action_creators_for_incidents(validated_alert_rule_data):
+    from rest_framework import serializers
+
+    from sentry.mediators import alert_rule_actions
+
+    sentry_app_actions = get_filtered_actions(
+        validated_alert_rule_data=validated_alert_rule_data,
+        action_type=AlertRuleTriggerAction.Type.SENTRY_APP,
+    )
+    for action in sentry_app_actions:
+        install = SentryAppInstallation.objects.get(uuid=action.get("sentry_app_installation_uuid"))
+        result = alert_rule_actions.AlertRuleActionCreator.run(
+            install=install,
+            fields=action.get("sentry_app_config"),
+        )
+
+        if not result["success"]:
+            raise serializers.ValidationError({"sentry_app": result["message"]})
+
+
+# TODO(Ecosystem): Convert to using get_filtered_actions
 def get_slack_actions_with_async_lookups(organization, user, data):
     try:
         from sentry.incidents.serializers import AlertRuleTriggerActionSerializer
@@ -1446,3 +1474,14 @@ def rewrite_trigger_action_fields(action_data):
     if "settings" in action_data:
         action_data["sentry_app_config"] = action_data.pop("settings")
     return action_data
+
+
+def get_filtered_actions(validated_alert_rule_data, action_type: AlertRuleTriggerAction.Type):
+    from sentry.incidents.serializers import STRING_TO_ACTION_TYPE
+
+    filtered_actions = []
+    for trigger in validated_alert_rule_data.get("triggers", []):
+        for action in trigger.get("actions", []):
+            if STRING_TO_ACTION_TYPE.get(action.get("type")) == action_type:
+                filtered_actions.append(rewrite_trigger_action_fields(action))
+    return filtered_actions

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -15,7 +15,6 @@ from sentry.incidents.serializers import (
     STRING_TO_ACTION_TYPE,
 )
 from sentry.integrations.slack.utils import validate_channel_id
-from sentry.mediators import alert_rule_actions
 from sentry.models import OrganizationMember, SentryAppInstallation, Team, User
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
 
@@ -134,19 +133,14 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                     )
 
                 try:
-                    install = SentryAppInstallation.objects.get(uuid=sentry_app_installation_uuid)
+                    SentryAppInstallation.objects.get(uuid=sentry_app_installation_uuid)
                 except SentryAppInstallation.DoesNotExist:
                     raise serializers.ValidationError(
                         {"sentry_app": "The installation does not exist."}
                     )
-                # Check response from creator and bubble up errors from providers as a ValidationError
-                result = alert_rule_actions.AlertRuleActionCreator.run(
-                    install=install,
-                    fields=attrs.get("sentry_app_config"),
-                )
 
-                if not result["success"]:
-                    raise serializers.ValidationError({"sentry_app": result["message"]})
+                # TODO(Ecosystem): Validate that all fields as part of the config
+                # See NotifyEventSentryAppAction for more details
 
         attrs["use_async_lookup"] = self.context.get("use_async_lookup")
         attrs["input_channel_id"] = self.context.get("input_channel_id")

--- a/src/sentry/incidents/utils/sentry_apps.py
+++ b/src/sentry/incidents/utils/sentry_apps.py
@@ -1,0 +1,27 @@
+from typing import Any, Mapping
+
+from rest_framework import serializers
+
+from sentry.incidents.logic import get_filtered_actions
+from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.mediators import alert_rule_actions
+from sentry.models import SentryAppInstallation
+
+
+def trigger_sentry_app_action_creators_for_incidents(
+    validated_alert_rule_data: Mapping[str, Any]
+) -> None:
+
+    sentry_app_actions = get_filtered_actions(
+        validated_alert_rule_data=validated_alert_rule_data,
+        action_type=AlertRuleTriggerAction.Type.SENTRY_APP,
+    )
+    for action in sentry_app_actions:
+        install = SentryAppInstallation.objects.get(uuid=action.get("sentry_app_installation_uuid"))
+        result = alert_rule_actions.AlertRuleActionCreator.run(
+            install=install,
+            fields=action.get("sentry_app_config"),
+        )
+
+        if not result["success"]:
+            raise serializers.ValidationError({"sentry_app": result["message"]})

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from exam import fixture
+import responses
 
 from sentry.api.serializers import serialize
 from sentry.incidents.models import (
@@ -18,9 +18,22 @@ from sentry.testutils import APITestCase
 class AlertRuleDetailsBase:
     endpoint = "sentry-api-0-project-alert-rule-details"
 
-    @fixture
-    def valid_params(self):
-        return {
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        self.alert_rule = self.create_alert_rule(name="hello")
+        self.owner_user = self.create_user()
+        self.create_member(
+            user=self.owner_user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        # Default to the 'owner' user
+        self.user = self.owner_user
+        self.member_user = self.create_user()
+        self.create_member(
+            user=self.member_user, organization=self.organization, role="member", teams=[self.team]
+        )
+        self.valid_params = {
             "name": "hello",
             "time_window": 10,
             "query": "level:error",
@@ -43,7 +56,11 @@ class AlertRuleDetailsBase:
                     "alertThreshold": 150,
                     "actions": [
                         {"type": "email", "targetType": "team", "targetIdentifier": self.team.id},
-                        {"type": "email", "targetType": "user", "targetIdentifier": self.user.id},
+                        {
+                            "type": "email",
+                            "targetType": "user",
+                            "targetIdentifier": self.owner_user.id,
+                        },
                     ],
                 },
             ],
@@ -63,34 +80,14 @@ class AlertRuleDetailsBase:
         self.method = original_method
         return serialized_alert_rule
 
-    @fixture
-    def organization(self):
-        return self.create_organization()
-
-    @fixture
-    def project(self):
-        return self.create_project(organization=self.organization)
-
-    @fixture
-    def user(self):
-        return self.create_user()
-
-    @fixture
-    def alert_rule(self):
-        return self.create_alert_rule(name="hello")
-
     def test_invalid_rule_id(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
+        self.login_as(self.owner_user)
         with self.feature("organizations:incidents"):
             resp = self.get_response(self.organization.slug, self.project.slug, 1234)
 
         assert resp.status_code == 404
 
     def test_permissions(self):
-        self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.create_user())
         with self.feature("organizations:incidents"):
             resp = self.get_response(self.organization.slug, self.project.slug, self.alert_rule.id)
@@ -98,18 +95,14 @@ class AlertRuleDetailsBase:
         assert resp.status_code == 403
 
     def test_no_feature(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
+        self.login_as(self.owner_user)
         resp = self.get_response(self.organization.slug, self.project.slug, self.alert_rule.id)
         assert resp.status_code == 404
 
 
 class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
     def test_simple(self):
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
+        self.login_as(self.member_user)
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id
@@ -118,10 +111,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data == serialize(self.alert_rule)
 
     def test_aggregate_translation(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
+        self.login_as(self.owner_user)
         alert_rule = self.create_alert_rule(aggregate="count_unique(tags[sentry:user])")
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(self.organization.slug, self.project.slug, alert_rule.id)
@@ -132,16 +122,15 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
     method = "put"
 
-    def test_simple(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.owner_user)
 
+    def test_simple(self):
         test_params = self.valid_params.copy()
         test_params["resolve_threshold"] = self.alert_rule.resolve_threshold
         test_params.update({"name": "what"})
 
-        self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
@@ -163,11 +152,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         test_params["resolve_threshold"] = self.alert_rule.resolve_threshold
         test_params["aggregate"] = self.alert_rule.snuba_query.aggregate
 
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-
-        self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
@@ -184,10 +168,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert updated_sub.subscription_id == existing_sub.subscription_id
 
     def test_update_snapshot(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         alert_rule = self.alert_rule
         # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
         serialized_alert_rule = self.get_serialized_alert_rule()
@@ -215,10 +195,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
     ):
         mock_uuid4.return_value = self.get_mock_uuid()
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         self.integration = Integration.objects.create(
             provider="slack",
             name="Team A",
@@ -254,7 +230,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             "uuid": "abc123",
             "alert_rule_id": self.alert_rule.id,
             "data": test_params,
-            "user_id": self.user.id,
+            "user_id": self.owner_user.id,
         }
         mock_find_channel_id_for_alert_rule.assert_called_once_with(kwargs=kwargs)
 
@@ -265,11 +241,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
     @patch("sentry.integrations.slack.tasks.uuid4")
     def test_async_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):
         mock_uuid4.return_value = self.get_mock_uuid()
-
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         self.integration = Integration.objects.create(
             provider="slack",
             name="Team A",
@@ -399,12 +370,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         )  # Did not increment from the last assertion because we early out on the validation error
 
     def test_no_owner(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-
-        self.login_as(self.user)
-
         alert_rule = self.alert_rule
         alert_rule.owner = self.user.actor
         alert_rule.save()
@@ -424,15 +389,124 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data == serialize(alert_rule, self.user)
         assert resp.data["owner"] is None
 
+    @responses.activate
+    def test_success_response_from_sentry_app(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=202,
+        )
+
+        sentry_app = self.create_sentry_app(
+            name="foo",
+            organization=self.organization,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
+        )
+        install = self.create_sentry_app_installation(
+            slug="foo", organization=self.organization, user=self.user
+        )
+
+        sentry_app_settings = [
+            {"name": "title", "value": "test title"},
+            {"name": "description", "value": "test description"},
+        ]
+
+        test_params = self.valid_params.copy()
+        test_params["triggers"] = [
+            {
+                "actions": [
+                    {
+                        "type": "sentry_app",
+                        "targetType": "sentry_app",
+                        "targetIdentifier": sentry_app.id,
+                        "hasSchemaFormConfig": True,
+                        "sentryAppId": sentry_app.id,
+                        "sentryAppInstallationUuid": install.uuid,
+                        "settings": sentry_app_settings,
+                    }
+                ],
+                "alertThreshold": 300,
+                "label": "critical",
+            }
+        ]
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            self.get_valid_response(
+                self.organization.slug,
+                self.project.slug,
+                self.alert_rule.id,
+                status_code=200,
+                **test_params,
+            )
+
+    @responses.activate
+    def test_error_response_from_sentry_app(self):
+        error_message = "Everything is broken!"
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=500,
+            json={"message": error_message},
+        )
+
+        sentry_app = self.create_sentry_app(
+            name="foo",
+            organization=self.organization,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
+        )
+        install = self.create_sentry_app_installation(
+            slug="foo", organization=self.organization, user=self.user
+        )
+
+        sentry_app_settings = [
+            {"name": "title", "value": "test title"},
+            {"name": "description", "value": "test description"},
+        ]
+
+        test_params = self.valid_params.copy()
+        test_params["triggers"] = [
+            {
+                "actions": [
+                    {
+                        "type": "sentry_app",
+                        "targetType": "sentry_app",
+                        "targetIdentifier": sentry_app.id,
+                        "hasSchemaFormConfig": True,
+                        "sentryAppId": sentry_app.id,
+                        "sentryAppInstallationUuid": install.uuid,
+                        "settings": sentry_app_settings,
+                    }
+                ],
+                "alertThreshold": 300,
+                "label": "critical",
+            }
+        ]
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_response(
+                self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
+            )
+
+        assert resp.status_code == 400
+        assert error_message in resp.data["sentry_app"]
+
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
     method = "delete"
 
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.owner_user)
+
     def test_simple(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         with self.feature("organizations:incidents"):
             self.get_valid_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, status_code=204
@@ -449,11 +523,6 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
 
     def test_snapshot_and_create_new_with_same_name(self):
         with self.tasks():
-            self.create_member(
-                user=self.user, organization=self.organization, role="owner", teams=[self.team]
-            )
-            self.login_as(self.user)
-
             # We attach the rule to an incident so the rule is snapshotted instead of deleted.
             incident = self.create_incident(alert_rule=self.alert_rule)
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytz
 import requests
+import responses
 from exam import fixture
 from freezegun import freeze_time
 
@@ -71,24 +72,12 @@ class AlertRuleCreateEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-alert-rules"
     method = "post"
 
-    @fixture
-    def organization(self):
-        return self.create_organization()
-
-    @fixture
-    def project(self):
-        return self.create_project(organization=self.organization)
-
-    @fixture
-    def user(self):
-        return self.create_user()
-
-    def test_simple(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
-        valid_alert_rule = {
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        self.user = self.create_user()
+        self.valid_alert_rule = {
             "aggregate": "count()",
             "query": "",
             "timeWindow": "300",
@@ -114,11 +103,16 @@ class AlertRuleCreateEndpointTest(APITestCase):
             "projects": [self.project.slug],
             "owner": self.user.id,
             "name": "JustAValidTestRule",
-            "comparisonDelta": 60,
         }
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+
+    def test_simple(self):
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_valid_response(
-                self.organization.slug, self.project.slug, status_code=201, **valid_alert_rule
+                self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule
             )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
@@ -130,20 +124,17 @@ class AlertRuleCreateEndpointTest(APITestCase):
         assert len(audit_log_entry) == 1
 
     def test_no_feature(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         resp = self.get_response(self.organization.slug, self.project.slug)
         assert resp.status_code == 404
 
     def test_no_perms(self):
+        member_user = self.create_user()
         self.create_member(
-            user=self.user, organization=self.organization, role="member", teams=[self.team]
+            user=member_user, organization=self.organization, role="member", teams=[self.team]
         )
         self.organization.update_option("sentry:alerts_member_write", False)
-        self.login_as(self.user)
-        resp = self.get_response(self.organization.slug, self.project.slug)
+        self.login_as(member_user)
+        resp = self.get_response(self.organization.slug, self.project.slug, **self.valid_alert_rule)
         assert resp.status_code == 403
 
     @patch(
@@ -156,10 +147,6 @@ class AlertRuleCreateEndpointTest(APITestCase):
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
     ):
         mock_uuid4.return_value = self.get_mock_uuid()
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         self.integration = Integration.objects.create(
             provider="slack",
             name="Team A",
@@ -168,11 +155,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         )
         self.integration.add_organization(self.organization, self.user)
         valid_alert_rule = {
-            "aggregate": "count()",
-            "query": "",
-            "timeWindow": "300",
-            "resolveThreshold": 100,
-            "thresholdType": 0,
+            **self.valid_alert_rule,
             "triggers": [
                 {
                     "label": "critical",
@@ -187,9 +170,6 @@ class AlertRuleCreateEndpointTest(APITestCase):
                     ],
                 },
             ],
-            "projects": [self.project.slug],
-            "owner": self.user.id,
-            "name": "JustAValidTestRule",
         }
         with self.feature(["organizations:incidents"]):
             resp = self.get_valid_response(
@@ -206,17 +186,8 @@ class AlertRuleCreateEndpointTest(APITestCase):
         mock_find_channel_id_for_alert_rule.assert_called_once_with(kwargs=kwargs)
 
     def test_no_owner(self):
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         rule_data = {
-            "aggregate": "count()",
-            "query": "",
-            "timeWindow": "300",
-            "projects": [self.project.slug],
-            "name": "JustATestRule",
-            "resolveThreshold": 100,
+            **self.valid_alert_rule,
             "thresholdType": 1,
             "triggers": [{"label": "critical", "alertThreshold": 75}],
         }
@@ -237,10 +208,6 @@ class AlertRuleCreateEndpointTest(APITestCase):
     def test_async_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):
         mock_uuid4.return_value = self.get_mock_uuid()
 
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         self.integration = Integration.objects.create(
             provider="slack",
             name="Team A",
@@ -250,12 +217,8 @@ class AlertRuleCreateEndpointTest(APITestCase):
         self.integration.add_organization(self.organization, self.user)
         name = "MySpecialAsyncTestRule"
         test_params = {
-            "aggregate": "count()",
-            "query": "",
-            "timeWindow": "300",
-            "projects": [self.project.slug],
+            **self.valid_alert_rule,
             "name": name,
-            "resolveThreshold": 100,
             "thresholdType": 1,
             "triggers": [
                 {
@@ -343,9 +306,115 @@ class AlertRuleCreateEndpointTest(APITestCase):
         with self.feature("organizations:incidents"), self.tasks():
             resp = self.get_response(self.organization.slug, self.project.slug, **test_params)
         assert resp.status_code == 400
-        assert (
-            mock_get_channel_id.call_count == 3
-        )  # Did not increment from the last assertion because we early out on the validation error
+        # Did not increment from the last assertion because we early out on the validation error
+        assert mock_get_channel_id.call_count == 3
+
+    @responses.activate
+    def test_success_response_from_sentry_app(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=202,
+        )
+
+        sentry_app = self.create_sentry_app(
+            name="foo",
+            organization=self.organization,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
+        )
+        install = self.create_sentry_app_installation(
+            slug="foo", organization=self.organization, user=self.user
+        )
+
+        sentry_app_settings = [
+            {"name": "title", "value": "test title"},
+            {"name": "description", "value": "test description"},
+        ]
+
+        alert_rule = {
+            **self.valid_alert_rule,
+            "triggers": [
+                {
+                    "actions": [
+                        {
+                            "type": "sentry_app",
+                            "targetType": "sentry_app",
+                            "targetIdentifier": sentry_app.id,
+                            "hasSchemaFormConfig": True,
+                            "sentryAppId": sentry_app.id,
+                            "sentryAppInstallationUuid": install.uuid,
+                            "settings": sentry_app_settings,
+                        }
+                    ],
+                    "alertThreshold": 300,
+                    "label": "critical",
+                }
+            ],
+        }
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            self.get_valid_response(
+                self.organization.slug, self.project.slug, status_code=201, **alert_rule
+            )
+
+    @responses.activate
+    def test_error_response_from_sentry_app(self):
+        error_message = "Everything is broken!"
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=500,
+            json={"message": error_message},
+        )
+
+        sentry_app = self.create_sentry_app(
+            name="foo",
+            organization=self.organization,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
+        )
+        install = self.create_sentry_app_installation(
+            slug="foo", organization=self.organization, user=self.user
+        )
+
+        sentry_app_settings = [
+            {"name": "title", "value": "test title"},
+            {"name": "description", "value": "test description"},
+        ]
+
+        alert_rule = {
+            **self.valid_alert_rule,
+            "triggers": [
+                {
+                    "actions": [
+                        {
+                            "type": "sentry_app",
+                            "targetType": "sentry_app",
+                            "targetIdentifier": sentry_app.id,
+                            "hasSchemaFormConfig": True,
+                            "sentryAppId": sentry_app.id,
+                            "sentryAppInstallationUuid": install.uuid,
+                            "settings": sentry_app_settings,
+                        }
+                    ],
+                    "alertThreshold": 300,
+                    "label": "critical",
+                }
+            ],
+        }
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_response(self.organization.slug, self.project.slug, **alert_rule)
+
+        assert resp.status_code == 400
+        assert error_message in resp.data["sentry_app"]
 
 
 class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestCase):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -995,44 +995,7 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
             {"sentryApp": ["Missing parameter: sentry_app_installation_uuid"]},
         )
 
-    @responses.activate
-    def test_sentry_app_action_creator_fails(self):
-        error_message = "Invalid channel."
-        responses.add(
-            method=responses.POST,
-            url="https://example.com/sentry/alert-rule",
-            status=400,
-            json={"message": error_message},
-        )
-
-        serializer = AlertRuleTriggerActionSerializer(
-            context=self.context,
-            data={
-                "type": AlertRuleTriggerAction.get_registered_type(
-                    AlertRuleTriggerAction.Type.SENTRY_APP
-                ).slug,
-                "target_type": ACTION_TARGET_TYPE_TO_STRING[
-                    AlertRuleTriggerAction.TargetType.SENTRY_APP
-                ],
-                "target_identifier": "1",
-                "sentry_app": self.sentry_app.id,
-                "sentry_app_config": {"channel": "#santry"},
-                "sentry_app_installation_uuid": self.sentry_app_installation.uuid,
-            },
-        )
-        assert not serializer.is_valid()
-        error = serializer.errors.get("sentryApp")[0]
-        assert str(error) == f"Super Awesome App: {error_message}"
-
-    @responses.activate
     def test_create_and_update_sentry_app_action_success(self):
-        responses.add(
-            method=responses.POST,
-            url="https://example.com/sentry/alert-rule",
-            status=200,
-            json={},
-        )
-
         serializer = AlertRuleTriggerActionSerializer(
             context=self.context,
             data={


### PR DESCRIPTION


<!-- Describe your PR here. -->

See [API-2631](https://getsentry.atlassian.net/browse/API-2631)

Previously, whenever the AlertRuleTriggerAction was serialized, we were sending a request to the SentryApp notifying them of the new alert. If they use these webhooks for metrics or  functionality, their counts would be incorrectly doubled for metric alerts since we serialized the same AlertRuleTriggerAction twice on each request, once for validation, the other as a part of a slack helper method `get_slack_actions_with_async_lookups`

This PR refactors the firing of the Requestor/Creator out into the endpoint to ensure it is only ever called once, and intentionally. It also adds tests to ensure that the responses from these errors are surfaced to the frontend.


<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
