### PR TITLE
ref: adjust deprecated calls to has_team

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -1,7 +1,6 @@
 __all__ = ["from_user", "from_member", "DEFAULT"]
 
 import abc
-import warnings
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Collection, FrozenSet, Iterable, Mapping, Optional, Tuple
@@ -158,10 +157,6 @@ class Access(abc.ABC):
 
     def get_organization_role(self) -> Optional[OrganizationRole]:
         return self.role and organization_roles.get(self.role)
-
-    def has_team(self, team: Team) -> bool:
-        warnings.warn("has_team() is deprecated in favor of has_team_access", DeprecationWarning)
-        return self.has_team_access(team)
 
     @abc.abstractmethod
     def has_team_access(self, team: Team) -> bool:

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -101,7 +101,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                     team = Team.objects.get(id=identifier)
                 except Team.DoesNotExist:
                     raise serializers.ValidationError("Team does not exist")
-                if not access.has_team(team):
+                if not access.has_team_access(team):
                     raise serializers.ValidationError("Team does not exist")
             elif target_type == AlertRuleTriggerAction.TargetType.USER:
                 try:

--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -14,7 +14,7 @@ def _get_user_from_email(group, email):
     for user in User.objects.filter(email__iexact=email):
         # Make sure that the user actually has access to this project
         context = access.from_user(user=user, organization=group.organization)
-        if not any(context.has_team(t) for t in group.project.teams.all()):
+        if not any(context.has_team_access(t) for t in group.project.teams.all()):
             logger.warning("User %r does not have access to group %r", user, group)
             continue
 

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -454,7 +454,7 @@ class ProjectView(OrganizationView):
                     project,
                 )
                 return False
-        elif not any(request.access.has_team(team) for team in teams):
+        elif not any(request.access.has_team_access(team) for team in teams):
             logger.info("User %s does not have access to project %s", request.user, project)
             return False
         return True


### PR DESCRIPTION
part of making tests warnings-clean -- this is currently being ignored and this patch fixes it:

```
________________ TestAlertRuleSerializer.test_owner_validation _________________
tests/sentry/incidents/endpoints/test_serializers.py:587: in test_owner_validation
    alert_rule = serializer.save()
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/rest_framework/serializers.py:212: in save
    self.instance = self.create(validated_data)
src/sentry/incidents/serializers/alert_rule.py:378: in create
    self._handle_triggers(alert_rule, triggers)
src/sentry/incidents/serializers/alert_rule.py:427: in _handle_triggers
    trigger_serializer.save()
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/rest_framework/serializers.py:212: in save
    self.instance = self.create(validated_data)
src/sentry/incidents/serializers/alert_rule_trigger.py:45: in create
    self._handle_actions(alert_rule_trigger, actions)
src/sentry/incidents/serializers/alert_rule_trigger.py:96: in _handle_actions
    if action_serializer.is_valid():
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/rest_framework/serializers.py:234: in is_valid
    self._validated_data = self.run_validation(self.initial_data)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/rest_framework/serializers.py:436: in run_validation
    value = self.validate(value)
src/sentry/incidents/serializers/alert_rule_trigger_action.py:104: in validate
    if not access.has_team(team):
src/sentry/auth/access.py:163: in has_team
    warnings.warn("has_team() is deprecated in favor of has_team_access", DeprecationWarning)
E   DeprecationWarning: has_team() is deprecated in favor of has_team_access
```