### PR TITLE
feat(replays): Show current time as line on Memory Chart

### DIFF
--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -19,6 +19,7 @@ export type Series = {
     opacity: number;
   };
   color?: string;
+  id?: string;
   lineStyle?: AxisPointerComponentOption['lineStyle'];
   // https://echarts.apache.org/en/option.html#series-line.z
   markLine?: LineSeriesOption['markLine'];

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -45,7 +45,7 @@ function FocusArea(props: Props) {
 
 function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
   const {routes, router} = useRouteContext();
-  const {setCurrentTime, setCurrentHoverTime} = useReplayContext();
+  const {currentTime, setCurrentTime, setCurrentHoverTime} = useReplayContext();
   const organization = useOrganization();
 
   const event = replay.getEvent();
@@ -113,6 +113,7 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
     case 'memory':
       return (
         <MemoryChart
+          currentTime={currentTime}
           memorySpans={memorySpans}
           setCurrentTime={setCurrentTime}
           setCurrentHoverTime={setCurrentHoverTime}

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 
 import EventEntry from 'sentry/components/events/eventEntry';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -36,16 +36,17 @@ function FocusArea(props: Props) {
   const tabFromHash = isReplayTab(hash) ? hash : DEFAULT_TAB;
 
   return (
-    <React.Fragment>
+    <Fragment>
       <FocusTabs active={tabFromHash} />
       <ActiveTab active={tabFromHash} {...props} />
-    </React.Fragment>
+    </Fragment>
   );
 }
 
 function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
   const {routes, router} = useRouteContext();
-  const {currentTime, setCurrentTime, setCurrentHoverTime} = useReplayContext();
+  const {currentTime, currentHoverTime, setCurrentTime, setCurrentHoverTime} =
+    useReplayContext();
   const organization = useOrganization();
 
   const event = replay.getEvent();
@@ -114,6 +115,7 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
       return (
         <MemoryChart
           currentTime={currentTime}
+          currentHoverTime={currentHoverTime}
           memorySpans={memorySpans}
           setCurrentTime={setCurrentTime}
           setCurrentHoverTime={setCurrentHoverTime}

--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -15,6 +15,7 @@ import {formatBytesBase2} from 'sentry/utils';
 import {getFormattedDate} from 'sentry/utils/dates';
 
 type Props = {
+  currentTime: number;
   memorySpans: MemorySpanType[];
   setCurrentHoverTime: (time: undefined | number) => void;
   setCurrentTime: (time: number) => void;
@@ -25,6 +26,7 @@ const formatTimestamp = timestamp =>
   getFormattedDate(timestamp * 1000, 'MMM D, YYYY hh:mm:ss A z', {local: false});
 
 function MemoryChart({
+  currentTime,
   memorySpans,
   startTimestamp = 0,
   setCurrentTime,
@@ -130,6 +132,20 @@ function MemoryChart({
       lineStyle: {
         opacity: 0.75,
         width: 1,
+      },
+      markLine: {
+        symbol: ['', ''],
+        data: [
+          {
+            name: 'Current player time',
+            xAxis: currentTime / 1000 + startTimestamp,
+          },
+        ],
+        label: '',
+        lineStyle: {
+          color: theme.purple300,
+          width: 2,
+        },
       },
     },
     {

--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -9,6 +9,7 @@ import XAxis from 'sentry/components/charts/components/xAxis';
 import YAxis from 'sentry/components/charts/components/yAxis';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {MemorySpanType} from 'sentry/components/events/interfaces/spans/types';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {formatBytesBase2} from 'sentry/utils';

--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -9,7 +9,6 @@ import XAxis from 'sentry/components/charts/components/xAxis';
 import YAxis from 'sentry/components/charts/components/yAxis';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {MemorySpanType} from 'sentry/components/events/interfaces/spans/types';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {formatBytesBase2} from 'sentry/utils';


### PR DESCRIPTION
Add a vertical line in Memory chart that syncs with the replay (and hover state as well).

We need to use a container that has `useEffects` to listen to the currentTime (and hoverTime) that will update echarts outside of React. This is because the React re-renders will conflict with mouse interactions (e.g. hovers and tooltips on echarts). `currentTime` also gets updated quite frequently and causes lots of heavy re-renders w/ the chart.

