### PR TITLE
chore(deps): Bump Django to 2.2.28

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -11,7 +11,7 @@ datadog==0.29.3
 django-crispy-forms==1.8.1
 django-picklefield==2.1.0
 django-pg-zero-downtime-migrations==0.10
-Django==2.2.24
+Django==2.2.28
 djangorestframework==3.11.2
 drf-spectacular==0.21.0
 email-reply-parser==0.5.12

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -706,5 +706,5 @@ urlpatterns += [
     ),
     # Legacy
     # This triggers a false positive for the urls.W002 Django warning
-    url(r"/$", react_page_view),
+    url(r"^.*/$", react_page_view),
 ]


### PR DESCRIPTION
#sync-getsentry

- Bumps Django from 2.2.24 to 2.2.28 resolving Django security vulnerabilities.
- The default catch-all route has been adjusted to ensure it behaves as expected. See [INC-137 ](https://getsentry.atlassian.net/browse/INC-137)for more details.