### PR TITLE
feat(basemanager): Add use_replica flag for get_from_cache

### DIFF
--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -259,6 +259,8 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
             retval = cache.get(cache_key, version=self.cache_version)
             if retval is None:
                 result = self.using_replica().get(**kwargs) if use_replica else self.get(**kwargs)
+                # need to satisfy mypy
+                assert result
                 # Ensure we're pushing it into the cache
                 self.__post_save(instance=result)
                 if local_cache is not None:

--- a/src/sentry/sentry_metrics/indexer/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres_v2.py
@@ -169,7 +169,11 @@ class PGStringIndexerV2(StringIndexer):
 
         metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "false", "caller": "resolve"})
         try:
-            id: int = StringIndexerTable.objects.get(organization_id=org_id, string=string).id
+            id: int = (
+                StringIndexerTable.objects.using_replica()
+                .get(organization_id=org_id, string=string)
+                .id
+            )
         except StringIndexerTable.DoesNotExist:
             return None
         indexer_cache.set(key, id)
@@ -182,7 +186,7 @@ class PGStringIndexerV2(StringIndexer):
         Returns None if the entry cannot be found.
         """
         try:
-            string: str = StringIndexerTable.objects.get_from_cache(id=id).string
+            string: str = StringIndexerTable.objects.get_from_cache(id=id, use_replica=True).string
         except StringIndexerTable.DoesNotExist:
             return None
 


### PR DESCRIPTION
**context**
The metrics indexer interface can be separated into two different concerns (and therefore two groups of methods)[^1]:
* methods that are needed for the ingestion pipeline for metrics data - the metrics indexer consumer in this case uses `bulk_record`
* methods that are needed to serve queries to the product - `resolve` and `reverse_resolve` here are used to look up ints (from strs) in order to make queries to snuba and to look up strs (from ints) in order to display snuba query results in a meaningful way to the user.

**situation**
we don't want queries from the product taking down the ingestion pipeline, so in order to achieve that, we can have product queries solely read from replicas.

We already have `using_replica()` at our disposal. However, for queries that use `get_from_cache` we can't actually use that. `using_replica()` only on a `BaseQuerySet` whereas the `get_from_cache` method is on the `BaseManager`.

For this reason I'm introducing a `use_replica` arg to `get_from_cache`.[^2]

[^1]: the `record` method is also available but it is only used in testing
[^2]: i'm not editing `get_many_from_cache` since we don't need that _yet_ from the indexer interface, but we will once we add `bulk_reverse_resolve`. 

**test plan**
- [x] needs https://github.com/getsentry/ops/pull/4632 first
- [x] as well as https://github.com/getsentry/getsentry/pull/7409
- [x] I plan on testing this on staging and in datadog I should be able to see whether the db replica is used for db queries: **I couldn't seem to get confirmation that this worked on staging, but I'm not sure if that's due to the staging env limitations. However, I didn't see any errors so I'm going to merge as is**