### PR TITLE
fix(dashboards): Fix Widget Viewer top results indicator colors off when < 5 results

### DIFF
--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -189,14 +189,16 @@ export const renderGridBodyCell =
         }
         break;
     }
-
+    const TopResultsCount = tableData
+      ? Math.min(tableData?.data.length, DEFAULT_NUM_TOP_EVENTS)
+      : DEFAULT_NUM_TOP_EVENTS;
     return (
       <Fragment>
         {isTopEvents &&
         isFirstPage &&
         rowIndex < DEFAULT_NUM_TOP_EVENTS &&
         columnIndex === 0 ? (
-          <TopResultsIndicator count={DEFAULT_NUM_TOP_EVENTS} index={rowIndex} />
+          <TopResultsIndicator count={TopResultsCount} index={rowIndex} />
         ) : null}
         {cell}
       </Fragment>

--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -189,7 +189,7 @@ export const renderGridBodyCell =
         }
         break;
     }
-    const TopResultsCount = tableData
+    const topResultsCount = tableData
       ? Math.min(tableData?.data.length, DEFAULT_NUM_TOP_EVENTS)
       : DEFAULT_NUM_TOP_EVENTS;
     return (

--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -198,7 +198,7 @@ export const renderGridBodyCell =
         isFirstPage &&
         rowIndex < DEFAULT_NUM_TOP_EVENTS &&
         columnIndex === 0 ? (
-          <TopResultsIndicator count={TopResultsCount} index={rowIndex} />
+          <TopResultsIndicator count={topResultsCount} index={rowIndex} />
         ) : null}
         {cell}
       </Fragment>


### PR DESCRIPTION
Fixes the top results indicator colors on the widget viewer table when there are less than 5 results. Indicator was previously displaying wrong colors
![image](https://user-images.githubusercontent.com/83961295/167436942-4fc2d94e-086c-4ec8-9747-a0594bdf2dc2.png)
