### PR TITLE
feat(codeowners): Make repository select field searchable

### DIFF
--- a/static/app/components/repositoryProjectPathConfigForm.tsx
+++ b/static/app/components/repositoryProjectPathConfigForm.tsx
@@ -38,8 +38,9 @@ export default class RepositoryProjectPathConfigForm extends Component<Props> {
   }
 
   get formFields(): Field[] {
-    const {projects, repos} = this.props;
-    const repoChoices = repos.map(({name, id}) => ({value: id, label: name}));
+    const {projects, repos, organization} = this.props;
+    const reposMapper = (r: Repository[]) =>
+      r.map(({name, id}) => ({value: id, label: name}));
     return [
       {
         name: 'projectId',
@@ -50,11 +51,13 @@ export default class RepositoryProjectPathConfigForm extends Component<Props> {
       },
       {
         name: 'repositoryId',
-        type: 'select',
+        type: 'select_async',
         required: true,
         label: t('Repo'),
         placeholder: t('Choose repo'),
-        options: repoChoices,
+        url: `/organizations/${organization.slug}/repos/?status=active`,
+        defaultOptions: reposMapper(repos),
+        onResults: result => reposMapper(result),
       },
       {
         name: 'defaultBranch',


### PR DESCRIPTION
## Objective:

Frontend portion of https://github.com/getsentry/sentry/pull/34284

For larger customers, they can have many repositories and want to setup Code Mappings. This PR, makes the repository select field searchable.


https://user-images.githubusercontent.com/10491193/166963032-b4c3032d-f6f0-4d26-abcd-66d4a7735c30.mov



<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
