### PR TITLE
fix(widget-builder): Widgets not opening with the correct ordering

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -143,7 +143,7 @@ export function normalizeQueries({
       // grouping in timeseries charts
       const ignoreOrderBy = isEquation(trimStart(queryOrderBy, '-')) && isTabularChart;
       const orderBy =
-        (!ignoreOrderBy && getAggregateAlias(queryOrderBy)) ||
+        (!ignoreOrderBy && getAggregateAlias(trimStart(queryOrderBy, '-'))) ||
         (widgetType === WidgetType.ISSUE
           ? IssueSortOptions.DATE
           : generateOrderOptions({

--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -153,13 +153,14 @@ export function normalizeQueries({
               aggregates: queries[0].aggregates,
             })[0].value);
 
+      // A widget should be descending if:
+      // - There is no orderby, so we're defaulting to desc
+      // - Not an issues widget since issues doesn't support descending and
+      //   the original ordering was descending
       const isDescending =
-        (widgetType === WidgetType.DISCOVER &&
-          !orderBy.startsWith('-') &&
-          queryOrderBy.startsWith('-')) ||
-        !query.orderby;
+        !query.orderby ||
+        (widgetType !== WidgetType.ISSUE && queryOrderBy.startsWith('-'));
 
-      // Issues data set doesn't support order by descending
       query.orderby = isDescending ? `-${String(orderBy)}` : String(orderBy);
 
       return query;

--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -153,11 +153,14 @@ export function normalizeQueries({
               aggregates: queries[0].aggregates,
             })[0].value);
 
+      const isDescending =
+        (widgetType === WidgetType.DISCOVER &&
+          !orderBy.startsWith('-') &&
+          queryOrderBy.startsWith('-')) ||
+        !query.orderby;
+
       // Issues data set doesn't support order by descending
-      query.orderby =
-        widgetType === WidgetType.DISCOVER && !orderBy.startsWith('-')
-          ? `-${String(orderBy)}`
-          : String(orderBy);
+      query.orderby = isDescending ? `-${String(orderBy)}` : String(orderBy);
 
       return query;
     });

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1904,6 +1904,50 @@ describe('WidgetBuilder', function () {
         'count_unique(user) * 2'
       );
     });
+
+    it.only.each`
+      directionPrefix | expectedOrderSelection
+      ${'-'}          | ${'High to low'}
+      ${''}           | ${'Low to high'}
+    `(
+      `opens a widget with the '$expectedOrderSelection' sort order when the widget is saved with that direction`,
+      async function ({directionPrefix, expectedOrderSelection}) {
+        const widget: Widget = {
+          id: '1',
+          title: 'Test Widget',
+          interval: '5m',
+          displayType: DisplayType.LINE,
+          queries: [
+            {
+              name: '',
+              conditions: '',
+              fields: ['count()'],
+              aggregates: ['count()'],
+              columns: ['project'],
+              orderby: `${directionPrefix}count`,
+            },
+          ],
+        };
+
+        const dashboard: DashboardDetails = {
+          id: '1',
+          title: 'Dashboard',
+          createdBy: undefined,
+          dateCreated: '2020-01-01T00:00:00.000Z',
+          widgets: [widget],
+        };
+
+        renderTestComponent({
+          orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        await screen.findByText(expectedOrderSelection);
+      }
+    );
   });
 
   describe('Widget creation coming from other verticals', function () {

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1906,9 +1906,11 @@ describe('WidgetBuilder', function () {
     });
 
     it.each`
-      directionPrefix | expectedOrderSelection
-      ${'-'}          | ${'High to low'}
-      ${''}           | ${'Low to high'}
+      directionPrefix | expectedOrderSelection | displayType
+      ${'-'}          | ${'High to low'}       | ${DisplayType.TABLE}
+      ${''}           | ${'Low to high'}       | ${DisplayType.TABLE}
+      ${'-'}          | ${'High to low'}       | ${DisplayType.LINE}
+      ${''}           | ${'Low to high'}       | ${DisplayType.LINE}
     `(
       `opens a widget with the '$expectedOrderSelection' sort order when the widget was saved with that direction`,
       async function ({directionPrefix, expectedOrderSelection}) {

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1905,12 +1905,12 @@ describe('WidgetBuilder', function () {
       );
     });
 
-    it.only.each`
+    it.each`
       directionPrefix | expectedOrderSelection
       ${'-'}          | ${'High to low'}
       ${''}           | ${'Low to high'}
     `(
-      `opens a widget with the '$expectedOrderSelection' sort order when the widget is saved with that direction`,
+      `opens a widget with the '$expectedOrderSelection' sort order when the widget was saved with that direction`,
       async function ({directionPrefix, expectedOrderSelection}) {
         const widget: Widget = {
           id: '1',
@@ -1921,10 +1921,10 @@ describe('WidgetBuilder', function () {
             {
               name: '',
               conditions: '',
-              fields: ['count()'],
-              aggregates: ['count()'],
+              fields: ['count_unique(user)'],
+              aggregates: ['count_unique(user)'],
               columns: ['project'],
-              orderby: `${directionPrefix}count`,
+              orderby: `${directionPrefix}count_unique_user`,
             },
           ],
         };


### PR DESCRIPTION
Editing widgets wasn't properly maintaining the sort order and always favouring "High to low". This PR assigns the descending ordering when:

* There was no order to begin with, so we default to "High to low"
* Not displaying an Issues widget AND the original ordering was also descending

That way, if there is an ordering, we can maintain it.