### PR TITLE
ref: close snuba test socket to avoid ResourceWarning

### DIFF
--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -13,7 +13,8 @@ def snuba_is_available():
         return _service_status["snuba"]
     try:
         parsed = urlparse(settings.SENTRY_SNUBA)
-        socket.create_connection((parsed.hostname, parsed.port), 1.0)
+        with socket.create_connection((parsed.hostname, parsed.port), 1.0):
+            pass
     except OSError:
         _service_status["snuba"] = False
     else:


### PR DESCRIPTION
in an effort to make tests warnings-clean

previously failing with:

```
src/sentry/testutils/skips.py:16
  /Users/asottile/workspace/sentry/src/sentry/testutils/skips.py:16: ResourceWarning: unclosed <socket.socket fd=16, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 64946), raddr=('127.0.0.1', 1218)>
    socket.create_connection((parsed.hostname, parsed.port), 1.0)
```