### PR TITLE
[1/3] ref(replay): Create a Replay class for data marshalling

### DIFF
--- a/static/app/utils/replays/Replay.tsx
+++ b/static/app/utils/replays/Replay.tsx
@@ -1,0 +1,96 @@
+import memoize from 'lodash/memoize';
+import type {eventWithTime} from 'rrweb/typings/types';
+
+import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
+import type {RawCrumb} from 'sentry/types/breadcrumbs';
+import type {Event, EventTransaction} from 'sentry/types/event';
+import {EntryType} from 'sentry/types/event';
+import mergeBreadcrumbEntries from 'sentry/utils/replays/mergeBreadcrumbEntries';
+import mergeSpanEntries from 'sentry/utils/replays/mergeSpanEntries';
+
+function last<T>(arr: T[]): T {
+  return arr[arr.length - 1];
+}
+
+export default class Replay {
+  static factory(
+    event: EventTransaction | undefined,
+    rrwebEvents: eventWithTime[] | undefined,
+    replayEvents: Event[] | undefined
+  ) {
+    if (!event || !rrwebEvents || !replayEvents) {
+      return null;
+    }
+    return new Replay(event, rrwebEvents, replayEvents);
+  }
+
+  private constructor(
+    /**
+     * The root Replay event, created at the start of the browser session.
+     */
+    private _event: EventTransaction,
+
+    /**
+     * The captured data from rrweb.
+     * Saved as N attachments that belong to the root Replay event.
+     */
+    private _rrwebEvents: eventWithTime[],
+
+    /**
+     * Regular Sentry SDK events that occurred during the rrweb session.
+     */
+    private _replayEvents: Event[]
+  ) {}
+
+  getEvent = memoize(() => {
+    const breadcrumbs = this.getEntryType(EntryType.BREADCRUMBS);
+    const spans = this.getEntryType(EntryType.SPANS);
+
+    const last_rrweb = last(this._rrwebEvents);
+    const last_breadcrumb = last(breadcrumbs?.data.values as RawCrumb[]);
+    const last_span = last(spans?.data as RawSpanType[]);
+
+    // The original `this._event.startTimestamp` and `this._event.endTimestamp`
+    // are the same. It's because the root replay event is re-purposing the
+    // `transaction` type, but it is not a real span occuring over time.
+    // So we need to figure out the real end time (in seconds).
+    const endTimestamp =
+      Math.max(
+        last_rrweb.timestamp,
+        +new Date(last_breadcrumb.timestamp || 0),
+        last_span.timestamp * 1000
+      ) / 1000;
+
+    return {
+      ...this._event,
+      entries: [breadcrumbs, spans],
+      endTimestamp,
+    } as EventTransaction;
+  });
+
+  getRRWebEvents() {
+    return this._rrwebEvents;
+  }
+
+  getEntryType = memoize((type: EntryType) => {
+    switch (type) {
+      case EntryType.BREADCRUMBS:
+        return mergeBreadcrumbEntries(this._replayEvents);
+      case EntryType.SPANS:
+        return mergeSpanEntries(this._replayEvents);
+      case EntryType.EXCEPTION:
+      case EntryType.MESSAGE:
+      case EntryType.REQUEST:
+      case EntryType.STACKTRACE:
+      case EntryType.TEMPLATE:
+      case EntryType.CSP:
+      case EntryType.EXPECTCT:
+      case EntryType.EXPECTSTAPLE:
+      case EntryType.HPKP:
+      case EntryType.THREADS:
+      case EntryType.DEBUGMETA:
+      default:
+        return undefined;
+    }
+  });
+}

--- a/static/app/utils/replays/mergeBreadcrumbEntries.tsx
+++ b/static/app/utils/replays/mergeBreadcrumbEntries.tsx
@@ -1,0 +1,23 @@
+import {Entry, EntryType, Event} from 'sentry/types/event';
+
+/**
+ * Merge all breadcrumbs from each Event in the `events` array
+ */
+export default function mergeBreadcrumbEntries(events: Event[]): Entry {
+  const allValues = events.flatMap(event =>
+    event.entries.flatMap((entry: Entry) =>
+      entry.type === EntryType.BREADCRUMBS ? entry.data.values : []
+    )
+  );
+
+  const stringified = allValues.map(value => JSON.stringify(value));
+  const deduped = Array.from(new Set(stringified));
+  const values = deduped.map(value => JSON.parse(value));
+
+  return {
+    type: EntryType.BREADCRUMBS,
+    data: {
+      values,
+    },
+  };
+}

--- a/static/app/utils/replays/mergeSpanEntries.tsx
+++ b/static/app/utils/replays/mergeSpanEntries.tsx
@@ -1,0 +1,15 @@
+import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
+import {Entry, EntryType, Event} from 'sentry/types/event';
+
+/**
+ * Merge all spans from each Event in the `events` array
+ */
+export default function mergeSpanEntries(events: Event[]): Entry {
+  const spans = events.flatMap(event =>
+    event.entries.flatMap((entry: Entry) =>
+      entry.type === EntryType.SPANS ? (entry.data as RawSpanType[]) : []
+    )
+  );
+
+  return {type: EntryType.SPANS, data: spans};
+}

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -12,7 +12,7 @@ function last<T>(arr: T[]): T {
   return arr[arr.length - 1];
 }
 
-export default class Replay {
+export default class ReplayReader {
   static factory(
     event: EventTransaction | undefined,
     rrwebEvents: eventWithTime[] | undefined,
@@ -21,7 +21,7 @@ export default class Replay {
     if (!event || !rrwebEvents || !replayEvents) {
       return null;
     }
-    return new Replay(event, rrwebEvents, replayEvents);
+    return new ReplayReader(event, rrwebEvents, replayEvents);
   }
 
   private constructor(
@@ -46,9 +46,9 @@ export default class Replay {
     const breadcrumbs = this.getEntryType(EntryType.BREADCRUMBS);
     const spans = this.getEntryType(EntryType.SPANS);
 
-    const last_rrweb = last(this._rrwebEvents);
-    const last_breadcrumb = last(breadcrumbs?.data.values as RawCrumb[]);
-    const last_span = last(spans?.data as RawSpanType[]);
+    const lastRRweb = last(this._rrwebEvents);
+    const lastBreadcrumb = last(breadcrumbs?.data.values as RawCrumb[]);
+    const lastSpan = last(spans?.data as RawSpanType[]);
 
     // The original `this._event.startTimestamp` and `this._event.endTimestamp`
     // are the same. It's because the root replay event is re-purposing the
@@ -56,9 +56,9 @@ export default class Replay {
     // So we need to figure out the real end time (in seconds).
     const endTimestamp =
       Math.max(
-        last_rrweb.timestamp,
-        +new Date(last_breadcrumb.timestamp || 0),
-        last_span.timestamp * 1000
+        lastRRweb.timestamp,
+        +new Date(lastBreadcrumb.timestamp || 0),
+        lastSpan.timestamp * 1000
       ) / 1000;
 
     return {
@@ -78,19 +78,10 @@ export default class Replay {
         return mergeBreadcrumbEntries(this._replayEvents);
       case EntryType.SPANS:
         return mergeSpanEntries(this._replayEvents);
-      case EntryType.EXCEPTION:
-      case EntryType.MESSAGE:
-      case EntryType.REQUEST:
-      case EntryType.STACKTRACE:
-      case EntryType.TEMPLATE:
-      case EntryType.CSP:
-      case EntryType.EXPECTCT:
-      case EntryType.EXPECTSTAPLE:
-      case EntryType.HPKP:
-      case EntryType.THREADS:
-      case EntryType.DEBUGMETA:
       default:
-        return undefined;
+        throw new Error(
+          `ReplayReader is unable to prepare EntryType ${type}. Type not supported.`
+        );
     }
   });
 }

--- a/static/app/views/replays/detail/detailLayout.tsx
+++ b/static/app/views/replays/detail/detailLayout.tsx
@@ -19,9 +19,9 @@ import getUrlPathname from 'sentry/utils/getUrlPathname';
 
 type Props = {
   children: React.ReactNode;
-  event: Event | undefined;
   orgId: string;
   crumbs?: RawCrumb[];
+  event?: Event;
 };
 
 function DetailLayout({children, event, orgId, crumbs}: Props) {

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -39,7 +39,7 @@ function ReplayDetails() {
     fetchError,
     fetching,
     onRetry,
-    rrwebEvents,
+    replay,
   } = useReplayEvent({
     eventSlug,
     location,
@@ -55,20 +55,20 @@ function ReplayDetails() {
       </DetailLayout>
     );
   }
-  if (!event) {
+  if (!replay) {
     // TODO(replay): Give the user more details when errors happen
     console.log({fetching, fetchError}); // eslint-disable-line no-console
     return (
-      <DetailLayout event={event} orgId={orgId}>
+      <DetailLayout event={undefined} orgId={orgId}>
         <PageContent>
           <NotFound />
         </PageContent>
       </DetailLayout>
     );
   }
-  if (!rrwebEvents || rrwebEvents.length < 2) {
+  if (replay.getRRWebEvents().length < 2) {
     return (
-      <DetailLayout event={event} orgId={orgId}>
+      <DetailLayout event={replay.getEvent()} orgId={orgId}>
         <DetailedError
           onRetry={onRetry}
           hideSupportLinks
@@ -89,7 +89,10 @@ function ReplayDetails() {
   }
 
   return (
-    <ReplayContextProvider events={rrwebEvents} initialTimeOffset={initialTimeOffset}>
+    <ReplayContextProvider
+      events={replay.getRRWebEvents()}
+      initialTimeOffset={initialTimeOffset}
+    >
       <DetailLayout
         event={event}
         orgId={orgId}
@@ -117,7 +120,7 @@ function ReplayDetails() {
               <BreadcrumbTimeline crumbs={breadcrumbEntry?.data.values || []} />
             </Panel>
             <FocusArea
-              event={event}
+              event={replay.getEvent()}
               eventWithSpans={mergedReplayEvent}
               memorySpans={memorySpans}
             />

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -50,7 +50,7 @@ function ReplayDetails() {
 
   if (fetching) {
     return (
-      <DetailLayout event={event} orgId={orgId}>
+      <DetailLayout orgId={orgId}>
         <LoadingIndicator />
       </DetailLayout>
     );
@@ -59,7 +59,7 @@ function ReplayDetails() {
     // TODO(replay): Give the user more details when errors happen
     console.log({fetching, fetchError}); // eslint-disable-line no-console
     return (
-      <DetailLayout event={undefined} orgId={orgId}>
+      <DetailLayout orgId={orgId}>
         <PageContent>
           <NotFound />
         </PageContent>

--- a/static/app/views/replays/utils/useReplayEvent.tsx
+++ b/static/app/views/replays/utils/useReplayEvent.tsx
@@ -7,7 +7,7 @@ import {IssueAttachment} from 'sentry/types';
 import {Entry, Event, EventTransaction} from 'sentry/types/event';
 import EventView from 'sentry/utils/discover/eventView';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
-import Replay from 'sentry/utils/replays/Replay';
+import ReplayReader from 'sentry/utils/replays/replayReader';
 import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 
@@ -70,7 +70,7 @@ type Options = {
 
 interface Result extends State {
   onRetry: () => void;
-  replay: Replay | null;
+  replay: ReplayReader | null;
 }
 
 const IS_RRWEB_ATTACHMENT_FILENAME = /rrweb-[0-9]{13}.json/;
@@ -215,7 +215,7 @@ function useReplayEvent({eventSlug, location, orgId}: Options): Result {
     fetchError: state.fetchError,
     fetching: state.fetching,
     onRetry,
-    replay: Replay.factory(state.event, state.rrwebEvents, state.replayEvents),
+    replay: ReplayReader.factory(state.event, state.rrwebEvents, state.replayEvents),
 
     breadcrumbEntry: state.breadcrumbEntry,
     event: state.event,


### PR DESCRIPTION
Create a `Replay` class to marshal the different replay data sources.

This class will allow the existing `useReplayEvent` react hook to offload the domain-specific filtering and type management that it's doing, and instead that react hook can focus on data loading and react-state. 

One domain specific task that's being newly handled: consistent `end_timestamp`. The `Replay` class has all the context to figure out the end_timestamp for a replay based on the last rrweb, span, or breadcrumb that has been saved.

There is no need for any of the values inside `Replay` to be inside react state anymore because they are all derived from state. They are however memoized because it's a) easy b) gives us flexibility to get data from anywhere without worrying about perf. If the upstream useState data is changed we will get a new class instance with an empty cache, so memoized values should be cleared. 

Related to #34172 