### PR TITLE
feat(sentryapps): Fetch projects for both internal and public apps

### DIFF
--- a/src/sentry/api/endpoints/project_index.py
+++ b/src/sentry/api/endpoints/project_index.py
@@ -10,7 +10,8 @@ from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import ProjectWithOrganizationSerializer, serialize
 from sentry.auth.superuser import is_active_superuser
 from sentry.db.models.query import in_iexact
-from sentry.models import Project, ProjectPlatform, ProjectStatus, SentryAppInstallationToken
+from sentry.models import Project, ProjectPlatform, ProjectStatus
+from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.search.utils import tokenize_query
 
 
@@ -46,7 +47,7 @@ class ProjectIndexEndpoint(Endpoint):
                 queryset = queryset.none()
         elif not (is_active_superuser(request) and request.GET.get("show") == "all"):
             if request.user.is_sentry_app:
-                queryset = SentryAppInstallationToken.objects.get_projects(request.auth)
+                queryset = SentryAppInstallation.objects.get_projects(request.auth)
                 if isinstance(queryset, EmptyQuerySet):
                     raise AuthenticationFailed("Token not found")
             else:

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -40,7 +40,7 @@ class SentryAppInstallationForProviderManager(ParanoidManager):
         from sentry.models import Project, SentryAppInstallationToken
 
         try:
-            installation = self.get_by_api_token(token.id).first()
+            installation = self.get_by_api_token(token.id).get()
         except SentryAppInstallation.DoesNotExist:
             installation = None
 

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -1,6 +1,6 @@
 import uuid
 from itertools import chain
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from django.db import models
 from django.db.models import OuterRef, QuerySet, Subquery
@@ -13,7 +13,9 @@ from sentry.db.models import (
     ParanoidManager,
     ParanoidModel,
 )
-from sentry.models import ApiToken
+
+if TYPE_CHECKING:
+    from sentry.models import ApiToken, Project
 
 
 def default_uuid():
@@ -34,7 +36,7 @@ class SentryAppInstallationForProviderManager(ParanoidManager):
     def get_by_api_token(self, token_id: str) -> QuerySet:
         return self.filter(status=SentryAppInstallationStatus.INSTALLED, api_token_id=token_id)
 
-    def get_projects(self, token: ApiToken) -> QuerySet:
+    def get_projects(self, token: ApiToken) -> QuerySet[Project]:
         from sentry.models import Project, SentryAppInstallationToken
 
         try:

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 from itertools import chain
 from typing import TYPE_CHECKING, List

--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -47,6 +47,7 @@ class SentryAppInstallationForProviderManager(ParanoidManager):
         if not installation:
             return Project.objects.none()
 
+        # TODO(nisanthan): Right now, Internal Integrations can have multiple ApiToken, so we use the join table `SentryAppInstallationToken` to map the one to many relationship. However, for Public Integrations, we can only have 1 ApiToken per installation. So we currently don't use the join table for Public Integrations. We should update to make records in the join table for Public Integrations so that we can have a common abstraction for finding an installation by ApiToken.
         if installation.sentry_app.status == SentryAppStatus.INTERNAL:
             return SentryAppInstallationToken.objects.get_projects(token)
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -749,7 +749,9 @@ class Factories:
         return _kwargs
 
     @staticmethod
-    def create_sentry_app_installation(organization=None, slug=None, user=None, status=None):
+    def create_sentry_app_installation(
+        organization=None, slug=None, user=None, status=None, prevent_token_exchange=False
+    ):
         if not organization:
             organization = Factories.create_organization()
 
@@ -764,7 +766,7 @@ class Factories:
         install.status = SentryAppInstallationStatus.INSTALLED if status is None else status
         install.save()
 
-        if install.sentry_app.status != SentryAppStatus.INTERNAL:
+        if not prevent_token_exchange and (install.sentry_app.status != SentryAppStatus.INTERNAL):
             token_exchange.GrantExchanger.run(
                 install=install,
                 code=install.api_grant.code,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -80,6 +80,7 @@ from sentry.models import (
     Repository,
     RepositoryProjectPathConfig,
     Rule,
+    SentryAppInstallation,
     Team,
     User,
     UserEmail,
@@ -773,6 +774,7 @@ class Factories:
                 client_id=install.sentry_app.application.client_id,
                 user=install.sentry_app.proxy_user,
             )
+            install = SentryAppInstallation.objects.get(id=install.id)
         return install
 
     @staticmethod

--- a/tests/acceptance/test_organization_sentry_app_detailed_view.py
+++ b/tests/acceptance/test_organization_sentry_app_detailed_view.py
@@ -36,7 +36,10 @@ class OrganizationSentryAppDetailedView(AcceptanceTestCase):
 
     def test_uninstallation(self):
         self.installation = self.create_sentry_app_installation(
-            slug=self.sentry_app.slug, organization=self.organization, user=self.user
+            slug=self.sentry_app.slug,
+            organization=self.organization,
+            user=self.user,
+            prevent_token_exchange=True,
         )
 
         self.load_page(self.sentry_app.slug)

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -27,6 +27,7 @@ class SentryAppInstallationDetailsTest(APITestCase):
             organization=self.super_org,
             user=self.superuser,
             status=SentryAppInstallationStatus.PENDING,
+            prevent_token_exchange=True,
         )
 
         self.unpublished_app = self.create_sentry_app(name="Testin", organization=self.org)
@@ -36,6 +37,7 @@ class SentryAppInstallationDetailsTest(APITestCase):
             organization=self.org,
             user=self.user,
             status=SentryAppInstallationStatus.PENDING,
+            prevent_token_exchange=True,
         )
 
         self.url = reverse(

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -17,11 +17,17 @@ class SentryAppInstallationsTest(APITestCase):
         self.unpublished_app = self.create_sentry_app(name="Testin", organization=self.org)
 
         self.installation = self.create_sentry_app_installation(
-            slug=self.published_app.slug, organization=self.super_org, user=self.superuser
+            slug=self.published_app.slug,
+            organization=self.super_org,
+            user=self.superuser,
+            prevent_token_exchange=True,
         )
 
         self.installation2 = self.create_sentry_app_installation(
-            slug=self.unpublished_app.slug, organization=self.org, user=self.user
+            slug=self.unpublished_app.slug,
+            organization=self.org,
+            user=self.user,
+            prevent_token_exchange=True,
         )
 
         self.url = reverse("sentry-api-0-sentry-app-installations", args=[self.org.slug])

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
+from rest_framework import status
 
-from sentry.mediators.token_exchange import GrantExchanger
 from sentry.models import Project, ProjectStatus, SentryAppInstallationToken
 from sentry.models.apitoken import ApiToken
 from sentry.testutils import APITestCase
@@ -156,55 +156,39 @@ class ProjectsListTest(APITestCase):
 
         # Delete the token
         SentryAppInstallationToken.objects.all().delete()
+        self.get_error_response(
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
 
-        path = reverse(self.endpoint)
-        response = self.client.get(path, HTTP_AUTHORIZATION=f"Bearer {token}")
-        assert response.status_code == 401
+    def get_installed_unpublished_sentry_app_access_token(self):
+        self.project = self.create_project(organization=self.organization, teams=[self.team])
+        sentry_app = self.create_sentry_app(
+            scopes=("project:read",),
+            published=False,
+            verify_install=False,
+            name="Super Awesome App",
+        )
+        installation = self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization, user=self.user
+        )
+        return installation.api_token.token
 
     def test_valid_with_public_integration(self):
-        project = self.create_project(organization=self.organization, teams=[self.team])
-        sentry_app = self.create_sentry_app(
-            scopes=("project:read",),
-            published=False,
-            verify_install=False,
-            name="Super Awesome App",
-        )
-        installation = self.create_sentry_app_installation(
-            slug=sentry_app.slug, organization=self.organization, user=self.user
-        )
+        token = self.get_installed_unpublished_sentry_app_access_token()
 
-        token = GrantExchanger.run(
-            install=installation,
-            code=installation.api_grant.code,
-            client_id=sentry_app.application.client_id,
-            user=sentry_app.proxy_user,
-        )
         # there should only be one record created so just grab the first one
-        path = reverse(self.endpoint)
-        response = self.client.get(path, HTTP_AUTHORIZATION=f"Bearer {token}")
-        assert project.name.encode("utf-8") in response.content
+        response = self.get_success_response(
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token}"}
+        )
+        assert self.project.name.encode("utf-8") in response.content
 
     def test_deleted_token_with_public_integration(self):
-        self.create_project(organization=self.organization, teams=[self.team])
-        sentry_app = self.create_sentry_app(
-            scopes=("project:read",),
-            published=False,
-            verify_install=False,
-            name="Super Awesome App",
-        )
-        installation = self.create_sentry_app_installation(
-            slug=sentry_app.slug, organization=self.organization, user=self.user
-        )
-
-        token = GrantExchanger.run(
-            install=installation,
-            code=installation.api_grant.code,
-            client_id=sentry_app.application.client_id,
-            user=sentry_app.proxy_user,
-        )
+        token = self.get_installed_unpublished_sentry_app_access_token()
 
         ApiToken.objects.all().delete()
 
-        path = reverse(self.endpoint)
-        response = self.client.get(path, HTTP_AUTHORIZATION=f"Bearer {token}")
-        assert response.status_code == 401
+        self.get_error_response(
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -1,6 +1,8 @@
 from django.urls import reverse
 
+from sentry.mediators.token_exchange import GrantExchanger
 from sentry.models import Project, ProjectStatus, SentryAppInstallationToken
+from sentry.models.apitoken import ApiToken
 from sentry.testutils import APITestCase
 
 
@@ -154,6 +156,54 @@ class ProjectsListTest(APITestCase):
 
         # Delete the token
         SentryAppInstallationToken.objects.all().delete()
+
+        path = reverse(self.endpoint)
+        response = self.client.get(path, HTTP_AUTHORIZATION=f"Bearer {token}")
+        assert response.status_code == 401
+
+    def test_valid_with_public_integration(self):
+        project = self.create_project(organization=self.organization, teams=[self.team])
+        sentry_app = self.create_sentry_app(
+            scopes=("project:read",),
+            published=False,
+            verify_install=False,
+            name="Super Awesome App",
+        )
+        installation = self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization, user=self.user
+        )
+
+        token = GrantExchanger.run(
+            install=installation,
+            code=installation.api_grant.code,
+            client_id=sentry_app.application.client_id,
+            user=sentry_app.proxy_user,
+        )
+        # there should only be one record created so just grab the first one
+        path = reverse(self.endpoint)
+        response = self.client.get(path, HTTP_AUTHORIZATION=f"Bearer {token}")
+        assert project.name.encode("utf-8") in response.content
+
+    def test_deleted_token_with_public_integration(self):
+        self.create_project(organization=self.organization, teams=[self.team])
+        sentry_app = self.create_sentry_app(
+            scopes=("project:read",),
+            published=False,
+            verify_install=False,
+            name="Super Awesome App",
+        )
+        installation = self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization, user=self.user
+        )
+
+        token = GrantExchanger.run(
+            install=installation,
+            code=installation.api_grant.code,
+            client_id=sentry_app.application.client_id,
+            user=sentry_app.proxy_user,
+        )
+
+        ApiToken.objects.all().delete()
 
         path = reverse(self.endpoint)
         response = self.client.get(path, HTTP_AUTHORIZATION=f"Bearer {token}")

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -28,7 +28,10 @@ class TestSentryAppAuthorizations(APITestCase):
         )
 
         self.install = self.create_sentry_app_installation(
-            organization=self.organization, slug="nulldb", user=self.user
+            organization=self.organization,
+            slug="nulldb",
+            user=self.user,
+            prevent_token_exchange=True,
         )
 
     def get_response(self, *args, **params):
@@ -64,7 +67,10 @@ class TestSentryAppAuthorizations(APITestCase):
 
     def test_invalid_installation(self):
         self.install = self.create_sentry_app_installation(
-            organization=self.organization, slug="slowdb", user=self.user
+            organization=self.organization,
+            slug="slowdb",
+            user=self.user,
+            prevent_token_exchange=True,
         )
 
         # URL with this new Install's uuid in it

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
@@ -1,6 +1,5 @@
 from django.urls import reverse
 
-from sentry.mediators.token_exchange import GrantExchanger
 from sentry.models import ApiToken
 from sentry.testutils import APITestCase
 
@@ -60,16 +59,9 @@ class SentryInternalAppTokenCreationTest(APITestCase):
             slug=sentry_app.slug, organization=self.org, user=self.user
         )
 
-        client_id = install.sentry_app.application.client_id
-        user = install.sentry_app.proxy_user
-
-        api_token = GrantExchanger.run(
-            install=install, code=install.api_grant.code, client_id=client_id, user=user
-        )
-
         url = reverse(
             "sentry-api-0-sentry-internal-app-token-details",
-            args=[install.sentry_app.slug, api_token.token],
+            args=[install.sentry_app.slug, install.api_token.token],
         )
 
         self.login_as(user=self.user)

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -39,7 +39,7 @@ class TestInstallationNotifier(TestCase):
         )
 
         self.install = self.create_sentry_app_installation(
-            slug="foo", organization=self.org, user=self.user
+            slug="foo", organization=self.org, user=self.user, prevent_token_exchange=True
         )
 
     @patch("sentry.tasks.sentry_apps.safe_urlopen", return_value=MockResponseInstance)

--- a/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
+++ b/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
@@ -9,7 +9,7 @@ from sentry.testutils import TestCase
 
 class TestGrantExchanger(TestCase):
     def setUp(self):
-        self.install = self.create_sentry_app_installation()
+        self.install = self.create_sentry_app_installation(prevent_token_exchange=True)
         self.code = self.install.api_grant.code
         self.client_id = self.install.sentry_app.application.client_id
         self.user = self.install.sentry_app.proxy_user

--- a/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
+++ b/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
@@ -34,7 +34,7 @@ class TestGrantExchanger(TestCase):
         )
 
     def test_grant_must_belong_to_installations(self):
-        other_install = self.create_sentry_app_installation()
+        other_install = self.create_sentry_app_installation(prevent_token_exchange=True)
         self.grant_exchanger.code = other_install.api_grant.code
 
         with self.assertRaises(APIUnauthorized):

--- a/tests/sentry/mediators/token_exchange/test_refresher.py
+++ b/tests/sentry/mediators/token_exchange/test_refresher.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from sentry.coreapi import APIUnauthorized
-from sentry.mediators.token_exchange import GrantExchanger, Refresher
+from sentry.mediators.token_exchange import Refresher
 from sentry.models import ApiApplication, ApiToken, SentryApp, SentryAppInstallation
 from sentry.testutils import TestCase
 
@@ -12,12 +12,7 @@ class TestRefresher(TestCase):
         self.client_id = self.install.sentry_app.application.client_id
         self.user = self.install.sentry_app.proxy_user
 
-        self.token = GrantExchanger.run(
-            install=self.install,
-            code=self.install.api_grant.code,
-            client_id=self.client_id,
-            user=self.user,
-        )
+        self.token = self.install.api_token
 
         self.refresher = Refresher(
             install=self.install,

--- a/tests/sentry/models/test_sentryapp.py
+++ b/tests/sentry/models/test_sentryapp.py
@@ -56,11 +56,15 @@ class SentryAppTest(TestCase):
 
     def test_is_installed_on(self):
         other_app = self.create_sentry_app()
-        self.create_sentry_app_installation(organization=self.org, slug=self.sentry_app.slug)
+        self.create_sentry_app_installation(
+            organization=self.org, slug=self.sentry_app.slug, prevent_token_exchange=True
+        )
         assert self.sentry_app.is_installed_on(self.org)
         assert not other_app.is_installed_on(self.org)
 
     def test_not_installed_on_org(self):
         other_org = self.create_organization()
-        self.create_sentry_app_installation(organization=other_org, slug=self.sentry_app.slug)
+        self.create_sentry_app_installation(
+            organization=other_org, slug=self.sentry_app.slug, prevent_token_exchange=True
+        )
         assert not self.sentry_app.is_installed_on(self.org)

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -4,7 +4,6 @@ from rest_framework.permissions import AllowAny
 from sentry.api.base import Endpoint
 from sentry.api.endpoints.organization_group_index import OrganizationGroupIndexEndpoint
 from sentry.auth.system import SystemToken
-from sentry.mediators.token_exchange import GrantExchanger
 from sentry.models import User
 from sentry.ratelimits import get_rate_limit_config, get_rate_limit_key
 from sentry.ratelimits.config import RateLimitConfig
@@ -75,16 +74,9 @@ class GetRateLimitKeyTest(TestCase):
             slug=sentry_app.slug, organization=self.organization, user=self.user
         )
 
-        client_id = sentry_app.application.client_id
-        user = sentry_app.proxy_user
-
-        api_token = GrantExchanger.run(
-            install=install, code=install.api_grant.code, client_id=client_id, user=user
-        )
-
         self.request.user = sentry_app.proxy_user
 
-        self.request.auth = api_token
+        self.request.auth = install.api_token
 
         assert (
             get_rate_limit_key(


### PR DESCRIPTION
## Objective:
Fixes https://github.com/getsentry/sentry/issues/33938

`/projects` only accepted Internal Integrations tokens. Because we handle Public and Internal SentryApps authentication differently, I made an abstraction to fetch projects.

<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
