### PR TITLE
ref(js): Avoid import * as React in simple Components

### DIFF
--- a/static/app/components/acl/access.tsx
+++ b/static/app/components/acl/access.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import Alert from 'sentry/components/alert';
 import {t} from 'sentry/locale';
@@ -71,7 +71,7 @@ type Props = {
 /**
  * Component to handle access restrictions.
  */
-class Access extends React.Component<Props> {
+class Access extends Component<Props> {
   static defaultProps = defaultProps;
 
   render() {

--- a/static/app/components/acl/feature.tsx
+++ b/static/app/components/acl/feature.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import HookStore from 'sentry/stores/hookStore';
 import {Config, Organization, Project} from 'sentry/types';
@@ -102,7 +102,7 @@ type AllFeatures = {
 /**
  * Component to handle feature flags.
  */
-class Feature extends React.Component<Props> {
+class Feature extends Component<Props> {
   static defaultProps = {
     renderDisabled: false,
     requireAll: true,

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -41,7 +41,7 @@ type Props = {
   shouldConfirm?: boolean;
 } & Partial<typeof defaultProps>;
 
-class ResolveActions extends React.Component<Props> {
+class ResolveActions extends Component<Props> {
   static defaultProps = defaultProps;
 
   handleAnotherExistingReleaseResolution(statusDetails: ResolutionStatusDetails) {

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {Mention, MentionsInput, MentionsInputProps} from 'react-mentions';
 import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -52,7 +52,7 @@ type State = {
   value: string;
 };
 
-class NoteInputComponent extends React.Component<Props, State> {
+class NoteInputComponent extends Component<Props, State> {
   state: State = {
     preview: false,
     value: this.props.text || '',
@@ -264,7 +264,7 @@ type MentionablesChildFunc = Parameters<
   React.ComponentProps<typeof Mentionables>['children']
 >[0];
 
-class NoteInputContainer extends React.Component<NoteInputContainerProps> {
+class NoteInputContainer extends Component<NoteInputContainerProps> {
   static defaultProps = defaultProps;
 
   renderInput = ({members, teams}: MentionablesChildFunc) => {

--- a/static/app/components/activity/note/inputWithStorage.tsx
+++ b/static/app/components/activity/note/inputWithStorage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import * as Sentry from '@sentry/react';
 import debounce from 'lodash/debounce';
 
@@ -24,7 +24,7 @@ type Props = {
 } & InputProps &
   typeof defaultProps;
 
-class NoteInputWithStorage extends React.Component<Props> {
+class NoteInputWithStorage extends Component<Props> {
   static defaultProps = defaultProps;
 
   fetchFromStorage() {

--- a/static/app/components/assigneeSelector.tsx
+++ b/static/app/components/assigneeSelector.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {assignToActor, assignToUser, clearAssignment} from 'sentry/actionCreators/group';
@@ -58,7 +58,7 @@ type State = {
   suggestedOwners?: SuggestedOwner[] | null;
 };
 
-class AssigneeSelector extends React.Component<Props, State> {
+class AssigneeSelector extends Component<Props, State> {
   static defaultProps = {
     size: 20,
   };

--- a/static/app/components/asyncComponentSearchInput.tsx
+++ b/static/app/components/asyncComponentSearchInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
@@ -59,7 +59,7 @@ type State = {
  *
  * It probably doesn't make too much sense outside of an AsyncComponent atm.
  */
-class AsyncComponentSearchInput extends React.Component<Props, State> {
+class AsyncComponentSearchInput extends Component<Props, State> {
   static defaultProps: DefaultProps = {
     placeholder: t('Search...'),
     debounceWait: 200,

--- a/static/app/components/avatar/actorAvatar.tsx
+++ b/static/app/components/avatar/actorAvatar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import * as Sentry from '@sentry/react';
 
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
@@ -26,7 +26,7 @@ type Props = DefaultProps & {
   tooltipOptions?: Omit<React.ComponentProps<typeof Tooltip>, 'children' | 'title'>;
 };
 
-class ActorAvatar extends React.Component<Props> {
+class ActorAvatar extends Component<Props> {
   static defaultProps: DefaultProps = {
     size: 24,
     hasTooltip: true,

--- a/static/app/components/avatar/baseAvatar.tsx
+++ b/static/app/components/avatar/baseAvatar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import * as qs from 'query-string';
@@ -111,7 +111,7 @@ type State = {
   showBackupAvatar: boolean;
 };
 
-class BaseAvatar extends React.Component<Props, State> {
+class BaseAvatar extends Component<Props, State> {
   static defaultProps = defaultProps;
 
   constructor(props: Props) {

--- a/static/app/components/avatar/userAvatar.tsx
+++ b/static/app/components/avatar/userAvatar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import BaseAvatar from 'sentry/components/avatar/baseAvatar';
 import {Actor, AvatarUser} from 'sentry/types';
@@ -25,7 +25,7 @@ function isActor(maybe: AvatarUser | Actor): maybe is Actor {
   return typeof (maybe as AvatarUser).email === 'undefined';
 }
 
-class UserAvatar extends React.Component<Props> {
+class UserAvatar extends Component<Props> {
   static defaultProps = defaultProps;
 
   getType = (user: AvatarUser | Actor, gravatar: boolean | undefined) => {

--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -59,7 +59,7 @@ type State = {
   savedDataUrl?: string | null;
 };
 
-class AvatarChooser extends React.Component<Props, State> {
+class AvatarChooser extends Component<Props, State> {
   static defaultProps: DefaultProps = {
     allowGravatar: true,
     allowLetter: true,

--- a/static/app/components/bases/pluginComponentBase.tsx
+++ b/static/app/components/bases/pluginComponentBase.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import isFunction from 'lodash/isFunction';
 
 import {
@@ -24,7 +24,7 @@ type State = {state: GenericFieldProps['formState']};
 class PluginComponentBase<
   P extends Props = Props,
   S extends State = State
-> extends React.Component<P, S> {
+> extends Component<P, S> {
   constructor(props: P, context: any) {
     super(props, context);
 

--- a/static/app/components/bulkController/index.tsx
+++ b/static/app/components/bulkController/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import intersection from 'lodash/intersection';
 import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
@@ -72,7 +72,7 @@ type Props = {
   onChange?: (props: State) => void;
 };
 
-class BulkController extends React.Component<Props, State> {
+class BulkController extends Component<Props, State> {
   state: State = this.getInitialState();
 
   getInitialState() {

--- a/static/app/components/charts/barChartZoom.tsx
+++ b/static/app/components/charts/barChartZoom.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
 
@@ -64,7 +64,7 @@ type Props = {
   onHistoryPush?: (start: number, end: number) => void;
 };
 
-class BarChartZoom extends React.Component<Props> {
+class BarChartZoom extends Component<Props> {
   zooming: (() => void) | null = null;
 
   /**

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {InjectedRouter} from 'react-router';
 import type {
   DataZoomComponentOption,
@@ -79,7 +79,7 @@ type Props = {
  * This also is very tightly coupled with the Global Selection Header. We can make it more
  * generic if need be in the future.
  */
-class ChartZoom extends React.Component<Props> {
+class ChartZoom extends Component<Props> {
   constructor(props: Props) {
     super(props);
 

--- a/static/app/components/charts/percentageAreaChart.tsx
+++ b/static/app/components/charts/percentageAreaChart.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import type {LineSeriesOption} from 'echarts';
 import moment from 'moment';
 
@@ -29,7 +29,7 @@ type Props = Omit<ChartProps, 'series'> &
  *
  * See https://exceljet.net/chart-type/100-stacked-bar-chart
  */
-export default class PercentageAreaChart extends React.Component<Props> {
+export default class PercentageAreaChart extends Component<Props> {
   static defaultProps: DefaultProps = {
     // TODO(billyvg): Move these into BaseChart? or get rid completely
     getDataItemName: ({name}) => name,

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 import {Query} from 'history';
@@ -85,7 +85,7 @@ type State = {
   releases: ReleaseMetaBasic[] | null;
 };
 
-class ReleaseSeries extends React.Component<Props, State> {
+class ReleaseSeries extends Component<Props, State> {
   state: State = {
     releases: null,
     releaseSeries: [],

--- a/static/app/components/charts/sessionsRequest.tsx
+++ b/static/app/components/charts/sessionsRequest.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import isEqual from 'lodash/isEqual';
 import omitBy from 'lodash/omitBy';
 
@@ -42,7 +42,7 @@ type State = {
   response: SessionApiResponse | null;
 };
 
-class SessionsRequest extends React.Component<Props, State> {
+class SessionsRequest extends Component<Props, State> {
   state: State = {
     reloading: false,
     errored: false,

--- a/static/app/components/charts/stackedAreaChart.tsx
+++ b/static/app/components/charts/stackedAreaChart.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import {AreaChart} from 'sentry/components/charts/areaChart';
 
@@ -6,7 +6,7 @@ type AreaChartProps = React.ComponentProps<typeof AreaChart>;
 
 type Props = Omit<AreaChartProps, 'stacked' | 'ref'>;
 
-class StackedAreaChart extends React.Component<Props> {
+class StackedAreaChart extends Component<Props> {
   render() {
     return <AreaChart tooltip={{filter: val => val > 0}} {...this.props} stacked />;
   }

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {components as selectComponents} from 'react-select';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -38,7 +38,7 @@ function VersionOption({
   );
 }
 
-class CustomResolutionModal extends React.Component<Props, State> {
+class CustomResolutionModal extends Component<Props, State> {
   state: State = {
     version: '',
   };

--- a/static/app/components/dashboards/issueWidgetQueriesForm.tsx
+++ b/static/app/components/dashboards/issueWidgetQueriesForm.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -37,7 +37,7 @@ type State = {
  * Contain widget queries interactions and signal changes via the onChange
  * callback. This component's state should live in the parent.
  */
-class IssueWidgetQueriesForm extends React.Component<Props, State> {
+class IssueWidgetQueriesForm extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {

--- a/static/app/components/dashboards/widgetQueriesForm.tsx
+++ b/static/app/components/dashboards/widgetQueriesForm.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -93,7 +93,7 @@ type Props = {
  * Contain widget queries interactions and signal changes via the onChange
  * callback. This component's state should live in the parent.
  */
-class WidgetQueriesForm extends React.Component<Props> {
+class WidgetQueriesForm extends Component<Props> {
   componentWillUnmount() {
     window.clearTimeout(this.blurTimeout);
   }

--- a/static/app/components/deprecatedforms/form.tsx
+++ b/static/app/components/deprecatedforms/form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
@@ -44,7 +44,7 @@ export type Context = FormContextData;
 class Form<
   Props extends FormProps = FormProps,
   State extends FormClassState = FormClassState
-> extends React.Component<Props, State> {
+> extends Component<Props, State> {
   static defaultProps = {
     cancelLabel: t('Cancel'),
     submitLabel: t('Save Changes'),

--- a/static/app/components/errorBoundary.tsx
+++ b/static/app/components/errorBoundary.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -32,7 +32,7 @@ function getExclamation() {
   return exclamation[Math.floor(Math.random() * exclamation.length)];
 }
 
-class ErrorBoundary extends React.Component<Props, State> {
+class ErrorBoundary extends Component<Props, State> {
   static defaultProps: DefaultProps = {
     mini: false,
   };

--- a/static/app/components/errors/detailedError.tsx
+++ b/static/app/components/errors/detailedError.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import * as Sentry from '@sentry/react';
 import classNames from 'classnames';
 
@@ -34,7 +34,7 @@ function openFeedback(e: React.MouseEvent) {
   Sentry.showReportDialog();
 }
 
-class DetailedError extends React.Component<Props> {
+class DetailedError extends Component<Props> {
   static defaultProps: DefaultProps = {
     hideSupportLinks: false,
   };

--- a/static/app/components/events/contexts/redux.tsx
+++ b/static/app/components/events/contexts/redux.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
@@ -12,7 +12,7 @@ type Props = {
   data: Record<string, any>;
 };
 
-class ReduxContextType extends React.Component<Props> {
+class ReduxContextType extends Component<Props> {
   getKnownData(): KeyValueListData {
     return [
       {

--- a/static/app/components/events/contexts/state.tsx
+++ b/static/app/components/events/contexts/state.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import upperFirst from 'lodash/upperFirst';
 
 import ClippedBox from 'sentry/components/clippedBox';
@@ -21,7 +21,7 @@ type Props = {
   };
 };
 
-class StateContextType extends React.Component<Props> {
+class StateContextType extends Component<Props> {
   getStateTitle(name: string, type?: string) {
     return `${name}${type ? ` (${upperFirst(type)})` : ''}`;
   }

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import capitalize from 'lodash/capitalize';
 
@@ -65,7 +65,7 @@ function addFingerprintInfo(data: VariantData, variant: EventGroupVariant) {
   }
 }
 
-class GroupVariant extends React.Component<Props, State> {
+class GroupVariant extends Component<Props, State> {
   state: State = {
     showNonContributing: false,
   };

--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
@@ -49,7 +49,7 @@ type State = {
   searchTerm: string;
 };
 
-class Candidates extends React.Component<Props, State> {
+class Candidates extends Component<Props, State> {
   state: State = {
     searchTerm: '',
     filterOptions: {},

--- a/static/app/components/events/interfaces/frame/line.tsx
+++ b/static/app/components/events/interfaces/frame/line.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import scrollToElement from 'scroll-to-element';
@@ -80,7 +80,7 @@ function makeFilter(
   return addr;
 }
 
-export class Line extends React.Component<Props, State> {
+export class Line extends Component<Props, State> {
   static defaultProps = {
     isExpanded: false,
     emptySourceNotation: false,

--- a/static/app/components/events/interfaces/frame/packageLink.tsx
+++ b/static/app/components/events/interfaces/frame/packageLink.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {trimPackage} from 'sentry/components/events/interfaces/frame/utils';
@@ -20,7 +20,7 @@ type Props = {
   isHoverPreviewed?: boolean;
 };
 
-class PackageLink extends React.Component<Props> {
+class PackageLink extends Component<Props> {
   handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     const {isClickable, onClick} = this.props;
 

--- a/static/app/components/events/interfaces/request.tsx
+++ b/static/app/components/events/interfaces/request.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
@@ -24,7 +24,7 @@ type State = {
   view: string;
 };
 
-class RequestInterface extends React.Component<Props, State> {
+class RequestInterface extends Component<Props, State> {
   state: State = {
     view: 'formatted',
   };

--- a/static/app/components/events/interfaces/spans/dragManager.tsx
+++ b/static/app/components/events/interfaces/spans/dragManager.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import {clamp, rectOfContent} from 'sentry/components/performance/waterfall/utils';
 import {PerformanceInteraction} from 'sentry/utils/performanceForSentry';
@@ -70,7 +70,7 @@ type DragManagerState = {
   windowSelectionSize: number;
 };
 
-class DragManager extends React.Component<DragManagerProps, DragManagerState> {
+class DragManager extends Component<DragManagerProps, DragManagerState> {
   state: DragManagerState = {
     // draggable handles
 

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
@@ -32,7 +32,7 @@ type PropType = ScrollbarManagerChildrenProps & {
   waterfallModel: WaterfallModel;
 };
 
-class SpanTree extends React.Component<PropType> {
+class SpanTree extends Component<PropType> {
   componentDidMount() {
     setSpansOnTransaction(this.props.spans.length);
   }

--- a/static/app/components/eventsTable/eventsTableRow.tsx
+++ b/static/app/components/eventsTable/eventsTableRow.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import DateTime from 'sentry/components/dateTime';
@@ -20,7 +20,7 @@ type Props = {
   hasUser?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 
-class EventsTableRow extends React.Component<Props> {
+class EventsTableRow extends Component<Props> {
   renderCrashFileLink() {
     const {event, projectId} = this.props;
     if (!event.crashFile) {

--- a/static/app/components/forms/booleanField.tsx
+++ b/static/app/components/forms/booleanField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import Confirm from 'sentry/components/confirm';
 import InputField, {InputFieldProps, onEvent} from 'sentry/components/forms/inputField';
@@ -11,7 +11,7 @@ export interface BooleanFieldProps extends InputFieldProps {
   };
 }
 
-export default class BooleanField extends React.Component<BooleanFieldProps> {
+export default class BooleanField extends Component<BooleanFieldProps> {
   coerceValue(value: any) {
     return !!value;
   }

--- a/static/app/components/forms/controls/multipleCheckbox.tsx
+++ b/static/app/components/forms/controls/multipleCheckbox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {Choices} from 'sentry/types';
@@ -30,7 +30,7 @@ type Props = {
   onChange?: (value: SelectedValue, event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
-class MultipleCheckbox extends React.Component<Props> {
+class MultipleCheckbox extends Component<Props> {
   onChange = (selectedValue: string | number, e: React.ChangeEvent<HTMLInputElement>) => {
     const {value, onChange} = this.props;
     let newValue: SelectedValue = [];

--- a/static/app/components/forms/field/index.tsx
+++ b/static/app/components/forms/field/index.tsx
@@ -1,11 +1,4 @@
-/**
- * A component to render a Field (i.e. label + help + form "control"),
- * generally inside of a Panel.
- *
- * This is unconnected to any Form state
- */
-
-import * as React from 'react';
+import {Component} from 'react';
 
 import ControlState, {
   ControlStateProps,
@@ -108,7 +101,13 @@ interface ChildRenderProps extends Omit<FieldProps, 'className' | 'disabled'> {
   disabled?: boolean;
 }
 
-class Field extends React.Component<FieldProps> {
+/**
+ * A component to render a Field (i.e. label + help + form "control"),
+ * generally inside of a Panel.
+ *
+ * This is unconnected to any Form state
+ */
+class Field extends Component<FieldProps> {
   static defaultProps = {
     alignRight: false,
     inline: true,

--- a/static/app/components/forms/form.tsx
+++ b/static/app/components/forms/form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import {Observer} from 'mobx-react';
 
@@ -86,7 +86,7 @@ type Props = {
   submitPriority?: ButtonProps['priority'];
 } & Pick<FormOptions, 'onSubmitSuccess' | 'onSubmitError' | 'onFieldChange'>;
 
-export default class Form extends React.Component<Props> {
+export default class Form extends Component<Props> {
   constructor(props: Props, context: FormContextData) {
     super(props, context);
     const {

--- a/static/app/components/forms/formPanel.tsx
+++ b/static/app/components/forms/formPanel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import FieldFromConfig from 'sentry/components/forms/fieldFromConfig';
@@ -55,7 +55,7 @@ type State = {
   collapsed: boolean;
 };
 
-export default class FormPanel extends React.Component<Props, State> {
+export default class FormPanel extends Component<Props, State> {
   static defaultProps: DefaultProps = {
     additionalFieldProps: {},
   };

--- a/static/app/components/forms/radioField.tsx
+++ b/static/app/components/forms/radioField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import RadioGroup, {RadioGroupProps} from 'sentry/components/forms/controls/radioGroup';
 import InputField, {InputFieldProps, onEvent} from 'sentry/components/forms/inputField';
@@ -8,7 +8,7 @@ export interface RadioFieldProps extends Omit<InputFieldProps, 'type'> {
   orientInline?: RadioGroupProps<any>['orientInline'];
 }
 
-class RadioField extends React.Component<RadioFieldProps> {
+class RadioField extends Component<RadioFieldProps> {
   onChange = (
     id: string,
     onChange: onEvent,

--- a/static/app/components/forms/selectAsyncField.tsx
+++ b/static/app/components/forms/selectAsyncField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import InputField, {InputFieldProps} from 'sentry/components/forms/inputField';
 import SelectAsyncControl, {
@@ -16,10 +16,7 @@ type SelectAsyncFieldState = {
   results: Result[];
   latestSelection?: GeneralSelectValue;
 };
-class SelectAsyncField extends React.Component<
-  SelectAsyncFieldProps,
-  SelectAsyncFieldState
-> {
+class SelectAsyncField extends Component<SelectAsyncFieldProps, SelectAsyncFieldState> {
   state: SelectAsyncFieldState = {
     results: [],
     latestSelection: undefined,

--- a/static/app/components/forms/selectField.tsx
+++ b/static/app/components/forms/selectField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {OptionsType, ValueType} from 'react-select';
 
 import {openConfirmModal} from 'sentry/components/confirm';
@@ -55,9 +55,9 @@ function isArray<T>(maybe: T | OptionsType<T>): maybe is OptionsType<T> {
   return Array.isArray(maybe);
 }
 
-export default class SelectField<
-  OptionType extends SelectValue<any>
-> extends React.Component<SelectFieldProps<OptionType>> {
+export default class SelectField<OptionType extends SelectValue<any>> extends Component<
+  SelectFieldProps<OptionType>
+> {
   static defaultProps = {
     allowClear: false,
     allowEmpty: false,

--- a/static/app/components/forms/sentryProjectSelectorField.tsx
+++ b/static/app/components/forms/sentryProjectSelectorField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {components} from 'react-select';
 
 import InputField, {InputFieldProps} from 'sentry/components/forms/inputField';
@@ -23,7 +23,7 @@ interface RenderProps
   projects: Project[]; // can't use AvatarProject since we need the ID
 }
 
-class RenderField extends React.Component<RenderProps> {
+class RenderField extends Component<RenderProps> {
   static defaultProps = defaultProps;
 
   // need to map the option object to the value

--- a/static/app/components/forms/textCopyInput.tsx
+++ b/static/app/components/forms/textCopyInput.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties} from 'react';
+import {Component} from 'react';
 import * as React from 'react';
 import {findDOMNode} from 'react-dom';
 import styled from '@emotion/styled';
@@ -49,10 +49,10 @@ type Props = {
    * Always show the ending of a long overflowing text in input
    */
   rtl?: boolean;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
 };
 
-class TextCopyInput extends React.Component<Props> {
+class TextCopyInput extends Component<Props> {
   textRef = React.createRef<HTMLInputElement>();
 
   // Select text when copy button is clicked

--- a/static/app/components/gridEditable/sortLink.tsx
+++ b/static/app/components/gridEditable/sortLink.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import {LocationDescriptorObject} from 'history';
 import omit from 'lodash/omit';
@@ -19,7 +19,7 @@ type Props = {
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 };
 
-class SortLink extends React.Component<Props> {
+class SortLink extends Component<Props> {
   renderArrow() {
     const {direction} = this.props;
     if (!direction) {

--- a/static/app/components/group/sentryAppExternalIssueActions.tsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -36,7 +36,7 @@ type State = {
   externalIssue?: PlatformExternalIssue;
 };
 
-class SentryAppExternalIssueActions extends React.Component<Props, State> {
+class SentryAppExternalIssueActions extends Component<Props, State> {
   state: State = {
     action: 'create',
     externalIssue: this.props.externalIssue,

--- a/static/app/components/hook.tsx
+++ b/static/app/components/hook.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import HookStore from 'sentry/stores/hookStore';
 import {HookName, Hooks} from 'sentry/types/hooks';
@@ -34,7 +34,7 @@ type HookState<H extends HookName> = {
  *   </Hook>
  */
 function Hook<H extends HookName>({name, ...props}: Props<H>) {
-  class HookComponent extends React.Component<{}, HookState<H>> {
+  class HookComponent extends Component<{}, HookState<H>> {
     static displayName = `Hook(${name})`;
 
     state = {

--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 import capitalize from 'lodash/capitalize';
@@ -22,7 +22,7 @@ type Props = {
   showHoverCard?: boolean;
 };
 
-class IssueSyncListElement extends React.Component<Props> {
+class IssueSyncListElement extends Component<Props> {
   isLinked(): boolean {
     return !!(this.props.externalIssueLink && this.props.externalIssueId);
   }

--- a/static/app/components/links/listLink.tsx
+++ b/static/app/components/links/listLink.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {Link as RouterLink, withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
@@ -28,7 +28,7 @@ type Props = WithRouterProps &
     query?: string;
   };
 
-class ListLink extends React.Component<Props> {
+class ListLink extends Component<Props> {
   static displayName = 'ListLink';
 
   static defaultProps: DefaultProps = {

--- a/static/app/components/loadingError.tsx
+++ b/static/app/components/loadingError.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
@@ -18,7 +18,7 @@ type Props = DefaultProps & {
 /**
  * Renders an Alert box of type "error". Renders a "Retry" button only if a `onRetry` callback is defined.
  */
-class LoadingError extends React.Component<Props> {
+class LoadingError extends Component<Props> {
   static defaultProps: DefaultProps = {
     message: t('There was an error loading data.'),
   };

--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {MultiValueProps, StylesConfig} from 'react-select';
 import {withTheme} from '@emotion/react';
 
@@ -49,7 +49,7 @@ function mapToOptions(values: string[]): SelectOption[] {
   return values.map(value => ({value, label: value}));
 }
 
-class InviteRowControl extends React.Component<Props, State> {
+class InviteRowControl extends Component<Props, State> {
   state: State = {inputValue: ''};
 
   handleInputChange = (inputValue: string) => {

--- a/static/app/components/numberDragControl.tsx
+++ b/static/app/components/numberDragControl.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {IconArrow} from 'sentry/icons';
@@ -25,7 +25,7 @@ type State = {
   isClicked: boolean;
 };
 
-class NumberDragControl extends React.Component<Props, State> {
+class NumberDragControl extends Component<Props, State> {
   state: State = {
     isClicked: false,
   };

--- a/static/app/components/organizations/timeRangeSelector/timePicker.tsx
+++ b/static/app/components/organizations/timeRangeSelector/timePicker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
@@ -19,7 +19,7 @@ type State = {
 };
 
 const TimePicker = styled(
-  class TimePicker extends React.Component<Props, State> {
+  class TimePicker extends Component<Props, State> {
     state: State = {
       focused: false,
     };

--- a/static/app/components/repositoryFileSummary.tsx
+++ b/static/app/components/repositoryFileSummary.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import FileChange from 'sentry/components/fileChange';
@@ -34,7 +34,7 @@ type State = {
   loading: boolean;
 };
 
-class RepositoryFileSummary extends React.Component<Props, State> {
+class RepositoryFileSummary extends Component<Props, State> {
   static defaultProps = {
     collapsible: true,
     maxWhenCollapsed: 5,

--- a/static/app/components/resultGrid.tsx
+++ b/static/app/components/resultGrid.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
 
@@ -20,7 +20,7 @@ type FilterProps = {
   value: string;
 };
 
-class Filter extends React.Component<FilterProps> {
+class Filter extends Component<FilterProps> {
   getCurrentLabel() {
     const selected = this.props.options.find(
       item => item[0] === (this.props.value ?? '')
@@ -89,7 +89,7 @@ type SortByProps = {
   value: string;
 };
 
-class SortBy extends React.Component<SortByProps> {
+class SortBy extends Component<SortByProps> {
   getCurrentSortLabel() {
     return this.props.options.find(([value]) => value === this.props.value)?.[1];
   }
@@ -169,7 +169,7 @@ type State = {
   sortBy: string;
 };
 
-class ResultGrid extends React.Component<Props, State> {
+class ResultGrid extends Component<Props, State> {
   static defaultProps: DefaultProps = {
     path: '',
     endpoint: '',

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import * as Sentry from '@sentry/react';
 import debounce from 'lodash/debounce';
@@ -289,7 +289,7 @@ type State = {
   searchResults: null | Result[];
 };
 
-class ApiSource extends React.Component<Props, State> {
+class ApiSource extends Component<Props, State> {
   static defaultProps = {
     searchOptions: {},
   };

--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {PlainRoute} from 'react-router';
 
 import {openHelpSearchModal, openSudo} from 'sentry/actionCreators/modal';
@@ -89,7 +89,7 @@ type State = {
 /**
  * This source is a hardcoded list of action creators and/or routes maybe
  */
-class CommandSource extends React.Component<Props, State> {
+class CommandSource extends Component<Props, State> {
   static defaultProps = {
     searchMap: [],
     searchOptions: {},

--- a/static/app/components/search/sources/formSource.tsx
+++ b/static/app/components/search/sources/formSource.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 
 import {loadSearchMap} from 'sentry/actionCreators/formSearch';
@@ -29,7 +29,7 @@ type State = {
   fuzzy: null | Fuse<FormSearchField>;
 };
 
-class FormSource extends React.Component<Props, State> {
+class FormSource extends Component<Props, State> {
   static defaultProps = {
     searchOptions: {},
   };
@@ -87,7 +87,7 @@ class FormSource extends React.Component<Props, State> {
 type ContainerProps = Omit<Props, 'searchMap'>;
 type ContainerState = Pick<Props, 'searchMap'>;
 
-class FormSourceContainer extends React.Component<ContainerProps, ContainerState> {
+class FormSourceContainer extends Component<ContainerProps, ContainerState> {
   state = {
     searchMap: FormSearchStore.get(),
   };

--- a/static/app/components/search/sources/helpSource.tsx
+++ b/static/app/components/search/sources/helpSource.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import {
   Result as SearchResult,
@@ -41,7 +41,7 @@ const MARK_TAGS = {
   highlightPostTag: '</mark>',
 };
 
-class HelpSource extends React.Component<Props, State> {
+class HelpSource extends Component<Props, State> {
   state: State = {
     loading: false,
     results: [],

--- a/static/app/components/search/sources/index.tsx
+++ b/static/app/components/search/sources/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import flatten from 'lodash/flatten';
 
 import type {Fuse} from 'sentry/utils/fuzzySearch';
@@ -24,7 +24,7 @@ type SourceResult = {
   results: Result[];
 };
 
-class SearchSources extends React.Component<Props> {
+class SearchSources extends Component<Props> {
   // `allSources` will be an array of all result objects from each source
   renderResults(allSources: SourceResult[]) {
     const {children} = this.props;

--- a/static/app/components/search/sources/routeSource.tsx
+++ b/static/app/components/search/sources/routeSource.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 import flattenDepth from 'lodash/flattenDepth';
 
@@ -72,7 +72,7 @@ type State = {
   fuzzy: undefined | null | Fuse<NavigationItem>;
 };
 
-class RouteSource extends React.Component<Props, State> {
+class RouteSource extends Component<Props, State> {
   static defaultProps: DefaultProps = {
     searchOptions: {},
   };

--- a/static/app/components/selectMembers/index.tsx
+++ b/static/app/components/selectMembers/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
@@ -55,7 +55,7 @@ type FilterOption<T> = {
 /**
  * A component that allows you to select either members and/or teams
  */
-class SelectMembers extends React.Component<Props, State> {
+class SelectMembers extends Component<Props, State> {
   state: State = {
     loading: false,
     inputValue: '',

--- a/static/app/components/truncate.tsx
+++ b/static/app/components/truncate.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';
@@ -21,7 +21,7 @@ type State = {
   isExpanded: boolean;
 };
 
-class Truncate extends React.Component<Props, State> {
+class Truncate extends Component<Props, State> {
   static defaultProps: DefaultProps = {
     className: '',
     minLength: 15,

--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import * as Sentry from '@sentry/react';
 import * as cbor from 'cbor-web';
 
@@ -42,7 +42,7 @@ type State = {
   responseElement: HTMLInputElement | null;
 };
 
-class U2fInterface extends React.Component<Props, State> {
+class U2fInterface extends Component<Props, State> {
   state: State = {
     isSupported: null,
     formElement: null,

--- a/static/app/components/versionHoverCard.tsx
+++ b/static/app/components/versionHoverCard.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {Client} from 'sentry/api';
@@ -42,7 +42,7 @@ type State = {
   visible: boolean;
 };
 
-class VersionHoverCard extends React.Component<Props, State> {
+class VersionHoverCard extends Component<Props, State> {
   state: State = {
     visible: false,
   };

--- a/static/app/utils/errorHandler.tsx
+++ b/static/app/utils/errorHandler.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import RouteError from 'sentry/views/routeError';
 
@@ -7,8 +7,8 @@ type State = {
   hasError: boolean;
 };
 
-export default function errorHandler<P>(Component: React.ComponentType<P>) {
-  class ErrorHandler extends React.Component<P, State> {
+export default function errorHandler<P>(WrappedComponent: React.ComponentType<P>) {
+  class ErrorHandler extends Component<P, State> {
     static getDerivedStateFromError(error: Error) {
       // Update state so the next render will show the fallback UI.
       return {
@@ -37,7 +37,7 @@ export default function errorHandler<P>(Component: React.ComponentType<P>) {
         return <RouteError error={this.state.error} />;
       }
 
-      return <Component {...this.props} />;
+      return <WrappedComponent {...this.props} />;
     }
   }
 

--- a/static/app/utils/eventWaiter.tsx
+++ b/static/app/utils/eventWaiter.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {Client} from 'sentry/api';
@@ -41,7 +41,7 @@ type EventWaiterState = {
  * This is a render prop component that can be used to wait for the first event
  * of a project to be received via polling.
  */
-class EventWaiter extends React.Component<EventWaiterProps, EventWaiterState> {
+class EventWaiter extends Component<EventWaiterProps, EventWaiterState> {
   state: EventWaiterState = {
     firstIssue: null,
   };

--- a/static/app/utils/metrics/metricsRequest.tsx
+++ b/static/app/utils/metrics/metricsRequest.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import isEqual from 'lodash/isEqual';
 import omitBy from 'lodash/omitBy';
 
@@ -71,7 +71,7 @@ type State = {
   responsePrevious: MetricsApiResponse | null;
 };
 
-class MetricsRequest extends React.Component<Props, State> {
+class MetricsRequest extends Component<Props, State> {
   static defaultProps: DefaultProps = {
     includePrevious: false,
     includeSeriesData: false,

--- a/static/app/utils/performance/histogram/index.tsx
+++ b/static/app/utils/performance/histogram/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
 
@@ -22,7 +22,7 @@ type Props = {
   zoomKeys: string[];
 };
 
-class Histogram extends React.Component<Props> {
+class Histogram extends Component<Props> {
   isZoomed() {
     const {location, zoomKeys} = this.props;
     return zoomKeys.map(key => location.query[key]).some(value => value !== undefined);

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import memoize from 'lodash/memoize';
 import partition from 'lodash/partition';
 import uniqBy from 'lodash/uniqBy';
@@ -119,7 +119,7 @@ type Props = {
   slugs?: string[];
 } & DefaultProps;
 
-class BaseProjects extends React.Component<Props, State> {
+class BaseProjects extends Component<Props, State> {
   static defaultProps: DefaultProps = {
     passthroughPlaceholderProject: true,
   };

--- a/static/app/views/alerts/incidentRules/triggers/thresholdControl.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/thresholdControl.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -31,7 +31,7 @@ type State = {
   currentValue: string | null;
 };
 
-class ThresholdControl extends React.Component<Props, State> {
+class ThresholdControl extends Component<Props, State> {
   state: State = {
     currentValue: null,
   };

--- a/static/app/views/alerts/issueRuleEditor/memberTeamFields.tsx
+++ b/static/app/views/alerts/issueRuleEditor/memberTeamFields.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import SelectControl from 'sentry/components/forms/selectControl';
@@ -26,7 +26,7 @@ type Props = {
   teamValue: string | number;
 };
 
-class MemberTeamFields extends React.Component<Props> {
+class MemberTeamFields extends Component<Props> {
   handleChange = (attribute: 'targetType' | 'targetIdentifier', newValue: string) => {
     const {onChange, ruleData} = this.props;
     if (newValue === ruleData[attribute]) {

--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {InjectedRouter} from 'react-router';
 import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -89,7 +89,7 @@ type State = {
   containerHeight: number;
 };
 
-class WidgetCardChart extends React.Component<WidgetCardChartProps, State> {
+class WidgetCardChart extends Component<WidgetCardChartProps, State> {
   state = {containerHeight: 0};
 
   shouldComponentUpdate(nextProps: WidgetCardChartProps, nextState: State): boolean {

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import LazyLoad from 'react-lazyload';
 import {withRouter, WithRouterProps} from 'react-router';
 import {useSortable} from '@dnd-kit/sortable';
@@ -70,7 +70,7 @@ type State = {
   totalIssuesCount?: string;
 };
 
-class WidgetCard extends React.Component<Props, State> {
+class WidgetCard extends Component<Props, State> {
   state: State = {};
   renderToolbar() {
     const {

--- a/static/app/views/dashboardsV2/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/issueWidgetQueries.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import isEqual from 'lodash/isEqual';
 
 import {Client} from 'sentry/api';
@@ -62,7 +62,7 @@ type State = {
   totalCount: null | string;
 };
 
-class IssueWidgetQueries extends React.Component<Props, State> {
+class IssueWidgetQueries extends Component<Props, State> {
   state: State = {
     loading: true,
     errorMessage: undefined,

--- a/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
@@ -49,7 +49,7 @@ type State = {
   timeseriesResults?: Series[];
 };
 
-class ReleaseWidgetQueries extends React.Component<Props, State> {
+class ReleaseWidgetQueries extends Component<Props, State> {
   state: State = {
     loading: true,
     queryFetchID: undefined,

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
@@ -175,7 +175,7 @@ type State = {
   timeseriesResults?: Series[];
 };
 
-class WidgetQueries extends React.Component<Props, State> {
+class WidgetQueries extends Component<Props, State> {
   state: State = {
     loading: true,
     queryFetchID: undefined,

--- a/static/app/views/eventsV2/miniGraph.tsx
+++ b/static/app/views/eventsV2/miniGraph.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -36,7 +36,7 @@ type Props = {
   yAxis?: string[];
 };
 
-class MiniGraph extends React.Component<Props> {
+class MiniGraph extends Component<Props> {
   shouldComponentUpdate(nextProps) {
     // We pay for the cost of the deep comparison here since it is cheaper
     // than the cost for rendering the graph, which can take ~200ms to ~300ms to
@@ -301,8 +301,8 @@ class MiniGraph extends React.Component<Props> {
               (Array.isArray(yAxis) && yAxis.length > 1),
           };
 
-          const Component = this.getChartComponent(chartType);
-          return <Component {...chartOptions} />;
+          const ChartComponent = this.getChartComponent(chartType);
+          return <ChartComponent {...chartOptions} />;
         }}
       </EventsRequest>
     );

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {browserHistory, InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -89,7 +89,7 @@ function getYAxis(location: Location, eventView: EventView, savedQuery?: SavedQu
     : [eventView.getYAxis()];
 }
 
-class Results extends React.Component<Props, State> {
+class Results extends Component<Props, State> {
   static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     if (nextProps.savedQuery || !nextProps.loading) {
       const eventView = EventView.fromSavedQueryOrLocation(

--- a/static/app/views/eventsV2/resultsHeader.tsx
+++ b/static/app/views/eventsV2/resultsHeader.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -36,7 +36,7 @@ type State = {
   savedQuery: SavedQuery | undefined;
 };
 
-class ResultsHeader extends React.Component<Props, State> {
+class ResultsHeader extends Component<Props, State> {
   state: State = {
     savedQuery: undefined,
     loading: true,

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {createPortal} from 'react-dom';
 import {Manager, Popper, PopperProps, Reference} from 'react-popper';
 import styled from '@emotion/styled';
@@ -287,7 +287,7 @@ type State = {
   isOpen: boolean;
 };
 
-class CellAction extends React.Component<Props, State> {
+class CellAction extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     let portal = document.getElementById('cell-action-portal');

--- a/static/app/views/issueList/createSavedSearchModal.tsx
+++ b/static/app/views/issueList/createSavedSearchModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import {addLoadingMessage, clearIndicators} from 'sentry/actionCreators/indicator';
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -33,7 +33,7 @@ const DEFAULT_SORT_OPTIONS = [
   IssueSortOptions.USER,
 ];
 
-class CreateSavedSearchModal extends React.Component<Props, State> {
+class CreateSavedSearchModal extends Component<Props, State> {
   state: State = {
     isSaving: false,
     error: null,

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import {fetchRecentSearches} from 'sentry/actionCreators/savedSearches';
 import {Client} from 'sentry/api';
@@ -68,7 +68,7 @@ type State = {
   recentSearches: string[];
 };
 
-class IssueListSearchBar extends React.Component<Props, State> {
+class IssueListSearchBar extends Component<Props, State> {
   state: State = {
     defaultSearchItems: [SEARCH_ITEMS, []],
     recentSearches: [],

--- a/static/app/views/issueList/tagFilter.tsx
+++ b/static/app/views/issueList/tagFilter.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import debounce from 'lodash/debounce';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -31,7 +31,7 @@ type State = {
   options?: SelectOption[];
 };
 
-class IssueListTagFilter extends React.Component<Props, State> {
+class IssueListTagFilter extends Component<Props, State> {
   static defaultProps = defaultProps;
 
   state: State = {

--- a/static/app/views/onboarding/components/fallingError.tsx
+++ b/static/app/views/onboarding/components/fallingError.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {motion} from 'framer-motion';
 
 import testableTransition from 'sentry/utils/testableTransition';
@@ -20,7 +20,7 @@ type State = {
   isFalling: boolean;
 };
 
-class FallingError extends React.Component<Props, State> {
+class FallingError extends Component<Props, State> {
   state: State = {
     isFalling: false,
     fallCount: 0,

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {browserHistory} from 'react-router';
 import * as Sentry from '@sentry/react';
 
@@ -53,10 +53,7 @@ async function latestEventAvailable(
   }
 }
 
-class CreateSampleEventButton extends React.Component<
-  CreateSampleEventButtonProps,
-  State
-> {
+class CreateSampleEventButton extends Component<CreateSampleEventButtonProps, State> {
   state: State = {
     creating: false,
   };

--- a/static/app/views/organizationGroupDetails/groupEvents.tsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
@@ -35,7 +35,7 @@ type State = {
   query: string;
 };
 
-class GroupEvents extends React.Component<Props, State> {
+class GroupEvents extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 

--- a/static/app/views/organizationGroupDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupMerged/mergedItem.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import GroupingActions from 'sentry/actions/groupingActions';
@@ -21,7 +21,7 @@ type State = {
   collapsed: boolean;
 };
 
-class MergedItem extends React.Component<Props, State> {
+class MergedItem extends Component<Props, State> {
   state: State = {
     collapsed: false,
     checked: false,

--- a/static/app/views/organizationGroupDetails/groupMerged/mergedToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/groupMerged/mergedToolbar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
@@ -26,7 +26,7 @@ type State = {
   unmergeList: Map<any, any>;
 };
 
-class MergedToolbar extends React.Component<Props, State> {
+class MergedToolbar extends Component<Props, State> {
   state: State = this.getInitialState();
 
   getInitialState() {

--- a/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -41,7 +41,7 @@ type State = {
   v2: boolean;
 };
 
-class SimilarStackTrace extends React.Component<Props, State> {
+class SimilarStackTrace extends Component<Props, State> {
   state: State = {
     similarItems: [],
     filteredSimilarItems: [],

--- a/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
@@ -42,7 +42,7 @@ const initialState = {visible: true, checked: false, busy: false};
 
 type State = typeof initialState;
 
-class Item extends React.Component<Props, State> {
+class Item extends Component<Props, State> {
   state: State = initialState;
 
   componentWillUnmount() {

--- a/static/app/views/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/organizationIntegrations/addIntegration.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import * as qs from 'query-string';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -25,7 +25,7 @@ type Props = {
   modalParams?: {[key: string]: string};
 };
 
-export default class AddIntegration extends React.Component<Props> {
+export default class AddIntegration extends Component<Props> {
   componentDidMount() {
     window.addEventListener('message', this.didReceiveMessage);
   }

--- a/static/app/views/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/organizationIntegrations/addIntegrationButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import Button, {ButtonPropsWithoutAriaLabel} from 'sentry/components/button';
 import Tooltip from 'sentry/components/tooltip';
@@ -18,7 +18,7 @@ interface AddIntegrationButtonProps
   reinstall?: boolean;
 }
 
-export default class AddIntegrationButton extends React.Component<AddIntegrationButtonProps> {
+export default class AddIntegrationButton extends Component<AddIntegrationButtonProps> {
   render() {
     const {
       provider,

--- a/static/app/views/organizationStats/usageTable/index.tsx
+++ b/static/app/views/organizationStats/usageTable/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorPanel from 'sentry/components/charts/errorPanel';
@@ -40,7 +40,7 @@ export type TableStat = {
   total: number;
 };
 
-class UsageTable extends React.Component<Props> {
+class UsageTable extends Component<Props> {
   get formatUsageOptions() {
     const {dataCategory} = this.props;
 

--- a/static/app/views/projectDetail/charts/projectSessionsChartRequest.tsx
+++ b/static/app/views/projectDetail/charts/projectSessionsChartRequest.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {withTheme} from '@emotion/react';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
@@ -65,7 +65,7 @@ type State = {
   totalSessions: number | null;
 };
 
-class ProjectSessionsChartRequest extends React.Component<Props, State> {
+class ProjectSessionsChartRequest extends Component<Props, State> {
   state: State = {
     reloading: false,
     errored: false,

--- a/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
+++ b/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import isString from 'lodash/isString';
@@ -34,7 +34,7 @@ type ChildProps = DetailsState & {
   projectId: null | string;
 };
 
-class ProjectDetailsInner extends React.Component<DetailsProps, DetailsState> {
+class ProjectDetailsInner extends Component<DetailsProps, DetailsState> {
   state: DetailsState = {
     loading: true,
     error: null,

--- a/static/app/views/releases/detail/commitsAndFiles/withReleaseRepos.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/withReleaseRepos.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 import * as Sentry from '@sentry/react';
 
@@ -39,7 +39,7 @@ type State = {
 function withReleaseRepos<P extends DependentProps>(
   WrappedComponent: React.ComponentType<P>
 ) {
-  class WithReleaseRepos extends React.Component<P & HoCsProps, State> {
+  class WithReleaseRepos extends Component<P & HoCsProps, State> {
     static displayName = `withReleaseRepos(${getDisplayName(WrappedComponent)})`;
 
     state: State = {

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 import round from 'lodash/round';
@@ -58,7 +58,7 @@ type Props = {
   utc?: boolean;
 } & WithRouterProps;
 
-class ReleaseSessionsChart extends React.Component<Props> {
+class ReleaseSessionsChart extends Component<Props> {
   formatTooltipValue = (value: string | number | null, label?: string) => {
     if (label && Object.values(releaseMarkLinesLabels).includes(label)) {
       return '';

--- a/static/app/views/releases/list/releasesRequest.tsx
+++ b/static/app/views/releases/list/releasesRequest.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
@@ -111,7 +111,7 @@ type State = {
   totalCountByReleaseInPeriod: SessionApiResponse | null;
 };
 
-class ReleasesRequest extends React.Component<Props, State> {
+class ReleasesRequest extends Component<Props, State> {
   state: State = {
     loading: false,
     errored: false,

--- a/static/app/views/settings/account/accountSettingsLayout.tsx
+++ b/static/app/views/settings/account/accountSettingsLayout.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organizations';
 import SentryTypes from 'sentry/sentryTypes';
@@ -11,7 +11,7 @@ type Props = React.ComponentProps<typeof SettingsLayout> & {
   organization: Organization;
 };
 
-class AccountSettingsLayout extends React.Component<Props> {
+class AccountSettingsLayout extends Component<Props> {
   static childContextTypes = {
     organization: SentryTypes.Organization,
   };

--- a/static/app/views/settings/components/dataScrubbing/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -39,7 +39,7 @@ type State = {
   relayPiiConfig?: string;
 };
 
-class DataScrubbing<T extends ProjectId = undefined> extends React.Component<
+class DataScrubbing<T extends ProjectId = undefined> extends Component<
   Props<T>,
   State
 > {

--- a/static/app/views/settings/components/dataScrubbing/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.tsx
@@ -39,10 +39,7 @@ type State = {
   relayPiiConfig?: string;
 };
 
-class DataScrubbing<T extends ProjectId = undefined> extends Component<
-  Props<T>,
-  State
-> {
+class DataScrubbing<T extends ProjectId = undefined> extends Component<Props<T>, State> {
   state: State = {
     rules: [],
     savedRules: [],

--- a/static/app/views/settings/components/dataScrubbing/modals/form/eventIdField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/eventIdField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
@@ -23,7 +23,7 @@ type State = {
   value: string;
 };
 
-class EventIdField extends React.Component<Props, State> {
+class EventIdField extends Component<Props, State> {
   state: State = {...this.props.eventId};
 
   componentDidUpdate(prevProps: Props) {

--- a/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/modalManager.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 
@@ -50,7 +50,7 @@ type State = {
   values: Values;
 };
 
-class ModalManager<T extends ProjectId> extends React.Component<Props<T>, State> {
+class ModalManager<T extends ProjectId> extends Component<Props<T>, State> {
   state = this.getDefaultState();
 
   componentDidMount() {

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import DropdownAutoCompleteMenu from 'sentry/components/dropdownAutoComplete/menu';
 import {Item} from 'sentry/components/dropdownAutoComplete/types';
@@ -29,7 +29,7 @@ type State = {
   isOpen: boolean;
 };
 
-class BreadcrumbDropdown extends React.Component<BreadcrumbDropdownProps, State> {
+class BreadcrumbDropdown extends Component<BreadcrumbDropdownProps, State> {
   state: State = {
     isOpen: false,
   };

--- a/static/app/views/settings/organization/organizationSettingsNavigation.tsx
+++ b/static/app/views/settings/organization/organizationSettingsNavigation.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 
 import HookStore from 'sentry/stores/hookStore';
 import {Organization} from 'sentry/types';
@@ -17,7 +17,7 @@ type State = {
   hooks: React.ReactElement[];
 };
 
-class OrganizationSettingsNavigation extends React.Component<Props, State> {
+class OrganizationSettingsNavigation extends Component<Props, State> {
   state: State = this.getHooks();
 
   componentDidMount() {

--- a/static/app/views/settings/organizationRelay/modals/modalManager.tsx
+++ b/static/app/views/settings/organizationRelay/modals/modalManager.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 
@@ -31,10 +31,10 @@ type State = {
   values: Values;
 };
 
-class DialogManager<
-  P extends Props = Props,
-  S extends State = State
-> extends React.Component<P, S> {
+class DialogManager<P extends Props = Props, S extends State = State> extends Component<
+  P,
+  S
+> {
   state = this.getDefaultState();
 
   componentDidMount() {

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -27,7 +27,7 @@ type State = {
   loading: boolean;
 };
 
-class AllTeamsRow extends React.Component<Props, State> {
+class AllTeamsRow extends Component<Props, State> {
   state: State = {
     loading: false,
     error: false,

--- a/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
+++ b/static/app/views/settings/organizationTeams/organizationAccessRequests.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -28,7 +28,7 @@ type HandleOpts = {
   successMessage: string;
 };
 
-class OrganizationAccessRequests extends React.Component<Props, State> {
+class OrganizationAccessRequests extends Component<Props, State> {
   state: State = {
     accessRequestBusy: {},
   };

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
@@ -49,7 +49,7 @@ type State = {
   teamMemberList: Member[];
 };
 
-class TeamMembers extends React.Component<Props, State> {
+class TeamMembers extends Component<Props, State> {
   state: State = {
     loading: true,
     error: false,

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -45,7 +45,7 @@ interface SettingsIndexProps extends RouteComponentProps<{}, {}> {
   organization: Organization;
 }
 
-class SettingsIndex extends React.Component<SettingsIndexProps> {
+class SettingsIndex extends Component<SettingsIndexProps> {
   componentDidUpdate(prevProps: SettingsIndexProps) {
     const {organization} = this.props;
     if (prevProps.organization === organization) {


### PR DESCRIPTION
This is the changeset for removing `import * as React from 'react'` for things that *only* use `Component`.