### PR TITLE
ref: replace exam.mock with stdlib unittest.mock

### DIFF
--- a/tests/acceptance/test_organization_integration_detail_view.py
+++ b/tests/acceptance/test_organization_integration_detail_view.py
@@ -1,4 +1,4 @@
-from exam import mock
+from unittest import mock
 
 from sentry.models import Integration
 from sentry.testutils import AcceptanceTestCase

--- a/tests/acceptance/test_organization_sentry_app.py
+++ b/tests/acceptance/test_organization_sentry_app.py
@@ -1,4 +1,4 @@
-from exam import mock
+from unittest import mock
 
 from sentry.testutils import AcceptanceTestCase
 

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -3,7 +3,6 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
-from exam import mock
 
 from sentry.integrations.vsts import VstsIntegration, VstsIntegrationProvider
 from sentry.models import (
@@ -450,7 +449,7 @@ class VstsIntegrationTest(VstsIntegrationTestCase):
         integration = Integration.objects.get(provider="vsts")
         installation = integration.get_installation(self.organization.id)
 
-        group_note = mock.Mock()
+        group_note = Mock()
         comment = "hello world\nThis is a comment.\n\n\n    I've changed it"
         group_note.data = {"text": comment, "external_id": "123"}
 


### PR DESCRIPTION
[`exam`](https://pypi.org/p/exam) appears to be abandonware -- `exam.mock` is a thin wrapper around `unittest.mock` which provides some extra methods (that we don't use) so this is a drop in replacement