### PR TITLE
ref(metrics): Add indexer shared string for "sdk" tag

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -63,7 +63,7 @@ TRANSACTION_METRICS_NAMES = {
 
 # 200 - 299
 SHARED_TAG_STRINGS = {
-    # release helth
+    # release health
     "abnormal": PREFIX + 200,
     "crashed": PREFIX + 201,
     "environment": PREFIX + 202,
@@ -96,6 +96,8 @@ SHARED_TAG_STRINGS = {
     "histogram_outlier": PREFIX + 227,
     "outlier": PREFIX + 228,
     "inlier": PREFIX + 229,
+    # added after the initial definition
+    "sdk": PREFIX + 230,  # release health
 }
 SHARED_STRINGS = {**SESSION_METRIC_NAMES, **TRANSACTION_METRICS_NAMES, **SHARED_TAG_STRINGS}
 REVERSE_SHARED_STRINGS = {v: k for k, v in SHARED_STRINGS.items()}


### PR DESCRIPTION
Release health metrics now contain an `sdk` tag that contains the name
and version of the client SDK submitting the metric. Since this is a
well-known and prevalent tag name, it should be added to the shared tags
list of the metrics indexer.

The tag is not used by the product and for now not accessible in the
sessions-v2 API.

See also:

- https://github.com/getsentry/relay/pull/1248