### PR TITLE
ref(metrics-indexer): Validate metric names and tags

### DIFF
--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -348,7 +348,7 @@ def valid_metric_name(name: str) -> bool:
 
 
 def valid_metric_tags(tags: Mapping[str, str]) -> Tuple[bool, Sequence[str]]:
-    invalid_strs: Sequence[str] = []
+    invalid_strs: List[str] = []
     is_valid = True
     for key, value in tags.items():
         if not key or len(key) > MAX_TAG_KEY_LENGTH:

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -309,7 +309,7 @@ def test_process_messages_invalid_messages(invalid_payload, error_text, caplog) 
     last = message_batch[-1]
     outer_message = Message(last.partition, last.offset, message_batch, last.timestamp)
 
-    with caplog.at_level(logging.WARNING), mock.patch(
+    with caplog.at_level(logging.ERROR), mock.patch(
         "sentry.sentry_metrics.multiprocess.get_indexer", return_value=MockIndexer()
     ):
         new_batch = process_messages(outer_message=outer_message)


### PR DESCRIPTION
**context**
We want to enforce a max length of `200` for metric names, tag keys, and tag values. This PR adds that and also checks for empty strings.
