### PR TITLE
fix(ui): Correct alignment of issue details row

### DIFF
--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -149,16 +149,16 @@ class GroupHeader extends React.Component<Props, State> {
     return (
       <Layout.Header>
         <div className={className}>
+          <StyledBreadcrumbs
+            crumbs={[
+              {label: 'Issues', to: `/organizations/${orgId}/issues/`},
+              {
+                label: 'Issue Details',
+              },
+            ]}
+          />
           <div className="row">
             <div className="col-sm-7">
-              <StyledBreadcrumbs
-                crumbs={[
-                  {label: 'Issues', to: `/organizations/${orgId}/issues/`},
-                  {
-                    label: 'Issue Details',
-                  },
-                ]}
-              />
               <TitleWrapper>
                 <StyledIdBadge
                   project={project}
@@ -373,8 +373,7 @@ const TitleWrapper = styled('div')`
 `;
 
 const StyledBreadcrumbs = styled(Breadcrumbs)`
-  padding-top: 0;
-  padding-bottom: ${space(2)};
+  margin-bottom: ${space(2)};
 `;
 
 const StyledIdBadge = styled(IdBadge)`


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1421724/165862753-cdd8034e-914b-4f20-b0ce-ab686404db5c.png)


After
![image](https://user-images.githubusercontent.com/1421724/165862742-9c5ff595-09b7-4d35-9e31-4e964342186f.png)
