### PR TITLE
feat(replays): Update Replays icon in sidebar

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -21,6 +21,7 @@ import {
   IconLightning,
   IconList,
   IconProject,
+  IconRefresh,
   IconReleases,
   IconSettings,
   IconSiren,
@@ -294,7 +295,7 @@ function Sidebar({location, organization}: Props) {
         onClick={(_id, evt) =>
           navigateWithPageFilters(`/organizations/${organization.slug}/replays/`, evt)
         }
-        icon={<IconLab size="md" />}
+        icon={<IconRefresh size="md" />}
         label={t('Replays')}
         to={`/organizations/${organization.slug}/replays/`}
         id="replays"
@@ -402,8 +403,10 @@ function Sidebar({location, organization}: Props) {
                 {profiling}
               </SidebarSection>
 
-              <SidebarSection>{monitors}</SidebarSection>
-              <SidebarSection>{replays}</SidebarSection>
+              <SidebarSection>
+                {replays}
+                {monitors}
+              </SidebarSection>
 
               <SidebarSection>
                 {activity}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -20,8 +20,8 @@ import {
   IconLab,
   IconLightning,
   IconList,
+  IconPlay,
   IconProject,
-  IconRefresh,
   IconReleases,
   IconSettings,
   IconSiren,
@@ -295,7 +295,7 @@ function Sidebar({location, organization}: Props) {
         onClick={(_id, evt) =>
           navigateWithPageFilters(`/organizations/${organization.slug}/replays/`, evt)
         }
-        icon={<IconRefresh size="md" />}
+        icon={<IconPlay size="md" />}
         label={t('Replays')}
         to={`/organizations/${organization.slug}/replays/`}
         id="replays"


### PR DESCRIPTION
Change icon from "lab" to "play" and group with Monitors (otherwise it looked a bit off when they are both displayed in solo groups).

![image](https://user-images.githubusercontent.com/79684/165781260-fd1a3c35-dbf3-4398-9aae-ae5ec1345fb1.png)
