### PR TITLE
ref: use pre-commit to manage lint-requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,9 +52,10 @@ repos:
     - id: lint-requirements
       name: lint-requirements
       entry: bin/lint-requirements
-      language: system
+      language: python
       files: requirements-base.txt
       pass_filenames: false
+      additional_dependencies: [packaging==21.3]
     - id: pyright
       name: pyright
       entry: pyright

--- a/bin/lint-requirements
+++ b/bin/lint-requirements
@@ -1,28 +1,28 @@
 #!/usr/bin/env python
-
-import sys
-
-import requirements
+import packaging.requirements
 
 
-def main():
+def main() -> None:
     """
     We cannot have non-specifier requirements if we want to publish to PyPI
     due to security concerns. This check ensures we don't have/add any URL/VCS
     dependencies in the base requirements file.
     """
     with open("requirements-base.txt") as reqs_file:
-        if any(not req.specifier for req in requirements.parse(reqs_file)):
-            print(  # noqa: S002
-                "\n".join(
-                    [
-                        "You cannot use dependencies that are not on PyPI directly.",
-                        "See PEP440: https://www.python.org/dev/peps/pep-0440/#direct-references",
-                    ]
-                ),
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        for lineno, line in enumerate(reqs_file, start=1):
+            line = line.strip()
+            line, _, _ = line.partition("#")
+            if not line:
+                continue
+
+            try:
+                packaging.requirements.Requirement(line)
+            except packaging.requirements.InvalidRequirement:
+                raise SystemExit(
+                    f"You cannot use dependencies that are not on PyPI directly.\n"
+                    f"See PEP440: https://www.python.org/dev/peps/pep-0440/#direct-references\n\n"
+                    f"{reqs_file.name}:{lineno}: {line}"
+                )
 
 
 if __name__ == "__main__":

--- a/requirements-pre-commit.txt
+++ b/requirements-pre-commit.txt
@@ -4,5 +4,4 @@ flake8==4.0.1
 flake8-bugbear==22.4.25
 pyupgrade==2.32.0
 isort==5.10.1
-requirements-parser>=0.2.0
 click==8.0.4


### PR DESCRIPTION
this allows it to be better cached in CI

I also refactored it to use the official pypa parser