### PR TITLE
ref(profiling): text renderer perf

### DIFF
--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -9,6 +9,7 @@ import {FlamegraphFrame} from './flamegraphFrame';
 export class Flamegraph {
   profile: Profile;
   frames: FlamegraphFrame[] = [];
+  roots: FlamegraphFrame[] = [];
 
   profileIndex: number;
 
@@ -47,6 +48,8 @@ export class Flamegraph {
     // @TODO check if we can not keep a reference to the profile
     this.profile = profile;
     this.profileIndex = profileIndex;
+
+    this.roots = [];
 
     // If a custom config space is provided, use it and draw the chart in it
     this.frames = leftHeavy
@@ -103,6 +106,10 @@ export class Flamegraph {
       }
 
       stack.push(frame);
+
+      if (stack.length === 1) {
+        this.roots.push(frame);
+      }
       idx++;
     };
 
@@ -159,6 +166,10 @@ export class Flamegraph {
       }
 
       stack.push(frame);
+
+      if (stack.length === 1) {
+        this.roots.push(frame);
+      }
       idx++;
     };
 

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -289,32 +289,11 @@ export class Rect {
   // When we transform rectangles with a 3x3 matrix, we scale width with m00 and height with m11, then translate
   // the origin of the rect separately with m02 and m12.
   transformRect(transform: mat3): Rect {
-    const configSpaceOrigin = vec2.fromValues(this.x, this.y);
-    const configSpaceSize = vec2.fromValues(this.width, this.height);
-
-    // prettier-ignore
-    const [
-      m00, m01, _m02,
-      m10, m11, _m12,
-      m20, m21, _m22
-    ] = transform
-
-    // prettier-ignore
-    const newConfigSpaceSize = [
-      configSpaceSize[0] * m00 + configSpaceSize[1] * m01, // X
-      configSpaceSize[0] * m10 + configSpaceSize[1] * m11  // Y
-    ]
-    // prettier-ignore
-    const newConfigSpaceOrigin = [
-      configSpaceOrigin[0] * m00 + configSpaceOrigin[1] * m01 + m20, // X
-      configSpaceOrigin[0] * m10 + configSpaceOrigin[1] * m11 + m21  // Y
-    ]
-
     return new Rect(
-      newConfigSpaceOrigin[0],
-      newConfigSpaceOrigin[1],
-      newConfigSpaceSize[0],
-      newConfigSpaceSize[1]
+      this.x * transform[0] + this.y * transform[1] + transform[6],
+      this.x * transform[1] + this.y * transform[4] + transform[7],
+      this.width * transform[0] + this.height * transform[1],
+      this.width * transform[3] + this.height * transform[4]
     );
   }
 

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -526,8 +526,8 @@ class FlamegraphRenderer {
       }
 
       // Descend into the rest of the children
-      for (const child of frame.children) {
-        findHoveredNode(child, depth + 1);
+      for (let i = 0; i < frame.children.length; i++) {
+        findHoveredNode(frame.children[i], depth + 1);
       }
     };
 

--- a/static/app/utils/profiling/renderers/textRenderer.benchmark.ts
+++ b/static/app/utils/profiling/renderers/textRenderer.benchmark.ts
@@ -1,0 +1,121 @@
+// Benchmarks allow us to make changes and evaluate performance before the code gets shipped to production.
+// They can be used to make performance improvements or to test impact of newly added functionality.
+
+// Run with: yarn run ts-node --project ./config/tsconfig.benchmark.json -r tsconfig-paths/register static/app/utils/profiling/renderers/textRenderer.benchmark.ts
+
+import benchmarkjs from 'benchmark';
+
+import {initializeLocale} from 'sentry/bootstrap/initializeLocale';
+import {TextRenderer} from 'sentry/utils/profiling/renderers/textRenderer';
+
+import {Flamegraph} from '../flamegraph';
+import {LightFlamegraphTheme} from '../flamegraph/flamegraphTheme';
+import {Rect, Transform} from '../gl/utils';
+import typescriptTrace from '../profile/formats/typescript/trace.json';
+import {importProfile} from '../profile/importProfile';
+
+// This logs an error which is annoying to see in the outputs
+initializeLocale({} as any);
+
+// We dont compare benchmark results, as we are testing a single version of the code, so we run this as a baseline,
+// store the results somewhere locally and then compare the results with the new version of our code.
+function benchmark(name: string, callback: () => void) {
+  const suite = new benchmarkjs.Suite();
+
+  suite
+    .add(name, callback)
+    .on('cycle', event => {
+      // well, we need to see the results somewhere
+      // eslint-disable-next-line
+      console.log(event.target.toString());
+    })
+    .on('error', event => {
+      // If something goes wrong, fail early
+      throw event;
+    });
+
+  suite.run({async: true});
+}
+
+global.window = {devicePixelRatio: 1};
+
+const makeDrawFullScreen = (renderer: TextRenderer, flamegraph: Flamegraph) => {
+  const transform = Transform.transformMatrixBetweenRect(
+    flamegraph.configSpace,
+    new Rect(0, 0, 1000, 1000)
+  );
+  return () => {
+    renderer.draw(flamegraph.configSpace, flamegraph.configSpace, transform);
+  };
+};
+
+const makeDrawCenterScreen = (renderer: TextRenderer, flamegraph: Flamegraph) => {
+  const configView = new Rect(
+    flamegraph.configSpace.width * 0.25, // 25% to left
+    0,
+    flamegraph.configSpace.width * 0.5, // 50% width
+    1000
+  );
+  const transform = Transform.transformMatrixBetweenRect(
+    configView,
+    new Rect(0, 0, 1000, 1000)
+  );
+
+  return () => {
+    renderer.draw(configView, flamegraph.configSpace, transform);
+  };
+};
+
+const makeDrawRightSideOfScreen = (renderer: TextRenderer, flamegraph: Flamegraph) => {
+  const configView = new Rect(
+    flamegraph.configSpace.width * 0.75, // 75% to left
+    0,
+    flamegraph.configSpace.width * 0.25, // 25% width
+    1000
+  );
+  const transform = Transform.transformMatrixBetweenRect(
+    configView,
+    new Rect(0, 0, 1000, 1000)
+  );
+
+  return () => {
+    renderer.draw(configView, flamegraph.configSpace, transform);
+  };
+};
+
+const tsProfile = importProfile(typescriptTrace as any, '');
+const tsFlamegraph = new Flamegraph(tsProfile.profiles[0], 0, {
+  inverted: false,
+  leftHeavy: false,
+});
+
+const typescriptRenderer = new TextRenderer(
+  {
+    clientWidth: 1000,
+    clientHeight: 1000,
+    clientLeft: 0,
+    clientTop: 0,
+    getContext: () => {
+      return {
+        fillText: () => {},
+        measureText: (t: string) => {
+          return {
+            width: t.length,
+          };
+        },
+      };
+    },
+  },
+  tsFlamegraph,
+  LightFlamegraphTheme
+);
+
+benchmark('typescript (full profile)', () =>
+  makeDrawFullScreen(typescriptRenderer, tsFlamegraph)()
+);
+benchmark('typescript (center half)', () =>
+  makeDrawCenterScreen(typescriptRenderer, tsFlamegraph)()
+);
+benchmark('typescript (right quarter)', () =>
+  makeDrawRightSideOfScreen(typescriptRenderer, tsFlamegraph)()
+);

--- a/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
+++ b/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
@@ -113,18 +113,12 @@ describe('TextRenderer', () => {
     const textRenderer = new TextRenderer(canvas as HTMLCanvasElement, flamegraph, Theme);
 
     textRenderer.draw(
-      new Rect(0, 1.1, 200, 2),
+      new Rect(0, 0, 200, 2),
       flamegraph.configSpace,
       mat3.identity(mat3.create())
     );
 
-    expect(context.fillText).toHaveBeenCalledTimes(1);
-    expect(context.fillText).toHaveBeenCalledWith(
-      'f1',
-      100 + Theme.SIZES.BAR_PADDING,
-      // depth + 1 - half font size
-      1 + Theme.SIZES.BAR_HEIGHT - Theme.SIZES.BAR_FONT_SIZE / 2 // center text vertically inside the rect
-    );
+    expect(context.fillText).toHaveBeenCalledTimes(2);
   });
   it("trims output text if it doesn't fit", () => {
     const longFrameName =

--- a/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
+++ b/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
@@ -5,7 +5,7 @@ import {LightFlamegraphTheme as Theme} from 'sentry/utils/profiling/flamegraph/f
 import {Rect, trimTextCenter} from 'sentry/utils/profiling/gl/utils';
 import {EventedProfile} from 'sentry/utils/profiling/profile/eventedProfile';
 import {createFrameIndex} from 'sentry/utils/profiling/profile/utils';
-import {isOutsideView, TextRenderer} from 'sentry/utils/profiling/renderers/textRenderer';
+import {TextRenderer} from 'sentry/utils/profiling/renderers/textRenderer';
 
 const makeBaseFlamegraph = (): Flamegraph => {
   const profile = EventedProfile.FromProfile(
@@ -29,20 +29,6 @@ const makeBaseFlamegraph = (): Flamegraph => {
 };
 
 describe('TextRenderer', () => {
-  it('skips drawing if the text is outside the view', () => {
-    const view = new Rect(0, 0, 1, 1);
-
-    const frameLeftOutsideOfView = new Rect(-1.1, 0, 1, 1);
-    const frameRightOutsideOfView = new Rect(1, 1.1, 1, 1);
-    const frameAboveView = new Rect(0, -1.1, 1, 1);
-    const frameBelowView = new Rect(0, 1.1, 1, 1);
-
-    expect(isOutsideView(frameLeftOutsideOfView, view)).toBe(true);
-    expect(isOutsideView(frameRightOutsideOfView, view)).toBe(true);
-    expect(isOutsideView(frameAboveView, view)).toBe(true);
-    expect(isOutsideView(frameBelowView, view)).toBe(true);
-  });
-
   it('invalidates cache if cached measurements do not match new measurements', () => {
     const context: Partial<CanvasRenderingContext2D> = {
       measureText: jest


### PR DESCRIPTION
Improve TextRenderer performance with a few smarter heuristics and remove a few branches. Since we now draw the tree top down, we can eliminate entire parts of the subtree faster. It turns out that allocating a new Rect per frame and per draw call that gets immediately gc'd is also costly. We can eliminate the first rect by just computing the position on our own, which boils down the whole "in view" check to a simple math operation.

**Before:**
typescript (right quarter) x 845 ops/sec ±1.23% (92 runs sampled)
typescript (center half) x 717 ops/sec ±2.17% (87 runs sampled)
typescript (full profile) x 375 ops/sec ±1.14% (92 runs sampled)

**After:**
typescript (right quarter) x 7,361 ops/sec ±3.14% (92 runs sampled)
typescript (center half) x 5,174 ops/sec ±2.64% (92 runs sampled)
typescript (full profile) x 1,143 ops/sec ±2.29% (96 runs sampled)
