### PR TITLE
fix(options): Remove `SENTRY_URL_PREFIX`

### DIFF
--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -142,11 +142,6 @@ class OptionsManager:
         if not (opt.flags & FLAG_NOSTORE):
             result = self.store.get(opt, silent=silent)
             if result is not None:
-                # HACK(mattrobenolt): SENTRY_URL_PREFIX must be kept in sync
-                # when reading values from the database. This should
-                # be replaced by a signal.
-                if key == "system.url-prefix":
-                    settings.SENTRY_URL_PREFIX = result
                 return result
 
         # Some values we don't want to allow them to be configured through

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -537,7 +537,6 @@ def apply_legacy_settings(settings):
 
     for old, new in (
         ("SENTRY_ADMIN_EMAIL", "system.admin-email"),
-        ("SENTRY_URL_PREFIX", "system.url-prefix"),
         ("SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE", "system.rate-limit"),
         ("SENTRY_ENABLE_EMAIL_REPLIES", "mail.enable-replies"),
         ("SENTRY_SMTP_HOSTNAME", "mail.reply-hostname"),
@@ -572,13 +571,6 @@ def apply_legacy_settings(settings):
         # deprecated. (This also assumes ``FLAG_NOSTORE`` on the configuration
         # option.)
         settings.SENTRY_REDIS_OPTIONS = options.get("redis.clusters")["default"]
-
-    if not hasattr(settings, "SENTRY_URL_PREFIX"):
-        url_prefix = options.get("system.url-prefix", silent=True)
-        if not url_prefix:
-            # HACK: We need to have some value here for backwards compatibility
-            url_prefix = "http://sentry.example.com"
-        settings.SENTRY_URL_PREFIX = url_prefix
 
     if settings.TIME_ZONE != "UTC":
         # non-UTC timezones are not supported

--- a/src/sentry/templatetags/sentry_avatars.py
+++ b/src/sentry/templatetags/sentry_avatars.py
@@ -1,10 +1,10 @@
 from urllib.parse import urlencode
 
 from django import template
-from django.conf import settings
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
+from sentry import options
 from sentry.models import User, UserAvatar
 from sentry.utils.avatar import get_email_avatar, get_gravatar_url, get_letter_avatar
 
@@ -33,7 +33,7 @@ def profile_photo_url(context, user_id, size=None):
     url = reverse("sentry-user-avatar-url", args=[avatar.ident])
     if size:
         url += "?" + urlencode({"s": size})
-    return settings.SENTRY_URL_PREFIX + url
+    return options.get("system.url-prefix") + url
 
 
 # Don't use this in any situations where you're rendering more

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -192,7 +192,6 @@ def test_apply_legacy_settings(settings):
     settings.SENTRY_USE_QUEUE = True
     settings.SENTRY_ALLOW_REGISTRATION = True
     settings.SENTRY_ADMIN_EMAIL = "admin-email"
-    settings.SENTRY_URL_PREFIX = "http://url-prefix"
     settings.SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE = 10
     settings.SENTRY_REDIS_OPTIONS = {"foo": "bar"}
     settings.SENTRY_ENABLE_EMAIL_REPLIES = True


### PR DESCRIPTION
When a user starts up a brand new server they're seeing this warning:
```
The SENTRY_URL_PREFIX setting is deprecated. Please use SENTRY_OPTIONS['system.url-prefix'] instead.
```
The setting was deprecated seven years ago in https://github.com/getsentry/sentry/pull/2402 so I hope it's safe to delete.

Fixes https://github.com/getsentry/self-hosted/issues/1309.