### PR TITLE
feat(dev): Allow using sentry-cli 2.x

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -30,7 +30,7 @@ configure-sentry-cli() {
     export SENTRY_CLI_NO_EXIT_TRAP=${SENTRY_CLI_NO_EXIT_TRAP-0}
     if [ -n "${SENTRY_DSN+x}" ] && [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
         if ! require sentry-cli; then
-            curl -sL https://sentry.io/get-cli/ | VERSION=2.0.4 bash
+            curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.0.4 bash
         fi
         eval "$(sentry-cli bash-hook)"
     fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -30,7 +30,7 @@ configure-sentry-cli() {
     export SENTRY_CLI_NO_EXIT_TRAP=${SENTRY_CLI_NO_EXIT_TRAP-0}
     if [ -n "${SENTRY_DSN+x}" ] && [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
         if ! require sentry-cli; then
-            curl -sL https://sentry.io/get-cli/ | bash
+            curl -sL https://sentry.io/get-cli/ | VERSION=2.0.4 bash
         fi
         eval "$(sentry-cli bash-hook)"
     fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -30,18 +30,9 @@ configure-sentry-cli() {
     export SENTRY_CLI_NO_EXIT_TRAP=${SENTRY_CLI_NO_EXIT_TRAP-0}
     if [ -n "${SENTRY_DSN+x}" ] && [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
         if ! require sentry-cli; then
-            # XXX: Temporary install version 1.74.3 until we upgrade to version 2.x
-            curl -sL https://gist.githubusercontent.com/armenzg/96481b0b653ecf807900373f5af09816/raw/caf5695e0eb6c214ec84f9fc217965aec928acc0/get-cli.sh | bash
+            curl -sL https://sentry.io/get-cli/ | bash
         fi
-        sentry_cli_major_version="$(sentry-cli --version | awk '{print $2}' | sed 's/\([0-9]*\).*/\1/')"
-        # XXX: Until we support version 2.x
-        if [ $sentry_cli_major_version -lt 2 ]; then
-            eval "$(sentry-cli bash-hook)"
-        else
-            echo "You are using the latest major release of sentry-cli."
-            echo "${yellow}Please remove it and we will install the correct version: rm $(which sentry-cli)${reset}"
-            exit 1
-        fi
+        eval "$(sentry-cli bash-hook)"
     fi
 }
 


### PR DESCRIPTION
Back in 8a21cbb662f1989edae4fdedb316782af07be550 we prevented users from using the newer version of sentry-cli since it did not support bash-hook.

This was added back in the latest release (see https://github.com/getsentry/sentry-cli/pull/1197).