### PR TITLE
tests(alerts): Tests for alert list row actions - duplicate

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -29,6 +29,7 @@ interface BaseButtonProps
   barId?: string;
   borderless?: boolean;
   busy?: boolean;
+  'data-test-id'?: string;
   disabled?: boolean;
   download?: HTMLAnchorElement['download'];
   external?: boolean;

--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -280,6 +280,7 @@ function RuleListRow({
               placement="bottom right"
               triggerProps={{
                 'aria-label': t('Show more'),
+                'data-test-id': 'alert-row-actions',
                 size: 'xsmall',
                 icon: <IconEllipsis size="xs" />,
                 showChevron: false,

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -12,7 +12,12 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 jest.mock('sentry/utils/analytics/trackAdvancedAnalyticsEvent');
 
 describe('AlertRulesList', () => {
-  const {routerContext, organization, router} = initializeOrg();
+  const {routerContext, organization, router} = initializeOrg({
+    organization: {
+      access: ['alerts:write'],
+      features: ['duplicate-alert-rule'],
+    },
+  });
   TeamStore.loadInitialData([], false, null);
   let rulesMock;
   let projectMock;
@@ -109,6 +114,41 @@ describe('AlertRulesList', () => {
     ).toBeInTheDocument();
 
     expect(rulesMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('displays dropdown context menu with actions', async () => {
+    createWrapper();
+    const actions = (await screen.findAllByTestId('alert-row-actions'))[0];
+    expect(actions).toBeInTheDocument();
+
+    userEvent.click(actions);
+
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+    expect(screen.getByText('Duplicate')).toBeInTheDocument();
+  });
+
+  it('sends user to new alert page on duplicate action', async () => {
+    createWrapper();
+    const actions = (await screen.findAllByTestId('alert-row-actions'))[0];
+    expect(actions).toBeInTheDocument();
+
+    userEvent.click(actions);
+
+    const duplicate = await screen.findByText('Duplicate');
+    expect(duplicate).toBeInTheDocument();
+
+    userEvent.click(duplicate);
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: '/organizations/org-slug/alerts/new/issue/',
+      query: {
+        createFromDuplicate: true,
+        duplicateRuleId: '123',
+        project: 'earth',
+        referrer: 'alert_stream',
+      },
+    });
   });
 
   it('sorts by date created', async () => {


### PR DESCRIPTION
This adds two tests one for alert list row context menu actions, all actions with duplicate feature and write access enabled and one for duplicate button action router push to create new alert page.