### PR TITLE
fix(js): Correct scrolling in settings search

### DIFF
--- a/static/app/components/search/searchResultWrapper.tsx
+++ b/static/app/components/search/searchResultWrapper.tsx
@@ -6,7 +6,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 function scrollIntoView(element: HTMLDivElement) {
-  element?.scrollIntoView?.(true);
+  element?.scrollIntoView?.({block: 'nearest'});
 }
 
 const SearchResultWrapper = styled(({highlighted, ...props}: Props) => (


### PR DESCRIPTION
Needs to be nearest block so it doesn't scroll the entire viewport