### PR TITLE
feat(sessions): Add option to filter by proj slug in query params [INGEST-1210]

### DIFF
--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -220,7 +220,7 @@ GROUPBY_MAP = {
     "session.status": SessionStatusGroupBy(),
 }
 
-CONDITION_COLUMNS = ["project", "environment", "release"]
+CONDITION_COLUMNS = ["project", "project_id", "environment", "release"]
 FILTER_KEY_COLUMNS = ["project_id"]
 
 

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -256,6 +256,18 @@ class SnubaSessionsV2Test(TestCase, SnubaTestCase):
         # the request.
         assert "project_id" not in query_def.conditions
 
+    def test_filter_env_in_query(self):
+        params = self._get_default_params()
+        params["environment"] = "production"
+        query_def = _make_query(
+            "field=sum(session)&groupBy=project&interval=1h&query=environment%3Aproduction&statsPeriod=7d",
+            params=params,
+        )
+
+        assert query_def.query == "environment:production"
+        assert query_def.params["environment"] == "production"
+        assert query_def.params["organization_id"] == self.organization.id
+
 
 @freeze_time("2020-12-18T11:14:17.105Z")
 def test_massage_empty():


### PR DESCRIPTION
Dashboards require the ability to filter by projects in query parameters, and right now this is only possible by the top-level `project` parameter. This PR introduces the feature to filter project slug and environment in the query. Filtering by the top-level parameter and filtering int he query at the same time is also supported.

Filtering by project slug is supported by adding `project_id` to the condition column list. Filtering by environment is a bit different - no need to explicitly add anything, it's enough to look for conditions in nested lists in the conditions (i.e. check conditions even if they are in `[[[<condition>]]]` format, instead of only considering `[<condition>]`).