### PR TITLE
ref(auditlog): Update audit log api endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -40,11 +40,10 @@ class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
         if "actor" in query:
             queryset = queryset.filter(actor=query["actor"])
 
-        if "event" in query:
-            if query["event"] is None:
-                queryset = queryset.none()
-            else:
-                queryset = queryset.filter(event=query["event"])
+        if "event" in query and query.get("event") is not None:
+            queryset = queryset.filter(event=query["event"])
+        if query.get("event") is None:
+            queryset = queryset.none()
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -40,10 +40,11 @@ class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
         if "actor" in query:
             queryset = queryset.filter(actor=query["actor"])
 
-        if "event" in query and query.get("event") is not None:
-            queryset = queryset.filter(event=query["event"])
-        if query.get("event") is None:
-            queryset = queryset.none()
+        if "event" in query:
+            if query.get("event") is None:
+                queryset = queryset.none()
+            else:
+                queryset = queryset.filter(event=query["event"])
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -2,14 +2,14 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import audit_log
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationAuditPermission
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
+from sentry.audit_log.manager import AuditLogEventNotRegistered
 from sentry.db.models.fields.bounded import BoundedIntegerField
 from sentry.models import AuditLogEntry
-
-EVENT_REVERSE_MAP = {v: k for k, v in AuditLogEntry._meta.get_field("event").choices}
 
 
 class AuditLogQueryParamSerializer(serializers.Serializer):
@@ -18,9 +18,10 @@ class AuditLogQueryParamSerializer(serializers.Serializer):
     actor = serializers.IntegerField(required=False, max_value=BoundedIntegerField.MAX_VALUE)
 
     def validate_event(self, event):
-        if event not in EVENT_REVERSE_MAP:
-            raise serializers.ValidationError("Invalid audit log event")
-        return EVENT_REVERSE_MAP[event]
+        try:
+            return audit_log.get_event_id_from_api_name(event)
+        except AuditLogEventNotRegistered:
+            return None
 
 
 class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
@@ -40,7 +41,10 @@ class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
             queryset = queryset.filter(actor=query["actor"])
 
         if "event" in query:
-            queryset = queryset.filter(event=query["event"])
+            if query["event"] is None:
+                queryset = queryset.none()
+            else:
+                queryset = queryset.filter(event=query["event"])
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/serializers/models/auditlogentry.py
+++ b/src/sentry/api/serializers/models/auditlogentry.py
@@ -1,5 +1,6 @@
 from django.db.models import prefetch_related_objects
 
+from sentry import audit_log
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import AuditLogEntry
 
@@ -42,12 +43,13 @@ class AuditLogEntrySerializer(Serializer):
         }
 
     def serialize(self, obj, attrs, user):
+        audit_log_event = audit_log.get(obj.event)
         return {
             "id": str(obj.id),
             "actor": attrs["actor"],
-            "event": obj.get_event_display(),
+            "event": audit_log_event.api_name,
             "ipAddress": obj.ip_address,
-            "note": obj.get_note(),
+            "note": audit_log_event.render(obj),
             "targetObject": obj.target_object,
             "targetUser": attrs["targetUser"],
             "data": fix(obj.data),

--- a/src/sentry/audit_log/__init__.py
+++ b/src/sentry/audit_log/__init__.py
@@ -2,8 +2,8 @@ from sentry.audit_log.manager import *  # NOQA
 from sentry.audit_log.register import default_manager
 
 # expose public api
-
 add = default_manager.add
 get = default_manager.get
 get_event_id = default_manager.get_event_id
 get_api_names = default_manager.get_api_names
+get_event_id_from_api_name = default_manager.get_event_id_from_api_name

--- a/src/sentry/audit_log/manager.py
+++ b/src/sentry/audit_log/manager.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
-from sentry_sdk import capture_exception
-
 from sentry.models.auditlogentry import AuditLogEntry
 
 
@@ -82,21 +80,20 @@ class AuditLogEventManager:
     def __init__(self) -> None:
         self._event_registry = {}
         self._event_id_lookup = {}
+        self._api_name_lookup = {}
 
     def add(self, audit_log_event: AuditLogEvent):
         if (
             audit_log_event.name in self._event_registry
             or audit_log_event.event_id in self._event_id_lookup
         ):
-            capture_exception(
-                DuplicateAuditLogEvent(
-                    f"Duplicate audit log: {audit_log_event.name} with ID {audit_log_event.event_id}"
-                )
+            raise DuplicateAuditLogEvent(
+                f"Duplicate audit log: {audit_log_event.name} with ID {audit_log_event.event_id}"
             )
-            return
 
         self._event_registry[audit_log_event.name] = audit_log_event
         self._event_id_lookup[audit_log_event.event_id] = audit_log_event
+        self._api_name_lookup[audit_log_event.api_name] = audit_log_event
 
     def get(self, event_id: int) -> AuditLogEvent:
         if event_id not in self._event_id_lookup:
@@ -108,9 +105,10 @@ class AuditLogEventManager:
             raise AuditLogEventNotRegistered(f"Event {name} does not exist")
         return self._event_registry[name].event_id
 
+    def get_event_id_from_api_name(self, api_name: str) -> int:
+        if api_name not in self._api_name_lookup:
+            return None
+        return self._api_name_lookup[api_name].event_id
+
     def get_api_names(self) -> List[str]:
-        # returns a list of all the api names
-        api_names: list = []
-        for audit_log_event in self._event_registry.values():
-            api_names.append(audit_log_event.api_name)
-        return api_names
+        return self._api_name_lookup.keys()

--- a/src/sentry/audit_log/manager.py
+++ b/src/sentry/audit_log/manager.py
@@ -86,9 +86,10 @@ class AuditLogEventManager:
         if (
             audit_log_event.name in self._event_registry
             or audit_log_event.event_id in self._event_id_lookup
+            or audit_log_event.api_name in self._api_name_lookup
         ):
             raise DuplicateAuditLogEvent(
-                f"Duplicate audit log: {audit_log_event.name} with ID {audit_log_event.event_id}"
+                f"Duplicate audit log: {audit_log_event.name} with ID {audit_log_event.event_id} and api name {audit_log_event.api_name}"
             )
 
         self._event_registry[audit_log_event.name] = audit_log_event

--- a/tests/sentry/audit_log/test_manager.py
+++ b/tests/sentry/audit_log/test_manager.py
@@ -64,7 +64,7 @@ class AuditLogEventManagerTest(TestCase):
         with self.assertRaises(AuditLogEventNotRegistered):
             test_manager.get_event_id(name="TEST_DUPLICATE")
 
-    def test_duplicate_event(self):
+    def test_duplicate_event_name(self):
         test_manager = AuditLogEventManager()
 
         test_manager.add(
@@ -86,6 +86,31 @@ class AuditLogEventManagerTest(TestCase):
             )
         assert test_manager.get_event_id(name="TEST_LOG_ENTRY") == 500
         assert "test.duplicate" not in test_manager.get_api_names()
+
+        with self.assertRaises(AuditLogEventNotRegistered):
+            test_manager.get(501)
+
+    def test_duplicate_api_name(self):
+        test_manager = AuditLogEventManager()
+
+        test_manager.add(
+            AuditLogEvent(
+                event_id=500,
+                name="TEST_LOG_ENTRY",
+                api_name="test-log.entry",
+                template="test member {email} is {role}",
+            )
+        )
+        with self.assertRaises(DuplicateAuditLogEvent):
+            test_manager.add(
+                AuditLogEvent(
+                    event_id=501,
+                    name="TEST_DUPLICATE",
+                    api_name="test-log.entry",
+                    template="test duplicate",
+                )
+            )
+        assert test_manager.get_event_id_from_api_name(api_name="test-log.entry") == 500
 
         with self.assertRaises(AuditLogEventNotRegistered):
             test_manager.get(501)


### PR DESCRIPTION
- Update `OrganizationAuditLogsEndpoint` and `AuditLogEntrySerializer` to use the `AuditLogEventManager` class. 
- Adds a `get_event_id_from_api_name` method to the `AuditLogEventManager` class for validating api names.