### PR TITLE
fix(profiling): Reset is_search_result before drawing

### DIFF
--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -35,6 +35,8 @@ function frameSearch(
   if (isRegExpString(query)) {
     const [_, lookup, flags] = parseRegExp(query) ?? [];
 
+    let matches = 0;
+
     try {
       if (!lookup) {
         throw new Error('Invalid RegExp');
@@ -51,10 +53,15 @@ function frameSearch(
               String(frame.start)
             }`
           ] = frame;
+          matches += 1;
         }
       }
     } catch (e) {
       Sentry.captureMessage(e.message);
+    }
+
+    if (matches <= 0) {
+      return null;
     }
 
     return results;

--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -30,7 +30,7 @@ function frameSearch(
   query: string,
   frames: ReadonlyArray<FlamegraphFrame>,
   index: Fuse<FlamegraphFrame>
-): Record<string, FlamegraphFrame> {
+): Record<string, FlamegraphFrame> | null {
   const results = {};
   if (isRegExpString(query)) {
     const [_, lookup, flags] = parseRegExp(query) ?? [];
@@ -61,6 +61,10 @@ function frameSearch(
   }
 
   const fuseResults = index.search(query);
+
+  if (fuseResults.length <= 0) {
+    return null;
+  }
 
   for (let i = 0; i < fuseResults.length; i++) {
     const frame = fuseResults[i];

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -609,6 +609,7 @@ class FlamegraphRenderer {
         this.gl.drawArrays(this.gl.TRIANGLES, vertexOffset, VERTICES);
       }
     } else {
+      this.gl.uniform1i(this.uniforms.u_is_search_result, 0);
       for (let i = 0; i < length; i++) {
         const vertexOffset = i * VERTICES;
 


### PR DESCRIPTION
When rendering the flamegraph without search results, make sure to clear
is_search_result. It may contain a 1 from a previous earch result which can
cause every frame to be highlighted.