### PR TITLE
feat(widget-builder): Change sort options to use either function or alias format

### DIFF
--- a/static/app/components/dashboards/widgetQueriesForm.tsx
+++ b/static/app/components/dashboards/widgetQueriesForm.tsx
@@ -49,6 +49,7 @@ export const generateOrderOptions = ({
     .forEach(field => {
       let alias = getAggregateAlias(field);
       const label = stripEquationPrefix(field);
+      const shouldUseField = (isRelease || isUsingFieldFormat) && !isEquation(field);
       // Equations are referenced via a standard alias following this pattern
       if (isEquation(field)) {
         alias = `equation[${equations}]`;
@@ -56,18 +57,18 @@ export const generateOrderOptions = ({
       }
 
       if (widgetBuilderNewDesign) {
-        options.push({label, value: isRelease || isUsingFieldFormat ? field : alias});
+        options.push({label, value: shouldUseField ? field : alias});
         return;
       }
 
       options.push({
         label: t('%s asc', label),
-        value: isRelease || isUsingFieldFormat ? field : alias,
+        value: shouldUseField ? field : alias,
       });
 
       options.push({
         label: t('%s desc', label),
-        value: isRelease || isUsingFieldFormat ? `-${field}` : `-${alias}`,
+        value: shouldUseField ? `-${field}` : `-${alias}`,
       });
     });
 

--- a/static/app/components/dashboards/widgetQueriesForm.tsx
+++ b/static/app/components/dashboards/widgetQueriesForm.tsx
@@ -33,10 +33,12 @@ export const generateOrderOptions = ({
   columns,
   widgetType,
   widgetBuilderNewDesign = false,
+  isUsingFieldFormat = false,
 }: {
   aggregates: string[];
   columns: string[];
   widgetType: WidgetType;
+  isUsingFieldFormat?: boolean;
   widgetBuilderNewDesign?: boolean;
 }): SelectValue<string>[] => {
   const isRelease = widgetType === WidgetType.RELEASE;
@@ -54,18 +56,18 @@ export const generateOrderOptions = ({
       }
 
       if (widgetBuilderNewDesign) {
-        options.push({label, value: isRelease ? field : alias});
+        options.push({label, value: isRelease || isUsingFieldFormat ? field : alias});
         return;
       }
 
       options.push({
         label: t('%s asc', label),
-        value: isRelease ? field : alias,
+        value: isRelease || isUsingFieldFormat ? field : alias,
       });
 
       options.push({
         label: t('%s desc', label),
-        value: isRelease ? `-${field}` : `-${alias}`,
+        value: isRelease || isUsingFieldFormat ? `-${field}` : `-${alias}`,
       });
     });
 

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/index.tsx
@@ -1,5 +1,6 @@
 import {useEffect} from 'react';
 import styled from '@emotion/styled';
+import trimStart from 'lodash/trimStart';
 
 import {generateOrderOptions} from 'sentry/components/dashboards/widgetQueriesForm';
 import Field from 'sentry/components/forms/field';
@@ -7,6 +8,7 @@ import SelectControl from 'sentry/components/forms/selectControl';
 import {t, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, SelectValue} from 'sentry/types';
+import {getAggregateAlias} from 'sentry/utils/discover/fields';
 import {DisplayType, WidgetQuery, WidgetType} from 'sentry/views/dashboardsV2/types';
 import {generateIssueWidgetOrderOptions} from 'sentry/views/dashboardsV2/widgetBuilder/issueWidget/utils';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
@@ -60,6 +62,14 @@ export function SortByStep({
 
   const orderBy = queries[0].orderby;
   const maxLimit = getResultsLimit(queries.length, queries[0].aggregates.length);
+
+  // We want to convert widgets to using functions in their field format (i.e. not alias form)
+  // for ordering. This check will skip the alias conversion unless the orderby is
+  // saved previously in the alias format
+  const isUsingFieldFormat =
+    trimStart(orderBy, '-') === '' ||
+    queries[0].columns.includes(trimStart(orderBy, '-')) ||
+    getAggregateAlias(trimStart(orderBy, '-')) !== trimStart(orderBy, '-');
 
   const isTimeseriesChart = [
     DisplayType.LINE,
@@ -125,6 +135,7 @@ export function SortByStep({
                     widgetBuilderNewDesign: true,
                     columns: queries[0].columns,
                     aggregates: queries[0].aggregates,
+                    isUsingFieldFormat,
                   })
             }
             values={{
@@ -165,6 +176,7 @@ export function SortByStep({
                   widgetType,
                   columns: queries[0].columns,
                   aggregates: queries[0].aggregates,
+                  isUsingFieldFormat,
                 })
               : generateIssueWidgetOrderOptions(
                   organization.features.includes('issue-list-trend-sort')

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/index.tsx
@@ -8,7 +8,7 @@ import SelectControl from 'sentry/components/forms/selectControl';
 import {t, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, SelectValue} from 'sentry/types';
-import {getAggregateAlias} from 'sentry/utils/discover/fields';
+import {isAggregateFieldOrEquation, isEquationAlias} from 'sentry/utils/discover/fields';
 import {DisplayType, WidgetQuery, WidgetType} from 'sentry/views/dashboardsV2/types';
 import {generateIssueWidgetOrderOptions} from 'sentry/views/dashboardsV2/widgetBuilder/issueWidget/utils';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
@@ -61,15 +61,14 @@ export function SortByStep({
   }
 
   const orderBy = queries[0].orderby;
+  const strippedOrderBy = trimStart(orderBy, '-');
   const maxLimit = getResultsLimit(queries.length, queries[0].aggregates.length);
 
   // We want to convert widgets to using functions in their field format (i.e. not alias form)
-  // for ordering. This check will skip the alias conversion unless the orderby is
-  // saved previously in the alias format
+  // for ordering. This check will skip the alias conversion unless the orderby was
+  // previously saved in the alias format
   const isUsingFieldFormat =
-    trimStart(orderBy, '-') === '' ||
-    queries[0].columns.includes(trimStart(orderBy, '-')) ||
-    getAggregateAlias(trimStart(orderBy, '-')) !== trimStart(orderBy, '-');
+    isAggregateFieldOrEquation(strippedOrderBy) || isEquationAlias(strippedOrderBy);
 
   const isTimeseriesChart = [
     DisplayType.LINE,
@@ -143,7 +142,7 @@ export function SortByStep({
                 orderBy[0] === '-'
                   ? SortDirection.HIGH_TO_LOW
                   : SortDirection.LOW_TO_HIGH,
-              sortBy: orderBy[0] === '-' ? orderBy.substring(1, orderBy.length) : orderBy,
+              sortBy: strippedOrderBy,
             }}
             onChange={({sortDirection, sortBy}) => {
               const newOrderBy =

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -101,7 +101,7 @@ function getDataSetQuery(widgetBuilderNewDesign: boolean): Record<DataSet, Widge
       fieldAliases: [],
       aggregates: ['count()'],
       conditions: '',
-      orderby: widgetBuilderNewDesign ? '-count' : '',
+      orderby: widgetBuilderNewDesign ? '-count()' : '',
     },
     [DataSet.ISSUES]: {
       name: '',
@@ -559,7 +559,7 @@ function WidgetBuilder({
     const aggregateAliasFieldStrings =
       state.dataSet === DataSet.RELEASES
         ? fieldStrings.map(stripDerivedMetricsPrefix)
-        : fieldStrings.map(getAggregateAlias);
+        : fieldStrings;
 
     const columnsAndAggregates = isColumn
       ? getColumnsAndAggregatesAsStrings(newFields)
@@ -576,7 +576,7 @@ function WidgetBuilder({
       const prevAggregateAliasFieldStrings = query.aggregates.map(aggregate =>
         state.dataSet === DataSet.RELEASES
           ? stripDerivedMetricsPrefix(aggregate)
-          : getAggregateAlias(aggregate)
+          : aggregate
       );
       const newQuery = cloneDeep(query);
 

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -556,7 +556,9 @@ function WidgetBuilder({
   ) {
     const fieldStrings = newFields
       .map(generateFieldAsString)
-      .map(stripDerivedMetricsPrefix);
+      .map(field =>
+        state.dataSet === DataSet.RELEASES ? stripDerivedMetricsPrefix(field) : field
+      );
 
     const columnsAndAggregates = isColumn
       ? getColumnsAndAggregatesAsStrings(newFields)
@@ -570,7 +572,11 @@ function WidgetBuilder({
     const newQueries = state.queries.map(query => {
       const isDescending = query.orderby.startsWith('-');
       const rawOrderby = trimStart(query.orderby, '-');
-      const prevAggregateFieldStrings = query.aggregates.map(stripDerivedMetricsPrefix);
+      const prevAggregateFieldStrings = query.aggregates.map(aggregate =>
+        state.dataSet === DataSet.RELEASES
+          ? stripDerivedMetricsPrefix(aggregate)
+          : aggregate
+      );
       const newQuery = cloneDeep(query);
 
       if (disableSortBy) {

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -41,7 +41,9 @@ import {
   getAggregateAlias,
   getColumnsAndAggregates,
   getColumnsAndAggregatesAsStrings,
+  isAggregateFieldOrEquation,
   isEquation,
+  isEquationAlias,
   QueryFieldValue,
   stripDerivedMetricsPrefix,
   stripEquationPrefix,
@@ -621,7 +623,11 @@ function WidgetBuilder({
 
           newQuery.orderby = `${isDescending ? '-' : ''}${newOrderByValue}`;
         } else {
-          const isFromAggregates = fieldStrings.includes(rawOrderby);
+          const isUsingFieldFormat =
+            isAggregateFieldOrEquation(rawOrderby) || isEquationAlias(rawOrderby);
+          const isFromAggregates = (
+            isUsingFieldFormat ? fieldStrings : fieldStrings.map(getAggregateAlias)
+          ).includes(rawOrderby);
           const isCustomEquation = isEquation(rawOrderby);
           const isUsedInGrouping = newQuery.columns.includes(rawOrderby);
 

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -554,12 +554,9 @@ function WidgetBuilder({
     newFields: QueryFieldValue[],
     isColumn = false
   ) {
-    const fieldStrings = newFields.map(generateFieldAsString);
-
-    const aggregateAliasFieldStrings =
-      state.dataSet === DataSet.RELEASES
-        ? fieldStrings.map(stripDerivedMetricsPrefix)
-        : fieldStrings;
+    const fieldStrings = newFields
+      .map(generateFieldAsString)
+      .map(stripDerivedMetricsPrefix);
 
     const columnsAndAggregates = isColumn
       ? getColumnsAndAggregatesAsStrings(newFields)
@@ -573,11 +570,7 @@ function WidgetBuilder({
     const newQueries = state.queries.map(query => {
       const isDescending = query.orderby.startsWith('-');
       const rawOrderby = trimStart(query.orderby, '-');
-      const prevAggregateAliasFieldStrings = query.aggregates.map(aggregate =>
-        state.dataSet === DataSet.RELEASES
-          ? stripDerivedMetricsPrefix(aggregate)
-          : aggregate
-      );
+      const prevAggregateFieldStrings = query.aggregates.map(stripDerivedMetricsPrefix);
       const newQuery = cloneDeep(query);
 
       if (disableSortBy) {
@@ -607,16 +600,14 @@ function WidgetBuilder({
         newQuery.columns = columnsAndAggregates?.columns ?? [];
       }
 
-      if (!aggregateAliasFieldStrings.includes(rawOrderby) && query.orderby !== '') {
+      if (!fieldStrings.includes(rawOrderby) && query.orderby !== '') {
         if (
-          prevAggregateAliasFieldStrings.length === newFields.length &&
-          prevAggregateAliasFieldStrings.includes(rawOrderby)
+          prevAggregateFieldStrings.length === newFields.length &&
+          prevAggregateFieldStrings.includes(rawOrderby)
         ) {
           // The aggregate that was used in orderby has changed. Get the new field.
           let newOrderByValue =
-            aggregateAliasFieldStrings[
-              prevAggregateAliasFieldStrings.indexOf(rawOrderby)
-            ];
+            fieldStrings[prevAggregateFieldStrings.indexOf(rawOrderby)];
 
           if (!stripEquationPrefix(newOrderByValue ?? '')) {
             newOrderByValue = '';
@@ -624,15 +615,15 @@ function WidgetBuilder({
 
           newQuery.orderby = `${isDescending ? '-' : ''}${newOrderByValue}`;
         } else {
-          const isFromAggregates = aggregateAliasFieldStrings.includes(rawOrderby);
+          const isFromAggregates = fieldStrings.includes(rawOrderby);
           const isCustomEquation = isEquation(rawOrderby);
           const isUsedInGrouping = newQuery.columns.includes(rawOrderby);
 
           const keepCurrentOrderby =
             isFromAggregates || isCustomEquation || isUsedInGrouping;
-          const firstAggregateAlias = isEquation(aggregateAliasFieldStrings[0])
-            ? `equation[${getNumEquations(aggregateAliasFieldStrings) - 1}]`
-            : aggregateAliasFieldStrings[0];
+          const firstAggregateAlias = isEquation(fieldStrings[0])
+            ? `equation[${getNumEquations(fieldStrings) - 1}]`
+            : fieldStrings[0];
 
           newQuery.orderby = widgetBuilderNewDesign
             ? (keepCurrentOrderby && newQuery.orderby) ||

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -299,12 +299,13 @@ class WidgetQueries extends React.Component<Props, State> {
       const params: DiscoverQueryRequestParams = {
         per_page: limit ?? DEFAULT_TABLE_LIMIT,
         cursor,
-        sort:
-          typeof query.orderby === 'string'
-            ? [query.orderby]
-            : query.orderby || undefined,
         ...getDashboardsMEPQueryParams(this.isMEPEnabled),
       };
+
+      if (query.orderby) {
+        params.sort = typeof query.orderby === 'string' ? [query.orderby] : query.orderby;
+      }
+
       if (widget.displayType === 'table') {
         url = `/organizations/${organization.slug}/eventsv2/`;
         params.referrer = 'api.dashboards.tablewidget';

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -299,6 +299,7 @@ class WidgetQueries extends React.Component<Props, State> {
       const params: DiscoverQueryRequestParams = {
         per_page: limit ?? DEFAULT_TABLE_LIMIT,
         cursor,
+        sort: typeof query.orderby === 'string' ? [query.orderby] : query.orderby,
         ...getDashboardsMEPQueryParams(this.isMEPEnabled),
       };
       if (widget.displayType === 'table') {

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -299,7 +299,10 @@ class WidgetQueries extends React.Component<Props, State> {
       const params: DiscoverQueryRequestParams = {
         per_page: limit ?? DEFAULT_TABLE_LIMIT,
         cursor,
-        sort: typeof query.orderby === 'string' ? [query.orderby] : query.orderby,
+        sort:
+          typeof query.orderby === 'string'
+            ? [query.orderby]
+            : query.orderby || undefined,
         ...getDashboardsMEPQueryParams(this.isMEPEnabled),
       };
       if (widget.displayType === 'table') {

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1644,7 +1644,7 @@ describe('WidgetBuilder', function () {
           })
         );
       });
-    });
+    }, 10000);
 
     it('persists the state when toggling between sorting options', async function () {
       renderTestComponent({

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2049,6 +2049,51 @@ describe('WidgetBuilder', function () {
         await screen.findByText(expectedOrderSelection);
       }
     );
+
+    it('saved widget with aggregate alias as orderby should persist alias when y-axes change', async function () {
+      const widget: Widget = {
+        id: '1',
+        title: 'Test Widget',
+        interval: '5m',
+        displayType: DisplayType.TABLE,
+        queries: [
+          {
+            name: '',
+            conditions: '',
+            fields: ['project', 'count_unique(user)'],
+            aggregates: ['count_unique(user)'],
+            columns: ['project'],
+            orderby: 'count_unique_user',
+          },
+        ],
+      };
+
+      const dashboard: DashboardDetails = {
+        id: '1',
+        title: 'Dashboard',
+        createdBy: undefined,
+        dateCreated: '2020-01-01T00:00:00.000Z',
+        widgets: [widget],
+      };
+
+      renderTestComponent({
+        orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
+        dashboard,
+        params: {
+          widgetIndex: '0',
+        },
+      });
+
+      await screen.findByText('Sort by a column');
+
+      // Assert for length 2 since one in the table header and one in sort by
+      expect(screen.getAllByText('count_unique(user)')).toHaveLength(2);
+
+      userEvent.click(screen.getByText('Add a Column'));
+
+      // The sort by should still have count_unique(user)
+      expect(screen.getAllByText('count_unique(user)')).toHaveLength(2);
+    });
   });
 
   describe('Widget creation coming from other verticals', function () {


### PR DESCRIPTION
Orderby is currently stored in the alias format (e.g. `count_unique_user`), but to allow timeseries charts with groupings to select any equation for sorting, it uses the field format (e.g. `count_unique(user)`.

Another PR will be put up to migrate (#34193) from alias form to field form. This PR is to drive adoption of the field format and bridges the gap where the backend may have both alias and field formats. The only case where we want the select field to match on the alias format is if we're already selecting on a function in alias form. 