### PR TITLE
fix(ui): Do not mutate location query directly

### DIFF
--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -406,7 +406,7 @@ class GroupDetails extends Component<Props, State> {
           // If it is defined, we do not so that our back button will bring us
           // to the issue list page with no project selected instead of the
           // locked project.
-          locationWithProject.query.project = project.id;
+          locationWithProject.query = {...locationWithProject.query, project: project.id};
         }
         // We delete _allp from the URL to keep the hack a bit cleaner, but
         // this is not an ideal solution and will ultimately be replaced with

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -164,7 +164,7 @@ describe('groupDetails', () => {
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     expect(
       await screen.findByText(
-        "You'll need to join a team with access before you can view this data."
+        'No teams have access to this project yet. Ask an admin to add your team to this project.'
       )
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
This was a problem in some components that assumed the location.query
would recieve a new identity when mutated.

Specifically, this fixes the case where page filters need to be updated
when the project is set