### PR TITLE
chore(discover): Remove tagstore sampling flag

### DIFF
--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -2,7 +2,7 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, tagstore
+from sentry import tagstore
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
@@ -22,10 +22,6 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
         except NoProjects:
             paginator = SequencePaginator([])
         else:
-            sampling = features.has(
-                "organizations:discover-tagstore-sampling", organization, actor=request.user
-            )
-            sentry_sdk.set_tag("discover.tagstore_sampling", sampling)
             with self.handle_query_errors():
                 environment_ids = None
                 if "environment_objects" in filter_params:
@@ -39,7 +35,6 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
                     query=request.GET.get("query"),
                     include_transactions=request.GET.get("includeTransactions") == "1",
                     include_sessions=request.GET.get("includeSessions") == "1",
-                    sampling=sampling,
                 )
 
         return self.paginate(

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -1,8 +1,7 @@
-import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, tagstore
+from sentry import tagstore
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -40,11 +39,6 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint, EnvironmentMixin):
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 
-        sampling = features.has(
-            "organizations:discover-tagstore-sampling", project.organization, actor=request.user
-        )
-        sentry_sdk.set_tag("discover.tagstore_sampling", sampling)
-
         start, end = get_date_range_from_params(request.GET)
 
         paginator = tagstore.get_tag_value_paginator(
@@ -55,7 +49,6 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint, EnvironmentMixin):
             end=end,
             query=request.GET.get("query"),
             order_by="-last_seen",
-            sampling=sampling,
         )
 
         return self.paginate(

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -64,7 +64,6 @@ default_manager.add("organizations:dashboards-releases", OrganizationFeature, Tr
 default_manager.add("organizations:dashboards-template", OrganizationFeature, True)
 default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, True)
 default_manager.add("organizations:discover", OrganizationFeature)
-default_manager.add("organizations:discover-tagstore-sampling", OrganizationFeature, True)
 default_manager.add("organizations:duplicate-alert-rule", OrganizationFeature, True)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature)
 default_manager.add("organizations:filters-and-sampling", OrganizationFeature, True)

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -198,7 +198,6 @@ class TagStorage(Service):
         key,
         query=None,
         order_by="-last_seen",
-        sampling=False,
     ):
         """
         >>> get_tag_value_paginator(1, 2, 'environment', query='prod')
@@ -214,7 +213,6 @@ class TagStorage(Service):
         end,
         query=None,
         order_by="-last_seen",
-        sampling=False,
     ):
         """
         Includes tags and also snuba columns, with the arrayjoin when they are nested.

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -688,7 +688,6 @@ class SnubaTagStorage(TagStorage):
         end=None,
         query=None,
         order_by="-last_seen",
-        sampling=False,
     ):
         return self.get_tag_value_paginator_for_projects(
             get_project_list(project_id),
@@ -903,7 +902,6 @@ class SnubaTagStorage(TagStorage):
         order_by="-last_seen",
         include_transactions=False,
         include_sessions=False,
-        sampling=False,
     ):
         from sentry.api.paginator import SequencePaginator
 
@@ -1057,7 +1055,7 @@ class SnubaTagStorage(TagStorage):
             # TODO: This means they can't actually paginate all TagValues.
             limit=1000,
             # 1 mill chosen arbitrarily, based it on a query that was timing out, and took 8s once this was set
-            sample=1_000_000 if sampling else None,
+            sample=1_000_000,
             arrayjoin=snuba.get_arrayjoin(snuba_key),
             referrer="tagstore.get_tag_value_paginator_for_projects",
         )


### PR DESCRIPTION
- This enables the 1mill sampling by default on the tagkey value endpoint since it looks to be successful at improving performance without impacting functionality
- Here's a [discover graph](https://sentry.io/organizations/sentry/discover/results/?id=13652&statsPeriod=48h) showing how the p99 will spike to 20s+ without sampling (actually timeouts with clickhouse reporting a very high estimated runtime), and a p99 of 5s with sampling
   - [Notion screenshot](https://www.notion.so/sentry/Tagkeyvalue-endpoint-perf-e1a454bbd2f643af8078bc2f8bac9d96)
- Clean up for https://github.com/getsentry/sentry/pull/34187
