### PR TITLE
style(replay): Iterate on the player & play/pause controller stylings

### DIFF
--- a/static/app/components/replays/player/bufferingOverlay.tsx
+++ b/static/app/components/replays/player/bufferingOverlay.tsx
@@ -4,9 +4,13 @@ import {IconClock} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 
-function BufferingOverlay() {
+type Props = {
+  className?: string;
+};
+
+function BufferingOverlay({className}: Props) {
   return (
-    <Overlay>
+    <Overlay className={className}>
       <Message>
         <IconClock size="sm" />
         {t('Buffering...')}
@@ -17,6 +21,7 @@ function BufferingOverlay() {
 
 /* Position the badge in the corner */
 const Overlay = styled('div')`
+  user-select: none;
   display: grid;
   place-items: center;
 `;

--- a/static/app/components/replays/player/fastForwardBadge.tsx
+++ b/static/app/components/replays/player/fastForwardBadge.tsx
@@ -7,11 +7,12 @@ import space from 'sentry/styles/space';
 
 type Props = {
   speed: number;
+  className?: string;
 };
 
-function FastForwardBadge({speed}: Props) {
+function FastForwardBadge({speed, className}: Props) {
   return (
-    <Badge>
+    <Badge className={className}>
       <FastForwardTooltip title={t('Fast forwarding')}>
         <IconArrow size="sm" direction="right" />
         {speed}x
@@ -22,6 +23,7 @@ function FastForwardBadge({speed}: Props) {
 
 /* Position the badge in the corner */
 const Badge = styled('div')`
+  user-select: none;
   display: grid;
   align-items: end;
   justify-items: start;
@@ -37,7 +39,6 @@ const FastForwardTooltip = styled(Tooltip)`
   background: ${p => p.theme.gray300};
   color: ${p => p.theme.white};
   padding: ${space(1.5)} ${space(2)};
-  border-bottom-left-radius: ${p => p.theme.borderRadius};
   border-top-right-radius: ${p => p.theme.borderRadius};
   z-index: ${p => p.theme.zIndex.initial};
 `;

--- a/static/app/components/replays/player/scrobber.tsx
+++ b/static/app/components/replays/player/scrobber.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import RangeSlider from 'sentry/components/forms/controls/rangeSlider';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import space from 'sentry/styles/space';
+
+type Props = {
+  className?: string;
+};
+
+function getPercentComplete(currentTime: number, duration: number | undefined) {
+  if (duration === undefined || isNaN(duration)) {
+    return 0;
+  }
+  return currentTime / duration;
+}
+
+function Scrobber({className}: Props) {
+  const {currentTime, duration, setCurrentTime} = useReplayContext();
+
+  const percentComplete = getPercentComplete(currentTime, duration);
+
+  return (
+    <Wrapper className={className}>
+      <Meter>
+        <Value percent={percentComplete} />
+      </Meter>
+      <RangeWrapper>
+        <Range
+          data-test-id="replay-timeline-range"
+          name="replay-timeline"
+          min={0}
+          max={duration}
+          value={Math.round(currentTime)}
+          onChange={value => setCurrentTime(value || 0)}
+          showLabel={false}
+        />
+      </RangeWrapper>
+    </Wrapper>
+  );
+}
+
+const Meter = styled('div')`
+  background: ${p => p.theme.gray200};
+  width: 100%;
+  height: 100%;
+  position: relative;
+`;
+
+const Value = styled('span')<{percent: number}>`
+  display: inline-block;
+  position: absolute;
+  background: ${p => p.theme.purple400};
+  width: ${p => p.percent * 100}%;
+  height: 100%;
+`;
+
+const RangeWrapper = styled('div')`
+  overflow: hidden;
+  width: 100%;
+`;
+
+const Range = styled(RangeSlider)`
+  input {
+    cursor: pointer;
+    opacity: 0;
+    height: 100%;
+  }
+`;
+
+const Wrapper = styled('div')`
+  position: relative;
+
+  width: 100%;
+  height: ${space(0.5)};
+
+  & > * {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  :hover {
+    margin-block: -${space(0.25)};
+    height: ${space(1)};
+  }
+
+  ${Value}:after {
+    content: '';
+    display: block;
+    width: ${space(2)};
+    height: ${space(2)}; /* equal to width */
+    background: ${p => p.theme.purple400};
+    box-sizing: content-box;
+    border-radius: ${space(2)}; /* greater than or equal to width */
+    border: solid ${p => p.theme.white};
+    border-width: ${space(0.5)};
+    position: absolute;
+    top: -${space(1)}; /* Half the width */
+    right: -${space(1.5)}; /* Half of (width + borderWidth) */
+    opacity: 0;
+    transition: opacity 0.1s ease;
+  }
+
+  :hover ${Value}:after {
+    opacity: 1;
+  }
+
+  ${RangeWrapper} {
+    height: ${space(0.5)};
+  }
+  :hover ${RangeWrapper} {
+    height: ${space(0.75)};
+  }
+`;
+
+export default Scrobber;

--- a/static/app/components/replays/player/scrobber.tsx
+++ b/static/app/components/replays/player/scrobber.tsx
@@ -28,7 +28,6 @@ function Scrobber({className}: Props) {
       </Meter>
       <RangeWrapper>
         <Range
-          data-test-id="replay-timeline-range"
           name="replay-timeline"
           min={0}
           max={duration}

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -3,8 +3,6 @@ import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import RangeSlider from 'sentry/components/forms/controls/rangeSlider';
-import {Panel as BasePanel, PanelBody as BasePanelBody} from 'sentry/components/panels';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useFullscreen from 'sentry/components/replays/useFullscreen';
 import {IconArrow, IconPause, IconPlay, IconRefresh, IconResize} from 'sentry/icons';
@@ -18,22 +16,6 @@ const SECOND = 1000;
 interface Props {
   speedOptions?: number[];
   toggleFullscreen?: () => void;
-}
-
-function ReplayBasicTimeline() {
-  const {currentTime, duration, setCurrentTime} = useReplayContext();
-
-  return (
-    <TimelineRange
-      data-test-id="replay-timeline-range"
-      name="replay-timeline"
-      min={0}
-      max={duration}
-      value={Math.round(currentTime)}
-      onChange={value => setCurrentTime(value || 0)}
-      showLabel={false}
-    />
-  );
 }
 
 function ReplayPlayPauseBar() {
@@ -107,51 +89,35 @@ const ReplayControls = ({
   const {isSkippingInactive, toggleSkipInactive} = useReplayContext();
 
   return (
-    <Panel isFullscreen={isFullscreen}>
-      <PanelBody withPadding>
-        <ReplayBasicTimeline />
+    <ButtonGrid>
+      <ReplayPlayPauseBar />
+      <ReplayCurrentTime />
 
-        <ButtonGrid>
-          <ReplayPlayPauseBar />
-          <ReplayCurrentTime />
+      {/* TODO(replay): Need a better icon for the FastForward toggle */}
+      <Button
+        data-test-id="replay-fast-forward"
+        size="xsmall"
+        title={t('Fast-forward idle moments')}
+        aria-label={t('Fast-forward idle moments')}
+        icon={<IconArrow size="sm" direction="right" />}
+        priority={isSkippingInactive ? 'primary' : undefined}
+        onClick={() => toggleSkipInactive(!isSkippingInactive)}
+      />
 
-          {/* TODO(replay): Need a better icon for the FastForward toggle */}
-          <Button
-            data-test-id="replay-fast-forward"
-            size="xsmall"
-            title={t('Fast-forward idle moments')}
-            aria-label={t('Fast-forward idle moments')}
-            icon={<IconArrow size="sm" direction="right" />}
-            priority={isSkippingInactive ? 'primary' : undefined}
-            onClick={() => toggleSkipInactive(!isSkippingInactive)}
-          />
+      <ReplayPlaybackSpeed speedOptions={speedOptions} />
 
-          <ReplayPlaybackSpeed speedOptions={speedOptions} />
-
-          <Button
-            data-test-id="replay-fullscreen"
-            size="xsmall"
-            title={isFullscreen ? t('Exit full screen') : t('View in full screen')}
-            aria-label={isFullscreen ? t('Exit full screen') : t('View in full screen')}
-            icon={<IconResize size="sm" />}
-            priority={isFullscreen ? 'primary' : undefined}
-            onClick={toggleFullscreen}
-          />
-        </ButtonGrid>
-      </PanelBody>
-    </Panel>
+      <Button
+        data-test-id="replay-fullscreen"
+        size="xsmall"
+        title={isFullscreen ? t('Exit full screen') : t('View in full screen')}
+        aria-label={isFullscreen ? t('Exit full screen') : t('View in full screen')}
+        icon={<IconResize size="sm" />}
+        priority={isFullscreen ? 'primary' : undefined}
+        onClick={toggleFullscreen}
+      />
+    </ButtonGrid>
   );
 };
-
-const Panel = styled(BasePanel)<{isFullscreen: boolean}>`
-  width: 100%;
-  ${p => (p.isFullscreen ? 'margin-bottom: 0;' : '')}
-`;
-
-const PanelBody = styled(BasePanelBody)`
-  display: grid;
-  flex-direction: column;
-`;
 
 const IconClockwise = styled(IconRefresh)`
   transform: scaleX(-1);
@@ -162,17 +128,6 @@ const ButtonGrid = styled('div')`
   grid-column-gap: ${space(1)};
   grid-template-columns: max-content auto max-content max-content max-content;
   align-items: center;
-`;
-
-const TimelineRange = styled(RangeSlider)`
-  flex-grow: 1;
-  margin-top: ${space(1)};
-  input {
-    padding: ${space(2)} 0 ${space(2)};
-    margin: -${space(1)} 0 0px;
-    height: 3px;
-    cursor: pointer;
-  }
 `;
 
 export default ReplayControls;

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -24,7 +24,6 @@ function ReplayPlayPauseBar() {
   return (
     <ButtonBar merged>
       <Button
-        data-test-id="replay-back-10s"
         size="xsmall"
         title={t('Go back 10 seconds')}
         icon={<IconRefresh size="sm" />}
@@ -32,7 +31,6 @@ function ReplayPlayPauseBar() {
         aria-label={t('Go back 10 seconds')}
       />
       <Button
-        data-test-id="replay-play-pause"
         size="xsmall"
         title={isPlaying ? t('Pause the Replay') : t('Play the Replay')}
         icon={isPlaying ? <IconPause size="sm" /> : <IconPlay size="sm" />}
@@ -40,7 +38,6 @@ function ReplayPlayPauseBar() {
         aria-label={isPlaying ? t('Pause the Replay') : t('Play the Replay')}
       />
       <Button
-        data-test-id="replay-forward-10s"
         size="xsmall"
         title={t('Go forward 10 seconds')}
         icon={<IconClockwise size="sm" />}
@@ -95,7 +92,6 @@ const ReplayControls = ({
 
       {/* TODO(replay): Need a better icon for the FastForward toggle */}
       <Button
-        data-test-id="replay-fast-forward"
         size="xsmall"
         title={t('Fast-forward idle moments')}
         aria-label={t('Fast-forward idle moments')}
@@ -107,7 +103,6 @@ const ReplayControls = ({
       <ReplayPlaybackSpeed speedOptions={speedOptions} />
 
       <Button
-        data-test-id="replay-fullscreen"
         size="xsmall"
         title={isFullscreen ? t('Exit full screen') : t('View in full screen')}
         aria-label={isFullscreen ? t('Exit full screen') : t('View in full screen')}

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -69,8 +69,8 @@ function BasePlayerRoot({className}: Props) {
   }, [windowDimensions, videoDimensions]);
 
   return (
-    <SizingWindow ref={windowEl} className="sr-block" data-test-id="replay-window">
-      <div ref={viewEl} data-test-id="replay-view" className={className} />
+    <SizingWindow ref={windowEl} className="sr-block">
+      <div ref={viewEl} className={className} />
       {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
       {isBuffering ? <PositionedBuffering /> : null}
     </SizingWindow>

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -5,14 +5,15 @@ import DetailedError from 'sentry/components/errors/detailedError';
 import NotFound from 'sentry/components/errors/notFound';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {Panel, PanelBody, PanelHeader as _PanelHeader} from 'sentry/components/panels';
 import ReplayBreadcrumbOverview from 'sentry/components/replays/breadcrumbs/replayBreadcrumbOverview';
+import Scrobber from 'sentry/components/replays/player/scrobber';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import useFullscreen from 'sentry/components/replays/useFullscreen';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
-import space from 'sentry/styles/space';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import DetailLayout from './detail/detailLayout';
@@ -92,16 +93,25 @@ function ReplayDetails() {
       >
         <Layout.Body>
           <ReplayLayout ref={fullscreenRef}>
-            {/* In fullscreen we need to consider the max-height that the player is able
-            to full up, on a page that scrolls we only consider the max-width. */}
-            <ReplayPlayer fixedHeight={isFullscreen} />
-            <ReplayController toggleFullscreen={toggleFullscreen} />
+            <Panel>
+              <PanelHeader disablePadding>
+                <ManualResize isFullscreen={isFullscreen}>
+                  <ReplayPlayer />
+                </ManualResize>
+              </PanelHeader>
+              <Scrobber />
+              <PanelBody withPadding>
+                <ReplayController toggleFullscreen={toggleFullscreen} />
+              </PanelBody>
+            </Panel>
           </ReplayLayout>
           <Layout.Side>
             <UserActionsNavigator event={event} entry={breadcrumbEntry} />
           </Layout.Side>
           <Layout.Main fullWidth>
-            <BreadcrumbTimeline crumbs={breadcrumbEntry?.data.values || []} />
+            <Panel>
+              <BreadcrumbTimeline crumbs={breadcrumbEntry?.data.values || []} />
+            </Panel>
             <FocusArea
               event={event}
               eventWithSpans={mergedReplayEvent}
@@ -114,6 +124,25 @@ function ReplayDetails() {
   );
 }
 
+const PanelHeader = styled(_PanelHeader)`
+  display: block;
+  padding: 0;
+`;
+
+const ManualResize = styled('div')<{isFullscreen: boolean}>`
+  resize: vertical;
+  overflow: auto;
+  max-width: 100%;
+
+  ${p =>
+    p.isFullscreen
+      ? `resize: none;
+      width: auto !important;
+      height: auto !important;
+      `
+      : ''}
+`;
+
 const ReplayLayout = styled(Layout.Main)`
   :fullscreen {
     display: grid;
@@ -124,7 +153,6 @@ const ReplayLayout = styled(Layout.Main)`
 
 const BreadcrumbTimeline = styled(ReplayBreadcrumbOverview)`
   max-height: 5em;
-  margin-bottom: ${space(2)};
 `;
 
 export default ReplayDetails;


### PR DESCRIPTION
Cleanup styles and the Panels around the Player window and Play/Pause controls. 

<img width="1396" alt="Screen Shot 2022-05-03 at 1 55 19 AM" src="https://user-images.githubusercontent.com/187460/166299437-02a9576f-a673-4d21-84fe-82db39b013c4.png">


The player window now has a vertical resize handle, which lets us simulate how the player will change when/if we start to control the player size in different situations.

Also the scrubber is all-new. Instead of trying to style the native `<input type="range">` and deal with browser inconsistencies I've instead created a hidden `<input>` and added some div's and normal css to show styling to the user. It's got a nice little puff-on-hover effect:
Normal:
<img width="949" alt="Screen Shot 2022-05-03 at 2 00 40 AM" src="https://user-images.githubusercontent.com/187460/166300306-7af5885b-2dc8-4353-88ab-fc82530e4637.png">

Hover:
<img width="951" alt="Screen Shot 2022-05-03 at 2 00 59 AM" src="https://user-images.githubusercontent.com/187460/166300313-5efb93b2-d8b9-48c4-9da3-984ef9ba0d73.png">


Going into fullscreen mode is a little messed up right now, that needs a quick followup.

