### PR TITLE
fix(ui): Restore tooltip animations

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -331,7 +331,12 @@ const PositionWrapper = styled('div')`
   z-index: ${p => p.theme.zIndex.tooltip};
 `;
 
-const TooltipContent = styled(motion.div, {shouldForwardProp: isPropValid})<{
+const animationProps = Object.keys(TOOLTIP_ANIMATION);
+
+const TooltipContent = styled(motion.div, {
+  shouldForwardProp: (prop: string) =>
+    typeof prop === 'string' && (animationProps.includes(prop) || isPropValid(prop)),
+})<{
   popperStyle: InternalTooltipProps['popperStyle'];
 }>`
   will-change: transform, opacity;


### PR DESCRIPTION
The framer motion.div props were being removed by emotions `isValidProp`

This is a regression from https://github.com/getsentry/sentry/commit/65776ad892e4751dc4331fa33db36cd265311710