### PR TITLE
fix(replay): RRWeb internally knows about the end timestamp of all data collected

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -347,13 +347,16 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
     setBufferTime({target: -1, previous: -1});
   }
 
+  const event = replay.getEvent();
+  const duration = (event.endTimestamp - event.startTimestamp) * 1000;
+
   return (
     <ReplayPlayerContext.Provider
       value={{
         currentHoverTime,
         currentTime,
         dimensions,
-        duration: replayerRef.current?.getMetaData().totalTime,
+        duration,
         events,
         fastForwardSpeed,
         initRoot,


### PR DESCRIPTION
Similar to the problem in #34360, the value of `replayerRef.current?.getMetaData().totalTime` might not include the endTimestamp of our last piece of data. Previously the `replayerRef` object had start & end timestamps based on when rrweb data was emitted. This might not match our span or breadcrumb data that was also captured during the replay session.

To create consistency we set the endTimestamp of the `event` based on the last a) rrweb event b) breadcrumb or c) span to be captured. Then using the difference between `event.startTimestamp` and `event.endTimestamp` we calculate the duration of the replay. 

Last, we insert a `Custom` rrweb event with the correct `endTimestamp`. This will allow the rrweb player and therefore the scrubber to move all the way to the end of our computed timespan. 

For example: the last rrweb event comes in at `time=1:45`, then a memory span is captured at `time=1:55`. The end timestamp is 1:55 but rrweb would only play until 1:45. The rrweb player should keep showing unchanged content until time has progressed all the way to 1:55.