### PR TITLE
ref: trim overly broad DeprecationWarning filters intended for escape sequences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,15 +34,6 @@ filterwarnings = [
 
     "ignore::django.utils.deprecation.RemovedInDjango30Warning",
 
-    # DeprecationWarnings from Python 3.6's sre_parse are just so painful,
-    # and I haven't found a way to ignore it specifically from a module.
-    # This one in particular is from the "cookies" packages as depended
-    # on by an outdated version of responses, and shows up all over tests.
-    # TODO(joshuarli): Upgrade responses, then revisit this.
-    #                  It'll probably show up in other dependencies.
-    "ignore::DeprecationWarning",
-    "error:Using or importing the ABCs from 'collections':DeprecationWarning",
-
     # At writing, the Google Bigtable Emulator relies on deprecated behavior
     # internally, this can be removed once a version containing this fix is
     # released: https://github.com/googleapis/python-bigtable/pull/246

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1983,7 +1983,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         )
 
     def test_run_query_with_hour_interval(self):
-        # See comment on resolve_time_column for explaination of this test
+        # See comment on resolve_time_column for explanation of this test
         self.start = datetime.datetime.now(timezone.utc).replace(
             hour=15, minute=30, second=0, microsecond=0
         )


### PR DESCRIPTION
I've fixed our current set of DeprecationWarnings in:
- https://github.com/getsentry/sentry/pull/34425
- https://github.com/getsentry/sentry/pull/34424
- https://github.com/getsentry/sentry/pull/34375
- https://github.com/getsentry/sentry/pull/34374
- https://github.com/getsentry/sentry/pull/34371
- https://github.com/getsentry/sentry/pull/34370
- https://github.com/getsentry/sentry/pull/34369
- https://github.com/getsentry/sentry/pull/34367
- https://github.com/getsentry/sentry/pull/34337
- https://github.com/getsentry/sentry/pull/34325
- https://github.com/getsentry/sentry/pull/34323
- https://github.com/getsentry/sentry/pull/34279
- https://github.com/getsentry/sentry/pull/34278
- https://github.com/getsentry/sentry/pull/34277
- https://github.com/getsentry/sentry/pull/34244
