### PR TITLE
tests: Fix flaky `OrganizationMetricDataTest.test_include_series` test

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1,5 +1,5 @@
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Optional
 from unittest import mock
 from unittest.mock import patch
@@ -945,6 +945,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             "per_page parameter."
         )
 
+    @freeze_time((datetime.now() - timedelta(hours=1)).replace(minute=30))
     def test_include_series(self):
         indexer.record(self.organization.id, "session.status")
         self.store_session(self.build_session(project_id=self.project.id, started=time.time() - 60))


### PR DESCRIPTION
This is consistently flaking in the first minute of the hour. I suspect that because we create a
session at time `time.time() - 60`, crossing the hour barrier here causes the test to fail. Just
freezing time to minute 30 of the previous hour to fix the error.