### PR TITLE
fix(workflow): Update Project Dashboards tests and convert to RTL

### DIFF
--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -144,7 +144,7 @@ class ProjectCard extends Component<Props> {
               />
               <StyledBookmarkStar organization={organization} project={project} />
             </HeaderRow>
-            <SummaryLinks>
+            <SummaryLinks data-test-id="summary-links">
               {stats ? (
                 <Fragment>
                   <Link

--- a/tests/js/spec/views/projectsDashboard/index.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/index.spec.jsx
@@ -1,5 +1,11 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
-import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import * as projectsActions from 'sentry/actionCreators/projects';
 import ProjectsStatsStore from 'sentry/stores/projectsStatsStore';
@@ -47,94 +53,31 @@ describe('ProjectsDashboard', function () {
   });
 
   describe('empty state', function () {
-    it('renders with no projects', function () {
-      const noProjectTeams = [TestStubs.Team({projects: []})];
+    it('renders with no projects', async function () {
+      const noProjectTeams = [TestStubs.Team({isMember: false, projects: []})];
 
-      const wrapper = mountWithTheme(
+      render(
         <Dashboard
           teams={noProjectTeams}
           organization={org}
           params={{orgId: org.slug}}
         />,
-        routerContext
+        {routerContext}
       );
 
-      expect(wrapper.find('Button[data-test-id="create-project"]').exists()).toBe(false);
-      expect(wrapper.find('NoProjectMessage').exists()).toBe(true);
+      expect(screen.queryByTestId('join-team')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('create-project')).not.toBeInTheDocument();
     });
 
     it('renders with 1 project, with no first event', function () {
-      const projects = [TestStubs.Project({teams})];
+      const projects = TestStubs.Project({teams, firstEvent: false});
 
       const teamsWithOneProject = [TestStubs.Team({projects})];
 
-      const wrapper = mountWithTheme(
+      render(
         <Dashboard
           teams={teamsWithOneProject}
           organization={org}
-          params={{orgId: org.slug}}
-        />,
-        routerContext
-      );
-
-      expect(wrapper.find('Button[data-test-id="create-project"]').exists()).toBe(true);
-      expect(wrapper.find('Resources').exists()).toBe(true);
-    });
-  });
-
-  describe('with projects', function () {
-    it('renders TeamSection with two projects', function () {
-      const projects = [
-        TestStubs.Project({
-          teams,
-          firstEvent: true,
-        }),
-
-        TestStubs.Project({
-          slug: 'project2',
-          teams,
-          isBookmarked: true,
-          firstEvent: true,
-        }),
-      ];
-
-      const teamsWithTwoProjects = [TestStubs.Team({projects})];
-
-      const wrapper = mountWithTheme(
-        <Dashboard
-          teams={teamsWithTwoProjects}
-          organization={org}
-          params={{orgId: org.slug}}
-        />,
-        routerContext
-      );
-
-      expect(wrapper.find('Button[data-test-id="create-project"]').exists()).toBe(true);
-      expect(wrapper.find('NoProjectMessage').exists()).toBe(false);
-      expect(wrapper.find('Resources').exists()).toBe(false);
-    });
-
-    it('renders users projects without team section for redesign', function () {
-      const projects = [
-        TestStubs.Project({
-          teams,
-          firstEvent: true,
-        }),
-
-        TestStubs.Project({
-          slug: 'project2',
-          teams,
-          isBookmarked: true,
-          firstEvent: true,
-        }),
-      ];
-
-      const userTeams = [TestStubs.Team({projects})];
-
-      render(
-        <Dashboard
-          teams={userTeams}
-          organization={{...org, features: [...org.features, 'projects-page-redesign']}}
           params={{orgId: org.slug}}
         />,
         {routerContext}
@@ -146,51 +89,205 @@ describe('ProjectsDashboard', function () {
         screen.getByPlaceholderText('Search for projects by name')
       ).toBeInTheDocument();
       expect(screen.getByText('My Teams')).toBeInTheDocument();
-      expect(screen.queryByTestId('team')).not.toBeInTheDocument();
-      expect(screen.queryByText('Resources')).not.toBeInTheDocument();
+      expect(screen.getByText('Resources')).toBeInTheDocument();
+      expect(screen.getByTestId('badge-display-name')).toBeInTheDocument();
     });
+  });
 
-    it('renders bookmarked projects first in team list', function () {
+  describe('with projects', function () {
+    it('renders with two projects', function () {
+      const teamA = TestStubs.Team({slug: 'team1', isMember: true});
       const projects = [
         TestStubs.Project({
           id: '1',
-          slug: 'm',
-          teams,
-          isBookmarked: false,
-          stats: [],
+          slug: 'project1',
+          teams: [teamA],
+          firstEvent: true,
         }),
         TestStubs.Project({
           id: '2',
-          slug: 'm-fave',
-          teams,
+          slug: 'project2',
+          teams: [teamA],
           isBookmarked: true,
-          stats: [],
+          firstEvent: true,
+        }),
+      ];
+
+      const teamsWithTwoProjects = [TestStubs.Team({projects})];
+
+      render(
+        <Dashboard
+          teams={teamsWithTwoProjects}
+          organization={org}
+          params={{orgId: org.slug}}
+        />,
+        {routerContext}
+      );
+      expect(screen.getByText('My Teams')).toBeInTheDocument();
+      expect(screen.getAllByTestId('badge-display-name')).toHaveLength(2);
+    });
+
+    it('renders correct project with selected team', function () {
+      const teamC = TestStubs.Team({
+        id: '1',
+        slug: 'teamC',
+        isMember: true,
+        projects: [
+          TestStubs.Project({
+            id: '1',
+            slug: 'project1',
+          }),
+          TestStubs.Project({
+            id: '2',
+            slug: 'project2',
+          }),
+        ],
+      });
+      const teamD = TestStubs.Team({
+        id: '2',
+        slug: 'teamD',
+        isMember: true,
+        projects: [
+          TestStubs.Project({
+            id: '3',
+            slug: 'project3',
+          }),
+        ],
+      });
+
+      const projectWithTeam = [teamC, teamD];
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/teams/?team=2`,
+        body: projectWithTeam,
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/projects/`,
+        body: [
+          TestStubs.Project({
+            id: '1',
+            slug: 'project1',
+            teams: [teamC],
+            firstEvent: true,
+            stats: [],
+          }),
+          TestStubs.Project({
+            id: '2',
+            slug: 'project2',
+            teams: [teamC],
+            isBookmarked: true,
+            firstEvent: true,
+            stats: [],
+          }),
+          TestStubs.Project({
+            id: '3',
+            slug: 'project3',
+            teams: [teamD],
+            firstEvent: true,
+            stats: [],
+          }),
+        ],
+      });
+
+      render(
+        <Dashboard
+          teams={projectWithTeam}
+          organization={org}
+          params={{orgId: org.slug}}
+          location={{
+            query: {team: '2'},
+            search: '?team=2`',
+          }}
+        />,
+        {routerContext}
+      );
+
+      expect(screen.getByText('project3')).toBeInTheDocument();
+      expect(screen.queryByText('project2')).not.toBeInTheDocument();
+    });
+
+    it('renders projects by search', async function () {
+      const teamA = TestStubs.Team({slug: 'team1', isMember: true});
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/projects/`,
+        body: [],
+      });
+      const projects = [
+        TestStubs.Project({
+          id: '1',
+          slug: 'project1',
+          teams: [teamA],
+          firstEvent: true,
         }),
         TestStubs.Project({
-          id: '3',
-          slug: 'a-fave',
-          teams,
+          id: '2',
+          slug: 'project2',
+          teams: [teamA],
           isBookmarked: true,
-          stats: [],
+          firstEvent: true,
         }),
+      ];
+
+      const teamsWithTwoProjects = [TestStubs.Team({projects})];
+
+      render(
+        <Dashboard
+          teams={teamsWithTwoProjects}
+          organization={org}
+          params={{orgId: org.slug}}
+        />,
+        {routerContext}
+      );
+      userEvent.type(screen.getByRole('textbox'), 'project2', '{enter}');
+      expect(screen.getByText('project2')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByText('project1')).not.toBeInTheDocument();
+      });
+    });
+
+    it('renders bookmarked projects first in team list', function () {
+      const teamA = TestStubs.Team({slug: 'team1', isMember: true});
+      const projects = [
         TestStubs.Project({
-          id: '4',
-          slug: 'z-fave',
-          teams,
-          isBookmarked: true,
-          stats: [],
-        }),
-        TestStubs.Project({
-          id: '5',
-          slug: 'a',
-          teams,
+          id: '11',
+          slug: 'm',
+          teams: [teamA],
           isBookmarked: false,
           stats: [],
         }),
         TestStubs.Project({
-          id: '6',
+          id: '12',
+          slug: 'm-fave',
+          teams: [teamA],
+          isBookmarked: true,
+          stats: [],
+        }),
+        TestStubs.Project({
+          id: '13',
+          slug: 'a-fave',
+          teams: [teamA],
+          isBookmarked: true,
+          stats: [],
+        }),
+        TestStubs.Project({
+          id: '14',
+          slug: 'z-fave',
+          teams: [teamA],
+          isBookmarked: true,
+          stats: [],
+        }),
+        TestStubs.Project({
+          id: '15',
+          slug: 'a',
+          teams: [teamA],
+          isBookmarked: false,
+          stats: [],
+        }),
+        TestStubs.Project({
+          id: '16',
           slug: 'z',
-          teams,
+          teams: [teamA],
           isBookmarked: false,
           stats: [],
         }),
@@ -212,29 +309,33 @@ describe('ProjectsDashboard', function () {
       });
 
       jest.useFakeTimers();
-      const wrapper = mountWithTheme(
+      render(
         <Dashboard
           teams={teamsWithFavProjects}
           organization={org}
           params={{orgId: org.slug}}
         />,
-        routerContext
+        {routerContext}
       );
 
       jest.runAllTimers();
       jest.useRealTimers();
+      // check that all projects are displayed
+      expect(screen.getAllByTestId('badge-display-name')).toHaveLength(6);
 
-      const projectCards = wrapper.find('LazyLoadMock ProjectCard');
-      expect(projectCards.at(0).prop('data-test-id')).toBe('a-fave');
-      expect(projectCards.at(1).prop('data-test-id')).toBe('m-fave');
-      expect(projectCards.at(2).prop('data-test-id')).toBe('z-fave');
-      expect(projectCards.at(3).prop('data-test-id')).toBe('a');
-      expect(projectCards.at(4).prop('data-test-id')).toBe('m');
-      expect(projectCards.at(5).prop('data-test-id')).toBe('z');
+      const projectName = screen.getAllByTestId('badge-display-name');
+      // check that projects are in the correct order - alphabetical with bookmarked projects in front
+      expect(within(projectName[0]).getByText('a-fave')).toBeInTheDocument();
+      expect(within(projectName[1]).getByText('m-fave')).toBeInTheDocument();
+      expect(within(projectName[2]).getByText('z-fave')).toBeInTheDocument();
+      expect(within(projectName[3]).getByText('a')).toBeInTheDocument();
+      expect(within(projectName[4]).getByText('m')).toBeInTheDocument();
+      expect(within(projectName[5]).getByText('z')).toBeInTheDocument();
     });
   });
 
   describe('ProjectsStatsStore', function () {
+    const teamA = TestStubs.Team({slug: 'team1', isMember: true});
     const projects = [
       TestStubs.Project({
         id: '1',
@@ -245,31 +346,31 @@ describe('ProjectsDashboard', function () {
       TestStubs.Project({
         id: '2',
         slug: 'm-fave',
-        teams,
+        teams: [teamA],
         isBookmarked: true,
       }),
       TestStubs.Project({
         id: '3',
         slug: 'a-fave',
-        teams,
+        teams: [teamA],
         isBookmarked: true,
       }),
       TestStubs.Project({
         id: '4',
         slug: 'z-fave',
-        teams,
+        teams: [teamA],
         isBookmarked: true,
       }),
       TestStubs.Project({
         id: '5',
         slug: 'a',
-        teams,
+        teams: [teamA],
         isBookmarked: false,
       }),
       TestStubs.Project({
         id: '6',
         slug: 'z',
-        teams,
+        teams: [teamA],
         isBookmarked: false,
       }),
     ];
@@ -291,23 +392,39 @@ describe('ProjectsDashboard', function () {
         })),
       });
 
-      const wrapper = mountWithTheme(
+      const {unmount} = render(
         <Dashboard
           teams={teamsWithStatTestProjects}
           organization={org}
           params={{orgId: org.slug}}
         />,
-        routerContext
+        {routerContext}
       );
 
       expect(loadStatsSpy).toHaveBeenCalledTimes(6);
       expect(mock).not.toHaveBeenCalled();
 
+      const projectSummary = screen.getAllByTestId('summary-links');
       // Has 5 Loading Cards because 1 project has been loaded in store already
-      expect(wrapper.find('Placeholder')).toHaveLength(5);
+      expect(
+        within(projectSummary[0]).getByTestId('loading-placeholder')
+      ).toBeInTheDocument();
+      expect(
+        within(projectSummary[1]).getByTestId('loading-placeholder')
+      ).toBeInTheDocument();
+      expect(
+        within(projectSummary[2]).getByTestId('loading-placeholder')
+      ).toBeInTheDocument();
+      expect(
+        within(projectSummary[3]).getByTestId('loading-placeholder')
+      ).toBeInTheDocument();
+      expect(within(projectSummary[4]).getByText('Errors: 2')).toBeInTheDocument();
+      expect(
+        within(projectSummary[5]).getByTestId('loading-placeholder')
+      ).toBeInTheDocument();
 
       // Advance timers so that batched request fires
-      jest.advanceTimersByTime(51);
+      act(() => jest.advanceTimersByTime(51));
       expect(mock).toHaveBeenCalledTimes(1);
       // query ids = 3, 2, 4 = bookmarked
       // 1 - already loaded in store so shouldn't be in query
@@ -322,24 +439,29 @@ describe('ProjectsDashboard', function () {
       jest.useRealTimers();
       await tick();
       await tick();
-      wrapper.update();
-      expect(wrapper.find('Placeholder')).toHaveLength(0);
-      expect(wrapper.find('Chart')).toHaveLength(6);
+
+      // All cards have loaded
+      expect(within(projectSummary[0]).getByText('Errors: 3')).toBeInTheDocument();
+      expect(within(projectSummary[1]).getByText('Errors: 3')).toBeInTheDocument();
+      expect(within(projectSummary[2]).getByText('Errors: 3')).toBeInTheDocument();
+      expect(within(projectSummary[3]).getByText('Errors: 3')).toBeInTheDocument();
+      expect(within(projectSummary[4]).getByText('Errors: 3')).toBeInTheDocument();
+      expect(within(projectSummary[5]).getByText('Errors: 3')).toBeInTheDocument();
 
       // Resets store when it unmounts
-      act(() => {
-        wrapper.unmount();
-      });
+      unmount();
       expect(ProjectsStatsStore.getAll()).toEqual({});
     });
 
     it('renders an error from withTeamsForUser', function () {
-      const wrapper = mountWithTheme(
+      render(
         <Dashboard error={Error('uhoh')} organization={org} params={{orgId: org.slug}} />,
-        routerContext
+        {routerContext}
       );
 
-      expect(wrapper.find('LoadingError').exists()).toBe(true);
+      expect(
+        screen.getByText('An error occurred while fetching your projects')
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
With the new Projects Dashboards page redesign, new tests were added/updated and also converted to React Testing Library.

[FIXES WOR-1823
](https://getsentry.atlassian.net/browse/WOR-1823)[FIXES WOR-1824](https://getsentry.atlassian.net/browse/WOR-1788)
