### PR TITLE
feat(metrics) fix input params for single-process last seen updater

### DIFF
--- a/src/sentry/sentry_metrics/last_seen_updater.py
+++ b/src/sentry/sentry_metrics/last_seen_updater.py
@@ -39,9 +39,6 @@ class LastSeenUpdaterCollector(ProcessingStrategy[int]):  # type: ignore
 def get_last_seen_updater(
     topic: str,
     group_id: str,
-    input_block_size: int,
-    output_block_size: int,
-    processes: int,
     max_batch_size: int,
     max_batch_time: float,
     auto_offset_reset: str,
@@ -50,9 +47,9 @@ def get_last_seen_updater(
     processing_factory = KafkaConsumerStrategyFactory(
         max_batch_time=max_batch_time,
         max_batch_size=max_batch_size,
-        processes=processes,
-        input_block_size=input_block_size,
-        output_block_size=output_block_size,
+        processes=None,
+        input_block_size=None,
+        output_block_size=None,
         process_message=lambda message: 1,
         prefilter=LastSeenUpdaterMessageFilter(),
         collector=lambda: LastSeenUpdaterCollector(),


### PR DESCRIPTION
These aren't necessary for a single-process consumer and they were blocking deploy when not provided by k8s

This also lets us run `sentry run indexer-last-seen-updater` on the command line with no arguments

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
