### PR TITLE
feat(selectControl): Add maxMenuWidth prop

### DIFF
--- a/static/app/components/forms/selectControl.tsx
+++ b/static/app/components/forms/selectControl.tsx
@@ -79,6 +79,11 @@ export type ControlProps<OptionType = GeneralSelectValue> = Omit<
    */
   isCompact?: boolean;
   /**
+   * Maximum width of the menu component. Menu item labels that overflow the
+   * menu's boundaries will automatically be truncated.
+   */
+  maxMenuWidth?: number | string;
+  /**
    * Used by MultiSelectControl.
    */
   multiple?: boolean;
@@ -126,7 +131,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
   props: WrappedControlProps<OptionType>
 ) {
   const theme = useTheme();
-  const {isCompact, isSearchable} = props;
+  const {isCompact, isSearchable, maxMenuWidth} = props;
 
   // TODO(epurkhiser): The loading indicator should probably also be our loading
   // indicator.
@@ -196,6 +201,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
       boxShadow: theme.dropShadowHeavy,
       width: 'auto',
       minWidth: '100%',
+      maxWidth: maxMenuWidth ?? 'auto',
       ...(isCompact && {
         position: 'relative',
         margin: 0,
@@ -216,7 +222,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
     }),
 
     menuPortal: () => ({
-      maxWidth: '24rem',
+      maxWidth: maxMenuWidth ?? '24rem',
       zIndex: theme.zIndex.dropdown,
       width: '90%',
       position: 'fixed',

--- a/static/app/components/forms/selectOption.tsx
+++ b/static/app/components/forms/selectOption.tsx
@@ -48,7 +48,7 @@ function SelectOption(props: Props) {
           <ContentWrap
             isFocused={isFocused}
             showDividers={showDividers}
-            addRightMargin={!defined(trailingItems)}
+            addRightMargin={defined(trailingItems)}
           >
             <LabelWrap>
               <Label as={typeof label === 'string' ? 'p' : 'div'}>{label}</Label>
@@ -135,6 +135,7 @@ const ContentWrap = styled('div')<{
   gap: ${space(1)};
   justify-content: space-between;
   padding: ${space(1)} 0;
+  min-width: 0;
 
   ${p =>
     p.addRightMargin &&


### PR DESCRIPTION
Add an optional prop called `maxMenuWidth` to limit the width of the menu component (by default this is not defined, so menus will take up as much horizontal space as needed). Menu items with labels that overflow the menu's width will be automatically truncated.

<img width="409" alt="image" src="https://user-images.githubusercontent.com/44172267/167466678-fcb10bfa-8759-4e67-8bbf-5a6c0f95427d.png">
