### PR TITLE
fix(dashboard): Check if big number height has changed before setting state

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -293,7 +293,9 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps, State> {
             ref={el => {
               if (el !== null && !!!expandNumbers) {
                 const {height} = el.getBoundingClientRect();
-                this.setState({containerHeight: height});
+                if (height !== this.state.containerHeight) {
+                  this.setState({containerHeight: height});
+                }
               }
             }}
           >


### PR DESCRIPTION
We're currently relying on the ref to calculate a height for the big
number widget. A small set of users are hitting a recursion depth issue
with setState. Add a conditional so we aren't calling it unless
necessary (i.e. the size has changed).

Fixes JAVASCRIPT-26WN

We can get this change in and monitor the issue for recurrence. It's a small subset of users with one user hitting it 87% of the time.