### PR TITLE
ref(integrations): consolidate integration hooks

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -521,8 +521,6 @@ type IntegrationsFeatureGatesHook = () => {
    * This component renders the list of integration features.
    */
   FeatureList: React.ComponentType<IntegrationFeatureListProps>;
-  IntegrationDirectoryFeatureList: React.ComponentType<IntegrationFeatureListProps>;
-  IntegrationDirectoryFeatures: React.ComponentType<IntegrationFeaturesProps>;
   /**
    * This is a render-prop style component that given a set of integration
    * features will call the children function with gating details about the

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -71,12 +71,10 @@ const generateIntegrationFeatures = p =>
     gatedFeatureGroups: [],
   });
 
-const defaultFeatureGateComponents = {
+const defaultFeatureGateComponents: ReturnType<Hooks['integrations:feature-gates']> = {
   IntegrationFeatures: generateIntegrationFeatures,
-  IntegrationDirectoryFeatures: generateIntegrationFeatures,
   FeatureList: generateFeaturesList,
-  IntegrationDirectoryFeatureList: generateFeaturesList,
-} as ReturnType<Hooks['integrations:feature-gates']>;
+};
 
 export const getIntegrationFeatureGate = () => {
   const defaultHook = () => defaultFeatureGateComponents;

--- a/static/app/views/integrationOrganizationLink.tsx
+++ b/static/app/views/integrationOrganizationLink.tsx
@@ -166,17 +166,14 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
       ),
     }));
 
-    const {IntegrationDirectoryFeatures} = getIntegrationFeatureGate();
+    const {IntegrationFeatures} = getIntegrationFeatureGate();
 
     // Github uses a different installation flow with the installationId as a parameter
     // We have to wrap our installation button with AddIntegration so we can get the
     // addIntegrationWithInstallationId callback.
     // if we don't hve an installationId, we need to use the finishInstallation callback.
     return (
-      <IntegrationDirectoryFeatures
-        organization={organization}
-        features={featuresComponents}
-      >
+      <IntegrationFeatures organization={organization} features={featuresComponents}>
         {({disabled}) => (
           <AddIntegration
             provider={provider}
@@ -202,7 +199,7 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
             )}
           </AddIntegration>
         )}
-      </IntegrationDirectoryFeatures>
+      </IntegrationFeatures>
     );
   }
 

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -253,10 +253,10 @@ class AbstractIntegrationDetailedView<
 
   renderAddInstallButton(hideButtonIfDisabled = false) {
     const {organization} = this.props;
-    const {IntegrationDirectoryFeatures} = getIntegrationFeatureGate();
+    const {IntegrationFeatures} = getIntegrationFeatureGate();
 
     return (
-      <IntegrationDirectoryFeatures {...this.featureProps}>
+      <IntegrationFeatures {...this.featureProps}>
         {({disabled, disabledReason}) => (
           <DisableWrapper>
             <Access organization={organization} access={['org:integrations']}>
@@ -278,7 +278,7 @@ class AbstractIntegrationDetailedView<
             {disabled && <DisabledNotice reason={disabledReason} />}
           </DisableWrapper>
         )}
-      </IntegrationDirectoryFeatures>
+      </IntegrationFeatures>
     );
   }
 
@@ -334,14 +334,14 @@ class AbstractIntegrationDetailedView<
 
   // Returns the information about the integration description and features
   renderInformationCard() {
-    const {IntegrationDirectoryFeatureList} = getIntegrationFeatureGate();
+    const {FeatureList} = getIntegrationFeatureGate();
 
     return (
       <React.Fragment>
         <Flex>
           <FlexContainer>
             <Description dangerouslySetInnerHTML={{__html: marked(this.description)}} />
-            <IntegrationDirectoryFeatureList
+            <FeatureList
               {...this.featureProps}
               provider={{key: this.props.params.integrationSlug}}
             />


### PR DESCRIPTION
This removes an old TODO to consolidate the `hookIntegrationFeatures`. There are no functional changes.

Related PR: https://github.com/getsentry/getsentry/pull/7400