### PR TITLE
feat(replays): Add mouse interactions to Memory chart

### DIFF
--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -2,7 +2,10 @@ import last from 'lodash/last';
 import memoize from 'lodash/memoize';
 import type {eventWithTime} from 'rrweb/typings/types';
 
-import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
+import type {
+  MemorySpanType,
+  RawSpanType,
+} from 'sentry/components/events/interfaces/spans/types';
 import type {RawCrumb} from 'sentry/types/breadcrumbs';
 import type {Event, EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
@@ -122,7 +125,7 @@ export default class ReplayReader {
     return this.getEntryType(EntryType.SPANS)?.data as RawSpanType[];
   };
 
-  isMemorySpan = (span: RawSpanType) => {
+  isMemorySpan = (span: RawSpanType): span is MemorySpanType => {
     return span.op === 'memory';
   };
 

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import EventEntry from 'sentry/components/events/eventEntry';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
 import TagsTable from 'sentry/components/tagsTable';
 import type {Entry, Event} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
@@ -43,6 +44,7 @@ function FocusArea(props: Props) {
 
 function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
   const {routes, router} = useRouteContext();
+  const {setCurrentTime, setCurrentHoverTime} = useReplayContext();
   const organization = useOrganization();
 
   const event = replay.getEvent();
@@ -98,6 +100,8 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
     case 'memory':
       return (
         <MemoryChart
+          setCurrentTime={setCurrentTime}
+          setCurrentHoverTime={setCurrentHoverTime}
           memorySpans={spansEntry?.data.filter(replay.isMemorySpan)}
           startTimestamp={event.startTimestamp}
         />

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -53,8 +53,8 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
   // Memoize this because re-renders will interfere with the mouse state of the
   // chart (e.g. on mouse over and out)
   const memorySpans = useMemo(() => {
-    return spansEntry?.data.filter(replay.isMemorySpan);
-  }, [spansEntry, replay]);
+    return replay.getRawSpans().filter(replay.isMemorySpan);
+  }, [replay]);
 
   switch (active) {
     case 'console':

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import EventEntry from 'sentry/components/events/eventEntry';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -50,6 +50,12 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
   const event = replay.getEvent();
   const spansEntry = replay.getEntryType(EntryType.SPANS);
 
+  // Memoize this because re-renders will interfere with the mouse state of the
+  // chart (e.g. on mouse over and out)
+  const memorySpans = useMemo(() => {
+    return spansEntry?.data.filter(replay.isMemorySpan);
+  }, [spansEntry, replay]);
+
   switch (active) {
     case 'console':
       const breadcrumbEntry = replay.getEntryType(EntryType.BREADCRUMBS);
@@ -100,9 +106,9 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
     case 'memory':
       return (
         <MemoryChart
+          memorySpans={memorySpans}
           setCurrentTime={setCurrentTime}
           setCurrentHoverTime={setCurrentHoverTime}
-          memorySpans={spansEntry?.data.filter(replay.isMemorySpan)}
           startTimestamp={event.startTimestamp}
         />
       );

--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -8,6 +8,7 @@ import Tooltip from 'sentry/components/charts/components/tooltip';
 import XAxis from 'sentry/components/charts/components/xAxis';
 import YAxis from 'sentry/components/charts/components/yAxis';
 import {MemorySpanType} from 'sentry/components/events/interfaces/spans/types';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {formatBytesBase2} from 'sentry/utils';

--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -8,7 +8,6 @@ import Tooltip from 'sentry/components/charts/components/tooltip';
 import XAxis from 'sentry/components/charts/components/xAxis';
 import YAxis from 'sentry/components/charts/components/yAxis';
 import {MemorySpanType} from 'sentry/components/events/interfaces/spans/types';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {formatBytesBase2} from 'sentry/utils';

--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -1,3 +1,4 @@
+import {memo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -15,14 +16,22 @@ import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
 
 type Props = {
   memorySpans: MemorySpanType[] | undefined;
+  setCurrentHoverTime: (time: undefined | number) => void;
+  setCurrentTime: (time: number) => void;
   startTimestamp: number | undefined;
 };
 
 const formatTimestamp = timestamp =>
   getFormattedDate(timestamp * 1000, 'MMM D, YYYY hh:mm:ss A z', {local: false});
 
-function MemoryChart({memorySpans = [], startTimestamp = 0}: Props) {
+function MemoryChart({
+  memorySpans = [],
+  startTimestamp = 0,
+  setCurrentTime,
+  setCurrentHoverTime,
+}: Props) {
   const theme = useTheme();
+
   if (memorySpans.length <= 0) {
     return <EmptyMessage>{t('No memory metrics exist for replay.')}</EmptyMessage>;
   }
@@ -91,6 +100,19 @@ function MemoryChart({memorySpans = [], startTimestamp = 0}: Props) {
         formatter: value => formatBytesBase2(value, 0),
       },
     }),
+
+    // XXX: For area charts, mouse events *only* occurs when interacting with
+    // the "line" of the area chart. Mouse events do not fire when interacting
+    // with the "area" under the line.
+    onMouseOver: ({data}) => {
+      setCurrentHoverTime((data[0] - startTimestamp) * 1000);
+    },
+    onMouseOut: () => {
+      setCurrentHoverTime(undefined);
+    },
+    onClick: ({data}) => {
+      setCurrentTime((data[0] - startTimestamp) * 1000);
+    },
   };
 
   const series = [
@@ -133,4 +155,5 @@ const MemoryChartWrapper = styled('div')`
   border: 1px solid ${p => p.theme.border};
 `;
 
-export default MemoryChart;
+const MemoizedMemoryChart = memo(MemoryChart);
+export default MemoizedMemoryChart;

--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -15,7 +15,7 @@ import {getFormattedDate} from 'sentry/utils/dates';
 import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
 
 type Props = {
-  memorySpans: MemorySpanType[] | undefined;
+  memorySpans: MemorySpanType[];
   setCurrentHoverTime: (time: undefined | number) => void;
   setCurrentTime: (time: number) => void;
   startTimestamp: number | undefined;
@@ -25,7 +25,7 @@ const formatTimestamp = timestamp =>
   getFormattedDate(timestamp * 1000, 'MMM D, YYYY hh:mm:ss A z', {local: false});
 
 function MemoryChart({
-  memorySpans = [],
+  memorySpans,
   startTimestamp = 0,
   setCurrentTime,
   setCurrentHoverTime,


### PR DESCRIPTION
This will set current hover time when hover over the Memory chart. Also will set the current player time when we click.

Be aware that due to eCharts, the area under the area chart does not capture mouse events properly. See https://github.com/apache/echarts/issues/12751