### PR TITLE
feat(issue-details): Show project icon next to issue title

### DIFF
--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -15,6 +15,7 @@ import EventAnnotation from 'sentry/components/events/eventAnnotation';
 import EventMessage from 'sentry/components/events/eventMessage';
 import InboxReason from 'sentry/components/group/inboxBadges/inboxReason';
 import UnhandledInboxTag from 'sentry/components/group/inboxBadges/unhandledTag';
+import IdBadge from 'sentry/components/idBadge';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -150,6 +151,12 @@ class GroupHeader extends React.Component<Props, State> {
           <div className="row">
             <div className="col-sm-7">
               <TitleWrapper>
+                <StyledIdBadge
+                  project={project}
+                  avatarSize={28}
+                  hideName
+                  avatarProps={{hasTooltip: true, tooltip: project.slug}}
+                />
                 <h3>
                   <EventOrGroupTitle hasGuideAnchor data={group} />
                 </h3>
@@ -354,6 +361,10 @@ export default withApi(withRouter(withOrganization(GroupHeader)));
 const TitleWrapper = styled('div')`
   display: flex;
   line-height: 24px;
+`;
+
+const StyledIdBadge = styled(IdBadge)`
+  margin-right: ${space(1)};
 `;
 
 const InboxReasonWrapper = styled('div')`

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -153,7 +153,7 @@ class GroupHeader extends React.Component<Props, State> {
               <TitleWrapper>
                 <StyledIdBadge
                   project={project}
-                  avatarSize={28}
+                  avatarSize={24}
                   hideName
                   avatarProps={{hasTooltip: true, tooltip: project.slug}}
                 />


### PR DESCRIPTION
With the replacement of GSH with page-filters, the locked project filter is no longer there. Similar to transaction details and release details we can hint at the project using the project icon.

Before:
<img width="1218" alt="image" src="https://user-images.githubusercontent.com/9372512/165645590-ed188989-3ff2-407c-ab85-101162b8ff76.png">


After:
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/9372512/165645524-0efb80e5-44e0-4a5a-bb49-7ce68ed22687.png">
