### PR TITLE
feat(dashboard): Display projects as slugs for release health widget

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -296,10 +296,16 @@ const SPECIAL_FIELDS: SpecialFields = {
   project: {
     sortField: 'project',
     renderFunc: (data, {organization}) => {
-      const slugs = typeof data.project === 'number' ? undefined : [data.project];
+      let slugs: string[] | undefined = undefined;
+      let projectIds: number[] | undefined = undefined;
+      if (typeof data.project === 'number') {
+        projectIds = [data.project];
+      } else {
+        slugs = [data.project];
+      }
       return (
         <Container>
-          <Projects orgId={organization.slug} slugs={slugs}>
+          <Projects orgId={organization.slug} slugs={slugs} projectIds={projectIds}>
             {({projects}) => {
               let project: Project | AvatarProject | undefined;
               if (typeof data.project === 'number') {

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -15,7 +15,7 @@ import Tooltip from 'sentry/components/tooltip';
 import UserMisery from 'sentry/components/userMisery';
 import Version from 'sentry/components/version';
 import {t} from 'sentry/locale';
-import {Organization, Project} from 'sentry/types';
+import {AvatarProject, Organization, Project} from 'sentry/types';
 import {defined, isUrl} from 'sentry/utils';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import EventView, {EventData, MetaType} from 'sentry/utils/discover/eventView';
@@ -31,13 +31,12 @@ import {
 import {getShortEventId} from 'sentry/utils/events';
 import {formatFloat, formatPercentage} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import Projects from 'sentry/utils/projects';
 import {
   filterToLocationQuery,
   SpanOperationBreakdownFilter,
   stringToFilter,
 } from 'sentry/views/performance/transactionSummary/filter';
-
-import useProjects from '../useProjects';
 
 import ArrayValue from './arrayValue';
 import {
@@ -297,20 +296,24 @@ const SPECIAL_FIELDS: SpecialFields = {
   project: {
     sortField: 'project',
     renderFunc: (data, {organization}) => {
-      let project: Project | undefined;
-      if (typeof data.project === 'number') {
-        const {projects} = useProjects({orgId: organization.id});
-        project = projects.find(p => p.id === data.project.toString());
-      } else {
-        const {projects} = useProjects({slugs: [data.project], orgId: organization.id});
-        project = projects.find(p => p.slug === data.project);
-      }
       return (
         <Container>
-          <ProjectBadge
-            project={project ? project : {slug: data.project}}
-            avatarSize={16}
-          />
+          <Projects orgId={organization.slug}>
+            {({projects}) => {
+              let project: Project | AvatarProject | undefined;
+              if (typeof data.project === 'number') {
+                project = projects.find(p => p.id === data.project.toString());
+              } else {
+                project = projects.find(p => p.slug === data.project);
+              }
+              return (
+                <ProjectBadge
+                  project={project ? project : {slug: data.project}}
+                  avatarSize={16}
+                />
+              );
+            }}
+          </Projects>
         </Container>
       );
     },

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -15,7 +15,7 @@ import Tooltip from 'sentry/components/tooltip';
 import UserMisery from 'sentry/components/userMisery';
 import Version from 'sentry/components/version';
 import {t} from 'sentry/locale';
-import {Organization} from 'sentry/types';
+import {Organization, Project} from 'sentry/types';
 import {defined, isUrl} from 'sentry/utils';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import EventView, {EventData, MetaType} from 'sentry/utils/discover/eventView';
@@ -31,12 +31,13 @@ import {
 import {getShortEventId} from 'sentry/utils/events';
 import {formatFloat, formatPercentage} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import Projects from 'sentry/utils/projects';
 import {
   filterToLocationQuery,
   SpanOperationBreakdownFilter,
   stringToFilter,
 } from 'sentry/views/performance/transactionSummary/filter';
+
+import useProjects from '../useProjects';
 
 import ArrayValue from './arrayValue';
 import {
@@ -296,19 +297,20 @@ const SPECIAL_FIELDS: SpecialFields = {
   project: {
     sortField: 'project',
     renderFunc: (data, {organization}) => {
+      let project: Project | undefined;
+      if (typeof data.project === 'number') {
+        const {projects} = useProjects({orgId: organization.id});
+        project = projects.find(p => p.id === data.project.toString());
+      } else {
+        const {projects} = useProjects({slugs: [data.project], orgId: organization.id});
+        project = projects.find(p => p.slug === data.project);
+      }
       return (
         <Container>
-          <Projects orgId={organization.slug} slugs={[data.project]}>
-            {({projects}) => {
-              const project = projects.find(p => p.slug === data.project);
-              return (
-                <ProjectBadge
-                  project={project ? project : {slug: data.project}}
-                  avatarSize={16}
-                />
-              );
-            }}
-          </Projects>
+          <ProjectBadge
+            project={project ? project : {slug: data.project}}
+            avatarSize={16}
+          />
         </Container>
       );
     },

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -296,9 +296,10 @@ const SPECIAL_FIELDS: SpecialFields = {
   project: {
     sortField: 'project',
     renderFunc: (data, {organization}) => {
+      const slugs = typeof data.project === 'number' ? undefined : [data.project];
       return (
         <Container>
-          <Projects orgId={organization.slug}>
+          <Projects orgId={organization.slug} slugs={slugs}>
             {({projects}) => {
               let project: Project | AvatarProject | undefined;
               if (typeof data.project === 'number') {

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -108,6 +108,11 @@ type Props = {
   limit?: number;
 
   /**
+   * List of project ids to look for summaries for, this can be from `props.projects`,
+   * otherwise fetch from API
+   */
+  projectIds?: number[];
+  /**
    * List of slugs to look for summaries for, this can be from `props.projects`,
    * otherwise fetch from API
    */
@@ -132,10 +137,12 @@ class BaseProjects extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    const {slugs} = this.props;
+    const {slugs, projectIds} = this.props;
 
     if (!!slugs?.length) {
       this.loadSpecificProjects();
+    } else if (!!projectIds?.length) {
+      this.loadSpecificProjectsFromIds();
     } else {
       this.loadAllProjects();
     }
@@ -181,6 +188,13 @@ class BaseProjects extends React.Component<Props, State> {
   );
 
   /**
+   * Memoized function that returns a `Map<project.id, project>`
+   */
+  getProjectsIdMap: (projects: Project[]) => Map<number, Project> = memoize(
+    projects => new Map(projects.map(project => [parseInt(project.id, 10), project]))
+  );
+
+  /**
    * When `props.slugs` is included, identifies what projects we already
    * have summaries for and what projects need to be fetched from API
    */
@@ -212,6 +226,34 @@ class BaseProjects extends React.Component<Props, State> {
     }
 
     this.fetchSpecificProjects();
+  };
+
+  /**
+   * When `props.projectIds` is included, identifies if we already
+   * have summaries them, otherwise fetches all projects from API
+   */
+  loadSpecificProjectsFromIds = () => {
+    const {projectIds, projects} = this.props;
+
+    const projectsMap = this.getProjectsIdMap(projects);
+
+    // Split projectIds into projects that are in store and not in store
+    // (so we can request projects not in store)
+    const [inStore, notInStore] = partition(projectIds, id => projectsMap.has(id));
+
+    if (notInStore.length) {
+      this.loadAllProjects();
+      return;
+    }
+
+    // Get the actual summaries of projects that are in store
+    const projectsFromStore = inStore.map(id => projectsMap.get(id)).filter(defined);
+
+    this.setState({
+      // set initiallyLoaded if any projects were fetched from store
+      initiallyLoaded: !!inStore.length,
+      projectsFromStore,
+    });
   };
 
   /**

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -63,6 +63,11 @@ describe('getFieldRenderer', function () {
       url: `/organizations/${organization.slug}/key-transactions/`,
       method: 'DELETE',
     });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [project],
+    });
   });
 
   it('can render string fields', function () {
@@ -226,6 +231,23 @@ describe('getFieldRenderer', function () {
       renderer(data, {location, organization}),
       context.routerContext
     );
+
+    const value = wrapper.find('ProjectBadge');
+    expect(value).toHaveLength(1);
+    expect(value.text()).toEqual(project.slug);
+  });
+
+  it('can render project id as an avatar', async function () {
+    const renderer = getFieldRenderer('project', {project: 'number'});
+
+    data = {...data, project: parseInt(project.id, 10)};
+
+    const wrapper = mountWithTheme(
+      renderer(data, {location, organization}),
+      context.routerContext
+    );
+
+    await tick();
 
     const value = wrapper.find('ProjectBadge');
     expect(value).toHaveLength(1);

--- a/tests/js/spec/utils/projects.spec.jsx
+++ b/tests/js/spec/utils/projects.spec.jsx
@@ -235,6 +235,100 @@ describe('utils.projects', function () {
     });
   });
 
+  describe('with predefined list of project ids', function () {
+    it('gets project ids that are in the ProjectsStore', async function () {
+      createWrapper({projectIds: [1, 2]});
+
+      // This is initial state
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fetching: false,
+          isIncomplete: null,
+          hasMore: null,
+          projects: [
+            expect.objectContaining({
+              id: '1',
+              slug: 'foo',
+            }),
+            expect.objectContaining({
+              id: '2',
+              slug: 'bar',
+            }),
+          ],
+        })
+      );
+    });
+
+    it('fetches projects from API if ids not found in store', async function () {
+      const request = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/projects/',
+        query: {
+          all_projects: '1',
+          collapse: ['latestDeploys'],
+        },
+        body: [
+          TestStubs.Project({
+            id: '1',
+            slug: 'foo',
+          }),
+          TestStubs.Project({
+            id: '100',
+            slug: 'a',
+          }),
+          TestStubs.Project({
+            id: '101',
+            slug: 'b',
+          }),
+        ],
+      });
+
+      createWrapper({projectIds: [1, 100, 101]});
+
+      // This is initial state
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fetching: true,
+          isIncomplete: null,
+          hasMore: null,
+          projects: [],
+        })
+      );
+
+      await waitFor(() =>
+        expect(request).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            query: {
+              collapse: ['latestDeploys'],
+            },
+          })
+        )
+      );
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fetching: false,
+          isIncomplete: null,
+          hasMore: false,
+          projects: [
+            expect.objectContaining({
+              id: '1',
+              slug: 'foo',
+            }),
+            expect.objectContaining({
+              id: '100',
+              slug: 'a',
+            }),
+            expect.objectContaining({
+              id: '101',
+              slug: 'b',
+            }),
+          ],
+        })
+      );
+    });
+  });
+
   describe('with no pre-defined projects', function () {
     let request;
 


### PR DESCRIPTION
The sessions api returns project ids, we want to display
them as project slugs, so updating the projects utils
to accept a list of project ids and return project summaries
if they are in the project store, otherwise load all projects.