### PR TITLE
fix(release_health): Introduce relay session metrics config [ingest-1303]

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -199,6 +199,11 @@ def get_project_config(project, full_config=True, project_keys=None):
             )
         except Exception:
             capture_exception()
+    if features.has("organizations:metrics-extraction", project.organization):
+        cfg["config"]["sessionMetrics"] = {
+            "version": 1,
+            "drop": False,
+        }
 
     if features.has("projects:performance-suspect-spans-ingestion", project=project):
         cfg["config"]["spanAttributes"] = project.get_option("sentry:span_attributes")


### PR DESCRIPTION
While renaming all session metrics, we found that old customer relays
are still sending sessions under the old name and are dropping the raw
data. This equates to data loss as we don't make any attempt to use or
rewrite metrics with legacy names.

Introduce config with versioning scheme to ensure this doesn't happen
again.

- [x] Deploy this PR
- [x] Deploy https://github.com/getsentry/relay/pull/1251
- [x] Deploy same Relay PR to PoPs
- [x] Remove metrics-extraction feature from EXPOSABLE_FEATURES, then customer relays stop marking sessions as extracted (https://github.com/getsentry/sentry/pull/34104)