### PR TITLE
feat(ui): Add CompositeSelect

### DIFF
--- a/docs-ui/stories/components/form-fields.stories.js
+++ b/docs-ui/stories/components/form-fields.stories.js
@@ -3,6 +3,7 @@ import {action} from '@storybook/addon-actions';
 import NewBooleanField from 'sentry/components/forms/booleanField';
 import CheckboxField from 'sentry/components/forms/checkboxField';
 import CompactSelect from 'sentry/components/forms/compactSelect';
+import CompositeSelect from 'sentry/components/forms/compositeSelect';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import RangeSlider from 'sentry/components/forms/controls/rangeSlider';
 import DatePickerField from 'sentry/components/forms/datePickerField';
@@ -369,6 +370,37 @@ CompactSelectField.argTypes = {
     control: {type: 'radio'},
   },
 };
+
+export const CompositeSelectField = props => (
+  <CompositeSelect
+    sections={[
+      {
+        label: 'Group 1',
+        value: 'group_1',
+        defaultValue: 'choice_one',
+        options: [
+          {value: 'choice_one', label: 'Choice One'},
+          {value: 'choice_two', label: 'Choice Two'},
+        ],
+      },
+      {
+        label: 'Group 2',
+        value: 'group_2',
+        defaultValue: ['choice_three'],
+        multiple: true,
+        options: [
+          {value: 'choice_three', label: 'Choice Three'},
+          {value: 'choice_four', label: 'Choice Four'},
+        ],
+      },
+    ]}
+    {...props}
+  />
+);
+CompositeSelectField.storyName = 'Select - Composite';
+CompositeSelectField.args = {...CompactSelectField.args};
+delete CompositeSelectField.args.multiple;
+CompositeSelectField.argTypes = CompactSelectField.argTypes;
 
 export const NonInlineField = () => (
   <Form>

--- a/static/app/components/forms/compactSelect.tsx
+++ b/static/app/components/forms/compactSelect.tsx
@@ -37,6 +37,7 @@ interface Props<OptionType>
    * Pass class name to the outer wrap
    */
   className?: string;
+  onChangeValueMap?: (value: OptionType[]) => ControlProps<OptionType>['value'];
   /**
    * Tag name for the outer wrap, defaults to `div`
    */
@@ -123,6 +124,7 @@ function CompactSelect<OptionType extends GeneralSelectValue = GeneralSelectValu
   isSearchable = false,
   multiple,
   placeholder = 'Search…',
+  onChangeValueMap,
   // Trigger button & wrapper props
   trigger,
   triggerLabel,
@@ -225,7 +227,8 @@ function CompactSelect<OptionType extends GeneralSelectValue = GeneralSelectValu
   }, [updateTriggerWidth]);
 
   function onValueChange(option) {
-    const newValue = Array.isArray(option) ? option.map(opt => opt.value) : option?.value;
+    const valueMap = onChangeValueMap ?? (opts => opts.map(opt => opt.value));
+    const newValue = Array.isArray(option) ? valueMap(option) : option?.value;
     setInternalValue(newValue);
     onChange?.(option);
 

--- a/static/app/components/forms/compositeSelect.tsx
+++ b/static/app/components/forms/compositeSelect.tsx
@@ -107,12 +107,24 @@ function CompositeSelect<OptionType extends GeneralSelectValue = GeneralSelectVa
 
       // If the section allows only single selection, then replace whatever the
       // old value is with the new one.
-      newValues[parentSectionIndex] = option.value;
+      if (option.value) {
+        newValues[parentSectionIndex] = option.value;
+      }
     });
 
-    newValues.forEach((value, sectionIndex) => {
-      if (!valueIsEqual(values[sectionIndex], value)) {
-        sections[sectionIndex].onChange?.(value);
+    sections.forEach((section, i) => {
+      // Prevent sections with single selection from losing their values. This might
+      // happen if the user clicks on an already-selected option.
+      if (!section.multiple && !newValues[i]) {
+        newValues[i] = values[i];
+        // Return an empty array for sections with multiple selection without any value.
+      } else if (!newValues[i]) {
+        newValues[i] = [];
+      }
+
+      // Trigger the onChange callback for sections whose values have changed.
+      if (!valueIsEqual(values[i], newValues[i])) {
+        sections[i].onChange?.(newValues[i]);
       }
     });
 

--- a/static/app/components/forms/compositeSelect.tsx
+++ b/static/app/components/forms/compositeSelect.tsx
@@ -1,0 +1,137 @@
+import {useMemo, useState} from 'react';
+
+import CompactSelect from 'sentry/components/forms/compactSelect';
+import {GeneralSelectValue} from 'sentry/components/forms/selectControl';
+import {valueIsEqual} from 'sentry/utils';
+/**
+ * CompositeSelect simulates independent selectors inside the same dropdown
+ * menu. Each selector is called a "section". The selection value of one
+ * section does not affect the value of the others.
+ */
+type Section<OptionType> = {
+  /**
+   * Text label that will be display on top of the section.
+   */
+  label: string;
+  /**
+   * Selectable options inside the section.
+   */
+  options: OptionType[];
+  /**
+   * Must be a unique indentifying key for the section. This value will be
+   * used in the onChange return value. For example, if there are two
+   * sections, "section1" and "section2", then the onChange callback will be
+   * invoked as onChange({section1: [selected option values], section2:
+   * [selected option values]}).
+   */
+  value: string;
+  defaultValue?: any;
+  /**
+   * Whether the section has multiple (versus) single selection.
+   */
+  multiple?: boolean;
+  onChange?: (value: any) => void;
+};
+
+type ExtendedOptionType = GeneralSelectValue & {
+  selectionMode?: 'multiple' | 'single';
+};
+
+type Props<OptionType> = Omit<
+  React.ComponentProps<typeof CompactSelect>,
+  'multiple' | 'defaultValue' | 'onChange'
+> & {
+  sections: Section<OptionType>[];
+};
+
+/**
+ * Special version of CompactSelect that simulates independent selectors (here
+ * implemented as "sections") within the same dropdown menu.
+ */
+function CompositeSelect<OptionType extends GeneralSelectValue = GeneralSelectValue>({
+  sections,
+  ...props
+}: Props<OptionType>) {
+  const [values, setValues] = useState(sections.map(section => section.defaultValue));
+  /**
+   * Object that maps an option value (e.g. "opt_one") to its parent section's index,
+   * to be used in onChangeValueMap.
+   */
+  const optionsMap = useMemo(() => {
+    const allOptions = sections
+      .map((section, i) => section.options.map(opt => [opt.value, i]))
+      .flat();
+    return Object.fromEntries(allOptions);
+  }, [sections]);
+
+  /**
+   * Options with the "selectionMode" key attached. This key overrides the
+   * isMulti setting from SelectControl and forces SelectOption
+   * (./selectOption.tsx) to display either a chekmark or a checkbox based on
+   * the selection mode of its parent section, rather than the selection mode
+   * of the entire select menu.
+   */
+  const options = useMemo(() => {
+    return sections.map(section => ({
+      ...section,
+      options: section.options.map(
+        opt =>
+          ({
+            ...opt,
+            selectionMode: section.multiple ? 'multiple' : 'single',
+          } as ExtendedOptionType)
+      ),
+    }));
+  }, [sections]);
+
+  /**
+   * Intercepts the incoming set of selected values, and trims it so that
+   * single-selection sections will only have one selected value at a time.
+   */
+  function onChangeValueMap(selectedOptions: ExtendedOptionType[]) {
+    const newValues = new Array(sections.length).fill(undefined);
+
+    selectedOptions.forEach(option => {
+      const parentSectionIndex = optionsMap[option.value];
+      const parentSection = sections[parentSectionIndex];
+
+      // If the section allows multiple selection, then add the value to the
+      // list of selected values
+      if (parentSection.multiple) {
+        if (!newValues[parentSectionIndex]) {
+          newValues[parentSectionIndex] = [];
+        }
+        newValues[parentSectionIndex].push(option.value);
+        return;
+      }
+
+      // If the section allows only single selection, then replace whatever the
+      // old value is with the new one.
+      newValues[parentSectionIndex] = option.value;
+    });
+
+    newValues.forEach((value, sectionIndex) => {
+      if (!valueIsEqual(values[sectionIndex], value)) {
+        sections[sectionIndex].onChange?.(value);
+      }
+    });
+
+    setValues(newValues);
+
+    // Return a flattened array of the selected values to be used inside
+    // CompactSelect and SelectControl.
+    return newValues.flat();
+  }
+
+  return (
+    <CompactSelect<ExtendedOptionType>
+      {...props}
+      multiple
+      options={options}
+      defaultValue={sections.map(section => section.defaultValue).flat()}
+      onChangeValueMap={onChangeValueMap}
+    />
+  );
+}
+
+export default CompositeSelect;

--- a/static/app/components/forms/compositeSelect.tsx
+++ b/static/app/components/forms/compositeSelect.tsx
@@ -3,6 +3,7 @@ import {useMemo, useState} from 'react';
 import CompactSelect from 'sentry/components/forms/compactSelect';
 import {GeneralSelectValue} from 'sentry/components/forms/selectControl';
 import {valueIsEqual} from 'sentry/utils';
+
 /**
  * CompositeSelect simulates independent selectors inside the same dropdown
  * menu. Each selector is called a "section". The selection value of one
@@ -41,6 +42,12 @@ type Props<OptionType> = Omit<
   React.ComponentProps<typeof CompactSelect>,
   'multiple' | 'defaultValue' | 'onChange'
 > & {
+  /**
+   * Array containing the independent selection sections. NOTE: This array
+   * should not change (i.e. we shouldn't add/remove sections) during the
+   * component's lifecycle. Updating the options array inside sech section is
+   * fine.
+   */
   sections: Section<OptionType>[];
 };
 
@@ -53,6 +60,7 @@ function CompositeSelect<OptionType extends GeneralSelectValue = GeneralSelectVa
   ...props
 }: Props<OptionType>) {
   const [values, setValues] = useState(sections.map(section => section.defaultValue));
+
   /**
    * Object that maps an option value (e.g. "opt_one") to its parent section's index,
    * to be used in onChangeValueMap.

--- a/static/app/components/forms/selectOption.tsx
+++ b/static/app/components/forms/selectOption.tsx
@@ -21,7 +21,7 @@ function SelectOption(props: Props) {
     trailingItems,
     leadingItemsSpanFullHeight,
     trailingItemsSpanFullHeight,
-    selectionMode = 'single',
+    selectionMode,
   } = data;
 
   const isMultiple = defined(selectionMode) ? selectionMode === 'multiple' : isMulti;

--- a/static/app/components/forms/selectOption.tsx
+++ b/static/app/components/forms/selectOption.tsx
@@ -21,18 +21,21 @@ function SelectOption(props: Props) {
     trailingItems,
     leadingItemsSpanFullHeight,
     trailingItemsSpanFullHeight,
+    selectionMode = 'single',
   } = data;
+
+  const isMultiple = defined(selectionMode) ? selectionMode === 'multiple' : isMulti;
 
   return (
     <selectComponents.Option className="select-option" {...props}>
       <Tooltip skipWrapper title={tooltip} {...tooltipOptions}>
         <InnerWrap isFocused={isFocused} isDisabled={isDisabled} data-test-id={value}>
-          <Indent isMulti={isMulti} centerCheckWrap={verticallyCenterCheckWrap}>
-            <CheckWrap isMulti={isMulti} isSelected={isSelected}>
+          <Indent isMultiple={isMultiple} centerCheckWrap={verticallyCenterCheckWrap}>
+            <CheckWrap isMultiple={isMultiple} isSelected={isSelected}>
               {isSelected && (
                 <IconCheckmark
-                  size={isMulti ? 'xs' : 'sm'}
-                  color={isMulti ? 'white' : undefined}
+                  size={isMultiple ? 'xs' : 'sm'}
+                  color={isMultiple ? 'white' : undefined}
                 />
               )}
             </CheckWrap>
@@ -80,24 +83,24 @@ const InnerWrap = styled('div')<{isDisabled: boolean; isFocused: boolean}>`
   `}
 `;
 
-const Indent = styled('div')<{centerCheckWrap?: boolean; isMulti?: boolean}>`
+const Indent = styled('div')<{centerCheckWrap?: boolean; isMultiple?: boolean}>`
   display: flex;
   justify-content: center;
   gap: ${space(1)};
   padding: ${space(1)};
   padding-left: ${space(0.5)};
 
-  ${p => p.isMulti && !p.centerCheckWrap && `margin-top: 0.2em;`}
+  ${p => p.isMultiple && !p.centerCheckWrap && `margin-top: 0.2em;`}
   ${p => p.centerCheckWrap && 'align-items: center;'}
 `;
 
-const CheckWrap = styled('div')<{isMulti: boolean; isSelected: boolean}>`
+const CheckWrap = styled('div')<{isMultiple: boolean; isSelected: boolean}>`
   display: flex;
   justify-content: center;
   align-items: center;
 
   ${p =>
-    p.isMulti
+    p.isMultiple
       ? `
       width: 1em;
       height: 1em;


### PR DESCRIPTION
Add a special, tweaked version of CompositeSelect that allows for multiple, independent selection "sections":

<img width="221" alt="Screen Shot 2022-04-28 at 8 43 11 AM" src="https://user-images.githubusercontent.com/44172267/165791576-c2da498f-7d3b-4d90-a4c9-41e0fc44aab0.png">

Each section has its own `value` and `onChange` callback.

[Storybook example.](https://storybook-jn2xiauqt.sentry.dev/?path=/story/components-forms-fields--composite-select-field)

Under the hood, this is just one `CompactSelect` with multiple selection. When the select value changes, we intercept and update the `value` array to simulate multiple independent selection sections (`onChangeValueMap`).
