### PR TITLE
feat(replay): Redesign the <Timeline> component with breadcrumb icons and network activity

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import Icon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
 import * as Timeline from 'sentry/components/replays/breadcrumbs/timeline';
+import Tooltip from 'sentry/components/tooltip';
 import space from 'sentry/styles/space';
 import {Crumb} from 'sentry/types/breadcrumbs';
+import type {Color} from 'sentry/utils/theme';
 
 import {getCrumbsByColumn} from '../utils';
 
@@ -20,34 +23,62 @@ function ReplayTimelineEvents({className, crumbs, width}: Props) {
   const eventsByCol = getCrumbsByColumn(crumbs, totalColumns);
 
   return (
-    <Timeline.Columns className={className} totalColumns={totalColumns} remainder={0}>
+    <EventColumns className={className} totalColumns={totalColumns} remainder={0}>
       {Array.from(eventsByCol.entries()).map(([column, breadcrumbs]) => (
         <EventColumn key={column} column={column}>
-          {breadcrumbs.map((breadcrumb, i) => (
-            <EventStickMarker
-              key={`${breadcrumb.timestamp}-${i}`}
-              color={breadcrumb.color}
-            />
-          ))}
+          <Icons crumbs={breadcrumbs} />
         </EventColumn>
       ))}
-    </Timeline.Columns>
+    </EventColumns>
   );
 }
+
+const EventColumns = styled(Timeline.Columns)`
+  height: ${space(4)};
+  margin-top: ${space(1)};
+`;
 
 const EventColumn = styled(Timeline.Col)<{column: number}>`
   grid-column: ${p => Math.floor(p.column)};
   place-items: stretch;
-  height: 100%;
-  min-height: ${space(4)};
   display: grid;
 `;
 
-const EventStickMarker = styled('div')<{color: string}>`
-  width: ${EVENT_STICK_MARKER_WIDTH}px;
+function ColumnIcons({crumbs, className}: {crumbs: Crumb[]; className?: string}) {
+  return (
+    <div className={className}>
+      {crumbs.map(breadcrumb => (
+        <Tooltip
+          key={breadcrumb.id}
+          title={`${breadcrumb.category}: ${breadcrumb.message}`}
+          skipWrapper
+          disableForVisualTest
+        >
+          <IconWrapper color={breadcrumb.color}>
+            <Icon type={breadcrumb.type} />
+          </IconWrapper>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}
+
+const Icons = styled(ColumnIcons)`
+  position: absolute;
+  transform: translate(-50%);
+`;
+const IconWrapper = styled('div')<{color: Color}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  color: ${p => p.theme.white};
   background: ${p => p.theme[p.color] ?? p.color};
-  /* Size only applies to the inside, not the border */
-  box-sizing: content-box;
+  border: 1px solid ${p => p.theme.white};
+  box-shadow: ${p => p.theme.dropShadowLightest};
+  position: relative;
 `;
 
 export default ReplayTimelineEvents;

--- a/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
+import {divide, flattenSpans} from 'sentry/components/replays/utils';
+import Tooltip from 'sentry/components/tooltip';
+import {tn} from 'sentry/locale';
+import space from 'sentry/styles/space';
+
+type Props = {
+  /**
+   * Duration, in milliseconds, of the timeline
+   */
+  duration: number;
+
+  /**
+   * The spans to render into the timeline
+   */
+  spans: RawSpanType[];
+
+  /**
+   * Timestamp when the timeline begins, in milliseconds
+   */
+  startTimestamp: number;
+
+  /**
+   * Extra classNames
+   */
+  className?: string;
+};
+
+function ReplayTimelineEvents({className, duration, spans, startTimestamp}: Props) {
+  const flattenedSpans = flattenSpans(spans);
+
+  const startMs = startTimestamp * 1000;
+  return (
+    <Spans className={className}>
+      {flattenedSpans.map(span => {
+        const sinceStart = span.startTimestamp - startMs;
+        const startPct = divide(sinceStart, duration);
+        const widthPct = divide(span.duration, duration);
+
+        const requestsCount = tn(
+          '%s network request',
+          '%s network requests',
+          span.spanCount
+        );
+        return (
+          <Tooltip
+            key={span.spanId}
+            title={
+              <React.Fragment>
+                {requestsCount}
+                <br />
+                {span.duration.toFixed(2)}ms
+              </React.Fragment>
+            }
+            skipWrapper
+            disableForVisualTest
+          >
+            <Span startPct={startPct} widthPct={widthPct} />
+          </Tooltip>
+        );
+      })}
+    </Spans>
+  );
+}
+
+const Spans = styled('ul')`
+  /* Reset defaults for <ul> */
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  height: ${space(3)};
+  position: relative;
+`;
+// TODO(replay): sync colors like #865189 with chartPalette so there is consistency
+const Span = styled('li')<{startPct: number; widthPct: number}>`
+  display: block;
+  position: absolute;
+  top: 0;
+  left: ${p => p.startPct * 100}%;
+  min-width: 1px;
+  width: ${p => p.widthPct * 100}%;
+  height: 100%;
+  background: #865189; /* plucked from static/app/constants/chartPalette.tsx */
+`;
+
+export default React.memo(ReplayTimelineEvents);

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -83,12 +83,7 @@ const Wrapper = styled('div')`
     box-sizing: content-box;
     position: absolute;
     top: -${space(0.5)};
-    /*
-    Should be -space(0.25), so the middle of the span:after aligns with the edge
-    of the span. But because of transparent background we need to
-    prevent the span and the span:after from overlapping.
-    */
-    right: -${space(0.5)};
+    right: -1px;
   }
 
   :hover ${MouseTrackingValue}:after {

--- a/static/app/components/replays/timelinePosition.tsx
+++ b/static/app/components/replays/timelinePosition.tsx
@@ -6,22 +6,23 @@ import {divide} from 'sentry/components/replays/utils';
 import space from 'sentry/styles/space';
 
 type Props = {
+  color: string;
   currentTime: number;
   duration: number | undefined;
 };
 
-function TimelinePosition({currentTime, duration}: Props) {
+function TimelinePosition({color, currentTime, duration}: Props) {
   const percentComplete = divide(currentTime, duration);
 
   return (
     <Progress.Meter>
-      <Value percent={percentComplete} />
+      <Value color={color} percent={percentComplete} />
     </Progress.Meter>
   );
 }
 
-const Value = styled(Progress.Value)`
-  border-right: ${space(0.25)} solid ${p => p.theme.purple300};
+const Value = styled(Progress.Value)<Pick<Props, 'color'>>`
+  border-right: ${space(0.25)} solid ${p => p.color};
 `;
 
 export default TimelinePosition;

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 
+import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import {Crumb} from 'sentry/types/breadcrumbs';
 
 function padZero(num: number, len = 2): string {
@@ -102,6 +103,7 @@ export function countColumns(duration: number, width: number, minWidth: number =
  * and the timestamp of the crumb.
  */
 export function getCrumbsByColumn(crumbs: Crumb[], totalColumns: number) {
+  // TODO(replay): we should pass in the startTimestamp and not rely on the first breadcrumb time
   const startTime = crumbs[0]?.timestamp;
   const endTime = crumbs[crumbs.length - 1]?.timestamp;
 
@@ -137,6 +139,81 @@ export function getCrumbsByColumn(crumbs: Crumb[], totalColumns: number) {
   }, new Map() as Map<number, Crumb[]>);
 
   return crumbsByColumn;
+}
+
+type FlattenedSpanRange = {
+  /**
+   * Duration of this range
+   */
+  duration: number;
+  /**
+   * Absolute time in ms when the range ends
+   */
+  endTimestamp: number;
+  /**
+   * Number of spans that got flattened into this range
+   */
+  spanCount: number;
+  /**
+   * ID of the original span that created this range
+   */
+  spanId: string;
+  //
+  /**
+   * Absolute time in ms when the span starts
+   */
+  startTimestamp: number;
+};
+
+function doesOverlap(a: FlattenedSpanRange, b: FlattenedSpanRange) {
+  const bStartsWithinA =
+    a.startTimestamp <= b.startTimestamp && b.startTimestamp <= a.endTimestamp;
+  const bEndsWithinA =
+    a.startTimestamp <= b.endTimestamp && b.endTimestamp <= a.endTimestamp;
+  return bStartsWithinA || bEndsWithinA;
+}
+
+export function flattenSpans(rawSpans: RawSpanType[]): FlattenedSpanRange[] {
+  if (!rawSpans.length) {
+    return [];
+  }
+
+  const spans = rawSpans.map(span => {
+    const startTimestamp = span.start_timestamp * 1000;
+
+    // `endTimestamp` is at least msPerPixel wide, otherwise it disappears
+    const endTimestamp = span.timestamp * 1000;
+    return {
+      spanCount: 1,
+      spanId: span.span_id,
+      startTimestamp,
+      endTimestamp,
+      duration: endTimestamp - startTimestamp,
+    } as FlattenedSpanRange;
+  });
+
+  // might need to make sure we've sorted by startTimestamp
+
+  const [firstSpan, ...restSpans] = spans;
+  const flatSpans = [firstSpan];
+
+  for (const span of restSpans) {
+    let overlap = false;
+    for (const fspan of flatSpans) {
+      if (doesOverlap(fspan, span)) {
+        overlap = true;
+        fspan.spanCount += 1;
+        fspan.startTimestamp = Math.min(fspan.startTimestamp, span.startTimestamp);
+        fspan.endTimestamp = Math.max(fspan.endTimestamp, span.endTimestamp);
+        fspan.duration = fspan.endTimestamp - fspan.startTimestamp;
+        break;
+      }
+    }
+    if (!overlap) {
+      flatSpans.push(span);
+    }
+  }
+  return flatSpans;
 }
 
 /**

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -93,7 +93,7 @@ function ReplayDetails() {
               <PanelHeader>
                 <ReplayCurrentUrl />
               </PanelHeader>
-              <PanelHeader disablePadding>
+              <PanelHeader disablePadding noBorder>
                 <ManualResize isFullscreen={isFullscreen}>
                   <ReplayPlayer />
                 </ManualResize>
@@ -128,9 +128,10 @@ const PanelNoMargin = styled(Panel)`
   margin-bottom: 0;
 `;
 
-const PanelHeader = styled(_PanelHeader)`
+const PanelHeader = styled(_PanelHeader)<{noBorder?: boolean}>`
   display: block;
   padding: 0;
+  ${p => (p.noBorder ? 'border-bottom: none;' : '')}
 `;
 
 const ManualResize = styled('div')<{isFullscreen: boolean}>`


### PR DESCRIPTION
New `<Timeline>` design:

Vertical lines to indicate the current video position, and mouse hover position:

<img width="1047" alt="Screen Shot 2022-05-10 at 12 12 03 AM" src="https://user-images.githubusercontent.com/187460/167458915-85a76a0b-f5f5-4122-b807-a3de524ffffe.png">

Tooltips for the breadcrumb icons and also flattened spans
<img width="1037" alt="Screen Shot 2022-05-10 at 12 12 10 AM" src="https://user-images.githubusercontent.com/187460/167458923-c0e74280-5582-4f6b-a7dc-ab81a278e380.png">


<img width="1043" alt="Screen Shot 2022-05-10 at 12 12 16 AM" src="https://user-images.githubusercontent.com/187460/167458927-788a8d7f-9602-47b6-82f7-9fbc509666e7.png">

Fixes #34164
