### PR TITLE
ref(notifications): Remove `get_activity_name()`

### DIFF
--- a/src/sentry/notifications/notifications/activity/assigned.py
+++ b/src/sentry/notifications/notifications/activity/assigned.py
@@ -8,10 +8,8 @@ from .base import GroupActivityNotification
 
 
 class AssignedActivityNotification(GroupActivityNotification):
+    title = "Assigned"
     referrer_base = "assigned-activity"
-
-    def get_activity_name(self) -> str:
-        return "Assigned"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         activity = self.activity

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -29,15 +29,18 @@ class ActivityNotification(ProjectNotification, abc.ABC):
         super().__init__(activity.project)
         self.activity = activity
 
-    def get_title(self) -> str:
-        raise NotImplementedError
+    @property
+    @abc.abstractmethod
+    def title(self) -> str:
+        """The header for Workflow notifications."""
+        pass
 
     def get_base_context(self) -> MutableMapping[str, Any]:
         """The most basic context shared by every notification type."""
         return {
             "data": self.activity.data,
             "author": self.activity.user,
-            "title": self.get_title(),
+            "title": self.title,
             "project": self.project,
             "project_link": self.get_project_link(),
             **super().get_base_context(),
@@ -80,14 +83,8 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
         super().__init__(activity)
         self.group = activity.group
 
-    def get_activity_name(self) -> str:
-        raise NotImplementedError
-
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         raise NotImplementedError
-
-    def get_title(self) -> str:
-        return self.get_activity_name()
 
     def get_group_link(self) -> str:
         # method only used for emails
@@ -119,7 +116,6 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
         description, params, html_params = self.get_description()
         return {
             **self.get_base_context(),
-            "activity_name": self.get_activity_name(),
             "text_description": self.description_as_text(description, params),
             "html_description": self.description_as_html(description, html_params or params),
         }

--- a/src/sentry/notifications/notifications/activity/new_processing_issues.py
+++ b/src/sentry/notifications/notifications/activity/new_processing_issues.py
@@ -50,7 +50,8 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return f"Processing Issues on {self.project.slug}"
 
-    def get_title(self) -> str:
+    @property
+    def title(self) -> str:
         return self.get_subject()
 
     def get_category(self) -> str:

--- a/src/sentry/notifications/notifications/activity/note.py
+++ b/src/sentry/notifications/notifications/activity/note.py
@@ -13,21 +13,19 @@ class NoteActivityNotification(GroupActivityNotification):
     referrer_base = "note-activity"
     template_path = "sentry/emails/activity/note"
 
-    def get_activity_name(self) -> str:
-        return "Note"
-
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return str(self.activity.data["text"]), {}, {}
 
     def get_category(self) -> str:
         return "note_activity_email"
 
-    def get_title(self) -> str:
+    @property
+    def title(self) -> str:
         author = self.activity.user.get_display_name()
         return f"New comment by {author}"
 
     def get_notification_title(self) -> str:
-        return self.get_title()
+        return self.title
 
     def get_message_description(self, recipient: Team | User) -> Any:
         return self.get_context()["text_description"]

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -12,15 +12,13 @@ from .base import GroupActivityNotification
 
 
 class RegressionActivityNotification(GroupActivityNotification):
+    title = "Regression"
     referrer_base = "regression-activity"
 
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity)
         self.version = self.activity.data.get("version", "")
         self.version_parsed = parse_release(self.version)["description"]
-
-    def get_activity_name(self) -> str:
-        return "Regression"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         message, params, html_params = "{author} marked {an issue} as a regression", {}, {}

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -130,7 +130,8 @@ class ReleaseActivityNotification(ActivityNotification):
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return f"Deployed version {self.version_parsed} to {self.environment}"
 
-    def get_title(self) -> str:
+    @property
+    def title(self) -> str:
         return self.get_subject()
 
     def get_notification_title(self) -> str:

--- a/src/sentry/notifications/notifications/activity/resolved.py
+++ b/src/sentry/notifications/notifications/activity/resolved.py
@@ -6,10 +6,8 @@ from .base import GroupActivityNotification
 
 
 class ResolvedActivityNotification(GroupActivityNotification):
+    title = "Resolved Issue"
     referrer_base = "resolved-activity"
-
-    def get_activity_name(self) -> str:
-        return "Resolved Issue"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} marked {an issue} as resolved", {}, {}

--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -9,10 +9,8 @@ from .base import GroupActivityNotification
 
 
 class ResolvedInReleaseActivityNotification(GroupActivityNotification):
+    title = "Resolved Issue"
     referrer_base = "resolved-in-release-activity"
-
-    def get_activity_name(self) -> str:
-        return "Resolved Issue"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         data = self.activity.data

--- a/src/sentry/notifications/notifications/activity/unassigned.py
+++ b/src/sentry/notifications/notifications/activity/unassigned.py
@@ -6,10 +6,8 @@ from .base import GroupActivityNotification
 
 
 class UnassignedActivityNotification(GroupActivityNotification):
+    title = "Unassigned"
     referrer_base = "unassigned-activity"
-
-    def get_activity_name(self) -> str:
-        return "Unassigned"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} unassigned {an issue}", {}, {}

--- a/src/sentry/templates/sentry/emails/activity/generic.html
+++ b/src/sentry/templates/sentry/emails/activity/generic.html
@@ -22,7 +22,7 @@
 
   {% block activity %}
 
-    <h2>{{ activity_name }}</h2>
+    <h2>{{ title }}</h2>
 
     <p>{{ html_description }}</p>
 

--- a/src/sentry/templates/sentry/emails/activity/generic.txt
+++ b/src/sentry/templates/sentry/emails/activity/generic.txt
@@ -1,6 +1,6 @@
 {% spaceless %}
 {% autoescape off %}
-# {{ activity_name }}
+# {{ title }}
 
 {{ text_description }}
 


### PR DESCRIPTION
The Ecosystem Team is starting to add more documentation to the Notification Platform. In this PR we remove a method that should have been a property.