### PR TITLE
fix(perf): Add MeasurementType

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -717,7 +717,9 @@ export enum MobileVital {
   StallPercentage = 'measurements.stall_percentage',
 }
 
-const MEASUREMENTS: Readonly<Record<WebVital | MobileVital, ColumnType>> = {
+export type MeasurementType = 'duration' | 'number' | 'integer' | 'percentage';
+
+const MEASUREMENTS: Readonly<Record<WebVital | MobileVital, MeasurementType>> = {
   [WebVital.FP]: 'duration',
   [WebVital.FCP]: 'duration',
   [WebVital.LCP]: 'duration',
@@ -788,7 +790,7 @@ export function isMeasurement(field: string): boolean {
   return !!results;
 }
 
-export function measurementType(field: string) {
+export function measurementType(field: string): MeasurementType {
   if (MEASUREMENTS.hasOwnProperty(field)) {
     return MEASUREMENTS[field];
   }


### PR DESCRIPTION
The `measurementType()` utility function had a return type of `any` in TypeScript. 

I've fixed this by adding a return type hint for this function with `MeasurementType` so that it's explicit.