### PR TITLE
perf(ui): Refactor AutoComplete for render performance

### DIFF
--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -55,7 +55,6 @@ type GetItemArgs<T> = {
   index: number;
   item: T;
   onClick?: (item: T) => (e: React.MouseEvent) => void;
-  style?: React.CSSProperties;
 };
 
 type ChildrenProps<T> = Parameters<DropdownMenu['props']['children']>[0] & {
@@ -70,7 +69,6 @@ type ChildrenProps<T> = Parameters<DropdownMenu['props']['children']>[0] & {
    */
   getItemProps: (args: GetItemArgs<T>) => {
     onClick: (e: React.MouseEvent) => void;
-    style?: React.CSSProperties;
   };
   /**
    * The actively highlighted item index
@@ -80,6 +78,25 @@ type ChildrenProps<T> = Parameters<DropdownMenu['props']['children']>[0] & {
    * The current value of the input box
    */
   inputValue: string;
+  /**
+   * Registers the total number of items in the dropdown menu.
+   *
+   * This must be called for keyboard navigation to work.
+   */
+  registerItemCount: (count?: number) => void;
+  /**
+   * Registers an item as being visible in the autocomplete menu. Returns an
+   * cleanup function that unregisters the item as visible.
+   *
+   * This is needed for managing keyboard navigation when using react virtualized.
+   *
+   * NOTE: Even when NOT using a virtualized list, this must still be called for
+   * keyboard navigation to work!
+   */
+  registerVisibleItem: (index: number, item: T) => () => void;
+  /**
+   * The current selected item
+   */
   selectedItem?: T;
 };
 
@@ -132,18 +149,12 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
     };
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps, nextState) {
+  componentDidUpdate(_prevProps: Props<T>, prevState: State<T>) {
     // If we do NOT want to close on select, then we should not reset highlight state
     // when we select an item (when we select an item, `this.state.selectedItem` changes)
-    if (!nextProps.closeOnSelect && this.state.selectedItem !== nextState.selectedItem) {
-      return;
+    if (this.props.closeOnSelect && this.state.selectedItem !== prevState.selectedItem) {
+      this.resetHighlightState();
     }
-
-    this.resetHighlightState();
-  }
-
-  UNSAFE_componentWillUpdate() {
-    this.items.clear();
   }
 
   componentWillUnmount() {
@@ -246,15 +257,13 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
     onKeyDown: GetInputArgs<E>['onKeyDown']
   ) {
     return (e: React.KeyboardEvent<E>) => {
-      const hasHighlightedItem = this.items.has(this.state.highlightedIndex);
+      const item = this.items.get(this.state.highlightedIndex);
 
       const isEnter = this.props.shouldSelectWithEnter && e.key === 'Enter';
       const isTab = this.props.shouldSelectWithTab && e.key === 'Tab';
 
-      if (hasHighlightedItem && (isEnter || isTab)) {
-        const item = this.items.get(this.state.highlightedIndex);
-
-        if (item && !item.disabled) {
+      if (item !== undefined && (isEnter || isTab)) {
+        if (!item.disabled) {
           this.handleSelect(item, e);
         }
 
@@ -399,32 +408,24 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
   }
 
   getItemProps = (itemProps: GetItemArgs<T>) => {
-    const {item, index, ...props} = itemProps ?? {};
-
-    if (!item) {
-      // eslint-disable-next-line no-console
-      console.warn('getItemProps requires an object with an `item` key');
-    }
-
-    const newIndex = index ?? this.items.size;
-    this.items.set(newIndex, item);
+    const {item, index: _index, ...props} = itemProps ?? {};
 
     return {
       ...props,
       'data-test-id': item['data-test-id'],
-      onClick: this.makeHandleItemClick({item, index: newIndex, ...props}),
-      onMouseEnter: this.makeHandleMouseEnter({item, index: newIndex, ...props}),
+      onClick: this.makeHandleItemClick(itemProps),
+      onMouseEnter: this.makeHandleMouseEnter(itemProps),
     };
   };
 
-  getMenuProps<E extends Element>(props?: GetMenuArgs<E>): GetMenuArgs<E> {
-    this.itemCount = props?.itemCount;
+  registerVisibleItem = (index: number, item: T) => {
+    this.items.set(index, item);
+    return () => this.items.delete(index);
+  };
 
-    return {
-      ...(props ?? {}),
-      onMouseDown: this.handleMenuMouseDown,
-    };
-  }
+  registerItemCount = (count?: number) => {
+    this.itemCount = count;
+  };
 
   render() {
     const {children, onMenuOpen, inputIsActor} = this.props;
@@ -441,7 +442,10 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
           children({
             ...dropdownMenuProps,
             getMenuProps: <E extends Element = Element>(props?: GetMenuArgs<E>) =>
-              dropdownMenuProps.getMenuProps(this.getMenuProps(props)),
+              dropdownMenuProps.getMenuProps({
+                ...props,
+                onMouseDown: this.handleMenuMouseDown,
+              }),
             getInputProps: <E extends HTMLInputElement = HTMLInputElement>(
               props?: GetInputArgs<E>
             ): GetInputOutput<E> => {
@@ -453,6 +457,8 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
             },
 
             getItemProps: this.getItemProps,
+            registerVisibleItem: this.registerVisibleItem,
+            registerItemCount: this.registerItemCount,
             inputValue,
             selectedItem,
             highlightedIndex,

--- a/static/app/components/dropdownAutoComplete/index.tsx
+++ b/static/app/components/dropdownAutoComplete/index.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import styled from '@emotion/styled';
 
 import Menu from './menu';

--- a/static/app/components/dropdownAutoComplete/list.tsx
+++ b/static/app/components/dropdownAutoComplete/list.tsx
@@ -1,16 +1,22 @@
-import * as React from 'react';
-import {AutoSizer, List as ReactVirtualizedList, ListRowProps} from 'react-virtualized';
+import {Fragment} from 'react';
+import {AutoSizer, List as ReactVirtualizedList} from 'react-virtualized';
 
 import Row from './row';
 import {ItemsAfterFilter} from './types';
 
 type RowProps = Pick<
   React.ComponentProps<typeof Row>,
-  'itemSize' | 'highlightedIndex' | 'inputValue' | 'getItemProps'
+  'itemSize' | 'inputValue' | 'getItemProps' | 'registerVisibleItem'
 >;
 
 type Props = {
-  // flat item array | grouped item array
+  /**
+   * The item index that is currently isActive
+   */
+  highlightedIndex: number;
+  /**
+   * Flat item array or grouped item array
+   */
   items: ItemsAfterFilter;
   /**
    * Max height of dropdown menu. Units are assumed as `px`
@@ -21,15 +27,17 @@ type Props = {
    */
   onScroll?: () => void;
   /**
-   * Supplying this height will force the dropdown menu to be a virtualized list.
-   * This is very useful (and probably required) if you have a large list. e.g. Project selector with many projects.
+   * Supplying this height will force the dropdown menu to be a virtualized
+   * list. This is very useful (and probably required) if you have a large list.
+   * e.g. Project selector with many projects.
    *
-   * Currently, our implementation of the virtualized list requires a fixed height.
+   * Currently, our implementation of the virtualized list requires a fixed
+   * height.
    */
   virtualizedHeight?: number;
-
   /**
-   * If you use grouping with virtualizedHeight, the labels will be that height unless specified here
+   * If you use grouping with virtualizedHeight, the labels will be that height
+   * unless specified here
    */
   virtualizedLabelHeight?: number;
 } & RowProps;
@@ -54,11 +62,9 @@ const List = ({
   virtualizedLabelHeight,
   onScroll,
   items,
-  itemSize,
   highlightedIndex,
-  inputValue,
-  getItemProps,
   maxHeight,
+  ...rowProps
 }: Props) => {
   if (virtualizedHeight) {
     return (
@@ -80,15 +86,13 @@ const List = ({
                 ? virtualizedLabelHeight
                 : virtualizedHeight
             }
-            rowRenderer={({key, index, style}: ListRowProps) => (
+            rowRenderer={({key, index, style}) => (
               <Row
                 key={key}
-                item={items[index]}
                 style={style}
-                itemSize={itemSize}
-                highlightedIndex={highlightedIndex}
-                inputValue={inputValue}
-                getItemProps={getItemProps}
+                item={items[index]}
+                isActive={items[index].index === highlightedIndex}
+                {...rowProps}
               />
             )}
           />
@@ -98,20 +102,18 @@ const List = ({
   }
 
   return (
-    <React.Fragment>
+    <Fragment>
       {items.map((item, index) => (
         <Row
           // Using only the index of the row might not re-render properly,
           // because the items shift around the list
           key={`${item.value}-${index}`}
           item={item}
-          itemSize={itemSize}
-          highlightedIndex={highlightedIndex}
-          inputValue={inputValue}
-          getItemProps={getItemProps}
+          isActive={item.index === highlightedIndex}
+          {...rowProps}
         />
       ))}
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
+import memoize from 'lodash/memoize';
 
 import AutoComplete from 'sentry/components/autoComplete';
 import DropdownBubble from 'sentry/components/dropdownBubble';
@@ -189,7 +190,7 @@ type Props = {
   'virtualizedHeight' | 'virtualizedLabelHeight' | 'itemSize' | 'onScroll'
 >;
 
-const Menu = ({
+function Menu({
   maxHeight = 300,
   emptyMessage = t('No items'),
   searchPlaceholder = t('Filter search'),
@@ -228,158 +229,173 @@ const Menu = ({
   closeOnSelect,
   'data-test-id': dataTestId,
   ...props
-}: Props) => (
-  <AutoComplete
-    onSelect={onSelect}
-    inputIsActor={false}
-    onOpen={onOpen}
-    onClose={onClose}
-    disabled={disabled}
-    closeOnSelect={closeOnSelect}
-    resetInputOnClose
-    {...props}
-  >
-    {({
-      getActorProps,
-      getRootProps,
-      getInputProps,
-      getMenuProps,
-      getItemProps,
-      inputValue,
-      selectedItem,
-      highlightedIndex,
-      isOpen,
-      actions,
-    }) => {
-      // This is the value to use to filter (default to value in filter input)
-      const filterValueOrInput = filterValue ?? inputValue;
+}: Props) {
+  // Can't search if there are no items
+  const hasItems = !!items?.length;
 
-      // Can't search if there are no items
-      const hasItems = !!items?.length;
+  // Items are loading if null
+  const itemsLoading = items === null;
 
-      // Only filter results if menu is open and there are items
-      const autoCompleteResults =
-        (isOpen && hasItems && autoCompleteFilter(items, filterValueOrInput)) || [];
+  // Hide the input when we have no items to filter, only if
+  // emptyHidesInput is set to true.
+  const showInput = !hideInput && (hasItems || !emptyHidesInput);
 
-      // Items are loading if null
-      const itemsLoading = items === null;
+  // Only redefine the autocomplete function if our items list has chagned.
+  // This avoids producing a new array on every call.
+  const stableItemFilter = useCallback(
+    (filterValueOrInput: string) => autoCompleteFilter(items, filterValueOrInput),
+    [items]
+  );
 
-      // Has filtered results
-      const hasResults = !!autoCompleteResults.length;
+  // Memoize the filterValueOrInput to the stableItemFilter so that we get the
+  // same list every time when the filter value doesn't change.
+  const getFilteredItems = memoize(stableItemFilter);
 
-      // No items to display
-      const showNoItems = !busy && !filterValueOrInput && !hasItems;
+  return (
+    <AutoComplete
+      onSelect={onSelect}
+      inputIsActor={false}
+      onOpen={onOpen}
+      onClose={onClose}
+      disabled={disabled}
+      closeOnSelect={closeOnSelect}
+      resetInputOnClose
+      {...props}
+    >
+      {({
+        getActorProps,
+        getRootProps,
+        getInputProps,
+        getMenuProps,
+        getItemProps,
+        registerItemCount,
+        registerVisibleItem,
+        inputValue,
+        selectedItem,
+        highlightedIndex,
+        isOpen,
+        actions,
+      }) => {
+        // This is the value to use to filter (default to value in filter input)
+        const filterValueOrInput = filterValue ?? inputValue;
 
-      // Results mean there was an attempt to search
-      const showNoResultsMessage =
-        !busy && !busyItemsStillVisible && filterValueOrInput && !hasResults;
+        // Only filter results if menu is open and there are items. Uses
+        // `getFilteredItems` to ensure we get a stable items list back.
+        const autoCompleteResults =
+          isOpen && hasItems ? getFilteredItems(filterValueOrInput) : [];
 
-      // Hide the input when we have no items to filter, only if
-      // emptyHidesInput is set to true.
-      const showInput = !hideInput && (hasItems || !emptyHidesInput);
+        // Has filtered results
+        const hasResults = !!autoCompleteResults.length;
 
-      // When virtualization is turned on, we need to pass in the number of
-      // selecteable items for arrow-key limits
-      const itemCount = virtualizedHeight
-        ? autoCompleteResults.filter(i => !i.groupLabel).length
-        : undefined;
+        // No items to display
+        const showNoItems = !busy && !filterValueOrInput && !hasItems;
 
-      const renderedFooter =
-        typeof menuFooter === 'function' ? menuFooter({actions}) : menuFooter;
+        // Results mean there was an attempt to search
+        const showNoResultsMessage =
+          !busy && !busyItemsStillVisible && filterValueOrInput && !hasResults;
 
-      return (
-        <AutoCompleteRoot
-          {...getRootProps()}
-          className={rootClassName}
-          disabled={disabled}
-          data-is-open={isOpen}
-          data-test-id={dataTestId}
-        >
-          {children({
-            getInputProps,
-            getActorProps,
-            actions,
-            isOpen,
-            selectedItem,
-          })}
-          {isOpen && (
-            <StyledDropdownBubble
-              className={className}
-              {...getMenuProps({
-                ...menuProps,
-                itemCount,
-              })}
-              style={style}
-              css={css}
-              blendCorner={blendCorner}
-              detached={detached}
-              alignMenu={alignMenu}
-              minWidth={minWidth}
-            >
-              <DropdownMainContent minWidth={minWidth}>
-                {itemsLoading && <LoadingIndicator mini />}
-                {showInput && (
-                  <InputWrapper>
-                    <StyledInput
-                      autoFocus
-                      placeholder={searchPlaceholder}
-                      {...getInputProps({...inputProps, onChange})}
-                    />
-                    <InputLoadingWrapper>
-                      {(busy || busyItemsStillVisible) && (
-                        <LoadingIndicator size={16} mini />
-                      )}
-                    </InputLoadingWrapper>
-                    {inputActions}
-                  </InputWrapper>
-                )}
-                <div>
-                  {menuHeader && (
-                    <LabelWithPadding disableLabelPadding={disableLabelPadding}>
-                      {menuHeader}
-                    </LabelWithPadding>
-                  )}
-                  <ItemList data-test-id="autocomplete-list" maxHeight={maxHeight}>
-                    {showNoItems && <EmptyMessage>{emptyMessage}</EmptyMessage>}
-                    {showNoResultsMessage && (
-                      <EmptyMessage>
-                        {noResultsMessage ?? `${emptyMessage} ${t('found')}`}
-                      </EmptyMessage>
-                    )}
-                    {busy && (
-                      <BusyMessage>
-                        <EmptyMessage>{t('Searching\u2026')}</EmptyMessage>
-                      </BusyMessage>
-                    )}
-                    {!busy && (
-                      <List
-                        items={autoCompleteResults}
-                        maxHeight={maxHeight}
-                        highlightedIndex={highlightedIndex}
-                        inputValue={inputValue}
-                        onScroll={onScroll}
-                        getItemProps={getItemProps}
-                        virtualizedLabelHeight={virtualizedLabelHeight}
-                        virtualizedHeight={virtualizedHeight}
-                        itemSize={itemSize}
+        // When virtualization is turned on, we need to pass in the number of
+        // selecteable items for arrow-key limits
+        const itemCount = virtualizedHeight
+          ? autoCompleteResults.filter(i => !i.groupLabel).length
+          : undefined;
+
+        const renderedFooter =
+          typeof menuFooter === 'function' ? menuFooter({actions}) : menuFooter;
+
+        // XXX(epurkhiser): Would be better if this happened in a useEffect,
+        // but hooks do not work inside render-prop callbacks.
+        registerItemCount(itemCount);
+
+        return (
+          <AutoCompleteRoot
+            {...getRootProps()}
+            className={rootClassName}
+            disabled={disabled}
+            data-is-open={isOpen}
+            data-test-id={dataTestId}
+          >
+            {children({
+              getInputProps,
+              getActorProps,
+              actions,
+              isOpen,
+              selectedItem,
+            })}
+            {isOpen && (
+              <StyledDropdownBubble
+                className={className}
+                {...getMenuProps(menuProps)}
+                {...{style, css, blendCorner, detached, alignMenu, minWidth}}
+              >
+                <DropdownMainContent minWidth={minWidth}>
+                  {itemsLoading && <LoadingIndicator mini />}
+                  {showInput && (
+                    <InputWrapper>
+                      <StyledInput
+                        autoFocus
+                        placeholder={searchPlaceholder}
+                        {...getInputProps({...inputProps, onChange})}
                       />
-                    )}
-                  </ItemList>
-                  {renderedFooter && (
-                    <LabelWithPadding disableLabelPadding={disableLabelPadding}>
-                      {renderedFooter}
-                    </LabelWithPadding>
+                      <InputLoadingWrapper>
+                        {(busy || busyItemsStillVisible) && (
+                          <LoadingIndicator size={16} mini />
+                        )}
+                      </InputLoadingWrapper>
+                      {inputActions}
+                    </InputWrapper>
                   )}
-                </div>
-              </DropdownMainContent>
-              {subPanel}
-            </StyledDropdownBubble>
-          )}
-        </AutoCompleteRoot>
-      );
-    }}
-  </AutoComplete>
-);
+                  <div>
+                    {menuHeader && (
+                      <LabelWithPadding disableLabelPadding={disableLabelPadding}>
+                        {menuHeader}
+                      </LabelWithPadding>
+                    )}
+                    <ItemList data-test-id="autocomplete-list" maxHeight={maxHeight}>
+                      {showNoItems && <EmptyMessage>{emptyMessage}</EmptyMessage>}
+                      {showNoResultsMessage && (
+                        <EmptyMessage>
+                          {noResultsMessage ?? `${emptyMessage} ${t('found')}`}
+                        </EmptyMessage>
+                      )}
+                      {busy && (
+                        <BusyMessage>
+                          <EmptyMessage>{t('Searching\u2026')}</EmptyMessage>
+                        </BusyMessage>
+                      )}
+                      {!busy && (
+                        <List
+                          items={autoCompleteResults}
+                          {...{
+                            maxHeight,
+                            highlightedIndex,
+                            inputValue,
+                            onScroll,
+                            getItemProps,
+                            registerVisibleItem,
+                            virtualizedLabelHeight,
+                            virtualizedHeight,
+                            itemSize,
+                          }}
+                        />
+                      )}
+                    </ItemList>
+                    {renderedFooter && (
+                      <LabelWithPadding disableLabelPadding={disableLabelPadding}>
+                        {renderedFooter}
+                      </LabelWithPadding>
+                    )}
+                  </div>
+                </DropdownMainContent>
+                {subPanel}
+              </StyledDropdownBubble>
+            )}
+          </AutoCompleteRoot>
+        );
+      }}
+    </AutoComplete>
+  );
+}
 
 export default Menu;
 
@@ -418,9 +434,7 @@ const EmptyMessage = styled('div')`
   text-transform: none;
 `;
 
-export const AutoCompleteRoot = styled(({isOpen: _isOpen, ...props}) => (
-  <div {...props} />
-))`
+export const AutoCompleteRoot = styled('div')<{disabled?: boolean}>`
   position: relative;
   display: inline-block;
   ${p => p.disabled && 'pointer-events: none;'}

--- a/static/app/components/dropdownAutoComplete/row.tsx
+++ b/static/app/components/dropdownAutoComplete/row.tsx
@@ -1,3 +1,4 @@
+import {memo, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import AutoComplete from 'sentry/components/autoComplete';
@@ -10,24 +11,40 @@ type AutoCompleteChildrenArgs<T> = Parameters<AutoComplete<T>['props']['children
 
 type Props<T> = Pick<
   AutoCompleteChildrenArgs<T>,
-  'highlightedIndex' | 'getItemProps' | 'inputValue'
+  'getItemProps' | 'registerVisibleItem' | 'inputValue'
 > &
   Omit<Parameters<AutoCompleteChildrenArgs<T>['getItemProps']>[0], 'index'> & {
+    /**
+     * Is the row 'active'
+     */
+    isActive: boolean;
     /**
      * Size for dropdown items
      */
     itemSize?: ItemSize;
+    /**
+     * Style is used by react-virtualized for alignment
+     */
+    style?: React.CSSProperties;
   };
 
 function Row<T extends Item>({
   item,
   style,
   itemSize,
-  highlightedIndex,
+  isActive,
   inputValue,
   getItemProps,
+  registerVisibleItem,
 }: Props<T>) {
   const {index} = item;
+
+  useEffect(() => registerVisibleItem(item.index, item), [registerVisibleItem, item]);
+
+  const itemProps = useMemo(
+    () => getItemProps({item, index}),
+    [getItemProps, item, index]
+  );
 
   if (item.groupLabel) {
     return (
@@ -41,15 +58,20 @@ function Row<T extends Item>({
     <AutoCompleteItem
       itemSize={itemSize}
       disabled={item.disabled}
-      isHighlighted={index === highlightedIndex}
-      {...getItemProps({item, index, style})}
+      isHighlighted={isActive}
+      style={style}
+      {...itemProps}
     >
       {typeof item.label === 'function' ? item.label({inputValue}) : item.label}
     </AutoCompleteItem>
   );
 }
 
-export default Row;
+// XXX(epurkhiser): We memoize the row component since there will be many of
+// them, we do not want them re-rendering every time we change the
+// highlightedIndex in the parent List.
+
+export default memo(Row);
 
 const getItemPaddingForSize = (itemSize?: ItemSize) => {
   if (itemSize === 'small') {
@@ -93,6 +115,7 @@ const AutoCompleteItem = styled('div')<{
   display: flex;
   flex-direction: column;
   justify-content: center;
+  scroll-margin: 20px 0;
 
   font-size: ${p => p.theme.fontSizeMedium};
   background-color: ${p => (p.isHighlighted ? p.theme.hover : 'transparent')};

--- a/static/app/components/dropdownMenu.tsx
+++ b/static/app/components/dropdownMenu.tsx
@@ -17,7 +17,6 @@ export type GetActorArgs<E extends Element> = {
 
 export type GetMenuArgs<E extends Element> = {
   className?: string;
-  itemCount?: number;
   onClick?: (e: React.MouseEvent<E>) => void;
   onKeyDown?: (event: React.KeyboardEvent<E>) => void;
   onMouseDown?: (e: React.MouseEvent<E>) => void;


### PR DESCRIPTION
This components was doing a pretty poor job in terms of react re-renders. There were a few things going on we needed to fix:

Every `Row` item was being re-rendered on keyboard navigation of the autocomplete dropdown. To fix this I've done the following

 - The `Row` no longer recieves the highlightedIndex, it instead is told if it `isActive`, since passing highlightedIndex would always cause it to re-render on prop change

 - The `items` list being produced in the dropdownAutoComplete `Menu` component was not stable, every keyboard navigation (or any other interaction with the autocomplete child) would cause the entire items list to be re-computed, thus causing all item references to be updated.

   I've fixed this by making the call to the filter stable using a combination of `useCallback` and `memoize`.

 - The `Row` component (and `ResultRow` component in Search) are now `memo`'d so that they do not re-render when no props change. The above two changes were required for this to work.

 - The `getItemProps` function is now memoized with useMemo if the item hasn't changed, thus we don't produce new itemProps on every render.

 - The call to `getItemProps` and `getMenuProps` were both quite deceiving. These both had side-effects that would update instance properties of the `AutoComplete` component use to track keyboard navigation.

   Because we're now no longer rendering the item on every interaction (and because getItemProps is memoized), we can no longer count on getItemProps to always be called. So I've added two new props passed into the `children` render function: `registerItemCount` and `registerVisibleItem`. These should be called when the item count is known for the dropdown and when items are rendered.

The biggest performance boost you can see from this is holding the Down key on your keyboard in autocomplete menu lists is now _actually fast_.

Before this change:
![image](https://user-images.githubusercontent.com/1421724/166836420-11410112-01db-4c2b-a60b-508993a5ca56.png)

After this change:
![image](https://user-images.githubusercontent.com/1421724/166836480-65b29d91-b871-4a5a-8891-783203f004d2.png)

This is because only two rows are re-rendered now, instead of _ALL ROWS_.