### PR TITLE
feat(ci): visual-diff should be skipped with pushes to `master`

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Diff snapshots
         id: visual-snapshots-diff
         uses: getsentry/action-visual-snapshot@v2
-        # Forks & master are handled in visual-diff.yml
+        # Forks are handled in visual-diff.yml
         if: github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   visual-diff:
-    # Only execute this check when a PR is opened from a fork rather than the upstream repo & master pushes
-    if: github.event.workflow_run.head_repository.full_name != 'getsentry/sentry' || github.event.workflow_run.head_branch == 'master'
+    # Only execute this check when a PR is opened from a fork rather than the upstream repo
+    if: github.event.workflow_run.head_repository.full_name != 'getsentry/sentry'
     runs-on: ubuntu-20.04
     timeout-minutes: 20
 


### PR DESCRIPTION
Upon further investigation, Visual Snapshots simply check for artifacts in the latest acceptance workflow on `master` rather than relying on `visual-diff.yml` to generating them.

In fact, `visual-diff.yml` is actually skipped when the action executes:

```
[debug]Push event triggered `workflow_run`... skipping as this only works for PRs
```