### PR TITLE
feat(alerts): Duplicate alert button

### DIFF
--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -124,6 +124,8 @@ class Create extends Component<Props, State> {
     };
     const eventView = createFromDiscover ? EventView.fromLocation(location) : undefined;
 
+    const hasDuplicateAlertRules = organization.features.includes('duplicate-alert-rule');
+
     let wizardAlertType: undefined | WizardAlertType;
     if (createFromWizard && alertType === AlertRuleType.METRIC) {
       wizardAlertType = wizardTemplate
@@ -172,7 +174,7 @@ class Create extends Component<Props, State> {
 
                     {hasMetricAlerts &&
                       alertType === AlertRuleType.METRIC &&
-                      (createFromDuplicate ? (
+                      (createFromDuplicate && hasDuplicateAlertRules ? (
                         <IncidentRulesDuplicate
                           {...this.props}
                           eventView={eventView}

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -44,8 +44,14 @@ class Create extends Component<Props, State> {
 
   getInitialState(): State {
     const {organization, location, project, params, router} = this.props;
-    const {createFromDiscover, createFromWizard, aggregate, dataset, eventTypes} =
-      location?.query ?? {};
+    const {
+      createFromDiscover,
+      createFromWizard,
+      aggregate,
+      dataset,
+      eventTypes,
+      createFromDuplicate,
+    } = location?.query ?? {};
     let alertType = AlertRuleType.ISSUE;
 
     const hasAlertWizardV3 = organization.features.includes('alert-wizard-v3');
@@ -54,7 +60,12 @@ class Create extends Component<Props, State> {
     if (hasAlertWizardV3) {
       alertType = params.alertType || AlertRuleType.METRIC;
 
-      if (alertType === AlertRuleType.METRIC && !(aggregate && dataset && eventTypes)) {
+      // TODO(taylangocmen): Remove redirect with aggregate && dataset && eventTypes, init from template
+      if (
+        alertType === AlertRuleType.METRIC &&
+        !(aggregate && dataset && eventTypes) &&
+        !createFromDuplicate
+      ) {
         router.replace({
           ...location,
           pathname: `/organizations/${organization.slug}/alerts/new/${alertType}`,

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -13,6 +13,7 @@ import {uniqueId} from 'sentry/utils/guid';
 import Teams from 'sentry/utils/teams';
 import BuilderBreadCrumbs from 'sentry/views/alerts/builder/builderBreadCrumbs';
 import IncidentRulesCreate from 'sentry/views/alerts/incidentRules/create';
+import IncidentRulesDuplicate from 'sentry/views/alerts/incidentRules/duplicate';
 import IssueRuleEditor from 'sentry/views/alerts/issueRuleEditor';
 import {AlertRuleType} from 'sentry/views/alerts/types';
 import {
@@ -108,8 +109,14 @@ class Create extends Component<Props, State> {
   render() {
     const {hasMetricAlerts, organization, project, location, routes} = this.props;
     const {alertType} = this.state;
-    const {aggregate, dataset, eventTypes, createFromWizard, createFromDiscover} =
-      location?.query ?? {};
+    const {
+      aggregate,
+      dataset,
+      eventTypes,
+      createFromWizard,
+      createFromDiscover,
+      createFromDuplicate,
+    } = location?.query ?? {};
     const wizardTemplate: WizardRuleTemplate = {
       aggregate: aggregate ?? DEFAULT_WIZARD_TEMPLATE.aggregate,
       dataset: dataset ?? DEFAULT_WIZARD_TEMPLATE.dataset,
@@ -163,16 +170,27 @@ class Create extends Component<Props, State> {
                       />
                     )}
 
-                    {hasMetricAlerts && alertType === AlertRuleType.METRIC && (
-                      <IncidentRulesCreate
-                        {...this.props}
-                        eventView={eventView}
-                        wizardTemplate={wizardTemplate}
-                        sessionId={this.sessionId}
-                        project={project}
-                        userTeamIds={teams.map(({id}) => id)}
-                      />
-                    )}
+                    {hasMetricAlerts &&
+                      alertType === AlertRuleType.METRIC &&
+                      (createFromDuplicate ? (
+                        <IncidentRulesDuplicate
+                          {...this.props}
+                          eventView={eventView}
+                          wizardTemplate={wizardTemplate}
+                          sessionId={this.sessionId}
+                          project={project}
+                          userTeamIds={teams.map(({id}) => id)}
+                        />
+                      ) : (
+                        <IncidentRulesCreate
+                          {...this.props}
+                          eventView={eventView}
+                          wizardTemplate={wizardTemplate}
+                          sessionId={this.sessionId}
+                          project={project}
+                          userTeamIds={teams.map(({id}) => id)}
+                        />
+                      ))}
                   </Fragment>
                 ) : (
                   <LoadingIndicator />

--- a/static/app/views/alerts/incidentRules/constants.tsx
+++ b/static/app/views/alerts/incidentRules/constants.tsx
@@ -69,6 +69,33 @@ const allAggregations: AggregationKey[] = [
   'count',
 ];
 
+export const DuplicateMetricFields: string[] = [
+  'dataset',
+  'eventTypes',
+  'aggregate',
+  'query',
+  'timeWindow',
+  'thresholdPeriod',
+  'projects',
+  'environment',
+  'resolveThreshold',
+  'thresholdType',
+  'owner',
+  'name',
+  'projectId',
+  'comparisonDelta',
+];
+
+export const DuplicateTriggerFields: string[] = ['alertThreshold', 'label'];
+
+export const DuplicateActionFields: string[] = [
+  'type',
+  'targetType',
+  'targetIdentifier',
+  'inputChannelId',
+  'options',
+];
+
 export const COMPARISON_DELTA_OPTIONS = [
   {value: 5, label: t('same time 5 minutes ago')}, // 5 minutes
   {value: 15, label: t('same time 15 minutes ago')}, // 15 minutes

--- a/static/app/views/alerts/incidentRules/duplicate.tsx
+++ b/static/app/views/alerts/incidentRules/duplicate.tsx
@@ -69,8 +69,10 @@ class IncidentRulesDuplicate extends AsyncView<Props, State> {
   get isDuplicateRule() {
     const {
       location: {query},
+      organization,
     } = this.props;
-    return query.createFromDuplicate && query.duplicateRuleId;
+    const hasDuplicateAlertRules = organization.features.includes('duplicate-alert-rule');
+    return hasDuplicateAlertRules && query.createFromDuplicate && query.duplicateRuleId;
   }
 
   getDefaultState() {

--- a/static/app/views/alerts/incidentRules/duplicate.tsx
+++ b/static/app/views/alerts/incidentRules/duplicate.tsx
@@ -2,13 +2,15 @@ import {RouteComponentProps} from 'react-router';
 import pick from 'lodash/pick';
 
 import {Organization, Project} from 'sentry/types';
-import {metric} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
 import {uniqueId} from 'sentry/utils/guid';
 import {
   createDefaultRule,
   createRuleFromEventView,
   createRuleFromWizardTemplate,
+  DuplicateActionFields,
+  DuplicateMetricFields,
+  DuplicateTriggerFields,
 } from 'sentry/views/alerts/incidentRules/constants';
 import {IncidentRule} from 'sentry/views/alerts/incidentRules/types';
 import {WizardRuleTemplate} from 'sentry/views/alerts/wizard/options';
@@ -41,31 +43,6 @@ type State = {
  */
 
 class IncidentRulesDuplicate extends AsyncView<Props, State> {
-  static duplicateMetricFields = [
-    'dataset',
-    'eventTypes',
-    'aggregate',
-    'query',
-    'timeWindow',
-    'thresholdPeriod',
-    'projects',
-    'environment',
-    'resolveThreshold',
-    'thresholdType',
-    'owner',
-    'name',
-    'projectId',
-    'comparisonDelta',
-  ];
-  static duplicateTriggerFields = ['alertThreshold', 'label'];
-  static duplicateActionFields = [
-    'type',
-    'targetType',
-    'targetIdentifier',
-    'inputChannelId',
-    'options',
-  ];
-
   get isDuplicateRule() {
     const {
       location: {query},
@@ -125,7 +102,6 @@ class IncidentRulesDuplicate extends AsyncView<Props, State> {
       ? (data.id as string | undefined)
       : undefined;
 
-    metric.endTransaction({name: 'saveAlertRule'});
     router.push(
       alertRuleId
         ? {pathname: `/organizations/${orgId}/alerts/rules/details/${alertRuleId}/`}
@@ -151,9 +127,9 @@ class IncidentRulesDuplicate extends AsyncView<Props, State> {
         onSubmitSuccess={this.handleSubmitSuccess}
         rule={
           {
-            ...pick(rule, IncidentRulesDuplicate.duplicateMetricFields),
+            ...pick(rule, DuplicateMetricFields),
             triggers: rule.triggers.map(trigger => ({
-              ...pick(trigger, IncidentRulesDuplicate.duplicateTriggerFields),
+              ...pick(trigger, DuplicateTriggerFields),
               actions: trigger.actions.map(action => ({
                 inputChannelId: null,
                 integrationId: undefined,
@@ -161,7 +137,7 @@ class IncidentRulesDuplicate extends AsyncView<Props, State> {
                 sentryAppId: undefined,
                 unsavedId: uniqueId(),
                 unsavedDateCreated: new Date().toISOString(),
-                ...pick(action, IncidentRulesDuplicate.duplicateActionFields),
+                ...pick(action, DuplicateActionFields),
               })),
             })),
             name: rule.name + ' copy',

--- a/static/app/views/alerts/incidentRules/duplicate.tsx
+++ b/static/app/views/alerts/incidentRules/duplicate.tsx
@@ -1,0 +1,149 @@
+import {RouteComponentProps} from 'react-router';
+
+import {Organization, Project} from 'sentry/types';
+import {metric} from 'sentry/utils/analytics';
+import EventView from 'sentry/utils/discover/eventView';
+import {
+  createDefaultRule,
+  createRuleFromEventView,
+  createRuleFromWizardTemplate,
+} from 'sentry/views/alerts/incidentRules/constants';
+import {IncidentRule} from 'sentry/views/alerts/incidentRules/types';
+import {WizardRuleTemplate} from 'sentry/views/alerts/wizard/options';
+import AsyncView from 'sentry/views/asyncView';
+
+import RuleForm from './ruleForm';
+
+type RouteParams = {
+  orgId: string;
+  projectId?: string;
+  ruleId?: string;
+};
+
+type Props = {
+  eventView: EventView | undefined;
+  organization: Organization;
+  project: Project;
+  userTeamIds: string[];
+  sessionId?: string;
+  wizardTemplate?: WizardRuleTemplate;
+} & RouteComponentProps<RouteParams, {}>;
+
+type State = {
+  defaultRule: IncidentRule;
+  duplicateTargetRule?: IncidentRule;
+} & AsyncView['state'];
+
+/**
+ * Show metric rules form with values from an existing rule. Redirects to alerts list after creation.
+ */
+
+class IncidentRulesDuplicate extends AsyncView<Props, State> {
+  get isDuplicateRule() {
+    const {
+      location: {query},
+    } = this.props;
+    return query.createFromDuplicate && query.duplicateRuleId;
+  }
+
+  getDefaultState() {
+    const {project, eventView, wizardTemplate, userTeamIds} = this.props;
+    const defaultRule = eventView
+      ? createRuleFromEventView(eventView)
+      : wizardTemplate
+      ? createRuleFromWizardTemplate(wizardTemplate)
+      : createDefaultRule();
+
+    const projectTeamIds = new Set(project.teams.map(({id}) => id));
+    const defaultOwnerId = userTeamIds.find(id => projectTeamIds.has(id)) ?? null;
+    const owner = defaultOwnerId && `team:${defaultOwnerId}`;
+
+    return {
+      ...super.getDefaultState(),
+      defaultRule: {
+        ...defaultRule,
+        owner,
+        projects: [project.slug],
+      },
+    };
+  }
+
+  getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
+    const {
+      params: {orgId},
+      location: {query},
+    } = this.props;
+
+    if (this.isDuplicateRule) {
+      return [
+        [
+          'duplicateTargetRule',
+          `/organizations/${orgId}/alert-rules/${query.duplicateRuleId}/`,
+        ],
+      ];
+    }
+
+    return [];
+  }
+
+  onRequestSuccess({stateKey, data}) {
+    if (stateKey === 'duplicateTargetRule') {
+      this.setState({
+        rule: {
+          ...data,
+          id: undefined,
+          name: 'Copy ' + data.name,
+        },
+      });
+    }
+  }
+
+  handleSubmitSuccess(data: any) {
+    const {
+      router,
+      project,
+      params: {orgId},
+    } = this.props;
+    const alertRuleId: string | undefined = data
+      ? (data.id as string | undefined)
+      : undefined;
+
+    metric.endTransaction({name: 'saveAlertRule'});
+    router.push(
+      alertRuleId
+        ? {pathname: `/organizations/${orgId}/alerts/rules/details/${alertRuleId}/`}
+        : {
+            pathname: `/organizations/${orgId}/alerts/rules/`,
+            query: {project: project.id},
+          }
+    );
+  }
+
+  renderBody() {
+    const {project, sessionId, userTeamIds, ...otherProps} = this.props;
+    const {defaultRule, duplicateTargetRule} = this.state;
+
+    if (this.isDuplicateRule && !duplicateTargetRule) {
+      return this.renderLoading();
+    }
+
+    const rule = duplicateTargetRule ?? defaultRule;
+
+    return (
+      <RuleForm
+        onSubmitSuccess={this.handleSubmitSuccess}
+        rule={{
+          ...rule,
+          id: undefined,
+          name: 'Copy ' + rule.name,
+        }}
+        sessionId={sessionId}
+        project={project}
+        userTeamIds={userTeamIds}
+        {...otherProps}
+      />
+    );
+  }
+}
+
+export default IncidentRulesDuplicate;

--- a/static/app/views/alerts/incidentRules/types.tsx
+++ b/static/app/views/alerts/incidentRules/types.tsx
@@ -56,7 +56,7 @@ export type UnsavedTrigger = {
   actions: Action[];
   alertThreshold: number | '' | null;
   label: AlertRuleTriggerType;
-  // UnsavedTrigger can be apart of an Unsaved Alert Rule that does not have an
+  // UnsavedTrigger can be a part of an Unsaved Alert Rule that does not have an
   // id yet
   alertRuleId?: string;
 };

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -212,7 +212,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
         rule: {
           ...data,
           id: undefined,
-          name: 'Copy ' + data.name,
+          name: data.name + ' copy',
         },
       });
     }

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -210,10 +210,9 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     if (stateKey === 'duplicateTargetRule') {
       this.setState({
         rule: {
-          ...data,
-          id: undefined,
+          ...omit(data, ['id']),
           name: data.name + ' copy',
-        },
+        } as UnsavedIssueAlertRule,
       });
     }
   }

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -178,11 +178,13 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {
-      params: {ruleId, orgId},
+      organization,
       location: {query},
+      params: {ruleId, orgId},
     } = this.props;
     // project in state isn't initialized when getEndpoints is first called
     const project = this.state?.project ?? this.props.project;
+    const hasDuplicateAlertRules = organization.features.includes('duplicate-alert-rule');
 
     const endpoints = [
       ['environments', `/projects/${orgId}/${project.slug}/environments/`],
@@ -193,7 +195,12 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       endpoints.push(['rule', `/projects/${orgId}/${project.slug}/rules/${ruleId}/`]);
     }
 
-    if (!ruleId && query.createFromDuplicate && query.duplicateRuleId) {
+    if (
+      hasDuplicateAlertRules &&
+      !ruleId &&
+      query.createFromDuplicate &&
+      query.duplicateRuleId
+    ) {
       endpoints.push([
         'duplicateTargetRule',
         `/projects/${orgId}/${project.slug}/rules/${query.duplicateRuleId}/`,

--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -115,6 +115,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
     const {
       params: {orgId},
       location,
+      organization,
       router,
     } = this.props;
     const {loading, ruleList = [], ruleListPageLinks} = this.state;
@@ -230,6 +231,9 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
                         orgId={orgId}
                         onDelete={this.handleDeleteRule}
                         userTeams={new Set(teams.map(team => team.id))}
+                        hasDuplicateAlertRules={organization.features.includes(
+                          'duplicate-alert-rule'
+                        )}
                       />
                     ))
                   }

--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -26,7 +26,7 @@ import {
   AlertRuleTriggerType,
 } from 'sentry/views/alerts/incidentRules/types';
 
-import {CombinedMetricIssueAlerts, IncidentStatus} from '../types';
+import {CombinedAlertType, CombinedMetricIssueAlerts, IncidentStatus} from '../types';
 import {isIssueAlert} from '../utils';
 
 type Props = {
@@ -152,6 +152,17 @@ function RuleListRow({
     isIssueAlert(rule) ? 'rules' : 'metric-rules'
   }/${slug}/${rule.id}/`;
 
+  const duplicateLink = {
+    pathname: `/organizations/${orgId}/alerts/new/${
+      rule.type === CombinedAlertType.METRIC ? 'metric' : 'issue'
+    }/`,
+    query: {
+      project: slug,
+      duplicateRuleId: rule.id,
+      createFromDuplicate: true,
+    },
+  };
+
   const detailsLink = `/organizations/${orgId}/alerts/rules/details/${rule.id}/`;
 
   const ownerId = rule.owner?.split(':')[1];
@@ -182,6 +193,11 @@ function RuleListRow({
       key: 'edit',
       label: t('Edit'),
       to: editLink,
+    },
+    {
+      key: 'duplicate',
+      label: t('Duplicate'),
+      to: duplicateLink,
     },
     {
       key: 'delete',

--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -160,6 +160,7 @@ function RuleListRow({
       project: slug,
       duplicateRuleId: rule.id,
       createFromDuplicate: true,
+      referrer: 'alert_stream',
     },
   };
 

--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -30,6 +30,7 @@ import {CombinedAlertType, CombinedMetricIssueAlerts, IncidentStatus} from '../t
 import {isIssueAlert} from '../utils';
 
 type Props = {
+  hasDuplicateAlertRules: boolean;
   onDelete: (projectId: string, rule: CombinedMetricIssueAlerts) => void;
   orgId: string;
   projects: Project[];
@@ -53,6 +54,7 @@ function RuleListRow({
   orgId,
   onDelete,
   userTeams,
+  hasDuplicateAlertRules,
 }: Props) {
   const activeIncident =
     rule.latestIncident?.status !== undefined &&
@@ -199,6 +201,7 @@ function RuleListRow({
       key: 'duplicate',
       label: t('Duplicate'),
       to: duplicateLink,
+      hidden: !hasDuplicateAlertRules,
     },
     {
       key: 'delete',

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -82,7 +82,12 @@ export enum AlertRuleStatus {
   DISABLED = 5,
 }
 
+export enum CombinedAlertType {
+  METRIC = 'alert_rule',
+  ISSUE = 'rule',
+}
+
 export type CombinedMetricIssueAlerts = (IssueAlertRule | IncidentRule) & {
-  type: string;
+  type: CombinedAlertType;
   latestIncident?: Incident | null;
 };


### PR DESCRIPTION
This adds a duplicate button to alert list row context menu. When clicked user is sent to create new alert page with the `createFromDuplicate` and `duplicateRuleId` url parameters, the alert wizard form sets all the values from the duplicated alert rule, when clicking save alert a new alert is created with the form values. See deployment to test the flow.

Jira: [WOR-1836](https://getsentry.atlassian.net/browse/WOR-1836) & [WOR-1837](https://getsentry.atlassian.net/browse/WOR-1837)