### PR TITLE
fix(sessions): Filter by healthy + groupBy [INGEST-1193]

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -147,6 +147,7 @@ class Field(ABC):
         self.name = name
         self._raw_groupby = raw_groupby
         self._status_filter = status_filter
+        self._hidden_fields = []
         self.metric_fields = self._get_metric_fields(raw_groupby, status_filter)
 
     @abstractmethod
@@ -164,11 +165,10 @@ class Field(ABC):
         input_groups: GroupedData,
         output_groups: GroupedData,
     ) -> None:
-        is_groupby_status = "session.status" in self._raw_groupby
         for metric_field in self.metric_fields:
             session_status = self._get_session_status(metric_field)
-            if is_groupby_status and session_status is None:
-                # We fetched this only to be consistent with the sort order
+            if metric_field in self._hidden_fields:
+                # We fetched this only to get a consistent sort order
                 # in the original implementation, don't add it to output data
                 continue
             field_name = (
@@ -218,6 +218,9 @@ class Field(ABC):
         return new_value
 
 
+UNSORTABLE = {SessionStatus.HEALTHY, SessionStatus.ERRORED}
+
+
 class CountField(Field):
     """Base class for sum(sessions) and count_unique(user)"""
 
@@ -231,9 +234,16 @@ class CountField(Field):
     ) -> Sequence[MetricField]:
         if status_filter:
             # Restrict fields to the included ones
-            return [self.status_to_metric_field[status] for status in status_filter]
+            metric_fields = [self.status_to_metric_field[status] for status in status_filter]
+            if UNSORTABLE & status_filter:
+                self._hidden_fields.append(self.get_all_field())
+                # We always order the results by one of the selected fields,
+                # even if no orderBy is specified (see _primary_field).
+                metric_fields = [self.get_all_field()] + metric_fields
+            return metric_fields
 
         if "session.status" in raw_groupby:
+            self._hidden_fields.append(self.get_all_field())
             return [
                 # Always also get ALL, because this is what we sort by
                 # in the sessions implementation, with which we want to be consistent
@@ -422,7 +432,6 @@ def run_sessions_query(
         orderby = OrderBy(primary_metric_field, Direction.DESC)
 
     max_groups = SNUBA_LIMIT // len(intervals)
-
     metrics_query = MetricsQuery(
         org_id,
         project_ids,

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -17,6 +17,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Type,
     TypedDict,
@@ -147,7 +148,7 @@ class Field(ABC):
         self.name = name
         self._raw_groupby = raw_groupby
         self._status_filter = status_filter
-        self._hidden_fields = []
+        self._hidden_fields: Set[MetricField] = set()
         self.metric_fields = self._get_metric_fields(raw_groupby, status_filter)
 
     @abstractmethod
@@ -236,14 +237,14 @@ class CountField(Field):
             # Restrict fields to the included ones
             metric_fields = [self.status_to_metric_field[status] for status in status_filter]
             if UNSORTABLE & status_filter:
-                self._hidden_fields.append(self.get_all_field())
+                self._hidden_fields.add(self.get_all_field())
                 # We always order the results by one of the selected fields,
                 # even if no orderBy is specified (see _primary_field).
                 metric_fields = [self.get_all_field()] + metric_fields
             return metric_fields
 
         if "session.status" in raw_groupby:
-            self._hidden_fields.append(self.get_all_field())
+            self._hidden_fields.add(self.get_all_field())
             return [
                 # Always also get ALL, because this is what we sort by
                 # in the sessions implementation, with which we want to be consistent

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -418,6 +418,7 @@ class SnubaQueryBuilder:
         op = orderby.field.op
         metric_mri = get_mri(orderby.field.metric_name)
         metric_field_obj = metric_object_factory(op, metric_mri)
+
         return metric_field_obj.generate_orderby_clause(
             projects=self._projects,
             direction=orderby.direction,

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -1190,6 +1190,38 @@ class OrganizationSessionsEndpointMetricsTest(
         assert result_sorted(response.data)["groups"] == []
 
     @freeze_time(MOCK_DATETIME)
+    def test_filter_by_session_status_with_groupby(self):
+        default_request = {
+            "project": [-1],
+            "statsPeriod": "1d",
+            "interval": "1d",
+            "groupBy": "release",
+        }
+
+        def req(**kwargs):
+            return self.do_request(dict(default_request, **kwargs))
+
+        response = req(field=["sum(session)"], query="session.status:healthy")
+        assert response.status_code == 200, response.content
+        assert result_sorted(response.data)["groups"] == [
+            {
+                "by": {"release": "foo@1.0.0"},
+                "series": {"sum(session)": [5]},
+                "totals": {"sum(session)": 5},
+            },
+            {
+                "by": {"release": "foo@1.1.0"},
+                "series": {"sum(session)": [1]},
+                "totals": {"sum(session)": 1},
+            },
+            {
+                "by": {"release": "foo@1.2.0"},
+                "series": {"sum(session)": [0]},
+                "totals": {"sum(session)": 0},
+            },
+        ]
+
+    @freeze_time(MOCK_DATETIME)
     def test_filter_by_session_status_with_orderby(self):
         default_request = {
             "project": [-1],


### PR DESCRIPTION
The sessions API always applies an `order by` to the underlying metrics query, even if the user did not request it, such that when the result is limited, only the most relevant groups are returned.

When filtering by `session.status:healthy` or `errored`, the metrics service layer does not allow us to order by the corresponding fields, though. In this case, also query `session.all` / `session.all_user` and sort by that.