### PR TITLE
fix(auditlog): Fix project key template

### DIFF
--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -132,7 +132,7 @@ default_manager.add(
         event_id=53,
         name="PROJECTKEY_CHANGE",
         api_name="projectkey.change",
-        template="{change} project key {public_key}",
+        template="edited project key {public_key}",
     )
 )
 default_manager.add(


### PR DESCRIPTION
Fixes SENTRY-TX5

The audit log entries with ID 53 had two different names associated with the same ID - `PROJECTKEY_ENABLE` and `PROJECTKEY_DISABLE`. These events have not been used since 2017. Currently, disabling or enabling a project key creates a  `PROJECTKEY_EDIT` event.
This update to the `PROJECTKEY_CHANGE` template that is now event ID 53 will be consistent with what is rendered for currently captured project key disabling and enabling audit log entries, and it will prevent the Keyerror in SENTRY-TX5 since there will no longer be a `change` key expected in the data. 
