### PR TITLE
feat(replay): Render a vertical bar ontop of the timeline indicating the current timestamp

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayBreadcrumbOverview.tsx
+++ b/static/app/components/replays/breadcrumbs/replayBreadcrumbOverview.tsx
@@ -9,7 +9,6 @@ import StackedContent from 'sentry/components/replays/stackedContent';
 import TimelinePosition from 'sentry/components/replays/timelinePosition';
 import space from 'sentry/styles/space';
 import {Crumb} from 'sentry/types/breadcrumbs';
-import {EntryType} from 'sentry/types/event';
 
 import {countColumns, formatTime, getCrumbsByColumn} from '../utils';
 
@@ -23,7 +22,7 @@ type LineStyle = 'dotted' | 'solid' | 'none';
 
 function ReplayBreadcrumbOverview({className}: Props) {
   const {replay, duration} = useReplayContext();
-  const crumbs = replay?.getEntryType(EntryType.BREADCRUMBS)?.data.values || [];
+  const crumbs = replay?.getRawCrumbs() || [];
   const transformedCrumbs = transformCrumbs(crumbs);
 
   return (

--- a/static/app/components/replays/breadcrumbs/replayBreadcrumbOverview.tsx
+++ b/static/app/components/replays/breadcrumbs/replayBreadcrumbOverview.tsx
@@ -6,6 +6,7 @@ import HorizontalMouseTracking from 'sentry/components/replays/player/horizontal
 import {TimelineScubber} from 'sentry/components/replays/player/scrubber';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import StackedContent from 'sentry/components/replays/stackedContent';
+import TimelinePosition from 'sentry/components/replays/timelinePosition';
 import space from 'sentry/styles/space';
 import {Crumb} from 'sentry/types/breadcrumbs';
 import {EntryType} from 'sentry/types/event';
@@ -44,8 +45,8 @@ function ReplayBreadcrumbOverview({className}: Props) {
               minWidth={50}
               lineStyle="solid"
             />
-
             <Events crumbs={transformedCrumbs} width={width} />
+            <TimelinePosition />
           </React.Fragment>
         )}
       </StackedContent>

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -2,28 +2,20 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import RangeSlider from 'sentry/components/forms/controls/rangeSlider';
+import * as Progress from 'sentry/components/replays/progress';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {divide} from 'sentry/components/replays/utils';
 import space from 'sentry/styles/space';
 
 type Props = {
   className?: string;
 };
 
-/**
- * Calculate the percent complete (0.0 to 1.0) of a given video duration.
- */
-function getPercentComplete(currentTime: number, duration: number | undefined) {
-  if (duration === undefined || isNaN(duration)) {
-    return 0;
-  }
-  return currentTime / duration;
-}
-
 function Scrubber({className}: Props) {
   const {currentHoverTime, currentTime, duration, setCurrentTime} = useReplayContext();
 
-  const percentComplete = getPercentComplete(currentTime, duration);
-  const hoverPlace = getPercentComplete(currentHoverTime || 0, duration);
+  const percentComplete = divide(currentTime, duration);
+  const hoverPlace = divide(currentHoverTime || 0, duration);
 
   return (
     <Wrapper className={className}>
@@ -45,20 +37,8 @@ function Scrubber({className}: Props) {
   );
 }
 
-const Meter = styled('div')`
+const Meter = styled(Progress.Meter)`
   background: ${p => p.theme.gray200};
-  width: 100%;
-  height: 100%;
-  position: relative;
-`;
-
-const Value = styled('span')<{
-  percent: number;
-}>`
-  display: inline-block;
-  position: absolute;
-  width: ${p => p.percent * 100}%;
-  height: 100%;
 `;
 
 const RangeWrapper = styled('div')`
@@ -74,11 +54,11 @@ const Range = styled(RangeSlider)`
   }
 `;
 
-const PlaybackTimeValue = styled(Value)`
+const PlaybackTimeValue = styled(Progress.Value)`
   background: ${p => p.theme.purple300};
 `;
 
-const MouseTrackingValue = styled(Value)`
+const MouseTrackingValue = styled(Progress.Value)`
   background: ${p => p.theme.purple200};
 `;
 

--- a/static/app/components/replays/progress.tsx
+++ b/static/app/components/replays/progress.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+
+/**
+ * A simple progress bar.
+ * ```
+ * <Meter>
+ *   <Value percent={0.75} />
+ * </Meter>
+ * ```
+ *
+ * Extend the components to set a background color.
+ *
+ * Return multiple <Value /> components to render multiple bars directly on top
+ * of each other with `position:absolute;`.
+ */
+export const Meter = styled('div')`
+  position: relative;
+  height: 100%;
+  width: 100%;
+  pointer-events: none;
+`;
+
+export const Value = styled('span')<{
+  percent: number;
+}>`
+  position: absolute;
+  height: 100%;
+  width: ${p => p.percent * 100}%;
+  pointer-events: none;
+`;

--- a/static/app/components/replays/timelinePosition.tsx
+++ b/static/app/components/replays/timelinePosition.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import * as Progress from 'sentry/components/replays/progress';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {divide} from 'sentry/components/replays/utils';
+import space from 'sentry/styles/space';
+
+type Props = {};
+
+function TimelinePosition({}: Props) {
+  const {currentTime, duration} = useReplayContext();
+
+  const percentComplete = divide(currentTime, duration);
+
+  return (
+    <Progress.Meter>
+      <Value percent={percentComplete} />
+    </Progress.Meter>
+  );
+}
+
+const Value = styled(Progress.Value)`
+  border-right: ${space(0.25)} solid ${p => p.theme.purple300};
+`;
+
+export default TimelinePosition;

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -138,3 +138,13 @@ export function getCrumbsByColumn(crumbs: Crumb[], totalColumns: number) {
 
   return crumbsByColumn;
 }
+
+/**
+ * Divide two numbers safely
+ */
+export function divide(numerator: number, denominator: number | undefined) {
+  if (denominator === undefined || isNaN(denominator) || denominator === 0) {
+    return 0;
+  }
+  return numerator / denominator;
+}

--- a/static/app/utils/replays/getCurrentUrl.tsx
+++ b/static/app/utils/replays/getCurrentUrl.tsx
@@ -2,7 +2,7 @@ import last from 'lodash/last';
 
 import {transformCrumbs} from 'sentry/components/events/interfaces/breadcrumbs/utils';
 import {BreadcrumbType, BreadcrumbTypeNavigation} from 'sentry/types/breadcrumbs';
-import {EntryType, EventTag} from 'sentry/types/event';
+import {EventTag} from 'sentry/types/event';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 
 function findUrlTag(tags: EventTag[]) {
@@ -11,7 +11,7 @@ function findUrlTag(tags: EventTag[]) {
 
 function getCurrentUrl(replay: ReplayReader, currentTime: number) {
   const event = replay.getEvent();
-  const crumbs = replay.getEntryType(EntryType.BREADCRUMBS)?.data.values || [];
+  const crumbs = replay.getRawCrumbs();
 
   const currentOffsetMs = Math.floor(currentTime);
   const startTimestampMs = event.startTimestamp * 1000;

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -61,16 +61,13 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
         </div>
       );
     case 'performance': {
-      if (!spansEntry) {
-        return null;
-      }
-      const nonMemorySpans = {
+      const nonMemorySpansEntry = {
         ...spansEntry,
         data: spansEntry.data.filter(replay.isNotMemorySpan),
       };
       const performanceEvent = {
         ...event,
-        entries: [nonMemorySpans],
+        entries: [nonMemorySpansEntry],
       } as Event;
       return (
         <div id="performance">
@@ -79,7 +76,7 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
             // group={group}
             organization={organization}
             event={performanceEvent}
-            entry={nonMemorySpans}
+            entry={nonMemorySpansEntry}
             route={routes[routes.length - 1]}
             router={router}
           />

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -17,7 +17,6 @@ import useFullscreen from 'sentry/components/replays/useFullscreen';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
-import {EntryType} from 'sentry/types/event';
 import useReplayData from 'sentry/utils/replays/useReplayData';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
@@ -87,7 +86,7 @@ function ReplayDetails() {
       <DetailLayout
         event={replay.getEvent()}
         orgId={orgId}
-        crumbs={replay.getEntryType(EntryType.BREADCRUMBS)?.data.values || []}
+        crumbs={replay.getRawCrumbs()}
       >
         <Layout.Body>
           <ReplayLayout ref={fullscreenRef}>
@@ -110,7 +109,7 @@ function ReplayDetails() {
           </ReplayLayout>
           <Side>
             <UserActionsNavigator
-              crumbs={replay.getEntryType(EntryType.BREADCRUMBS)?.data.values || []}
+              crumbs={replay.getRawCrumbs()}
               event={replay.getEvent()}
             />
           </Side>


### PR DESCRIPTION
Adds a visual indicator into the timeline component, so people can more clearly see the timing of events relative to the playback.

**Before**
<img width="1086" alt="before" src="https://user-images.githubusercontent.com/187460/167401652-893edb0d-d4e4-430f-8daa-5dd5362b09d8.png">

**After**
<img width="1086" alt="after" src="https://user-images.githubusercontent.com/187460/167401666-02519961-5d66-4ce6-aec7-9c1f540637f3.png">

