### PR TITLE
fix(ui) Don't reset scroll on query string changes in settings

### DIFF
--- a/static/app/views/settings/components/settingsWrapper.tsx
+++ b/static/app/views/settings/components/settingsWrapper.tsx
@@ -12,8 +12,7 @@ function SettingsWrapper({location, children}: Props) {
   useScrollToTop({
     location,
     disable: (newLocation, prevLocation) =>
-      newLocation.pathname === prevLocation.pathname &&
-      newLocation.query?.query !== prevLocation.query?.query,
+      newLocation.pathname === prevLocation.pathname,
   });
 
   return <StyledSettingsWrapper>{children}</StyledSettingsWrapper>;


### PR DESCRIPTION
Settings views (including subscription overview) were resetting scroll offsets when URL changes occurred. By ignoring query string changes we won't reset scroll offsets when persistent charts are manipulated.

I checked a few settings pages and didn't find any commonly used views that relied on query string parameters resetting scroll state but losing that reset is a risk of this change.
