### PR TITLE
fix(ios-device-list): do not delete file

### DIFF
--- a/scripts/extract-ios-device-names.ts
+++ b/scripts/extract-ios-device-names.ts
@@ -81,21 +81,12 @@ const formatOutput = async (unformatted: string) => {
 };
 
 export async function extractIOSDeviceNames() {
-  try {
-    if (fs.statSync(outputPath)) {
-      // Out with the old, in with the new
-      fs.unlinkSync(outputPath);
-    }
-  } catch (e) {
-    // File does not exists, carry along
-  }
-
   const files = await getDefinitionFiles();
   const definitions = await collectDefinitions(files);
   const formatted = await formatOutput(
     template(JSON.stringify(definitions, undefined, 2))
   );
 
+  // This will always overwrite the file with a fresh version
   fs.writeFileSync(outputPath, formatted);
-  console.log('✅ Regenerated ios-device-list.tsx');
 }


### PR DESCRIPTION
If a user runs the build locally and it that process gets interrupted for some reason, it is possible that they end up with a removed file which can end up in commit diffs and break tests. To fix it, just avoid deleting the original file and always overwrite it.