### PR TITLE
ref(js): Disable Sentry SDK in `yarn dev-ui`

### DIFF
--- a/static/app/bootstrap/initializeApp.tsx
+++ b/static/app/bootstrap/initializeApp.tsx
@@ -1,6 +1,7 @@
 import './legacyTwitterBootstrap';
 import './exportGlobals';
 
+import {EXPERIMENTAL_SPA, NODE_ENV} from 'sentry/constants';
 import routes from 'sentry/routes';
 import {Config} from 'sentry/types';
 import {metric} from 'sentry/utils/analytics';
@@ -13,7 +14,10 @@ import {renderOnDomReady} from './renderOnDomReady';
 
 export async function initializeApp(config: Config) {
   commonInitialization(config);
-  initializeSdk(config, {routes});
+
+  if (!EXPERIMENTAL_SPA && NODE_ENV !== 'development') {
+    initializeSdk(config, {routes});
+  }
 
   // Used for operational metrics to determine that the application js
   // bundle was loaded by browser.


### PR DESCRIPTION
This avoids lots of 4xx errors when the Sentry SDK tries to send errors
to production Sentry.