### PR TITLE
fix(issueDetails): Fix nested permalink

### DIFF
--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {DataSection} from 'sentry/components/events/styles';
+import Link from 'sentry/components/links/link';
 import {IconAnchor} from 'sentry/icons/iconAnchor';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -63,7 +64,8 @@ function EventDataSection({
         <SectionHeader id={type} isCentered={isCentered}>
           <Title>
             {showPermalink ? (
-              <Permalink href={`#${type}`} className="permalink">
+              <Permalink className="permalink">
+                <PermalinkAnchor href={`#${type}`} />
                 <StyledIconAnchor size="xs" color="subText" />
                 {titleNode}
               </Permalink>
@@ -109,7 +111,7 @@ const StyledIconAnchor = styled(IconAnchor)`
   transition: opacity 100ms;
 `;
 
-const Permalink = styled('a')`
+const Permalink = styled('span')`
   width: 100%;
   position: relative;
 
@@ -126,6 +128,14 @@ const Permalink = styled('a')`
   :hover ${StyledIconAnchor} {
     opacity: 1;
   }
+`;
+
+const PermalinkAnchor = styled(Link)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 `;
 
 const SectionHeader = styled('div')<{isCentered?: boolean}>`

--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {DataSection} from 'sentry/components/events/styles';
-import Link from 'sentry/components/links/link';
+import {Anchor} from 'sentry/components/links/link';
 import {IconAnchor} from 'sentry/icons/iconAnchor';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -130,7 +130,7 @@ const Permalink = styled('span')`
   }
 `;
 
-const PermalinkAnchor = styled(Link)`
+const PermalinkAnchor = styled(Anchor)`
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
The current Permalink structure allows for nested anchor tags, which triggers a `DOMnesting` error.

<img width="401" alt="Screen Shot 2022-05-02 at 9 46 45 AM" src="https://user-images.githubusercontent.com/44172267/166289610-a896fd00-eafb-4b32-80e4-0937f61d9860.png">

<img width="433" alt="Screen Shot 2022-05-02 at 9 46 21 AM" src="https://user-images.githubusercontent.com/44172267/166289548-2eeb0790-ef12-4291-b0fa-9c01e6244795.png">

This PR fixes that by moving the anchor tag inside the Permalink to become a sibling, not a parent, of the Permalink's contents.
