### PR TITLE
feat(ui): Remove "auto" as default width/height in charts

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -332,7 +332,7 @@ function BaseChartUnwrapped({
 
   autoHeightResize = false,
   height = 200,
-  width = 'auto',
+  width,
   renderer = 'svg',
   notMerge = true,
   lazyUpdate = false,
@@ -534,7 +534,7 @@ function BaseChartUnwrapped({
         onEvents={eventsMap}
         style={chartStyles}
         opts={{
-          height: autoHeightResize ? 'auto' : height,
+          height: autoHeightResize ? undefined : height,
           width,
           renderer,
           devicePixelRatio,


### PR DESCRIPTION
"auto" is not a valid value for svg width/height. I've checked performance, dashboards, discover, and issues stream and things *seem* to be ok....

![image](https://user-images.githubusercontent.com/79684/165827765-ce3edd62-cf92-4406-a1de-4ba1a45f249c.png)
