### PR TITLE
feat(sampling): Add device and os sampling [TET-23]

### DIFF
--- a/static/app/types/dynamicSampling.tsx
+++ b/static/app/types/dynamicSampling.tsx
@@ -44,6 +44,11 @@ export enum DynamicSamplingInnerOperator {
   CUSTOM = 'custom',
 }
 
+/**
+ * String of the sampling category that's used on the backend.
+ * Default naming strategy should be based on the path in the event, prefixed with `event.`.
+ * To see the path in the event, click on the JSON button on the issue details page.
+ */
 export enum DynamicSamplingInnerName {
   TRACE_RELEASE = 'trace.release',
   TRACE_ENVIRONMENT = 'trace.environment',
@@ -58,6 +63,10 @@ export enum DynamicSamplingInnerName {
   EVENT_WEB_CRAWLERS = 'event.web_crawlers',
   EVENT_BROWSER_EXTENSIONS = 'event.has_bad_browser_extensions',
   EVENT_TRANSACTION = 'event.transaction',
+  EVENT_OS_NAME = 'event.contexts.os.name',
+  EVENT_OS_VERSION = 'event.contexts.os.version',
+  EVENT_DEVICE_NAME = 'event.contexts.device.name',
+  EVENT_DEVICE_FAMILY = 'event.contexts.device.family',
   // Custom operators
   EVENT_IP_ADDRESSES = 'event.client_ip',
   EVENT_LEGACY_BROWSER = 'event.legacy_browser',
@@ -81,7 +90,11 @@ type DynamicSamplingConditionLogicalInnerGlob = {
     | DynamicSamplingInnerName.EVENT_RELEASE
     | DynamicSamplingInnerName.TRACE_RELEASE
     | DynamicSamplingInnerName.EVENT_TRANSACTION
-    | DynamicSamplingInnerName.TRACE_TRANSACTION;
+    | DynamicSamplingInnerName.TRACE_TRANSACTION
+    | DynamicSamplingInnerName.EVENT_OS_NAME
+    | DynamicSamplingInnerName.EVENT_OS_VERSION
+    | DynamicSamplingInnerName.EVENT_DEVICE_FAMILY
+    | DynamicSamplingInnerName.EVENT_DEVICE_NAME;
   op: DynamicSamplingInnerOperator.GLOB_MATCH;
   value: Array<string>;
 };

--- a/static/app/views/settings/project/filtersAndSampling/modal/autoComplete.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/autoComplete.tsx
@@ -21,12 +21,16 @@ type Tag = {
 
 type Props = {
   category:
-    | DynamicSamplingInnerName.TRACE_ENVIRONMENT
     | DynamicSamplingInnerName.EVENT_ENVIRONMENT
     | DynamicSamplingInnerName.EVENT_RELEASE
+    | DynamicSamplingInnerName.EVENT_TRANSACTION
+    | DynamicSamplingInnerName.EVENT_OS_NAME
+    | DynamicSamplingInnerName.EVENT_OS_VERSION
+    | DynamicSamplingInnerName.EVENT_DEVICE_FAMILY
+    | DynamicSamplingInnerName.EVENT_DEVICE_NAME
+    | DynamicSamplingInnerName.TRACE_ENVIRONMENT
     | DynamicSamplingInnerName.TRACE_RELEASE
-    | DynamicSamplingInnerName.TRACE_TRANSACTION
-    | DynamicSamplingInnerName.EVENT_TRANSACTION;
+    | DynamicSamplingInnerName.TRACE_TRANSACTION;
   onChange: (value: string) => void;
   orgSlug: Organization['slug'];
   projectId: Project['id'];
@@ -52,6 +56,14 @@ function AutoComplete({orgSlug, projectId, category, onChange, value}: Props) {
       case DynamicSamplingInnerName.TRACE_TRANSACTION:
       case DynamicSamplingInnerName.EVENT_TRANSACTION:
         return 'transaction';
+      case DynamicSamplingInnerName.EVENT_OS_NAME:
+        return 'os.name';
+      case DynamicSamplingInnerName.EVENT_OS_VERSION:
+        return 'os.version';
+      case DynamicSamplingInnerName.EVENT_DEVICE_FAMILY:
+        return 'device.family';
+      case DynamicSamplingInnerName.EVENT_DEVICE_NAME:
+        return 'device.name';
       default:
         Sentry.captureException(
           new Error('Unknown dynamic sampling condition inner name')
@@ -71,6 +83,14 @@ function AutoComplete({orgSlug, projectId, category, onChange, value}: Props) {
       case DynamicSamplingInnerName.TRACE_TRANSACTION:
       case DynamicSamplingInnerName.EVENT_TRANSACTION:
         return t('Search or add a transaction');
+      case DynamicSamplingInnerName.EVENT_OS_NAME:
+        return t('Search or add an os name');
+      case DynamicSamplingInnerName.EVENT_OS_VERSION:
+        return t('Search or add an os version');
+      case DynamicSamplingInnerName.EVENT_DEVICE_FAMILY:
+        return t('Search or add a device family');
+      case DynamicSamplingInnerName.EVENT_DEVICE_NAME:
+        return t('Search or add a device name');
       default:
         Sentry.captureException(
           new Error('Unknown dynamic sampling condition inner name')

--- a/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
@@ -39,15 +39,20 @@ function Conditions({conditions, orgSlug, projectId, onDelete, onChange}: Props)
           category === DynamicSamplingInnerName.EVENT_LEGACY_BROWSER;
 
         const isBooleanField =
-          category === DynamicSamplingInnerName.EVENT_BROWSER_EXTENSIONS ||
-          category === DynamicSamplingInnerName.EVENT_LOCALHOST ||
-          category === DynamicSamplingInnerName.EVENT_WEB_CRAWLERS ||
-          displayLegacyBrowsers;
+          [
+            DynamicSamplingInnerName.EVENT_BROWSER_EXTENSIONS,
+            DynamicSamplingInnerName.EVENT_LOCALHOST,
+            DynamicSamplingInnerName.EVENT_WEB_CRAWLERS,
+          ].includes(category) || displayLegacyBrowsers;
 
         const isAutoCompleteField =
           category === DynamicSamplingInnerName.EVENT_ENVIRONMENT ||
           category === DynamicSamplingInnerName.EVENT_RELEASE ||
           category === DynamicSamplingInnerName.EVENT_TRANSACTION ||
+          category === DynamicSamplingInnerName.EVENT_OS_NAME ||
+          category === DynamicSamplingInnerName.EVENT_OS_VERSION ||
+          category === DynamicSamplingInnerName.EVENT_DEVICE_FAMILY ||
+          category === DynamicSamplingInnerName.EVENT_DEVICE_NAME ||
           category === DynamicSamplingInnerName.TRACE_ENVIRONMENT ||
           category === DynamicSamplingInnerName.TRACE_RELEASE ||
           category === DynamicSamplingInnerName.TRACE_TRANSACTION;

--- a/static/app/views/settings/project/filtersAndSampling/modal/errorRuleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/errorRuleModal.tsx
@@ -10,6 +10,8 @@ import {
 } from 'sentry/types/dynamicSampling';
 import {defined} from 'sentry/utils';
 
+import {getInnerNameLabel} from '../utils';
+
 import RuleModal from './ruleModal';
 import {getNewCondition} from './utils';
 
@@ -69,19 +71,25 @@ function ErrorRuleModal({rule, errorRules, transactionRules, ...props}: Props) {
       title={rule ? t('Edit Error Sampling Rule') : t('Add Error Sampling Rule')}
       emptyMessage={t('Apply sampling rate to all errors')}
       conditionCategories={[
-        [DynamicSamplingInnerName.EVENT_RELEASE, t('Release')],
-        [DynamicSamplingInnerName.EVENT_ENVIRONMENT, t('Environment')],
-        [DynamicSamplingInnerName.EVENT_USER_ID, t('User Id')],
-        [DynamicSamplingInnerName.EVENT_USER_SEGMENT, t('User Segment')],
-        [DynamicSamplingInnerName.EVENT_BROWSER_EXTENSIONS, t('Browser Extensions')],
-        [DynamicSamplingInnerName.EVENT_LOCALHOST, t('Localhost')],
-        [DynamicSamplingInnerName.EVENT_LEGACY_BROWSER, t('Legacy Browser')],
-        [DynamicSamplingInnerName.EVENT_WEB_CRAWLERS, t('Web Crawlers')],
-        [DynamicSamplingInnerName.EVENT_IP_ADDRESSES, t('IP Address')],
-        [DynamicSamplingInnerName.EVENT_CSP, t('Content Security Policy')],
-        [DynamicSamplingInnerName.EVENT_ERROR_MESSAGES, t('Error Message')],
-        [DynamicSamplingInnerName.EVENT_TRANSACTION, t('Transaction')],
-      ]}
+        DynamicSamplingInnerName.EVENT_RELEASE,
+        DynamicSamplingInnerName.EVENT_ENVIRONMENT,
+        DynamicSamplingInnerName.EVENT_USER_ID,
+        DynamicSamplingInnerName.EVENT_USER_SEGMENT,
+        DynamicSamplingInnerName.EVENT_BROWSER_EXTENSIONS,
+        DynamicSamplingInnerName.EVENT_LOCALHOST,
+        DynamicSamplingInnerName.EVENT_LEGACY_BROWSER,
+        DynamicSamplingInnerName.EVENT_WEB_CRAWLERS,
+        DynamicSamplingInnerName.EVENT_IP_ADDRESSES,
+        DynamicSamplingInnerName.EVENT_CSP,
+        DynamicSamplingInnerName.EVENT_ERROR_MESSAGES,
+        DynamicSamplingInnerName.EVENT_TRANSACTION,
+        DynamicSamplingInnerName.EVENT_OS_NAME,
+        DynamicSamplingInnerName.EVENT_OS_VERSION,
+        DynamicSamplingInnerName.EVENT_DEVICE_FAMILY,
+        DynamicSamplingInnerName.EVENT_DEVICE_NAME,
+      ]
+        .sort((a, b) => getInnerNameLabel(a).localeCompare(getInnerNameLabel(b)))
+        .map(innerName => [innerName, getInnerNameLabel(innerName)])}
       rule={rule}
       onSubmit={handleSubmit}
     />

--- a/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
@@ -19,7 +19,7 @@ import {
 } from 'sentry/types/dynamicSampling';
 import {defined} from 'sentry/utils';
 
-import {DYNAMIC_SAMPLING_DOC_LINK} from '../utils';
+import {DYNAMIC_SAMPLING_DOC_LINK, getInnerNameLabel} from '../utils';
 
 import RuleModal from './ruleModal';
 import {getNewCondition} from './utils';
@@ -104,33 +104,35 @@ function TransactionRuleModal({rule, errorRules, transactionRules, ...props}: Pr
         rule ? t('Edit Transaction Sampling Rule') : t('Add Transaction Sampling Rule')
       }
       emptyMessage={t('Apply sampling rate to all transactions')}
-      conditionCategories={
-        tracing
-          ? [
-              [DynamicSamplingInnerName.TRACE_RELEASE, t('Release')],
-              [DynamicSamplingInnerName.TRACE_ENVIRONMENT, t('Environment')],
-              [DynamicSamplingInnerName.TRACE_USER_ID, t('User Id')],
-              [DynamicSamplingInnerName.TRACE_USER_SEGMENT, t('User Segment')],
-              [DynamicSamplingInnerName.TRACE_TRANSACTION, t('Transaction')],
-            ]
-          : [
-              [DynamicSamplingInnerName.EVENT_RELEASE, t('Release')],
-              [DynamicSamplingInnerName.EVENT_ENVIRONMENT, t('Environment')],
-              [DynamicSamplingInnerName.EVENT_USER_ID, t('User Id')],
-              [DynamicSamplingInnerName.EVENT_USER_SEGMENT, t('User Segment')],
-              [
-                DynamicSamplingInnerName.EVENT_BROWSER_EXTENSIONS,
-                t('Browser Extensions'),
-              ],
-              [DynamicSamplingInnerName.EVENT_LOCALHOST, t('Localhost')],
-              [DynamicSamplingInnerName.EVENT_LEGACY_BROWSER, t('Legacy Browser')],
-              [DynamicSamplingInnerName.EVENT_WEB_CRAWLERS, t('Web Crawlers')],
-              [DynamicSamplingInnerName.EVENT_IP_ADDRESSES, t('IP Address')],
-              [DynamicSamplingInnerName.EVENT_CSP, t('Content Security Policy')],
-              [DynamicSamplingInnerName.EVENT_ERROR_MESSAGES, t('Error Message')],
-              [DynamicSamplingInnerName.EVENT_TRANSACTION, t('Transaction')],
-            ]
-      }
+      conditionCategories={(tracing
+        ? [
+            DynamicSamplingInnerName.TRACE_RELEASE,
+            DynamicSamplingInnerName.TRACE_ENVIRONMENT,
+            DynamicSamplingInnerName.TRACE_USER_ID,
+            DynamicSamplingInnerName.TRACE_USER_SEGMENT,
+            DynamicSamplingInnerName.TRACE_TRANSACTION,
+          ]
+        : [
+            DynamicSamplingInnerName.EVENT_RELEASE,
+            DynamicSamplingInnerName.EVENT_ENVIRONMENT,
+            DynamicSamplingInnerName.EVENT_USER_ID,
+            DynamicSamplingInnerName.EVENT_USER_SEGMENT,
+            DynamicSamplingInnerName.EVENT_BROWSER_EXTENSIONS,
+            DynamicSamplingInnerName.EVENT_LOCALHOST,
+            DynamicSamplingInnerName.EVENT_LEGACY_BROWSER,
+            DynamicSamplingInnerName.EVENT_WEB_CRAWLERS,
+            DynamicSamplingInnerName.EVENT_IP_ADDRESSES,
+            DynamicSamplingInnerName.EVENT_CSP,
+            DynamicSamplingInnerName.EVENT_ERROR_MESSAGES,
+            DynamicSamplingInnerName.EVENT_TRANSACTION,
+            DynamicSamplingInnerName.EVENT_OS_NAME,
+            DynamicSamplingInnerName.EVENT_OS_VERSION,
+            DynamicSamplingInnerName.EVENT_DEVICE_FAMILY,
+            DynamicSamplingInnerName.EVENT_DEVICE_NAME,
+          ]
+      )
+        .sort((a, b) => getInnerNameLabel(a).localeCompare(getInnerNameLabel(b)))
+        .map(innerName => [innerName, getInnerNameLabel(innerName)])}
       rule={rule}
       onSubmit={handleSubmit}
       onChange={handleChange}

--- a/static/app/views/settings/project/filtersAndSampling/modal/utils.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/utils.tsx
@@ -69,7 +69,15 @@ export function getMatchFieldPlaceholder(category: DynamicSamplingInnerName) {
       return t('ex. TypeError* (Multiline)');
     case DynamicSamplingInnerName.TRACE_TRANSACTION:
     case DynamicSamplingInnerName.EVENT_TRANSACTION:
-      return t('ex. "page-load"');
+      return t('ex. page-load');
+    case DynamicSamplingInnerName.EVENT_OS_NAME:
+      return t('ex. Mac OS X, Windows');
+    case DynamicSamplingInnerName.EVENT_OS_VERSION:
+      return t('ex. 11, 9*');
+    case DynamicSamplingInnerName.EVENT_DEVICE_FAMILY:
+      return t('ex. Mac, Pixel*');
+    case DynamicSamplingInnerName.EVENT_DEVICE_NAME:
+      return t('ex. Mac, Pixel*');
     default:
       Sentry.captureException(new Error('Unknown dynamic sampling condition inner name'));
       return ''; // this shall never happen
@@ -123,7 +131,11 @@ export function getNewCondition(
     condition.category === DynamicSamplingInnerName.EVENT_RELEASE ||
     condition.category === DynamicSamplingInnerName.TRACE_RELEASE ||
     condition.category === DynamicSamplingInnerName.EVENT_TRANSACTION ||
-    condition.category === DynamicSamplingInnerName.TRACE_TRANSACTION
+    condition.category === DynamicSamplingInnerName.TRACE_TRANSACTION ||
+    condition.category === DynamicSamplingInnerName.EVENT_OS_NAME ||
+    condition.category === DynamicSamplingInnerName.EVENT_OS_VERSION ||
+    condition.category === DynamicSamplingInnerName.EVENT_DEVICE_FAMILY ||
+    condition.category === DynamicSamplingInnerName.EVENT_DEVICE_NAME
   ) {
     return {
       op: DynamicSamplingInnerOperator.GLOB_MATCH,

--- a/static/app/views/settings/project/filtersAndSampling/utils.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/utils.tsx
@@ -73,9 +73,18 @@ export function getInnerNameLabel(name: DynamicSamplingInnerName) {
       return t('Content Security Policy');
     case DynamicSamplingInnerName.EVENT_IP_ADDRESSES:
       return t('IP Address');
+    case DynamicSamplingInnerName.EVENT_OS_NAME:
+      return t('OS Name');
+    case DynamicSamplingInnerName.EVENT_OS_VERSION:
+      return t('OS Version');
+    case DynamicSamplingInnerName.EVENT_DEVICE_FAMILY:
+      return t('Device Family');
+    case DynamicSamplingInnerName.EVENT_DEVICE_NAME:
+      return t('Device Name');
+
     default: {
       Sentry.captureException(new Error('Unknown dynamic sampling condition inner name'));
-      return null; // this shall never happen
+      return ''; // this shall never happen
     }
   }
 }


### PR DESCRIPTION
This PR adds 4 new categories to the dynamic sampling conditions:
- os name
- os version
- device family
- device name

OS version will require a follow-up on the backend side of things to work properly.

https://user-images.githubusercontent.com/9060071/166718917-7b1188d6-f189-464c-80c1-a4fba9704f6e.mp4

