### PR TITLE
feat: Add SESSION as a search type

### DIFF
--- a/src/sentry/models/search_common.py
+++ b/src/sentry/models/search_common.py
@@ -4,3 +4,4 @@ from enum import IntEnum
 class SearchType(IntEnum):
     ISSUE = 0
     EVENT = 1
+    SESSION = 2

--- a/tests/sentry/api/endpoints/test_organization_recent_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_recent_searches.py
@@ -47,6 +47,14 @@ class RecentSearchesListTest(APITestCase):
             last_seen=timezone.now(),
             date_added=timezone.now(),
         )
+        session_recent_search = RecentSearch.objects.create(
+            organization=self.organization,
+            user=self.user,
+            type=SearchType.SESSION.value,
+            query="some test",
+            last_seen=timezone.now(),
+            date_added=timezone.now(),
+        )
         issue_recent_searches = [
             RecentSearch.objects.create(
                 organization=self.organization,
@@ -75,6 +83,7 @@ class RecentSearchesListTest(APITestCase):
         ]
         self.check_results(issue_recent_searches, search_type=SearchType.ISSUE)
         self.check_results([event_recent_search], search_type=SearchType.EVENT)
+        self.check_results([session_recent_search], search_type=SearchType.SESSION)
 
     def test_param_validation(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Since dashboards is introducing a new sessions
dataset, we'd like to show recent searches pertaining
to sessions. Hence adding a new saved search type.

Needed for: https://github.com/getsentry/sentry/pull/34015