### PR TITLE
style(replay): Fix header sizing and layout for narrow browsers

### DIFF
--- a/static/app/views/replays/detail/detailLayout.tsx
+++ b/static/app/views/replays/detail/detailLayout.tsx
@@ -12,7 +12,6 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
 import {RawCrumb} from 'sentry/types/breadcrumbs';
 import {Event} from 'sentry/types/event';
 import getUrlPathname from 'sentry/utils/getUrlPathname';
@@ -31,7 +30,7 @@ function DetailLayout({children, event, orgId, crumbs}: Props) {
     <SentryDocumentTitle title={title}>
       <React.Fragment>
         <Layout.Header>
-          <HeaderContent>
+          <Layout.HeaderContent>
             <Breadcrumbs
               crumbs={[
                 {
@@ -48,17 +47,21 @@ function DetailLayout({children, event, orgId, crumbs}: Props) {
                 },
               ]}
             />
-            <ButtonWrapper>
-              <Button
-                title={t('Send us feedback via email')}
-                href="mailto:replay-feedback@sentry.io?subject=Replay Details Feedback"
-              >
-                {t('Give Feedback')}
-              </Button>
-            </ButtonWrapper>
+          </Layout.HeaderContent>
+          <ButtonWrapper>
+            <Button
+              title={t('Send us feedback via email')}
+              href="mailto:replay-feedback@sentry.io?subject=Replay Details Feedback"
+            >
+              {t('Give Feedback')}
+            </Button>
+          </ButtonWrapper>
+          <Layout.HeaderContent>
             <EventHeader event={event} />
+          </Layout.HeaderContent>
+          <Layout.HeaderActions>
             <EventMetaData event={event} crumbs={crumbs} />
-          </HeaderContent>
+          </Layout.HeaderActions>
         </Layout.Header>
         {children}
       </React.Fragment>
@@ -124,15 +127,9 @@ function msToSec(ms: number) {
   return ms / 1000;
 }
 
-const HeaderContent = styled(Layout.HeaderContent)`
-  display: grid;
-  grid-template-rows: auto auto;
-  grid-template-columns: 2fr 1fr;
-  gap: ${space(1)};
-`;
-
-const ButtonWrapper = styled('div')`
-  text-align: right;
+// TODO(replay); This could make a lot of sense to put inside HeaderActions by default
+const ButtonWrapper = styled(Layout.HeaderActions)`
+  align-items: end;
 `;
 
 export default DetailLayout;


### PR DESCRIPTION
Previously the header was using a bespoke grid to lay out the four quadrants. To optimize for narrow browser windows we can use `<Layout.*>` components instead.

1. The right side of the header is set to 325px wide, matching the column on the page:
<img width="1321" alt="Screen Shot 2022-05-03 at 11 55 28 PM" src="https://user-images.githubusercontent.com/187460/166489982-6570ae4a-c25e-4395-8bfd-6034055dfc74.png">

2. The header collapses into a single column when the browser is narrow:

   **Before:**

<img width="750" alt="Screen Shot 2022-05-03 at 11 55 37 PM" src="https://user-images.githubusercontent.com/187460/166490026-9b5bb0ab-91ed-48ab-a084-f825dffd489c.png">

   **After:**

<img width="750" alt="Screen Shot 2022-05-03 at 11 55 35 PM" src="https://user-images.githubusercontent.com/187460/166490001-d48c2979-0fae-4b7a-a8b8-c383dd6adc2a.png">
