### PR TITLE
fix(releases): Make sure we set `Project.flags.has_releases` in release monitor

### DIFF
--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -11,7 +11,6 @@ from sentry.models import (
     Project,
     Release,
     ReleaseEnvironment,
-    ReleaseProject,
     ReleaseProjectEnvironment,
     ReleaseStatus,
 )
@@ -122,9 +121,8 @@ def adopt_releases(org_id: int, totals: Totals) -> Sequence[int]:
                                     release = Release.objects.get(
                                         organization_id=org_id, version=release_version
                                     )
-                                ReleaseProject.objects.get_or_create(
-                                    project_id=project_id, release=release
-                                )
+
+                                release.add_project(Project.objects.get(id=project_id))
 
                                 ReleaseEnvironment.objects.get_or_create(
                                     environment=env, organization_id=org_id, release=release
@@ -141,7 +139,6 @@ def adopt_releases(org_id: int, totals: Totals) -> Sequence[int]:
                                 Environment.DoesNotExist,
                                 Release.DoesNotExist,
                                 ReleaseEnvironment.DoesNotExist,
-                                ReleaseProject.DoesNotExist,
                             ) as exc:
                                 metrics.incr(
                                     "sentry.tasks.process_projects_with_sessions.skipped_update"


### PR DESCRIPTION
I found that we're still creating new rows with the `has_releases` flag incorrectly set. Tracked
down another place that this can happen, this should hopefully cover all corner cases here.