### PR TITLE
ref(performance): Extract `<TraceView>` into a component

### DIFF
--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -1,6 +1,5 @@
 import {Component, createRef, Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
@@ -8,21 +7,12 @@ import ButtonBar from 'sentry/components/buttonBar';
 import DiscoverButton from 'sentry/components/discoverButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
-import Link from 'sentry/components/links/link';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {
-  ErrorDot,
-  ErrorLevel,
-  ErrorMessageContent,
-  ErrorTitle,
-} from 'sentry/components/performance/waterfall/rowDetails';
 import TimeSince from 'sentry/components/timeSince';
 import {t, tct, tn} from 'sentry/locale';
-import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
-import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {getDuration} from 'sentry/utils/formatters';
@@ -120,77 +110,6 @@ class TraceDetailsContent extends Component<Props, State> {
 
   renderTraceRequiresDateRangeSelection() {
     return <LoadingError message={t('Trace view requires a date range selection.')} />;
-  }
-
-  renderTraceNotFound() {
-    const {meta, traceEventView, traceSlug, organization, location} = this.props;
-
-    const transactions = meta?.transactions ?? 0;
-    const errors = meta?.errors ?? 0;
-
-    if (transactions === 0 && errors > 0) {
-      const errorsEventView = traceEventView.withColumns([
-        {kind: 'field', field: 'project'},
-        {kind: 'field', field: 'title'},
-        {kind: 'field', field: 'issue.id'},
-        {kind: 'field', field: 'level'},
-      ]);
-      errorsEventView.query = `trace:${traceSlug} !event.type:transaction `;
-
-      return (
-        <DiscoverQuery
-          eventView={errorsEventView}
-          orgSlug={organization.slug}
-          location={location}
-          referrer="api.trace-view.errors-view"
-        >
-          {({isLoading, tableData, error}) => {
-            if (isLoading) {
-              return <LoadingIndicator />;
-            }
-
-            if (error) {
-              return (
-                <Alert type="error" showIcon>
-                  <ErrorLabel>
-                    {tct(
-                      'The trace cannot be shown when all events are errors. An error occurred when attempting to fetch these error events: [error]',
-                      {error: error.message}
-                    )}
-                  </ErrorLabel>
-                </Alert>
-              );
-            }
-
-            return (
-              <Alert type="error" showIcon>
-                <ErrorLabel>
-                  {t('The trace cannot be shown when all events are errors.')}
-                </ErrorLabel>
-
-                <ErrorMessageContent data-test-id="trace-view-errors">
-                  {tableData?.data.map(data => (
-                    <Fragment key={data.id}>
-                      <ErrorDot level={data.level as any} />
-                      <ErrorLevel>{data.level}</ErrorLevel>
-                      <ErrorTitle>
-                        <Link
-                          to={`/organizations/${organization.slug}/issues/${data['issue.id']}/events/${data.id}`}
-                        >
-                          {data.title}
-                        </Link>
-                      </ErrorTitle>
-                    </Fragment>
-                  ))}
-                </ErrorMessageContent>
-              </Alert>
-            );
-          }}
-        </DiscoverQuery>
-      );
-    }
-
-    return <LoadingError message={t('The trace you are looking for was not found.')} />;
   }
 
   handleTransactionFilter = (searchQuery: string) => {
@@ -427,9 +346,5 @@ class TraceDetailsContent extends Component<Props, State> {
     );
   }
 }
-
-const ErrorLabel = styled('div')`
-  margin-bottom: ${space(1)};
-`;
 
 export default TraceDetailsContent;

--- a/static/app/views/performance/traceDetails/limitExceededMessage.tsx
+++ b/static/app/views/performance/traceDetails/limitExceededMessage.tsx
@@ -1,7 +1,7 @@
 import DiscoverFeature from 'sentry/components/discover/discoverFeature';
 import Link from 'sentry/components/links/link';
 import {MessageRow} from 'sentry/components/performance/waterfall/messageRow';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {TraceMeta} from 'sentry/utils/performance/quickTrace/types';
@@ -38,7 +38,7 @@ function LimitExceededMessage({
             <DiscoverFeature>
               {({hasFeature}) => (
                 <Link disabled={!hasFeature} to={target}>
-                  Open in Discover
+                  {t('Open in Discover')}
                 </Link>
               )}
             </DiscoverFeature>

--- a/static/app/views/performance/traceDetails/limitExceededMessage.tsx
+++ b/static/app/views/performance/traceDetails/limitExceededMessage.tsx
@@ -1,0 +1,52 @@
+import DiscoverFeature from 'sentry/components/discover/discoverFeature';
+import Link from 'sentry/components/links/link';
+import {MessageRow} from 'sentry/components/performance/waterfall/messageRow';
+import {tct} from 'sentry/locale';
+import {Organization} from 'sentry/types';
+import EventView from 'sentry/utils/discover/eventView';
+import {TraceMeta} from 'sentry/utils/performance/quickTrace/types';
+import {TraceInfo} from 'sentry/views/performance/traceDetails/types';
+
+interface LimitExceededMessageProps {
+  meta: TraceMeta | null;
+  organization: Organization;
+  traceEventView: EventView;
+  traceInfo: TraceInfo;
+}
+function LimitExceededMessage({
+  traceInfo,
+  traceEventView,
+  organization,
+  meta,
+}: LimitExceededMessageProps) {
+  const count = traceInfo.transactions.size;
+  const totalTransactions = meta?.transactions ?? count;
+
+  if (totalTransactions === null || count >= totalTransactions) {
+    return null;
+  }
+
+  const target = traceEventView.getResultsViewUrlTarget(organization.slug);
+
+  return (
+    <MessageRow>
+      {tct(
+        'Limited to a view of [count] transactions. To view the full list, [discover].',
+        {
+          count,
+          discover: (
+            <DiscoverFeature>
+              {({hasFeature}) => (
+                <Link disabled={!hasFeature} to={target}>
+                  Open in Discover
+                </Link>
+              )}
+            </DiscoverFeature>
+          ),
+        }
+      )}
+    </MessageRow>
+  );
+}
+
+export default LimitExceededMessage;

--- a/static/app/views/performance/traceDetails/traceNotFound.tsx
+++ b/static/app/views/performance/traceDetails/traceNotFound.tsx
@@ -1,0 +1,108 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
+import Link from 'sentry/components/links/link';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {
+  ErrorDot,
+  ErrorLevel,
+  ErrorMessageContent,
+  ErrorTitle,
+} from 'sentry/components/performance/waterfall/rowDetails';
+import {t, tct} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
+import EventView from 'sentry/utils/discover/eventView';
+import {TraceMeta} from 'sentry/utils/performance/quickTrace/types';
+
+interface TraceNotFoundProps {
+  location: any;
+  meta: TraceMeta | null;
+  organization: Organization;
+  traceEventView: EventView;
+  traceSlug: string;
+}
+
+function TraceNotFound({
+  meta,
+  traceEventView,
+  traceSlug,
+  organization,
+  location,
+}: TraceNotFoundProps) {
+  const transactions = meta?.transactions ?? 0;
+  const errors = meta?.errors ?? 0;
+
+  if (transactions === 0 && errors > 0) {
+    const errorsEventView = traceEventView.withColumns([
+      {kind: 'field', field: 'project'},
+      {kind: 'field', field: 'title'},
+      {kind: 'field', field: 'issue.id'},
+      {kind: 'field', field: 'level'},
+    ]);
+    errorsEventView.query = `trace:${traceSlug} !event.type:transaction `;
+
+    return (
+      <DiscoverQuery
+        eventView={errorsEventView}
+        orgSlug={organization.slug}
+        location={location}
+        referrer="api.trace-view.errors-view"
+      >
+        {({isLoading, tableData, error}) => {
+          if (isLoading) {
+            return <LoadingIndicator />;
+          }
+
+          if (error) {
+            return (
+              <Alert type="error" showIcon>
+                <ErrorLabel>
+                  {tct(
+                    'The trace cannot be shown when all events are errors. An error occurred when attempting to fetch these error events: [error]',
+                    {error: error.message}
+                  )}
+                </ErrorLabel>
+              </Alert>
+            );
+          }
+
+          return (
+            <Alert type="error" showIcon>
+              <ErrorLabel>
+                {t('The trace cannot be shown when all events are errors.')}
+              </ErrorLabel>
+
+              <ErrorMessageContent data-test-id="trace-view-errors">
+                {tableData?.data.map(data => (
+                  <Fragment key={data.id}>
+                    <ErrorDot level={data.level as any} />
+                    <ErrorLevel>{data.level}</ErrorLevel>
+                    <ErrorTitle>
+                      <Link
+                        to={`/organizations/${organization.slug}/issues/${data['issue.id']}/events/${data.id}`}
+                      >
+                        {data.title}
+                      </Link>
+                    </ErrorTitle>
+                  </Fragment>
+                ))}
+              </ErrorMessageContent>
+            </Alert>
+          );
+        }}
+      </DiscoverQuery>
+    );
+  }
+
+  return <LoadingError message={t('The trace you are looking for was not found.')} />;
+}
+
+const ErrorLabel = styled('div')`
+  margin-bottom: ${space(1)};
+`;
+
+export default TraceNotFound;

--- a/static/app/views/performance/traceDetails/traceView.tsx
+++ b/static/app/views/performance/traceDetails/traceView.tsx
@@ -1,0 +1,335 @@
+import React, {createRef} from 'react';
+import {RouteComponentProps} from 'react-router';
+import * as Sentry from '@sentry/react';
+
+import * as AnchorLinkManager from 'sentry/components/events/interfaces/spans/anchorLinkManager';
+import * as DividerHandlerManager from 'sentry/components/events/interfaces/spans/dividerHandlerManager';
+import * as ScrollbarManager from 'sentry/components/events/interfaces/spans/scrollbarManager';
+import {MessageRow} from 'sentry/components/performance/waterfall/messageRow';
+import {
+  DividerSpacer,
+  ScrollbarContainer,
+  VirtualScrollbar,
+  VirtualScrollbarGrip,
+} from 'sentry/components/performance/waterfall/miniHeader';
+import {pickBarColor, toPercent} from 'sentry/components/performance/waterfall/utils';
+import {tct} from 'sentry/locale';
+import {Organization} from 'sentry/types';
+import EventView from 'sentry/utils/discover/eventView';
+import {TraceFullDetailed, TraceMeta} from 'sentry/utils/performance/quickTrace/types';
+import {
+  TraceDetailBody,
+  TracePanel,
+  TraceViewContainer,
+  TraceViewHeaderContainer,
+} from 'sentry/views/performance/traceDetails/styles';
+import TransactionGroup from 'sentry/views/performance/traceDetails/transactionGroup';
+import {TraceInfo, TreeDepth} from 'sentry/views/performance/traceDetails/types';
+import {
+  getTraceInfo,
+  isRootTransaction,
+} from 'sentry/views/performance/traceDetails/utils';
+
+import LimitExceededMessage from './limitExceededMessage';
+import TraceNotFound from './traceNotFound';
+
+type AccType = {
+  lastIndex: number;
+  numberOfHiddenTransactionsAbove: number;
+  renderedChildren: React.ReactNode[];
+};
+
+type Props = Pick<RouteComponentProps<{}, {}>, 'location'> & {
+  filteredTransactionIds: Set<string> | undefined;
+  meta: TraceMeta | null;
+  organization: Organization;
+  traceEventView: EventView;
+  traceInfo: TraceInfo;
+  traceSlug: string;
+  traces: TraceFullDetailed[] | null;
+};
+
+function TraceHiddenMessage({
+  isVisible,
+  numberOfHiddenTransactionsAbove,
+}: {
+  isVisible: boolean;
+  numberOfHiddenTransactionsAbove: number;
+}) {
+  if (!isVisible || numberOfHiddenTransactionsAbove < 1) {
+    return null;
+  }
+
+  return (
+    <MessageRow>
+      <span key="trace-info-message">
+        {numberOfHiddenTransactionsAbove === 1
+          ? tct('[numOfTransaction] hidden transaction', {
+              numOfTransaction: <strong>{numberOfHiddenTransactionsAbove}</strong>,
+            })
+          : tct('[numOfTransaction] hidden transactions', {
+              numOfTransaction: <strong>{numberOfHiddenTransactionsAbove}</strong>,
+            })}
+      </span>
+    </MessageRow>
+  );
+}
+
+function isTransactionVisible(
+  transaction: TraceFullDetailed,
+  filteredTransactionIds?: Set<string>
+): boolean {
+  return filteredTransactionIds ? filteredTransactionIds.has(transaction.event_id) : true;
+}
+
+export default function TraceView({
+  location,
+  meta,
+  organization,
+  traces,
+  traceSlug,
+  traceEventView,
+  filteredTransactionIds,
+}: Props) {
+  const sentryTransaction = Sentry.getCurrentHub().getScope()?.getTransaction();
+  const sentrySpan = sentryTransaction?.startChild({
+    op: 'trace.render',
+    description: 'trace-view-content',
+  });
+
+  function renderTransaction(
+    transaction: TraceFullDetailed,
+    {
+      continuingDepths,
+      isOrphan,
+      isLast,
+      index,
+      numberOfHiddenTransactionsAbove,
+      traceInfo,
+      hasGuideAnchor,
+    }: {
+      continuingDepths: TreeDepth[];
+      hasGuideAnchor: boolean;
+      index: number;
+      isLast: boolean;
+      isOrphan: boolean;
+      numberOfHiddenTransactionsAbove: number;
+      traceInfo: TraceInfo;
+    }
+  ) {
+    const {children, event_id: eventId} = transaction;
+    // Add 1 to the generation to make room for the "root trace"
+    const generation = transaction.generation + 1;
+
+    const isVisible = isTransactionVisible(transaction, filteredTransactionIds);
+
+    const accumulated: AccType = children.reduce(
+      (acc: AccType, child: TraceFullDetailed, idx: number) => {
+        const isLastChild = idx === children.length - 1;
+        const hasChildren = child.children.length > 0;
+
+        const result = renderTransaction(child, {
+          continuingDepths:
+            !isLastChild && hasChildren
+              ? [...continuingDepths, {depth: generation, isOrphanDepth: isOrphan}]
+              : continuingDepths,
+          isOrphan,
+          isLast: isLastChild,
+          index: acc.lastIndex + 1,
+          numberOfHiddenTransactionsAbove: acc.numberOfHiddenTransactionsAbove,
+          traceInfo,
+          hasGuideAnchor: false,
+        });
+
+        acc.lastIndex = result.lastIndex;
+        acc.numberOfHiddenTransactionsAbove = result.numberOfHiddenTransactionsAbove;
+        acc.renderedChildren.push(result.transactionGroup);
+
+        return acc;
+      },
+      {
+        renderedChildren: [],
+        lastIndex: index,
+        numberOfHiddenTransactionsAbove: isVisible
+          ? 0
+          : numberOfHiddenTransactionsAbove + 1,
+      }
+    );
+
+    return {
+      transactionGroup: (
+        <React.Fragment key={eventId}>
+          <TraceHiddenMessage
+            isVisible={isVisible}
+            numberOfHiddenTransactionsAbove={numberOfHiddenTransactionsAbove}
+          />
+          <TransactionGroup
+            location={location}
+            organization={organization}
+            traceInfo={traceInfo}
+            transaction={{
+              ...transaction,
+              generation,
+            }}
+            continuingDepths={continuingDepths}
+            isOrphan={isOrphan}
+            isLast={isLast}
+            index={index}
+            isVisible={isVisible}
+            hasGuideAnchor={hasGuideAnchor}
+            renderedChildren={accumulated.renderedChildren}
+            barColor={pickBarColor(transaction['transaction.op'])}
+          />
+        </React.Fragment>
+      ),
+      lastIndex: accumulated.lastIndex,
+      numberOfHiddenTransactionsAbove: accumulated.numberOfHiddenTransactionsAbove,
+    };
+  }
+
+  const traceViewRef = createRef<HTMLDivElement>();
+  const virtualScrollbarContainerRef = createRef<HTMLDivElement>();
+
+  if (traces === null || traces.length <= 0) {
+    return (
+      <TraceNotFound
+        meta={meta}
+        traceEventView={traceEventView}
+        traceSlug={traceSlug}
+        location={location}
+        organization={organization}
+      />
+    );
+  }
+
+  const traceInfo = getTraceInfo(traces);
+
+  const accumulator: {
+    index: number;
+    numberOfHiddenTransactionsAbove: number;
+    traceInfo: TraceInfo;
+    transactionGroups: React.ReactNode[];
+  } = {
+    index: 1,
+    numberOfHiddenTransactionsAbove: 0,
+    traceInfo,
+    transactionGroups: [],
+  };
+
+  const {transactionGroups, numberOfHiddenTransactionsAbove} = traces.reduce(
+    (acc, trace, index) => {
+      const isLastTransaction = index === traces.length - 1;
+      const hasChildren = trace.children.length > 0;
+      const isNextChildOrphaned =
+        !isLastTransaction && traces[index + 1].parent_span_id !== null;
+
+      const result = renderTransaction(trace, {
+        ...acc,
+        // if the root of a subtrace has a parent_span_id, then it must be an orphan
+        isOrphan: !isRootTransaction(trace),
+        isLast: isLastTransaction,
+        continuingDepths:
+          !isLastTransaction && hasChildren
+            ? [{depth: 0, isOrphanDepth: isNextChildOrphaned}]
+            : [],
+        hasGuideAnchor: index === 0,
+      });
+
+      acc.index = result.lastIndex + 1;
+      acc.numberOfHiddenTransactionsAbove = result.numberOfHiddenTransactionsAbove;
+      acc.transactionGroups.push(result.transactionGroup);
+      return acc;
+    },
+    accumulator
+  );
+
+  const traceView = (
+    <TraceDetailBody>
+      <DividerHandlerManager.Provider interactiveLayerRef={traceViewRef}>
+        <DividerHandlerManager.Consumer>
+          {({dividerPosition}) => (
+            <ScrollbarManager.Provider
+              dividerPosition={dividerPosition}
+              interactiveLayerRef={virtualScrollbarContainerRef}
+            >
+              <TracePanel>
+                <TraceViewHeaderContainer>
+                  <ScrollbarManager.Consumer>
+                    {({virtualScrollbarRef, scrollBarAreaRef, onDragStart, onScroll}) => {
+                      return (
+                        <ScrollbarContainer
+                          ref={virtualScrollbarContainerRef}
+                          style={{
+                            // the width of this component is shrunk to compensate for half of the width of the divider line
+                            width: `calc(${toPercent(dividerPosition)} - 0.5px)`,
+                          }}
+                          onScroll={onScroll}
+                        >
+                          <div
+                            style={{
+                              width: 0,
+                              height: '1px',
+                            }}
+                            ref={scrollBarAreaRef}
+                          />
+                          <VirtualScrollbar
+                            data-type="virtual-scrollbar"
+                            ref={virtualScrollbarRef}
+                            onMouseDown={onDragStart}
+                          >
+                            <VirtualScrollbarGrip />
+                          </VirtualScrollbar>
+                        </ScrollbarContainer>
+                      );
+                    }}
+                  </ScrollbarManager.Consumer>
+                  <DividerSpacer />
+                </TraceViewHeaderContainer>
+                <TraceViewContainer ref={traceViewRef}>
+                  <AnchorLinkManager.Provider>
+                    <TransactionGroup
+                      location={location}
+                      organization={organization}
+                      traceInfo={traceInfo}
+                      transaction={{
+                        traceSlug,
+                        generation: 0,
+                        'transaction.duration':
+                          traceInfo.endTimestamp - traceInfo.startTimestamp,
+                        children: traces,
+                        start_timestamp: traceInfo.startTimestamp,
+                        timestamp: traceInfo.endTimestamp,
+                      }}
+                      continuingDepths={[]}
+                      isOrphan={false}
+                      isLast={false}
+                      index={0}
+                      isVisible
+                      hasGuideAnchor={false}
+                      renderedChildren={transactionGroups}
+                      barColor={pickBarColor('')}
+                    />
+                  </AnchorLinkManager.Provider>
+                  <TraceHiddenMessage
+                    isVisible
+                    numberOfHiddenTransactionsAbove={numberOfHiddenTransactionsAbove}
+                  />
+                  <LimitExceededMessage
+                    traceInfo={traceInfo}
+                    organization={organization}
+                    traceEventView={traceEventView}
+                    meta={meta}
+                  />
+                </TraceViewContainer>
+              </TracePanel>
+            </ScrollbarManager.Provider>
+          )}
+        </DividerHandlerManager.Consumer>
+      </DividerHandlerManager.Provider>
+    </TraceDetailBody>
+  );
+
+  sentrySpan?.finish();
+
+  return traceView;
+}


### PR DESCRIPTION
We are looking to use TraceView in Replays, so we extracted it into a new component (as well as some others that were being rendered via class methods)