### PR TITLE
feat(profiling): add invert and natural zoom options

### DIFF
--- a/static/app/components/profiling/flamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsMenu.tsx
@@ -15,7 +15,7 @@ interface FlamegraphOptionsMenuProps {
 function FlamegraphOptionsMenu({
   canvasPoolManager,
 }: FlamegraphOptionsMenuProps): React.ReactElement {
-  const [{colorCoding, xAxis, interactionMode}, dispatch] = useFlamegraphPreferences();
+  const [{colorCoding, xAxis, scroll}, dispatch] = useFlamegraphPreferences();
 
   return (
     <Fragment>
@@ -59,16 +59,16 @@ function FlamegraphOptionsMenu({
               }),
           },
           {
-            label: t('Interaction mode'),
-            value: 'interaction',
-            defaultValue: interactionMode,
+            label: t('Scroll'),
+            value: 'scroll',
+            defaultValue: scroll,
             options: Object.entries(INTERACTION_MODES).map(([value, label]) => ({
               label,
               value,
             })),
             onChange: value =>
               dispatch({
-                type: 'set interaction mode',
+                type: 'set scroll',
                 payload: value,
               }),
           },
@@ -83,7 +83,7 @@ const X_AXIS: Record<FlamegraphPreferences['xAxis'], string> = {
   transaction: t('Transaction'),
 };
 
-const INTERACTION_MODES: Record<FlamegraphPreferences['interactionMode'], string> = {
+const INTERACTION_MODES: Record<FlamegraphPreferences['scroll'], string> = {
   inverted: t('Inverted'),
   natural: t('Natural'),
 };

--- a/static/app/components/profiling/flamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsMenu.tsx
@@ -15,7 +15,7 @@ interface FlamegraphOptionsMenuProps {
 function FlamegraphOptionsMenu({
   canvasPoolManager,
 }: FlamegraphOptionsMenuProps): React.ReactElement {
-  const [{colorCoding, xAxis}, dispatch] = useFlamegraphPreferences();
+  const [{colorCoding, xAxis, interactionMode}, dispatch] = useFlamegraphPreferences();
 
   return (
     <Fragment>
@@ -58,6 +58,20 @@ function FlamegraphOptionsMenu({
                 payload: value,
               }),
           },
+          {
+            label: t('Interaction mode'),
+            value: 'interaction',
+            defaultValue: interactionMode,
+            options: Object.entries(INTERACTION_MODES).map(([value, label]) => ({
+              label,
+              value,
+            })),
+            onChange: value =>
+              dispatch({
+                type: 'set interaction mode',
+                payload: value,
+              }),
+          },
         ]}
       />
     </Fragment>
@@ -67,6 +81,11 @@ function FlamegraphOptionsMenu({
 const X_AXIS: Record<FlamegraphPreferences['xAxis'], string> = {
   standalone: t('Standalone'),
   transaction: t('Transaction'),
+};
+
+const INTERACTION_MODES: Record<FlamegraphPreferences['interactionMode'], string> = {
+  inverted: t('Inverted'),
+  natural: t('Natural'),
 };
 
 const COLOR_CODINGS: Record<FlamegraphPreferences['colorCoding'], string> = {

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -548,8 +548,7 @@ function FlamegraphZoomView({
       const identity = mat3.identity(mat3.create());
       const damping = 0.01;
       // For inverted views, invert the delta by multiplying it with -1
-      const delta =
-        evt.deltaY * (flamegraphPreferences.interactionMode === 'inverted' ? -1 : 1);
+      const delta = evt.deltaY * (flamegraphPreferences.scroll === 'inverted' ? -1 : 1);
       const scale = 1 + delta * damping;
 
       const mouseInConfigSpace = flamegraphRenderer.getConfigSpaceCursor(
@@ -573,7 +572,7 @@ function FlamegraphZoomView({
 
       canvasPoolManager.dispatch('transformConfigView', [translatedBack]);
     },
-    [flamegraphRenderer, flamegraphPreferences.interactionMode, canvasPoolManager]
+    [flamegraphRenderer, flamegraphPreferences.scroll, canvasPoolManager]
   );
 
   const scroll = useCallback(
@@ -582,7 +581,7 @@ function FlamegraphZoomView({
         return;
       }
 
-      const multiplier = flamegraphPreferences.interactionMode === 'inverted' ? -1 : 1;
+      const multiplier = flamegraphPreferences.scroll === 'inverted' ? -1 : 1;
       const physicalDelta = vec2.multiply(
         vec2.create(),
         vec2.fromValues(evt.deltaX, evt.deltaY),
@@ -609,7 +608,7 @@ function FlamegraphZoomView({
       const translate = mat3.fromTranslation(mat3.create(), configDelta);
       canvasPoolManager.dispatch('transformConfigView', [translate]);
     },
-    [flamegraphRenderer, flamegraphPreferences.interactionMode, canvasPoolManager]
+    [flamegraphRenderer, flamegraphPreferences.scroll, canvasPoolManager]
   );
 
   useEffect(() => {

--- a/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
@@ -346,7 +346,7 @@ function FlamegraphZoomViewMinimap({
         return;
       }
 
-      const multiplier = flamegraphPreferences.interactionMode === 'inverted' ? -1 : 1;
+      const multiplier = flamegraphPreferences.scroll === 'inverted' ? -1 : 1;
       const physicalDelta = vec2.multiply(
         vec2.create(),
         vec2.fromValues(evt.deltaX, evt.deltaY),
@@ -374,7 +374,7 @@ function FlamegraphZoomViewMinimap({
       const translate = mat3.fromTranslation(mat3.create(), configDelta);
       canvasPoolManager.dispatch('transformConfigView', [translate]);
     },
-    [flamegraphMiniMapRenderer, flamegraphPreferences.interactionMode, canvasPoolManager]
+    [flamegraphMiniMapRenderer, flamegraphPreferences.scroll, canvasPoolManager]
   );
 
   const onMinimapZoom = useCallback(
@@ -386,8 +386,7 @@ function FlamegraphZoomViewMinimap({
       const identity = mat3.identity(mat3.create());
       const damping = 0.01;
       // For inverted views, invert the delta by multiplying it with -1
-      const delta =
-        evt.deltaY * (flamegraphPreferences.interactionMode === 'inverted' ? -1 : 1);
+      const delta = evt.deltaY * (flamegraphPreferences.scroll === 'inverted' ? -1 : 1);
       const scale = 1 + delta * damping;
 
       const mouseInConfigSpace = flamegraphMiniMapRenderer.getConfigSpaceCursor(
@@ -412,7 +411,7 @@ function FlamegraphZoomViewMinimap({
 
       canvasPoolManager.dispatch('transformConfigView', [translatedBack]);
     },
-    [flamegraphMiniMapRenderer, flamegraphPreferences.interactionMode, canvasPoolManager]
+    [flamegraphMiniMapRenderer, flamegraphPreferences.scroll, canvasPoolManager]
   );
 
   const onMinimapCanvasMouseDown = useCallback(

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
@@ -8,11 +8,11 @@ export type FlamegraphColorCodings = [
 export type FlamegraphSorting = ['left heavy', 'call order'];
 export type FlamegraphViewOptions = ['top down', 'bottom up'];
 export type FlamegraphAxisOptions = ['standalone', 'transaction'];
-export type FlamegraphInteractionMode = ['inverted', 'natural'];
+export type FlamegraphScroll = ['inverted', 'natural'];
 
 export interface FlamegraphPreferences {
   colorCoding: FlamegraphColorCodings[number];
-  interactionMode: FlamegraphInteractionMode[number];
+  scroll: FlamegraphScroll[number];
   sorting: FlamegraphSorting[number];
   view: FlamegraphViewOptions[number];
   xAxis: FlamegraphAxisOptions[number];
@@ -26,7 +26,7 @@ type FlamegraphPreferencesAction =
       payload: FlamegraphPreferences['xAxis'];
       type: 'set xAxis';
     }
-  | {payload: FlamegraphPreferences['interactionMode']; type: 'set interaction mode'};
+  | {payload: FlamegraphPreferences['scroll']; type: 'set scroll'};
 
 export function flamegraphPreferencesReducer(
   state: FlamegraphPreferences,
@@ -54,8 +54,8 @@ export function flamegraphPreferencesReducer(
     case 'set xAxis': {
       return {...state, xAxis: action.payload};
     }
-    case 'set interaction mode': {
-      return {...state, interactionMode: action.payload};
+    case 'set scroll': {
+      return {...state, scroll: action.payload};
     }
     default: {
       return state;

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
@@ -8,9 +8,11 @@ export type FlamegraphColorCodings = [
 export type FlamegraphSorting = ['left heavy', 'call order'];
 export type FlamegraphViewOptions = ['top down', 'bottom up'];
 export type FlamegraphAxisOptions = ['standalone', 'transaction'];
+export type FlamegraphInteractionMode = ['inverted', 'natural'];
 
 export interface FlamegraphPreferences {
   colorCoding: FlamegraphColorCodings[number];
+  interactionMode: FlamegraphInteractionMode[number];
   sorting: FlamegraphSorting[number];
   view: FlamegraphViewOptions[number];
   xAxis: FlamegraphAxisOptions[number];
@@ -23,7 +25,8 @@ type FlamegraphPreferencesAction =
   | {
       payload: FlamegraphPreferences['xAxis'];
       type: 'set xAxis';
-    };
+    }
+  | {payload: FlamegraphPreferences['interactionMode']; type: 'set interaction mode'};
 
 export function flamegraphPreferencesReducer(
   state: FlamegraphPreferences,
@@ -50,6 +53,9 @@ export function flamegraphPreferencesReducer(
     }
     case 'set xAxis': {
       return {...state, xAxis: action.payload};
+    }
+    case 'set interaction mode': {
+      return {...state, interactionMode: action.payload};
     }
     default: {
       return state;

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -169,6 +169,7 @@ const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
     view: Rect.Empty(),
   },
   preferences: {
+    interactionMode: 'inverted',
     colorCoding: 'by symbol name',
     sorting: 'call order',
     view: 'top down',
@@ -196,6 +197,9 @@ export function FlamegraphStateProvider(
         DEFAULT_FLAMEGRAPH_STATE.position.view) as Rect,
     },
     preferences: {
+      interactionMode:
+        props.initialState?.preferences?.interactionMode ??
+        DEFAULT_FLAMEGRAPH_STATE.preferences.interactionMode,
       colorCoding:
         props.initialState?.preferences?.colorCoding ??
         DEFAULT_FLAMEGRAPH_STATE.preferences.colorCoding,

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -169,7 +169,7 @@ const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
     view: Rect.Empty(),
   },
   preferences: {
-    interactionMode: 'inverted',
+    scroll: 'inverted',
     colorCoding: 'by symbol name',
     sorting: 'call order',
     view: 'top down',
@@ -197,9 +197,9 @@ export function FlamegraphStateProvider(
         DEFAULT_FLAMEGRAPH_STATE.position.view) as Rect,
     },
     preferences: {
-      interactionMode:
-        props.initialState?.preferences?.interactionMode ??
-        DEFAULT_FLAMEGRAPH_STATE.preferences.interactionMode,
+      scroll:
+        props.initialState?.preferences?.scroll ??
+        DEFAULT_FLAMEGRAPH_STATE.preferences.scroll,
       colorCoding:
         props.initialState?.preferences?.colorCoding ??
         DEFAULT_FLAMEGRAPH_STATE.preferences.colorCoding,


### PR DESCRIPTION
Because some users invert scroll through the scroll direction system option, using the flamechart might be unnecessarily unintuitive and hard to get used to. To better support them, we add a new option that allows them to mimic this behavior.

This is a simplified solution that still requires them to click the preference to get the desired behavior. In an ideal world, this would have been transparent (or we could have at least read this. The proper solution to this have been to listen to a "scroll" event, but that would require a larger overhaul of the way we render the flamegraph as we currently do not allow for any real scrolling.