### PR TITLE
style(replay): Set a default background color behind replays

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -16,6 +16,7 @@ interface Props {
 
 function BasePlayerRoot({className}: Props) {
   const {isFullscreen} = useFullscreen();
+
   // In fullscreen we need to consider the max-height that the player is able
   // to full up, on a page that scrolls we only consider the max-width.
   const fixedHeight = isFullscreen;

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -16,7 +16,6 @@ interface Props {
 
 function BasePlayerRoot({className}: Props) {
   const {isFullscreen} = useFullscreen();
-
   // In fullscreen we need to consider the max-height that the player is able
   // to full up, on a page that scrolls we only consider the max-width.
   const fixedHeight = isFullscreen;
@@ -135,6 +134,9 @@ const Centered = styled('div')`
 
 // Base styles, to make the Replayer instance work
 const PlayerRoot = styled(BasePlayerRoot)`
+  .replayer-wrapper {
+    background: white;
+  }
   .replayer-wrapper > .replayer-mouse-tail {
     position: absolute;
     pointer-events: none;

--- a/static/app/components/replays/useFullscreen.tsx
+++ b/static/app/components/replays/useFullscreen.tsx
@@ -74,7 +74,7 @@ export default function useFullscreen(): FullscreenHook {
   useEffect(() => {
     screenfull.on('change', onChange);
     return () => screenfull.off('change', onChange);
-  });
+  }, [screenfull]);
 
   return {
     enter,


### PR DESCRIPTION
If a captured site doesn't set their own `background-color`, usually on the `<html>` node or `<body>`, then they're relying on the browser default `background: white` to show through. 

We need to include that default background color so that in fullscreen mode we can more clearly show boundaries between the capture and any extra space surrounding it.

Here's a corner from a captured site:

**Before**
<img width="428" alt="Screen Shot 2022-04-26 at 12 39 40 PM" src="https://user-images.githubusercontent.com/187460/165379640-1b0a0110-1821-4813-87ee-d13da32b6ad3.png">

**After**
<img width="354" alt="Screen Shot 2022-04-26 at 12 39 19 PM" src="https://user-images.githubusercontent.com/187460/165379659-113cfa5a-ad46-4838-8538-6f3e1f57c8ee.png">

And in dark mode (we always have the same purple)
Before
<img width="379" alt="Screen Shot 2022-04-26 at 12 39 35 PM" src="https://user-images.githubusercontent.com/187460/165379735-3805f924-4605-4664-85cd-7e26e811192e.png">

After
<img width="448" alt="Screen Shot 2022-04-26 at 12 39 27 PM" src="https://user-images.githubusercontent.com/187460/165379742-cd2e8f96-4f8d-402a-8992-b2fefa8e2341.png">


Fixes #33934
