### PR TITLE
fix(mep): Handle empty primary query

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1899,7 +1899,7 @@ class MetricsQueryBuilder(QueryBuilder):
                     groupby_key = tuple(row[key] for key in groupby_aliases)
                     value_map_key = ",".join(str(value) for value in groupby_key)
                     # First time we're seeing this value, add it to the values we're going to filter by
-                    if value_map_key not in value_map:
+                    if value_map_key not in value_map and groupby_key:
                         groupby_values.append(groupby_key)
                     value_map[value_map_key].update(row)
                 for meta in current_result["meta"]:

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1719,7 +1719,6 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             allow_metric_aggregates=False,
             use_aggregate_conditions=True,
         ).run_query("test")
-        print(result["data"])
         assert len(result["data"]) == 1
         data = result["data"][0]
         assert data["count_unique_user"] == 0

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1,4 +1,5 @@
 import datetime
+import math
 import re
 from typing import List
 from unittest import mock
@@ -1706,6 +1707,24 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             allow_metric_aggregates=False,
             use_aggregate_conditions=False,
         )
+
+    def test_multiple_dataset_but_no_data(self):
+        """When there's no data from the primary dataset we shouldn't error out"""
+        result = MetricsQueryBuilder(
+            self.params,
+            selected_columns=[
+                "p50()",
+                "count_unique(user)",
+            ],
+            allow_metric_aggregates=False,
+            use_aggregate_conditions=True,
+        ).run_query("test")
+        print(result["data"])
+        assert len(result["data"]) == 1
+        data = result["data"][0]
+        assert data["count_unique_user"] == 0
+        # Handled by the discover transform later so its fine that this is nan
+        assert math.isnan(data["p50"])
 
     @mock.patch("sentry.search.events.builder.raw_snql_query")
     @mock.patch("sentry.search.events.builder.indexer.resolve", return_value=-1)

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -5037,6 +5037,20 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             == "Parse error at 'hi \n ther' (column 4). This is commonly caused by unmatched parentheses. Enclose any text in double quotes."
         )
 
+    def test_percentile_with_no_data(self):
+        response = self.do_request(
+            {
+                "field": ["p50()"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "metricsEnhanced",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["p50"] == 0
+
     def test_project_name(self):
         self.store_metric(
             1,


### PR DESCRIPTION
- This fixes a bug that caused tuple() in tuple(tuple())
   - This was cause the primary query would get no results back, but we were still adding something to the groupby_values since groupby_key would be `()`, resulting in groupby_values = `[()]`
   - This meant that on L1849 where we check if there are groupby_values we'd get a truthy value when there wasn't actually any values to groupby
- Fixes SNUBA-2SS
