### PR TITLE
feat(replay): Add a big Play button on top of the captured page

### DIFF
--- a/static/app/components/replays/player/bufferingOverlay.tsx
+++ b/static/app/components/replays/player/bufferingOverlay.tsx
@@ -19,7 +19,7 @@ function BufferingOverlay({className}: Props) {
   );
 }
 
-/* Position the badge in the corner */
+/* Position the badge in the center */
 const Overlay = styled('div')`
   user-select: none;
   display: grid;

--- a/static/app/components/replays/player/playButtonOverlay.tsx
+++ b/static/app/components/replays/player/playButtonOverlay.tsx
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled';
+
+import Button from 'sentry/components/button';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {t} from 'sentry/locale';
+
+type Props = {
+  className?: string;
+};
+
+function PlayButtonOverlay({className}: Props) {
+  const {togglePlayPause} = useReplayContext();
+
+  return (
+    <Overlay className={className}>
+      <PlayButton
+        title={t('Play')}
+        onClick={() => togglePlayPause(true)}
+        aria-label={t('Play')}
+      >
+        {'\u25B6'}
+      </PlayButton>
+    </Overlay>
+  );
+}
+
+/* Position the badge in the center */
+const Overlay = styled('div')`
+  background: rgba(255, 255, 255, 0.75);
+  user-select: none;
+  display: grid;
+  place-items: center;
+`;
+
+const PlayButton = styled(Button)`
+  color: white;
+  font-size: 46px;
+  width: 80px;
+  height: 80px;
+  background: ${p => p.theme.purple400};
+  border-radius: 50%;
+  padding: 5px 0 0 10px;
+
+  :hover {
+    color: ${p => p.theme.purple400};
+    border-color: ${p => p.theme.purple400};
+  }
+`;
+
+export default PlayButtonOverlay;

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -7,6 +7,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 
 import BufferingOverlay from './player/bufferingOverlay';
 import FastForwardBadge from './player/fastForwardBadge';
+import PlayButtonOverlay from './player/playButtonOverlay';
 
 interface Props {
   className?: string;
@@ -18,6 +19,7 @@ function BasePlayerRoot({className}: Props) {
     dimensions: videoDimensions,
     fastForwardSpeed,
     isBuffering,
+    isPlaying,
   } = useReplayContext();
 
   const windowEl = useRef<HTMLDivElement>(null);
@@ -73,6 +75,7 @@ function BasePlayerRoot({className}: Props) {
       <div ref={viewEl} className={className} />
       {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
       {isBuffering ? <PositionedBuffering /> : null}
+      {isPlaying ? null : <PositionedPlayButton />}
     </SizingWindow>
   );
 }
@@ -97,6 +100,14 @@ const PositionedFastForward = styled(FastForwardBadge)`
 `;
 
 const PositionedBuffering = styled(BufferingOverlay)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`;
+
+const PositionedPlayButton = styled(PlayButtonOverlay)`
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
Adds a big "Play" button on top of the captured webpage, so people have a big clear call to action.

<img width="705" alt="Screen Shot 2022-05-09 at 8 00 03 PM" src="https://user-images.githubusercontent.com/187460/167405745-03d66bf3-78a9-45f0-8a74-ec9f7b8d9d4a.png">


I don't like it!

It covers a big useful debugging area. I think one use-case will be for people to pause at an interesting part and then use the inspector to investigate html nodes. So we shouldn’t cover that.

We could iterate on this idea and only show the button on pageload, then after the video starts playing, if it's paused again don't show the overlay. That's not too hard to build, but I don't think it's a good experience because we'd be teaching people one way to interact with the captured page, then changing the rules on them. Better to not make this change.