### PR TITLE
fix(buffer): Fix noisy error when processing buffer entries for a group that no longer exists

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -82,8 +82,14 @@ class Buffer(Service, metaclass=BufferMount):
                 # ends up in the cache. This causes issues when handling issue alerts, and likely
                 # elsewhere. Use `update` here since we're already special casing, and we know that
                 # the group will already exist.
-                group = Group.objects.get(**filters)
-                group.update(**update_kwargs)
+                try:
+                    group = Group.objects.get(**filters)
+                except Group.DoesNotExist:
+                    # If the group was deleted by the time we flush buffers we don't care, just
+                    # continue
+                    pass
+                else:
+                    group.update(**update_kwargs)
                 created = False
             else:
                 _, created = model.objects.create_or_update(values=update_kwargs, **filters)


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/getsentry/sentry/pull/33950. Previously, when updating
values for groups we would use `create_or_update` to update the row. If the row had been deleted, we
would attempt to update it, affect no rows, then attempt to create it, fail due to not providing
values for not-null columns, catch the integrity error, attemp to update again, do nothing and then
return.

Now we attempt to fetch the row explicitly and raise a `DoesNotExist` exception. We don't actually
care that the row doesn't exist, so just catch the exception and continue on.

Fixes SENTRY-TWB