### PR TITLE
fix(profiling): Convert the Apple debug images to Mach-O

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -106,7 +106,14 @@ def _symbolicate(profile: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
     symbolicator = Symbolicator(project=project, event_id=profile["profile_id"])
 
     for i in profile["debug_meta"]["images"]:
-        i["debug_id"] = i["uuid"]
+        if i["type"] == "apple":
+            i.update(
+                {
+                    "type": "macho",
+                    "debug_file": i["name"],
+                    "debug_id": i["uuid"],
+                }
+            )
 
     for s in profile["sampled_profile"]["samples"]:
         for f in s["frames"]:


### PR DESCRIPTION
The SDK will start sending us a new image type, `macho`, so the `uuid` key won't be set anymore and we need to handle the change.