### PR TITLE
fix(perf): Vital detail chart title should change based on chosen web vital

### DIFF
--- a/static/app/views/performance/vitalDetail/utils.tsx
+++ b/static/app/views/performance/vitalDetail/utils.tsx
@@ -91,6 +91,13 @@ export function vitalNameFromLocation(location: Location): WebVital {
   return WebVital.LCP;
 }
 
+export function getVitalChartTitle(webVital: WebVital): string {
+  if (webVital === WebVital.CLS) {
+    return t('CLS p75');
+  }
+  return t('Duration p75');
+}
+
 export function getVitalDetailTablePoorStatusFunction(vitalName: WebVital): string {
   const vitalThreshold = webVitalPoor[vitalName];
   const statusFunction = `compare_numeric_aggregate(${getAggregateAlias(

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -26,6 +26,7 @@ import {ViewProps} from '../types';
 import {
   getMaxOfSeries,
   getVitalChartDefinitions,
+  getVitalChartTitle,
   vitalNameFromLocation,
   VitalState,
   vitalStateColors,
@@ -86,7 +87,7 @@ function VitalChart({
     <Panel>
       <ChartContainer>
         <HeaderTitleLegend>
-          {t('Duration p75')}
+          {getVitalChartTitle(vitalName)}
           <QuestionTooltip
             size="sm"
             position="top"

--- a/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
@@ -21,7 +21,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import {replaceSeriesName, transformEventStatsSmoothed} from '../trends/utils';
 import {ViewProps} from '../types';
 
-import {getMaxOfSeries, getVitalChartDefinitions} from './utils';
+import {getMaxOfSeries, getVitalChartDefinitions, getVitalChartTitle} from './utils';
 
 type Props = WithRouterProps &
   Omit<ViewProps, 'query' | 'start' | 'end'> & {
@@ -81,7 +81,7 @@ function VitalChartMetrics({
     <Panel>
       <ChartContainer>
         <HeaderTitleLegend>
-          {t('Duration p75')}
+          {getVitalChartTitle(vital)}
           <QuestionTooltip
             size="sm"
             position="top"


### PR DESCRIPTION
We were hardcoding the title of "Duration p75" for the chart on all web vitals. 

This is incorrect for the CLS web vital, as it is a unitless metric. All other web vitals are duration based metrics.

<img width="1665" alt="Screen Shot 2022-04-29 at 3 35 54 PM" src="https://user-images.githubusercontent.com/139499/166058358-b9305be3-91ea-419a-85e6-b4b79e3edb57.png">

<img width="1671" alt="Screen Shot 2022-04-29 at 3 36 11 PM" src="https://user-images.githubusercontent.com/139499/166058360-40d381ae-d9a2-49d0-9af2-1f8f955fcddc.png">
