### PR TITLE
fix(replay): Render the timeline legend using the duration from replayContext

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayBreadcrumbOverview.tsx
+++ b/static/app/components/replays/breadcrumbs/replayBreadcrumbOverview.tsx
@@ -4,22 +4,25 @@ import styled from '@emotion/styled';
 import {transformCrumbs} from 'sentry/components/events/interfaces/breadcrumbs/utils';
 import HorizontalMouseTracking from 'sentry/components/replays/player/horizontalMouseTracking';
 import {TimelineScubber} from 'sentry/components/replays/player/scrubber';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
 import StackedContent from 'sentry/components/replays/stackedContent';
 import space from 'sentry/styles/space';
-import {Crumb, RawCrumb} from 'sentry/types/breadcrumbs';
+import {Crumb} from 'sentry/types/breadcrumbs';
+import {EntryType} from 'sentry/types/event';
 
 import {countColumns, formatTime, getCrumbsByColumn} from '../utils';
 
 const EVENT_STICK_MARKER_WIDTH = 2;
 
 interface Props {
-  crumbs: Array<RawCrumb>;
   className?: string;
 }
 
 type LineStyle = 'dotted' | 'solid' | 'none';
 
-function ReplayBreadcrumbOverview({crumbs, className}: Props) {
+function ReplayBreadcrumbOverview({className}: Props) {
+  const {replay, duration} = useReplayContext();
+  const crumbs = replay?.getEntryType(EntryType.BREADCRUMBS)?.data.values || [];
   const transformedCrumbs = transformCrumbs(crumbs);
 
   return (
@@ -29,13 +32,13 @@ function ReplayBreadcrumbOverview({crumbs, className}: Props) {
         {({width}) => (
           <React.Fragment>
             <Ticks
-              crumbs={transformedCrumbs}
+              duration={duration || 0}
               width={width}
               minWidth={20}
               lineStyle="dotted"
             />
             <Ticks
-              crumbs={transformedCrumbs}
+              duration={duration || 0}
               width={width}
               showTimestamp
               minWidth={50}
@@ -51,31 +54,19 @@ function ReplayBreadcrumbOverview({crumbs, className}: Props) {
 }
 
 function Ticks({
-  crumbs,
+  duration,
   width,
   minWidth = 50,
   showTimestamp,
   lineStyle = 'solid',
 }: {
-  crumbs: Crumb[];
+  duration: number;
   lineStyle: LineStyle;
   width: number;
   minWidth?: number;
   showTimestamp?: boolean;
 }) {
-  const startTime = crumbs[0]?.timestamp;
-  const endTime = crumbs[crumbs.length - 1]?.timestamp;
-
-  const startMilliSeconds = +new Date(String(startTime));
-  const endMilliSeconds = +new Date(String(endTime));
-
-  const duration = endMilliSeconds - startMilliSeconds;
-
-  const {timespan, cols, remaining} = countColumns(
-    isNaN(duration) ? 0 : duration,
-    width,
-    minWidth
-  );
+  const {timespan, cols, remaining} = countColumns(duration, width, minWidth);
 
   return (
     <TimelineMarkerList totalColumns={cols} remainder={remaining}>

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -116,9 +116,7 @@ function ReplayDetails() {
           </Side>
           <Layout.Main fullWidth>
             <Panel>
-              <BreadcrumbTimeline
-                crumbs={replay.getEntryType(EntryType.BREADCRUMBS)?.data.values || []}
-              />
+              <BreadcrumbTimeline />
             </Panel>
             <FocusArea replay={replay} />
           </Layout.Main>


### PR DESCRIPTION
Previously the gridlines or `<Ticks>` were spaced relative to the start and end times found within the list of breadcrumbs. This was inaccurate because the last breadcrumb might not have the same duration as `replayContext`. This causes the scale of the timeline to be different from everything else.

Example of different scales:

<img width="1143" alt="Screen Shot 2022-05-09 at 7 04 11 PM" src="https://user-images.githubusercontent.com/187460/167398730-8b802675-b985-4ddc-88f0-b7ff789289c5.png">

And fixed:
<img width="1081" alt="Screen Shot 2022-05-09 at 7 15 38 PM" src="https://user-images.githubusercontent.com/187460/167399087-5ec02c33-5a9f-4eb4-a41c-60dd86ab171b.png">

