### PR TITLE
feat(workflow): Remove projects-page-redesign flag for GA

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -965,8 +965,6 @@ SENTRY_FEATURES = {
     "organizations:performance-view": True,
     # Enable profiling
     "organizations:profiling": False,
-    # Enable projects page redesign
-    "organizations:projects-page-redesign": False,
     # Enable multi project selection
     "organizations:global-views": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -107,7 +107,6 @@ default_manager.add("organizations:performance-use-metrics", OrganizationFeature
 default_manager.add("organizations:performance-dry-run-mep", OrganizationFeature, True)
 default_manager.add("organizations:profiling", OrganizationFeature, True)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)
-default_manager.add("organizations:projects-page-redesign", OrganizationFeature, True)
 default_manager.add("organizations:related-events", OrganizationFeature)
 default_manager.add("organizations:release-comparison-performance", OrganizationFeature, True)
 default_manager.add("organizations:release-health-check-metrics", OrganizationFeature, True)


### PR DESCRIPTION
Remove projects-page-redesign flag for GA.

[FIXES WOR-1785
](https://getsentry.atlassian.net/browse/WOR-1785)