### PR TITLE
fix(issue_alerts): Make sure that we update cached groups after flushing buffers.

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -71,14 +71,22 @@ class Buffer(Service, metaclass=BufferMount):
 
             # HACK(dcramer): this is gross, but we don't have a good hook to compute this property today
             # XXX(dcramer): remove once we can replace 'priority' with something reasonable via Snuba
-            if model is Group and "last_seen" in update_kwargs and "times_seen" in update_kwargs:
-                update_kwargs["score"] = ScoreClause(
-                    group=None,
-                    times_seen=update_kwargs["times_seen"],
-                    last_seen=update_kwargs["last_seen"],
-                )
-
-            _, created = model.objects.create_or_update(values=update_kwargs, **filters)
+            if model is Group:
+                if "last_seen" in update_kwargs and "times_seen" in update_kwargs:
+                    update_kwargs["score"] = ScoreClause(
+                        group=None,
+                        times_seen=update_kwargs["times_seen"],
+                        last_seen=update_kwargs["last_seen"],
+                    )
+                # XXX: create_or_update doesn't fire `post_save` signals, and so this update never
+                # ends up in the cache. This causes issues when handling issue alerts, and likely
+                # elsewhere. Use `update` here since we're already special casing, and we know that
+                # the group will already exist.
+                group = Group.objects.get(**filters)
+                group.update(**update_kwargs)
+                created = False
+            else:
+                _, created = model.objects.create_or_update(values=update_kwargs, **filters)
 
         buffer_incr_complete.send_robust(
             model=model,


### PR DESCRIPTION
This fixes a bug with issue alerts where `IssueOccurrencesFilter` will cause an alert to not fire
correctly. This is because the value of `group.times_seen` is cached and ends up being inaccurate.

This happens because we cache groups for 5 minutes in `post_process_group`. We usually try to push
to the cache when updating a group, but when we update `times_seen` using buffers we were using
`create_or_update`, which just updates the database and doesn't fire `post_save` signals. We rely on
`post_save` to properly populate the cache here.

Special casing `Group` here so that we fetch the actual row and call `.update` on it directly. This
fires `post_save` which then updates the cached value.