### PR TITLE
feat(superuser): Local Dev settings for superuser access

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -117,7 +117,7 @@ class AuthIndexEndpoint(Endpoint):
 
         if _require_password_or_u2f_check():
             authenticated = self._verify_user_via_inputs(validator, request)
-        breakpoint()
+
         if Superuser.org_id:
             if (
                 not has_completed_sso(request, Superuser.org_id)

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib.auth import logout
 from django.contrib.auth.models import AnonymousUser
 from django.utils.http import is_safe_url
@@ -94,6 +95,11 @@ class AuthIndexEndpoint(Endpoint):
         SSO and if they do not, we redirect them back to the SSO login.
 
         """
+
+        DISABLE_SSO_CHECK_SU_FORM_FOR_LOCAL_DEV = getattr(
+            settings, "DISABLE_SSO_CHECK_SU_FORM_FOR_LOCAL_DEV", False
+        )
+
         # TODO Look at AuthVerifyValidator
         validator.is_valid()
         authenticated = None
@@ -111,9 +117,12 @@ class AuthIndexEndpoint(Endpoint):
 
         if _require_password_or_u2f_check():
             authenticated = self._verify_user_via_inputs(validator, request)
-
+        breakpoint()
         if Superuser.org_id:
-            if not has_completed_sso(request, Superuser.org_id):
+            if (
+                not has_completed_sso(request, Superuser.org_id)
+                and not DISABLE_SSO_CHECK_SU_FORM_FOR_LOCAL_DEV
+            ):
                 self._reauthenticate_with_sso(request, Superuser.org_id)
             # below is a special case if the user is a superuser but doesn't have a password or
             # u2f device set up, the only way to authenticate this case is to see if they have a

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -61,6 +61,8 @@ SUPERUSER_ACCESS_CATEGORIES = getattr(settings, "SUPERUSER_ACCESS_CATEGORIES", [
 
 UNSET = object()
 
+ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV = getattr(settings, "ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV", False)
+
 
 def is_active_superuser(request):
     if is_system_auth(getattr(request, "auth", None)):
@@ -116,7 +118,7 @@ class Superuser:
 
     @staticmethod
     def _needs_validation():
-        if is_self_hosted():
+        if is_self_hosted() or ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV:
             return False
         return settings.VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON
 

--- a/src/sentry/receivers/superuser.py
+++ b/src/sentry/receivers/superuser.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 
 from sentry.utils.settings import is_self_hosted
@@ -6,7 +7,10 @@ from sentry.utils.settings import is_self_hosted
 # Upon login, we automatically want to enable superuser
 # status
 def enable_superuser(request, user, **kwargs):
-    if is_self_hosted():
+    ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV = getattr(
+        settings, "ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV", False
+    )
+    if is_self_hosted() or ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV:
         su = getattr(request, "superuser", None)
         if su:
             if user.is_superuser:


### PR DESCRIPTION
Devs couldn't get superuser access on local dev as some don't have SSO setup locally. The solution was to add settings to disabled validation of superuser access form and enabled superuser session upon login for local dev