### PR TITLE
feat(perf): Change frontend transaction status defaults from 'unknown' to 'ok'

### DIFF
--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -7,11 +7,12 @@ import DateTime from 'sentry/components/dateTime';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import TimeSince from 'sentry/components/timeSince';
 import Tooltip from 'sentry/components/tooltip';
+import {frontend} from 'sentry/data/platformCategories';
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {OrganizationSummary} from 'sentry/types';
-import {Event} from 'sentry/types/event';
+import {AvatarProject, OrganizationSummary} from 'sentry/types';
+import {Event, EventTransaction} from 'sentry/types/event';
 import {getShortEventId} from 'sentry/utils/events';
 import {getDuration} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
@@ -140,7 +141,7 @@ class EventMetas extends React.Component<Props, State> {
                   tooltipText={t(
                     'The status of this transaction indicating if it succeeded or otherwise.'
                   )}
-                  bodyText={event.contexts?.trace?.status ?? '\u2014'}
+                  bodyText={getStatusBodyText(project, event, meta)}
                   subtext={httpStatus}
                 />
               )}
@@ -234,6 +235,34 @@ function HttpStatus({event}: {event: Event}) {
   }
 
   return <React.Fragment>HTTP {tag.value}</React.Fragment>;
+}
+
+/*
+  TODO: Ash
+  I put this in place as a temporary patch to prevent successful frontend transactions from being set as 'unknown', which is what Relay sets by default
+  if there is no status set by the SDK. In the future, the possible statuses will be revised and frontend transactions should properly have a status set.
+  When that change is implemented, this function can simply be replaced with:
+
+  event.contexts?.trace?.status ?? '\u2014';
+*/
+
+function getStatusBodyText(
+  project: AvatarProject | undefined,
+  event: EventTransaction,
+  meta: TraceMeta | null
+): string {
+  const isFrontendProject = frontend.some(val => val === project?.platform);
+
+  if (
+    isFrontendProject &&
+    meta &&
+    meta.errors === 0 &&
+    event.contexts?.trace?.status === 'unknown'
+  ) {
+    return 'ok';
+  }
+
+  return event.contexts?.trace?.status ?? '\u2014';
 }
 
 export default EventMetas;


### PR DESCRIPTION
In frontend transactions, the status is always set to 'unknown' for successful transactions, as this is the default status set by Relay if no status is provided. This is a temporary fix to lessen confusion regarding the status of frontend transactions, and can be reverted once statuses are being set in the SDK.

If a frontend transaction is successful, it will display 'ok' as the status instead of 'unknown'. However, if any errors are present anywhere within the transaction, it will not be changed, and will use the value provided by the API.

Fixes PERF-1428