### PR TITLE
fix(metrics): Filter invalid conditions [INGEST-1260]

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -524,7 +524,8 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
                     where = []
                     for condition in snuba_query.where:
                         if not (
-                            isinstance(condition.lhs, Column)
+                            isinstance(condition, Condition)
+                            and isinstance(condition.lhs, Column)
                             and condition.lhs.name == "project_id"
                             and "project_id" in groupby_tags
                         ):

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -13,7 +13,7 @@ import math
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
-from snuba_sdk import Column, Condition, Entity, Function, Granularity, Limit, Offset, Op, Query
+from snuba_sdk import Column, Condition, Entity, Function, Granularity, Limit, Offset, Op, Or, Query
 from snuba_sdk.conditions import BooleanCondition
 from snuba_sdk.orderby import Direction, OrderBy
 
@@ -22,6 +22,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Project
 from sentry.search.events.builder import UnresolvedQuery
 from sentry.sentry_metrics.utils import (
+    STRING_NOT_FOUND,
     resolve_tag_key,
     resolve_weak,
     reverse_resolve,
@@ -100,21 +101,33 @@ def resolve_tags(org_id: int, input_: Any) -> Any:
     pass Column("metric_id") or Column("project_id") into this function.
 
     """
+    if input_ is None:
+        return None
     if isinstance(input_, (list, tuple)):
-        return [resolve_tags(org_id, item) for item in input_]
-    if isinstance(input_, Function):
-        if input_.function == "ifNull":
-            # This was wrapped automatically by QueryBuilder, remove wrapper
-            return resolve_tags(org_id, input_.parameters[0])
-        return Function(
-            function=input_.function,
-            parameters=input_.parameters
-            and [resolve_tags(org_id, item) for item in input_.parameters],
-        )
+        elements = [resolve_tags(org_id, item) for item in input_]
+        # Lists are either arguments to IN or NOT IN. In both cases, we can
+        # drop unknown strings:
+        return [x for x in elements if x != STRING_NOT_FOUND]
+    if isinstance(input_, Function) and input_.function == "ifNull":
+        # This was wrapped automatically by QueryBuilder, remove wrapper
+        return resolve_tags(org_id, input_.parameters[0])
+    if (
+        isinstance(input_, Or)
+        and len(input_.conditions) == 2
+        and isinstance(c := input_.conditions[0], Condition)
+        and isinstance(c.lhs, Function)
+        and c.lhs.function == "isNull"
+        and c.op == Op.EQ
+        and c.rhs == 1
+    ):
+        # Remove another "null" wrapper. We should really write our own parser instead.
+        return resolve_tags(org_id, input_.conditions[1])
+
     if isinstance(input_, Condition):
         return Condition(
             lhs=resolve_tags(org_id, input_.lhs), op=input_.op, rhs=resolve_tags(org_id, input_.rhs)
         )
+
     if isinstance(input_, BooleanCondition):
         return input_.__class__(
             conditions=[resolve_tags(org_id, item) for item in input_.conditions]
@@ -129,7 +142,7 @@ def resolve_tags(org_id: int, input_: Any) -> Any:
     if isinstance(input_, str):
         return resolve_weak(org_id, input_)
 
-    return input_
+    raise InvalidParams("Unable to resolve conditions")
 
 
 def parse_query(query_string: str) -> Sequence[Condition]:

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -17,6 +17,7 @@ from snuba_sdk import (
     Limit,
     Offset,
     Op,
+    Or,
     OrderBy,
     Query,
 )
@@ -149,6 +150,33 @@ def get_entity_of_metric_mocked(_, metric_name):
                     Op.NOT_IN,
                     rhs=[SHARED_TAG_STRINGS["production"]],
                 )
+            ],
+        ),
+        (
+            "release:[foo]",
+            [
+                Condition(
+                    Column(name=resolve_tag_key(ORG_ID, "release")),
+                    Op.IN,
+                    rhs=[],
+                )
+            ],
+        ),
+        (
+            "release:myapp@2.0.0 or environment:[production,staging]",
+            [
+                Or(
+                    [
+                        Condition(
+                            Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10001]
+                        ),
+                        Condition(
+                            Column(name=resolve_tag_key(ORG_ID, "environment")),
+                            Op.IN,
+                            rhs=[resolve(ORG_ID, "production"), resolve(ORG_ID, "staging")],
+                        ),
+                    ]
+                ),
             ],
         ),
     ],

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -23,6 +23,7 @@ from snuba_sdk import (
 
 from sentry.api.utils import InvalidParams
 from sentry.sentry_metrics.indexer.mock import MockIndexer
+from sentry.sentry_metrics.indexer.strings import SHARED_TAG_STRINGS
 from sentry.sentry_metrics.utils import resolve, resolve_tag_key, resolve_weak
 from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics import (
@@ -129,6 +130,26 @@ def get_entity_of_metric_mocked(_, metric_name):
         (
             'transaction:"/bar/:orgId/"',
             [Condition(Column(name=resolve_tag_key(ORG_ID, "transaction")), Op.EQ, rhs=10002)],
+        ),
+        (
+            "release:[production,foo]",
+            [
+                Condition(
+                    Column(name=resolve_tag_key(ORG_ID, "release")),
+                    Op.IN,
+                    rhs=[SHARED_TAG_STRINGS["production"]],
+                )
+            ],
+        ),
+        (
+            "!release:[production,foo]",
+            [
+                Condition(
+                    Column(name=resolve_tag_key(ORG_ID, "release")),
+                    Op.NOT_IN,
+                    rhs=[SHARED_TAG_STRINGS["production"]],
+                )
+            ],
         ),
     ],
 )

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -394,7 +394,7 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
                 "statsPeriod": "1d",
                 "interval": "1d",
                 "field": ["sum(session)"],
-                "query": 'release:"foo@1.1.0" or release:"foo@1.2.0" or release:"foo@1.3.0"',
+                "query": 'release:"foo@1.1.0" or release:["foo@1.2.0", release:"foo@1.3.0"]',
                 "groupBy": ["release"],
             }
         )


### PR DESCRIPTION
We currently pass `-1` as a tag value to snuba when the indexer cannot resolve the corresponding string. This leads to problems when this sentinel value appears in arrays with large unsigned integers such as our [reserved strings](https://github.com/getsentry/sentry/pull/33399), because ClickHouse cannot parse them into a common type:

```
DB::Exception: There is no supertype for types Int8, UInt64 because some of them are signed integers and some are unsigned integers, but there is no signed integer type, that can exactly represent all required unsigned integer values: While processing [-1, 9223372036854776015]
```

As a short-term fix, this PR removes unresolved values from arrays when processing conditions. Long-term, we should process the conditions to exclude _all_ unknown strings.

See also SNUBA-2RX.