### PR TITLE
ref(issue-alerts): Move AlertRuleAction logic away from endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -3,7 +3,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.rule import RuleEndpoint
-from sentry.api.endpoints.project_rules import trigger_alert_rule_action_creators
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer
 from sentry.api.serializers.rest_framework.rule import RuleSerializer as DrfRuleSerializer
@@ -19,6 +18,7 @@ from sentry.models import (
     Team,
     User,
 )
+from sentry.rules.actions.base import trigger_sentry_app_action_creators_for_issues
 from sentry.signals import alert_rule_edited
 from sentry.web.decorators import transaction_start
 
@@ -138,7 +138,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 context = {"uuid": client.uuid}
                 return Response(context, status=202)
 
-            trigger_alert_rule_action_creators(kwargs.get("actions"))
+            trigger_sentry_app_action_creators_for_issues(kwargs.get("actions"))
 
             updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -1,6 +1,4 @@
-from typing import Mapping, Optional, Sequence
-
-from rest_framework import serializers, status
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -8,42 +6,19 @@ from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import RuleSerializer
 from sentry.integrations.slack import tasks
-from sentry.mediators import alert_rule_actions, project_rules
-from sentry.mediators.external_requests.alert_rule_action_requester import AlertRuleActionResult
+from sentry.mediators import project_rules
 from sentry.models import (
     AuditLogEntryEvent,
     Rule,
     RuleActivity,
     RuleActivityType,
     RuleStatus,
-    SentryAppInstallation,
     Team,
     User,
 )
+from sentry.rules.actions.base import trigger_sentry_app_action_creators_for_issues
 from sentry.signals import alert_rule_created
 from sentry.web.decorators import transaction_start
-
-
-# TODO(Leander): Move this method into a relevant abstract base class
-def trigger_alert_rule_action_creators(
-    actions: Sequence[Mapping[str, str]],
-) -> Optional[str]:
-    created = None
-    for action in actions:
-        # Only call creator for Sentry Apps with UI Components for alert rules.
-        if not action.get("hasSchemaFormConfig"):
-            continue
-
-        install = SentryAppInstallation.objects.get(uuid=action.get("sentryAppInstallationUuid"))
-        result: AlertRuleActionResult = alert_rule_actions.AlertRuleActionCreator.run(
-            install=install,
-            fields=action.get("settings"),
-        )
-        # Bubble up errors from Sentry App to the UI
-        if not result["success"]:
-            raise serializers.ValidationError({"actions": [result["message"]]})
-        created = "alert-rule-action"
-    return created
 
 
 class ProjectRulesEndpoint(ProjectEndpoint):
@@ -128,7 +103,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 tasks.find_channel_id_for_rule.apply_async(kwargs=kwargs)
                 return Response(uuid_context, status=202)
 
-            created_alert_rule_ui_component = trigger_alert_rule_action_creators(
+            created_alert_rule_ui_component = trigger_sentry_app_action_creators_for_issues(
                 kwargs.get("actions")
             )
             rule = project_rules.Creator.run(request=request, **kwargs)

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -68,11 +68,11 @@ class SentryAppEventAction(EventAction, abc.ABC):
 
     @abc.abstractmethod
     def get_custom_actions(self, project: Project) -> Sequence[Mapping[str, Any]]:
-        raise NotImplementedError()
+        pass
 
     @abc.abstractmethod
     def self_validate(self) -> None:
-        raise NotImplementedError()
+        pass
 
 
 def trigger_sentry_app_action_creators_for_issues(

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -6,12 +6,15 @@ from typing import Any, Callable, Generator, Mapping, Sequence
 
 from django import forms
 from django.db.models import QuerySet
+from rest_framework import serializers
 from rest_framework.response import Response
 
-from sentry.constants import ObjectStatus
+from sentry.constants import SENTRY_APP_ACTIONS, ObjectStatus
 from sentry.eventstore.models import Event
 from sentry.integrations import IntegrationInstallation
-from sentry.models import ExternalIssue, GroupLink, Integration
+from sentry.mediators import alert_rule_actions
+from sentry.mediators.external_requests.alert_rule_action_requester import AlertRuleActionResult
+from sentry.models import ExternalIssue, GroupLink, Integration, Project, SentryAppInstallation
 from sentry.rules.base import CallbackFuture, EventState, RuleBase
 from sentry.types.rules import RuleFuture
 
@@ -58,6 +61,39 @@ class EventAction(RuleBase, abc.ABC):
         >>>         print(future)
         """
         pass
+
+
+class SentryAppEventAction(EventAction, abc.ABC):
+    """Abstract class to ensure that actions in SENTRY_APP_ACTIONS have all required methods"""
+
+    @abc.abstractmethod
+    def get_custom_actions(self, project: Project) -> Sequence[Mapping[str, Any]]:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def self_validate(self) -> None:
+        raise NotImplementedError()
+
+
+def trigger_sentry_app_action_creators_for_issues(
+    actions: Sequence[Mapping[str, str]]
+) -> str | None:
+    created = None
+    for action in actions:
+        # Only call creator for Sentry Apps with UI Components for alert rules.
+        if not action.get("id") in SENTRY_APP_ACTIONS:
+            continue
+
+        install = SentryAppInstallation.objects.get(uuid=action.get("sentryAppInstallationUuid"))
+        result: AlertRuleActionResult = alert_rule_actions.AlertRuleActionCreator.run(
+            install=install,
+            fields=action.get("settings"),
+        )
+        # Bubble up errors from Sentry App to the UI
+        if not result["success"]:
+            raise serializers.ValidationError({"actions": [result["message"]]})
+        created = "alert-rule-action"
+    return created
 
 
 class IntegrationEventAction(EventAction, abc.ABC):

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -58,8 +58,6 @@ class ProjectRuleDetailsBaseTestCase(APITestCase):
 
 
 class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
-    endpoint = "sentry-api-0-project-rule-details"
-
     def test_simple(self):
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200
@@ -607,7 +605,6 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             method=responses.POST,
             url="https://example.com/sentry/alert-rule",
             status=202,
-            json={},
         )
         actions = [
             {

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -2,35 +2,54 @@ from copy import deepcopy
 from unittest.mock import patch
 
 import responses
-from django.urls import reverse
 
 from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType
 from sentry.testutils import APITestCase
 from sentry.utils import json
 
 
-class ProjectRuleListTest(APITestCase):
-    def test_simple(self):
+class ProjectRuleBaseTestCase(APITestCase):
+    endpoint = "sentry-api-0-project-rules"
+
+    def setUp(self):
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.rule = self.create_project_rule(project=self.project)
+        self.slack_integration = Integration.objects.create(
+            provider="slack",
+            name="Awesome Team",
+            external_id="TXXXXXXX1",
+            metadata={
+                "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+                "installation_type": "born_as_bot",
+            },
+        )
+        self.slack_integration.add_organization(self.organization, self.user)
+        self.sentry_app = self.create_sentry_app(
+            name="Pied Piper",
+            organization=self.organization,
+            schema={"elements": [self.create_alert_rule_action_schema()]},
+        )
+        self.sentry_app_installation = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug, organization=self.organization
+        )
+        self.sentry_app_settings_payload = [
+            {"name": "title", "value": "Team Rocket"},
+            {"name": "summary", "value": "We're blasting off again."},
+        ]
         self.login_as(user=self.user)
 
-        team = self.create_team()
-        project1 = self.create_project(teams=[team], name="foo")
-        self.create_project(teams=[team], name="bar")
 
-        url = reverse(
-            "sentry-api-0-project-rules",
-            kwargs={"organization_slug": project1.organization.slug, "project_slug": project1.slug},
+class ProjectRuleListTest(ProjectRuleBaseTestCase):
+    def test_simple(self):
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, status_code=200
         )
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 200, response.content
-
-        rule_count = Rule.objects.filter(project=project1).count()
-        assert len(response.data) == rule_count
+        assert len(response.data) == Rule.objects.filter(project=self.project).count()
 
 
-class CreateProjectRuleTest(APITestCase):
-    endpoint = "sentry-api-0-project-rules"
+class CreateProjectRuleTest(ProjectRuleBaseTestCase):
     method = "post"
 
     def run_test(
@@ -45,7 +64,6 @@ class CreateProjectRuleTest(APITestCase):
         conditions=None,
         **kwargs,
     ):
-        self.login_as(user=self.user)
         owner = self.user.actor.get_actor_identifier()
         query_args = {}
         if "environment" in kwargs:
@@ -121,59 +139,42 @@ class CreateProjectRuleTest(APITestCase):
 
     @responses.activate
     def test_slack_channel_id_saved(self):
-        self.login_as(user=self.user)
-
-        project = self.create_project()
-        integration = Integration.objects.create(
-            provider="slack",
-            name="Awesome Team",
-            external_id="TXXXXXXX1",
-            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
-        )
-        integration.add_organization(project.organization, self.user)
-
-        url = reverse(
-            "sentry-api-0-project-rules",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
-        )
+        channel_id = "CSVK0921"
         responses.add(
             method=responses.GET,
             url="https://slack.com/api/conversations.info",
             status=200,
             content_type="application/json",
             body=json.dumps(
-                {"ok": "true", "channel": {"name": "team-team-team", "id": "CSVK0921"}}
+                {"ok": "true", "channel": {"name": "team-team-team", "id": channel_id}}
             ),
         )
-        response = self.client.post(
-            url,
-            data={
-                "name": "hello world",
-                "owner": f"user:{self.user.id}",
-                "environment": None,
-                "actionMatch": "any",
-                "frequency": 5,
-                "actions": [
-                    {
-                        "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
-                        "name": "Send a notification to the funinthesun Slack workspace to #team-team-team and show tags [] in notification",
-                        "workspace": integration.id,
-                        "channel": "#team-team-team",
-                        "input_channel_id": "CSVK0921",
-                    }
-                ],
-                "conditions": [
-                    {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
-                ],
-            },
-            format="json",
-        )
+        payload = {
+            "name": "hello world",
+            "owner": f"user:{self.user.id}",
+            "environment": None,
+            "actionMatch": "any",
+            "frequency": 5,
+            "actions": [
+                {
+                    "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+                    "name": "Send a notification to the funinthesun Slack workspace to #team-team-team and show tags [] in notification",
+                    "workspace": self.slack_integration.id,
+                    "channel": "#team-team-team",
+                    "input_channel_id": channel_id,
+                }
+            ],
+            "conditions": [
+                {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
+            ],
+        }
 
-        assert response.status_code == 200, response.content
-        assert response.data["actions"][0]["channel_id"] == "CSVK0921"
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, status_code=200, **payload
+        )
+        assert response.data["actions"][0]["channel_id"] == channel_id
 
     def test_missing_name(self):
-        self.login_as(user=self.user)
         conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
         actions = [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}]
         self.get_error_response(
@@ -188,7 +189,6 @@ class CreateProjectRuleTest(APITestCase):
         )
 
     def test_owner_perms(self):
-        self.login_as(user=self.user)
         other_user = self.create_user()
         response = self.get_error_response(
             self.organization.slug,
@@ -217,7 +217,6 @@ class CreateProjectRuleTest(APITestCase):
         assert str(response.data["owner"][0]) == "Team is not a member of this organization"
 
     def test_frequency_percent_validation(self):
-        self.login_as(user=self.user)
         condition = {
             "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
             "interval": "1h",
@@ -310,7 +309,6 @@ class CreateProjectRuleTest(APITestCase):
         )
 
     def test_with_filters_without_match(self):
-        self.login_as(user=self.user)
         conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
         filters = [
             {"id": "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter", "value": 10}
@@ -347,27 +345,8 @@ class CreateProjectRuleTest(APITestCase):
     def test_kicks_off_slack_async_job(
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
     ):
-        project = self.create_project()
-
         mock_uuid4.return_value = self.get_mock_uuid()
-        self.login_as(self.user)
-
-        integration = Integration.objects.create(
-            provider="slack",
-            name="Awesome Team",
-            external_id="TXXXXXXX1",
-            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
-        )
-        integration.add_organization(project.organization, self.user)
-
-        url = reverse(
-            "sentry-api-0-project-rules",
-            kwargs={
-                "organization_slug": project.organization.slug,
-                "project_slug": project.slug,
-            },
-        )
-        data = {
+        payload = {
             "name": "hello world",
             "owner": f"user:{self.user.id}",
             "environment": None,
@@ -377,7 +356,7 @@ class CreateProjectRuleTest(APITestCase):
                 {
                     "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
                     "name": "Send a notification to the funinthesun Slack workspace to #team-team-team and show tags [] in notification",
-                    "workspace": str(integration.id),
+                    "workspace": str(self.slack_integration.id),
                     "channel": "#team-team-team",
                     "channel_id": "",
                     "tags": "",
@@ -387,27 +366,26 @@ class CreateProjectRuleTest(APITestCase):
                 {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
             ],
         }
-        self.client.post(
-            url,
-            data=data,
-            format="json",
+
+        self.get_success_response(
+            self.organization.slug, self.project.slug, status_code=202, **payload
         )
 
-        assert not Rule.objects.filter(label="hello world").exists()
+        assert not Rule.objects.filter(label=payload["name"]).exists()
         kwargs = {
-            "name": data["name"],
+            "name": payload["name"],
             "owner": self.user.actor.id,
-            "environment": data.get("environment"),
-            "action_match": data["actionMatch"],
-            "filter_match": data.get("filterMatch"),
-            "conditions": data.get("conditions", []) + data.get("filters", []),
-            "actions": data.get("actions", []),
-            "frequency": data.get("frequency"),
+            "environment": payload.get("environment"),
+            "action_match": payload["actionMatch"],
+            "filter_match": payload.get("filterMatch"),
+            "conditions": payload.get("conditions", []) + payload.get("filters", []),
+            "actions": payload.get("actions", []),
+            "frequency": payload.get("frequency"),
             "user_id": self.user.id,
             "uuid": "abc123",
         }
         call_args = mock_find_channel_id_for_alert_rule.call_args[1]["kwargs"]
-        assert call_args.pop("project").id == project.id
+        assert call_args.pop("project").id == self.project.id
         assert call_args == kwargs
 
     def test_comparison_condition(self):
@@ -439,7 +417,6 @@ class CreateProjectRuleTest(APITestCase):
         self.run_test(actions=actions, conditions=[condition])
 
     def test_comparison_condition_validation(self):
-        self.login_as(user=self.user)
         condition = {
             "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
             "interval": "1h",
@@ -480,69 +457,71 @@ class CreateProjectRuleTest(APITestCase):
             == "Select a valid choice. bad data is not one of the available choices."
         )
 
-    @patch("sentry.mediators.alert_rule_actions.AlertRuleActionCreator.run")
-    def test_runs_alert_rule_action_creator(self, mock_alert_rule_action_creator):
-        """
-        Ensures that Sentry Apps with schema forms (UI components)
-        receive a payload when an alert rule is created with them.
-        """
-        self.login_as(user=self.user)
-
-        project = self.create_project()
-
-        self.create_sentry_app(
-            name="Pied Piper",
-            organization=project.organization,
-            schema={"elements": [self.create_alert_rule_action_schema()]},
+    @responses.activate
+    def test_create_sentry_app_action_success(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=202,
         )
-        install = self.create_sentry_app_installation(
-            slug="pied-piper", organization=project.organization
-        )
-
         actions = [
             {
                 "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
-                "settings": [
-                    {"name": "title", "value": "Team Rocket"},
-                    {"name": "summary", "value": "We're blasting off again."},
-                ],
-                "sentryAppInstallationUuid": install.uuid,
+                "settings": self.sentry_app_settings_payload,
+                "sentryAppInstallationUuid": self.sentry_app_installation.uuid,
                 "hasSchemaFormConfig": True,
             },
         ]
-
-        url = reverse(
-            "sentry-api-0-project-rules",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
-        )
-
-        response = self.client.post(
-            url,
-            data={
-                "name": "my super cool rule",
-                "owner": f"user:{self.user.id}",
-                "conditions": [],
-                "filters": [],
-                "actions": actions,
-                "filterMatch": "any",
-                "actionMatch": "any",
-                "frequency": 30,
-            },
-            format="json",
-        )
-
-        assert response.status_code == 200, response.content
-        assert response.data["id"]
-
-        rule = Rule.objects.get(id=response.data["id"])
-        assert rule.data["actions"] == actions
-
-        kwargs = {
-            "install": install,
-            "fields": actions[0].get("settings"),
+        payload = {
+            "name": "my super cool rule",
+            "owner": f"user:{self.user.id}",
+            "conditions": [],
+            "filters": [],
+            "actions": actions,
+            "filterMatch": "any",
+            "actionMatch": "any",
+            "frequency": 30,
         }
 
-        call_kwargs = mock_alert_rule_action_creator.call_args[1]
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, status_code=200, **payload
+        )
+        new_rule_id = response.data["id"]
+        assert new_rule_id is not None
+        rule = Rule.objects.get(id=new_rule_id)
+        assert rule.data["actions"] == actions
+        assert len(responses.calls) == 1
 
-        assert call_kwargs["install"].id == kwargs["install"].id
-        assert call_kwargs["fields"] == kwargs["fields"]
+    @responses.activate
+    def test_create_sentry_app_action_failure(self):
+        error_message = "Something is totally broken :'("
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/sentry/alert-rule",
+            status=500,
+            json={"message": error_message},
+        )
+        actions = [
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "settings": self.sentry_app_settings_payload,
+                "sentryAppInstallationUuid": self.sentry_app_installation.uuid,
+                "hasSchemaFormConfig": True,
+            },
+        ]
+        payload = {
+            "name": "my super cool rule",
+            "owner": f"user:{self.user.id}",
+            "conditions": [],
+            "filters": [],
+            "actions": actions,
+            "filterMatch": "any",
+            "actionMatch": "any",
+            "frequency": 30,
+        }
+
+        response = self.get_error_response(
+            self.organization.slug, self.project.slug, status_code=400, **payload
+        )
+        assert len(responses.calls) == 1
+        assert error_message in response.json().get("actions")[0]


### PR DESCRIPTION

<!-- Describe your PR here. -->
This PR moves a function that was in `project_rules.py` out of there and into an appropriate separate location. It also adds the ` SentryAppEventAction` class to outline the required methods on creating new members of `SENTRY_APP_ACTIONS` (this is following a similar pattern for `TicketEventAction` and `TICKET_ACTIONS`).

This refactor was also done and for Metric Alerts in https://github.com/getsentry/sentry/pull/33948/.

I also added a bunch of tests for the error surfacing that was added in https://github.com/getsentry/sentry/pull/33571


<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
