### PR TITLE
feat(replay): Implement mouse tracking along the scrubber and timeline

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayBreadcrumbOverview.tsx
+++ b/static/app/components/replays/breadcrumbs/replayBreadcrumbOverview.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {transformCrumbs} from 'sentry/components/events/interfaces/breadcrumbs/utils';
+import HorizontalMouseTracking from 'sentry/components/replays/player/horizontalMouseTracking';
+import {TimelineScubber} from 'sentry/components/replays/player/scrubber';
 import StackedContent from 'sentry/components/replays/stackedContent';
 import space from 'sentry/styles/space';
 import {Crumb, RawCrumb} from 'sentry/types/breadcrumbs';
@@ -21,26 +23,30 @@ function ReplayBreadcrumbOverview({crumbs, className}: Props) {
   const transformedCrumbs = transformCrumbs(crumbs);
 
   return (
-    <StackedContent className={className}>
-      {({width}) => (
-        <React.Fragment>
-          <Ticks
-            crumbs={transformedCrumbs}
-            width={width}
-            minWidth={20}
-            lineStyle="dotted"
-          />
-          <Ticks
-            crumbs={transformedCrumbs}
-            width={width}
-            showTimestamp
-            minWidth={50}
-            lineStyle="solid"
-          />
-          <Events crumbs={transformedCrumbs} width={width} />
-        </React.Fragment>
-      )}
-    </StackedContent>
+    <HorizontalMouseTracking>
+      <TimelineScubber />
+      <StackedContent className={className}>
+        {({width}) => (
+          <React.Fragment>
+            <Ticks
+              crumbs={transformedCrumbs}
+              width={width}
+              minWidth={20}
+              lineStyle="dotted"
+            />
+            <Ticks
+              crumbs={transformedCrumbs}
+              width={width}
+              showTimestamp
+              minWidth={50}
+              lineStyle="solid"
+            />
+
+            <Events crumbs={transformedCrumbs} width={width} />
+          </React.Fragment>
+        )}
+      </StackedContent>
+    </HorizontalMouseTracking>
   );
 }
 

--- a/static/app/components/replays/player/horizontalMouseTracking.tsx
+++ b/static/app/components/replays/player/horizontalMouseTracking.tsx
@@ -24,7 +24,7 @@ function getBoundingRect(elem: Element): Promise<DOMRectReadOnly> {
 
 // TODO(replay): should this be an HoC?
 function HorizontalMouseTracking({children}: Props) {
-  const elem = useRef(null); // HTMLDivElement
+  const elem = useRef<HTMLDivElement>(null);
   const {duration, setCurrentHoverTime} = useReplayContext();
 
   const onMouseMove = useCallback(

--- a/static/app/components/replays/player/horizontalMouseTracking.tsx
+++ b/static/app/components/replays/player/horizontalMouseTracking.tsx
@@ -1,0 +1,66 @@
+import React, {useCallback, useRef} from 'react';
+
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+/**
+ * Replace `elem.getBoundingClientRect()` which is too laggy for onMouseMove
+ */
+function getBoundingRect(elem: Element): Promise<DOMRectReadOnly> {
+  return new Promise((resolve, _reject) => {
+    const observer = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        const bounds = entry.boundingClientRect;
+        resolve(bounds);
+      }
+      observer.disconnect();
+    });
+    observer.observe(elem);
+  });
+}
+
+// TODO(replay): should this be an HoC?
+function HorizontalMouseTracking({children}: Props) {
+  const elem = useRef(null); // HTMLDivElement
+  const {duration, setCurrentHoverTime} = useReplayContext();
+
+  const onMouseMove = useCallback(
+    async (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      if (!elem.current || duration === undefined) {
+        setCurrentHoverTime(undefined);
+        return;
+      }
+
+      const rect = await getBoundingRect(elem.current);
+      const left = e.clientX - rect.left;
+      if (left >= 0) {
+        const percent = left / rect.width;
+        const time = percent * duration;
+        setCurrentHoverTime(time);
+      } else {
+        setCurrentHoverTime(undefined);
+      }
+    },
+    [duration, setCurrentHoverTime]
+  );
+
+  const onMouseLeave = useCallback(() => {
+    setCurrentHoverTime(undefined);
+  }, [setCurrentHoverTime]);
+
+  return (
+    <div
+      ref={elem}
+      onMouseEnter={onMouseMove}
+      onMouseMove={onMouseMove}
+      onMouseLeave={onMouseLeave}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default HorizontalMouseTracking;

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -9,6 +9,9 @@ type Props = {
   className?: string;
 };
 
+/**
+ * Calculate the percent complete (0.0 to 1.0) of a given video duration.
+ */
 function getPercentComplete(currentTime: number, duration: number | undefined) {
   if (duration === undefined || isNaN(duration)) {
     return 0;
@@ -17,14 +20,16 @@ function getPercentComplete(currentTime: number, duration: number | undefined) {
 }
 
 function Scrubber({className}: Props) {
-  const {currentTime, duration, setCurrentTime} = useReplayContext();
+  const {currentHoverTime, currentTime, duration, setCurrentTime} = useReplayContext();
 
   const percentComplete = getPercentComplete(currentTime, duration);
+  const hoverPlace = getPercentComplete(currentHoverTime || 0, duration);
 
   return (
     <Wrapper className={className}>
       <Meter>
-        <Value percent={percentComplete} />
+        {currentHoverTime ? <MouseTrackingValue percent={hoverPlace} /> : null}
+        <PlaybackTimeValue percent={percentComplete} />
       </Meter>
       <RangeWrapper>
         <Range
@@ -47,10 +52,11 @@ const Meter = styled('div')`
   position: relative;
 `;
 
-const Value = styled('span')<{percent: number}>`
+const Value = styled('span')<{
+  percent: number;
+}>`
   display: inline-block;
   position: absolute;
-  background: ${p => p.theme.purple400};
   width: ${p => p.percent * 100}%;
   height: 100%;
 `;
@@ -68,11 +74,18 @@ const Range = styled(RangeSlider)`
   }
 `;
 
+const PlaybackTimeValue = styled(Value)`
+  background: ${p => p.theme.purple300};
+`;
+
+const MouseTrackingValue = styled(Value)`
+  background: ${p => p.theme.purple200};
+`;
+
 const Wrapper = styled('div')`
   position: relative;
 
   width: 100%;
-  height: ${space(0.5)};
 
   & > * {
     position: absolute;
@@ -80,30 +93,36 @@ const Wrapper = styled('div')`
     left: 0;
   }
 
+  ${MouseTrackingValue}:after {
+    content: '';
+    display: block;
+    width: ${space(0.5)};
+    height: ${space(1.5)};
+    pointer-events: none;
+    background: ${p => p.theme.purple200};
+    box-sizing: content-box;
+    position: absolute;
+    top: -${space(0.5)};
+    /*
+    Should be -space(0.25), so the middle of the span:after aligns with the edge
+    of the span. But because of transparent background we need to
+    prevent the span and the span:after from overlapping.
+    */
+    right: -${space(0.5)};
+  }
+
+  :hover ${MouseTrackingValue}:after {
+    height: ${space(2)};
+    top: -${space(0.5)};
+  }
+`;
+
+export const TimelineScubber = styled(Scrubber)`
+  height: ${space(0.5)};
+
   :hover {
     margin-block: -${space(0.25)};
     height: ${space(1)};
-  }
-
-  ${Value}:after {
-    content: '';
-    display: block;
-    width: ${space(2)};
-    height: ${space(2)}; /* equal to width */
-    background: ${p => p.theme.purple400};
-    box-sizing: content-box;
-    border-radius: ${space(2)}; /* greater than or equal to width */
-    border: solid ${p => p.theme.white};
-    border-width: ${space(0.5)};
-    position: absolute;
-    top: -${space(1)}; /* Half the width */
-    right: -${space(1.5)}; /* Half of (width + borderWidth) */
-    opacity: 0;
-    transition: opacity 0.1s ease;
-  }
-
-  :hover ${Value}:after {
-    opacity: 1;
   }
 
   ${RangeWrapper} {
@@ -114,4 +133,40 @@ const Wrapper = styled('div')`
   }
 `;
 
-export default Scrubber;
+export const PlayerScrubber = styled(Scrubber)`
+  height: ${space(0.5)};
+
+  :hover {
+    margin-block: -${space(0.25)};
+    height: ${space(1)};
+  }
+
+  ${RangeWrapper} {
+    height: ${space(0.5)};
+  }
+  :hover ${RangeWrapper} {
+    height: ${space(0.75)};
+  }
+
+  ${PlaybackTimeValue}:after {
+    content: '';
+    display: block;
+    width: ${space(2)};
+    height: ${space(2)}; /* equal to width */
+    z-index: ${p => p.theme.zIndex.initial};
+    pointer-events: none;
+    background: ${p => p.theme.purple300};
+    box-sizing: content-box;
+    border-radius: ${space(2)}; /* greater than or equal to width */
+    border: solid ${p => p.theme.white};
+    border-width: ${space(0.5)};
+    position: absolute;
+    top: -${space(1)}; /* Half the width */
+    right: -${space(1.5)}; /* Half of (width + borderWidth) */
+    opacity: 0;
+    transition: opacity 0.1s ease;
+  }
+  :hover ${PlaybackTimeValue}:after {
+    opacity: 1;
+  }
+`;

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -17,7 +17,14 @@ type RootElem = null | HTMLDivElement;
 // Instead only expose methods that wrap `Replayer` and manage state.
 type ReplayPlayerContextProps = {
   /**
-   * The current time of the video, in miliseconds
+   * The time, in milliseconds, where the user focus is.
+   * The user focus can be reported by any collaborating object, usually on
+   * hover.
+   */
+  currentHoverTime: undefined | number;
+
+  /**
+   * The current time of the video, in milliseconds
    * The value is updated on every animation frame, about every 16.6ms
    */
   currentTime: number;
@@ -73,6 +80,12 @@ type ReplayPlayerContextProps = {
   replay: ReplayReader | null;
 
   /**
+   * Set the currentHoverTime so collaborating components can highlight related
+   * information
+   */
+  setCurrentHoverTime: (time: undefined | number) => void;
+
+  /**
    * Jump the video to a specific time
    */
   setCurrentTime: (time: number) => void;
@@ -103,6 +116,7 @@ type ReplayPlayerContextProps = {
 };
 
 const ReplayPlayerContext = React.createContext<ReplayPlayerContextProps>({
+  currentHoverTime: undefined,
   currentTime: 0,
   dimensions: {height: 0, width: 0},
   duration: undefined,
@@ -113,6 +127,7 @@ const ReplayPlayerContext = React.createContext<ReplayPlayerContextProps>({
   isPlaying: false,
   isSkippingInactive: false,
   replay: null,
+  setCurrentHoverTime: () => {},
   setCurrentTime: () => {},
   setSpeed: () => {},
   speed: 1,
@@ -148,6 +163,7 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
   const oldEvents = usePrevious(events);
   const replayerRef = useRef<Replayer>(null);
   const [dimensions, setDimensions] = useState<Dimensions>({height: 0, width: 0});
+  const [currentHoverTime, setCurrentHoverTime] = useState<undefined | number>();
   const [isPlaying, setIsPlaying] = useState(false);
   const [isSkippingInactive, setIsSkippingInactive] = useState(false);
   const [speed, setSpeedState] = useState(1);
@@ -334,6 +350,7 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
   return (
     <ReplayPlayerContext.Provider
       value={{
+        currentHoverTime,
         currentTime,
         dimensions,
         duration: replayerRef.current?.getMetaData().totalTime,
@@ -344,6 +361,7 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
         isPlaying,
         isSkippingInactive,
         replay,
+        setCurrentHoverTime,
         setCurrentTime,
         setSpeed,
         speed,

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -7,7 +7,8 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader as _PanelHeader} from 'sentry/components/panels';
 import ReplayBreadcrumbOverview from 'sentry/components/replays/breadcrumbs/replayBreadcrumbOverview';
-import Scrubber from 'sentry/components/replays/player/scrubber';
+import HorizontalMouseTracking from 'sentry/components/replays/player/horizontalMouseTracking';
+import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
@@ -99,7 +100,9 @@ function ReplayDetails() {
                   <ReplayPlayer />
                 </ManualResize>
               </PanelHeader>
-              <Scrubber />
+              <HorizontalMouseTracking>
+                <PlayerScrubber />
+              </HorizontalMouseTracking>
               <PanelBody withPadding>
                 <ReplayController toggleFullscreen={toggleFullscreen} />
               </PanelBody>


### PR DESCRIPTION
This adds mouse tracking to the video `<Scrubber>` as well as the `<ReplayBreadcrumbOverview>` timeline component.

When the mouse is inside one of those components then `currentHoverTime` will be set and an additional scrubber bar will appear and will follow the mouse position.

**First Example**
- the video is paused at `0:58`, as indicated by the dark purple bar.
- the mouse is near `1:27` and the transparent-purple bar is extended past the dark purple bar to track it (mouse isn't captured in the screen shot)

<img width="660" alt="Screen Shot 2022-05-09 at 6 53 27 PM" src="https://user-images.githubusercontent.com/187460/167396124-f44159de-51b0-4e33-a53c-a055bc34ef9b.png">

**Second example**
- Video paused at the same spot
- Mouse is at the `0:30`, so the mouse tracking indicators are sticking out around the dark-purple bars.

<img width="611" alt="Screen Shot 2022-05-09 at 6 53 33 PM" src="https://user-images.githubusercontent.com/187460/167396117-7cd84df7-1ae4-4a78-9d5e-fb97d18f55ec.png">

Fixes #33626