### PR TITLE
ref: fix progresbar2 DeprecationWarning for maxval

### DIFF
--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -193,7 +193,7 @@ class WithProgressBar:
                 " ",
                 progressbar.ETA(),
             ]
-            pbar = progressbar.ProgressBar(widgets=widgets, maxval=self.count)
+            pbar = progressbar.ProgressBar(widgets=widgets, max_value=self.count)
             pbar.start()
             for idx, item in enumerate(self.iterator):
                 yield item


### PR DESCRIPTION
part of an effort to make tests warning-clean

failing previously with:

```
______________________________ TestBackfill.test _______________________________
src/sentry/testutils/cases.py:1564: in setUp
    executor.migrate(self.migrate_to)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/db/migrations/executor.py:117: in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/db/migrations/executor.py:147: in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
src/sentry/new_migrations/monkey/executor.py:79: in apply_migration
    return super().apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/db/migrations/executor.py:245: in apply_migration
    state = migration.apply(state, schema_editor)
src/sentry/new_migrations/migrations.py:15: in apply
    return super().apply(project_state, schema_editor, collect_sql)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/db/migrations/migration.py:124: in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/db/migrations/operations/special.py:190: in database_forwards
    self.code(from_state.apps, schema_editor)
src/sentry/migrations/0286_backfill_alertrule_organization.py:13: in backfill_alertrule_organization
    for alert_rule in RangeQuerySetWrapperWithProgressBar(AlertRule.objects_with_snapshots.all()):
src/sentry/utils/query.py:196: in __iter__
    pbar = progressbar.ProgressBar(widgets=widgets, maxval=self.count)
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/progressbar/bar.py:244: in __init__
    warnings.warn('The usage of `maxval` is deprecated, please use '
E   DeprecationWarning: The usage of `maxval` is deprecated, please use `max_value` instead
```