### PR TITLE
ref: factor out before-after testing library

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-before_after==1.0.1
 docker>=3.7.0,<3.8.0
 exam>=0.5.1
 freezegun==1.1.0

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -2,7 +2,6 @@ from concurrent.futures import ThreadPoolExecutor
 from time import sleep, time
 from unittest.mock import patch
 
-from before_after import before
 from django.conf.urls import url
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, override_settings
@@ -362,8 +361,9 @@ class TestRatelimitHeader(APITestCase):
         def parallel_request(*args, **kwargs):
             self.client.get(reverse("race-condition-endpoint"))
 
-        with before(
-            "tests.sentry.middleware.test_ratelimit_middleware.RateLimitHeaderTestEndpoint.inject_call",
+        with patch.object(
+            RateLimitHeaderTestEndpoint,
+            "inject_call",
             parallel_request,
         ):
             response = self.get_success_response()


### PR DESCRIPTION
the library appears to be unmaintained, [last released in 2017](https://pypi.org/project/before_after/).  additionally it pulls in the deprecated `mock` backport