### PR TITLE
fix(slack): Invalid Team

### DIFF
--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -124,7 +124,7 @@ class SlackRequest:
         try:
             idp = IdentityProvider.objects.get(type="slack", external_id=self.team_id)
         except IdentityProvider.DoesNotExist as e:
-            logger.error("slack.action.invalid-team-id", extra={"slack_team": self.team_id})
+            logger.info("slack.action.invalid-team-id", extra={"slack_team": self.team_id})
             raise e
 
         try:
@@ -172,7 +172,7 @@ class SlackRequest:
         try:
             self._integration = Integration.objects.get(provider="slack", external_id=self.team_id)
         except Integration.DoesNotExist:
-            self._error("slack.action.invalid-team-id")
+            self._info("slack.action.invalid-team-id")
             raise SlackRequestError(status=status_.HTTP_403_FORBIDDEN)
 
     def _log_request(self) -> None:

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -117,9 +117,7 @@ class SlackLinkTeamView(BaseView):  # type: ignore
         try:
             idp = IdentityProvider.objects.get(type="slack", external_id=integration.external_id)
         except IdentityProvider.DoesNotExist:
-            logger.error(
-                "slack.action.invalid-team-id", extra={"slack_id": integration.external_id}
-            )
+            logger.info("slack.action.invalid-team-id", extra={"slack_id": integration.external_id})
             return render_error_page(request, body_text="HTTP 403: Invalid team ID")
 
         if not Identity.objects.filter(idp=idp, external_id=params["slack_id"]).exists():


### PR DESCRIPTION
When a Slack integration is deleted on Sentry's side without removing the bot from the user's workspace, we get events that we cannot route. This PR silences these errors since we're already returning a 403 to Slack.

Fixes [SENTRY-P2Q](https://sentry.io/organizations/sentry/issues/2277287298/).