### PR TITLE
ref(js): Fix hook dependency warning for complex expression

### DIFF
--- a/static/app/components/acl/role.tsx
+++ b/static/app/components/acl/role.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {useMemo} from 'react';
 
 import ConfigStore from 'sentry/stores/configStore';
 import {Organization, User} from 'sentry/types';
@@ -56,10 +56,12 @@ interface RoleProps {
 }
 
 function Role({role, organization, children}: RoleProps): React.ReactElement | null {
-  const hasRole = React.useMemo(
-    () => checkUserRole(ConfigStore.get('user'), organization, role),
+  const user = ConfigStore.get('user');
+
+  const hasRole = useMemo(
+    () => checkUserRole(user, organization, role),
     // It seems that this returns a stable reference, but
-    [organization, role, ConfigStore.get('user')]
+    [organization, role, user]
   );
 
   if (isRenderFunc<ChildrenRenderFn>(children)) {


### PR DESCRIPTION
It was complaining about the function call inside the dependecy