### PR TITLE
ref: remove deprecated checksum= from create_group calls

### DIFF
--- a/tests/sentry/api/endpoints/test_group_activities.py
+++ b/tests/sentry/api/endpoints/test_group_activities.py
@@ -4,7 +4,7 @@ from sentry.testutils import APITestCase
 
 class GroupActivitiesEndpointTest(APITestCase):
     def test_endpoint_with_no_group_activities(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -18,7 +18,7 @@ class GroupActivitiesEndpointTest(APITestCase):
         assert len(response.data["activity"]) == 1
 
     def test_endpoint_with_group_activities(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         for i in range(0, 4):
             Activity.objects.create(

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -265,7 +265,7 @@ class GroupUpdateTest(APITestCase):
         assert GroupResolution.objects.filter(group=group).exists()
 
     def test_snooze_duration(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
+        group = self.create_group(status=GroupStatus.RESOLVED)
 
         self.login_as(user=self.user)
 

--- a/tests/sentry/api/endpoints/test_team_groups_old.py
+++ b/tests/sentry/api/endpoints/test_team_groups_old.py
@@ -13,12 +13,10 @@ class TeamGroupsOldTest(APITestCase):
         project1 = self.create_project(teams=[self.team], slug="foo")
         project2 = self.create_project(teams=[self.team], slug="bar")
         group1 = self.create_group(
-            checksum="a" * 32,
             project=project1,
             first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
         )
         group2 = self.create_group(
-            checksum="b" * 32,
             project=project2,
             first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
         )
@@ -29,13 +27,11 @@ class TeamGroupsOldTest(APITestCase):
 
         other_user = self.create_user()
         assigned_to_other = self.create_group(
-            checksum="b" * 32,
             project=project2,
             first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
         )
         GroupAssignee.objects.assign(assigned_to_other, other_user)
         self.create_group(
-            checksum="b" * 32,
             project=project2,
             first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
         )
@@ -57,7 +53,6 @@ class TeamGroupsOldTest(APITestCase):
         environment = self.create_environment(name="prod", project=project1)
         self.create_environment(name="dev", project=project1)
         group1 = self.create_group(
-            checksum="a" * 32,
             project=project1,
             first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
         )

--- a/tests/sentry/api/endpoints/test_team_issue_breakdown.py
+++ b/tests/sentry/api/endpoints/test_team_issue_breakdown.py
@@ -16,8 +16,8 @@ class TeamIssueBreakdownTest(APITestCase):
     def test_status_format(self):
         project1 = self.create_project(teams=[self.team], slug="foo")
         project2 = self.create_project(teams=[self.team], slug="bar")
-        group1 = self.create_group(checksum="a" * 32, project=project1)
-        group2 = self.create_group(checksum="b" * 32, project=project2)
+        group1 = self.create_group(project=project1)
+        group2 = self.create_group(project=project2)
         GroupAssignee.objects.assign(group1, self.user)
         GroupAssignee.objects.assign(group2, self.user)
 
@@ -102,7 +102,7 @@ class TeamIssueBreakdownTest(APITestCase):
 
     def test_filter_by_environment(self):
         project1 = self.create_project(teams=[self.team], slug="foo")
-        group1 = self.create_group(checksum="a" * 32, project=project1)
+        group1 = self.create_group(project=project1)
         env1 = self.create_environment(name="prod", project=project1)
         self.create_environment(name="dev", project=project1)
         GroupAssignee.objects.assign(group1, self.user)
@@ -155,8 +155,8 @@ class TeamIssueBreakdownTest(APITestCase):
     def test_old_format(self):
         project1 = self.create_project(teams=[self.team], slug="foo")
         project2 = self.create_project(teams=[self.team], slug="bar")
-        group1 = self.create_group(checksum="a" * 32, project=project1, times_seen=10)
-        group2 = self.create_group(checksum="b" * 32, project=project2, times_seen=5)
+        group1 = self.create_group(project=project1, times_seen=10)
+        group2 = self.create_group(project=project2, times_seen=5)
         GroupAssignee.objects.assign(group1, self.user)
         GroupAssignee.objects.assign(group2, self.user)
 

--- a/tests/sentry/api/endpoints/test_team_time_to_resolution.py
+++ b/tests/sentry/api/endpoints/test_team_time_to_resolution.py
@@ -15,10 +15,8 @@ class TeamTimeToResolutionTest(APITestCase):
     def test_simple(self):
         project1 = self.create_project(teams=[self.team], slug="foo")
         project2 = self.create_project(teams=[self.team], slug="bar")
-        group1 = self.create_group(checksum="a" * 32, project=project1, times_seen=10)
-        group2 = self.create_group(
-            checksum="b" * 32, project=project2, times_seen=5, first_seen=before_now(days=20)
-        )
+        group1 = self.create_group(project=project1, times_seen=10)
+        group2 = self.create_group(project=project2, times_seen=5, first_seen=before_now(days=20))
         GroupAssignee.objects.assign(group1, self.user)
         GroupAssignee.objects.assign(group2, self.user)
 
@@ -98,7 +96,7 @@ class TeamTimeToResolutionTest(APITestCase):
 
     def test_filter_by_environment(self):
         project1 = self.create_project(teams=[self.team], slug="foo")
-        group1 = self.create_group(checksum="a" * 32, project=project1, times_seen=10)
+        group1 = self.create_group(project=project1, times_seen=10)
         env1 = self.create_environment(project=project1, name="prod")
         self.create_environment(project=project1, name="dev")
         GroupAssignee.objects.assign(group1, self.user)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -335,7 +335,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     def test_invalid_query(self):
         now = timezone.now()
-        self.create_group(checksum="a" * 32, last_seen=now - timedelta(seconds=1))
+        self.create_group(last_seen=now - timedelta(seconds=1))
         self.login_as(user=self.user)
 
         response = self.get_response(sort_by="date", query="timesSeen:>1t")
@@ -344,7 +344,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     def test_valid_numeric_query(self):
         now = timezone.now()
-        self.create_group(checksum="a" * 32, last_seen=now - timedelta(seconds=1))
+        self.create_group(last_seen=now - timedelta(seconds=1))
         self.login_as(user=self.user)
 
         response = self.get_response(sort_by="date", query="timesSeen:>1k")
@@ -352,7 +352,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     def test_invalid_sort_key(self):
         now = timezone.now()
-        self.create_group(checksum="a" * 32, last_seen=now - timedelta(seconds=1))
+        self.create_group(last_seen=now - timedelta(seconds=1))
         self.login_as(user=self.user)
 
         response = self.get_response(sort="meow", query="is:unresolved")
@@ -393,8 +393,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
         # TODO(dcramer): this test really only checks if validation happens
         # on groupStatsPeriod
         now = timezone.now()
-        self.create_group(checksum="a" * 32, last_seen=now - timedelta(seconds=1))
-        self.create_group(checksum="b" * 32, last_seen=now)
+        self.create_group(last_seen=now - timedelta(seconds=1))
+        self.create_group(last_seen=now)
 
         self.login_as(user=self.user)
 
@@ -507,8 +507,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
     def test_lookup_by_unknown_event_id(self):
         project = self.project
         project.update_option("sentry:resolve_age", 1)
-        self.create_group(checksum="a" * 32)
-        self.create_group(checksum="b" * 32)
+        self.create_group()
+        self.create_group()
 
         self.login_as(user=self.user)
         response = self.get_valid_response(query="c" * 32)
@@ -1659,7 +1659,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
-        self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        self.create_group(status=GroupStatus.UNRESOLVED)
         self.login_as(user=self.user)
         response = self.get_response(
             sort_by="date", limit=10, query="is:unresolved", expand="inbox", collapse="stats"
@@ -1679,7 +1679,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
-        self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        self.create_group(status=GroupStatus.UNRESOLVED)
         self.login_as(user=self.user)
         response = self.get_response(
             sort_by="date", limit=10, query="is:unresolved", collapse="lifetime"
@@ -1699,7 +1699,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
-        self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        self.create_group(status=GroupStatus.UNRESOLVED)
         self.login_as(user=self.user)
         response = self.get_response(
             sort_by="date", limit=10, query="is:unresolved", collapse="filtered"
@@ -1719,7 +1719,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
-        self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        self.create_group(status=GroupStatus.UNRESOLVED)
         self.login_as(user=self.user)
         response = self.get_response(
             sort_by="date", limit=10, query="is:unresolved", collapse=["filtered", "lifetime"]
@@ -1739,7 +1739,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
-        self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        self.create_group(status=GroupStatus.UNRESOLVED)
         self.login_as(user=self.user)
         response = self.get_response(
             sort_by="date", limit=10, query="is:unresolved", collapse=["base"]
@@ -1800,12 +1800,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupResolution.objects.filter(group=group).exists()
 
     def test_global_resolve(self):
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
-        group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group3 = self.create_group(checksum="c" * 32, status=GroupStatus.IGNORED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group2 = self.create_group(status=GroupStatus.UNRESOLVED)
+        group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(
             project=self.create_project(slug="foo"),
-            checksum="b" * 32,
             status=GroupStatus.UNRESOLVED,
         )
 
@@ -1857,7 +1856,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         ).exists()
 
     def test_resolve_member(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
         member = self.create_user()
         self.create_member(
             organization=self.organization, teams=group.project.teams.all(), user=member
@@ -1949,7 +1948,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     @patch("sentry.integrations.example.integration.ExampleIntegration.sync_status_outbound")
     def test_set_unresolved_with_integration(self, mock_sync_status_outbound):
         release = self.create_release(project=self.project, version="abc")
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
+        group = self.create_group(status=GroupStatus.RESOLVED)
         org = self.organization
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
@@ -1998,7 +1997,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
                 )
 
     def test_self_assign_issue(self):
-        group = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
         user = self.user
 
         uo1 = UserOption.objects.create(key="self_assign_issue", value="1", project=None, user=user)
@@ -2019,7 +2018,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         uo1 = UserOption.objects.create(
             key="self_assign_issue", value="1", project=None, user=self.user
@@ -2267,12 +2266,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert activity.data["version"] == release_2.version
 
     def test_selective_status_update(self):
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
-        group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group3 = self.create_group(checksum="c" * 32, status=GroupStatus.IGNORED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group2 = self.create_group(status=GroupStatus.UNRESOLVED)
+        group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(
             project=self.create_project(slug="foo"),
-            checksum="b" * 32,
             status=GroupStatus.UNRESOLVED,
         )
 
@@ -2307,7 +2305,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -2343,7 +2341,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release2 = Release.objects.create(organization_id=self.project.organization_id, version="b")
         release2.add_project(self.project)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -2422,7 +2420,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -2454,7 +2452,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -2488,7 +2486,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     def test_set_resolved_in_explicit_commit_unreleased(self):
         repo = self.create_repo(project=self.project, name=self.project.name)
         commit = self.create_commit(project=self.project, repo=repo)
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -2525,7 +2523,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         repo = self.create_repo(project=self.project, name=self.project.name)
         commit = self.create_commit(project=self.project, repo=repo, release=release)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -2564,7 +2562,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
     def test_set_resolved_in_explicit_commit_missing(self):
         repo = self.create_repo(project=self.project, name=self.project.name)
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -2584,7 +2582,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
     def test_set_unresolved(self):
         release = self.create_release(project=self.project, version="abc")
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
+        group = self.create_group(status=GroupStatus.RESOLVED)
         GroupResolution.objects.create(group=group, release=release)
 
         self.login_as(user=self.user)
@@ -2605,7 +2603,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         ).exists()
 
     def test_set_unresolved_on_snooze(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.IGNORED)
+        group = self.create_group(status=GroupStatus.IGNORED)
 
         GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(days=1))
 
@@ -2621,7 +2619,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         ).exists()
 
     def test_basic_ignore(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
+        group = self.create_group(status=GroupStatus.RESOLVED)
 
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now())
 
@@ -2640,7 +2638,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert response.data == {"status": "ignored", "statusDetails": {}, "inbox": None}
 
     def test_snooze_duration(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
+        group = self.create_group(status=GroupStatus.RESOLVED)
 
         self.login_as(user=self.user)
 
@@ -2672,7 +2670,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
 
     def test_snooze_count(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED, times_seen=1)
+        group = self.create_group(status=GroupStatus.RESOLVED, times_seen=1)
 
         self.login_as(user=self.user)
 
@@ -2733,12 +2731,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
 
     def test_set_bookmarked(self):
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
-        group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group3 = self.create_group(checksum="c" * 32, status=GroupStatus.IGNORED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group2 = self.create_group(status=GroupStatus.UNRESOLVED)
+        group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(
             project=self.create_project(slug="foo"),
-            checksum="b" * 32,
             status=GroupStatus.UNRESOLVED,
         )
 
@@ -2770,10 +2767,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not bookmark4.exists()
 
     def test_subscription(self):
-        group1 = self.create_group(checksum="a" * 32)
-        group2 = self.create_group(checksum="b" * 32)
-        group3 = self.create_group(checksum="c" * 32)
-        group4 = self.create_group(project=self.create_project(slug="foo"), checksum="b" * 32)
+        group1 = self.create_group()
+        group2 = self.create_group()
+        group3 = self.create_group()
+        group4 = self.create_group(project=self.create_project(slug="foo"))
 
         self.login_as(user=self.user)
         with self.feature("organizations:global-views"):
@@ -2795,8 +2792,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupSubscription.objects.filter(group=group4, user=self.user).exists()
 
     def test_set_public(self):
-        group1 = self.create_group(checksum="a" * 32)
-        group2 = self.create_group(checksum="b" * 32)
+        group1 = self.create_group()
+        group2 = self.create_group()
 
         self.login_as(user=self.user)
         response = self.get_valid_response(
@@ -2812,8 +2809,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert bool(new_group2.get_share_id())
 
     def test_set_private(self):
-        group1 = self.create_group(checksum="a" * 32)
-        group2 = self.create_group(checksum="b" * 32)
+        group1 = self.create_group()
+        group2 = self.create_group()
 
         # Manually mark them as shared
         for g in group1, group2:
@@ -2833,12 +2830,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not bool(new_group2.get_share_id())
 
     def test_set_has_seen(self):
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
-        group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group3 = self.create_group(checksum="c" * 32, status=GroupStatus.IGNORED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group2 = self.create_group(status=GroupStatus.UNRESOLVED)
+        group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(
             project=self.create_project(slug="foo"),
-            checksum="b" * 32,
             status=GroupStatus.UNRESOLVED,
         )
 
@@ -2869,10 +2865,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         mock_eventstream.start_merge = Mock(return_value=eventstream_state)
 
         mock_uuid4.return_value = self.get_mock_uuid()
-        group1 = self.create_group(checksum="a" * 32, times_seen=1)
-        group2 = self.create_group(checksum="b" * 32, times_seen=50)
-        group3 = self.create_group(checksum="c" * 32, times_seen=2)
-        self.create_group(checksum="d" * 32)
+        group1 = self.create_group(times_seen=1)
+        group2 = self.create_group(times_seen=50)
+        group3 = self.create_group(times_seen=2)
+        self.create_group()
 
         self.login_as(user=self.user)
         response = self.get_valid_response(
@@ -2896,8 +2892,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
     def test_assign(self):
-        group1 = self.create_group(checksum="a" * 32, is_public=True)
-        group2 = self.create_group(checksum="b" * 32, is_public=True)
+        group1 = self.create_group(is_public=True)
+        group2 = self.create_group(is_public=True)
         user = self.user
 
         self.login_as(user=user)
@@ -2924,7 +2920,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         ).exists()
 
     def test_assign_non_member(self):
-        group = self.create_group(checksum="a" * 32, is_public=True)
+        group = self.create_group(is_public=True)
         member = self.user
         non_member = self.create_user("bar@example.com")
 
@@ -2968,8 +2964,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         ).exists()
 
     def test_discard(self):
-        group1 = self.create_group(checksum="a" * 32, is_public=True)
-        group2 = self.create_group(checksum="b" * 32, is_public=True)
+        group1 = self.create_group(is_public=True)
+        group2 = self.create_group(is_public=True)
         group_hash = GroupHash.objects.create(hash="x" * 32, project=group1.project, group=group1)
         user = self.user
 
@@ -2999,8 +2995,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             self.get_error_response(status_code=status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_set_inbox(self):
-        group1 = self.create_group(checksum="a" * 32)
-        group2 = self.create_group(checksum="b" * 32)
+        group1 = self.create_group()
+        group2 = self.create_group()
 
         self.login_as(user=self.user)
         response = self.get_valid_response(qs_params={"id": [group1.id, group2.id]}, inbox="true")
@@ -3026,8 +3022,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupInbox.objects.filter(group=group2).exists()
 
     def test_set_resolved_inbox(self):
-        group1 = self.create_group(checksum="a" * 32)
-        group2 = self.create_group(checksum="b" * 32)
+        group1 = self.create_group()
+        group2 = self.create_group()
 
         self.login_as(user=self.user)
         response = self.get_valid_response(
@@ -3065,12 +3061,11 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         eventstream_state = {"event_stream_state": uuid4()}
         mock_eventstream_api.start_delete_groups = Mock(return_value=eventstream_state)
 
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
-        group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group3 = self.create_group(checksum="c" * 32, status=GroupStatus.IGNORED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group2 = self.create_group(status=GroupStatus.UNRESOLVED)
+        group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(
             project=self.create_project(slug="foo"),
-            checksum="b" * 32,
             status=GroupStatus.UNRESOLVED,
         )
 
@@ -3134,7 +3129,6 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             groups.append(
                 self.create_group(
                     project=self.project,
-                    checksum=str(i).encode("utf-8") * 16,
                     status=GroupStatus.RESOLVED,
                 )
             )

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -31,9 +31,9 @@ class GroupListTest(APITestCase, SnubaTestCase):
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
-        group_a = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
-        self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group_c = self.create_group(checksum="c" * 32, status=GroupStatus.UNRESOLVED)
+        group_a = self.create_group(status=GroupStatus.UNRESOLVED)
+        self.create_group(status=GroupStatus.UNRESOLVED)
+        group_c = self.create_group(status=GroupStatus.UNRESOLVED)
         self.login_as(user=self.user)
         response = self.get_response(
             sort_by="date", limit=10, query="is:unresolved", groups=[group_a.id, group_c.id]

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -55,7 +55,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     def test_sort_by_date_with_tag(self):
         # XXX(dcramer): this tests a case where an ambiguous column name existed
-        group1 = self.create_group(checksum="a" * 32, last_seen=before_now(seconds=1))
+        group1 = self.create_group(last_seen=before_now(seconds=1))
         self.login_as(user=self.user)
 
         response = self.client.get(f"{self.path}?sort_by=date&query=is:unresolved", format="json")
@@ -64,7 +64,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.data[0]["id"] == str(group1.id)
 
     def test_invalid_query(self):
-        self.create_group(checksum="a" * 32, last_seen=before_now(seconds=1))
+        self.create_group(last_seen=before_now(seconds=1))
         self.login_as(user=self.user)
 
         response = self.client.get(f"{self.path}?sort_by=date&query=timesSeen:>1t", format="json")
@@ -110,8 +110,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
     def test_stats_period(self):
         # TODO(dcramer): this test really only checks if validation happens
         # on statsPeriod
-        self.create_group(checksum="a" * 32, last_seen=before_now(seconds=1))
-        self.create_group(checksum="b" * 32, last_seen=timezone.now())
+        self.create_group(last_seen=before_now(seconds=1))
+        self.create_group(last_seen=timezone.now())
 
         self.login_as(user=self.user)
 
@@ -159,8 +159,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
     def test_auto_resolved(self):
         project = self.project
         project.update_option("sentry:resolve_age", 1)
-        self.create_group(checksum="a" * 32, last_seen=before_now(days=1))
-        group2 = self.create_group(checksum="b" * 32, last_seen=timezone.now())
+        self.create_group(last_seen=before_now(days=1))
+        group2 = self.create_group(last_seen=timezone.now())
 
         self.login_as(user=self.user)
         response = self.client.get(self.path, format="json")
@@ -223,8 +223,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
     def test_lookup_by_unknown_event_id(self):
         project = self.project
         project.update_option("sentry:resolve_age", 1)
-        self.create_group(checksum="a" * 32)
-        self.create_group(checksum="b" * 32)
+        self.create_group()
+        self.create_group()
 
         self.login_as(user=self.user)
         response = self.client.get("{}?query={}".format(self.path, "c" * 32), format="json")
@@ -311,10 +311,10 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert int(issues[0]["id"]) == group.id
 
     def test_pending_delete_pending_merge_excluded(self):
-        self.create_group(checksum="a" * 32, status=GroupStatus.PENDING_DELETION)
-        group = self.create_group(checksum="b" * 32)
-        self.create_group(checksum="c" * 32, status=GroupStatus.DELETION_IN_PROGRESS)
-        self.create_group(checksum="d" * 32, status=GroupStatus.PENDING_MERGE)
+        self.create_group(status=GroupStatus.PENDING_DELETION)
+        group = self.create_group()
+        self.create_group(status=GroupStatus.DELETION_IN_PROGRESS)
+        self.create_group(status=GroupStatus.PENDING_MERGE)
 
         self.login_as(user=self.user)
 
@@ -365,12 +365,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupResolution.objects.filter(group=group).exists()
 
     def test_global_resolve(self):
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
-        group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group3 = self.create_group(checksum="c" * 32, status=GroupStatus.IGNORED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group2 = self.create_group(status=GroupStatus.UNRESOLVED)
+        group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(
             project=self.create_project(slug="foo"),
-            checksum="b" * 32,
             status=GroupStatus.UNRESOLVED,
         )
 
@@ -490,7 +489,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     @patch("sentry.integrations.example.integration.ExampleIntegration.sync_status_outbound")
     def test_set_unresolved_with_integration(self, mock_sync_status_outbound):
         release = self.create_release(project=self.project, version="abc")
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
+        group = self.create_group(status=GroupStatus.RESOLVED)
         org = self.organization
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
@@ -541,7 +540,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
                 )
 
     def test_self_assign_issue(self):
-        group = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
         user = self.user
 
         uo1 = UserOption.objects.create(key="self_assign_issue", value="1", project=None, user=user)
@@ -565,7 +564,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         uo1 = UserOption.objects.create(
             key="self_assign_issue", value="1", project=None, user=self.user
@@ -595,12 +594,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         uo1.delete()
 
     def test_selective_status_update(self):
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
-        group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group3 = self.create_group(checksum="c" * 32, status=GroupStatus.IGNORED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group2 = self.create_group(status=GroupStatus.UNRESOLVED)
+        group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(
             project=self.create_project(slug="foo"),
-            checksum="b" * 32,
             status=GroupStatus.UNRESOLVED,
         )
 
@@ -634,7 +632,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -672,7 +670,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release2 = Release.objects.create(organization_id=self.project.organization_id, version="b")
         release2.add_project(self.project)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -708,7 +706,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -744,7 +742,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -774,7 +772,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     def test_set_resolved_in_explicit_commit_unreleased(self):
         repo = self.create_repo(project=self.project, name=self.project.name)
         commit = self.create_commit(project=self.project, repo=repo)
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -812,7 +810,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         repo = self.create_repo(project=self.project, name=self.project.name)
         commit = self.create_commit(project=self.project, repo=repo, release=release)
 
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -852,7 +850,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
     def test_set_resolved_in_explicit_commit_missing(self):
         repo = self.create_repo(project=self.project, name=self.project.name)
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         self.login_as(user=self.user)
 
@@ -873,7 +871,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
     def test_set_unresolved(self):
         release = self.create_release(project=self.project, version="abc")
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
+        group = self.create_group(status=GroupStatus.RESOLVED)
         GroupResolution.objects.create(group=group, release=release)
 
         self.login_as(user=self.user)
@@ -893,7 +891,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         ).exists()
 
     def test_set_unresolved_on_snooze(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.IGNORED)
+        group = self.create_group(status=GroupStatus.IGNORED)
 
         GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(days=1))
 
@@ -908,7 +906,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert group.status == GroupStatus.UNRESOLVED
 
     def test_basic_ignore(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
+        group = self.create_group(status=GroupStatus.RESOLVED)
 
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now())
 
@@ -928,7 +926,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert response.data == {"status": "ignored", "statusDetails": {}, "inbox": None}
 
     def test_snooze_duration(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
+        group = self.create_group(status=GroupStatus.RESOLVED)
 
         self.login_as(user=self.user)
 
@@ -959,7 +957,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
 
     def test_snooze_count(self):
-        group = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED, times_seen=1)
+        group = self.create_group(status=GroupStatus.RESOLVED, times_seen=1)
 
         self.login_as(user=self.user)
 
@@ -1028,12 +1026,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
 
     def test_set_bookmarked(self):
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
-        group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group3 = self.create_group(checksum="c" * 32, status=GroupStatus.IGNORED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group2 = self.create_group(status=GroupStatus.UNRESOLVED)
+        group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(
             project=self.create_project(slug="foo"),
-            checksum="b" * 32,
             status=GroupStatus.UNRESOLVED,
         )
 
@@ -1064,10 +1061,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not bookmark4.exists()
 
     def test_subscription(self):
-        group1 = self.create_group(checksum="a" * 32)
-        group2 = self.create_group(checksum="b" * 32)
-        group3 = self.create_group(checksum="c" * 32)
-        group4 = self.create_group(project=self.create_project(slug="foo"), checksum="b" * 32)
+        group1 = self.create_group()
+        group2 = self.create_group()
+        group3 = self.create_group()
+        group4 = self.create_group(project=self.create_project(slug="foo"))
 
         self.login_as(user=self.user)
         url = f"{self.path}?id={group1.id}&id={group2.id}&group4={group4.id}"
@@ -1088,8 +1085,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupSubscription.objects.filter(group=group4, user=self.user).exists()
 
     def test_set_public(self):
-        group1 = self.create_group(checksum="a" * 32)
-        group2 = self.create_group(checksum="b" * 32)
+        group1 = self.create_group()
+        group2 = self.create_group()
 
         self.login_as(user=self.user)
         url = f"{self.path}?id={group1.id}&id={group2.id}"
@@ -1105,8 +1102,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert bool(new_group2.get_share_id())
 
     def test_set_private(self):
-        group1 = self.create_group(checksum="a" * 32)
-        group2 = self.create_group(checksum="b" * 32)
+        group1 = self.create_group()
+        group2 = self.create_group()
 
         # Manually mark them as shared
         for g in group1, group2:
@@ -1126,12 +1123,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not bool(new_group2.get_share_id())
 
     def test_set_has_seen(self):
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
-        group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group3 = self.create_group(checksum="c" * 32, status=GroupStatus.IGNORED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group2 = self.create_group(status=GroupStatus.UNRESOLVED)
+        group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(
             project=self.create_project(slug="foo"),
-            checksum="b" * 32,
             status=GroupStatus.UNRESOLVED,
         )
 
@@ -1154,7 +1150,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not r4.exists()
 
     def test_inbox_fields(self):
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
         add_group_to_inbox(group1, GroupInboxReason.NEW)
         self.login_as(user=self.user)
         url = f"{self.path}?id={group1.id}"
@@ -1170,10 +1166,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         mock_eventstream.start_merge = Mock(return_value=eventstream_state)
 
         mock_uuid4.return_value = self.get_mock_uuid()
-        group1 = self.create_group(checksum="a" * 32, times_seen=1)
-        group2 = self.create_group(checksum="b" * 32, times_seen=50)
-        group3 = self.create_group(checksum="c" * 32, times_seen=2)
-        self.create_group(checksum="d" * 32)
+        group1 = self.create_group(times_seen=1)
+        group2 = self.create_group(times_seen=50)
+        group3 = self.create_group(times_seen=2)
+        self.create_group()
 
         self.login_as(user=self.user)
         url = f"{self.path}?id={group1.id}&id={group2.id}&id={group3.id}"
@@ -1197,8 +1193,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
     def test_assign(self):
-        group1 = self.create_group(checksum="a" * 32, is_public=True)
-        group2 = self.create_group(checksum="b" * 32, is_public=True)
+        group1 = self.create_group(is_public=True)
+        group2 = self.create_group(is_public=True)
         user = self.user
 
         self.login_as(user=user)
@@ -1224,7 +1220,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupAssignee.objects.filter(group=group1, user=user).exists()
 
     def test_assign_non_member(self):
-        group = self.create_group(checksum="a" * 32, is_public=True)
+        group = self.create_group(is_public=True)
         member = self.user
         non_member = self.create_user("bar@example.com")
 
@@ -1264,8 +1260,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert response.data["assignedTo"] is None
 
     def test_discard(self):
-        group1 = self.create_group(checksum="a" * 32, is_public=True)
-        group2 = self.create_group(checksum="b" * 32, is_public=True)
+        group1 = self.create_group(is_public=True)
+        group2 = self.create_group(is_public=True)
         group_hash = GroupHash.objects.create(hash="x" * 32, project=group1.project, group=group1)
         user = self.user
 
@@ -1292,7 +1288,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         return_value=frozenset(s for s in settings.SENTRY_SCOPES if s != "event:admin"),
     )
     def test_discard_requires_events_admin(self, mock_get_scopes):
-        group1 = self.create_group(checksum="a" * 32, is_public=True)
+        group1 = self.create_group(is_public=True)
         user = self.user
 
         self.login_as(user=user)
@@ -1316,12 +1312,11 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         eventstream_state = {"event_stream_state": uuid4()}
         mock_eventstream_api.start_delete_groups = Mock(return_value=eventstream_state)
 
-        group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
-        group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)
-        group3 = self.create_group(checksum="c" * 32, status=GroupStatus.IGNORED)
+        group1 = self.create_group(status=GroupStatus.RESOLVED)
+        group2 = self.create_group(status=GroupStatus.UNRESOLVED)
+        group3 = self.create_group(status=GroupStatus.IGNORED)
         group4 = self.create_group(
             project=self.create_project(slug="foo"),
-            checksum="b" * 32,
             status=GroupStatus.UNRESOLVED,
         )
 
@@ -1381,7 +1376,6 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             groups.append(
                 self.create_group(
                     project=self.project,
-                    checksum=str(i).encode("utf-8") * 16,
                     status=GroupStatus.RESOLVED,
                 )
             )


### PR DESCRIPTION
part of an effort to make tests warnings-clean

I'll remove the parameter in a followup since there's so many callsites I'm worried about someone copy-pasting while landing this

originally these failed (similar to this):

```
_____________________ GroupActivitiesEndpointTest.test_endpoint_with_no_group_activities ______________________
tests/sentry/api/endpoints/test_group_activities.py:7: in test_endpoint_with_no_group_activities
    group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
src/sentry/testutils/fixtures.py:215: in create_group
    return Factories.create_group(project=project, *args, **kwargs)
src/sentry/testutils/factories.py:619: in create_group
    warnings.warn("Checksum passed to create_group", DeprecationWarning)
E   DeprecationWarning: Checksum passed to create_group
```