### PR TITLE
fix(ui): Remove `boundaryGap` from `<BarChart>`

### DIFF
--- a/static/app/components/charts/barChart.tsx
+++ b/static/app/components/charts/barChart.tsx
@@ -20,7 +20,7 @@ export function BarChart({series, stacked, xAxis, animation, ...props}: BarChart
   return (
     <BaseChart
       {...props}
-      xAxis={xAxis !== null ? {...(xAxis || {}), boundaryGap: true} : null}
+      xAxis={xAxis !== null ? {...(xAxis || {})} : null}
       series={series.map(({seriesName, data, ...options}) =>
         BarSeries({
           name: seriesName,


### PR DESCRIPTION
This was throwing lots of warnings in console in dev which makes it harder to debug as it makes console not readable. I don't believe this was doing anything (at least according to the warnings).

Tested on dashboards and BarCharts seemed to render the same.

![image](https://user-images.githubusercontent.com/79684/165822325-7a4ca821-5234-4d24-aafb-22d67f286f6a.png)
