### PR TITLE
ref: use driver.switch_to.window instead of driver.switch_to_window to avoid DeprecationWarning

### DIFF
--- a/tests/acceptance/page_objects/organization_integration_settings.py
+++ b/tests/acceptance/page_objects/organization_integration_settings.py
@@ -34,11 +34,11 @@ class OrganizationAbstractDetailViewPage(BasePage):
 
 class OrganizationIntegrationDetailViewPage(OrganizationAbstractDetailViewPage):
     def click_through_integration_setup(self, setup_window_cls, installation_data):
-        self.driver.switch_to_window(self.driver.window_handles[1])
+        self.driver.switch_to.window(self.driver.window_handles[1])
         integration_setup_window = setup_window_cls(element=self.browser)
         integration_setup_window.fill_in_setup_form(installation_data)
         integration_setup_window.continue_button.click()
-        self.driver.switch_to_window(self.driver.window_handles[0])
+        self.driver.switch_to.window(self.driver.window_handles[0])
 
 
 class OrganizationSentryAppDetailViewPage(OrganizationAbstractDetailViewPage):


### PR DESCRIPTION
this is part of an effort to make tests warnings-clean

previously failing with:

```console
_________________________ OrganizationIntegrationDetailView.test_example_installation _________________________
tests/acceptance/test_organization_integration_detail_view.py:37: in test_example_installation
    detail_view_page.click_through_integration_setup(
tests/acceptance/page_objects/organization_integration_settings.py:37: in click_through_integration_setup
    self.driver.switch_to_window(self.driver.window_handles[1])
.venv/lib/python3.8/site-packages/selenium/webdriver/remote/webdriver.py:780: in switch_to_window
    warnings.warn("use driver.switch_to.window instead",
E   DeprecationWarning: use driver.switch_to.window instead
```