### PR TITLE
test(alerts): Avoid alert test flake, render modal earlier

### DIFF
--- a/tests/js/spec/views/alerts/issueRuleEditor/issueRuleEditor.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/issueRuleEditor.spec.jsx
@@ -161,9 +161,9 @@ describe('ProjectAlerts -> IssueRuleEditor', function () {
         body: {},
       });
       createWrapper();
+      renderGlobalModal();
       userEvent.click(screen.getByLabelText('Delete Rule'));
 
-      renderGlobalModal();
       expect(
         await screen.findByText('Are you sure you want to delete this rule?')
       ).toBeInTheDocument();


### PR DESCRIPTION
just going to try rendering the modal earlier

https://sentry.io/organizations/sentry/performance/jest:7e50d9946f08423095eb6560bf979da5/?end=2022-05-05T20%3A52%3A24.000&environment=ci&project=4857230&query=branch%3Arefs%2Fheads%2Fmaster+transaction.status%3Ainternal_error&start=2022-05-05T07%3A47%3A00.000&transaction=ProjectAlerts+-%3E+IssueRuleEditor+%3E+Edit+Rule+%3E+deletes+rule&unselectedSeries=p100%28%29#span-852bdd7718f899fc