### PR TITLE
feat(sessions): Add option to filter by proj slug in query params [INGEST-1210]

### DIFF
--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -104,9 +104,7 @@ FUNCTION_ALLOWLIST = ("and", "or", "equals", "in")
 def resolve_tags(org_id: int, input_: Any) -> Any:
     """Translate tags in snuba condition
 
-    This assumes that all strings are either tag names or tag values, so do not
-    pass Column("metric_id") or Column("project_id") into this function.
-
+    Column("metric_id") is not supported.
     """
     if input_ is None:
         return None

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -160,6 +160,8 @@ def resolve_tags(org_id: int, input_: Any) -> Any:
             conditions=[resolve_tags(org_id, item) for item in input_.conditions]
         )
     if isinstance(input_, Column):
+        if input_.name == "project_id":
+            return input_
         # HACK: Some tags already take the form "tags[...]" in discover, take that into account:
         if input_.subscriptable == "tags":
             name = input_.key

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -220,7 +220,7 @@ GROUPBY_MAP = {
     "session.status": SessionStatusGroupBy(),
 }
 
-CONDITION_COLUMNS = ["project", "environment", "release"]
+CONDITION_COLUMNS = ["project", "project_id", "environment", "release"]
 FILTER_KEY_COLUMNS = ["project_id"]
 
 

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import pytest
 import pytz
 from django.http import QueryDict
+from django.test import TestCase
 from freezegun import freeze_time
 
 from sentry.release_health.base import SessionsQueryConfig
@@ -17,15 +18,16 @@ from sentry.snuba.sessions_v2 import (
     get_timestamps,
     massage_sessions_result,
 )
+from sentry.testutils.cases import SnubaTestCase
 
 
-def _make_query(qs, allow_minute_resolution=True):
+def _make_query(qs, allow_minute_resolution=True, params=None):
     query_config = SessionsQueryConfig(
         (AllowedResolution.one_minute if allow_minute_resolution else AllowedResolution.one_hour),
         allow_session_status_query=False,
         restrict_date_range=True,
     )
-    return QueryDefinition(QueryDict(qs), {}, query_config)
+    return QueryDefinition(QueryDict(qs), params or {}, query_config)
 
 
 def result_sorted(result):
@@ -220,6 +222,68 @@ def test_virtual_groupby_query():
         "users_errored",
     ]
     assert query.query_groupby == []
+
+
+class SnubaSessionsV2Test(TestCase, SnubaTestCase):
+    # This test suite needs a project to exist in the database.
+
+    @freeze_time("2022-05-04T09:00:00.000Z")
+    def _get_default_params(self):
+        # These parameters are computed in the API endpoint, before the
+        # QueryDefinition is built. Since we're only testing the query
+        # definition here, we can safely mock these.
+        return {
+            "start": datetime.now(),
+            "end": datetime.now(),
+            "organization_id": self.organization.id,
+        }
+
+    def test_filter_proj_slug_in_query(self):
+        params = self._get_default_params()
+        params["project_id"] = [self.project.id]
+        query_def = _make_query(
+            f"field=sum(session)&interval=2h&statsPeriod=2h&query=project%3A{self.project.slug}",
+            params=params,
+        )
+        assert query_def.query == f"project:{self.project.slug}"
+        assert query_def.params["project_id"] == [self.project.id]
+        assert query_def.conditions == [["project_id", "=", self.project.id]]
+        assert query_def.filter_keys == {"project_id": [self.project.id]}
+
+    def test_filter_proj_slug_in_top_filter(self):
+        params = self._get_default_params()
+        params["project_id"] = [self.project.id]
+        query_def = _make_query(
+            f"field=sum(session)&interval=2h&statsPeriod=2h&project={self.project.id}",
+            params=params,
+        )
+        assert query_def.query == ""
+        assert query_def.params["project_id"] == [self.project.id]
+        assert query_def.conditions == []
+        assert query_def.filter_keys == {"project_id": [self.project.id]}
+
+    def test_filter_proj_slug_in_top_filter_and_query(self):
+        params = self._get_default_params()
+        params["project_id"] = [self.project.id]
+        query_def = _make_query(
+            f"field=sum(session)&interval=2h&statsPeriod=2h&project={self.project.id}&query=project%3A{self.project.slug}",
+            params=params,
+        )
+        assert query_def.query == f"project:{self.project.slug}"
+        assert query_def.params["project_id"] == [self.project.id]
+        assert query_def.conditions == [["project_id", "=", self.project.id]]
+        assert query_def.filter_keys == {"project_id": [self.project.id]}
+
+    def test_proj_neither_in_top_filter_nor_query(self):
+        params = self._get_default_params()
+        query_def = _make_query(
+            "field=sum(session)&interval=2h&statsPeriod=2h",
+            params=params,
+        )
+        assert query_def.query == ""
+        assert "project_id" not in query_def.params
+        assert query_def.conditions == []
+        assert query_def.filter_keys == {}
 
 
 @freeze_time("2020-12-18T11:14:17.105Z")


### PR DESCRIPTION
Dashboards require the ability to filter by projects in query parameters, and right now this is only possible by the top-level `project` parameter. This PR introduces the feature to filter project slug and environment in the query. Filtering by the top-level parameter and filtering in the query at the same time is also supported.