### PR TITLE
feat(profiling): Add proxy to the profiling functions endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict
 
+from django.http import StreamingHttpResponse
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,6 +19,8 @@ from sentry.utils.profiling import (
 
 
 class OrganizationProfilingBaseEndpoint(OrganizationEndpoint):  # type: ignore
+    private = True
+
     def get_profiling_params(self, request: Request, organization: Organization) -> Dict[str, Any]:
         try:
             params: Dict[str, Any] = parse_profile_filters(request.query_params.get("query", ""))
@@ -66,7 +69,7 @@ class OrganizationProfilingProfilesEndpoint(OrganizationProfilingBaseEndpoint):
 
 
 class OrganizationProfilingFiltersEndpoint(OrganizationProfilingBaseEndpoint):
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> StreamingHttpResponse:
         if not features.has("organizations:profiling", organization, actor=request.user):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -1,15 +1,35 @@
 from typing import Any, Dict
 
+from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.utils.profiling import proxy_profiling_service
+from sentry.exceptions import InvalidSearchQuery
+from sentry.models import Project
+from sentry.utils.profiling import parse_profile_filters, proxy_profiling_service
 
 
-class ProjectProfilingProfileEndpoint(ProjectEndpoint):
-    def get(self, request: Request, project, profile_id: str) -> Response:
+class ProjectProfilingBaseEndpoint(ProjectEndpoint):  # type: ignore
+    def get_profiling_params(self, request: Request, project: Project) -> Dict[str, Any]:
+        try:
+            params: Dict[str, Any] = parse_profile_filters(request.query_params.get("query", ""))
+        except InvalidSearchQuery as err:
+            raise ParseError(detail=str(err))
+
+        params.update(
+            {
+                key: value.isoformat() if key in {"start", "end"} else value
+                for key, value in self.get_filter_params(request, project).items()
+            }
+        )
+
+        return params
+
+
+class ProjectProfilingProfileEndpoint(ProjectEndpoint):  # type: ignore
+    def get(self, request: Request, project: Project, profile_id: str) -> Response:
         if not features.has("organizations:profiling", project.organization, actor=request.user):
             return Response(status=404)
         kwargs: Dict[str, Any] = {
@@ -19,3 +39,23 @@ class ProjectProfilingProfileEndpoint(ProjectEndpoint):
         if "Accept-Encoding" in request.headers:
             kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
         return proxy_profiling_service(**kwargs)
+
+
+class ProjectProfilingFunctionsEndpoint(ProjectProfilingBaseEndpoint):
+    def get(self, request: Request, project: Project) -> Response:
+        if not features.has("organizations:profiling", project.organization, actor=request.user):
+            return Response(404)
+
+        params = self.get_profiling_params(request, project)
+
+        headers = {}
+
+        if "Accept-Encoding" in request.headers:
+            headers["Accept-Encoding"] = request.headers.get("Accept-Encoding")
+
+        return proxy_profiling_service(
+            "GET",
+            f"/organizations/{project.organization.id}/projects/{project.id}/functions_versions",
+            params=params,
+            headers=headers,
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -379,7 +379,10 @@ from .endpoints.project_processingissues import (
     ProjectProcessingIssuesEndpoint,
     ProjectProcessingIssuesFixEndpoint,
 )
-from .endpoints.project_profiling_profile import ProjectProfilingProfileEndpoint
+from .endpoints.project_profiling_profile import (
+    ProjectProfilingFunctionsEndpoint,
+    ProjectProfilingProfileEndpoint,
+)
 from .endpoints.project_release_commits import ProjectReleaseCommitsEndpoint
 from .endpoints.project_release_details import ProjectReleaseDetailsEndpoint
 from .endpoints.project_release_file_details import ProjectReleaseFileDetailsEndpoint
@@ -2179,6 +2182,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/(?P<credentials_id>[^\/]+)/refresh/$",
                     AppStoreConnectRefreshEndpoint.as_view(),
                     name="sentry-api-0-project-appstoreconnect-refresh",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/profiling/functions/$",
+                    ProjectProfilingFunctionsEndpoint.as_view(),
+                    name="sentry-api-0-project-profiling-functions",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/profiling/profiles/(?P<profile_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",

--- a/src/sentry/utils/profiling.py
+++ b/src/sentry/utils/profiling.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import google.auth.transport.requests
 import google.oauth2.id_token
@@ -73,7 +73,7 @@ PROFILE_FILTERS = {
 }
 
 
-def parse_profile_filters(query: str) -> Dict[str, List[str]]:
+def parse_profile_filters(query: str) -> Dict[str, str]:
     try:
         parsed_terms = parse_search_query(query)
     except ParseError as e:

--- a/tests/sentry/api/endpoints/test_project_profiling_profile.py
+++ b/tests/sentry/api/endpoints/test_project_profiling_profile.py
@@ -1,6 +1,11 @@
 from uuid import uuid4
 
+from django.urls import reverse
+from rest_framework.exceptions import ErrorDetail
+
 from sentry.testutils import APITestCase
+
+PROFILING_FEATURES = {"organizations:profiling": True}
 
 
 class ProjectProfilingProfileTest(APITestCase):
@@ -12,3 +17,29 @@ class ProjectProfilingProfileTest(APITestCase):
     def test_feature_flag_disabled(self):
         response = self.get_response(self.project.organization.slug, self.project.id, str(uuid4()))
         assert response.status_code == 404
+
+
+class ProjectProfilingFunctionsEndpoint(APITestCase):
+    endpoint = "sentry-api-0-project-profiling-functions"
+
+    def setUp(self):
+        self.login_as(user=self.user)
+        self.url = reverse(
+            self.endpoint,
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+            },
+        )
+
+    def test_feature_flag_disabled(self):
+        response = self.get_response(self.project.organization.slug, self.project.id)
+        assert response.status_code == 404
+
+    def test_bad_filter(self):
+        with self.feature(PROFILING_FEATURES):
+            response = self.client.get(self.url, {"query": "foo:bar"})
+        assert response.status_code == 400
+        assert response.data == {
+            "detail": ErrorDetail(string="Invalid query: foo is not supported", code="parse_error")
+        }


### PR DESCRIPTION
To support #34245, this change exposes a new endpoint that returns the top N
functions for a transaction.