### PR TITLE
test(vitals): Make vital details tests faster

### DIFF
--- a/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
+++ b/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
@@ -291,7 +291,6 @@ describe('Performance > VitalDetail', function () {
       await screen.findByLabelText('Search events'),
       'user.email:uhoh*{enter}'
     );
-
     // Check the navigation.
     expect(browserHistory.push).toHaveBeenCalledTimes(1);
     expect(browserHistory.push).toHaveBeenCalledWith({
@@ -304,7 +303,7 @@ describe('Performance > VitalDetail', function () {
     });
   });
 
-  it('Applies conditions when linking to transaction summary', async function () {
+  it('applies conditions when linking to transaction summary', async function () {
     const newRouter = {
       ...router,
       location: {
@@ -356,7 +355,7 @@ describe('Performance > VitalDetail', function () {
     });
   });
 
-  it('Check CLS', async function () {
+  it('check CLS', async function () {
     const newRouter = {
       ...router,
       location: {
@@ -410,9 +409,7 @@ describe('Performance > VitalDetail', function () {
     expect(screen.getByText('0.215').closest('td')).toBeInTheDocument();
   });
 
-  // Disabling for CI, but should run locally when making changes
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('can switch vitals with dropdown menu', async function () {
+  it('can switch vitals with dropdown menu', function () {
     const newRouter = {
       ...router,
       location: {
@@ -438,13 +435,13 @@ describe('Performance > VitalDetail', function () {
       organization: org,
     });
 
-    expect(
-      await screen.findByRole('button', {name: 'Web Vitals: LCP'})
-    ).toBeInTheDocument();
-    userEvent.click(screen.getByRole('button', {name: 'Web Vitals: LCP'}));
+    const button = screen.getByRole('button', {name: /web vitals: lcp/i});
+    expect(button).toBeInTheDocument();
+    userEvent.click(button);
 
-    expect(await screen.findByRole('menuitemradio', {name: 'FCP'})).toBeInTheDocument();
-    userEvent.click(screen.getByRole('menuitemradio', {name: 'FCP'}));
+    const menuItem = screen.getByRole('menuitemradio', {name: /fcp/i});
+    expect(menuItem).toBeInTheDocument();
+    userEvent.click(menuItem);
 
     expect(browserHistory.push).toHaveBeenCalledTimes(1);
     expect(browserHistory.push).toHaveBeenCalledWith({
@@ -457,7 +454,7 @@ describe('Performance > VitalDetail', function () {
     });
   });
 
-  it('Check LCP vital renders correctly', async function () {
+  it('renders LCP vital correctly', async function () {
     render(<TestComponent />, {
       context: routerContext,
       organization: org,


### PR DESCRIPTION
<!-- Describe your PR here. -->
The vitals toggle button should be rendered right from the start of the test (since it appears not as a result of an async action), so querying for it synchronously makes sense. Also storing queried nodes instead of duplicating queries seems to make a difference (see screenshot below)

![Screen Shot 2022-05-03 at 4 05 58 PM](https://user-images.githubusercontent.com/23648387/166560765-10b5fa4f-0bec-4ea6-a47a-3a86247721e4.png)

Re-enabling this test with caution. Will keep an eye in case it flakes again. Addresses https://github.com/getsentry/sentry/issues/34114
<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.

