### PR TITLE
fix(metrics-indexer): Allow empty strings

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -98,6 +98,8 @@ SHARED_TAG_STRINGS = {
     "inlier": PREFIX + 229,
     # added after the initial definition
     "sdk": PREFIX + 230,  # release health
+    # GENERAL/MISC (don't have a category)
+    "": PREFIX + 1000,
 }
 SHARED_STRINGS = {**SESSION_METRIC_NAMES, **TRANSACTION_METRICS_NAMES, **SHARED_TAG_STRINGS}
 REVERSE_SHARED_STRINGS = {v: k for k, v in SHARED_STRINGS.items()}

--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -337,7 +337,7 @@ class ProduceStep(ProcessingStep[MessageBatch]):  # type: ignore
         self.__producer.close()
 
 
-def valid_metric_name(name: str) -> bool:
+def valid_metric_name(name: Optional[str]) -> bool:
     if name is None:
         return False
     if len(name) > MAX_NAME_LENGTH:

--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -338,7 +338,7 @@ class ProduceStep(ProcessingStep[MessageBatch]):  # type: ignore
 
 
 def valid_metric_name(name: str) -> bool:
-    if not name:
+    if name is None:
         return False
     if len(name) > MAX_NAME_LENGTH:
         return False
@@ -349,9 +349,9 @@ def valid_metric_name(name: str) -> bool:
 def invalid_metric_tags(tags: Mapping[str, str]) -> Sequence[str]:
     invalid_strs: List[str] = []
     for key, value in tags.items():
-        if not key or len(key) > MAX_TAG_KEY_LENGTH:
+        if key is None or len(key) > MAX_TAG_KEY_LENGTH:
             invalid_strs.append(key)
-        if not value or len(value) > MAX_TAG_VALUE_LENGTH:
+        if value is None or len(value) > MAX_TAG_VALUE_LENGTH:
             invalid_strs.append(value)
 
     return invalid_strs

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -19,7 +19,9 @@ from sentry.sentry_metrics.multiprocess import (
     DuplicateMessage,
     MetricsBatchBuilder,
     ProduceStep,
+    invalid_metric_tags,
     process_messages,
+    valid_metric_name,
 )
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.utils import json
@@ -406,3 +408,20 @@ def test_produce_step() -> None:
 
     produce_step.close()
     produce_step.join()
+
+
+def test_valid_metric_name() -> None:
+    assert valid_metric_name("") is True
+    assert valid_metric_name("blah") is True
+    assert valid_metric_name("invalid" * 200) is False
+
+
+def test_invalid_metric_tags() -> None:
+    bad_tag = "invalid" * 200
+    tags = {"environment": "", "release": "good_tag"}
+    assert invalid_metric_tags(tags) == []
+    assert invalid_metric_tags(tags) == []
+    tags["release"] = bad_tag
+    assert invalid_metric_tags(tags) == [bad_tag]
+    tags["release"] = None
+    assert invalid_metric_tags(tags) == [None]

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -78,11 +78,17 @@ def get_entity_of_metric_mocked(_, metric_name):
     [
         (
             'release:""',
-            [Condition(Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10000])],
+            [
+                Condition(
+                    Column(name=resolve_tag_key(ORG_ID, "release")),
+                    Op.IN,
+                    rhs=[resolve(ORG_ID, "")],
+                )
+            ],
         ),
         (
             "release:myapp@2.0.0",
-            [Condition(Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10001])],
+            [Condition(Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10000])],
         ),
         (
             "release:myapp@2.0.0 and environment:production",
@@ -90,7 +96,7 @@ def get_entity_of_metric_mocked(_, metric_name):
                 And(
                     [
                         Condition(
-                            Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10001]
+                            Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10000]
                         ),
                         Condition(
                             Column(name=resolve_tag_key(ORG_ID, "environment")),
@@ -104,7 +110,7 @@ def get_entity_of_metric_mocked(_, metric_name):
         (
             "release:myapp@2.0.0 environment:production",
             [
-                Condition(Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10001]),
+                Condition(Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10000]),
                 Condition(
                     Column(name=resolve_tag_key(ORG_ID, "environment")),
                     Op.EQ,
@@ -118,7 +124,7 @@ def get_entity_of_metric_mocked(_, metric_name):
                 And(
                     [
                         Condition(
-                            Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10001]
+                            Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10000]
                         ),
                         Condition(
                             Column(name=resolve_tag_key(ORG_ID, "environment")),
@@ -131,7 +137,7 @@ def get_entity_of_metric_mocked(_, metric_name):
         ),
         (
             'transaction:"/bar/:orgId/"',
-            [Condition(Column(name=resolve_tag_key(ORG_ID, "transaction")), Op.EQ, rhs=10002)],
+            [Condition(Column(name=resolve_tag_key(ORG_ID, "transaction")), Op.EQ, rhs=10001)],
         ),
         (
             "release:[production,foo]",
@@ -169,7 +175,7 @@ def get_entity_of_metric_mocked(_, metric_name):
                 Or(
                     [
                         Condition(
-                            Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10001]
+                            Column(name=resolve_tag_key(ORG_ID, "release")), Op.IN, rhs=[10000]
                         ),
                         Condition(
                             Column(name=resolve_tag_key(ORG_ID, "environment")),
@@ -185,8 +191,8 @@ def get_entity_of_metric_mocked(_, metric_name):
 def test_parse_query(monkeypatch, query_string, expected):
     org_id = ORG_ID
     local_indexer = MockIndexer()
-    for s in ("", "myapp@2.0.0", "/bar/:orgId/"):
-        # will be values 10000, 10001, 10002 respectively
+    for s in ("myapp@2.0.0", "/bar/:orgId/"):
+        # will be values 10000, 10001 respectively
         local_indexer.record(org_id, s)
     monkeypatch.setattr("sentry.sentry_metrics.indexer.resolve", local_indexer.resolve)
     parsed = resolve_tags(org_id, parse_query(query_string))


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/34059 I considered empty strings as invalid, but we shouldn't be doing that. 