### PR TITLE
ref: upgrade googleapis-common-protos to avoid DeprecationWarning

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -19,7 +19,7 @@ google-api-core==1.25.1
 google-auth==1.24.0
 google-cloud-bigtable==1.6.1
 google-cloud-core==1.5.0
-googleapis-common-protos==1.52.0
+googleapis-common-protos==1.56.0
 google-cloud-pubsub==2.2.0
 google-cloud-storage==1.35.0
 # Only necessary to prevent installing the latest version


### PR DESCRIPTION
fixes this warning:

```console
$ python3 -Werror -c 'import google.api.http_pb2'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/google/api/http_pb2.py", line 30, in <module>
    DESCRIPTOR = _descriptor.FileDescriptor(
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/google/protobuf/descriptor.py", line 1034, in __init__
    _Deprecated('FileDescriptor')
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/google/protobuf/descriptor.py", line 97, in _Deprecated
    warnings.warn(
DeprecationWarning: Call to deprecated create function FileDescriptor(). Note: Create unlinked descriptors is going to go away. Please use get/find descriptors from generated code or query the descriptor_pool.
```