### PR TITLE
feat(profiling): Allow to stream response from backend

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -47,8 +47,13 @@ class OrganizationProfilingProfilesEndpoint(OrganizationProfilingBaseEndpoint):
         def data_fn(offset: int, limit: int) -> Any:
             params["offset"] = offset
             params["limit"] = limit
+            kwargs = {"params": params}
+            if "Accept-Encoding" in request.headers:
+                kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
             response = get_from_profiling_service(
-                "GET", f"/organizations/{organization.id}/profiles", params=params
+                "GET",
+                f"/organizations/{organization.id}/profiles",
+                **kwargs,
             )
             return response.json().get("profiles", [])
 
@@ -70,6 +75,8 @@ class OrganizationProfilingFiltersEndpoint(OrganizationProfilingBaseEndpoint):
         except NoProjects:
             return Response([])
 
-        return proxy_profiling_service(
-            "GET", f"/organizations/{organization.id}/filters", params=params
-        )
+        kwargs = {"params": params}
+        if "Accept-Encoding" in request.headers:
+            kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
+
+        return proxy_profiling_service("GET", f"/organizations/{organization.id}/filters", **kwargs)

--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -10,7 +12,10 @@ class ProjectProfilingProfileEndpoint(ProjectEndpoint):
     def get(self, request: Request, project, profile_id: str) -> Response:
         if not features.has("organizations:profiling", project.organization, actor=request.user):
             return Response(status=404)
-        return proxy_profiling_service(
-            "GET",
-            f"/organizations/{project.organization.id}/projects/{project.id}/profiles/{profile_id}",
-        )
+        kwargs: Dict[str, Any] = {
+            "method": "GET",
+            "path": f"/organizations/{project.organization.id}/projects/{project.id}/profiles/{profile_id}",
+        }
+        if "Accept-Encoding" in request.headers:
+            kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
+        return proxy_profiling_service(**kwargs)

--- a/src/sentry/http.py
+++ b/src/sentry/http.py
@@ -65,6 +65,7 @@ def safe_urlopen(
     timeout=30,
     verify_ssl=True,
     user_agent=None,
+    stream=False,
 ):
     """
     A slightly safer version of ``urlib2.urlopen`` which prevents redirection
@@ -100,6 +101,7 @@ def safe_urlopen(
             allow_redirects=allow_redirects,
             timeout=timeout,
             verify=verify_ssl,
+            stream=stream,
             **kwargs,
         )
 

--- a/src/sentry/utils/profiling.py
+++ b/src/sentry/utils/profiling.py
@@ -48,7 +48,8 @@ def proxy_profiling_service(
         status=profiling_response.status_code,
     )
     for h in ["Content-Type", "Content-Encoding", "Vary"]:
-        response[h] = profiling_response.headers[h]
+        if h in profiling_response.headers:
+            response[h] = profiling_response.headers[h]
     return response
 
 

--- a/src/sentry/utils/profiling.py
+++ b/src/sentry/utils/profiling.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 import google.auth.transport.requests
 import google.oauth2.id_token
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import StreamingHttpResponse
 from parsimonious.exceptions import ParseError
 from requests import Response
 
@@ -13,14 +13,19 @@ from sentry.http import safe_urlopen
 
 
 def get_from_profiling_service(
-    method: str, path: str, params: Optional[Dict[Any, Any]] = None
+    method: str,
+    path: str,
+    params: Optional[Dict[Any, Any]] = None,
+    headers: Optional[Dict[Any, Any]] = None,
 ) -> Response:
-    kwargs: Dict[str, Any] = {"method": method}
+    kwargs: Dict[str, Any] = {"method": method, "headers": {}, "stream": True}
     if params:
         kwargs["params"] = params
+    if headers:
+        kwargs["headers"].update(headers)
     if settings.ENVIRONMENT == "production":
         id_token = fetch_id_token_for_service(settings.SENTRY_PROFILING_SERVICE_URL)
-        kwargs["headers"] = {"Authorization": f"Bearer {id_token}"}
+        kwargs["headers"].update({"Authorization": f"Bearer {id_token}"})
     return safe_urlopen(
         f"{settings.SENTRY_PROFILING_SERVICE_URL}{path}",
         **kwargs,
@@ -28,14 +33,22 @@ def get_from_profiling_service(
 
 
 def proxy_profiling_service(
-    method: str, path: str, params: Optional[Dict[Any, Any]] = None
-) -> HttpResponse:
-    profiling_response = get_from_profiling_service(method, path, params=params)
-    response = HttpResponse(
-        content=profiling_response.content, status=profiling_response.status_code
+    method: str,
+    path: str,
+    params: Optional[Dict[Any, Any]] = None,
+    headers: Optional[Dict[Any, Any]] = None,
+) -> StreamingHttpResponse:
+    profiling_response = get_from_profiling_service(method, path, params=params, headers=headers)
+
+    def stream():
+        yield from profiling_response.raw.stream(decode_content=False)
+
+    response = StreamingHttpResponse(
+        streaming_content=stream(),
+        status=profiling_response.status_code,
     )
-    if "Content-Type" in profiling_response.headers:
-        response["Content-Type"] = profiling_response.headers["Content-Type"]
+    for h in ["Content-Type", "Content-Encoding", "Vary"]:
+        response[h] = profiling_response.headers[h]
     return response
 
 

--- a/src/sentry/utils/profiling.py
+++ b/src/sentry/utils/profiling.py
@@ -35,8 +35,8 @@ def get_from_profiling_service(
 def proxy_profiling_service(
     method: str,
     path: str,
-    params: Optional[Dict[Any, Any]] = None,
-    headers: Optional[Dict[Any, Any]] = None,
+    params: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None,
 ) -> StreamingHttpResponse:
     profiling_response = get_from_profiling_service(method, path, params=params, headers=headers)
 


### PR DESCRIPTION
This PR aims to stream the response we get from the profiling API to the client instead of buffering the whole response. We're also passing the necessary headers to the profiling backend so it can compress the response accordingly.
