### PR TITLE
ref: use pytests's warning filter instead of manually re-configuring

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,14 +9,6 @@ pytest_plugins = ["sentry.utils.pytest"]
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
 
-def pytest_configure(config):
-    import warnings
-
-    # XXX(dcramer): Kombu throws a warning due to transaction.commit_manually
-    # being used
-    warnings.filterwarnings("error", "", Warning, r"^(?!(|kombu|raven|sentry))")
-
-
 # XXX: The below code is vendored code from https://github.com/utgwkk/pytest-github-actions-annotate-failures
 # so that we can add support for pytest_rerunfailures
 # retried tests will no longer be annotated in GHA


### PR DESCRIPTION
I *think* this is redundant with the warnings filters in `pyproject.toml`