### PR TITLE
feat(eventstream): Support producing to separate transactions topic

### DIFF
--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -52,7 +52,12 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
         # insert what would have been the Kafka payload directly
         # into Snuba, expect an HTTP 200 and for the event to now exist
         snuba_eventstream = SnubaEventStream()
-        snuba_eventstream._send(self.project.id, "insert", (payload1, payload2))
+        snuba_eventstream._send(
+            self.project.id,
+            "insert",
+            (payload1, payload2),
+            is_transaction_event=insert_kwargs["group"] is None,
+        )
 
     @patch("sentry.eventstream.insert")
     def test(self, mock_eventstream_insert):


### PR DESCRIPTION
This is the next small step towards splitting the events and transactions topic.
Now we can produce to a separate transactions topic in the eventstream.