### PR TITLE
feat(replays): Connect event chapters to see in timeline user actions

### DIFF
--- a/static/app/utils/replays/getCurrentUserAction.tsx
+++ b/static/app/utils/replays/getCurrentUserAction.tsx
@@ -1,0 +1,17 @@
+import {relativeTimeInMs} from 'sentry/components/replays/utils';
+import {Crumb} from 'sentry/types/breadcrumbs';
+
+export function getCurrentUserAction(
+  userActionCrumbs: Crumb[],
+  startTimestamp: number,
+  currentHoverTime: number
+) {
+  return userActionCrumbs.reduce((prev, curr) => {
+    return Math.abs(
+      relativeTimeInMs(curr.timestamp ?? '', startTimestamp) - currentHoverTime
+    ) <
+      Math.abs(relativeTimeInMs(prev.timestamp ?? '', startTimestamp) - currentHoverTime)
+      ? curr
+      : prev;
+  });
+}

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -74,8 +74,6 @@ function UserActionsNavigator({event, crumbs}: Props) {
         {userActionCrumbs.map(item => (
           <PanelItemCenter
             key={item.id}
-            isHovered={closestUserAction?.id === item.id}
-            isSelected={currentUserAction?.id === item.id}
             onClick={() => {
               setCurrentUserAction(item);
               item.timestamp
@@ -83,14 +81,24 @@ function UserActionsNavigator({event, crumbs}: Props) {
                 : '';
             }}
           >
-            <Wrapper>
-              <Type type={item.type} color={item.color} description={item.description} />
-              <ActionCategory category={item} />
-            </Wrapper>
-            <PlayerRelativeTime
-              relativeTime={startTimestamp}
-              timestamp={item.timestamp}
-            />
+            {/* Create a Container div to avoid messing with PanelItem inherited styled */}
+            <Container
+              isHovered={closestUserAction?.id === item.id}
+              isSelected={currentUserAction?.id === item.id}
+            >
+              <Wrapper>
+                <Type
+                  type={item.type}
+                  color={item.color}
+                  description={item.description}
+                />
+                <ActionCategory category={item} />
+              </Wrapper>
+              <PlayerRelativeTime
+                relativeTime={startTimestamp}
+                timestamp={item.timestamp}
+              />
+            </Container>
           </PanelItemCenter>
         ))}
       </PanelBody>
@@ -127,23 +135,21 @@ const PanelBody = styled(BasePanelBody)`
 `;
 
 const PanelItemCenter = styled(PanelItem)<PanelItemCenterProps>`
+  display: block;
+  padding: ${space(0)};
+  cursor: pointer;
+`;
+
+const Container = styled('div')<PanelItemCenterProps>`
   display: flex;
   justify-content: space-between;
   align-items: center;
   border-left: 4px solid transparent;
   padding: ${space(1)} ${space(1.5)};
-  cursor: pointer;
-  &:last-child {
-    border-left: 4px solid transparent;
-  }
   &:hover {
     background: ${p => p.theme.surface400};
-    border-color: transparent;
   }
-  ${p =>
-    p.isHovered &&
-    `background: ${p.theme.surface400};
-        border-color: transparent;`}
+  ${p => p.isHovered && `background: ${p.theme.surface400};`}
   ${p =>
     p.isSelected &&
     `border-left: 4px solid ${p.theme.purple300};

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -36,8 +36,11 @@ function UserActionsNavigator({event, crumbs}: Props) {
   const [currentUserAction, setCurrentUserAction] = useState<Crumb>();
   const [closestUserAction, setClosestUserAction] = useState<Crumb>();
 
+  const {startTimestamp} = event;
+  const userActionCrumbs = onlyUserActions(transformCrumbs(crumbs));
+
   useEffect(() => {
-    if (!currentHoverTime) {
+    if (!currentHoverTime || !userActionCrumbs || !startTimestamp) {
       setClosestUserAction(undefined);
       return;
     }
@@ -53,14 +56,11 @@ function UserActionsNavigator({event, crumbs}: Props) {
         : prev;
     });
     setClosestUserAction(closestUserActionItem);
-  }, [currentHoverTime]);
+  }, [currentHoverTime, startTimestamp, userActionCrumbs]);
 
   if (!event) {
     return null;
   }
-
-  const {startTimestamp} = event;
-  const userActionCrumbs = onlyUserActions(transformCrumbs(crumbs));
 
   return (
     <Panel>

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -129,6 +129,9 @@ const PanelItemCenter = styled(PanelItem)<PanelItemCenterProps>`
   border-left: 4px solid transparent;
   padding: ${space(1)} ${space(1.5)};
   cursor: pointer;
+  &:last-child {
+    border-left: 4px solid transparent;
+  }
   &:hover {
     background: ${p => p.theme.surface400};
     border-color: transparent;

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -27,9 +27,9 @@ type Props = {
   event: EventTransaction;
 };
 
-type PanelItemCenterProps = {
-  isHovered?: boolean;
-  isSelected?: boolean;
+type ContainerProps = {
+  isHovered: boolean;
+  isSelected: boolean;
 };
 
 function UserActionsNavigator({event, crumbs}: Props) {

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -135,7 +135,7 @@ const PanelItemCenter = styled(PanelItem)`
   cursor: pointer;
 `;
 
-const Container = styled('div')<PanelItemCenterProps>`
+const Container = styled('div')<ContainerProps>`
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -129,7 +129,7 @@ const PanelBody = styled(BasePanelBody)`
   overflow-y: auto;
 `;
 
-const PanelItemCenter = styled(PanelItem)<PanelItemCenterProps>`
+const PanelItemCenter = styled(PanelItem)`
   display: block;
   padding: ${space(0)};
   cursor: pointer;

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -26,6 +26,11 @@ type Props = {
   event: EventTransaction;
 };
 
+type PanelItemCenterProps = {
+  isHovered?: boolean;
+  isSelected?: boolean;
+};
+
 function UserActionsNavigator({event, crumbs}: Props) {
   const {setCurrentTime, currentHoverTime} = useReplayContext();
   const [currentUserAction, setCurrentUserAction] = useState<Crumb>();
@@ -65,9 +70,8 @@ function UserActionsNavigator({event, crumbs}: Props) {
         {userActionCrumbs.map(item => (
           <PanelItemCenter
             key={item.id}
-            className={`${
-              currentUserAction && currentUserAction.id === item.id ? 'selected' : ''
-            } ${closestUserAction && closestUserAction.id === item.id ? 'onHover' : ''}`}
+            isHovered={closestUserAction && closestUserAction.id === item.id}
+            isSelected={currentUserAction && currentUserAction.id === item.id}
             onClick={() => {
               setCurrentUserAction(item);
               item.timestamp
@@ -118,22 +122,25 @@ const PanelBody = styled(BasePanelBody)`
   overflow-y: auto;
 `;
 
-const PanelItemCenter = styled(PanelItem)`
+const PanelItemCenter = styled(PanelItem)<PanelItemCenterProps>`
   display: flex;
   justify-content: space-between;
   align-items: center;
   border-left: 4px solid transparent;
   padding: ${space(1)} ${space(1.5)};
   cursor: pointer;
-  &:hover,
-  &.onHover {
+  &:hover {
     background: ${p => p.theme.surface400};
     border-color: transparent;
   }
-  &.selected {
-    border-left: 4px solid ${p => p.theme.purple300};
-    background-color: ${p => p.theme.surface400};
-  }
+  ${p =>
+    p.isHovered &&
+    `background: ${p.theme.surface400};
+        border-color: transparent;`}
+  ${p =>
+    p.isSelected &&
+    `border-left: 4px solid ${p.theme.purple300};
+          background-color: ${p.theme.surface400};`}
 `;
 
 const Wrapper = styled('div')`

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -55,6 +55,10 @@ function UserActionsNavigator({event, crumbs}: Props) {
   );
 
   useEffect(() => {
+    if (!currentHoverTime) {
+      setClosestUserAction(undefined);
+      return;
+    }
     getClosestUserAction(currentHoverTime);
   }, [getClosestUserAction, currentHoverTime]);
 

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -77,7 +77,6 @@ function UserActionsNavigator({event, crumbs}: Props) {
                 : '';
             }}
           >
-            {/* Create a Container div to avoid messing with PanelItem inherited styled */}
             <Container
               isHovered={closestUserAction?.id === item.id}
               isSelected={currentUserAction?.id === item.id}

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -23,7 +23,7 @@ import {EventTransaction} from 'sentry/types/event';
 import {getCurrentUserAction} from 'sentry/utils/replays/getCurrentUserAction';
 
 type Props = {
-  crumbs: Array<RawCrumb>;
+  crumbs: RawCrumb[];
   event: EventTransaction;
 };
 

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -55,10 +55,6 @@ function UserActionsNavigator({event, crumbs}: Props) {
   );
 
   useEffect(() => {
-    if (!currentHoverTime) {
-      setClosestUserAction(undefined);
-      return;
-    }
     getClosestUserAction(currentHoverTime);
   }, [getClosestUserAction, currentHoverTime]);
 

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -150,10 +150,7 @@ const Container = styled('div')<PanelItemCenterProps>`
     background: ${p => p.theme.surface400};
   }
   ${p => p.isHovered && `background: ${p.theme.surface400};`}
-  ${p =>
-    p.isSelected &&
-    `border-left: 4px solid ${p.theme.purple300};
-          background-color: ${p.theme.surface400};`}
+  ${p => p.isSelected && `border-left: 4px solid ${p.theme.purple300};`}
 `;
 
 const Wrapper = styled('div')`


### PR DESCRIPTION
### Description

- Connect event chapters to see in timeline user actions

When you highlight in the timeline or the scrubber, will show highlighted in the Events Chapters the closest user action will take place.

### Screenshots

<img width="952" alt="image" src="https://user-images.githubusercontent.com/14813235/167483789-3b83d1f5-8f40-486c-a96f-a91671fbe852.png">

Also was added the UI changes for when was selected/hovered.

Fixes #34400 

<img width="958" alt="image" src="https://user-images.githubusercontent.com/14813235/168089628-6652ffd1-01cc-44a5-9295-3aa84c949c6e.png">

<img width="956" alt="image" src="https://user-images.githubusercontent.com/14813235/168093440-25f3d572-6199-4224-aac6-abe6b1fdc262.png">





----
