### PR TITLE
fix: replace usage of global functions in Lua with locals

### DIFF
--- a/src/sentry/scripts/digests/digests.lua
+++ b/src/sentry/scripts/digests/digests.lua
@@ -8,7 +8,7 @@ local function identity(...)
     return ...
 end
 
-function table.extend(t, items, length)
+local function table_extend(t, items, length)
     -- The table length can be provided if you know the length of the table
     -- beforehand to avoid a potentially expensive length operator call.
     if length == nil then
@@ -123,7 +123,7 @@ local function zrange_move_slice(source, destination, threshold, callback)
         local zadd_args = {}
         local zrem_args = {}
         for i, key, score in chunk_iterator do
-            table.extend(zadd_args, {score, key}, (i - 1) * 2)
+            table_extend(zadd_args, {score, key}, (i - 1) * 2)
             zrem_args[i] = key
             callback(key, score)
         end

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -37,8 +37,19 @@ local function identity(...)
     return ...
 end
 
+local function table_ireduce(t, f, i)
+    if i == nil then
+        i = {}
+    end
+    local result = i
+    for i, value in ipairs(t) do
+        result = f(result, value)
+    end
+    return result
+end
+
 local function sum(t)
-    return table.ireduce(
+    return table_ireduce(
         t,
         function (total, value)
             return total + value
@@ -51,7 +62,7 @@ local function avg(t)
     return sum(t) / #t
 end
 
-function table.count(t)
+local function table_count(t)
     -- Shitty O(N) table size implementation
     local n = 0
     for k in pairs(t) do
@@ -60,7 +71,7 @@ function table.count(t)
     return n
 end
 
-function table.slice(t, start, stop)
+local function table_slice(t, start, stop)
     -- NOTE: ``stop`` is inclusive!
     local result = {}
     for i = start or 1, stop or #t do
@@ -69,7 +80,7 @@ function table.slice(t, start, stop)
     return result
 end
 
-function table.get_or_set_default(t, k, f)
+local function table_get_or_set_default(t, k, f)
     local v = t[k]
     if v ~= nil then
         return v
@@ -80,29 +91,19 @@ function table.get_or_set_default(t, k, f)
     end
 end
 
-function table.imap(t, f)
+local function table_imap(t, f)
     local result = {}
     for i, value in ipairs(t) do
         result[i] = f(value)
     end
     return result
 end
-function table.ireduce(t, f, i)
-    if i == nil then
-        i = {}
-    end
-    local result = i
-    for i, value in ipairs(t) do
-        result = f(result, value)
-    end
-    return result
-end
 
-function table.izip(...)
+local function table_izip(...)
     local args = {...}
     local n = math.max(
         unpack(
-            table.imap(
+            table_imap(
                 args,
                 function (t) return #t end
             )
@@ -495,8 +496,8 @@ local function calculate_similarity(configuration, item_frequencies, candidate_f
     end
 
     return avg(
-        table.imap(
-            table.izip(
+        table_imap(
+            table_izip(
                 item_frequencies,
                 candidate_frequencies
             ),
@@ -530,14 +531,14 @@ local function fetch_candidates(configuration, index, frequencies)
             -- period.
             local members = get_bucket_membership_set(configuration, index, band, bucket):members()
             for member in pairs(members) do
-                table.get_or_set_default(candidates, member, create_table)[band] = true
+                table_get_or_set_default(candidates, member, create_table)[band] = true
             end
         end
     end
 
     local results = {}
     for candidate, bands in pairs(candidates) do
-        results[candidate] = table.count(bands)
+        results[candidate] = table_count(bands)
     end
     return results
 end
@@ -551,7 +552,7 @@ local function search(configuration, parameters, limit)
     for i, p in ipairs(parameters) do
         for candidate, hits in pairs(fetch_candidates(configuration, p.index, p.frequencies)) do
             if hits >= p.threshold then
-                table.get_or_set_default(possible_candidates, candidate, create_table)[i] = hits
+                table_get_or_set_default(possible_candidates, candidate, create_table)[i] = hits
             end
         end
     end
@@ -584,7 +585,7 @@ local function search(configuration, parameters, limit)
                 end
             end
         )
-        candidates = table.slice(candidates, 1, limit)
+        candidates = table_slice(candidates, 1, limit)
     end
 
     local results = {}
@@ -618,7 +619,7 @@ local commands = {
             )
         )(cursor, arguments)
 
-        return table.imap(
+        return table_imap(
             signatures,
             function (signature)
                 set_frequencies(configuration, signature.index, key, signature.frequencies)
@@ -735,7 +736,7 @@ local commands = {
             })
         )(cursor, arguments)
 
-        return table.imap(
+        return table_imap(
             entries,
             function (source)
                 if #source.data == 0 then
@@ -770,7 +771,7 @@ local commands = {
             })
         )(cursor, arguments)
 
-        return table.imap(
+        return table_imap(
             entries,
             function (source)
                 local frequency_key = get_frequency_key(configuration, source.index, source.key)
@@ -809,7 +810,7 @@ local commands = {
                 {'count', argument_parser(validate_integer)}
             })
         )(cursor, arguments)
-        return table.imap(
+        return table_imap(
             entries,
             function (argument)
                 return redis.call(

--- a/src/sentry/scripts/tsdb/cmsketch.lua
+++ b/src/sentry/scripts/tsdb/cmsketch.lua
@@ -337,7 +337,7 @@ function Sketch:export()
     })
 end
 
-function table.is_empty(t)
+local function table_is_empty(t)
     return next(t) == nil
 end
 
@@ -349,7 +349,7 @@ function Sketch:import(payload)
 
     local source_index, source_estimators = unpack(data)
 
-    if table.is_empty(source_estimators) then
+    if table_is_empty(source_estimators) then
         -- If we're just writing the source index values (and not estimators)
         -- to the destination, we can just directly increment the sketch which
         -- will take care of destination estimator updates and index truncation,


### PR DESCRIPTION
Redis 6.2.7 and 7.0.0 include a [security fix](https://github.com/redis/redis/pull/10651) which forbids modifying Lua globals, including by defining new global functions. This causes e.g. the current `digests.lua` script to fail with an error: `redis.exceptions.ResponseError: Error running script (call to f_094f8735408af273da283389ad983f63977831e8): @user_script:11: user_script:11: Attempt to modify a readonly table`
To fix the issue, this PR replaces global function definitions with local functions.

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
