### PR TITLE
feat(kvstore): add range read functionality to bigtable backend

### DIFF
--- a/tests/sentry/utils/kvstore/test_bigtable.py
+++ b/tests/sentry/utils/kvstore/test_bigtable.py
@@ -95,3 +95,13 @@ def test_compression_compatibility(request, store_factory) -> None:
 
         for reader in stores.values():
             assert reader.get(key) == value
+
+
+def test_get_range_read(store_factory) -> None:
+    store = store_factory(None)
+
+    store.set("abbb", b"test")
+    store.set("accc", b"test2")
+    store.set("zzzz", b"test3")
+
+    assert list(store.get_many_range_read("a")) == [("abbb", b"test"), ("accc", b"test2")]


### PR DESCRIPTION
For session replays, we'll be taking advantage of bigtable's range read functionality, this PR adds a new function `get_many_range_read` to our BigTableKVStore. 

I chose to add a new function instead of combining with `get_many` as I didn't want to interfere with the signature/use of the other KVStores.

The overall greater spec is here, we'll next be creating our own storage backend interface `ReplayStore`, which will use this new function. 

https://www.notion.so/sentry/Session-Replay-V1-alpha-Ingest-Backend-ae068d1e1d514221b6c3ea2233f360f4