### PR TITLE
ref: test deprecated warnings raised by legacy conversion

### DIFF
--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -2,6 +2,7 @@ import pytest
 
 from sentry.runner.importer import ConfigurationError
 from sentry.runner.initializer import apply_legacy_settings, bootstrap_options
+from sentry.utils.warnings import DeprecatedSettingWarning
 
 
 @pytest.fixture
@@ -22,6 +23,11 @@ def settings():
 @pytest.fixture
 def config_yml(tmpdir):
     return tmpdir.join("config.yml")
+
+
+def _assert_settings_warnings(warninfo, expected):
+    actual = {(w.message.setting, w.message.replacement) for w in warninfo}
+    assert actual == expected
 
 
 def test_bootstrap_options_simple(settings, config_yml):
@@ -105,7 +111,23 @@ def test_bootstrap_options_no_config(settings):
     settings.EMAIL_SUBJECT_PREFIX = "my-mail-subject-prefix"
     settings.FOO_BAR = "lol"
 
-    bootstrap_options(settings)
+    with pytest.warns(DeprecatedSettingWarning) as warninfo:
+        bootstrap_options(settings)
+    _assert_settings_warnings(
+        warninfo,
+        {
+            ("EMAIL_BACKEND", "SENTRY_OPTIONS['mail.backend']"),
+            ("EMAIL_HOST", "SENTRY_OPTIONS['mail.host']"),
+            ("EMAIL_HOST_PASSWORD", "SENTRY_OPTIONS['mail.password']"),
+            ("EMAIL_HOST_USER", "SENTRY_OPTIONS['mail.username']"),
+            ("EMAIL_PORT", "SENTRY_OPTIONS['mail.port']"),
+            ("EMAIL_SUBJECT_PREFIX", "SENTRY_OPTIONS['mail.subject-prefix']"),
+            ("EMAIL_USE_SSL", "SENTRY_OPTIONS['mail.use-ssl']"),
+            ("EMAIL_USE_TLS", "SENTRY_OPTIONS['mail.use-tls']"),
+            ("SECRET_KEY", "SENTRY_OPTIONS['system.secret-key']"),
+            ("SERVER_EMAIL", "SENTRY_OPTIONS['mail.from']"),
+        },
+    )
     assert settings.SENTRY_OPTIONS == {
         "system.secret-key": "my-system-secret-key",
         "mail.backend": "my-mail-backend",
@@ -179,7 +201,8 @@ def test_apply_legacy_settings(settings):
     settings.SENTRY_OPTIONS = {"system.secret-key": "secret-key", "mail.from": "mail-from"}
     settings.SENTRY_FILESTORE = "some-filestore"
     settings.SENTRY_FILESTORE_OPTIONS = {"filestore-foo": "filestore-bar"}
-    apply_legacy_settings(settings)
+    with pytest.warns(DeprecatedSettingWarning) as warninfo:
+        apply_legacy_settings(settings)
     assert settings.CELERY_ALWAYS_EAGER is False
     assert settings.SENTRY_FEATURES["auth:register"] is True
     assert settings.SENTRY_OPTIONS == {
@@ -197,6 +220,23 @@ def test_apply_legacy_settings(settings):
     }
     assert settings.DEFAULT_FROM_EMAIL == "mail-from"
     assert settings.ALLOWED_HOSTS == ["*"]
+
+    _assert_settings_warnings(
+        warninfo,
+        {
+            ("MAILGUN_API_KEY", "SENTRY_OPTIONS['mail.mailgun-api-key']"),
+            ("SENTRY_ADMIN_EMAIL", "SENTRY_OPTIONS['system.admin-email']"),
+            ("SENTRY_ALLOW_REGISTRATION", 'SENTRY_FEATURES["auth:register"]'),
+            ("SENTRY_ENABLE_EMAIL_REPLIES", "SENTRY_OPTIONS['mail.enable-replies']"),
+            ("SENTRY_FILESTORE", "SENTRY_OPTIONS['filestore.backend']"),
+            ("SENTRY_FILESTORE_OPTIONS", "SENTRY_OPTIONS['filestore.options']"),
+            ("SENTRY_REDIS_OPTIONS", 'SENTRY_OPTIONS["redis.clusters"]'),
+            ("SENTRY_SMTP_HOSTNAME", "SENTRY_OPTIONS['mail.reply-hostname']"),
+            ("SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE", "SENTRY_OPTIONS['system.rate-limit']"),
+            ("SENTRY_URL_PREFIX", "SENTRY_OPTIONS['system.url-prefix']"),
+            ("SENTRY_USE_QUEUE", "CELERY_ALWAYS_EAGER"),
+        },
+    )
 
 
 def test_initialize_app(settings):


### PR DESCRIPTION
part of an effort to make tests warnings-clean

previously this was crashing with errors:

```
__________________________ test_apply_legacy_settings __________________________
tests/sentry/runner/test_initializer.py:182: in test_apply_legacy_settings
    apply_legacy_settings(settings)
src/sentry/runner/initializer.py:529: in apply_legacy_settings
    warnings.warn(
src/sentry/utils/warnings.py:59: in warn
    handler(warning, **kwargs)
src/sentry/utils/warnings.py:92: in <lambda>
    lambda warning, stacklevel=1: warnings.warn(warning, stacklevel=stacklevel + 2),
E   sentry.utils.warnings.DeprecatedSettingWarning: The SENTRY_USE_QUEUE setting is deprecated. Please use CELERY_ALWAYS_EAGER instead. See 
```