### PR TITLE
feat(replays): Use canvas to highlight LCP in Replays

### DIFF
--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -22,7 +22,7 @@ export type MemorySpanType = RawSpanType & {
 };
 
 export type RawSpanType = {
-  data: Object;
+  data: Record<string, any>;
   span_id: string;
   start_timestamp: number;
   // this is essentially end_timestamp

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -11,18 +11,16 @@ export type GapSpanType = {
   description?: string;
 };
 
-export type MemorySpanType = RawSpanType & {
-  data: {
-    memory: {
-      jsHeapSizeLimit: number;
-      totalJSHeapSize: number;
-      usedJSHeapSize: number;
-    };
+export type MemorySpanType = RawSpanType<{
+  memory: {
+    jsHeapSizeLimit: number;
+    totalJSHeapSize: number;
+    usedJSHeapSize: number;
   };
-};
+}>;
 
-export type RawSpanType = {
-  data: Object;
+export type RawSpanType<T = Record<string, any>> = {
+  data: T;
   span_id: string;
   start_timestamp: number;
   // this is essentially end_timestamp

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -11,16 +11,18 @@ export type GapSpanType = {
   description?: string;
 };
 
-export type MemorySpanType = RawSpanType<{
-  memory: {
-    jsHeapSizeLimit: number;
-    totalJSHeapSize: number;
-    usedJSHeapSize: number;
+export type MemorySpanType = RawSpanType & {
+  data: {
+    memory: {
+      jsHeapSizeLimit: number;
+      totalJSHeapSize: number;
+      usedJSHeapSize: number;
+    };
   };
-}>;
+};
 
-export type RawSpanType<T = Record<string, any>> = {
-  data: T;
+export type RawSpanType = {
+  data: Object;
   span_id: string;
   start_timestamp: number;
   // this is essentially end_timestamp

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -1,12 +1,11 @@
 import React, {useCallback, useContext, useEffect, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import {Replayer, ReplayerEvents} from 'rrweb';
-import type {eventWithTime, ReplayPlugin} from 'rrweb/typings/types';
+import type {eventWithTime} from 'rrweb/typings/types';
 
 import usePrevious from 'sentry/utils/usePrevious';
-import type {HighlightsByTime} from 'sentry/views/replays/types';
 
-import {HighlightReplayPlugin} from './highlightReplayPlugin';
+import HighlightReplayPlugin from './highlightReplayPlugin';
 import useRAF from './useRAF';
 
 type Dimensions = {height: number; width: number};
@@ -117,7 +116,6 @@ const ReplayPlayerContext = React.createContext<ReplayPlayerContextProps>({
 type Props = {
   children: React.ReactNode;
   events: eventWithTime[];
-  highlights: HighlightsByTime;
   value?: Partial<ReplayPlayerContextProps>;
 };
 
@@ -127,7 +125,7 @@ function useCurrentTime(callback: () => number) {
   return currentTime;
 }
 
-export function Provider({children, events, highlights, value = {}}: Props) {
+export function Provider({children, events, value = {}}: Props) {
   const theme = useTheme();
   const oldEvents = usePrevious(events);
   const replayerRef = useRef<Replayer>(null);
@@ -175,7 +173,7 @@ export function Provider({children, events, highlights, value = {}}: Props) {
         }
       }
 
-      const highlightReplayPlugin: ReplayPlugin = new HighlightReplayPlugin({highlights});
+      const highlightReplayPlugin = new HighlightReplayPlugin();
 
       // eslint-disable-next-line no-new
       const inst = new Replayer(events, {
@@ -206,7 +204,7 @@ export function Provider({children, events, highlights, value = {}}: Props) {
       // @ts-expect-error
       replayerRef.current = inst;
     },
-    [events, oldEvents, theme.purple200, highlights]
+    [events, oldEvents, theme.purple200]
   );
 
   useEffect(() => {

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -19,7 +19,6 @@ import DetailLayout from './detail/detailLayout';
 import FocusArea from './detail/focusArea';
 import UserActionsNavigator from './detail/userActionsNavigator';
 import useReplayEvent from './utils/useReplayEvent';
-import {HighlightsByTime} from './types';
 
 function ReplayDetails() {
   const {
@@ -84,16 +83,9 @@ function ReplayDetails() {
     );
   }
 
-  // Find LCP spans that have a valid replay node id, this will be used to
-  const highlights: HighlightsByTime = new Map(
-    mergedReplayEvent?.entries[0].data
-      .filter(({op, data}) => op === 'largest-contentful-paint' && data?.nodeId > 0)
-      .map(({start_timestamp, data: {nodeId}}) => [Math.floor(start_timestamp), {nodeId}])
-  );
-
   return (
     <DetailLayout event={event} orgId={orgId}>
-      <ReplayContextProvider events={rrwebEvents} highlights={highlights}>
+      <ReplayContextProvider events={rrwebEvents}>
         <Layout.Body>
           <ReplayLayout ref={fullscreenRef}>
             {/* In fullscreen we need to consider the max-height that the player is able

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -12,8 +12,8 @@ export type TabBarId = 'console' | 'performance' | 'errors' | 'tags' | 'memory';
 /**
  * Highlight Replay Plugin types
  */
-export type HighlightsByTime = Map<number, Highlight>;
 export interface Highlight {
   nodeId: number;
+  text: string;
   color?: string;
 }

--- a/static/app/views/replays/utils/createHighlightEvents.tsx
+++ b/static/app/views/replays/utils/createHighlightEvents.tsx
@@ -1,0 +1,16 @@
+import type {eventWithTime} from 'rrweb/typings/types';
+
+import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
+
+export default function createHighlightEvents(entries: RawSpanType[]): eventWithTime[] {
+  return entries
+    .filter(({op, data}) => op === 'largest-contentful-paint' && data?.nodeId > 0)
+    .map(({start_timestamp, data: {nodeId}}) => ({
+      type: 6, // plugin type
+      data: {
+        nodeId,
+        text: 'LCP',
+      },
+      timestamp: Math.floor(start_timestamp * 1000),
+    }));
+}

--- a/static/app/views/replays/utils/mergeAndSortEvents.tsx
+++ b/static/app/views/replays/utils/mergeAndSortEvents.tsx
@@ -1,0 +1,11 @@
+import type {eventWithTime} from 'rrweb/typings/types';
+
+/**
+ * Merge a list of replay events and sort by `timestamp`
+ */
+
+export default function mergeAndSortEvents(...args: eventWithTime[][]): eventWithTime[] {
+  return Array.prototype.concat(...args).sort((a, b) => {
+    return a.timestamp - b.timestamp;
+  });
+}

--- a/tests/js/spec/views/replays/utils/createHighlightEvents.spec.tsx
+++ b/tests/js/spec/views/replays/utils/createHighlightEvents.spec.tsx
@@ -1,0 +1,69 @@
+import createHighlightEvents from 'sentry/views/replays/utils/createHighlightEvents';
+
+it('returns a list of replay events for highlights', function () {
+  const events = [
+    {
+      op: 'foo',
+      data: {},
+      start_timestamp: 1,
+    },
+    {
+      op: 'largest-contentful-paint',
+      data: {
+        nodeId: 2,
+      },
+      start_timestamp: 1,
+    },
+    {
+      op: 'largest-contentful-paint',
+      data: {
+        nodeId: null,
+      },
+      start_timestamp: 1,
+    },
+    {
+      op: 'largest-contentful-paint',
+      data: {
+        nodeId: -0,
+      },
+      start_timestamp: 1,
+    },
+    {
+      op: 'largest-contentful-paint',
+      data: {
+        nodeId: -1,
+      },
+      start_timestamp: 1,
+    },
+    {
+      op: 'largest-contentful-paint',
+      data: {
+        nodeId: 10,
+      },
+      start_timestamp: 1,
+    },
+  ];
+
+  const results = createHighlightEvents(events);
+
+  expect(results).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "data": Object {
+          "nodeId": 2,
+          "text": "LCP",
+        },
+        "timestamp": 1000,
+        "type": 6,
+      },
+      Object {
+        "data": Object {
+          "nodeId": 10,
+          "text": "LCP",
+        },
+        "timestamp": 1000,
+        "type": 6,
+      },
+    ]
+  `);
+});

--- a/tests/js/spec/views/replays/utils/mergeAndSortEvents.spec.tsx
+++ b/tests/js/spec/views/replays/utils/mergeAndSortEvents.spec.tsx
@@ -1,0 +1,15 @@
+import mergeAndSortEvents from 'sentry/views/replays/utils/mergeAndSortEvents';
+
+it('merges and sorts multiple lists of events', function () {
+  expect(
+    mergeAndSortEvents(
+      [{type: 0, timestamp: 5}],
+      [{type: 1, timestamp: 1}],
+      [{type: 2, timestamp: 3}]
+    )
+  ).toEqual([
+    {type: 1, timestamp: 1},
+    {type: 2, timestamp: 3},
+    {type: 0, timestamp: 5},
+  ]);
+});


### PR DESCRIPTION
Use canvas to draw some rects. The current implementation is to change the background of the highlighted element, but this a bit awkward depending on the layout of the element (or if it has a visible background). Instead we should use the existing canvas to draw a highlight box on top of the element as well as label it.