### PR TITLE
debug(tests): Attempting to reset responses

### DIFF
--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -53,6 +53,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
         debug_data_capture = azuredevops_rule.data  # noqa: F841
         debug_rule_obj = Rule.objects.create(project=self.project, label="test rule")
         azuredevops_rule.rule = debug_rule_obj
+        responses.reset()
         responses.add(
             responses.PATCH,
             "https://fabrikam-fiber-inc.visualstudio.com/0987654321/_apis/wit/workitems/$Microsoft.VSTS.WorkItemTypes.Task",


### PR DESCRIPTION
The debug logs added from the last merges indicated that the URIs needed for the test weren't getting added to the responses registry. This is likely why the test is failing.
Trying to reset the responses registry before adding the new response to see if this works
