### PR TITLE
ref(profiling): improve text renderer performance

### DIFF
--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -68,6 +68,7 @@ class TextRenderer {
     const BASELINE_OFFSET =
       (this.theme.SIZES.BAR_HEIGHT - this.theme.SIZES.BAR_FONT_SIZE / 2) *
       window.devicePixelRatio;
+    const BASELINE = this.flamegraph.inverted ? configSpace.height - 1 : 0;
 
     const drawFrame = (frame: FlamegraphFrame): void => {
       // Check if our rect overlaps with the current viewport and skip it
@@ -81,9 +82,7 @@ class TextRenderer {
 
       // This rect gets discarded after each render which is wasteful
       const width = pinnedEnd - pinnedStart;
-      const depth = this.flamegraph.inverted
-        ? configSpace.height - frame.depth - 1
-        : frame.depth;
+      const depth = Math.abs(BASELINE - frame.depth);
 
       // Transform frame to physical space coordinates. This does the same operation as
       // Rect.transformRect, but without allocating a new Rect object.
@@ -102,6 +101,7 @@ class TextRenderer {
       // from the total width, so that we can truncate the center of the text accurately.
       const paddedRectangleWidth = frameInPhysicalSpace[2] - SIDE_PADDING;
 
+      // Since children of a frame cannot be wider than the frame itself, we can exit early and discard the entire subtree
       if (paddedRectangleWidth <= minWidth) {
         return;
       }
@@ -111,8 +111,6 @@ class TextRenderer {
 
       // Offset x by 1x the padding
       const x = frameInPhysicalSpace[0] + HALF_SIDE_PADDING;
-
-      // Since children of a frame cannot be wider than the frame itself, we can exit early and discard the entire subtree
 
       this.context.fillText(
         trimTextCenter(

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -71,7 +71,7 @@ class TextRenderer {
 
     const drawFrame = (frame: FlamegraphFrame): void => {
       // Check if our rect overlaps with the current viewport and skip it
-      if (frame.end <= configViewSpace.left || frame.start >= configViewSpace.right) {
+      if (frame.end < configViewSpace.left || frame.start > configViewSpace.right) {
         return;
       }
 
@@ -80,31 +80,39 @@ class TextRenderer {
       const pinnedEnd = Math.min(frame.end, configViewSpace.right);
 
       // This rect gets discarded after each render which is wasteful
-      const offsetFrame = new Rect(
-        pinnedStart,
-        this.flamegraph.inverted ? configSpace.height - frame.depth - 1 : frame.depth,
-        pinnedEnd - pinnedStart,
-        1
-      );
+      const width = pinnedEnd - pinnedStart;
+      const depth = this.flamegraph.inverted
+        ? configSpace.height - frame.depth - 1
+        : frame.depth;
 
-      // Transform frame to physical space coordinates
-      const frameInPhysicalSpace = offsetFrame.transformRect(configViewToPhysicalSpace);
+      // Transform frame to physical space coordinates. This does the same operation as
+      // Rect.transformRect, but without allocating a new Rect object.
+      const frameInPhysicalSpace = [
+        pinnedStart * configViewToPhysicalSpace[0] +
+          depth * configViewToPhysicalSpace[1] +
+          configViewToPhysicalSpace[6],
+        pinnedStart * configViewToPhysicalSpace[1] +
+          depth * configViewToPhysicalSpace[4] +
+          configViewToPhysicalSpace[7],
+        width * configViewToPhysicalSpace[0] + 1 * configViewToPhysicalSpace[1],
+        width * configViewToPhysicalSpace[3] + 1 * configViewToPhysicalSpace[4],
+      ];
 
       // Since the text is not exactly aligned to the left/right bounds of the frame, we need to subtract the padding
       // from the total width, so that we can truncate the center of the text accurately.
-      const paddedRectangleWidth = frameInPhysicalSpace.width - SIDE_PADDING;
+      const paddedRectangleWidth = frameInPhysicalSpace[2] - SIDE_PADDING;
 
-      // We want to draw the text in the vertical center of the frame, so we substract half the height of the text
-      const y = frameInPhysicalSpace.y + BASELINE_OFFSET;
-
-      // Offset x by 1x the padding
-      const x = frameInPhysicalSpace.x + HALF_SIDE_PADDING;
-
-      // If the width of the text is greater than the minimum width to render, we should render it
-      // Since children of a frame cannot be wider than the frame itself, we can exit early and discard the entire subtree
       if (paddedRectangleWidth <= minWidth) {
         return;
       }
+
+      // We want to draw the text in the vertical center of the frame, so we substract half the height of the text
+      const y = frameInPhysicalSpace[1] + BASELINE_OFFSET;
+
+      // Offset x by 1x the padding
+      const x = frameInPhysicalSpace[0] + HALF_SIDE_PADDING;
+
+      // Since children of a frame cannot be wider than the frame itself, we can exit early and discard the entire subtree
 
       this.context.fillText(
         trimTextCenter(


### PR DESCRIPTION
Since this is the most expensive step in our render process, squeezing out a bit of extra performance here (noticed this was starting to be a bit janky). Main change is to drop usage of the Rect class and just compute the final rect manually + a tad smarter draw heuristic

Full profile draw from devtools profiler for `static/app/utils/profiling/profile/formats/typescript/trace.json`.

Before:
<img width="516" alt="CleanShot 2022-04-29 at 08 59 50@2x" src="https://user-images.githubusercontent.com/9317857/165949034-b71dee29-cfa1-4cad-9824-ac03b3ef1916.png">

After:
<img width="551" alt="CleanShot 2022-04-28 at 19 01 26@2x" src="https://user-images.githubusercontent.com/9317857/165948739-7ab2fd91-c6b8-49ae-b7c9-1a0645f02883.png">


**Before:**
typescript (center half) x 5,175 ops/sec ±2.53% (92 runs sampled)
typescript (full profile) x 1,153 ops/sec ±2.04% (95 runs sampled)
typescript (right quarter) x 7,400 ops/sec ±2.21% (92 runs sampled)

**After:**
typescript (center half) x 12,634 ops/sec ±1.73% (93 runs sampled)
typescript (right quarter) x 14,950 ops/sec ±1.97% (93 runs sampled)
typescript (full profile) x 6,911 ops/sec ±1.62% (96 runs sampled)