### PR TITLE
fix(dashboards): Update release widget filter searchbar

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -6,6 +6,7 @@ import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {SearchBarProps} from 'sentry/components/events/searchBar';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
 import {MAX_QUERY_LENGTH, NEGATION_OPERATOR, SEARCH_WILDCARD} from 'sentry/constants';
+import {t} from 'sentry/locale';
 import {Organization, Tag, TagValue} from 'sentry/types';
 import useApi from 'sentry/utils/useApi';
 import {WidgetQuery} from 'sentry/views/dashboardsV2/types';
@@ -65,6 +66,7 @@ export function ReleaseSearchBar({orgSlug, query, projectIds, onSearch, onBlur}:
             ({key}, searchQuery) => `${key}-${searchQuery}`
           )}
           supportedTags={supportedTags}
+          placeholder={t('Search for release version, session status, and more')}
           prepareQuery={prepareQuery}
           excludeEnvironment
           dropdownClassName={css`
@@ -77,7 +79,6 @@ export function ReleaseSearchBar({orgSlug, query, projectIds, onSearch, onBlur}:
           maxSearchItems={MAX_SEARCH_ITEMS}
           searchSource="widget_builder"
           query={query.conditions}
-          hasRecentSearches
         />
       )}
     </ClassNames>


### PR DESCRIPTION
This PR
- updates the copy of the placeholder
- removes the recent searches - they are usually irrelevant as the release search bar supports only a very limited amount of tags (a better potential solution might be to add the ability to filter recent searches by allow listed tags)


## Before
<img width="780" alt="Screen Shot 2022-04-27 at 13 56 13" src="https://user-images.githubusercontent.com/9060071/165513052-3fa6166e-2cbf-42eb-a263-fff18f8d5479.png">

## After
<img width="788" alt="image" src="https://user-images.githubusercontent.com/9060071/165513182-d30d7a12-c39b-4daa-8869-8d496febf9ff.png">
