### PR TITLE
Revert "Revert "ref: fix invalid escapes to avoid DeprecationWarning (#34279)" (#34347)"

### DIFF
--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -45,7 +45,7 @@ INVALID_ESCAPE = re.compile(
 def unescape_string(value: str):
     """Unescapes a backslash escaped string."""
     value = INVALID_ESCAPE.sub(r"\1\\", value)
-    return ast.literal_eval(f'"{value}"')
+    return ast.literal_eval(f'"""{value}"""')
 
 
 def strip_lone_surrogates(string):

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -1,3 +1,4 @@
+import ast
 import base64
 import codecs
 import re
@@ -27,23 +28,24 @@ _lone_surrogate = re.compile(
 """
 )
 
+INVALID_ESCAPE = re.compile(
+    r"""
+(?<!\\)              # no backslash behind
+((?:\\\\)*\\)        # odd number of backslashes
+(?!x[0-9a-fA-F]{2})  # char escape: \x__
+(?!u[0-9a-fA-F]{4})  # char escape: \u____
+(?!U[0-9a-fA-F]{8})  # char escape: \U________
+(?![0-7]{1,3})       # octal escape: \_, \__, \___
+(?![\\'"abfnrtv])    # other escapes: https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
+""",
+    re.VERBOSE,
+)
 
-def unicode_escape_recovery_handler(err):
-    try:
-        value = err.object[err.start : err.end].decode("utf-8")
-    except UnicodeError:
-        value = ""
-    return value, err.end
 
-
-codecs.register_error("unicode-escape-recovery", unicode_escape_recovery_handler)
-
-
-def unescape_string(value):
+def unescape_string(value: str):
     """Unescapes a backslash escaped string."""
-    return value.encode("ascii", "backslashreplace").decode(
-        "unicode-escape", "unicode-escape-recovery"
-    )
+    value = INVALID_ESCAPE.sub(r"\1\\", value)
+    return ast.literal_eval(f'"{value}"')
 
 
 def strip_lone_surrogates(string):

--- a/tests/sentry/utils/test_strings.py
+++ b/tests/sentry/utils/test_strings.py
@@ -1,5 +1,7 @@
 import functools
 
+import pytest
+
 from sentry.utils.strings import (
     codec_lookup,
     is_valid_dot_atom,
@@ -15,42 +17,31 @@ ZWSP = "\u200b"  # zero width space
 SHY = "\u00ad"  # soft hyphen
 
 
-def test_unescape_string():
-    # For raw string literals, python escapes any backslash,
-    # regardless if it's part of a recognized escape sequence or not.
-    value = r"\x80"
-    assert r"\x80" == "\\x80"
-
-    # We want to unescape that.
-    assert unescape_string(value) == "\x80"
-    assert r"\x80" != "\x80"
-
-    # For string literals, python leaves recognized escape sequences alone,
-    # and we should as well.
-    assert unescape_string("\x80") == "\x80"
-
-    # Essentially, we want the resulting str to
-    # have the same number of backslashes as the raw string.
-    assert unescape_string(r"\\x80") == "\\x80"
-    assert unescape_string(r"\\\x80") == "\\\x80"
-    assert unescape_string(r"\\\\x80") == "\\\\x80"
-
-    # Now for a real world example.
-    # If we specify this value as a string literal, we'll get a DeprecationWarning
-    # because \* is not a recognized escape sequence.
-    # This raw string literal reflects what was read off disk from our grouping
-    # enhancement config text files, before they were corrected to be \\**.
-    value = r"C:/WINDOWS/system32/DriverStore\**"
-    assert value == "C:/WINDOWS/system32/DriverStore\\**"
-
-    # This string should remain unchanged after unescape_string,
-    # because there are no recognized escape sequences to unescape.
-    # From 3.6 to 3.8 a DeprecationWarning which we suppress will
-    # be emitted during .decode("unicode-escape", "unicode-escape-recovery"),
-    # because \* isn't a recognized escape sequence.
-    # We just want this to be a reminder if the warning is upgraded to a
-    # behavior change in 3.9+.
-    assert unescape_string(value) == "C:/WINDOWS/system32/DriverStore\\**"
+@pytest.mark.parametrize(
+    ("s", "expected"),
+    (
+        # the literal \x escape sequence is converted to the character
+        (r"\x80", "\x80"),
+        # the result should have the same number of backslashes as the raw string
+        (r"\\x80", "\\x80"),
+        (r"\\\x80", "\\\x80"),
+        (r"\\\\x80", "\\\\x80"),
+        # this string has an invalid escape sequence: \*
+        (r"C:/WINDOWS/system32/DriverStore\**", "C:/WINDOWS/system32/DriverStore\\**"),
+        # this string has an unterminated invalid escape sequence: \x
+        (r"\x", "\\x"),
+        (r"\\\x", "\\\\x"),
+        # decodes character escapes
+        (r"\t", "\t"),
+        (r"\0", "\0"),
+        (r"\11", "\11"),
+        (r"\111", "\111"),
+        (r"\u2603", "☃"),
+        (r"\U0001f643", "🙃"),
+    ),
+)
+def test_unescape_string(s, expected):
+    assert unescape_string(s) == expected
 
 
 def test_codec_lookup():

--- a/tests/sentry/utils/test_strings.py
+++ b/tests/sentry/utils/test_strings.py
@@ -38,6 +38,9 @@ SHY = "\u00ad"  # soft hyphen
         (r"\111", "\111"),
         (r"\u2603", "☃"),
         (r"\U0001f643", "🙃"),
+        # probably a mistake in the configuration but it allows quoted strings
+        # with embedded newlines
+        ("hello\nworld", "hello\nworld"),
     ),
 )
 def test_unescape_string(s, expected):


### PR DESCRIPTION
this reapplies #34279 but with a fix for strings containing an embedded newlines

___

this fixes https://sentry.io/organizations/sentry/issues/3254639529/events/2a41a66701af492289f41b34485f09f9/?project=1#exception

previously it was failing with:

```
SyntaxError: EOL while scanning string literal (<unknown>, line 1)
  File "parsimonious/nodes.py", line 217, in visit
    return method(node, [self.visit(n) for n in node])
  File "sentry/grouping/fingerprinting.py", line 481, in visit_quoted
    return unescape_string(node.text[1:-1])
  File "sentry/utils/strings.py", line 48, in unescape_string
    return ast.literal_eval(f'"{value}"')
  File "ast.py", line 59, in literal_eval
    node_or_string = parse(node_or_string, mode='eval')
  File "ast.py", line 47, in parse
    return compile(source, filename, mode, flags,
VisitationError: SyntaxError: EOL while scanning string literal (<unknown>, line 1)

Parse tree:
<RegexNode called "quoted" matching ""null is not an object (evaluating 'document.getElementById(`st_proxy_${random}`).innerHTML')
"">  <-- *** We were here. ***
  File "celery/app/trace.py", line 704, in __protected_call__
    return self.run(*args, **kwargs)
  File "sentry/tasks/base.py", line 46, in _wrapped
    result = func(*args, **kwargs)
  File "sentry/tasks/store.py", line 763, in save_event
    _do_save_event(cache_key, data, start_time, event_id, project_id, **kwargs)
  File "sentry/tasks/store.py", line 662, in _do_save_event
    manager.save(
  File "sentry/utils/metrics.py", line 210, in inner
    return f(*args, **kwargs)
  File "sentry/event_manager.py", line 408, in save
    hashes = _calculate_event_grouping(project, job["event"], grouping_config)
  File "sentry/utils/metrics.py", line 210, in inner
    return f(*args, **kwargs)
  File "sentry/event_manager.py", line 1732, in _calculate_event_grouping
    get_fingerprinting_config_for_project(project),
  File "sentry/grouping/api.py", line 190, in get_fingerprinting_config_for_project
    rv = FingerprintingRules.from_config_string(rules)
  File "sentry/grouping/fingerprinting.py", line 230, in from_config_string
    return FingerprintingVisitor().visit(tree)
  File "parsimonious/nodes.py", line 217, in visit
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in <listcomp>
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in visit
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in <listcomp>
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in visit
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in <listcomp>
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in visit
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in <listcomp>
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in visit
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in <listcomp>
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in visit
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in <listcomp>
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in visit
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 217, in <listcomp>
    return method(node, [self.visit(n) for n in node])
  File "parsimonious/nodes.py", line 227, in visit
    reraise(VisitationError, VisitationError(exc, exc_class, node), tb)
  File "six.py", line 718, in reraise
    raise value.with_traceback(tb)
  File "parsimonious/nodes.py", line 217, in visit
    return method(node, [self.visit(n) for n in node])
  File "sentry/grouping/fingerprinting.py", line 481, in visit_quoted
    return unescape_string(node.text[1:-1])
  File "sentry/utils/strings.py", line 48, in unescape_string
    return ast.literal_eval(f'"{value}"')
  File "ast.py", line 59, in literal_eval
    node_or_string = parse(node_or_string, mode='eval')
  File "ast.py", line 47, in parse
    return compile(source, filename, mode, flags,
```