### PR TITLE
ref: upgrade to black stable

### DIFF
--- a/bin/typed_code.py
+++ b/bin/typed_code.py
@@ -215,13 +215,10 @@ def print_results(
     teams: Set[str],
 ) -> None:
     """Pretty print the results."""
-    tuples = (
-        sorted(
-            ((team, get_result(covered_by_team, not_covered_by_team, team)) for team in teams),
-            key=lambda x: x[1],
-        )
-        + [(TOTALS_KEY, get_result(covered_by_team, not_covered_by_team, TOTALS_KEY))]
-    )
+    tuples = sorted(
+        ((team, get_result(covered_by_team, not_covered_by_team, team)) for team in teams),
+        key=lambda x: x[1],
+    ) + [(TOTALS_KEY, get_result(covered_by_team, not_covered_by_team, TOTALS_KEY))]
 
     bar = "=" * int(BAR_LENGTH / 2)
     print(f"{bar} Python coverage by team {bar}")  # NOQA S002

--- a/requirements-pre-commit.txt
+++ b/requirements-pre-commit.txt
@@ -1,5 +1,5 @@
 pre-commit==2.15.0
-black==21.9b0
+black==22.3.0
 flake8==3.9.2
 flake8-bugbear==21.4.3
 pyupgrade==2.29.0

--- a/src/bitfield/models.py
+++ b/src/bitfield/models.py
@@ -133,7 +133,7 @@ class BitField(BigIntegerField):
             if isinstance(value, int) and value < 0:
                 new_value = 0
                 for bit_number, _ in enumerate(self.flags):
-                    new_value |= value & (2 ** bit_number)
+                    new_value |= value & (2**bit_number)
                 value = new_value
 
             value = BitHandler(value, self.flags, self.labels)

--- a/src/sentry/auth/password_validation.py
+++ b/src/sentry/auth/password_validation.py
@@ -95,14 +95,11 @@ class MinimumLengthValidator:
             )
 
     def get_help_text(self):
-        return (
-            ungettext(
-                "Your password must contain at least %(min_length)d character.",
-                "Your password must contain at least %(min_length)d characters.",
-                self.min_length,
-            )
-            % {"min_length": self.min_length}
-        )
+        return ungettext(
+            "Your password must contain at least %(min_length)d character.",
+            "Your password must contain at least %(min_length)d characters.",
+            self.min_length,
+        ) % {"min_length": self.min_length}
 
 
 class MaximumLengthValidator:
@@ -126,14 +123,11 @@ class MaximumLengthValidator:
             )
 
     def get_help_text(self):
-        return (
-            ungettext(
-                "Your password must contain no more than %(max_length)d character.",
-                "Your password must contain no more than %(max_length)d characters.",
-                self.max_length,
-            )
-            % {"max_length": self.max_length}
-        )
+        return ungettext(
+            "Your password must contain no more than %(max_length)d character.",
+            "Your password must contain no more than %(max_length)d characters.",
+            self.max_length,
+        ) % {"max_length": self.max_length}
 
 
 class NumericPasswordValidator:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2480,7 +2480,7 @@ SENTRY_USE_UWSGI = True
 
 # When copying attachments for to-be-reprocessed events into processing store,
 # how large is an individual file chunk? Each chunk is stored as Redis key.
-SENTRY_REPROCESSING_ATTACHMENT_CHUNK_SIZE = 2 ** 20
+SENTRY_REPROCESSING_ATTACHMENT_CHUNK_SIZE = 2**20
 
 # Which cluster is used to store auxiliary data for reprocessing. Note that
 # this cluster is not used to store attachments etc, that still happens on

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -290,7 +290,7 @@ def store_export_chunk_as_blob(data_export, bytes_written, fileobj, blob_size=DE
                 # there is a maximum file size allowed, so we need to make sure we don't exceed it
                 # NOTE: there seems to be issues with downloading files larger than 1 GB on slower
                 # networks, limit the export to 1 GB for now to improve reliability
-                if bytes_written + bytes_offset >= min(MAX_FILE_SIZE, 2 ** 30):
+                if bytes_written + bytes_offset >= min(MAX_FILE_SIZE, 2**30):
                     raise ExportDataFileTooBig()
     except ExportDataFileTooBig:
         return 0

--- a/src/sentry/db/models/fields/bounded.py
+++ b/src/sentry/db/models/fields/bounded.py
@@ -80,7 +80,6 @@ if settings.SENTRY_USE_BIG_INTS:
                 assert value <= self.MAX_VALUE
             return cast(int, super().get_prep_value(value))
 
-
 else:
     # we want full on classes for these
     class BoundedBigIntegerField(BoundedIntegerField):  # type: ignore

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -391,16 +391,12 @@ def frame(
         # special case empty functions not to have a hint
         if not func:
             function_component.update(contributes=False)
-        elif (
-            func
-            in (
-                "?",
-                "<anonymous function>",
-                "<anonymous>",
-                "Anonymous function",
-            )
-            or func.endswith("/<")
-        ):
+        elif func in (
+            "?",
+            "<anonymous function>",
+            "<anonymous>",
+            "Anonymous function",
+        ) or func.endswith("/<"):
             function_component.update(contributes=False, hint="ignored unknown function name")
         if (func == "eval") or frame.abs_path in (
             "[native code]",

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -38,7 +38,7 @@ UPLOAD_RETRY_TIME = getattr(settings, "SENTRY_UPLOAD_RETRY_TIME", 60)  # 1min
 DEFAULT_BLOB_SIZE = 1024 * 1024  # one mb
 CHUNK_STATE_HEADER = "__state"
 MULTI_BLOB_UPLOAD_CONCURRENCY = 8
-MAX_FILE_SIZE = 2 ** 31  # 2GB is the maximum offset supported by fileblob
+MAX_FILE_SIZE = 2**31  # 2GB is the maximum offset supported by fileblob
 
 
 class nooplogger:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -29,7 +29,7 @@ register("system.root-api-key", flags=FLAG_PRIORITIZE_DISK)
 register("system.logging-format", default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint
 register("system.upload-url-prefix", flags=FLAG_PRIORITIZE_DISK)
-register("system.maximum-file-size", default=2 ** 31, flags=FLAG_PRIORITIZE_DISK)
+register("system.maximum-file-size", default=2**31, flags=FLAG_PRIORITIZE_DISK)
 
 # Redis
 register(

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -40,7 +40,7 @@ CODEOWNERS = "codeowners"
 
 # Grammar is defined in EBNF syntax.
 ownership_grammar = Grammar(
-    fr"""
+    rf"""
 
 ownership = line+
 

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -73,9 +73,9 @@ ALIAS_REGEX = r"(\w+)?(?!\d+)\w+"
 MISERY_ALPHA = 5.8875
 MISERY_BETA = 111.8625
 
-ALIAS_PATTERN = re.compile(fr"{ALIAS_REGEX}$")
+ALIAS_PATTERN = re.compile(rf"{ALIAS_REGEX}$")
 FUNCTION_PATTERN = re.compile(
-    fr"^(?P<function>[^\(]+)\((?P<columns>.*)\)( (as|AS) (?P<alias>{ALIAS_REGEX}))?$"
+    rf"^(?P<function>[^\(]+)\((?P<columns>.*)\)( (as|AS) (?P<alias>{ALIAS_REGEX}))?$"
 )
 
 DURATION_PATTERN = re.compile(r"(\d+\.?\d?)(\D{1,3})")

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -205,21 +205,18 @@ def assigned_or_suggested_filter(
 
     if Team in types_to_owners:
         teams = types_to_owners[Team]
-        query |= (
-            Q(
-                **{
-                    f"{field_filter}__in": GroupOwner.objects.filter(
-                        Q(group__assignee_set__isnull=True),
-                        team__in=teams,
-                        project_id__in=project_ids,
-                        organization_id=organization_id,
-                    )
-                    .values_list("group_id", flat=True)
-                    .distinct()
-                }
-            )
-            | assigned_to_filter(teams, projects, field_filter=field_filter)
-        )
+        query |= Q(
+            **{
+                f"{field_filter}__in": GroupOwner.objects.filter(
+                    Q(group__assignee_set__isnull=True),
+                    team__in=teams,
+                    project_id__in=project_ids,
+                    organization_id=organization_id,
+                )
+                .values_list("group_id", flat=True)
+                .distinct()
+            }
+        ) | assigned_to_filter(teams, projects, field_filter=field_filter)
 
     if User in types_to_owners:
         users = types_to_owners[User]

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -104,7 +104,7 @@ def parse_numeric_value(value, suffix=None):
     if not suffix:
         return value
 
-    numeric_multiples = {"k": 10.0 ** 3, "m": 10.0 ** 6, "b": 10.0 ** 9}
+    numeric_multiples = {"k": 10.0**3, "m": 10.0**6, "b": 10.0**9}
     if suffix not in numeric_multiples:
         raise InvalidQuery(f"{suffix} is not a valid number suffix, must be k, m or b")
 

--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -215,7 +215,6 @@ if TYPE_CHECKING:
         message: Message[KafkaPayload]
         future: Future[Message[KafkaPayload]]
 
-
 else:
 
     class ProducerResultFuture(NamedTuple):

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -708,7 +708,7 @@ def spans_histogram_query(
     :param [Condition] extra_condition: Adds any additional conditions to the histogram query
     :param bool normalize_results: Indicate whether to normalize the results by column into bins.
     """
-    multiplier = int(10 ** precision)
+    multiplier = int(10**precision)
     if max_value is not None:
         # We want the specified max_value to be exclusive, and the queried max_value
         # to be inclusive. So we adjust the specified max_value using the multiplier.
@@ -803,7 +803,7 @@ def histogram_query(
     :param bool normalize_results: Indicate whether to normalize the results by column into bins.
     """
 
-    multiplier = int(10 ** precision)
+    multiplier = int(10**precision)
     if max_value is not None:
         # We want the specified max_value to be exclusive, and the queried max_value
         # to be inclusive. So we adjust the specified max_value using the multiplier.

--- a/src/sentry/testutils/helpers/link_header.py
+++ b/src/sentry/testutils/helpers/link_header.py
@@ -31,7 +31,7 @@ QUOTED_STRING = r'(?:"(?:\\"|[^"])*")'
 PARAMETER = r"(?:%(TOKEN)s(?:=(?:%(TOKEN)s|%(QUOTED_STRING)s))?)" % locals()
 LINK = r"<[^>]*>\s*(?:;\s*%(PARAMETER)s?\s*)*" % locals()
 COMMA = r"(?:\s*(?:,\s*)+)"
-LINK_SPLIT = fr"{LINK}(?={COMMA}|\s*$)"
+LINK_SPLIT = rf"{LINK}(?={COMMA}|\s*$)"
 
 link_splitter = re.compile(LINK_SPLIT)
 
@@ -46,7 +46,7 @@ def _unquotestring(instr):
 def _splitstring(instr, item, split):
     if not instr:
         return []
-    return [h.strip() for h in re.findall(fr"{item}(?={split}|\s*$)", instr)]
+    return [h.strip() for h in re.findall(rf"{item}(?={split}|\s*$)", instr)]
 
 
 def parse_link_header(instr):

--- a/src/sentry/utils/locking/lock.py
+++ b/src/sentry/utils/locking/lock.py
@@ -60,7 +60,7 @@ class Lock:
             try:
                 return self.acquire()
             except UnableToAcquireLock:
-                delay = (exp_base ** attempt) * random.random() * initial_delay
+                delay = (exp_base**attempt) * random.random() * initial_delay
                 # Redundant check to prevent futile sleep in last iteration:
                 if time.monotonic() + delay > stop:
                     break

--- a/src/sentry/utils/otp.py
+++ b/src/sentry/utils/otp.py
@@ -59,7 +59,7 @@ class TOTP:
             | (h[offset + 2] & 0xFF) << 8
             | (h[offset + 3] & 0xFF)
         )
-        str_code = str(code % 10 ** self.digits)
+        str_code = str(code % 10**self.digits)
         return ("0" * (self.digits - len(str_code))) + str_code
 
     def verify(self, otp, ts=None, window=None, return_counter=False, check_counter_func=None):

--- a/src/sentry/utils/pytest/relay.py
+++ b/src/sentry/utils/pytest/relay.py
@@ -140,7 +140,7 @@ def relay_server(relay_server_setup, settings):
         except Exception as ex:
             if i == 4:
                 raise ValueError(f"relay did not start in time:\n{container.logs()}") from ex
-            time.sleep(0.1 * 2 ** i)
+            time.sleep(0.1 * 2**i)
     else:
         raise ValueError("relay did not start in time")
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -199,7 +199,7 @@ class FailoverRedis(StrictRedis):
                 time.sleep(
                     min(
                         self._backoff_max,
-                        (self._backoff_min * (self._backoff_multiplier ** retries))
+                        (self._backoff_min * (self._backoff_multiplier**retries))
                         * (1 + random.random()),
                     )
                 )

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -118,7 +118,7 @@ def soft_break(value, length, process=lambda chunk: chunk):
 
         return "".join(results).rstrip("\u200b")
 
-    return re.sub(fr"\S{{{length},}}", soft_break_delimiter, value)
+    return re.sub(rf"\S{{{length},}}", soft_break_delimiter, value)
 
 
 def to_unicode(value):

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -70,7 +70,7 @@ if getattr(settings, "SERVE_UPLOADED_FILES", settings.DEBUG):
     # would typically be handled by some static server.
     urlpatterns += [
         url(
-            fr"^{re.escape(settings.MEDIA_URL)}(?P<path>.*)$",
+            rf"^{re.escape(settings.MEDIA_URL)}(?P<path>.*)$",
             serve,
             {"document_root": settings.MEDIA_ROOT},
             name="sentry-serve-media",

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -193,7 +193,7 @@ class EventManagerTest(TestCase):
             manager = EventManager(
                 make_event(
                     message="foo 123",
-                    event_id=hex(2 ** 127 + int(ts))[-32:],
+                    event_id=hex(2**127 + int(ts))[-32:],
                     timestamp=ts,
                     exception={
                         "values": [
@@ -1034,37 +1034,28 @@ class EventManagerTest(TestCase):
             tsdb.models.users_affected_by_group, (event.group.id,), event.datetime, event.datetime
         ) == {event.group.id: 1}
 
-        assert (
-            tsdb.get_distinct_counts_totals(
-                tsdb.models.users_affected_by_project,
-                (event.project.id,),
-                event.datetime,
-                event.datetime,
-            )
-            == {event.project.id: 1}
-        )
+        assert tsdb.get_distinct_counts_totals(
+            tsdb.models.users_affected_by_project,
+            (event.project.id,),
+            event.datetime,
+            event.datetime,
+        ) == {event.project.id: 1}
 
-        assert (
-            tsdb.get_distinct_counts_totals(
-                tsdb.models.users_affected_by_group,
-                (event.group.id,),
-                event.datetime,
-                event.datetime,
-                environment_id=environment_id,
-            )
-            == {event.group.id: 1}
-        )
+        assert tsdb.get_distinct_counts_totals(
+            tsdb.models.users_affected_by_group,
+            (event.group.id,),
+            event.datetime,
+            event.datetime,
+            environment_id=environment_id,
+        ) == {event.group.id: 1}
 
-        assert (
-            tsdb.get_distinct_counts_totals(
-                tsdb.models.users_affected_by_project,
-                (event.project.id,),
-                event.datetime,
-                event.datetime,
-                environment_id=environment_id,
-            )
-            == {event.project.id: 1}
-        )
+        assert tsdb.get_distinct_counts_totals(
+            tsdb.models.users_affected_by_project,
+            (event.project.id,),
+            event.datetime,
+            event.datetime,
+            environment_id=environment_id,
+        ) == {event.project.id: 1}
 
         euser = EventUser.objects.get(project_id=self.project.id, ident="1")
         assert event.get_tag("sentry:user") == euser.tag_value

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -342,24 +342,21 @@ def test_range_matching():
 
     (rule,) = enhancement.rules
 
-    assert (
-        sorted(
-            dict(
-                _get_matching_frame_actions(
-                    rule,
-                    [
-                        {"function": "main"},
-                        {"function": "foo"},
-                        {"function": "bar"},
-                        {"function": "baz"},
-                        {"function": "abort"},
-                    ],
-                    "python",
-                )
+    assert sorted(
+        dict(
+            _get_matching_frame_actions(
+                rule,
+                [
+                    {"function": "main"},
+                    {"function": "foo"},
+                    {"function": "bar"},
+                    {"function": "baz"},
+                    {"function": "abort"},
+                ],
+                "python",
             )
         )
-        == [2]
-    )
+    ) == [2]
 
 
 def test_range_matching_direct():
@@ -371,24 +368,21 @@ def test_range_matching_direct():
 
     (rule,) = enhancement.rules
 
-    assert (
-        sorted(
-            dict(
-                _get_matching_frame_actions(
-                    rule,
-                    [
-                        {"function": "main"},
-                        {"function": "foo"},
-                        {"function": "bar"},
-                        {"function": "baz"},
-                        {"function": "abort"},
-                    ],
-                    "python",
-                )
+    assert sorted(
+        dict(
+            _get_matching_frame_actions(
+                rule,
+                [
+                    {"function": "main"},
+                    {"function": "foo"},
+                    {"function": "bar"},
+                    {"function": "baz"},
+                    {"function": "abort"},
+                ],
+                "python",
             )
         )
-        == [2]
-    )
+    ) == [2]
 
     assert not _get_matching_frame_actions(
         rule,

--- a/tests/sentry/integrations/bitbucket/testutils.py
+++ b/tests/sentry/integrations/bitbucket/testutils.py
@@ -23,7 +23,7 @@ GET_LAST_COMMITS_EXAMPLE = b"""{
 }
 """
 
-COMMIT_DIFF_PATCH = br"""diff --git a/README.md b/README.md
+COMMIT_DIFF_PATCH = rb"""diff --git a/README.md b/README.md
 index 89821ce..9e09a8a 100644
 --- a/README.md
 +++ b/README.md

--- a/tests/sentry/models/test_monitor.py
+++ b/tests/sentry/models/test_monitor.py
@@ -60,30 +60,27 @@ class MonitorTestCase(TestCase):
 
         event = mock_insert_data_to_database_legacy.mock_calls[0].args[0]
 
-        assert (
-            dict(
-                event,
-                **{
-                    "level": "error",
-                    "project": self.project.id,
-                    "platform": "other",
-                    "contexts": {
-                        "monitor": {
-                            "status": "active",
-                            "type": "cron_job",
-                            "config": {"schedule_type": 2, "schedule": [1, "month"]},
-                            "id": str(monitor.guid),
-                            "name": monitor.name,
-                        }
-                    },
-                    "logentry": {"formatted": "Monitor failure: test monitor (unknown)"},
-                    "fingerprint": ["monitor", str(monitor.guid), "unknown"],
-                    "logger": "",
-                    "type": "default",
+        assert dict(
+            event,
+            **{
+                "level": "error",
+                "project": self.project.id,
+                "platform": "other",
+                "contexts": {
+                    "monitor": {
+                        "status": "active",
+                        "type": "cron_job",
+                        "config": {"schedule_type": 2, "schedule": [1, "month"]},
+                        "id": str(monitor.guid),
+                        "name": monitor.name,
+                    }
                 },
-            )
-            == dict(event)
-        )
+                "logentry": {"formatted": "Monitor failure: test monitor (unknown)"},
+                "fingerprint": ["monitor", str(monitor.guid), "unknown"],
+                "logger": "",
+                "type": "default",
+            },
+        ) == dict(event)
 
     @patch("sentry.coreapi.insert_data_to_database_legacy")
     def test_mark_failed_with_reason(self, mock_insert_data_to_database_legacy):
@@ -100,27 +97,24 @@ class MonitorTestCase(TestCase):
 
         event = mock_insert_data_to_database_legacy.mock_calls[0].args[0]
 
-        assert (
-            dict(
-                event,
-                **{
-                    "level": "error",
-                    "project": self.project.id,
-                    "platform": "other",
-                    "contexts": {
-                        "monitor": {
-                            "status": "active",
-                            "type": "cron_job",
-                            "config": {"schedule_type": 2, "schedule": [1, "month"]},
-                            "id": str(monitor.guid),
-                            "name": monitor.name,
-                        }
-                    },
-                    "logentry": {"formatted": "Monitor failure: test monitor (duration)"},
-                    "fingerprint": ["monitor", str(monitor.guid), "duration"],
-                    "logger": "",
-                    "type": "default",
+        assert dict(
+            event,
+            **{
+                "level": "error",
+                "project": self.project.id,
+                "platform": "other",
+                "contexts": {
+                    "monitor": {
+                        "status": "active",
+                        "type": "cron_job",
+                        "config": {"schedule_type": 2, "schedule": [1, "month"]},
+                        "id": str(monitor.guid),
+                        "name": monitor.name,
+                    }
                 },
-            )
-            == dict(event)
-        )
+                "logentry": {"formatted": "Monitor failure: test monitor (duration)"},
+                "fingerprint": ["monitor", str(monitor.guid), "duration"],
+                "logger": "",
+                "type": "default",
+            },
+        ) == dict(event)

--- a/tests/sentry/notifications/utils/test_get_groups_for_query.py
+++ b/tests/sentry/notifications/utils/test_get_groups_for_query.py
@@ -68,21 +68,18 @@ class GetGroupsForQueryTestCase(TestCase):
         assert {group.id for group in query_groups} == {10, 11, 13}
 
     def test_get_groups_for_query_simple(self):
-        assert (
-            get_groups_for_query(
-                {self.project: {self.group}},
-                {
-                    NotificationScopeType.PROJECT: {
-                        self.project.id: {
-                            ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
-                            ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
-                        },
+        assert get_groups_for_query(
+            {self.project: {self.group}},
+            {
+                NotificationScopeType.PROJECT: {
+                    self.project.id: {
+                        ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                        ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
                     },
                 },
-                user=self.user,
-            )
-            == {self.group}
-        )
+            },
+            user=self.user,
+        ) == {self.group}
 
     def test_get_groups_for_query_never(self):
         assert (

--- a/tests/sentry/notifications/utils/test_get_user_subscriptions_for_groups.py
+++ b/tests/sentry/notifications/utils/test_get_user_subscriptions_for_groups.py
@@ -51,25 +51,19 @@ class GetUserSubscriptionsForGroupsTestCase(TestCase):
             == {}
         )
 
-        assert (
-            get_user_subscriptions_for_groups(
-                groups_by_project=groups_by_project,
-                notification_settings_by_scope={},
-                subscriptions_by_group_id=subscriptions_by_group_id,
-                user=self.user,
-            )
-            == {self.group.id: (False, True, self.group_subscription)}
-        )
+        assert get_user_subscriptions_for_groups(
+            groups_by_project=groups_by_project,
+            notification_settings_by_scope={},
+            subscriptions_by_group_id=subscriptions_by_group_id,
+            user=self.user,
+        ) == {self.group.id: (False, True, self.group_subscription)}
 
-        assert (
-            get_user_subscriptions_for_groups(
-                groups_by_project=groups_by_project,
-                notification_settings_by_scope=notification_settings_by_scope,
-                subscriptions_by_group_id={},
-                user=self.user,
-            )
-            == {self.group.id: (True, False, None)}
-        )
+        assert get_user_subscriptions_for_groups(
+            groups_by_project=groups_by_project,
+            notification_settings_by_scope=notification_settings_by_scope,
+            subscriptions_by_group_id={},
+            user=self.user,
+        ) == {self.group.id: (True, False, None)}
 
     def test_get_user_subscriptions_for_groups(self):
         groups_by_project = {self.project: {self.group}}
@@ -88,12 +82,9 @@ class GetUserSubscriptionsForGroupsTestCase(TestCase):
             },
         }
         subscriptions_by_group_id = {self.group.id: self.group_subscription}
-        assert (
-            get_user_subscriptions_for_groups(
-                groups_by_project,
-                notification_settings_by_scope,
-                subscriptions_by_group_id,
-                user=self.user,
-            )
-            == {self.group.id: (False, True, self.group_subscription)}
-        )
+        assert get_user_subscriptions_for_groups(
+            groups_by_project,
+            notification_settings_by_scope,
+            subscriptions_by_group_id,
+            user=self.user,
+        ) == {self.group.id: (False, True, self.group_subscription)}

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -71,37 +71,31 @@ def test_dump_schema():
 
 
 def test_load_schema():
-    assert (
-        load_schema(
-            {
-                "$version": 1,
-                "rules": [
-                    {
-                        "matcher": {"type": "path", "pattern": "*.js"},
-                        "owners": [{"type": "team", "identifier": "frontend"}],
-                    }
-                ],
-            }
-        )
-        == [Rule(Matcher("path", "*.js"), [Owner("team", "frontend")])]
-    )
+    assert load_schema(
+        {
+            "$version": 1,
+            "rules": [
+                {
+                    "matcher": {"type": "path", "pattern": "*.js"},
+                    "owners": [{"type": "team", "identifier": "frontend"}],
+                }
+            ],
+        }
+    ) == [Rule(Matcher("path", "*.js"), [Owner("team", "frontend")])]
 
 
 def test_load_tag_schema():
-    assert (
-        load_schema(
-            {
-                "$version": 1,
-                "rules": [
-                    {
-                        "matcher": {"type": "tags.release", "pattern": "*"},
-                        "owners": [{"type": "user", "identifier": "test@sentry.io"}],
-                    }
-                ],
-            }
-        )
-        == [Rule(Matcher("tags.release", "*"), [Owner("user", "test@sentry.io")])]
-    )
+    assert load_schema(
+        {
+            "$version": 1,
+            "rules": [
+                {
+                    "matcher": {"type": "tags.release", "pattern": "*"},
+                    "owners": [{"type": "user", "identifier": "test@sentry.io"}],
+                }
+            ],
+        }
+    ) == [Rule(Matcher("tags.release", "*"), [Owner("user", "test@sentry.io")])]
 
 
 def test_matcher_test_url():

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -17,46 +17,31 @@ def test_is_rate_limited_script():
     client = cluster.get_local_client(next(iter(cluster.hosts)))
 
     # The item should not be rate limited by either key.
-    assert (
-        list(
-            map(
-                bool,
-                is_rate_limited(
-                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                ),
-            )
+    assert list(
+        map(
+            bool,
+            is_rate_limited(client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)),
         )
-        == [False, False]
-    )
+    ) == [False, False]
 
     # The item should be rate limited by the first key (1).
-    assert (
-        list(
-            map(
-                bool,
-                is_rate_limited(
-                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                ),
-            )
+    assert list(
+        map(
+            bool,
+            is_rate_limited(client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)),
         )
-        == [True, False]
-    )
+    ) == [True, False]
 
     # The item should still be rate limited by the first key (1), but *not*
     # rate limited by the second key (2) even though this is the third time
     # we've checked the quotas. This ensures items that are rejected by a lower
     # quota don't affect unrelated items that share a parent quota.
-    assert (
-        list(
-            map(
-                bool,
-                is_rate_limited(
-                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                ),
-            )
+    assert list(
+        map(
+            bool,
+            is_rate_limited(client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)),
         )
-        == [True, False]
-    )
+    ) == [True, False]
 
     assert client.get("foo") == b"1"
     assert 59 <= client.ttl("foo") <= 60
@@ -226,7 +211,7 @@ class RedisQuotaTest(TestCase):
                 id="a",
                 scope=QuotaScope.PROJECT,
                 scope_id=1,
-                limit=1 ** 6,
+                limit=1**6,
                 window=1,
                 reason_code="attachment_quota",
                 categories=[DataCategory.ATTACHMENT],
@@ -273,7 +258,7 @@ class RedisQuotaTest(TestCase):
                 id="a",
                 scope=QuotaScope.PROJECT,
                 scope_id=1,
-                limit=1 ** 6,
+                limit=1**6,
                 window=1,
                 reason_code="attachment_quota",
                 categories=[DataCategory.ATTACHMENT],

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -764,27 +764,18 @@ class GetSnubaQueryArgsTest(TestCase):
         project_2 = self.create_project()
         group = self.create_group(project=self.project, short_id=self.project.next_short_id())
         group_2 = self.create_group(project=project_2, short_id=self.project.next_short_id())
-        assert (
-            get_filter(
-                f"project.name:[{self.project.slug}, {project_2.slug}]",
-                params={"project_id": [self.project.id, project_2.id]},
-            ).conditions
-            == [["project_id", "IN", [project_2.id, self.project.id]]]
-        )
-        assert (
-            get_filter(
-                f"issue:[{group.qualified_short_id}, {group_2.qualified_short_id}]",
-                params={"organization_id": self.project.organization_id},
-            ).conditions
-            == [["issue.id", "IN", [group.id, group_2.id]]]
-        )
-        assert (
-            get_filter(
-                f"issue:[{group.qualified_short_id}, unknown]",
-                params={"organization_id": self.project.organization_id},
-            ).conditions
-            == [[["coalesce", ["issue.id", 0]], "IN", [0, group.id]]]
-        )
+        assert get_filter(
+            f"project.name:[{self.project.slug}, {project_2.slug}]",
+            params={"project_id": [self.project.id, project_2.id]},
+        ).conditions == [["project_id", "IN", [project_2.id, self.project.id]]]
+        assert get_filter(
+            f"issue:[{group.qualified_short_id}, {group_2.qualified_short_id}]",
+            params={"organization_id": self.project.organization_id},
+        ).conditions == [["issue.id", "IN", [group.id, group_2.id]]]
+        assert get_filter(
+            f"issue:[{group.qualified_short_id}, unknown]",
+            params={"organization_id": self.project.organization_id},
+        ).conditions == [[["coalesce", ["issue.id", 0]], "IN", [0, group.id]]]
         assert get_filter("environment:[prod, dev]").conditions == [
             [["environment", "IN", {"prod", "dev"}]]
         ]

--- a/tests/sentry/snuba/metrics/test_snql.py
+++ b/tests/sentry/snuba/metrics/test_snql.py
@@ -305,14 +305,11 @@ class DerivedMetricSnQLTestCase(TestCase):
         alias = "session.crashed_and_abnormal_user"
         arg1_snql = crashed_users(self.org_id, self.metric_ids, alias="session.crashed_user")
         arg2_snql = abnormal_users(self.org_id, self.metric_ids, alias="session.abnormal_user")
-        assert (
-            addition(
-                arg1_snql,
-                arg2_snql,
-                alias=alias,
-            )
-            == Function("plus", [arg1_snql, arg2_snql], alias=alias)
-        )
+        assert addition(
+            arg1_snql,
+            arg2_snql,
+            alias=alias,
+        ) == Function("plus", [arg1_snql, arg2_snql], alias=alias)
 
     def test_subtraction_in_snql(self):
         arg1_snql = all_users(self.org_id, self.metric_ids, alias="session.all_user")
@@ -320,14 +317,11 @@ class DerivedMetricSnQLTestCase(TestCase):
             self.org_id, self.metric_ids, alias="session.errored_user_all"
         )
 
-        assert (
-            subtraction(
-                arg1_snql,
-                arg2_snql,
-                alias="session.healthy_user",
-            )
-            == Function("minus", [arg1_snql, arg2_snql], alias="session.healthy_user")
-        )
+        assert subtraction(
+            arg1_snql,
+            arg2_snql,
+            alias="session.healthy_user",
+        ) == Function("minus", [arg1_snql, arg2_snql], alias="session.healthy_user")
 
     def test_division_in_snql(self):
         alias = "transactions.failure_rate"

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -76,14 +76,11 @@ def test_merge_mappings():
 
 
 def test_merge_mappings_custom_operator():
-    assert (
-        merge_mappings(
-            {"a": {"x": 1, "y": 1}, "b": {"x": 2, "y": 2}},
-            {"a": {"x": 1, "y": 1}, "b": {"x": 2, "y": 2}},
-            lambda left, right: merge_mappings(left, right),
-        )
-        == {"a": {"x": 2, "y": 2}, "b": {"x": 4, "y": 4}}
-    )
+    assert merge_mappings(
+        {"a": {"x": 1, "y": 1}, "b": {"x": 2, "y": 2}},
+        {"a": {"x": 1, "y": 1}, "b": {"x": 2, "y": 2}},
+        lambda left, right: merge_mappings(left, right),
+    ) == {"a": {"x": 2, "y": 2}, "b": {"x": 4, "y": 4}}
 
 
 def test_merge_mapping_different_keys():
@@ -96,14 +93,11 @@ def test_merge_sequences():
 
 
 def test_merge_sequences_custom_operator():
-    assert (
-        merge_sequences(
-            [{chr(65 + i): i} for i in range(0, 26)],
-            [{chr(65 + i): i} for i in range(0, 26)],
-            merge_mappings,
-        )
-        == [{chr(65 + i): i * 2} for i in range(0, 26)]
-    )
+    assert merge_sequences(
+        [{chr(65 + i): i} for i in range(0, 26)],
+        [{chr(65 + i): i} for i in range(0, 26)],
+        merge_mappings,
+    ) == [{chr(65 + i): i * 2} for i in range(0, 26)]
 
 
 def test_merge_series():
@@ -113,14 +107,11 @@ def test_merge_series():
 
 
 def test_merge_series_custom_operator():
-    assert (
-        merge_series(
-            [(i, {chr(65 + i): i}) for i in range(0, 26)],
-            [(i, {chr(65 + i): i}) for i in range(0, 26)],
-            merge_mappings,
-        )
-        == [(i, {chr(65 + i): i * 2}) for i in range(0, 26)]
-    )
+    assert merge_series(
+        [(i, {chr(65 + i): i}) for i in range(0, 26)],
+        [(i, {chr(65 + i): i}) for i in range(0, 26)],
+        merge_mappings,
+    ) == [(i, {chr(65 + i): i * 2}) for i in range(0, 26)]
 
 
 def test_merge_series_offset_timestamps():

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -402,17 +402,14 @@ class RedisTSDBTest(TestCase):
             "organization:2": [("project:5", 1.5)],
         }
 
-        assert (
-            self.db.get_most_frequent(
-                model,
-                ("organization:1", "organization:2"),
-                now - timedelta(hours=1),
-                now,
-                rollup=rollup,
-                environment_id=0,
-            )
-            == {"organization:1": [], "organization:2": []}
-        )
+        assert self.db.get_most_frequent(
+            model,
+            ("organization:1", "organization:2"),
+            now - timedelta(hours=1),
+            now,
+            rollup=rollup,
+            environment_id=0,
+        ) == {"organization:1": [], "organization:2": []}
 
         timestamp = int(to_timestamp(now) // rollup) * rollup
 

--- a/tests/sentry_plugins/jira/test_plugin.py
+++ b/tests/sentry_plugins/jira/test_plugin.py
@@ -282,16 +282,13 @@ class JiraPluginTest(TestCase):
         ) == {"text": "Foo Bar - foo@sentry.io (foobar)", "id": "foobar"}
 
         # test weird addon users that don't have email addresses
-        assert (
-            self.plugin._get_formatted_user(
-                {
-                    "name": "robot",
-                    "avatarUrls": {
-                        "16x16": "https://avatar-cdn.atlassian.com/someid",
-                        "24x24": "https://avatar-cdn.atlassian.com/someotherid",
-                    },
-                    "self": "https://something.atlassian.net/rest/api/2/user?username=someaddon",
-                }
-            )
-            == {"id": "robot", "text": "robot (robot)"}
-        )
+        assert self.plugin._get_formatted_user(
+            {
+                "name": "robot",
+                "avatarUrls": {
+                    "16x16": "https://avatar-cdn.atlassian.com/someid",
+                    "24x24": "https://avatar-cdn.atlassian.com/someotherid",
+                },
+                "self": "https://something.atlassian.net/rest/api/2/user?username=someaddon",
+            }
+        ) == {"id": "robot", "text": "robot (robot)"}

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1088,16 +1088,13 @@ class CheckReleasesHaveHealthDataTest(TestCase, SnubaTestCase):
             start = datetime.now() - timedelta(days=1)
         if not end:
             end = datetime.now()
-        assert (
-            self.backend.check_releases_have_health_data(
-                self.organization.id,
-                [p.id for p in projects],
-                [r.version for r in releases],
-                start,
-                end,
-            )
-            == {v.version for v in expected}
-        )
+        assert self.backend.check_releases_have_health_data(
+            self.organization.id,
+            [p.id for p in projects],
+            [r.version for r in releases],
+            start,
+            end,
+        ) == {v.version for v in expected}
 
     def test_empty(self):
         # Test no errors when no session data

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -308,14 +308,11 @@ class TagStorageTest(TestCase, SnubaTestCase):
         assert self.ts.get_tag_value_label("sentry:user", "ip:stuff") == "stuff"
 
     def test_get_groups_user_counts(self):
-        assert (
-            self.ts.get_groups_user_counts(
-                project_ids=[self.proj1.id],
-                group_ids=[self.proj1group1.id, self.proj1group2.id],
-                environment_ids=[self.proj1env1.id],
-            )
-            == {self.proj1group1.id: 2, self.proj1group2.id: 1}
-        )
+        assert self.ts.get_groups_user_counts(
+            project_ids=[self.proj1.id],
+            group_ids=[self.proj1group1.id, self.proj1group2.id],
+            environment_ids=[self.proj1env1.id],
+        ) == {self.proj1group1.id: 2, self.proj1group2.id: 1}
 
         # test filtering by date range where there shouldn't be results
         assert (
@@ -437,65 +434,50 @@ class TagStorageTest(TestCase, SnubaTestCase):
             self.proj1.id, self.proj1group1.id, [self.proj1env1.id], {"foo": "bar"}, None, None
         ) == {"event_id__in": {"1" * 32, "2" * 32}}
 
-        assert (
-            self.ts.get_group_event_filter(
-                self.proj1.id,
-                self.proj1group1.id,
-                [self.proj1env1.id],
-                {"foo": "bar"},
-                (self.now - timedelta(seconds=1)),
-                None,
-            )
-            == {"event_id__in": {"1" * 32}}
-        )
+        assert self.ts.get_group_event_filter(
+            self.proj1.id,
+            self.proj1group1.id,
+            [self.proj1env1.id],
+            {"foo": "bar"},
+            (self.now - timedelta(seconds=1)),
+            None,
+        ) == {"event_id__in": {"1" * 32}}
 
-        assert (
-            self.ts.get_group_event_filter(
-                self.proj1.id,
-                self.proj1group1.id,
-                [self.proj1env1.id],
-                {"foo": "bar"},
-                None,
-                (self.now - timedelta(seconds=1)),
-            )
-            == {"event_id__in": {"2" * 32}}
-        )
+        assert self.ts.get_group_event_filter(
+            self.proj1.id,
+            self.proj1group1.id,
+            [self.proj1env1.id],
+            {"foo": "bar"},
+            None,
+            (self.now - timedelta(seconds=1)),
+        ) == {"event_id__in": {"2" * 32}}
 
-        assert (
-            self.ts.get_group_event_filter(
-                self.proj1.id,
-                self.proj1group1.id,
-                [self.proj1env1.id, self.proj1env2.id],
-                {"foo": "bar"},
-                None,
-                None,
-            )
-            == {"event_id__in": {"1" * 32, "2" * 32, "4" * 32}}
-        )
+        assert self.ts.get_group_event_filter(
+            self.proj1.id,
+            self.proj1group1.id,
+            [self.proj1env1.id, self.proj1env2.id],
+            {"foo": "bar"},
+            None,
+            None,
+        ) == {"event_id__in": {"1" * 32, "2" * 32, "4" * 32}}
 
-        assert (
-            self.ts.get_group_event_filter(
-                self.proj1.id,
-                self.proj1group1.id,
-                [self.proj1env1.id],
-                {"foo": "bar", "sentry:release": "200"},  # AND
-                None,
-                None,
-            )
-            == {"event_id__in": {"2" * 32}}
-        )
+        assert self.ts.get_group_event_filter(
+            self.proj1.id,
+            self.proj1group1.id,
+            [self.proj1env1.id],
+            {"foo": "bar", "sentry:release": "200"},  # AND
+            None,
+            None,
+        ) == {"event_id__in": {"2" * 32}}
 
-        assert (
-            self.ts.get_group_event_filter(
-                self.proj1.id,
-                self.proj1group2.id,
-                [self.proj1env1.id],
-                {"browser": "chrome"},
-                None,
-                None,
-            )
-            == {"event_id__in": {"3" * 32}}
-        )
+        assert self.ts.get_group_event_filter(
+            self.proj1.id,
+            self.proj1group2.id,
+            [self.proj1env1.id],
+            {"browser": "chrome"},
+            None,
+            None,
+        ) == {"event_id__in": {"3" * 32}}
 
         assert (
             self.ts.get_group_event_filter(

--- a/tests/snuba/test_snuba.py
+++ b/tests/snuba/test_snuba.py
@@ -55,16 +55,13 @@ class SnubaTest(TestCase, SnubaTestCase):
         ]
 
         self.snuba_insert(events)
-        assert (
-            snuba.query(
-                start=now - timedelta(days=1),
-                end=now + timedelta(days=1),
-                groupby=["project_id"],
-                filter_keys={"project_id": [self.project.id]},
-                referrer="testing.test",
-            )
-            == {self.project.id: 1}
-        )
+        assert snuba.query(
+            start=now - timedelta(days=1),
+            end=now + timedelta(days=1),
+            groupby=["project_id"],
+            filter_keys={"project_id": [self.project.id]},
+            referrer="testing.test",
+        ) == {self.project.id: 1}
 
     def test_fail(self) -> None:
         now = datetime.now()

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -314,16 +314,13 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             self.proj1group1.id: 1  # Only 1 unique user in the first hour
         }
 
-        assert (
-            self.db.get_distinct_counts_totals(
-                TSDBModel.users_affected_by_project,
-                [self.proj1.id],
-                self.now,
-                self.now + timedelta(hours=4),
-                rollup=3600,
-            )
-            == {self.proj1.id: 2}
-        )
+        assert self.db.get_distinct_counts_totals(
+            TSDBModel.users_affected_by_project,
+            [self.proj1.id],
+            self.now,
+            self.now + timedelta(hours=4),
+            rollup=3600,
+        ) == {self.proj1.id: 2}
 
         assert (
             self.db.get_distinct_counts_totals(


### PR DESCRIPTION
this gets us to black stable -- and also the newer, faster black (~7s to format the entire codebase vs. ~18 previously)

testing done: `pre-commit run black --all-files`