### PR TITLE
chore(snql): Remove visibility's remaining usage of get_filter

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
-from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, Generator, Optional, Sequence, Union, cast
+from datetime import timedelta
+from typing import Any, Callable, Dict, Generator, Optional, Sequence, cast
 
 import sentry_sdk
 from django.utils import timezone
@@ -20,7 +20,6 @@ from sentry.models import Organization, Project, Team
 from sentry.models.group import Group
 from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
 from sentry.search.events.fields import get_function_alias
-from sentry.search.events.filter import get_filter
 from sentry.snuba import discover, metrics_enhanced_performance
 from sentry.utils import snuba
 from sentry.utils.cursors import Cursor
@@ -110,32 +109,6 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):  # type: ignore
         if orderby:
             return orderby
         return None
-
-    def get_snuba_query_args_legacy(
-        self, request: Request, organization: Organization
-    ) -> Dict[
-        str,
-        Union[
-            Optional[datetime],
-            Sequence[Sequence[Union[str, str, Any]]],
-            Optional[Dict[str, Sequence[int]]],
-        ],
-    ]:
-        params = self.get_filter_params(request, organization)
-        query = request.GET.get("query")
-        try:
-            _filter = get_filter(query, params)
-        except InvalidSearchQuery as e:
-            raise ParseError(detail=str(e))
-
-        snuba_args = {
-            "start": _filter.start,
-            "end": _filter.end,
-            "conditions": _filter.conditions,
-            "filter_keys": _filter.filter_keys,
-        }
-
-        return snuba_args
 
     def quantize_date_params(self, request: Request, params: Dict[str, Any]) -> Dict[str, Any]:
         # We only need to perform this rounding on relative date periods

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -591,3 +591,20 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
             )
         assert response.status_code == 400, response.content
         assert not DiscoverSavedQuery.objects.filter(name="Bad query").exists()
+
+    def test_save_invalid_query_orderby(self):
+        with self.feature(self.feature_name):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Bad query",
+                    "projects": [-1],
+                    "fields": ["title", "count()"],
+                    "orderby": "fake()",
+                    "range": "24h",
+                    "query": "title:1",
+                    "version": 2,
+                },
+            )
+        assert response.status_code == 400, response.content
+        assert not DiscoverSavedQuery.objects.filter(name="Bad query").exists()

--- a/tests/snuba/api/endpoints/test_organization_events_trends.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trends.py
@@ -2,10 +2,7 @@ from datetime import timedelta
 
 from django.urls import reverse
 
-from sentry.api.endpoints.organization_events_trends import OrganizationEventsTrendsEndpointBase
-from sentry.search.events.filter import get_filter
 from sentry.testutils import APITestCase, SnubaTestCase
-from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.samples import load_data
@@ -916,107 +913,3 @@ class OrganizationEventsTrendsPagingTest(APITestCase, SnubaTestCase):
             assert links["previous"]["results"] == "false"
             assert links["next"]["results"] == "false"
             assert len(response.data["events"]["data"]) == 5
-
-
-class OrganizationEventsTrendsAliasTest(TestCase):
-    def setUp(self):
-        self.improved_aliases = OrganizationEventsTrendsEndpointBase.get_function_aliases(
-            "improved"
-        )
-        self.regression_aliases = OrganizationEventsTrendsEndpointBase.get_function_aliases(
-            "regression"
-        )
-
-    def test_simple(self):
-        result = get_filter(
-            "trend_percentage():>0% trend_difference():>0", {"aliases": self.improved_aliases}
-        )
-
-        assert result.having == [
-            ["trend_percentage", "<", 1.0],
-            ["trend_difference", "<", 0.0],
-        ]
-
-        result = get_filter(
-            "trend_percentage():>0% trend_difference():>0", {"aliases": self.regression_aliases}
-        )
-
-        assert result.having == [
-            ["trend_percentage", ">", 1.0],
-            ["trend_difference", ">", 0.0],
-        ]
-
-    def test_and_query(self):
-        result = get_filter(
-            "trend_percentage():>0% AND trend_percentage():<100%",
-            {"aliases": self.improved_aliases},
-        )
-
-        assert result.having == [["trend_percentage", "<", 1.0], ["trend_percentage", ">", 0.0]]
-
-        result = get_filter(
-            "trend_percentage():>0% AND trend_percentage():<100%",
-            {"aliases": self.regression_aliases},
-        )
-
-        assert result.having == [["trend_percentage", ">", 1.0], ["trend_percentage", "<", 2.0]]
-
-    def test_or_query(self):
-        result = get_filter(
-            "trend_percentage():>0% OR trend_percentage():<100%",
-            {"aliases": self.improved_aliases},
-        )
-
-        assert result.having == [
-            [
-                [
-                    "or",
-                    [["less", ["trend_percentage", 1.0]], ["greater", ["trend_percentage", 0.0]]],
-                ],
-                "=",
-                1,
-            ]
-        ]
-
-        result = get_filter(
-            "trend_percentage():>0% OR trend_percentage():<100%",
-            {"aliases": self.regression_aliases},
-        )
-
-        assert result.having == [
-            [
-                [
-                    "or",
-                    [["greater", ["trend_percentage", 1.0]], ["less", ["trend_percentage", 2.0]]],
-                ],
-                "=",
-                1,
-            ]
-        ]
-
-    def test_greater_than(self):
-        result = get_filter("trend_difference():>=0", {"aliases": self.improved_aliases})
-
-        assert result.having == [["trend_difference", "<=", 0.0]]
-
-        result = get_filter("trend_difference():>=0", {"aliases": self.regression_aliases})
-
-        assert result.having == [["trend_difference", ">=", 0.0]]
-
-    def test_negation(self):
-        result = get_filter("!trend_difference():>=0", {"aliases": self.improved_aliases})
-
-        assert result.having == [["trend_difference", ">", 0.0]]
-
-        result = get_filter("!trend_difference():>=0", {"aliases": self.regression_aliases})
-
-        assert result.having == [["trend_difference", "<", 0.0]]
-
-    def test_confidence(self):
-        result = get_filter("confidence():>6", {"aliases": self.improved_aliases})
-
-        assert result.having == [["t_test", ">", 6.0]]
-
-        result = get_filter("confidence():>6", {"aliases": self.regression_aliases})
-
-        assert result.having == [["t_test", "<", -6.0]]


### PR DESCRIPTION
- `get_snuba_query_args_legacy` is unused
- discover saved queries were still using get_filter to validate the
  filter
- trends tests still tested get-filter, removing these since trends uses a
  custom querybuilder instead now
