### PR TITLE
fix: Skip trying to symbolicate frames with null instruction_addr

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -291,7 +291,7 @@ def _handles_frame(data, frame):
 
     # TODO: Consider ignoring platform
     platform = frame.get("platform") or data.get("platform")
-    return is_native_platform(platform) and "instruction_addr" in frame
+    return is_native_platform(platform) and frame.get("instruction_addr") is not None
 
 
 def get_frames_for_symbolication(frames, data, modules):

--- a/tests/sentry/lang/native/test_processing.py
+++ b/tests/sentry/lang/native/test_processing.py
@@ -8,7 +8,11 @@ from unittest import mock
 
 import pytest
 
-from sentry.lang.native.processing import _merge_image, process_payload
+from sentry.lang.native.processing import (
+    _merge_image,
+    get_frames_for_symbolication,
+    process_payload,
+)
 from sentry.models.eventerror import EventError
 from sentry.utils.safe import get_path
 
@@ -152,3 +156,23 @@ def test_cocoa_function_name(mock_symbolicator, default_project):
 
     function_name = get_path(data, "exception", "values", 0, "stacktrace", "frames", 0, "function")
     assert function_name == "thunk for closure"
+
+
+def test_filter_frames():
+
+    frames = [
+        {
+            "instruction_addr": None,
+        },
+        {
+            "platform": "not native",
+            "instruction_addr": "0xdeadbeef",
+        },
+        {
+            "platform": "cocoa",
+        },
+    ]
+
+    filtered_frames = get_frames_for_symbolication(frames, {"platform": "native"}, {})
+
+    assert len(filtered_frames) == 0


### PR DESCRIPTION
When sending such frames, symbolicator will reject the request as it does not comply with its schema, leading to a 422 error.