### PR TITLE
ref(sentry apps): Order Sentry App stats by install count

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/stats/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/stats/index.py
@@ -15,7 +15,7 @@ class SentryAppsStatsEndpoint(SentryAppsBaseEndpoint):
         sentry_apps = (
             SentryApp.objects.filter(installations__date_deleted=None)
             .annotate(Count("installations"))
-            .order_by()
+            .order_by("-installations__count")
         )
 
         if "per_page" in request.query_params:


### PR DESCRIPTION
Order the Sentry app stats by install count so that the _admin table can show the most installed ones. 

**Before**
<img width="490" alt="Screen Shot 2022-05-06 at 3 53 18 PM" src="https://user-images.githubusercontent.com/29959063/167226022-6734da24-050a-4f6e-9cbf-0b053186aa64.png">

**After**
<img width="458" alt="Screen Shot 2022-05-06 at 3 56 17 PM" src="https://user-images.githubusercontent.com/29959063/167226028-e75b42dd-6624-44ee-b07e-c5c81a9ca42c.png">
