### PR TITLE
chore(snql): Remove facets usage of raw query

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -325,7 +325,7 @@ def query_top_tags(
             query=filter_query,
             params=params,
             orderby=orderby,
-            extra_snql_condition=[
+            conditions=[
                 Condition(Column(translated_aggregate_column), Op.IS_NOT_NULL),
                 Condition(Column("tags_key"), Op.EQ, tag_key),
             ],
@@ -482,10 +482,6 @@ def query_facet_performance_key_histogram(
         precision=precision,
         group_by=["tags_value", "tags_key"],
         extra_conditions=[
-            ["tags_key", "IN", [tag_key]],
-            ["tags_value", "IN", tag_values],
-        ],
-        extra_snql_condition=[
             Condition(Column("tags_key"), Op.EQ, tag_key),
             Condition(Column("tags_value"), Op.IN, tag_values),
         ],

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -204,7 +204,6 @@ def query(
     allow_metric_aggregates=False,
     use_aggregate_conditions=False,
     conditions=None,
-    extra_snql_condition=None,
     functions_acl=None,
 ):
     """
@@ -232,9 +231,8 @@ def query(
                     equations
     allow_metric_aggregates (bool) Ignored here, only used in metric enhanced performance
     use_aggregate_conditions (bool) Set to true if aggregates conditions should be used at all.
-    conditions (Sequence[any]) List of conditions that are passed directly to snuba without
+    conditions (Sequence[Condition]) List of conditions that are passed directly to snuba without
                     any additional processing.
-    extra_snql_condition (Sequence[Condition]) Replacement for conditions while migrating to snql
     """
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")
@@ -254,8 +252,8 @@ def query(
         offset=offset,
         equation_config={"auto_add": include_equation_fields},
     )
-    if extra_snql_condition is not None:
-        builder.add_conditions(extra_snql_condition)
+    if conditions is not None:
+        builder.add_conditions(conditions)
     result = builder.run_query(referrer)
     with sentry_sdk.start_span(
         op="discover.discover", description="query.transform_results"
@@ -773,7 +771,6 @@ def histogram_query(
     limit_by=None,
     histogram_rows=None,
     extra_conditions=None,
-    extra_snql_condition=None,
     normalize_results=True,
 ):
     """
@@ -798,8 +795,7 @@ def histogram_query(
     :param [str] order_by: Allows additional ordering within each alias to serve multifacet histograms.
     :param [str] limit_by: Allows limiting within a group when serving multifacet histograms.
     :param int histogram_rows: Used to modify the limit when fetching multiple rows of buckets (performance facets).
-    :param [str] extra_conditions: Adds any additional conditions to the histogram query that aren't received from params.
-    :param [Condition] extra_snql_condition: Replacement for extra_condition while migrating to snql
+    :param [Condition] extra_conditions: Adds any additional conditions to the histogram query that aren't received from params.
     :param bool normalize_results: Indicate whether to normalize the results by column into bins.
     """
 
@@ -857,8 +853,8 @@ def histogram_query(
         orderby=order_by,
         limitby=limit_by,
     )
-    if extra_snql_condition is not None:
-        builder.add_conditions(extra_snql_condition)
+    if extra_conditions is not None:
+        builder.add_conditions(extra_conditions)
     results = builder.run_query(referrer)
 
     if not normalize_results:

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -48,7 +48,6 @@ def query(
     use_aggregate_conditions=False,
     allow_metric_aggregates=True,
     conditions=None,
-    extra_snql_condition=None,
     functions_acl=None,
     dry_run=False,
 ):
@@ -125,7 +124,6 @@ def query(
             auto_aggregations=auto_aggregations,
             use_aggregate_conditions=use_aggregate_conditions,
             conditions=conditions,
-            extra_snql_condition=extra_snql_condition,
             functions_acl=functions_acl,
         )
         results["meta"]["isMetricsData"] = False

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
@@ -156,6 +156,7 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
             }
         )
 
+        assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
         assert data[0]["count"] == 5
@@ -197,6 +198,7 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
 
         # With feature access
         response = self.do_request(request)
+        assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 5
         assert data[0]["count"] == 19
@@ -217,6 +219,7 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
         }
 
         response = self.do_request(request)
+        assert response.status_code == 200, response.content
 
         data = response.data["data"]
         assert len(data) == 5
@@ -237,6 +240,7 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
         }
         # With feature access
         response = self.do_request(request)
+        assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 3
         assert data[0]["count"] == 14
@@ -257,6 +261,7 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
         }
 
         response = self.do_request(request)
+        assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
         assert data[0]["count"] == 1


### PR DESCRIPTION
- This removes the raw_query call in the facets endpoint since that's
  still the old json syntax
- Replacing it with QueryBuilder calls instead