### PR TITLE
feat(profiling): use threadId instead of profileIndex

### DIFF
--- a/static/app/components/profiling/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph.tsx
@@ -44,7 +44,7 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
       return FlamegraphModel.Empty();
     }
 
-    // This could happen if activeProfileIndex was initialized from query string, but for some
+    // This could happen if threadId was initialized from query string, but for some
     // reason the profile was removed from the list of profiles.
     const profile = props.profiles.profiles.find(p => p.threadId === threadId);
     if (!profile) {

--- a/static/app/components/profiling/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph.tsx
@@ -51,7 +51,6 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
       return FlamegraphModel.Empty();
     }
 
-    // if the activeProfileIndex is null, use the activeProfileIndex from the profile group
     return new FlamegraphModel(profile, threadId, {
       inverted: view === 'bottom up',
       leftHeavy: sorting === 'left heavy',

--- a/static/app/components/profiling/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph.tsx
@@ -35,22 +35,20 @@ interface FlamegraphProps {
 function Flamegraph(props: FlamegraphProps): ReactElement {
   const flamegraphTheme = useFlamegraphTheme();
   const [{sorting, view, xAxis}, dispatch] = useFlamegraphPreferences();
-  const [{activeProfileIndex}, dispatchActiveProfileIndex] = useFlamegraphProfiles();
+  const [{threadId}, dispatchActiveProfileIndex] = useFlamegraphProfiles();
 
   const canvasPoolManager = useMemo(() => new CanvasPoolManager(), []);
 
   const flamegraph = useMemo(() => {
-    if (
-      !props.profiles.profiles[activeProfileIndex ?? props.profiles.activeProfileIndex]
-    ) {
+    if (typeof threadId !== 'number' || !props.profiles.profiles[threadId]) {
       // This could happen if activeProfileIndex was initialized from query string, but for some
       // reason the profile was removed from the list of profiles.
       return FlamegraphModel.Empty();
     }
     // if the activeProfileIndex is null, use the activeProfileIndex from the profile group
     return new FlamegraphModel(
-      props.profiles.profiles[activeProfileIndex ?? props.profiles.activeProfileIndex],
-      activeProfileIndex ?? props.profiles.activeProfileIndex,
+      props.profiles.profiles[threadId],
+      threadId ?? props.profiles.activeProfileIndex,
       {
         inverted: view === 'bottom up',
         leftHeavy: sorting === 'left heavy',
@@ -60,16 +58,16 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
             : undefined,
       }
     );
-  }, [props.profiles, activeProfileIndex, sorting, xAxis, view]);
+  }, [props.profiles, threadId, sorting, xAxis, view]);
 
   return (
     <Fragment>
       <FlamegraphToolbar>
         <ThreadMenuSelector
           profileGroup={props.profiles}
-          activeProfileIndex={flamegraph.profileIndex}
-          onProfileIndexChange={index =>
-            dispatchActiveProfileIndex({type: 'set active profile index', payload: index})
+          threadId={threadId}
+          onProfileIndexChange={newThreadId =>
+            dispatchActiveProfileIndex({type: 'set thread id', payload: newThreadId})
           }
         />
         <FlamegraphViewSelectMenu

--- a/static/app/components/profiling/threadSelector.tsx
+++ b/static/app/components/profiling/threadSelector.tsx
@@ -5,17 +5,18 @@ import {ControlProps, GeneralSelectValue} from 'sentry/components/forms/selectCo
 import {IconList} from 'sentry/icons';
 import {SelectValue} from 'sentry/types';
 import {defined} from 'sentry/utils';
+import {FlamegraphState} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/index';
 import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
 
 interface ThreadSelectorProps {
-  activeProfileIndex: ProfileGroup['activeProfileIndex'];
   onProfileIndexChange: (index: number) => void;
   profileGroup: ProfileGroup;
+  threadId: FlamegraphState['profiles']['threadId'];
 }
 
 function ThreadMenuSelector<OptionType extends GeneralSelectValue = GeneralSelectValue>({
-  activeProfileIndex,
+  threadId,
   onProfileIndexChange,
   profileGroup,
 }: ThreadSelectorProps) {
@@ -46,7 +47,7 @@ function ThreadMenuSelector<OptionType extends GeneralSelectValue = GeneralSelec
         size: 'xsmall',
       }}
       options={options}
-      value={activeProfileIndex}
+      value={threadId}
       onChange={handleChange}
       isSearchable
     />

--- a/static/app/components/profiling/threadSelector.tsx
+++ b/static/app/components/profiling/threadSelector.tsx
@@ -10,34 +10,34 @@ import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
 
 interface ThreadSelectorProps {
-  onProfileIndexChange: (index: number) => void;
+  onThreadIdChange: (threadId: Profile['threadId']) => void;
   profileGroup: ProfileGroup;
   threadId: FlamegraphState['profiles']['threadId'];
 }
 
 function ThreadMenuSelector<OptionType extends GeneralSelectValue = GeneralSelectValue>({
   threadId,
-  onProfileIndexChange,
+  onThreadIdChange,
   profileGroup,
 }: ThreadSelectorProps) {
   const options: SelectValue<number>[] = useMemo(() => {
     return profileGroup.profiles
-      .map((profile, i) => ({
+      .map(profile => ({
         name: profile.name,
         duration: profile.duration,
-        index: i,
+        threadId: profile.threadId,
       }))
       .sort(compareProfiles)
-      .map(item => ({label: item.name, value: item.index}));
+      .map(item => ({label: item.name, value: item.threadId}));
   }, [profileGroup]);
 
   const handleChange: NonNullable<ControlProps<OptionType>['onChange']> = useCallback(
     opt => {
       if (defined(opt)) {
-        onProfileIndexChange(opt.value);
+        onThreadIdChange(opt.value);
       }
     },
-    [onProfileIndexChange]
+    [onThreadIdChange]
   );
 
   return (
@@ -56,8 +56,8 @@ function ThreadMenuSelector<OptionType extends GeneralSelectValue = GeneralSelec
 
 type ProfileLight = {
   duration: Profile['duration'];
-  index: number;
   name: Profile['name'];
+  threadId: Profile['threadId'];
 };
 
 function compareProfiles(a: ProfileLight, b: ProfileLight): number {

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1897,7 +1897,7 @@ function buildRoutes() {
       <Route
         path="flamegraph/:projectId/:eventId"
         component={SafeLazyLoad}
-        componentPromise={() => import('sentry/views/profiling/flamegraphProvider')}
+        componentPromise={() => import('sentry/views/profiling/profileGroupProvider')}
       >
         <Route
           path="summary/"

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
@@ -2,7 +2,7 @@ import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 
 type SetProfilesActiveIndex = {
   payload: number;
-  type: 'set active profile index';
+  type: 'set thread id';
 };
 
 type SetSelectedNode = {
@@ -13,8 +13,8 @@ type SetSelectedNode = {
 type FlamegraphProfilesAction = SetProfilesActiveIndex | SetSelectedNode;
 
 type FlamegraphProfilesState = {
-  activeProfileIndex: number | null;
   selectedNode: FlamegraphFrame | null;
+  threadId: number | null;
 };
 
 export function flamegraphProfilesReducer(
@@ -25,12 +25,12 @@ export function flamegraphProfilesReducer(
     case 'set selected node': {
       return {...state, selectedNode: action.payload};
     }
-    case 'set active profile index': {
+    case 'set thread id': {
       // When the profile index changes, we want to drop the selected and hovered nodes
       return {
         ...state,
         selectedNode: null,
-        activeProfileIndex: action.payload,
+        threadId: action.payload,
       };
     }
     default: {

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -70,9 +70,9 @@ export function decodeFlamegraphStateFromQueryParams(
 ): DeepPartial<FlamegraphState> {
   return {
     profiles: {
-      activeProfileIndex:
-        typeof query.profileIndex === 'string' && !isNaN(parseInt(query.profileIndex, 10))
-          ? parseInt(query.profileIndex, 10)
+      threadId:
+        typeof query.tid === 'string' && !isNaN(parseInt(query.tid, 10))
+          ? parseInt(query.tid, 10)
           : null,
     },
     position: {view: Rect.decode(query.fov) ?? Rect.Empty()},
@@ -104,8 +104,8 @@ export function encodeFlamegraphStateToQueryParams(state: FlamegraphState) {
     ...(state.position.view.isEmpty()
       ? {fov: undefined}
       : {fov: Rect.encode(state.position.view)}),
-    ...(typeof state.profiles.activeProfileIndex === 'number'
-      ? {profileIndex: state.profiles.activeProfileIndex}
+    ...(typeof state.profiles.threadId === 'number'
+      ? {tid: state.profiles.threadId}
       : {}),
   };
 }
@@ -162,7 +162,7 @@ interface FlamegraphStateProviderProps {
 
 const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
   profiles: {
-    activeProfileIndex: null,
+    threadId: null,
     selectedNode: null,
   },
   position: {
@@ -187,9 +187,9 @@ export function FlamegraphStateProvider(
   const reducer = useUndoableReducer(combinedReducers, {
     profiles: {
       selectedNode: null,
-      activeProfileIndex:
-        props.initialState?.profiles?.activeProfileIndex ??
-        DEFAULT_FLAMEGRAPH_STATE.profiles.activeProfileIndex,
+      threadId:
+        props.initialState?.profiles?.threadId ??
+        DEFAULT_FLAMEGRAPH_STATE.profiles.threadId,
     },
     position: {
       view: (props.initialState?.position?.view ??

--- a/static/app/views/profiling/flamegraph.tsx
+++ b/static/app/views/profiling/flamegraph.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
@@ -7,8 +7,17 @@ import {Flamegraph} from 'sentry/components/profiling/flamegraph';
 import {ProfileDragDropImportProps} from 'sentry/components/profiling/profileDragDropImport';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import {DeepPartial} from 'sentry/types/utils';
+import {
+  decodeFlamegraphStateFromQueryParams,
+  FlamegraphState,
+  FlamegraphStateProvider,
+  FlamegraphStateQueryParamSync,
+} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/index';
+import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
 import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {useProfileGroup} from './profileGroupProvider';
@@ -21,6 +30,7 @@ const LoadingGroup: ProfileGroup = {
 };
 
 function FlamegraphView(): React.ReactElement {
+  const location = useLocation();
   const organization = useOrganization();
   const [profileGroup, setProfileGroup] = useProfileGroup();
 
@@ -28,28 +38,39 @@ function FlamegraphView(): React.ReactElement {
     setProfileGroup({type: 'resolved', data: profiles});
   };
 
+  const initialFlamegraphPreferencesState = useMemo((): DeepPartial<FlamegraphState> => {
+    return decodeFlamegraphStateFromQueryParams(location.query);
+    // We only want to decode this when our component mounts
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <Fragment>
       <SentryDocumentTitle
         title={t('Profiling \u2014 Flamegraph')}
         orgSlug={organization.slug}
       >
-        <FlamegraphContainer>
-          {profileGroup.type === 'errored' ? (
-            <Alert type="error" showIcon>
-              {profileGroup.error}
-            </Alert>
-          ) : profileGroup.type === 'loading' ? (
-            <Fragment>
-              <Flamegraph onImport={onImport} profiles={LoadingGroup} />
-              <LoadingIndicatorContainer>
-                <LoadingIndicator />
-              </LoadingIndicatorContainer>
-            </Fragment>
-          ) : profileGroup.type === 'resolved' ? (
-            <Flamegraph onImport={onImport} profiles={profileGroup.data} />
-          ) : null}
-        </FlamegraphContainer>
+        <FlamegraphStateProvider initialState={initialFlamegraphPreferencesState}>
+          <FlamegraphThemeProvider>
+            <FlamegraphStateQueryParamSync />
+            <FlamegraphContainer>
+              {profileGroup.type === 'errored' ? (
+                <Alert type="error" showIcon>
+                  {profileGroup.error}
+                </Alert>
+              ) : profileGroup.type === 'loading' ? (
+                <Fragment>
+                  <Flamegraph onImport={onImport} profiles={LoadingGroup} />
+                  <LoadingIndicatorContainer>
+                    <LoadingIndicator />
+                  </LoadingIndicatorContainer>
+                </Fragment>
+              ) : profileGroup.type === 'resolved' ? (
+                <Flamegraph onImport={onImport} profiles={profileGroup.data} />
+              ) : null}
+            </FlamegraphContainer>
+          </FlamegraphThemeProvider>
+        </FlamegraphStateProvider>
       </SentryDocumentTitle>
     </Fragment>
   );

--- a/static/app/views/profiling/flamegraphSummary.tsx
+++ b/static/app/views/profiling/flamegraphSummary.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useMemo} from 'react';
 import {Link} from 'react-router';
-import * as qs from 'query-string';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
@@ -10,8 +9,6 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
-import {encodeFlamegraphStateToQueryParams} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/index';
-import {useFlamegraphStateValue} from 'sentry/utils/profiling/flamegraph/useFlamegraphState';
 import {getSlowestProfileCallsFromProfileGroup} from 'sentry/utils/profiling/profile/utils';
 import {makeFormatter} from 'sentry/utils/profiling/units/units';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -137,9 +134,6 @@ function ProfilingFunctionsTableCell({
   dataRow,
 }: ProfilingFunctionsTableCellProps) {
   const value = dataRow[column.key];
-
-  const flamegraphstate = useFlamegraphStateValue();
-  const [profileGroup] = useProfileGroup();
   const {orgId, projectId, eventId} = useParams();
 
   switch (column.key) {
@@ -150,39 +144,19 @@ function ProfilingFunctionsTableCell({
     case 'image':
       return <Container>{value ?? 'Unknown'}</Container>;
     case 'thread': {
-      const threadIndex =
-        profileGroup.type === 'resolved'
-          ? profileGroup.data.profiles.findIndex(
-              profile => profile.threadId === parseInt(dataRow.thread, 10)
-            )
-          : undefined;
-
       return (
         <Container>
-          {typeof threadIndex === 'number' && threadIndex !== -1 ? (
-            <Link
-              to={
-                generateFlamegraphRoute({
-                  orgSlug: orgId,
-                  projectSlug: projectId,
-                  profileId: eventId,
-                }) +
-                `?${qs.stringify(
-                  encodeFlamegraphStateToQueryParams({
-                    ...flamegraphstate,
-                    profiles: {
-                      ...flamegraphstate.profiles,
-                      threadId: threadIndex,
-                    },
-                  })
-                )}`
-              }
-            >
-              {value}
-            </Link>
-          ) : (
-            value
-          )}
+          <Link
+            to={
+              generateFlamegraphRoute({
+                orgSlug: orgId,
+                projectSlug: projectId,
+                profileId: eventId,
+              }) + `?tid=${dataRow.thread}`
+            }
+          >
+            {value}
+          </Link>
         </Container>
       );
     }

--- a/static/app/views/profiling/flamegraphSummary.tsx
+++ b/static/app/views/profiling/flamegraphSummary.tsx
@@ -11,7 +11,7 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {encodeFlamegraphStateToQueryParams} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/index';
-import {useFlamegraphState} from 'sentry/utils/profiling/flamegraph/useFlamegraphState';
+import {useFlamegraphStateValue} from 'sentry/utils/profiling/flamegraph/useFlamegraphState';
 import {getSlowestProfileCallsFromProfileGroup} from 'sentry/utils/profiling/profile/utils';
 import {makeFormatter} from 'sentry/utils/profiling/units/units';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -138,7 +138,7 @@ function ProfilingFunctionsTableCell({
 }: ProfilingFunctionsTableCellProps) {
   const value = dataRow[column.key];
 
-  const [flamegraphstate, dispatch] = useFlamegraphState();
+  const flamegraphstate = useFlamegraphStateValue();
   const [profileGroup] = useProfileGroup();
   const {orgId, projectId, eventId} = useParams();
 
@@ -161,9 +161,6 @@ function ProfilingFunctionsTableCell({
         <Container>
           {typeof threadIndex === 'number' && threadIndex !== -1 ? (
             <Link
-              onClick={() =>
-                dispatch({type: 'set active profile index', payload: threadIndex})
-              }
               to={
                 generateFlamegraphRoute({
                   orgSlug: orgId,
@@ -175,7 +172,7 @@ function ProfilingFunctionsTableCell({
                     ...flamegraphstate,
                     profiles: {
                       ...flamegraphstate.profiles,
-                      activeProfileIndex: threadIndex,
+                      threadId: threadIndex,
                     },
                   })
                 )}`

--- a/static/app/views/profiling/profileGroupProvider.tsx
+++ b/static/app/views/profiling/profileGroupProvider.tsx
@@ -2,6 +2,7 @@ import {createContext, useContext, useEffect, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {Client} from 'sentry/api';
+import {FlamegraphHeader} from 'sentry/components/profiling/flamegraphHeader';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import {RequestState} from 'sentry/types/core';
@@ -80,6 +81,7 @@ function ProfileGroupProvider(props: FlamegraphViewProps): React.ReactElement {
 
   return (
     <ProfileGroupContext.Provider value={[profileGroupState, setProfileGroupState]}>
+      <FlamegraphHeader />
       {props.children}
     </ProfileGroupContext.Provider>
   );


### PR DESCRIPTION
ProfileIndex was legacy before we had threadID. Tid is more stable and not subject to the way profiles are sorted, so it should be used instead.