### PR TITLE
ref(releases): Use grid display for search & filter

### DIFF
--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -720,8 +720,8 @@ function getTransactionsListSort(location: Location): {
 const ReleaseDetailsPageFilters = styled('div')`
   display: grid;
   grid-template-columns: minmax(0, max-content) minmax(0, max-content);
-  gap: ${space(1)};
-  margin-bottom: ${space(1.5)};
+  gap: ${space(2)};
+  margin-bottom: ${space(2)};
 `;
 
 const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -552,7 +552,7 @@ class ReleasesList extends AsyncView<Props, State> {
                   position="bottom"
                   disabled={!showReleaseAdoptionStages}
                 >
-                  <SmartSearchBar
+                  <StyledSmartSearchBar
                     searchSource="releases"
                     query={this.getQuery()}
                     placeholder={t('Search by version, build, package, or stage')}
@@ -571,22 +571,20 @@ class ReleasesList extends AsyncView<Props, State> {
                   />
                 </GuideAnchor>
               </GuideAnchor>
-              <DropdownsWrapper>
-                <ReleasesStatusOptions
-                  selected={activeStatus}
-                  onSelect={this.handleStatus}
-                />
-                <ReleasesSortOptions
-                  selected={activeSort}
-                  selectedDisplay={activeDisplay}
-                  onSelect={this.handleSortBy}
-                  environments={selection.environments}
-                />
-                <ReleasesDisplayOptions
-                  selected={activeDisplay}
-                  onSelect={this.handleDisplay}
-                />
-              </DropdownsWrapper>
+              <ReleasesStatusOptions
+                selected={activeStatus}
+                onSelect={this.handleStatus}
+              />
+              <ReleasesSortOptions
+                selected={activeSort}
+                selectedDisplay={activeDisplay}
+                onSelect={this.handleSortBy}
+                environments={selection.environments}
+              />
+              <ReleasesDisplayOptions
+                selected={activeDisplay}
+                onSelect={this.handleDisplay}
+              />
             </SortAndFilterWrapper>
 
             {!reloading &&
@@ -619,69 +617,26 @@ const AlertText = styled('div')`
 `;
 
 const ReleasesPageFilterBar = styled(PageFilterBar)`
-  margin-bottom: ${space(1)};
+  margin-bottom: ${space(2)};
 `;
 
 const SortAndFilterWrapper = styled('div')`
-  display: flex;
-  flex-direction: column;
-  justify-content: stretch;
+  display: grid;
+  grid-template-columns: 1fr repeat(3, max-content);
+  gap: ${space(2)};
   margin-bottom: ${space(2)};
 
-  > *:nth-child(1) {
-    flex: 1;
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
+    grid-template-columns: repeat(3, 1fr);
   }
-
-  /* Below this width search bar needs its own row no to wrap placeholder text
-   * Above this width search bar and controls can be on the same row */
-  @media (min-width: ${p => p.theme.breakpoints[2]}) {
-    flex-direction: row;
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: minmax(0, 1fr);
   }
 `;
 
-const DropdownsWrapper = styled('div')`
-  display: flex;
-  flex-direction: column;
-
-  & > * {
-    margin-top: ${space(2)};
-  }
-
-  /* At the narrower widths wrapper is on its own in a row
-   * Expand the dropdown controls to fill the empty space */
-  & button {
-    width: 100%;
-  }
-
-  /* At narrower widths space bar needs a separate row
-   * Divide space evenly when 3 dropdowns are in their own row */
-  @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    margin-top: ${space(2)};
-
-    & > * {
-      margin-top: ${space(0)};
-      margin-left: ${space(1)};
-    }
-
-    & > *:nth-child(1) {
-      margin-left: ${space(0)};
-    }
-
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-  }
-
-  /* At wider widths everything is in 1 row
-   * Auto space dropdowns when they are in the same row with search bar */
-  @media (min-width: ${p => p.theme.breakpoints[2]}) {
-    margin-top: ${space(0)};
-
-    & > * {
-      margin-left: ${space(1)} !important;
-    }
-
-    display: grid;
-    grid-template-columns: auto auto auto;
+const StyledSmartSearchBar = styled(SmartSearchBar)`
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
+    grid-column: 1 / -1;
   }
 `;
 

--- a/static/app/views/releases/list/releasesDropdown.tsx
+++ b/static/app/views/releases/list/releasesDropdown.tsx
@@ -30,7 +30,7 @@ const ReleasesDropdown = ({
   return (
     <DropdownControl
       alwaysRenderMenu={false}
-      buttonProps={{prefix}}
+      buttonProps={{prefix, style: {width: '100%'}}}
       label={selectedLabel?.label}
       className={className}
     >


### PR DESCRIPTION
In the search & filter area, use grid display and spacing that is more consistent with other pages (`space(2)` instead of `space(1)`).

**List - Large View Width**
<img width="1466" alt="Screen Shot 2022-05-03 at 11 31 39 AM" src="https://user-images.githubusercontent.com/44172267/166519331-e82d246e-1a4a-425c-99e3-991a245a2f5b.png">
<img width="1466" alt="Screen Shot 2022-05-03 at 11 31 51 AM" src="https://user-images.githubusercontent.com/44172267/166519351-c2416500-f84e-42ca-b4dd-77f0b4c95c63.png">

**List - Medium View Width**
<img width="771" alt="Screen Shot 2022-05-03 at 11 32 34 AM" src="https://user-images.githubusercontent.com/44172267/166519464-c572000a-d1b1-468f-87d9-f98e58a886b4.png">
<img width="771" alt="Screen Shot 2022-05-03 at 11 32 45 AM" src="https://user-images.githubusercontent.com/44172267/166519485-b962828a-4af2-4e2b-bed9-cbff9ce3d4c1.png">

**Details**
<img width="1120" alt="Screen Shot 2022-05-03 at 11 38 52 AM" src="https://user-images.githubusercontent.com/44172267/166520498-6388b168-4242-4084-a3c7-0a53ee03bed9.png">
<img width="1120" alt="Screen Shot 2022-05-03 at 11 39 04 AM" src="https://user-images.githubusercontent.com/44172267/166520532-97c1fcad-ab56-4140-9b40-01e0890e948a.png">

