### PR TITLE
fix(metric-alerts): Allow Sentry Apps without Alert Rule Actions to perform actions

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1450,13 +1450,13 @@ def rewrite_trigger_action_fields(action_data):
 
 
 def get_filtered_actions(
-    validated_alert_rule_data: Mapping[str, Any], action_type: AlertRuleTriggerAction.Type
+    alert_rule_data: Mapping[str, Any], action_type: AlertRuleTriggerAction.Type
 ):
     from sentry.incidents.serializers import STRING_TO_ACTION_TYPE
 
     return [
         rewrite_trigger_action_fields(action)
-        for trigger in validated_alert_rule_data.get("triggers", [])
+        for trigger in alert_rule_data.get("triggers", [])
         for action in trigger.get("actions", [])
         if STRING_TO_ACTION_TYPE.get(action.get("type")) == action_type
     ]

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -139,8 +139,8 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                         {"sentry_app": "The installation does not exist."}
                     )
 
-                # TODO(Ecosystem): Validate that all fields as part of the config
-                # See NotifyEventSentryAppAction for more details
+            # TODO(Ecosystem): Validate fields on schema config if alert-rule-action component exists
+            # See NotifyEventSentryAppAction::self_validate for more details
 
         attrs["use_async_lookup"] = self.context.get("use_async_lookup")
         attrs["input_channel_id"] = self.context.get("input_channel_id")

--- a/src/sentry/incidents/utils/sentry_apps.py
+++ b/src/sentry/incidents/utils/sentry_apps.py
@@ -18,7 +18,7 @@ def trigger_sentry_app_action_creators_for_incidents(alert_rule_data: Mapping[st
     )
     # We're doing this so that Sentry Apps without alert-rule-action schemas still get saved
     sentry_app_actions_with_components = list(
-        filter(lambda x: x.get("sentry_app_installation_uuid"), sentry_app_actions)
+        filter(lambda x: x.get("sentry_app_config"), sentry_app_actions)
     )
 
     for action in sentry_app_actions_with_components:

--- a/src/sentry/incidents/utils/sentry_apps.py
+++ b/src/sentry/incidents/utils/sentry_apps.py
@@ -2,7 +2,7 @@ from typing import Any, Mapping
 
 from rest_framework import serializers
 
-from sentry.auth.access import SystemAccess
+from sentry.auth.access import NoAccess
 from sentry.incidents.logic import get_filtered_actions
 from sentry.incidents.models import AlertRuleTriggerAction
 from sentry.incidents.serializers import AlertRuleTriggerActionSerializer
@@ -23,7 +23,7 @@ def trigger_sentry_app_action_creators_for_incidents(alert_rule_data: Mapping[st
 
     for action in sentry_app_actions_with_components:
         action_serializer = AlertRuleTriggerActionSerializer(
-            context={"access": SystemAccess()},
+            context={"access": NoAccess()},
             data=action,
         )
         if not action_serializer.is_valid():

--- a/src/sentry/incidents/utils/sentry_apps.py
+++ b/src/sentry/incidents/utils/sentry_apps.py
@@ -2,21 +2,32 @@ from typing import Any, Mapping
 
 from rest_framework import serializers
 
+from sentry.auth.access import SystemAccess
 from sentry.incidents.logic import get_filtered_actions
 from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.serializers import AlertRuleTriggerActionSerializer
 from sentry.mediators import alert_rule_actions
 from sentry.models import SentryAppInstallation
 
 
-def trigger_sentry_app_action_creators_for_incidents(
-    validated_alert_rule_data: Mapping[str, Any]
-) -> None:
+def trigger_sentry_app_action_creators_for_incidents(alert_rule_data: Mapping[str, Any]) -> None:
 
     sentry_app_actions = get_filtered_actions(
-        validated_alert_rule_data=validated_alert_rule_data,
+        alert_rule_data=alert_rule_data,
         action_type=AlertRuleTriggerAction.Type.SENTRY_APP,
     )
-    for action in sentry_app_actions:
+    # We're doing this so that Sentry Apps without alert-rule-action schemas still get saved
+    sentry_app_actions_with_components = list(
+        filter(lambda x: x.get("sentry_app_installation_uuid"), sentry_app_actions)
+    )
+
+    for action in sentry_app_actions_with_components:
+        action_serializer = AlertRuleTriggerActionSerializer(
+            context={"access": SystemAccess()},
+            data=action,
+        )
+        if not action_serializer.is_valid():
+            raise serializers.ValidationError(action_serializer.errors)
         install = SentryAppInstallation.objects.get(uuid=action.get("sentry_app_installation_uuid"))
         result = alert_rule_actions.AlertRuleActionCreator.run(
             install=install,

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -389,6 +389,37 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data == serialize(alert_rule, self.user)
         assert resp.data["owner"] is None
 
+    def test_no_config_sentry_app(self):
+        sentry_app = self.create_sentry_app(is_alertable=True)
+        self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization, user=self.user
+        )
+        test_params = {
+            **self.valid_params,
+            "triggers": [
+                {
+                    "actions": [
+                        {
+                            "type": "sentry_app",
+                            "targetType": "sentry_app",
+                            "targetIdentifier": sentry_app.id,
+                            "sentryAppId": sentry_app.id,
+                        }
+                    ],
+                    "alertThreshold": 300,
+                    "label": "critical",
+                }
+            ],
+        }
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            self.get_valid_response(
+                self.organization.slug,
+                self.project.slug,
+                self.alert_rule.id,
+                status_code=200,
+                **test_params,
+            )
+
     @responses.activate
     def test_success_response_from_sentry_app(self):
         responses.add(


### PR DESCRIPTION
See: [API-2669](https://getsentry.atlassian.net/browse/API-2669)

This PR allows for Sentry Apps without alert rule UI components to still be saved onto metric alerts.

This also fixes SENTRY-TWV

<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
