### PR TITLE
fix: prevent black from fork-bombing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
       entry: black
       language: system
       types: [python]
+      require_serial: true
     # Configuration for isort exists in pyproject.toml,
     # but we let pre-commit take care of the file filtering.
     - id: isort


### PR DESCRIPTION
this improves execution of black against everything by about a second (and significantly less `user` / `sys` time due to fewer context switches) -- this is one of the disadvantages of using `repo: local` since we have to be careful about the configuration rather than getting the community-driven fixes from psf/black.  black itself implements multiprocessing so stacking pre-commit's multiprocessing on top of blacks results in excessive forking

more on [`require_serial`](https://pre-commit.com/#hooks-require_serial) and the reference from black's configuration: https://github.com/psf/black/blob/c940f75d5b646777427aef1beb18a0d2c391f5e2/.pre-commit-hooks.yaml#L7

```console
$ rm -rf ~/Library/Caches/black/; time pre-commit run black --all-files
black....................................................................Passed

real	0m17.021s
user	1m51.283s
sys	0m5.433s
$ babi .pre-commit-config.yaml 
$ rm -rf ~/Library/Caches/black/; time pre-commit run black --all-files
black....................................................................Passed

real	0m16.280s
user	1m38.106s
sys	0m2.326s
```