### PR TITLE
ref(replay): Make it easier to acess the arrays of breadcrumbs and spans

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayBreadcrumbOverview.tsx
+++ b/static/app/components/replays/breadcrumbs/replayBreadcrumbOverview.tsx
@@ -9,7 +9,6 @@ import StackedContent from 'sentry/components/replays/stackedContent';
 import TimelinePosition from 'sentry/components/replays/timelinePosition';
 import space from 'sentry/styles/space';
 import {Crumb} from 'sentry/types/breadcrumbs';
-import {EntryType} from 'sentry/types/event';
 
 import {countColumns, formatTime, getCrumbsByColumn} from '../utils';
 
@@ -23,7 +22,7 @@ type LineStyle = 'dotted' | 'solid' | 'none';
 
 function ReplayBreadcrumbOverview({className}: Props) {
   const {replay, duration} = useReplayContext();
-  const crumbs = replay?.getEntryType(EntryType.BREADCRUMBS)?.data.values || [];
+  const crumbs = replay?.getRawCrumbs() || [];
   const transformedCrumbs = transformCrumbs(crumbs);
 
   return (

--- a/static/app/utils/replays/getCurrentUrl.tsx
+++ b/static/app/utils/replays/getCurrentUrl.tsx
@@ -2,7 +2,7 @@ import last from 'lodash/last';
 
 import {transformCrumbs} from 'sentry/components/events/interfaces/breadcrumbs/utils';
 import {BreadcrumbType, BreadcrumbTypeNavigation} from 'sentry/types/breadcrumbs';
-import {EntryType, EventTag} from 'sentry/types/event';
+import {EventTag} from 'sentry/types/event';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 
 function findUrlTag(tags: EventTag[]) {
@@ -11,7 +11,7 @@ function findUrlTag(tags: EventTag[]) {
 
 function getCurrentUrl(replay: ReplayReader, currentTime: number) {
   const event = replay.getEvent();
-  const crumbs = replay.getEntryType(EntryType.BREADCRUMBS)?.data.values || [];
+  const crumbs = replay.getRawCrumbs();
 
   const currentOffsetMs = Math.floor(currentTime);
   const startTimestampMs = event.startTimestamp * 1000;

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -61,16 +61,13 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
         </div>
       );
     case 'performance': {
-      if (!spansEntry) {
-        return null;
-      }
-      const nonMemorySpans = {
+      const nonMemorySpansEntry = {
         ...spansEntry,
         data: spansEntry.data.filter(replay.isNotMemorySpan),
       };
       const performanceEvent = {
         ...event,
-        entries: [nonMemorySpans],
+        entries: [nonMemorySpansEntry],
       } as Event;
       return (
         <div id="performance">
@@ -79,7 +76,7 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
             // group={group}
             organization={organization}
             event={performanceEvent}
-            entry={nonMemorySpans}
+            entry={nonMemorySpansEntry}
             route={routes[routes.length - 1]}
             router={router}
           />

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -17,7 +17,6 @@ import useFullscreen from 'sentry/components/replays/useFullscreen';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
-import {EntryType} from 'sentry/types/event';
 import useReplayData from 'sentry/utils/replays/useReplayData';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
@@ -87,7 +86,7 @@ function ReplayDetails() {
       <DetailLayout
         event={replay.getEvent()}
         orgId={orgId}
-        crumbs={replay.getEntryType(EntryType.BREADCRUMBS)?.data.values || []}
+        crumbs={replay.getRawCrumbs()}
       >
         <Layout.Body>
           <ReplayLayout ref={fullscreenRef}>
@@ -110,7 +109,7 @@ function ReplayDetails() {
           </ReplayLayout>
           <Side>
             <UserActionsNavigator
-              crumbs={replay.getEntryType(EntryType.BREADCRUMBS)?.data.values || []}
+              crumbs={replay.getRawCrumbs()}
               event={replay.getEvent()}
             />
           </Side>


### PR DESCRIPTION
Calling `replay.getEntryType(EntryType.BREADCRUMBS)?.data.values || [];` all day is annoying.

`ReplayReader` has multiple ways to access the same, either through the higher layers or diving down directly. But I think for the frequency that we need to dive down this is going to be a win.

```javascript
const {replay} = useReplayContext();

/* High-level */

// ✅ The only way to get an event
const event = replay.getEvent();

/* Mid-level */

// ❌ Don't do this
// const [breadcrumbEntry, spanEntry] = event.entries; 

// ✅ The following is the way to get Entry objects:
const breadcrumbEntry = replay.getEntryType(EntryType.BREADCRUMBS);
const spanEntry = replay.getEntryType(EntryType.SPANS);

/* Low-level */

// ❌ Don't do this, types will be set to `any`
const breadcrumbs = breadcrumbEntry.data.values
const spans = spanEntry.data

// ✅ Get breadcrumbs and spans directly. No need to import EntryType
const breadcrumbs = replay.getRawCrumbs();
const spans = replay.getRawSpans();
```