### PR TITLE
ref: Log response of failed Symbolicator requests

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -594,6 +594,10 @@ class SymbolicatorSession:
                 if response.ok:
                     json = response.json()
                 else:
+                    with sentry_sdk.push_scope():
+                        sentry_sdk.set_extra("symbolicator_response", response.text)
+                        sentry_sdk.capture_message("Symbolicator request failed")
+
                     json = {"status": "failed", "message": "internal server error"}
 
                 return self._process_response(json)


### PR DESCRIPTION
After some recent fixes in #34101, we have lowered the number of 4xx responses quite a bit, lets log the remaining ones so we know how to fix them.

![image](https://user-images.githubusercontent.com/580492/166710801-2b5f2878-b29c-41eb-9268-847b9d2e2bfc.png)
