### PR TITLE
feat(alerts): Add duplicate-alert-rule to feature flags

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -945,6 +945,8 @@ SENTRY_FEATURES = {
     "organizations:create": True,
     # Enable the 'discover' interface.
     "organizations:discover": False,
+    # Enable duplicating alert rules.
+    "organizations:duplicate-alert-rule": False,
     # Enable attaching arbitrary files to events.
     "organizations:event-attachments": True,
     # Enable Filters & Sampling in the org settings

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -64,6 +64,7 @@ default_manager.add("organizations:dashboards-metrics", OrganizationFeature, Tru
 default_manager.add("organizations:dashboards-template", OrganizationFeature, True)
 default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, True)
 default_manager.add("organizations:discover", OrganizationFeature)
+default_manager.add("organizations:duplicate-alert-rule", OrganizationFeature, True)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature)
 default_manager.add("organizations:filters-and-sampling", OrganizationFeature, True)
 default_manager.add("organizations:filters-and-sampling-error-rules", OrganizationFeature, True)


### PR DESCRIPTION
This adds a new feature flag `duplicate-alert-rule` to test with sentry org.