### PR TITLE
fix(performance): pagefilters inline with search in summary

### DIFF
--- a/static/app/views/performance/transactionSummary/filter.tsx
+++ b/static/app/views/performance/transactionSummary/filter.tsx
@@ -147,8 +147,6 @@ const FilterLabel = styled('span')`
 const Wrapper = styled('div')`
   position: relative;
   display: flex;
-
-  margin-right: ${space(1)};
 `;
 
 const StyledDropdownButton = styled(DropdownButton)<{hasDarkBorderBottomColor?: boolean}>`

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -266,29 +266,27 @@ function SummaryContent({
   return (
     <React.Fragment>
       <Layout.Main>
-        {organization.features.includes('selection-filters-v2') && (
-          <StyledPageFilterBar condensed>
-            <EnvironmentPageFilter />
-            <DatePageFilter alignDropdown="left" />
-          </StyledPageFilterBar>
-        )}
         <Search>
           <Filter
             organization={organization}
             currentFilter={spanOperationBreakdownFilter}
             onChangeFilter={onChangeFilter}
           />
-          <SearchBarContainer>
-            <SearchBar
-              searchSource="transaction_summary"
-              organization={organization}
-              projectIds={eventView.project}
-              query={query}
-              fields={eventView.fields}
-              onSearch={handleSearch}
-              maxQueryLength={MAX_QUERY_LENGTH}
-            />
-          </SearchBarContainer>
+          {organization.features.includes('selection-filters-v2') && (
+            <PageFilterBar condensed>
+              <EnvironmentPageFilter />
+              <DatePageFilter alignDropdown="left" />
+            </PageFilterBar>
+          )}
+          <SearchBar
+            searchSource="transaction_summary"
+            organization={organization}
+            projectIds={eventView.project}
+            query={query}
+            fields={eventView.fields}
+            onSearch={handleSearch}
+            maxQueryLength={MAX_QUERY_LENGTH}
+          />
           <MetricsEventsDropdown />
         </Search>
         <TransactionSummaryCharts
@@ -468,18 +466,11 @@ function getTransactionsListSort(
   return {selected: selectedSort, options: sortOptions};
 }
 
-const StyledPageFilterBar = styled(PageFilterBar)`
-  margin-bottom: ${space(1)};
-`;
-
 const Search = styled('div')`
-  display: flex;
-  width: 100%;
-  margin-bottom: ${space(3)};
-`;
-
-const SearchBarContainer = styled('div')`
-  flex-grow: 1;
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: ${space(2)};
+  margin-bottom: ${space(2)};
 `;
 
 export default withProjects(SummaryContent);

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -468,9 +468,12 @@ function getTransactionsListSort(
 
 const Search = styled('div')`
   display: grid;
-  grid-template-columns: auto auto 1fr;
   gap: ${space(2)};
   margin-bottom: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: auto auto 1fr;
+  }
 `;
 
 export default withProjects(SummaryContent);


### PR DESCRIPTION
Temporary fix until we can collapse these into the filter button

Before:
![Screen Shot 2022-04-26 at 10 18 20 AM](https://user-images.githubusercontent.com/4830259/165356641-dbff1d3c-e95a-4498-9956-db578c301a24.png)

After:
![Screen Shot 2022-04-26 at 10 18 11 AM](https://user-images.githubusercontent.com/4830259/165356660-08336a85-1d0c-4a8d-b628-93cc60c27d68.png)