### PR TITLE
Revert "fix(ci): Do not skip step for visual diffs on PRs or master (…

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -324,8 +324,8 @@ jobs:
       - name: Diff snapshots
         id: visual-snapshots-diff
         uses: getsentry/action-visual-snapshot@v2
-        # Do not execute on forks. Forks are handled in visual-diff.yml
-        if: github.event.pull_request.head.repo.full_name == 'getsentry/sentry' || github.ref == 'refs/heads/master'
+        # Do not execute on forks or on master. Forks are handled in visual-diff.yml
+        if: github.head_repository.full_name == 'getsentry/sentry' && github.ref != 'refs/heads/master'
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           gcs-bucket: 'sentry-visual-snapshots'

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   visual-diff:
-    # Only execute this check when a PR is opened from a fork rather than the upstream repo
-    if: github.event.workflow_run.head_repository.full_name != 'getsentry/sentry'
+    # This is the opposite condition as acceptance.yml/visual-diff
+    if: github.head_repository.full_name != 'getsentry/sentry'
     runs-on: ubuntu-20.04
     timeout-minutes: 20
 


### PR DESCRIPTION
It seems to fail to run on `master` pushes because the Github context is different.

See [this log](https://github.com/getsentry/sentry/runs/6178228381?check_suite_focus=true#step:3:316).

```
Starting build using API...
  ##[debug]sha/ref: undefined, undefined
  ::group::Error starting build with API
Error starting build with API
  ##[debug]{"name":"StatusError","message":"Unprocessable Entity","statusCode":422,"headers":{"access-control-allow-origin":"*","access-control-expose-headers":"ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset","content-security-policy":"default-src 'none'","content-type":"application/json; charset=utf-8","referrer-policy":"origin-when-cross-origin, strict-origin-when-cross-origin","strict-transport-security":"max-age=31536000; includeSubdomains; preload","vary":"Accept-Encoding, Accept, X-Requested-With","x-content-type-options":"nosniff","x-frame-options":"deny","x-github-media-type":"github.v3; param=antiope-preview; format=json","x-github-request-id":"FC73:78DC:283C209:7418EAD:626809FA","x-ratelimit-limit":"15000","x-ratelimit-remaining":"14984","x-ratelimit-reset":"1650986906","x-ratelimit-resource":"core","x-ratelimit-used":"16","x-xss-protection":"0","x-cloud-trace-context":"49d0c9f706ed8a6e973f61ad8b74d994;o=1","date":"Tue, 26 Apr 2022 15:04:27 GMT","server":"Google Frontend","content-length":"124","alt-svc":"h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"","connection":"close"}}
  ::endgroup::
```