### PR TITLE
fix(dashboards): Update the widget query selector modal to use getWidgetDiscoverUrl

### DIFF
--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
@@ -12,11 +12,10 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
-import {DisplayModes} from 'sentry/utils/discover/types';
 import withApi from 'sentry/utils/withApi';
 import withPageFilters from 'sentry/utils/withPageFilters';
-import {DisplayType, Widget} from 'sentry/views/dashboardsV2/types';
-import {eventViewFromWidget} from 'sentry/views/dashboardsV2/utils';
+import {Widget} from 'sentry/views/dashboardsV2/types';
+import {getWidgetDiscoverUrl} from 'sentry/views/dashboardsV2/utils';
 
 export type DashboardWidgetQuerySelectorModalOptions = {
   organization: Organization;
@@ -34,27 +33,14 @@ class DashboardWidgetQuerySelectorModal extends Component<Props> {
   renderQueries() {
     const {organization, widget, selection} = this.props;
     const querySearchBars = widget.queries.map((query, index) => {
-      const eventView = eventViewFromWidget(
-        widget.title,
-        query,
+      const discoverLocation = getWidgetDiscoverUrl(
+        {
+          ...widget,
+          queries: [query],
+        },
         selection,
-        widget.displayType
+        organization
       );
-      const discoverLocation = eventView.getResultsViewUrlTarget(organization.slug);
-      // Pull a max of 3 valid Y-Axis from the widget
-      const yAxisOptions = eventView.getYAxisOptions().map(({value}) => value);
-      discoverLocation.query.yAxis = [
-        ...new Set(
-          query.aggregates.filter(aggregate => yAxisOptions.includes(aggregate))
-        ),
-      ].slice(0, 3);
-      switch (widget.displayType) {
-        case DisplayType.BAR:
-          discoverLocation.query.display = DisplayModes.BAR;
-          break;
-        default:
-          break;
-      }
       return (
         <Fragment key={index}>
           <QueryContainer>

--- a/tests/js/spec/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
+++ b/tests/js/spec/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
@@ -130,15 +130,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     const wrapper = mountModal({initialData, widget: mockWidget});
     await tick();
     expect(wrapper.find('QueryContainer').find('Link').props().to).toEqual(
-      expect.objectContaining({
-        pathname: '/organizations/org-slug/discover/results/',
-        query: expect.objectContaining({
-          field: ['count()', 'failure_count()'],
-          name: 'Test Widget',
-          query: 'title:/organizations/:orgId/performance/summary/',
-          yAxis: ['count()', 'failure_count()'],
-        }),
-      })
+      '/organizations/org-slug/discover/results/?field=count%28%29&field=failure_count%28%29&name=Test%20Widget&query=title%3A%2Forganizations%2F%3AorgId%2Fperformance%2Fsummary%2F&statsPeriod=14d&yAxis=count%28%29&yAxis=failure_count%28%29'
     );
     wrapper.unmount();
   });
@@ -149,15 +141,9 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     mockWidget.displayType = DisplayType.WORLD_MAP;
     const wrapper = mountModal({initialData, widget: mockWidget});
     await tick();
-    expect(wrapper.find('QueryContainer').find('Link').props().to).toEqual({
-      pathname: '/organizations/org-slug/discover/results/',
-      query: expect.objectContaining({
-        field: ['geo.country_code', 'count()'],
-        name: 'Test Widget',
-        query: 'title:/organizations/:orgId/performance/summary/ has:geo.country_code',
-        yAxis: ['count()'],
-      }),
-    });
+    expect(wrapper.find('QueryContainer').find('Link').props().to).toEqual(
+      '/organizations/org-slug/discover/results/?display=worldmap&field=geo.country_code&field=count%28%29&name=Test%20Widget&query=title%3A%2Forganizations%2F%3AorgId%2Fperformance%2Fsummary%2F%20has%3Ageo.country_code&statsPeriod=14d&yAxis=count%28%29'
+    );
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
Updates the widget query selector modal to use `getWidgetDiscoverUrl` when constructing links in the modal.
This makes the results consistent with the `Open in Discover` buttons found in the Widget Viewer and Widget Context Menu (for single query widgets).