### PR TITLE
ref(dropdownBubble): Remove menuWithArrow prop

### DIFF
--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -135,11 +135,6 @@ type Props = {
   menuProps?: Parameters<AutoCompleteChildrenArgs['getMenuProps']>[0];
 
   /**
-   * Changes the menu style to have an arrow at the top
-   */
-  menuWithArrow?: boolean;
-
-  /**
    * Minimum menu width, defaults to 250
    */
   minWidth?: number;
@@ -206,7 +201,6 @@ const Menu = ({
   disableLabelPadding = false,
   busy = false,
   busyItemsStillVisible = false,
-  menuWithArrow = false,
   disabled = false,
   subPanel = null,
   itemSize,
@@ -320,7 +314,6 @@ const Menu = ({
               blendCorner={blendCorner}
               detached={detached}
               alignMenu={alignMenu}
-              menuWithArrow={menuWithArrow}
               minWidth={minWidth}
             >
               <DropdownMainContent minWidth={minWidth}>

--- a/static/app/components/dropdownBubble.tsx
+++ b/static/app/components/dropdownBubble.tsx
@@ -22,10 +22,6 @@ type Params = {
    */
   detached?: boolean;
   /**
-   * enable the arrow on the menu
-   */
-  menuWithArrow?: boolean;
-  /**
    * The width of the menu
    */
   width?: string;
@@ -66,40 +62,6 @@ const getMenuBorderRadius = ({
   `;
 };
 
-const getMenuArrow = ({menuWithArrow, alignMenu, theme}: ParamsWithTheme) => {
-  if (!menuWithArrow) {
-    return '';
-  }
-  const alignRight = alignMenu === 'right';
-
-  return css`
-    top: 32px;
-
-    &::before,
-    &::after {
-      content: '';
-      position: absolute;
-      display: block;
-      width: 0;
-      height: 0;
-      border: 8px solid transparent;
-      top: -16px;
-      left: 10px;
-      z-index: -2;
-      ${alignRight && 'left: auto;'};
-      ${alignRight && 'right: 11px;'};
-    }
-
-    &::before {
-      border-bottom-color: ${theme.border};
-      transform: translateY(-1px);
-    }
-    &:after {
-      border-bottom-color: ${theme.background};
-    }
-  `;
-};
-
 const DropdownBubble = styled('div')<Params>`
   background: ${p => p.theme.background};
   color: ${p => p.theme.textColor};
@@ -123,7 +85,6 @@ const DropdownBubble = styled('div')<Params>`
   `};
 
   ${getMenuBorderRadius};
-  ${getMenuArrow};
 
   /* This is needed to be able to cover e.g. pagination buttons, but also be
    * below dropdown actor button's zindex */


### PR DESCRIPTION
It's not being used anywhere. We're also moving toward arrow-less dropdown menus in our design system.