### PR TITLE
test(perf): Skip flakey vital detail test until it has been fixed

### DIFF
--- a/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
+++ b/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
@@ -410,7 +410,9 @@ describe('Performance > VitalDetail', function () {
     expect(screen.getByText('0.215').closest('td')).toBeInTheDocument();
   });
 
-  it('can switch vitals with dropdown menu', async function () {
+  // Disabling for CI, but should run locally when making changes
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('can switch vitals with dropdown menu', async function () {
     const newRouter = {
       ...router,
       location: {


### PR DESCRIPTION
To unblock eng, skipping the test that is known to be flakey. It's tracked https://github.com/getsentry/sentry/issues/34114

<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
