### PR TITLE
chore(dashboard): Remove low granularity interval logic for RH widgets

### DIFF
--- a/static/app/views/dashboardsV2/utils.tsx
+++ b/static/app/views/dashboardsV2/utils.tsx
@@ -11,12 +11,7 @@ import WidgetTable from 'sentry-images/dashboard/widget-table.svg';
 import WidgetWorldMap from 'sentry-images/dashboard/widget-world-map.svg';
 
 import {parseArithmetic} from 'sentry/components/arithmeticInput/parser';
-import {
-  getDiffInMinutes,
-  getInterval,
-  SIX_HOURS,
-  TWENTY_FOUR_HOURS,
-} from 'sentry/components/charts/utils';
+import {getDiffInMinutes, getInterval} from 'sentry/components/charts/utils';
 import {Organization, PageFilters} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {getUtcDateString, parsePeriodToHours} from 'sentry/utils/dates';
@@ -162,16 +157,6 @@ export function getWidgetInterval(
   }
   const desiredPeriod = parsePeriodToHours(interval);
   const selectedRange = getDiffInMinutes(datetimeObj);
-
-  if (widget.widgetType === WidgetType.METRICS) {
-    // Lower fidelity for Release Health widgets because of what
-    // the sessions endpoint can currently support.
-    interval = getInterval(datetimeObj, 'medium');
-    if (selectedRange > SIX_HOURS && selectedRange <= TWENTY_FOUR_HOURS) {
-      interval = '1h';
-    }
-    return widget.displayType === 'bar' ? '1d' : interval;
-  }
 
   // selectedRange is in minutes, desiredPeriod is in hours
   // convert desiredPeriod to minutes

--- a/tests/js/spec/views/dashboardsV2/metricsWidgetQueries.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/metricsWidgetQueries.spec.tsx
@@ -297,7 +297,7 @@ describe('Dashboards > MetricsWidgetQueries', function () {
           environment: ['prod'],
           field: ['sum(session)'],
           groupBy: [],
-          interval: '1h',
+          interval: '30m',
           project: [1],
           statsPeriod: '14d',
         },
@@ -311,7 +311,7 @@ describe('Dashboards > MetricsWidgetQueries', function () {
           environment: ['prod'],
           field: ['sum(session)'],
           groupBy: [],
-          interval: '1h',
+          interval: '30m',
           project: [1],
           query: 'environment:prod',
           statsPeriod: '14d',
@@ -379,7 +379,7 @@ describe('Dashboards > MetricsWidgetQueries', function () {
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
-          interval: '1d',
+          interval: '4h',
           statsPeriod: '90d',
           environment: ['prod'],
           project: [1],

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2386,7 +2386,7 @@ describe('WidgetBuilder', function () {
               environment: [],
               field: [`sum(session)`],
               groupBy: [],
-              interval: '1h',
+              interval: '5m',
               project: [],
               statsPeriod: '24h',
             },


### PR DESCRIPTION
With #34043 we can now request smaller intervals for release
health widgets, so removing the temp code added to support
the sessions limitions.

Requires #34043