### PR TITLE
ref(replay): Adhere to the Rules of Hooks

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -31,7 +31,7 @@ function BasePlayerRoot({className, fixedHeight = false}: Props) {
   });
 
   // Create the `rrweb` instance which creates an iframe inside `viewEl`
-  useEffect(() => initRoot(viewEl.current), [viewEl.current]);
+  useEffect(() => initRoot(viewEl.current), [initRoot]);
 
   // Read the initial width & height where the player will be inserted, this is
   // so we can shrink the video into the available space.
@@ -42,7 +42,7 @@ function BasePlayerRoot({className, fixedHeight = false}: Props) {
         width: windowEl.current?.clientWidth || 0,
         height: windowEl.current?.clientHeight || 0,
       }),
-    [windowEl.current]
+    [setWindowDimensions]
   );
   useResizeObserver({ref: windowEl, onResize: updateWindowDimensions});
   // If your browser doesn't have ResizeObserver then set the size once.
@@ -70,7 +70,7 @@ function BasePlayerRoot({className, fixedHeight = false}: Props) {
         viewEl.current.style.height = `${videoDimensions.height * scale}px`;
       }
     }
-  }, [windowDimensions, videoDimensions]);
+  }, [fixedHeight, windowDimensions, videoDimensions]);
 
   return (
     <Panel fixedHeight={fixedHeight}>

--- a/static/app/views/replays/utils/useReplayEvent.tsx
+++ b/static/app/views/replays/utils/useReplayEvent.tsx
@@ -188,7 +188,7 @@ function useReplayEvent({eventSlug, location, orgId}: Options): Result {
     }
   }
 
-  useEffect(() => void loadEvents(), [orgId, eventSlug, retry]);
+  useEffect(() => void loadEvents(), [orgId, eventSlug, retry]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onRetry = useCallback(() => {
     setRetry(true);


### PR DESCRIPTION
Make sure useCallback() dependencies are exhaustively declared

This is a re-do of #33789 which had accidentally created an infinite render situation in `useReplayEvent()`.