### PR TITLE
ref: manually initialize redis Cluster to avoid DeprecationWarning

### DIFF
--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 import pytest
 import pytz
+from django.test import override_settings
 
 from sentry.testutils import TestCase
 from sentry.tsdb.base import ONE_DAY, ONE_HOUR, ONE_MINUTE, TSDBModel
@@ -28,6 +29,11 @@ def test_suppression_wrapper():
 
 
 class RedisTSDBTest(TestCase):
+    @override_settings(
+        SENTRY_OPTIONS={
+            "redis.clusters": {"tsdb": {"hosts": {i - 6: {"db": i} for i in range(6, 9)}}}
+        }
+    )
     def setUp(self):
         self.db = RedisTSDB(
             rollups=(
@@ -39,8 +45,11 @@ class RedisTSDBTest(TestCase):
             ),
             vnodes=64,
             enable_frequency_sketches=True,
-            hosts={i - 6: {"db": i} for i in range(6, 9)},
+            cluster="tsdb",
         )
+
+        # the point of this test is to demonstrate behaviour with a multi-host cluster
+        assert len(self.db.cluster.hosts) == 3
 
     def tearDown(self):
         with self.db.cluster.all() as client:


### PR DESCRIPTION
part of an effort to make tests warnings-clean

previously failing with:

```
__________________________________________ RedisTSDBTest.test_simple __________________________________________
tests/sentry/tsdb/test_redis.py:32: in setUp
    self.db = RedisTSDB(
src/sentry/tsdb/redis.py:111: in __init__
    self.cluster, options = get_cluster_from_options("SENTRY_TSDB_OPTIONS", options)
src/sentry/utils/redis.py:308: in get_cluster_from_options
    warnings.warn(
src/sentry/utils/warnings.py:59: in warn
    handler(warning, **kwargs)
src/sentry/utils/warnings.py:92: in <lambda>
    lambda warning, stacklevel=1: warnings.warn(warning, stacklevel=stacklevel + 2),
E   sentry.utils.warnings.DeprecatedSettingWarning: The 'hosts' parameter of SENTRY_TSDB_OPTIONS setting is deprecated. Please use SENTRY_TSDB_OPTIONS["cluster"] instead. This setting will be removed in Sentry 8.5.
```