### PR TITLE
fix(workflow): Update project name and slug at the same time

### DIFF
--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -1,3 +1,4 @@
+import find from 'lodash/find';
 import isEqual from 'lodash/isEqual';
 import {action, computed, makeObservable, observable, ObservableMap} from 'mobx';
 
@@ -566,6 +567,20 @@ class FormModel {
             addErrorMessage(nonFieldErrors[0], {duration: 10000});
             // Reset saving state
             this.setError(id, '');
+            // find the first entry with an error
+          } else if (
+            find(
+              Object.entries(resp.responseJSON),
+              ([_, v]) => Array.isArray(v) && v.length
+            )
+          ) {
+            this.setError(
+              id,
+              find(
+                Object.entries(resp.responseJSON),
+                ([_, v]) => Array.isArray(v) && v.length
+              )?.[1]
+            );
           } else {
             this.setError(id, 'Failed to save');
           }

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -44,7 +44,7 @@ export const fields: Record<string, Field> = {
     type: 'string',
     required: true,
     label: t('Name'),
-    placeholder: t('My Awesome Project'),
+    placeholder: t('my-awesome-project'),
     help: t('A name for this project'),
     transformInput: slugify,
     getData: (data: {name?: string}) => {

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -7,7 +7,6 @@ import {t, tct, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {convertMultilineFieldValue, extractMultilineFields} from 'sentry/utils';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import slugify from 'sentry/utils/slugify';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/projects/:projectId/';
@@ -39,15 +38,19 @@ const ORG_DISABLED_REASON = t(
 );
 
 export const fields: Record<string, Field> = {
-  slug: {
-    name: 'slug',
+  name: {
+    name: 'name',
     type: 'string',
     required: true,
     label: t('Name'),
-    placeholder: t('my-service-name'),
-    help: t('A unique ID used to identify this project'),
-    transformInput: slugify,
-
+    placeholder: t('My Awesome Project'),
+    help: t('A name for this project'),
+    getData: (data: {name?: string}) => {
+      return {
+        name: data.name,
+        slug: data.name?.replace(/\s+/g, '-').toLowerCase(),
+      };
+    },
     saveOnBlur: false,
     saveMessageAlertType: 'info',
     saveMessage: t('You will be redirected to the new project slug after saving'),

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -7,6 +7,7 @@ import {t, tct, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {convertMultilineFieldValue, extractMultilineFields} from 'sentry/utils';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import slugify from 'sentry/utils/slugify';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/projects/:projectId/';
@@ -45,12 +46,14 @@ export const fields: Record<string, Field> = {
     label: t('Name'),
     placeholder: t('My Awesome Project'),
     help: t('A name for this project'),
+    transformInput: slugify,
     getData: (data: {name?: string}) => {
       return {
         name: data.name,
-        slug: data.name?.replace(/\s+/g, '-').toLowerCase(),
+        slug: data.name,
       };
     },
+
     saveOnBlur: false,
     saveMessageAlertType: 'info',
     saveMessage: t('You will be redirected to the new project slug after saving'),

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -19,7 +19,6 @@ import space from 'sentry/styles/space';
 import {Organization, Project, Team} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import getPlatformName from 'sentry/utils/getPlatformName';
-import slugify from 'sentry/utils/slugify';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withTeams from 'sentry/utils/withTeams';
@@ -99,7 +98,7 @@ class CreateProject extends React.Component<Props, State> {
               placeholder={t('Project name')}
               autoComplete="off"
               value={projectName}
-              onChange={e => this.setState({projectName: slugify(e.target.value)})}
+              onChange={e => this.setState({projectName: e.target.value})}
             />
           </ProjectNameInput>
         </div>

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -96,7 +96,7 @@ class CreateProject extends React.Component<Props, State> {
             <input
               type="text"
               name="name"
-              placeholder={t('Project name')}
+              placeholder={t('project-name')}
               autoComplete="off"
               value={projectName}
               onChange={e => this.setState({projectName: slugify(e.target.value)})}

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -19,6 +19,7 @@ import space from 'sentry/styles/space';
 import {Organization, Project, Team} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import getPlatformName from 'sentry/utils/getPlatformName';
+import slugify from 'sentry/utils/slugify';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withTeams from 'sentry/utils/withTeams';
@@ -98,7 +99,7 @@ class CreateProject extends React.Component<Props, State> {
               placeholder={t('Project name')}
               autoComplete="off"
               value={projectName}
-              onChange={e => this.setState({projectName: e.target.value})}
+              onChange={e => this.setState({projectName: slugify(e.target.value)})}
             />
           </ProjectNameInput>
         </div>

--- a/static/app/views/settings/projectGeneralSettings.tsx
+++ b/static/app/views/settings/projectGeneralSettings.tsx
@@ -268,7 +268,7 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
           <JsonForm
             {...jsonFormProps}
             title={t('Project Details')}
-            fields={[fields.slug, fields.platform]}
+            fields={[fields.name, fields.platform]}
           />
 
           <JsonForm
@@ -338,11 +338,12 @@ class ProjectGeneralSettingsContainer extends Component<ContainerProps> {
     this.unsubscribe();
   }
 
+  changedName: string | undefined = undefined;
   changedSlug: string | undefined = undefined;
   unsubscribe = ProjectsStore.listen(() => this.onProjectsUpdate(), undefined);
 
   onProjectsUpdate() {
-    if (!this.changedSlug) {
+    if (!this.changedName && !this.changedSlug) {
       return;
     }
     const project = ProjectsStore.getBySlug(this.changedSlug);
@@ -357,6 +358,7 @@ class ProjectGeneralSettingsContainer extends Component<ContainerProps> {
         params: {
           ...this.props.params,
           projectId: this.changedSlug,
+          projectName: this.changedName,
         },
       })
     );

--- a/static/app/views/settings/projectGeneralSettings.tsx
+++ b/static/app/views/settings/projectGeneralSettings.tsx
@@ -338,12 +338,11 @@ class ProjectGeneralSettingsContainer extends Component<ContainerProps> {
     this.unsubscribe();
   }
 
-  changedName: string | undefined = undefined;
   changedSlug: string | undefined = undefined;
   unsubscribe = ProjectsStore.listen(() => this.onProjectsUpdate(), undefined);
 
   onProjectsUpdate() {
-    if (!this.changedName && !this.changedSlug) {
+    if (!this.changedSlug) {
       return;
     }
     const project = ProjectsStore.getBySlug(this.changedSlug);
@@ -358,7 +357,6 @@ class ProjectGeneralSettingsContainer extends Component<ContainerProps> {
         params: {
           ...this.props.params,
           projectId: this.changedSlug,
-          projectName: this.changedName,
         },
       })
     );

--- a/tests/js/spec/components/deprecatedforms/jsonForm.spec.tsx
+++ b/tests/js/spec/components/deprecatedforms/jsonForm.spec.tsx
@@ -104,7 +104,7 @@ describe('JsonForm', function () {
   });
 
   describe('fields prop', function () {
-    const jsonFormFields = [fields.slug, fields.platform];
+    const jsonFormFields = [fields.name, fields.platform];
 
     it('default', function () {
       const wrapper = mountWithTheme(<JsonForm fields={jsonFormFields} />);

--- a/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
@@ -86,7 +86,7 @@ describe('projectGeneralSettings', function () {
       <ProjectGeneralSettings params={{orgId: org.slug, projectId: project.slug}} />
     );
 
-    expect(wrapper.find('Input[name="slug"]').prop('value')).toBe('project-slug');
+    expect(wrapper.find('Input[name="name"]').prop('value')).toBe('Project Name');
     expect(wrapper.find('Input[name="subjectPrefix"]').prop('value')).toBe('[my-org]');
     expect(wrapper.find('RangeSlider[name="resolveAge"]').prop('value')).toBe(48);
     expect(wrapper.find('TextArea[name="allowedDomains"]').prop('value')).toBe(
@@ -285,7 +285,7 @@ describe('projectGeneralSettings', function () {
     expect(ProjectsStore.itemsById['2'].platform).toBe('javascript');
   });
 
-  it('changing slug updates ProjectsStore', async function () {
+  it('changing name updates ProjectsStore', async function () {
     const params = {orgId: org.slug, projectId: project.slug};
     act(() => ProjectsStore.loadInitialData([project]));
 
@@ -314,8 +314,8 @@ describe('projectGeneralSettings', function () {
 
     // Change slug to new-slug
     wrapper
-      .find('input[name="slug"]')
-      .simulate('change', {target: {value: 'NEW PROJECT'}})
+      .find('input[name="name"]')
+      .simulate('change', {target: {value: 'New Project'}})
       .simulate('blur');
 
     // Slug does not save on blur
@@ -340,7 +340,7 @@ describe('projectGeneralSettings', function () {
     // updates ProjectsStore
     expect(ProjectsStore.itemsById['2'].slug).toBe('new-project');
     expect(browserHistory.replace).toHaveBeenCalled();
-    expect(wrapper.find('Input[name="slug"]').prop('value')).toBe('new-project');
+    expect(wrapper.find('Input[name="name"]').prop('value')).toBe('New Project');
 
     wrapper.setProps({
       projectId: 'new-project',

--- a/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
@@ -340,7 +340,7 @@ describe('projectGeneralSettings', function () {
     // updates ProjectsStore
     expect(ProjectsStore.itemsById['2'].slug).toBe('new-project');
     expect(browserHistory.replace).toHaveBeenCalled();
-    expect(wrapper.find('Input[name="name"]').prop('value')).toBe('New Project');
+    expect(wrapper.find('Input[name="name"]').prop('value')).toBe('new-project');
 
     wrapper.setProps({
       projectId: 'new-project',


### PR DESCRIPTION
Simultaneously update the name and slug when updating the Project 'Name'. 'Name' in the settings page and Project creation page is mis-named before - it was really the slug. This change will now update both fields behind the scenes and propagate the error, if any, back to the user.

Fixes ISSUE-1422