### PR TITLE
test(alerts): Tests for alert wizard for duplicating alert rules

### DIFF
--- a/static/app/views/alerts/incidentRules/duplicate.tsx
+++ b/static/app/views/alerts/incidentRules/duplicate.tsx
@@ -20,20 +20,19 @@ import RuleForm from './ruleForm';
 
 type RouteParams = {
   orgId: string;
-  projectId?: string;
-  ruleId?: string;
 };
 
 type Props = {
-  eventView: EventView | undefined;
   organization: Organization;
   project: Project;
   userTeamIds: string[];
+  eventView?: EventView;
   sessionId?: string;
   wizardTemplate?: WizardRuleTemplate;
 } & RouteComponentProps<RouteParams, {}>;
 
 type State = {
+  IncidentRulesDuplicate;
   defaultRule: IncidentRule;
   duplicateTargetRule?: IncidentRule;
 } & AsyncView['state'];

--- a/static/app/views/alerts/incidentRules/duplicate.tsx
+++ b/static/app/views/alerts/incidentRules/duplicate.tsx
@@ -32,7 +32,6 @@ type Props = {
 } & RouteComponentProps<RouteParams, {}>;
 
 type State = {
-  IncidentRulesDuplicate;
   defaultRule: IncidentRule;
   duplicateTargetRule?: IncidentRule;
 } & AsyncView['state'];

--- a/static/app/views/alerts/incidentRules/ruleNameOwnerForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleNameOwnerForm.tsx
@@ -19,6 +19,7 @@ type Props = {
 export default function RuleNameOwnerForm({disabled, project, hasAlertWizardV3}: Props) {
   const renderRuleName = () => (
     <StyledTextField
+      data-test-id="alert-name"
       hasAlertWizardV3={hasAlertWizardV3}
       disabled={disabled}
       name="name"

--- a/static/app/views/alerts/incidentRules/wizardField.tsx
+++ b/static/app/views/alerts/incidentRules/wizardField.tsx
@@ -118,7 +118,7 @@ export default function WizardField({
       {({onChange, value, model, disabled}) => {
         const aggregate = model.getValue('aggregate');
         const dataset = model.getValue('dataset');
-        const eventTypes = [...model.getValue('eventTypes')];
+        const eventTypes = [...(model.getValue('eventTypes') ?? [])];
 
         const selectedTemplate =
           findKey(

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -625,6 +625,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
           type="text"
           name="name"
           value={name}
+          data-test-id="alert-name"
           placeholder={hasAlertWizardV3 ? t('Enter Alert Name') : t('My Rule Name')}
           onChange={(event: ChangeEvent<HTMLInputElement>) =>
             this.handleChange('name', event.target.value)

--- a/tests/js/spec/views/alerts/incidentRules/duplicate.spec.tsx
+++ b/tests/js/spec/views/alerts/incidentRules/duplicate.spec.tsx
@@ -1,0 +1,111 @@
+import {Fragment} from 'react';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import GlobalModal from 'sentry/components/globalModal';
+import IncidentRulesDuplicate from 'sentry/views/alerts/incidentRules/duplicate';
+import {AlertRuleTriggerType} from 'sentry/views/alerts/incidentRules/types';
+
+describe('Incident Rules Duplicate', function () {
+  beforeAll(function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/environments/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: null,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-meta/',
+      body: {count: 5},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/alert-rules/available-actions/',
+      body: [
+        {
+          allowedTargetTypes: ['user', 'team'],
+          integrationName: null,
+          type: 'email',
+          integrationId: null,
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      body: [TestStubs.Member()],
+    });
+  });
+
+  it('renders new alert form with values copied over', async function () {
+    const rule = TestStubs.IncidentRule();
+    rule.triggers.push({
+      label: AlertRuleTriggerType.WARNING,
+      alertThreshold: 60,
+      actions: [],
+    });
+    rule.resolveThreshold = 50;
+
+    const {organization, project, router} = initializeOrg({
+      organization: {
+        access: ['alerts:write'],
+        features: ['alert-wizard-v3', 'duplicate-alert-rule'],
+      },
+      router: {
+        // we need this to be set to make sure org in context is same as
+        // current org in URL
+        params: {orgId: 'org-slug'},
+        location: {
+          query: {
+            createFromDuplicate: true,
+            duplicateRuleId: `${rule.id}`,
+          },
+        },
+      },
+      project: rule.projects[0],
+      projects: rule.projects,
+    });
+
+    const req = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rules/${rule.id}/`,
+      body: rule,
+    });
+
+    render(
+      <Fragment>
+        <GlobalModal />
+        <IncidentRulesDuplicate
+          params={{orgId: organization.slug}}
+          route={{}}
+          routeParams={router.params}
+          router={router}
+          routes={router.routes}
+          location={router.location}
+          organization={organization}
+          project={project}
+          userTeamIds={[]}
+        />
+      </Fragment>
+    );
+
+    // Duplicated alert has been called
+    expect(req).toHaveBeenCalled();
+
+    // Has correct values copied from the duplicated alert
+    expect(screen.getByTestId('critical-threshold')).toHaveValue('70');
+    expect(screen.getByTestId('warning-threshold')).toHaveValue('60');
+    expect(screen.getByTestId('resolve-threshold')).toHaveValue('50');
+
+    // Has the updated alert rule name
+    expect(screen.getByTestId('alert-name')).toHaveValue(`${rule.name} copy`);
+  });
+});

--- a/tests/js/spec/views/alerts/issueRuleEditor/issueRuleEditor.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/issueRuleEditor.spec.jsx
@@ -80,13 +80,17 @@ const projectAlertRuleDetailsRoutes = [
 
 const createWrapper = (props = {}) => {
   const {organization, project, routerContext, router} = initializeOrg(props);
-  const params = {orgId: organization.slug, projectId: project.slug, ruleId: '1'};
+  const params = {
+    orgId: organization.slug,
+    projectId: project.slug,
+    ruleId: router.location.query.createFromDuplicate ? undefined : '1',
+  };
   const onChangeTitleMock = jest.fn();
   const wrapper = render(
     <ProjectAlerts organization={organization} params={params}>
       <IssueRuleEditor
         params={params}
-        location={{pathname: ''}}
+        location={router.location}
         routes={projectAlertRuleDetailsRoutes}
         router={router}
         onChangeTitle={onChangeTitleMock}
@@ -295,6 +299,39 @@ describe('ProjectAlerts -> IssueRuleEditor', function () {
       await waitFor(() => expect(mockFailed).toHaveBeenCalledTimes(1));
       expect(screen.getByText('An error occurred')).toBeInTheDocument();
       expect(addErrorMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Duplicate Rule', function () {
+    let mock;
+    const rule = TestStubs.ProjectAlertRule();
+    const endpoint = `/projects/org-slug/project-slug/rules/${rule.id}/`;
+
+    beforeEach(function () {
+      mock = MockApiClient.addMockResponse({
+        url: endpoint,
+        method: 'GET',
+        body: rule,
+      });
+    });
+
+    it('gets correct rule to duplicate and renders fields correctly', function () {
+      createWrapper({
+        organization: {
+          access: ['alerts:write'],
+          features: ['alert-wizard-v3', 'duplicate-alert-rule'],
+        },
+        router: {
+          location: {
+            query: {
+              createFromDuplicate: true,
+              duplicateRuleId: `${rule.id}`,
+            },
+          },
+        },
+      });
+      expect(mock).toHaveBeenCalled();
+      expect(screen.getByTestId('alert-name')).toHaveValue(`${rule.name} copy`);
     });
   });
 });


### PR DESCRIPTION
This adds basic tests for duplicating alert rules in alert wizard, tests rule parameters being copied over and name updated. Saving alerts is already tested elsewhere, won't be adding saving tests to these.