### PR TITLE
feat(alerts): Prevent refresh of alert wizard on metric change

### DIFF
--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -159,7 +159,6 @@ class Create extends Component<Props, State> {
                         wizardTemplate={wizardTemplate}
                         sessionId={this.sessionId}
                         project={project}
-                        isCustomMetric={wizardAlertType === 'custom'}
                         userTeamIds={teams.map(({id}) => id)}
                       />
                     )}

--- a/static/app/views/alerts/incidentRules/create.tsx
+++ b/static/app/views/alerts/incidentRules/create.tsx
@@ -23,7 +23,6 @@ type Props = {
   organization: Organization;
   project: Project;
   userTeamIds: string[];
-  isCustomMetric?: boolean;
   sessionId?: string;
   wizardTemplate?: WizardRuleTemplate;
 } & RouteComponentProps<RouteParams, {}>;

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -4,7 +4,6 @@ import {InjectedRouter} from 'react-router';
 import {components} from 'react-select';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 import pick from 'lodash/pick';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -61,7 +60,6 @@ type Props = {
   dataset: Dataset;
   disabled: boolean;
   hasAlertWizardV3: boolean;
-  location: Location;
   onComparisonDeltaChange: (value: number) => void;
   onFilterSearch: (query: string) => void;
   onTimeWindowChange: (value: number) => void;

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -120,13 +120,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   }
 
   getDefaultState(): State {
-    const {
-      rule,
-      location: {
-        query: {aggregate, eventTypes: _eventTypes, dataset},
-      },
-    } = this.props;
+    const {rule, location} = this.props;
     const triggersClone = [...rule.triggers];
+    const {aggregate, eventTypes: _eventTypes, dataset} = location?.query ?? {};
     const eventTypes = typeof _eventTypes === 'string' ? [_eventTypes] : _eventTypes;
 
     // Warning trigger is removed if it is blank when saving

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -120,8 +120,14 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   }
 
   getDefaultState(): State {
-    const {rule} = this.props;
+    const {
+      rule,
+      location: {
+        query: {aggregate, eventTypes: _eventTypes, dataset},
+      },
+    } = this.props;
     const triggersClone = [...rule.triggers];
+    const eventTypes = typeof _eventTypes === 'string' ? [_eventTypes] : _eventTypes;
 
     // Warning trigger is removed if it is blank when saving
     if (triggersClone.length !== 2) {
@@ -131,9 +137,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     return {
       ...super.getDefaultState(),
 
-      dataset: rule.dataset,
-      eventTypes: rule.eventTypes,
-      aggregate: rule.aggregate,
+      aggregate: aggregate ?? rule.aggregate,
+      dataset: dataset ?? rule.dataset,
+      eventTypes: eventTypes ?? rule.eventTypes,
       query: rule.query || '',
       timeWindow: rule.timeWindow,
       environment: rule.environment || null,
@@ -410,22 +416,21 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
   handleFieldChange = (name: string, value: unknown) => {
     const {projects} = this.props;
-    const {aggregate: _aggregate, project: _project} = this.state;
     if (
       [
+        'aggregate',
         'dataset',
         'eventTypes',
         'timeWindow',
         'environment',
-        'aggregate',
         'comparisonDelta',
         'projectId',
       ].includes(name)
     ) {
-      const aggregate = name === 'aggregate' ? value : _aggregate;
-      const project =
-        name === 'projectId' ? projects.find(({id}) => id === value) : _project;
-      this.setState({aggregate, [name]: value, project});
+      this.setState(({project: _project}) => ({
+        [name]: value,
+        project: name === 'projectId' ? projects.find(({id}) => id === value) : _project,
+      }));
     }
   };
 
@@ -661,16 +666,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {
-      organization,
-      ruleId,
-      rule,
-      onSubmitSuccess,
-      userTeamIds,
-      isCustomMetric,
-      router,
-      location,
-    } = this.props;
+    const {organization, ruleId, rule, onSubmitSuccess, userTeamIds, router} = this.props;
     const {
       query,
       project,
@@ -787,9 +783,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
             submitDisabled={!hasAccess || loading || !canEdit}
             initialData={{
               name: rule.name || '',
-              dataset: rule.dataset,
-              eventTypes: rule.eventTypes,
-              aggregate: rule.aggregate,
+              dataset,
+              eventTypes,
+              aggregate,
               query: rule.query || '',
               timeWindow: rule.timeWindow,
               environment: rule.environment || null,
@@ -825,12 +821,13 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                 project={project}
                 organization={organization}
                 router={router}
-                location={location}
                 disabled={!hasAccess || !canEdit}
                 thresholdChart={wizardBuilderChart}
                 onFilterSearch={this.handleFilterUpdate}
-                allowChangeEventTypes={isCustomMetric || dataset === Dataset.ERRORS}
-                alertType={isCustomMetric ? 'custom' : alertType}
+                allowChangeEventTypes={
+                  alertType === 'custom' || dataset === Dataset.ERRORS
+                }
+                alertType={alertType}
                 hasAlertWizardV3={hasAlertWizardV3}
                 dataset={dataset}
                 timeWindow={timeWindow}

--- a/static/app/views/alerts/incidentRules/wizardField.tsx
+++ b/static/app/views/alerts/incidentRules/wizardField.tsx
@@ -1,7 +1,5 @@
-import {InjectedRouter, withRouter} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 import findKey from 'lodash/findKey';
 
 import FormField from 'sentry/components/forms/formField';
@@ -25,9 +23,7 @@ import {getFieldOptionConfig} from './metricField';
 type MenuOption = {label: string; value: AlertType};
 
 type Props = Omit<FormField['props'], 'children'> & {
-  location: Location;
   organization: Organization;
-  router: InjectedRouter;
   alertType?: AlertType;
   /**
    * Optionally set a width for each column of selector
@@ -110,28 +106,28 @@ const menuOptions: {label: string; options: Array<MenuOption>}[] = [
   },
 ];
 
-function WizardField({
-  location,
-  router,
+export default function WizardField({
   organization,
   columnWidth,
   inFieldLabels,
   alertType,
   ...fieldProps
 }: Props) {
-  const selectedTemplate =
-    findKey(
-      AlertWizardRuleTemplates,
-      template =>
-        template.aggregate === location.query.aggregate &&
-        template.dataset === location.query.dataset &&
-        template.eventTypes === location.query.eventTypes
-    ) || 'num_errors';
-
   return (
     <FormField {...fieldProps}>
       {({onChange, value, model, disabled}) => {
+        const aggregate = model.getValue('aggregate');
         const dataset = model.getValue('dataset');
+        const eventTypes = [...model.getValue('eventTypes')];
+
+        const selectedTemplate =
+          findKey(
+            AlertWizardRuleTemplates,
+            template =>
+              template.aggregate === aggregate &&
+              template.dataset === dataset &&
+              eventTypes.includes(template.eventTypes)
+          ) || 'num_errors';
 
         const {fieldOptionsConfig, hidePrimarySelector, hideParameterSelector} =
           getFieldOptionConfig({
@@ -169,13 +165,6 @@ function WizardField({
                 model.setValue('aggregate', template.aggregate);
                 model.setValue('dataset', template.dataset);
                 model.setValue('eventTypes', [template.eventTypes]);
-                router.replace({
-                  ...location,
-                  query: {
-                    ...location.query,
-                    ...template,
-                  },
-                });
               }}
             />
             <StyledQueryField
@@ -199,8 +188,6 @@ function WizardField({
     </FormField>
   );
 }
-
-export default withRouter(WizardField);
 
 const Container = styled('div')<{hideGap: boolean}>`
   display: grid;


### PR DESCRIPTION
There are two parts in this pr for rule templates:
1. This updates alert wizard template selector ie `<WizardField>` to not replace url parameters to refresh the page, the state still updates on template field changing and the data is still fetched.
Jira: [WOR-1835](https://getsentry.atlassian.net/browse/WOR-1835)

2. The values for template parameters (aggregate, dataset, eventTypes) are now set from url parameters initially if there are any and are modified by the wizard field because `eventView`s used to create new alerts don't have `yAxis` values set properly and was defaulting to `count()` for aggregate. This was causing the alerts created from transaction page to not initialize properly.

Demo for both cases:

https://user-images.githubusercontent.com/15015880/165867602-0df8bf6f-ea76-4103-b690-3fa50826b1bd.mov




