### PR TITLE
ref(pageFilters): Add space between filter bar & search in Issues Index

### DIFF
--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import DatePageFilter from 'sentry/components/datePageFilter';
@@ -37,7 +37,7 @@ function IssueListFilters({
   tags,
 }: Props) {
   return (
-    <FilterContainer>
+    <Fragment>
       <SearchContainer>
         <PageFilterBar>
           <ProjectPageFilter />
@@ -57,21 +57,15 @@ function IssueListFilters({
           onSidebarToggle={onSidebarToggle}
         />
       </SearchContainer>
-    </FilterContainer>
+    </Fragment>
   );
 }
 
-const FilterContainer = styled('div')`
-  display: grid;
-  gap: ${space(1)};
-  margin-bottom: ${space(1)};
-`;
-
 const SearchContainer = styled('div')`
-  display: inline-grid;
-  gap: ${space(1)};
+  display: grid;
+  gap: ${space(2)};
   width: 100%;
-  margin-bottom: ${space(1)};
+  margin-bottom: ${space(2)};
   grid-template-columns: minmax(0, max-content) minmax(20rem, 1fr);
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {


### PR DESCRIPTION
Increase the horizontal spacing between the filter bar and the search bar from `space(1)` to `${space(2)}`, to better match other pages and general vertical spacing between panels (which currently stands at `${space(2)}`). Doing so shrinks the search bar by `8px`, but I don't think that's too big of a change to worry about.

**Before**
<img width="797" alt="Screen Shot 2022-05-02 at 4 27 12 PM" src="https://user-images.githubusercontent.com/44172267/166342087-fffb8fe3-fa61-4cd8-ade5-8e90364a0c53.png">



**After**
<img width="797" alt="Screen Shot 2022-05-02 at 4 24 10 PM" src="https://user-images.githubusercontent.com/44172267/166341873-ee4aa23e-2b51-46e1-a367-fca1060c4671.png">

**On mobile**
<img width="375" alt="Screen Shot 2022-05-02 at 4 27 41 PM" src="https://user-images.githubusercontent.com/44172267/166342113-d9825f5c-7d1e-4152-bb3c-b7d55759df18.png">
<img width="375" alt="Screen Shot 2022-05-02 at 4 28 06 PM" src="https://user-images.githubusercontent.com/44172267/166342141-0d51a94c-4fb9-4f5e-bf7a-5fde7d8a763a.png">