### PR TITLE
fix(span-summary): Hardcode event id to prevent it from changing

### DIFF
--- a/tests/acceptance/test_performance_span_summary.py
+++ b/tests/acceptance/test_performance_span_summary.py
@@ -82,6 +82,8 @@ class PerformanceSpanSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
         data = load_data("transaction", **kwargs)
         data["transaction"] = "root transaction"
+        data["event_id"] = "c" * 32
+        data["contexts"]["trace"]["trace_id"] = "a" * 32
 
         return self.store_event(data, project_id=self.project.id)
 


### PR DESCRIPTION
We need to make the event id static so it doesn't get dynamically generated and, thus, change from a test to test.

<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
