### PR TITLE
feat(profiling): sync flamechart state with qs and intialize from it

### DIFF
--- a/docs-ui/stories/components/profiling/flamegraphZoomView.stories.js
+++ b/docs-ui/stories/components/profiling/flamegraphZoomView.stories.js
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Flamegraph} from 'sentry/components/profiling/flamegraph';
@@ -20,11 +21,13 @@ const eventedProfiles = importProfile(
 );
 
 export const EventedTrace = () => {
+  const [profiles, setProfiles] = useState(eventedProfiles);
+
   return (
     <FlamegraphStateProvider>
       <FlamegraphThemeProvider>
         <FlamegraphContainer>
-          <Flamegraph profiles={eventedProfiles} />
+          <Flamegraph onImport={p => setProfiles(p)} profiles={profiles} />
         </FlamegraphContainer>
       </FlamegraphThemeProvider>
     </FlamegraphStateProvider>
@@ -36,11 +39,13 @@ const sampledTrace = importProfile(
 );
 
 export const SampledTrace = () => {
+  const [profiles, setProfiles] = useState(sampledTrace);
+
   return (
     <FlamegraphStateProvider>
       <FlamegraphThemeProvider>
         <FlamegraphContainer>
-          <Flamegraph profiles={sampledTrace} />
+          <Flamegraph onImport={p => setProfiles(p)} profiles={profiles} />
         </FlamegraphContainer>
       </FlamegraphThemeProvider>
     </FlamegraphStateProvider>
@@ -52,11 +57,13 @@ const jsSelfProfile = importProfile(
 );
 
 export const JSSelfProfiling = () => {
+  const [profiles, setProfiles] = useState(jsSelfProfile);
+
   return (
     <FlamegraphStateProvider>
       <FlamegraphThemeProvider>
         <FlamegraphContainer>
-          {jsSelfProfile ? <Flamegraph profiles={jsSelfProfile} /> : null}
+          <Flamegraph onImport={p => setProfiles(p)} profiles={profiles} />
         </FlamegraphContainer>
       </FlamegraphThemeProvider>
     </FlamegraphStateProvider>
@@ -68,11 +75,13 @@ const typescriptProfile = importProfile(
 );
 
 export const TypescriptProfile = () => {
+  const [profiles, setProfiles] = useState(typescriptProfile);
+
   return (
     <FlamegraphStateProvider>
       <FlamegraphThemeProvider>
         <FlamegraphContainer>
-          {typescriptProfile ? <Flamegraph profiles={typescriptProfile} /> : null}
+          <Flamegraph onImport={p => setProfiles(p)} profiles={profiles} />
         </FlamegraphContainer>
       </FlamegraphThemeProvider>
     </FlamegraphStateProvider>

--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -106,7 +106,6 @@ function BoundTooltip({
   // If users screen is on right half of the screen, then we have more space to position on the left and vice versa
   // since default is right, we only need to handle 1 case
   if (cursorHorizontalPosition > mid) {
-    // console.log('Cursor over mid');
     cursorHorizontalPosition -= tooltipBounds.width;
   }
 

--- a/static/app/components/profiling/flamegraphAxisOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraphAxisOptionsMenu.tsx
@@ -7,7 +7,7 @@ import space from 'sentry/styles/space';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/useFlamegraphPreferences';
 
 function FlamegraphXAxisOptionsMenu(): React.ReactElement {
-  const [{synchronizeXAxisWithTransaction}, dispatch] = useFlamegraphPreferences();
+  const [{xAxis}, dispatch] = useFlamegraphPreferences();
 
   return (
     <OptionsMenuContainer>
@@ -19,29 +19,29 @@ function FlamegraphXAxisOptionsMenu(): React.ReactElement {
             prefix={t('X Axis')}
             size="xsmall"
           >
-            {synchronizeXAxisWithTransaction ? 'Transaction' : 'Standalone'}
+            {xAxis ? 'Transaction' : 'Standalone'}
           </DropdownButton>
         )}
       >
         <DropdownItem
           onSelect={() =>
             dispatch({
-              type: 'set synchronizeXAxisWithTransaction',
-              payload: false,
+              type: 'set xAxis',
+              payload: 'standalone',
             })
           }
-          isActive={!synchronizeXAxisWithTransaction}
+          isActive={xAxis === 'standalone'}
         >
           Standalone
         </DropdownItem>
         <DropdownItem
           onSelect={() =>
             dispatch({
-              type: 'set synchronizeXAxisWithTransaction',
-              payload: true,
+              type: 'set xAxis',
+              payload: 'transaction',
             })
           }
-          isActive={synchronizeXAxisWithTransaction}
+          isActive={xAxis === 'transaction'}
         >
           Transaction
         </DropdownItem>

--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -32,7 +32,6 @@ function frameSearch(
   index: Fuse<FlamegraphFrame>
 ): Record<string, FlamegraphFrame> | null {
   const results = {};
-  let hasMatches = false;
 
   if (isRegExpString(query)) {
     const [_, lookup, flags] = parseRegExp(query) ?? [];
@@ -48,7 +47,6 @@ function frameSearch(
         const frame = frames[i];
 
         if (new RegExp(lookup, flags ?? 'g').test(frame.frame.name.trim())) {
-          hasMatches = true;
           results[
             `${
               frame.frame.name +
@@ -77,7 +75,6 @@ function frameSearch(
   }
 
   for (let i = 0; i < fuseResults.length; i++) {
-    hasMatches = true;
     const frame = fuseResults[i];
 
     results[
@@ -89,7 +86,7 @@ function frameSearch(
     ] = frame.item;
   }
 
-  return hasMatches ? results : null;
+  return results;
 }
 
 const numericSort = (

--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import Fuse from 'fuse.js';
@@ -193,7 +193,7 @@ function FlamegraphSearch({
         query: search.query,
       },
     });
-  }, [searchIndex, allFrames]);
+  }, [searchIndex, allFrames, search.query, search.results, dispatchSearch]);
 
   const onNextSearchClick = useCallback(() => {
     const frames = memoizedSortFrameResults(search.results);

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -237,7 +237,7 @@ function FlamegraphZoomView({
 
     // Check if we are starting a new interaction
     if (previousInteraction === null && lastInteraction) {
-      beforeInteractionConfigView.current = flamegraphRenderer.configView.clone();
+      beforeInteractionConfigView.current = flamegraphRenderer.configView;
       return;
     }
 
@@ -245,7 +245,7 @@ function FlamegraphZoomView({
       beforeInteractionConfigView.current &&
       !beforeInteractionConfigView.current.equals(flamegraphRenderer.configView)
     ) {
-      dispatch({type: 'checkpoint', payload: flamegraphRenderer.configView.clone()});
+      dispatch({type: 'checkpoint', payload: flamegraphRenderer.configView});
     }
   }, [lastInteraction, flamegraphRenderer, dispatch, previousInteraction]);
 
@@ -376,7 +376,7 @@ function FlamegraphZoomView({
 
     const onResetZoom = () => {
       flamegraphRenderer.resetConfigView();
-      dispatch({type: 'checkpoint', payload: flamegraphRenderer.configView.clone()});
+      dispatch({type: 'checkpoint', payload: flamegraphRenderer.configView});
       setConfigSpaceCursor(null);
       scheduler.draw();
     };
@@ -427,9 +427,7 @@ function FlamegraphZoomView({
         setCanvasBounds(new Rect(bounds.x, bounds.y, bounds.width, bounds.height));
 
         flamegraphRenderer.onResizeUpdateSpace();
-        canvasPoolManager.dispatch('setConfigView', [
-          flamegraphRenderer.configView.clone(),
-        ]);
+        canvasPoolManager.dispatch('setConfigView', [flamegraphRenderer.configView]);
         scheduler.drawSync();
       }
     );

--- a/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
@@ -236,7 +236,7 @@ function FlamegraphZoomViewMinimap({
 
     // Check if we are starting a new interaction
     if (previousInteraction === null && lastInteraction) {
-      beforeInteractionConfigView.current = flamegraphMiniMapRenderer.configView.clone();
+      beforeInteractionConfigView.current = flamegraphMiniMapRenderer.configView;
       return;
     }
 
@@ -246,7 +246,7 @@ function FlamegraphZoomViewMinimap({
     ) {
       dispatch({
         type: 'checkpoint',
-        payload: flamegraphMiniMapRenderer.configView.clone(),
+        payload: flamegraphMiniMapRenderer.configView,
       });
     }
   }, [lastInteraction, flamegraphMiniMapRenderer, dispatch, previousInteraction]);

--- a/static/app/components/profiling/profileDragDropImport.tsx
+++ b/static/app/components/profiling/profileDragDropImport.tsx
@@ -7,7 +7,7 @@ import {
   ProfileGroup,
 } from 'sentry/utils/profiling/profile/importProfile';
 
-interface ProfileImportProps {
+export interface ProfileDragDropImportProps {
   children: React.ReactNode;
   onImport: (profile: ProfileGroup) => void;
 }
@@ -15,7 +15,7 @@ interface ProfileImportProps {
 function ProfileDragDropImport({
   onImport,
   children,
-}: ProfileImportProps): React.ReactElement {
+}: ProfileDragDropImportProps): React.ReactElement {
   const [dropState, setDropState] = React.useState<'idle' | 'dragover' | 'processing'>(
     'idle'
   );

--- a/static/app/types/utils.tsx
+++ b/static/app/types/utils.tsx
@@ -19,3 +19,9 @@ export function isNotSharedOrganization(
 ): maybe is Organization {
   return typeof (maybe as Organization).id !== 'undefined';
 }
+
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -10,6 +10,7 @@ export class Flamegraph {
   profile: Profile;
   frames: FlamegraphFrame[] = [];
 
+  isEmpty: boolean = false;
   profileIndex: number;
 
   inverted?: boolean = false;
@@ -22,10 +23,12 @@ export class Flamegraph {
   frameIndex: Record<string, FlamegraphFrame> = {};
 
   static Empty(): Flamegraph {
-    return new Flamegraph(Profile.Empty(), 0, {
+    const flamegraph = new Flamegraph(Profile.Empty(), 0, {
       inverted: false,
       leftHeavy: false,
     });
+    flamegraph.isEmpty = true;
+    return flamegraph;
   }
 
   static From(from: Flamegraph, {inverted = false, leftHeavy = false}): Flamegraph {
@@ -39,7 +42,11 @@ export class Flamegraph {
       inverted = false,
       leftHeavy = false,
       configSpace,
-    }: {configSpace?: Rect; inverted?: boolean; leftHeavy?: boolean} = {}
+    }: {
+      configSpace?: Rect;
+      inverted?: boolean;
+      leftHeavy?: boolean;
+    } = {}
   ) {
     this.inverted = inverted;
     this.leftHeavy = leftHeavy;

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
@@ -5,8 +5,8 @@ export interface FlamegraphPreferences {
     | 'by library'
     | 'by recursion';
   sorting: 'left heavy' | 'call order';
-  synchronizeXAxisWithTransaction: boolean;
   view: 'top down' | 'bottom up';
+  xAxis: 'standalone' | 'transaction';
 }
 
 type FlamegraphPreferencesAction =
@@ -14,8 +14,8 @@ type FlamegraphPreferencesAction =
   | {payload: FlamegraphPreferences['sorting']; type: 'set sorting'}
   | {payload: FlamegraphPreferences['view']; type: 'set view'}
   | {
-      payload: FlamegraphPreferences['synchronizeXAxisWithTransaction'];
-      type: 'set synchronizeXAxisWithTransaction';
+      payload: FlamegraphPreferences['xAxis'];
+      type: 'set xAxis';
     };
 
 export function flamegraphPreferencesReducer(
@@ -41,8 +41,8 @@ export function flamegraphPreferencesReducer(
         view: action.payload,
       };
     }
-    case 'set synchronizeXAxisWithTransaction': {
-      return {...state, synchronizeXAxisWithTransaction: action.payload};
+    case 'set xAxis': {
+      return {...state, xAxis: action.payload};
     }
     default: {
       return state;

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
@@ -1,0 +1,22 @@
+type FlamegraphProfilesgAction = {
+  payload: number;
+  type: 'set active profile index';
+};
+
+type FlamegraphProfiles = {
+  activeProfileIndex: number | null;
+};
+
+export function flamegraphProfilesReducer(
+  state: FlamegraphProfiles,
+  action: FlamegraphProfilesgAction
+): FlamegraphProfiles {
+  switch (action.type) {
+    case 'set active profile index': {
+      return {activeProfileIndex: action.payload};
+    }
+    default: {
+      return state;
+    }
+  }
+}

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -1,30 +1,137 @@
-import {createContext} from 'react';
+import {createContext, useEffect} from 'react';
+import {browserHistory} from 'react-router';
+import {Query} from 'history';
 
+import {DeepPartial} from 'sentry/types/utils';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
 import {makeCombinedReducers} from 'sentry/utils/useCombinedReducer';
+import {useLocation} from 'sentry/utils/useLocation';
 import {
   UndoableReducer,
   UndoableReducerAction,
   useUndoableReducer,
 } from 'sentry/utils/useUndoableReducer';
 
+import {useFlamegraphStateValue} from '../useFlamegraphState';
+
 import {flamegraphPreferencesReducer} from './flamegraphPreferences';
+import {flamegraphProfilesReducer} from './flamegraphProfiles';
 import {flamegraphSearchReducer} from './flamegraphSearch';
 import {flamegraphZoomPositionReducer} from './flamegraphZoomPosition';
 
+// Intersect the types so we can properly guard
+type PossibleQuery =
+  | Query
+  | (Pick<FlamegraphState['preferences'], 'colorCoding' | 'sorting' | 'view' | 'xAxis'> &
+      Pick<FlamegraphState['search'], 'query'>);
+
+function isColorCoding(
+  value: PossibleQuery['colorCoding'] | FlamegraphState['preferences']['colorCoding']
+): value is FlamegraphState['preferences']['colorCoding'] {
+  return (
+    value === 'by symbol name' ||
+    value === 'by library' ||
+    value === 'by recursion' ||
+    value === 'by system / application'
+  );
+}
+
+function isSorting(
+  value: PossibleQuery['sorting'] | FlamegraphState['preferences']['sorting']
+): value is FlamegraphState['preferences']['sorting'] {
+  return value === 'left heavy' || value === 'call order';
+}
+
+function isView(
+  value: PossibleQuery['view'] | FlamegraphState['preferences']['view']
+): value is FlamegraphState['preferences']['view'] {
+  return value === 'top down' || value === 'bottom up';
+}
+
+function isXAxis(
+  value: PossibleQuery['xAxis'] | FlamegraphState['preferences']['xAxis']
+): value is FlamegraphState['preferences']['xAxis'] {
+  return value === 'standalone' || value === 'transaction';
+}
+
+export function decodeFlamegraphStateFromQueryParams(
+  query: Query
+): DeepPartial<FlamegraphState> {
+  return {
+    profiles: {
+      activeProfileIndex:
+        typeof query.profileIndex === 'string' && !isNaN(parseInt(query.profileIndex, 10))
+          ? parseInt(query.profileIndex, 10)
+          : null,
+    },
+    position: {view: Rect.decode(query.fov) ?? Rect.Empty()},
+    preferences: {
+      colorCoding: isColorCoding(query.colorCoding)
+        ? query.colorCoding
+        : DEFAULT_FLAMEGRAPH_STATE.preferences.colorCoding,
+      sorting: isSorting(query.sorting)
+        ? query.sorting
+        : DEFAULT_FLAMEGRAPH_STATE.preferences.sorting,
+      view: isView(query.view) ? query.view : DEFAULT_FLAMEGRAPH_STATE.preferences.view,
+      xAxis: isXAxis(query.xAxis)
+        ? query.xAxis
+        : DEFAULT_FLAMEGRAPH_STATE.preferences.xAxis,
+    },
+    search: {
+      query: typeof query.query === 'string' ? query.query : '',
+    },
+  };
+}
+
+function encodeFlamegraphStateToQueryParams(state: FlamegraphState) {
+  return {
+    colorCoding: state.preferences.colorCoding,
+    sorting: state.preferences.sorting,
+    view: state.preferences.view,
+    xAxis: state.preferences.xAxis,
+    query: state.search.query,
+    ...(state.position.view.isEmpty()
+      ? {fov: undefined}
+      : {fov: Rect.encode(state.position.view)}),
+    ...(typeof state.profiles.activeProfileIndex === 'number'
+      ? {profileIndex: state.profiles.activeProfileIndex}
+      : {}),
+  };
+}
+
 export const combinedReducers = makeCombinedReducers({
+  profiles: flamegraphProfilesReducer,
   position: flamegraphZoomPositionReducer,
   preferences: flamegraphPreferencesReducer,
   search: flamegraphSearchReducer,
 });
 
-type FlamegraphState = React.ReducerState<FlamegraphStateReducer>['current'];
-
+export type FlamegraphState = React.ReducerState<FlamegraphStateReducer>['current'];
 type FlamegraphAction = React.Dispatch<
   UndoableReducerAction<React.ReducerAction<FlamegraphStateReducer>>
 >;
 
 type FlamegraphStateReducer = UndoableReducer<typeof combinedReducers>;
+
+export function FlamegraphStateQueryParamSync() {
+  const location = useLocation();
+  const state = useFlamegraphStateValue();
+
+  useEffect(() => {
+    browserHistory.push({
+      ...location,
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        ...encodeFlamegraphStateToQueryParams(state),
+      },
+    });
+    // We only want to sync the query params when the state changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
+
+  return null;
+}
 
 export type FlamegraphStateContextValue = [
   FlamegraphState,
@@ -38,28 +145,52 @@ export type FlamegraphStateContextValue = [
 export const FlamegraphStateContext = createContext<FlamegraphStateContextValue | null>(
   null
 );
-
 interface FlamegraphStateProviderProps {
   children: React.ReactNode;
+  initialState?: DeepPartial<FlamegraphState>;
 }
+
+const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
+  profiles: {
+    activeProfileIndex: null,
+  },
+  position: {
+    view: Rect.Empty(),
+  },
+  preferences: {
+    colorCoding: 'by symbol name',
+    sorting: 'call order',
+    view: 'top down',
+    xAxis: 'standalone',
+  },
+  search: {
+    index: null,
+    results: null,
+    query: '',
+  },
+};
 
 export function FlamegraphStateProvider(
   props: FlamegraphStateProviderProps
 ): React.ReactElement {
   const reducer = useUndoableReducer(combinedReducers, {
+    profiles: {
+      ...DEFAULT_FLAMEGRAPH_STATE.profiles,
+      ...(props.initialState?.profiles ?? {}),
+    },
+    // @ts-ignore the view here never gets override, it's set as a default in the DEFAULT_FLAMEGRAPH_STATE
     position: {
-      view: Rect.Empty(),
+      ...DEFAULT_FLAMEGRAPH_STATE.position,
+      ...(props.initialState?.position ?? {}),
     },
     preferences: {
-      colorCoding: 'by symbol name',
-      sorting: 'call order',
-      view: 'top down',
-      synchronizeXAxisWithTransaction: false,
+      ...DEFAULT_FLAMEGRAPH_STATE.preferences,
+      ...(props.initialState?.preferences ?? {}),
     },
     search: {
-      index: null,
+      ...DEFAULT_FLAMEGRAPH_STATE.search,
+      ...(props.initialState?.search ?? {}),
       results: null,
-      query: '',
     },
   });
 

--- a/static/app/utils/profiling/flamegraph/useFlamegraphProfiles.tsx
+++ b/static/app/utils/profiling/flamegraph/useFlamegraphProfiles.tsx
@@ -1,0 +1,29 @@
+import {useContext} from 'react';
+
+import {
+  FlamegraphStateContext,
+  FlamegraphStateContextValue,
+} from './flamegraphStateProvider/index';
+
+export function useFlamegraphProfiles(): [
+  FlamegraphStateContextValue[0]['profiles'],
+  FlamegraphStateContextValue[1]
+] {
+  const context = useContext(FlamegraphStateContext);
+
+  if (context === null) {
+    throw new Error('useFlamegraphProfiles called outside of FlamegraphStateProvider');
+  }
+
+  return [context[0].profiles, context[1]];
+}
+
+export function useFlamegraphProfilesValue(): FlamegraphStateContextValue[0]['profiles'] {
+  const context = useContext(FlamegraphStateContext);
+
+  if (context === null) {
+    throw new Error('useFlamegraphProfiles called outside of FlamegraphStateProvider');
+  }
+
+  return context[0].profiles;
+}

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -231,6 +231,40 @@ export class Rect {
     return this.top + this.height;
   }
 
+  static decode(query: string | ReadonlyArray<string> | null | undefined): Rect | null {
+    let maybeEncodedRect = query;
+
+    if (typeof query === 'string') {
+      maybeEncodedRect = query.split(',');
+    }
+
+    if (!Array.isArray(maybeEncodedRect)) {
+      return null;
+    }
+
+    if (maybeEncodedRect.length !== 4) {
+      return null;
+    }
+
+    const rect = new Rect(
+      ...(maybeEncodedRect.map(p => parseFloat(p)) as [number, number, number, number])
+    );
+
+    if (rect.isValid()) {
+      return rect;
+    }
+
+    return null;
+  }
+
+  static encode(rect: Rect): string {
+    return rect.toString();
+  }
+
+  toString() {
+    return [this.x, this.y, this.width, this.height].map(n => Math.round(n)).join(',');
+  }
+
   toMatrix(): mat3 {
     const {width: w, height: h, x, y} = this;
     // it's easier to display a matrix as a 3x3 array. WebGl matrices are row first and not column first

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -360,6 +360,14 @@ export class Rect {
     return new Rect(this.x, this.y, width, this.height);
   }
 
+  withX(x: number): Rect {
+    return new Rect(x, this.y, this.width, this.height);
+  }
+
+  withY(y: number) {
+    return new Rect(this.x, y, this.width, this.height);
+  }
+
   toBounds(): [number, number, number, number] {
     return [this.x, this.y, this.x + this.width, this.y + this.height];
   }

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -577,6 +577,8 @@ class FlamegraphRenderer {
     const physicalToConfig = mat3.invert(mat3.create(), configViewToPhysicalSpace);
     const configSpacePixel = physicalSpacePixel.transformRect(physicalToConfig);
 
+    // Reset the uniform values from previous draw
+    this.gl.uniform1i(this.uniforms.u_is_search_result, 0);
     this.gl.uniform2f(
       this.uniforms.u_border_width,
       configSpacePixel.width,
@@ -612,7 +614,6 @@ class FlamegraphRenderer {
       this.gl.uniform1i(this.uniforms.u_is_search_result, 0);
       for (let i = 0; i < length; i++) {
         const vertexOffset = i * VERTICES;
-
         this.gl.drawArrays(this.gl.TRIANGLES, vertexOffset, VERTICES);
       }
     }

--- a/static/app/utils/useUndoableReducer.tsx
+++ b/static/app/utils/useUndoableReducer.tsx
@@ -1,4 +1,4 @@
-import {ReducerAction, ReducerState, useReducer} from 'react';
+import {ReducerAction, ReducerState, useMemo, useReducer} from 'react';
 
 export type UndoableNode<S> = {
   current: S;
@@ -80,7 +80,9 @@ export function useUndoableReducer<
     previousState: ReducerState<R> | undefined;
   }
 ] {
-  const [state, dispatch] = useReducer(makeUndoableReducer(reducer), {
+  // In dev, react will test the purity of the reducer, so it may sometimes fire actions multiple times.
+  const finalReducer = useMemo(() => makeUndoableReducer(reducer), [reducer]);
+  const [state, dispatch] = useReducer(finalReducer, {
     current: initialState,
     previous: undefined,
     next: undefined,

--- a/static/app/views/profiling/flamegraph.tsx
+++ b/static/app/views/profiling/flamegraph.tsx
@@ -95,6 +95,7 @@ function FlamegraphView(props: FlamegraphViewProps): React.ReactElement {
     return {
       ...decodedState,
       profiles: {
+        // We either initialize from query param or from the response
         activeProfileIndex:
           decodedState?.profiles?.activeProfileIndex ??
           requestState.data.activeProfileIndex ??
@@ -137,28 +138,28 @@ function FlamegraphView(props: FlamegraphViewProps): React.ReactElement {
 
   return (
     <SentryDocumentTitle title={t('Profiling')} orgSlug={organization.slug}>
-      <Fragment>
-        <Layout.Header>
-          <Layout.HeaderContent>
-            <Breadcrumb
-              location={props.location}
-              organization={organization}
-              trails={[
-                {type: 'profiling'},
-                {
-                  type: 'flamegraph',
-                  payload: {
-                    interactionName:
-                      requestState.type === 'resolved' ? requestState.data.name : '',
-                    profileId: props.params.eventId ?? '',
-                    projectSlug: props.params.projectId ?? '',
+      <FlamegraphStateProvider initialState={initialFlamegraphPreferencesState}>
+        <Fragment>
+          <Layout.Header>
+            <Layout.HeaderContent>
+              <Breadcrumb
+                location={props.location}
+                organization={organization}
+                trails={[
+                  {type: 'profiling'},
+                  {
+                    type: 'flamegraph',
+                    payload: {
+                      interactionName:
+                        requestState.type === 'resolved' ? requestState.data.name : '',
+                      profileId: props.params.eventId ?? '',
+                      projectSlug: props.params.projectId ?? '',
+                    },
                   },
-                },
-              ]}
-            />
-          </Layout.HeaderContent>
-        </Layout.Header>
-        <FlamegraphStateProvider initialState={initialFlamegraphPreferencesState}>
+                ]}
+              />
+            </Layout.HeaderContent>
+          </Layout.Header>
           <FlamegraphStateQueryParamSync />
           <FlamegraphThemeProvider>
             <FlamegraphContainer>
@@ -178,8 +179,8 @@ function FlamegraphView(props: FlamegraphViewProps): React.ReactElement {
               ) : null}
             </FlamegraphContainer>
           </FlamegraphThemeProvider>
-        </FlamegraphStateProvider>
-      </Fragment>
+        </Fragment>
+      </FlamegraphStateProvider>
     </SentryDocumentTitle>
   );
 }

--- a/static/app/views/profiling/flamegraph.tsx
+++ b/static/app/views/profiling/flamegraph.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {Location} from 'history';
@@ -9,6 +9,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Breadcrumb} from 'sentry/components/profiling/breadcrumb';
 import {Flamegraph} from 'sentry/components/profiling/flamegraph';
+import {ProfileDragDropImportProps} from 'sentry/components/profiling/profileDragDropImport';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
@@ -98,6 +99,10 @@ function FlamegraphView(props: FlamegraphViewProps): React.ReactElement {
     };
   }, [props.params.eventId, props.params.projectId, api, organization]);
 
+  const onImport: ProfileDragDropImportProps['onImport'] = useCallback(profileGroup => {
+    setRequestState({type: 'resolved', data: profileGroup});
+  }, []);
+
   return (
     <SentryDocumentTitle title={t('Profiling')} orgSlug={organization.slug}>
       <Fragment>
@@ -130,7 +135,7 @@ function FlamegraphView(props: FlamegraphViewProps): React.ReactElement {
                 </Alert>
               ) : requestState.type === 'loading' ? (
                 <Fragment>
-                  <Flamegraph profiles={LoadingGroup} />
+                  <Flamegraph onImport={onImport} profiles={LoadingGroup} />
                   <LoadingIndicatorContainer>
                     <LoadingIndicator />
                   </LoadingIndicatorContainer>

--- a/tests/js/spec/utils/useUndoableReducer.spec.tsx
+++ b/tests/js/spec/utils/useUndoableReducer.spec.tsx
@@ -170,12 +170,13 @@ describe('makeUndoableReducer', () => {
       useReducer(makeUndoableReducer(combinedReducers), {
         previous: undefined,
         current: {
+          profiles: {activeProfileIndex: 0},
           position: {view: Rect.Empty()},
           preferences: {
             colorCoding: 'by symbol name',
             sorting: 'call order',
             view: 'top down',
-            synchronizeXAxisWithTransaction: false,
+            xAxis: 'standalone',
           },
           search: {
             index: null,


### PR DESCRIPTION
This PR adds syncing of flamegraph state with query string (and initializing from it), meaning flamegraph views can now be shared via URL. I lifted the importProfile code and activeProfileIndex out of the flamegraph to avoid reading it from multiple places and somewhat centralize it... In general, I'm not very happy with how state management is evolving (the side effects are getting hard to track) and not being able to test this is starting to weigh down on us (webgl initialize calls fail in node). 

I dont expect us to do many more changes to the state management in the near future, but we should think about how we can improve it.

![CleanShot 2022-04-26 at 14 21 32](https://user-images.githubusercontent.com/9317857/165366682-ced134a3-87e4-4e0d-88d5-2c985c24ad01.gif)

