### PR TITLE
docs(replay): Update Storybook example to reflect what the real page looks like

### DIFF
--- a/docs-ui/stories/components/replays/replayPage.stories.js
+++ b/docs-ui/stories/components/replays/replayPage.stories.js
@@ -1,6 +1,10 @@
 import {useState} from 'react';
+import styled from '@emotion/styled';
+import {action} from '@storybook/addon-actions';
 
 import SelectControl from 'sentry/components/forms/selectControl';
+import {Panel, PanelBody, PanelHeader as _PanelHeader} from 'sentry/components/panels';
+import Scrubber from 'sentry/components/replays/player/scrubber';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
@@ -13,10 +17,38 @@ export default {
   component: ReplayPlayer,
 };
 
+const PanelHeader = styled(_PanelHeader)`
+  display: block; /* Override flex */
+  padding: 0; /* The disablePadding prop doesn't disable all the padding */
+`;
+
+const ManualResize = styled('div')`
+  resize: vertical;
+  overflow: auto;
+  max-width: 100%;
+
+  ${p =>
+    p.isFullscreen
+      ? `resize: none;
+      width: auto !important;
+      height: auto !important;
+      `
+      : ''}
+`;
+
 export const PlayerWithController = () => (
   <ReplayContextProvider events={rrwebEvents1}>
-    <ReplayPlayer />
-    <ReplayController speedOptions={[0.5, 1, 2, 8]} />
+    <Panel>
+      <PanelHeader>
+        <ManualResize isFullscreen={false}>
+          <ReplayPlayer />
+        </ManualResize>
+      </PanelHeader>
+      <Scrubber />
+      <PanelBody withPadding>
+        <ReplayController toggleFullscreen={action('toggleFullscreen')} />
+      </PanelBody>
+    </Panel>
   </ReplayContextProvider>
 );
 

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -16,7 +16,7 @@ function getPercentComplete(currentTime: number, duration: number | undefined) {
   return currentTime / duration;
 }
 
-function Scrobber({className}: Props) {
+function Scrubber({className}: Props) {
   const {currentTime, duration, setCurrentTime} = useReplayContext();
 
   const percentComplete = getPercentComplete(currentTime, duration);
@@ -114,4 +114,4 @@ const Wrapper = styled('div')`
   }
 `;
 
-export default Scrobber;
+export default Scrubber;

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -7,7 +7,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader as _PanelHeader} from 'sentry/components/panels';
 import ReplayBreadcrumbOverview from 'sentry/components/replays/breadcrumbs/replayBreadcrumbOverview';
-import Scrobber from 'sentry/components/replays/player/scrobber';
+import Scrubber from 'sentry/components/replays/player/scrubber';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
@@ -92,12 +92,12 @@ function ReplayDetails() {
         <Layout.Body>
           <ReplayLayout ref={fullscreenRef}>
             <Panel>
-              <PanelHeader disablePadding>
+              <PanelHeader>
                 <ManualResize isFullscreen={isFullscreen}>
                   <ReplayPlayer />
                 </ManualResize>
               </PanelHeader>
-              <Scrobber />
+              <Scrubber />
               <PanelBody withPadding>
                 <ReplayController toggleFullscreen={toggleFullscreen} />
               </PanelBody>
@@ -124,8 +124,8 @@ function ReplayDetails() {
 }
 
 const PanelHeader = styled(_PanelHeader)`
-  display: block;
-  padding: 0;
+  display: block; /* Override flex */
+  padding: 0; /* The disablePadding prop doesn't disable all the padding */
 `;
 
 const ManualResize = styled('div')<{isFullscreen: boolean}>`


### PR DESCRIPTION
Make the storybook example exactly like the real page: with the new scrubber component and everything.

Also, rename from scrobber to scrubber, google suggests that this is the correct term: https://www.google.com/search?q=video+scrobber