### PR TITLE
fix(dashboards): Use auto menu placement for all query fields

### DIFF
--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -441,6 +441,7 @@ class QueryField extends Component<Props> {
           <SelectControl
             key="select"
             name="parameter"
+            menuPlacement="auto"
             placeholder={t('Select value')}
             options={aggregateParameters}
             value={descriptor.value}
@@ -500,6 +501,7 @@ class QueryField extends Component<Props> {
           <SelectControl
             key="dropdown"
             name="dropdown"
+            menuPlacement="auto"
             placeholder={t('Select value')}
             options={descriptor.options}
             value={descriptor.value}
@@ -599,6 +601,7 @@ class QueryField extends Component<Props> {
       inFieldLabel: inFieldLabels ? t('Function: ') : undefined,
       disabled,
       noOptionsMessage: () => noFieldsMessage,
+      menuPlacement: 'auto',
     };
     if (takeFocus && field === null) {
       selectProps.autoFocus = true;


### PR DESCRIPTION
When a `QueryField` menu would overflow, it would push the bottom of the page down

https://user-images.githubusercontent.com/22846452/167212328-ca280198-d923-49ac-b97c-a9a15115dbfb.mov

This PR makes it so the menu will try to place itself above or below depending on the available space.

https://user-images.githubusercontent.com/22846452/167212713-6432e51e-6302-4660-b757-5cea29a3efb2.mov

Fixes the visual jank reported in: https://github.com/getsentry/sentry/pull/34011#pullrequestreview-964859815