### PR TITLE
ref(pageFilters): Use grid display for Project Details filter bar

### DIFF
--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -274,7 +274,6 @@ class ProjectDetail extends AsyncView<Props, State> {
                     query={query}
                     onSearch={this.handleSearch}
                     tagValueLoader={this.tagValueLoader}
-                    hasBottomMargin={false}
                   />
                 </ProjectFiltersWrapper>
 

--- a/static/app/views/projectDetail/projectFilters.tsx
+++ b/static/app/views/projectDetail/projectFilters.tsx
@@ -16,15 +16,9 @@ type Props = {
   onSearch: (q: string) => void;
   query: string;
   tagValueLoader: TagValueLoader;
-  hasBottomMargin?: boolean;
 };
 
-function ProjectFilters({
-  query,
-  tagValueLoader,
-  onSearch,
-  hasBottomMargin = true,
-}: Props) {
+function ProjectFilters({query, tagValueLoader, onSearch}: Props) {
   const getTagValues = async (tag: Tag, currentQuery: string): Promise<string[]> => {
     const values = await tagValueLoader(tag.key, currentQuery);
     return values.map(({value}) => value);
@@ -32,51 +26,40 @@ function ProjectFilters({
 
   return (
     <FiltersWrapper>
-      <StyledPageFilterBar hasBottomMargin={hasBottomMargin}>
+      <PageFilterBar>
         <EnvironmentPageFilter />
         <DatePageFilter alignDropdown="left" />
-      </StyledPageFilterBar>
-      <SearchBarWrapper>
-        <GuideAnchor target="releases_search" position="bottom">
-          <SmartSearchBar
-            searchSource="project_filters"
-            query={query}
-            placeholder={t('Search by release version, build, package, or stage')}
-            maxSearchItems={5}
-            hasRecentSearches={false}
-            supportedTags={{
-              ...SEMVER_TAGS,
-              release: {
-                key: 'release',
-                name: 'release',
-              },
-            }}
-            onSearch={onSearch}
-            onGetTagValues={getTagValues}
-          />
-        </GuideAnchor>
-      </SearchBarWrapper>
+      </PageFilterBar>
+      <GuideAnchor target="releases_search" position="bottom">
+        <SmartSearchBar
+          searchSource="project_filters"
+          query={query}
+          placeholder={t('Search by release version, build, package, or stage')}
+          maxSearchItems={5}
+          hasRecentSearches={false}
+          supportedTags={{
+            ...SEMVER_TAGS,
+            release: {
+              key: 'release',
+              name: 'release',
+            },
+          }}
+          onSearch={onSearch}
+          onGetTagValues={getTagValues}
+        />
+      </GuideAnchor>
     </FiltersWrapper>
   );
 }
 
-const StyledPageFilterBar = styled(PageFilterBar)<{hasBottomMargin: boolean}>`
-  margin-bottom: ${p => (p.hasBottomMargin ? `${space(1)}` : '0')};
-  margin-right: ${space(1)};
-
-  @media (max-width: ${p => p.theme.breakpoints[2]}) {
-    margin-bottom: ${space(1)};
-  }
-`;
-
 const FiltersWrapper = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-`;
+  display: grid;
+  grid-template-columns: minmax(0, max-content) 1fr;
+  gap: ${space(2)};
 
-const SearchBarWrapper = styled('div')`
-  flex: 1;
-  flex-basis: 430px;
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: minmax(0, 1fr);
+  }
 `;
 
 export default ProjectFilters;


### PR DESCRIPTION
Use grid display for more even spacing between the panels.

**Before**
<img width="978" alt="Screen Shot 2022-05-02 at 3 03 27 PM" src="https://user-images.githubusercontent.com/44172267/166334701-ccc850bd-7693-4795-89c9-47aa10406789.png">

**After**
<img width="982" alt="Screen Shot 2022-05-02 at 3 03 55 PM" src="https://user-images.githubusercontent.com/44172267/166334759-340e86e5-3932-488a-a8ad-de3830c8b9c1.png">

