### PR TITLE
feat(profiling): add context menu

### DIFF
--- a/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
@@ -1,0 +1,540 @@
+import {forwardRef, Fragment, useEffect, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {IconCheckmark} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {clamp} from 'sentry/utils/profiling/colors/utils';
+import {
+  FlamegraphAxisOptions,
+  FlamegraphColorCodings,
+  FlamegraphSorting,
+  FlamegraphViewOptions,
+} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences';
+import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/useFlamegraphPreferences';
+import {Rect} from 'sentry/utils/profiling/gl/utils';
+
+function useLatestRef(val) {
+  const ref = useRef(val);
+  // technically this is not "concurrent mode safe" because we're manipulating
+  // the value during render (so it's not idempotent). However, the places this
+  // hook is used is to support memoizing callbacks which will be called
+  // *during* render, so we need the latest values *during* render.
+  // If not for this, then we'd probably want to use useLayoutEffect instead.
+  ref.current = val;
+  return ref;
+}
+
+function useContextMenu() {
+  const [open, setOpen] = useState<boolean>(false);
+  const itemProps = useKeyboardNavigation();
+
+  function wrapSetOpen(newOpen: boolean) {
+    if (!newOpen) {
+      itemProps.setTabIndex(null);
+    }
+    setOpen(newOpen);
+  }
+
+  function getMenuProps() {
+    const menuProps = itemProps.getMenuKeyboardEventHandlers();
+
+    return {
+      ...menuProps,
+      onKeyDown: (evt: React.KeyboardEvent) => {
+        if (evt.key === 'Escape') {
+          setOpen(false);
+        }
+        menuProps.onKeyDown(evt);
+      },
+    };
+  }
+
+  function getMenuItemProps() {
+    const menuItemProps = itemProps.getMenuItemKeyboardEventHandlers();
+
+    return {
+      ...menuItemProps,
+      onKeyDown: (evt: React.KeyboardEvent) => {
+        if (evt.key === 'Escape') {
+          setOpen(false);
+        }
+        menuItemProps.onKeyDown(evt);
+      },
+    };
+  }
+
+  return {
+    open,
+    setOpen: wrapSetOpen,
+    menuRef: itemProps.menuRef,
+    getMenuProps,
+    getMenuItemProps,
+  };
+}
+
+function useKeyboardNavigation() {
+  const [menuRef, setMenuRef] = useState<HTMLDivElement | null>(null);
+  const [tabIndex, setTabIndex] = useState<number | null>(null);
+
+  const items = useLatestRef([]);
+  const latestTabIndex = useLatestRef(tabIndex).current;
+
+  useEffect(() => {
+    if (menuRef) {
+      menuRef.focus();
+    }
+  }, [menuRef]);
+
+  useEffect(() => {
+    if (typeof tabIndex !== 'number') {
+      return;
+    }
+    if (items.current[tabIndex]?.node) {
+      items.current[tabIndex]?.node.focus();
+    }
+  }, [tabIndex, items]);
+
+  function getMenuKeyboardEventHandlers() {
+    return {
+      tabIndex: -1,
+      ref: setMenuRef,
+      onKeyDown: (evt: React.KeyboardEvent) => {
+        if (items.current.length === 0) {
+          return;
+        }
+
+        if (evt.key === 'Escape') {
+          setTabIndex(null);
+        }
+
+        if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
+          evt.preventDefault();
+
+          if (latestTabIndex === items.current.length - 1 || latestTabIndex === null) {
+            setTabIndex(0);
+          } else {
+            setTabIndex((latestTabIndex ?? 0) + 1);
+          }
+        }
+
+        if (evt.key === 'ArrowUp' || (evt.key === 'Tab' && evt.shiftKey)) {
+          evt.preventDefault();
+
+          if (latestTabIndex === 0 || latestTabIndex === null) {
+            setTabIndex(items.current.length - 1);
+          } else {
+            setTabIndex((latestTabIndex ?? 0) - 1);
+          }
+        }
+      },
+    };
+  }
+
+  function getMenuItemKeyboardEventHandlers() {
+    const idx = items.current.length;
+    items.current.push({id: idx, node: null});
+
+    return {
+      tabIndex: latestTabIndex === idx ? 0 : -1,
+      ref: (node: HTMLElement | null) => {
+        if (items.current[idx]) {
+          items.current[idx].node = node;
+        }
+      },
+      onMouseEnter: () => {
+        setTabIndex(idx);
+      },
+      onKeyDown: (evt: React.KeyboardEvent) => {
+        if (items.current.length === 0) {
+          return;
+        }
+
+        if (evt.key === 'Escape') {
+          setTabIndex(null);
+        }
+
+        if (evt.key === 'Enter' || evt.key === ' ') {
+          items?.current?.[idx]?.node?.click?.();
+        }
+
+        if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
+          evt.preventDefault();
+
+          if (latestTabIndex === items.current.length || latestTabIndex === null) {
+            setTabIndex(0);
+          } else {
+            setTabIndex((latestTabIndex ?? 0) + 1);
+          }
+        }
+
+        if (evt.key === 'ArrowUp' || (evt.key === 'Tab' && evt.shiftKey)) {
+          evt.preventDefault();
+
+          if (latestTabIndex === 0 || latestTabIndex === null) {
+            setTabIndex(items.current.length);
+          } else {
+            setTabIndex((latestTabIndex ?? 0) - 1);
+          }
+        }
+      },
+    };
+  }
+
+  return {
+    menuRef,
+    getMenuItemKeyboardEventHandlers,
+    getMenuKeyboardEventHandlers,
+    tabIndex,
+    setTabIndex,
+  };
+}
+
+interface MenuProps
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+const Menu = styled(
+  forwardRef((props: MenuProps, ref: React.Ref<HTMLDivElement> | undefined) => {
+    return <div ref={ref} role="menu" {...props} />;
+  })
+)`
+  position: absolute;
+  font-size: ${p => p.theme.fontSizeMedium};
+  z-index: ${p => p.theme.zIndex.dropdown};
+  background: ${p => p.theme.backgroundElevated};
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  box-shadow: ${p => p.theme.dropShadowHeavy};
+  width: auto;
+  overflow: auto;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+interface MenuItemCheckboxProps
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  checked?: boolean;
+}
+
+const MenuLeadingItem = styled('div')`
+  display: flex;
+  align-items: center;
+  height: 1.4em;
+  width: 1em;
+  gap: ${space(1)};
+  padding: ${space(1)} 0;
+  position: relative;
+`;
+
+const MenuContent = styled('div')`
+  position: relative;
+  width: 100%;
+  display: flex;
+  gap: ${space(0.5)};
+  justify-content: space-between;
+  padding: ${space(0.5)} 0;
+  margin-left: ${space(0.5)};
+  text-transform: capitalize;
+
+  margin-bottom: 0;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const Input = styled('input')`
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  padding-right: ${space(1)};
+
+  & + svg {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 1em;
+    height: 1.4em;
+    display: none;
+  }
+
+  &:checked + svg {
+    display: block;
+  }
+`;
+
+const MenuItemCheckbox = styled(
+  forwardRef(
+    (props: MenuItemCheckboxProps, ref: React.Ref<HTMLDivElement> | undefined) => {
+      const {children, checked, className, style, ...rest} = props;
+
+      return (
+        // @ts-ignore this ref is forwarded
+        <MenuItem ref={ref} {...rest}>
+          <label className={className} style={style}>
+            <MenuLeadingItem>
+              <Input type="checkbox" checked={checked} />
+              <IconCheckmark />
+            </MenuLeadingItem>
+            <MenuContent>{children}</MenuContent>
+          </label>
+        </MenuItem>
+      );
+    }
+  )
+)`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  font-weight: normal;
+  padding: 0 ${space(1)};
+  border-radius: ${p => p.theme.borderRadius};
+  box-sizing: border-box;
+  background: ${p => (p.tabIndex === 0 ? p.theme.hover : undefined)};
+
+  &:focus {
+    color: ${p => p.theme.textColor};
+    background: ${p => p.theme.hover};
+  }
+`;
+
+interface MenuItemProps
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+const MenuItem = styled(
+  forwardRef((props: MenuItemProps, ref: React.Ref<HTMLDivElement> | undefined) => {
+    const {children, ...rest} = props;
+    return (
+      <div ref={ref} role="menuitem" {...rest}>
+        {children}
+      </div>
+    );
+  })
+)`
+  cursor: pointer;
+  color: ${p => p.theme.textColor};
+  background: transparent;
+  padding: 0 ${space(0.5)};
+
+  &:focus {
+    outline: none;
+  }
+
+  &:active: {
+    background: transparent;
+  }
+`;
+
+const MenuGroup = styled('div')`
+  padding-top: 0;
+  padding-bottom: ${space(1)};
+
+  &:last-of-type {
+    padding-bottom: 0;
+  }
+`;
+
+interface MenuHeadingProps
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+const MenuHeading = styled((props: MenuHeadingProps) => {
+  const {children, ...rest} = props;
+  return <div {...rest}>{children}</div>;
+})`
+  text-transform: uppercase;
+  line-height: 1.5;
+  font-weight: 600;
+  color: ${p => p.theme.subText};
+  margin-bottom: 0;
+  cursor: default;
+  font-size: 75%;
+  padding: ${space(0.5)} ${space(1.5)};
+`;
+
+const Layer = styled('div')`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: ${p => p.theme.zIndex.dropdown - 1};
+`;
+
+const FLAMEGRAPH_COLOR_CODINGS: FlamegraphColorCodings = [
+  'by symbol name',
+  'by system / application',
+  'by library',
+  'by recursion',
+];
+const FLAMEGRAPH_VIEW_OPTIONS: FlamegraphViewOptions = ['top down', 'bottom up'];
+const FLAMEGRAPH_SORTING_OPTIONS: FlamegraphSorting = ['left heavy', 'call order'];
+const FLAMEGRAPH_AXIS_OPTIONS: FlamegraphAxisOptions = ['standalone', 'transaction'];
+
+function computeBestContextMenuPosition(mouse: Rect, container: Rect, target: Rect) {
+  const maxY = Math.floor(container.height - target.height);
+  const minY = container.top;
+
+  const minX = container.left;
+  const maxX = Math.floor(container.right - target.width);
+
+  // We add a tiny offset so that the menu is not directly where the user places their cursor.
+  const OFFSET = 6;
+
+  return {
+    left: clamp(mouse.x + OFFSET, minX, maxX),
+    top: clamp(mouse.y + OFFSET, minY, maxY),
+  };
+}
+
+interface FlameGraphOptionsContextMenuProps {
+  container: HTMLElement | null;
+  mouseCoordinates: Rect | null;
+}
+
+export function FlamegraphOptionsContextMenu(props: FlameGraphOptionsContextMenuProps) {
+  const [containerCoordinates, setContainerCoordinates] = useState<Rect | null>(null);
+  const [menuCoordinates, setMenuCoordinates] = useState<Rect | null>(null);
+
+  const {open, setOpen, menuRef, getMenuProps, getMenuItemProps} = useContextMenu();
+
+  const [preferences, dispatch] = useFlamegraphPreferences();
+
+  useEffect(() => {
+    if (props.mouseCoordinates) {
+      setOpen(true);
+    }
+  }, [props.mouseCoordinates, setOpen]);
+
+  // Observe the menu
+  useEffect(() => {
+    if (!menuRef) {
+      return undefined;
+    }
+
+    const resizeObserver = new window.ResizeObserver(entries => {
+      const contentRect = entries[0].contentRect;
+      setMenuCoordinates(new Rect(0, 0, contentRect.width, contentRect.height));
+    });
+
+    resizeObserver.observe(menuRef);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [menuRef]);
+
+  // Observe the container
+  useEffect(() => {
+    if (!props.container) {
+      return undefined;
+    }
+
+    const resizeObserver = new window.ResizeObserver(entries => {
+      const contentRect = entries[0].contentRect;
+      setContainerCoordinates(new Rect(0, 0, contentRect.width, contentRect.height));
+    });
+
+    resizeObserver.observe(props.container);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [props.container]);
+
+  const position =
+    props.mouseCoordinates && containerCoordinates && menuCoordinates
+      ? computeBestContextMenuPosition(
+          props.mouseCoordinates,
+          containerCoordinates,
+          menuCoordinates
+        )
+      : null;
+
+  return (
+    <Fragment>
+      {open ? (
+        <Layer
+          onClick={() => {
+            setOpen(false);
+          }}
+        />
+      ) : null}
+      {props.mouseCoordinates && open ? (
+        <Menu
+          {...getMenuProps()}
+          style={{
+            position: 'absolute',
+            visibility: open ? 'initial' : 'hidden',
+            left: position?.left ?? -9999,
+            top: position?.top ?? -9999,
+            pointerEvents: open ? 'initial' : 'none',
+            maxHeight: containerCoordinates?.height ?? 'auto',
+          }}
+        >
+          <MenuGroup>
+            <MenuHeading>{t('Color Coding')}</MenuHeading>
+            {FLAMEGRAPH_COLOR_CODINGS.map((coding, idx) => (
+              <MenuItemCheckbox
+                key={idx}
+                {...getMenuItemProps()}
+                onClick={() => dispatch({type: 'set color coding', payload: coding})}
+                checked={preferences.colorCoding === coding}
+              >
+                {coding}
+              </MenuItemCheckbox>
+            ))}
+          </MenuGroup>
+          <MenuGroup>
+            <MenuHeading>{t('View')}</MenuHeading>
+            {FLAMEGRAPH_VIEW_OPTIONS.map((view, idx) => (
+              <MenuItemCheckbox
+                key={idx}
+                {...getMenuItemProps()}
+                onClick={() => dispatch({type: 'set view', payload: view})}
+                checked={preferences.view === view}
+              >
+                {view}
+              </MenuItemCheckbox>
+            ))}
+          </MenuGroup>
+          <MenuGroup>
+            <MenuHeading>{t('Sorting')}</MenuHeading>
+            {FLAMEGRAPH_SORTING_OPTIONS.map((sorting, idx) => (
+              <MenuItemCheckbox
+                key={idx}
+                {...getMenuItemProps()}
+                onClick={() => dispatch({type: 'set sorting', payload: sorting})}
+                checked={preferences.sorting === sorting}
+              >
+                {sorting}
+              </MenuItemCheckbox>
+            ))}
+          </MenuGroup>
+          <MenuGroup>
+            <MenuHeading>{t('X Axis')}</MenuHeading>
+            {FLAMEGRAPH_AXIS_OPTIONS.map((axis, idx) => (
+              <MenuItemCheckbox
+                key={idx}
+                {...getMenuItemProps()}
+                onClick={() => dispatch({type: 'set xAxis', payload: axis})}
+                checked={preferences.xAxis === axis}
+              >
+                {axis}
+              </MenuItemCheckbox>
+            ))}
+          </MenuGroup>
+        </Menu>
+      ) : null}
+    </Fragment>
+  );
+}

--- a/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
@@ -462,13 +462,7 @@ export function FlamegraphOptionsContextMenu(props: FlameGraphOptionsContextMenu
 
   return (
     <Fragment>
-      {open ? (
-        <Layer
-          onClick={() => {
-            setOpen(false);
-          }}
-        />
-      ) : null}
+      {open ? <Layer onClick={() => setOpen(false)} /> : null}
       {props.mouseCoordinates && open ? (
         <Menu
           {...getMenuProps()}

--- a/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
@@ -399,6 +399,24 @@ export function FlamegraphOptionsContextMenu(props: FlameGraphOptionsContextMenu
 
   const [preferences, dispatch] = useFlamegraphPreferences();
 
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      // Do nothing if clicking ref's element or descendent elements
+      if (!menuRef || menuRef.contains(event.target as Node)) {
+        return;
+      }
+
+      setOpen(false);
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [menuRef, setOpen]);
+
   // Observe the menu
   useEffect(() => {
     if (!menuRef) {

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -21,6 +21,7 @@ import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
 import usePrevious from 'sentry/utils/usePrevious';
 
 import {BoundTooltip} from './boundTooltip';
+import {FlamegraphOptionsContextMenu} from './flamegraphOptionsContextMenu';
 
 interface FlamegraphZoomViewProps {
   canvasPoolManager: CanvasPoolManager;
@@ -641,6 +642,31 @@ function FlamegraphZoomView({
     };
   }, [flamegraphCanvasRef, flamegraphRenderer, zoom, scroll]);
 
+  // Context menu coordinates
+  const [mouseCoordinates, setMouseCoordinates] = useState<Rect | null>(null);
+  const onContextMenu = useCallback(
+    (evt: React.MouseEvent) => {
+      evt.preventDefault();
+      evt.stopPropagation();
+
+      if (!flamegraphCanvasRef) {
+        return;
+      }
+
+      const parentPosition = flamegraphCanvasRef.getBoundingClientRect();
+
+      setMouseCoordinates(
+        new Rect(
+          evt.clientX - parentPosition.left,
+          evt.clientY - parentPosition.top,
+          0,
+          0
+        )
+      );
+    },
+    [flamegraphCanvasRef]
+  );
+
   return (
     <Fragment>
       <Canvas
@@ -649,6 +675,7 @@ function FlamegraphZoomView({
         onMouseUp={onCanvasMouseUp}
         onMouseMove={onCanvasMouseMove}
         onMouseLeave={onCanvasMouseLeave}
+        onContextMenu={onContextMenu}
         style={{cursor: lastInteraction === 'pan' ? 'grab' : 'default'}}
       />
       <Canvas
@@ -657,6 +684,12 @@ function FlamegraphZoomView({
           pointerEvents: 'none',
         }}
       />
+      {
+        <FlamegraphOptionsContextMenu
+          container={flamegraphCanvasRef}
+          mouseCoordinates={mouseCoordinates}
+        />
+      }
       {flamegraphRenderer ? (
         <BoundTooltip
           bounds={canvasBounds}

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -21,7 +21,10 @@ import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
 import usePrevious from 'sentry/utils/usePrevious';
 
 import {BoundTooltip} from './boundTooltip';
-import {FlamegraphOptionsContextMenu} from './flamegraphOptionsContextMenu';
+import {
+  FlamegraphOptionsContextMenu,
+  useContextMenu,
+} from './flamegraphOptionsContextMenu';
 
 interface FlamegraphZoomViewProps {
   canvasPoolManager: CanvasPoolManager;
@@ -643,7 +646,8 @@ function FlamegraphZoomView({
   }, [flamegraphCanvasRef, flamegraphRenderer, zoom, scroll]);
 
   // Context menu coordinates
-  const [mouseCoordinates, setMouseCoordinates] = useState<Rect | null>(null);
+  const contextMenuProps = useContextMenu();
+  const [contextMenuCoordinates, setContextMenuCoordinates] = useState<Rect | null>(null);
   const onContextMenu = useCallback(
     (evt: React.MouseEvent) => {
       evt.preventDefault();
@@ -655,7 +659,7 @@ function FlamegraphZoomView({
 
       const parentPosition = flamegraphCanvasRef.getBoundingClientRect();
 
-      setMouseCoordinates(
+      setContextMenuCoordinates(
         new Rect(
           evt.clientX - parentPosition.left,
           evt.clientY - parentPosition.top,
@@ -663,8 +667,9 @@ function FlamegraphZoomView({
           0
         )
       );
+      contextMenuProps.setOpen(true);
     },
-    [flamegraphCanvasRef]
+    [flamegraphCanvasRef, contextMenuProps]
   );
 
   return (
@@ -684,12 +689,13 @@ function FlamegraphZoomView({
           pointerEvents: 'none',
         }}
       />
-      {
+      {contextMenuProps.open ? (
         <FlamegraphOptionsContextMenu
           container={flamegraphCanvasRef}
-          mouseCoordinates={mouseCoordinates}
+          contextMenuCoordinates={contextMenuCoordinates}
+          contextMenuProps={contextMenuProps}
         />
-      }
+      ) : null}
       {flamegraphRenderer ? (
         <BoundTooltip
           bounds={canvasBounds}


### PR DESCRIPTION
Add a context menu implementation for the flamechart. Should be easily reusable, doesn't support nested menus as we don't need them for now. The implementation of the menu decouples the component from their UI logic and composes useKeyboardNavigation with useContextMenu. Sort of follows aria specs (no aria-activedescendant) and missing Home and Page up/down keyboard events.

![CleanShot 2022-05-04 at 10 43 24](https://user-images.githubusercontent.com/9317857/166706874-393c314d-fa31-40fb-96a5-2e5ca7fad690.gif)
.