### PR TITLE
fix(perf): Remove boundaryGap from non-category axes

### DIFF
--- a/static/app/views/performance/landing/chart/histogramChart.tsx
+++ b/static/app/views/performance/landing/chart/histogramChart.tsx
@@ -156,7 +156,6 @@ export function Chart(props: ChartProps) {
   const xAxis = {
     type: 'category' as const,
     truncate: true,
-    boundaryGap: false,
     axisTick: {
       alignWithLabel: true,
     },

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeHistogram.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeHistogram.tsx
@@ -148,7 +148,6 @@ export function Chart(props: ChartProps) {
     xAxis: {
       type: 'category' as const,
       truncate: true,
-      boundaryGap: false,
       axisTick: {
         alignWithLabel: true,
       },

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -176,7 +176,6 @@ const TagsHeatMap = (
       },
     },
     xAxis: {
-      boundaryGap: true,
       type: 'category' as const,
       splitArea: {
         show: true,


### PR DESCRIPTION
According to the [docs](https://echarts.apache.org/en/option.html#%2Fsearch%2Fboundarygap), boundary gap of type `boolean` has no effect on the non-category axes. For these axes it should be an array of min and max values or `undefined`. Since we're setting it to be a boolean previously, it's effectively the same as setting it `undefined` which is a default value. Verified that all instances look unchanged which confirms that boolean wasn't doing anything.