### PR TITLE
chore(perf): Remove un-used dep for useMemo on Anomalies

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
@@ -199,7 +199,7 @@ function Anomalies(props: AnomaliesSectionProps) {
       component: provided => <Fragment>{provided.children(props.queryData)}</Fragment>,
       transform: transformAnomalyData,
     };
-  }, [props.eventView, props.queryData]);
+  }, [props.queryData]);
 
   return (
     <GenericPerformanceWidget<DataType>


### PR DESCRIPTION
This PR addresses this warning:

> React Hook useMemo has an unnecessary dependency: 'props.eventView'. Either exclude it or remove the dependency array