### PR TITLE
ref: upgrade python3-saml to avoid deprecated defusedxml

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -43,7 +43,7 @@ python-dateutil==2.8.1
 python-memcached==1.59
 python-u2flib-server==5.0.0
 fido2==0.9.2
-python3-saml==1.10.1
+python3-saml==1.14.0
 PyYAML==5.4
 rb==1.9.0
 redis-py-cluster==2.1.0


### PR DESCRIPTION
fixes this DeprecationWarning:

```
$ python3 -Werror -c 'import onelogin.saml2.xmlparser'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/onelogin/saml2/xmlparser.py", line 16, in <module>
    from defusedxml.lxml import DTDForbidden, EntitiesForbidden, NotSupportedError
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/defusedxml/lxml.py", line 26, in <module>
    warnings.warn(
DeprecationWarning: defusedxml.lxml is no longer supported and will be removed in a future release.
```