### PR TITLE
fix(releases): Fix bug where project.has_releases would be false whenthere are releases associated with the project

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -733,14 +733,14 @@ class Release(Model):
 
         try:
             with atomic_transaction(using=router.db_for_write(ReleaseProject)):
-                ReleaseProject.objects.create(project=project, release=self)
+                created = ReleaseProject.objects.get_or_create(project=project, release=self)[1]
                 if not project.flags.has_releases:
                     project.flags.has_releases = True
                     project.update(flags=F("flags").bitor(Project.flags.has_releases))
         except IntegrityError:
-            return False
-        else:
-            return True
+            created = False
+
+        return created
 
     def handle_commit_ranges(self, refs):
         """


### PR DESCRIPTION
We increment `new_groups` in `ReleaseProject` in buffers. If `ReleaseProject` doesn't already exist,
then buffers will also create the row. The problem here is that we usually rely on
`Release.add_project` to create a `ReleaseProject` row, which also makes sure we set the
`has_releases` flag on the project.

To fix this, we add a receive on `buffer_incr_complete` and set the flag there if it is not already
set. Also put some defensive code in `add_project`, although I don't think it will make a large
difference.

This should make it so that going forward we'll properly set this flag. Will follow up with a
backfill to correct the existing data.