### PR TITLE
fix(metrics): Derived metrics with partial components [INGEST-1193]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -129,6 +129,18 @@ def run_metrics_query(
 
 
 def _get_entity_of_metric_mri(projects: Sequence[Project], metric_mri: str) -> EntityKey:
+    for KnownMRI in (SessionMRI, TransactionMRI):
+        try:
+            KnownMRI(metric_mri)
+        except ValueError:
+            pass
+        else:
+            return {
+                "c": EntityKey.MetricsCounters,
+                "d": EntityKey.MetricsDistributions,
+                "s": EntityKey.MetricsSets,
+            }[metric_mri[0]]
+
     assert projects
     org_id = org_id_from_projects(projects)
     metric_id = indexer.resolve(org_id, metric_mri)

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1678,6 +1678,54 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["totals"]["session.healthy"] == 3
         assert group["series"]["session.healthy"] == [3]
 
+    def test_healthy_sessions_preaggr(self):
+        """Healthy sessions works also when there are no individual errors"""
+        user_ts = time.time()
+        org_id = self.organization.id
+        self._send_buckets(
+            [
+                {
+                    "org_id": org_id,
+                    "project_id": self.project.id,
+                    "metric_id": self.session_metric,
+                    "timestamp": (user_ts // 60) * 60,
+                    "tags": {
+                        self.session_status_tag: indexer.record(org_id, "errored_preaggr"),
+                        self.release_tag: indexer.record(org_id, "foo"),
+                    },
+                    "type": "c",
+                    "value": 4,
+                    "retention_days": 90,
+                },
+                {
+                    "org_id": org_id,
+                    "project_id": self.project.id,
+                    "metric_id": self.session_metric,
+                    "timestamp": user_ts,
+                    "tags": {
+                        self.session_status_tag: indexer.record(org_id, "init"),
+                        self.release_tag: indexer.record(org_id, "foo"),
+                    },
+                    "type": "c",
+                    "value": 10,
+                    "retention_days": 90,
+                },
+            ],
+            entity="metrics_counters",
+        )
+        # Can get session healthy even before all components exist
+        # (projects that send errored_preaggr usually do not send individual errors)
+        response = self.get_success_response(
+            self.organization.slug,
+            field=["session.healthy"],
+            statsPeriod="6m",
+            interval="6m",
+        )
+        print(response.data["groups"])
+        group = response.data["groups"][0]
+        assert group["totals"]["session.healthy"] == 6
+        assert group["series"]["session.healthy"] == [6]
+
     def test_errored_user_sessions(self):
         org_id = self.organization.id
         user_ts = time.time()

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -2034,7 +2034,13 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             interval="1m",
         )
 
-        assert response.data["groups"] == []
+        assert response.data["groups"] == [
+            {
+                "by": {},
+                "series": {"transaction.failure_rate": [None]},
+                "totals": {"transaction.failure_rate": None},
+            },
+        ]
 
     def test_request_private_derived_metric(self):
         for private_name in [

--- a/tests/sentry/snuba/metrics/fields/test_base.py
+++ b/tests/sentry/snuba/metrics/fields/test_base.py
@@ -11,7 +11,6 @@ from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics import (
     DERIVED_METRICS,
     DerivedMetricParseException,
-    MetricDoesNotExistException,
     NotSupportedOverCompositeEntityException,
     SingularEntityDerivedMetric,
 )
@@ -376,14 +375,13 @@ class CompositeEntityDerivedMetricTestCase(TestCase):
         Test that ensures that the even when generating the component entities dict of instances
         of SingleEntityDerivedMetric, we are still validating that they exist
         """
-        with pytest.raises(MetricDoesNotExistException):
-            assert self.sessions_errored.get_entity(projects=[PseudoProject(1, 1)]) == {
-                "metrics_counters": [
-                    SessionMRI.ERRORED_PREAGGREGATED.value,
-                    SessionMRI.CRASHED_AND_ABNORMAL.value,
-                ],
-                "metrics_sets": [SessionMRI.ERRORED_SET.value],
-            }
+        assert self.sessions_errored.get_entity(projects=[PseudoProject(1, 1)]) == {
+            "metrics_counters": [
+                SessionMRI.ERRORED_PREAGGREGATED.value,
+                SessionMRI.CRASHED_AND_ABNORMAL.value,
+            ],
+            "metrics_sets": [SessionMRI.ERRORED_SET.value],
+        }
 
     @mock.patch(
         "sentry.snuba.metrics.fields.base._get_entity_of_metric_mri", get_entity_of_metric_mocked

--- a/tests/sentry/snuba/metrics/fields/test_base.py
+++ b/tests/sentry/snuba/metrics/fields/test_base.py
@@ -14,7 +14,11 @@ from sentry.snuba.metrics import (
     NotSupportedOverCompositeEntityException,
     SingularEntityDerivedMetric,
 )
-from sentry.snuba.metrics.fields.base import DERIVED_ALIASES, CompositeEntityDerivedMetric
+from sentry.snuba.metrics.fields.base import (
+    DERIVED_ALIASES,
+    CompositeEntityDerivedMetric,
+    _get_known_entity_of_metric_mri,
+)
 from sentry.snuba.metrics.fields.snql import (
     abnormal_sessions,
     abnormal_users,
@@ -505,3 +509,20 @@ class DerivedMetricAliasTestCase(TestCase):
                 ),
             ],
         )
+
+
+@pytest.mark.parametrize(
+    "metric_mri,expected_entity",
+    [
+        ("c:sessions/session@none", EntityKey.MetricsCounters),
+        ("s:sessions/user@none", EntityKey.MetricsSets),
+        ("d:sessions/duration@second", EntityKey.MetricsDistributions),
+        ("d:sessions/unknown_metric@second", None),
+        ("e:sessions/all@none", None),  # derived metric
+        ("", None),
+        ("foo", None),
+        ("foo:foo:foo", None),
+    ],
+)
+def test_known_entity_of_metric_mri(metric_mri, expected_entity):
+    assert _get_known_entity_of_metric_mri(metric_mri) == expected_entity

--- a/tests/sentry/snuba/metrics/fields/test_base.py
+++ b/tests/sentry/snuba/metrics/fields/test_base.py
@@ -378,7 +378,10 @@ class CompositeEntityDerivedMetricTestCase(TestCase):
         """
         with pytest.raises(MetricDoesNotExistException):
             assert self.sessions_errored.get_entity(projects=[PseudoProject(1, 1)]) == {
-                "metrics_counters": [SessionMRI.ERRORED_PREAGGREGATED.value],
+                "metrics_counters": [
+                    SessionMRI.ERRORED_PREAGGREGATED.value,
+                    SessionMRI.CRASHED_AND_ABNORMAL.value,
+                ],
                 "metrics_sets": [SessionMRI.ERRORED_SET.value],
             }
 


### PR DESCRIPTION
When a derived metrics depending on multiple raw metrics, but the entity of one of those cannot be determined, we return an empty result (see test case).

But there are use cases where not all constituent raw metrics will be populated. For example, a project that sends preaggregated sessions will probably never send individual errors (see test case).

This PR fixes the problem for known metrics by hard-coding `_get_entity_of_metric_mri`. In the long run, we probably want to fix this problem for any derived metric though.