### PR TITLE
fix(superuser modal): Redirect to SSO login instead of general login when SSO session expires

### DIFF
--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -141,7 +141,7 @@ class SudoModal extends Component<Props, State> {
     } catch {
       // ignore errors
     }
-    window.location.assign('/auth/login/');
+    window.location.assign(`/auth/login/?next=${encodeURIComponent(location.pathname)}`);
   };
 
   async getAuthenticators() {


### PR DESCRIPTION
Based on https://sentry.slack.com/archives/CSD1XPPQA/p1652123032890809

When the user has an invalid SSO session, we are redirecting them to the general login instead of the SSO login. 

Now we guide the user to the SSO login and retain the page they were on before they needed to authenticate

<img width="405" alt="image" src="https://user-images.githubusercontent.com/22259802/167513675-d7660fc8-1a7e-4c3d-8e08-d019773fe2eb.png">
