### PR TITLE
fix(ui): Fix eCharts deprecation: `itemStyle.emphasis`

### DIFF
--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -122,8 +122,8 @@ function MiniBarChart({
       }
       set(updated, 'itemStyle.color', colorList[i]);
       set(updated, 'itemStyle.opacity', 0.6);
-      set(updated, 'itemStyle.emphasis.opacity', 1.0);
-      set(updated, 'itemStyle.emphasis.color', emphasisColors?.[i] ?? colorList[i]);
+      set(updated, 'emphasis.itemStyle.opacity', 1.0);
+      set(updated, 'emphasis.itemStyle.color', emphasisColors?.[i] ?? colorList[i]);
 
       return updated;
     });


### PR DESCRIPTION
It is now `emphasis.itemStyle`. This occurs on the Issues stream.

![image](https://user-images.githubusercontent.com/79684/165835672-4be0d931-dc6d-47c2-a34f-9392bb3ba507.png)
