### PR TITLE
feat(eventstream): Introduce the "transactions" topic

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2304,6 +2304,11 @@ KAFKA_CLUSTERS = {
 }
 
 KAFKA_EVENTS = "events"
+# TODO: KAFKA_TRANSACTIONS is temporarily mapped to "events" since events
+# transactions curently share a Kafka topic. Once we are ready with the code
+# changes to support different topic, switch this to "transactions" to start
+# producing to the new topic.
+KAFKA_TRANSACTIONS = "events"
 KAFKA_OUTCOMES = "outcomes"
 KAFKA_OUTCOMES_BILLING = "outcomes-billing"
 KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS = "events-subscription-results"
@@ -2325,6 +2330,7 @@ KAFKA_PROFILES = "profiles"
 
 KAFKA_TOPICS = {
     KAFKA_EVENTS: {"cluster": "default", "topic": KAFKA_EVENTS},
+    KAFKA_TRANSACTIONS: {"cluster": "default", "topic": KAFKA_TRANSACTIONS},
     KAFKA_OUTCOMES: {"cluster": "default", "topic": KAFKA_OUTCOMES},
     # When OUTCOMES_BILLING is None, it inherits from OUTCOMES and does not
     # create a separate producer. Check ``track_outcome`` for details.

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -211,7 +211,8 @@ class KafkaEventStream(SnubaProtocolEventStream):
         else:
             # Default implementation which processes both errors and transactions
             # irrespective of values in the header. This would most likely be the case
-            # for development environments.
+            # for development environments. For the combined post process forwarder
+            # to work KAFKA_EVENTS and KAFKA_TRANSACTIONS must be the same currently.
             cluster_name = settings.KAFKA_TOPICS[settings.KAFKA_EVENTS]["cluster"]
             assert cluster_name == settings.KAFKA_TOPICS[settings.KAFKA_TRANSACTIONS]["cluster"]
             worker = PostProcessForwarderWorker(concurrency=concurrency)

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -213,7 +213,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
             # irrespective of values in the header. This would most likely be the case
             # for development environments.
             cluster_name = settings.KAFKA_TOPICS[settings.KAFKA_EVENTS]["cluster"]
-            assert cluster_name == settings.KAFKA_TOPICS[settings.KAFKA_TRANSACTIONS["cluster"]]
+            assert cluster_name == settings.KAFKA_TOPICS[settings.KAFKA_TRANSACTIONS]["cluster"]
             worker = PostProcessForwarderWorker(concurrency=concurrency)
 
         synchronized_consumer = SynchronizedConsumer(

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -664,6 +664,8 @@ class BatchedConsumerTest(TestCase):
         self.override_settings_cm = override_settings(
             KAFKA_TOPICS={
                 "events": {"cluster": "default", "topic": self.events_topic},
+                # Temporarily mapped to the same topic as events
+                "transactions": {"cluster": "default", "topic": self.events_topic},
                 "snuba-commit-log": {"cluster": "default", "topic": self.commit_log_topic},
             },
         )

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -336,12 +336,7 @@ def test_consumer_rebalance_from_partition_start(requires_kafka):
 
             assert producer.flush(5) == 0, "producer did not successfully flush queue"
 
-            # We should have received a single message.
-            # TODO: Can we also assert that the position is unpaused?)
-            for i in range(5):
-                received_message = consumer.poll(1)
-                if received_message is not None:
-                    break
+            received_message = consumer.poll(5.0)
 
             assert received_message is not None, "no message received"
 
@@ -468,10 +463,7 @@ def test_consumer_rebalance_from_committed_offset(requires_kafka):
 
             # We should have received a single message.
             # TODO: Can we also assert that the position is unpaused?)
-            for i in range(5):
-                received_message = consumer.poll(1)
-                if received_message is not None:
-                    break
+            received_message = consumer.poll(5.0)
 
             assert received_message is not None, "no message received"
 


### PR DESCRIPTION
This is small first step in preparing to split transactions from the
errors topic "events" into their own "transactions" topic.
We introduce the KAFKA_TRANSACTIONS setting; currently this is mapped
to "event". Once we are done with the code changes required, this
can be changed to "transactions" to start producing to the new topic.