### PR TITLE
feat(dashboards): Use metricsEnhanced dataset

### DIFF
--- a/static/app/views/dashboardsV2/utils.tsx
+++ b/static/app/views/dashboardsV2/utils.tsx
@@ -309,7 +309,7 @@ export function flattenErrors(
 export function getDashboardsMEPQueryParams(isMEPEnabled: boolean) {
   return isMEPEnabled
     ? {
-        metricsEnhanced: '1',
+        dataset: 'metricsEnhanced',
       }
     : {};
 }

--- a/tests/js/spec/views/dashboardsV2/utils.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/utils.spec.tsx
@@ -254,7 +254,7 @@ describe('Dashboards util', () => {
   describe('getDashboardsMEPQueryParams', function () {
     it('returns correct params if enabled', function () {
       expect(getDashboardsMEPQueryParams(true)).toEqual({
-        metricsEnhanced: '1',
+        dataset: 'metricsEnhanced',
       });
     });
     it('returns empty object if disabled', function () {

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -856,7 +856,7 @@ describe('Dashboards > WidgetQueries', function () {
     expect(mock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
-        query: expect.objectContaining({metricsEnhanced: '1'}),
+        query: expect.objectContaining({dataset: 'metricsEnhanced'}),
       })
     );
 
@@ -902,7 +902,7 @@ describe('Dashboards > WidgetQueries', function () {
     expect(mock).toHaveBeenCalledWith(
       '/organizations/org-slug/eventsv2/',
       expect.objectContaining({
-        query: expect.objectContaining({metricsEnhanced: '1'}),
+        query: expect.objectContaining({dataset: 'metricsEnhanced'}),
       })
     );
 


### PR DESCRIPTION
`?metricsEnhanced=1` will be deprecated in favor of `?dataset=metricsEnhanced`

Relates to https://github.com/getsentry/sentry/pull/33892 and https://github.com/getsentry/sentry/pull/33822