### PR TITLE
ref(issueDetails): Add breadcrumbs to header

### DIFF
--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -8,6 +8,7 @@ import {Client} from 'sentry/api';
 import AssigneeSelector from 'sentry/components/assigneeSelector';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Badge from 'sentry/components/badge';
+import Breadcrumbs from 'sentry/components/breadcrumbs';
 import Count from 'sentry/components/count';
 import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
 import ErrorLevel from 'sentry/components/events/errorLevel';
@@ -150,6 +151,14 @@ class GroupHeader extends React.Component<Props, State> {
         <div className={className}>
           <div className="row">
             <div className="col-sm-7">
+              <StyledBreadcrumbs
+                crumbs={[
+                  {label: 'Issues', to: `/organizations/${orgId}/issues/`},
+                  {
+                    label: 'Issue Details',
+                  },
+                ]}
+              />
               <TitleWrapper>
                 <StyledIdBadge
                   project={project}
@@ -361,6 +370,11 @@ export default withApi(withRouter(withOrganization(GroupHeader)));
 const TitleWrapper = styled('div')`
   display: flex;
   line-height: 24px;
+`;
+
+const StyledBreadcrumbs = styled(Breadcrumbs)`
+  padding-top: 0;
+  padding-bottom: ${space(2)};
 `;
 
 const StyledIdBadge = styled(IdBadge)`


### PR DESCRIPTION
Now that the global selection header is gone, in Issue Details there's no longer a back button to go back to Issues Index. Adding a breadcrumbs component fixes that. This is based on @robinrendle's design.

**Before**
<img width="1649" alt="Screen Shot 2022-04-28 at 11 58 56 AM" src="https://user-images.githubusercontent.com/44172267/165826559-08e191ca-ef36-4c54-8408-2f8b8726fa20.png">

**After**
<img width="1649" alt="Screen Shot 2022-04-28 at 11 58 43 AM" src="https://user-images.githubusercontent.com/44172267/165826530-05643670-7474-47ea-8bce-8eaa1252ba0b.png">

