### PR TITLE
fix(replay): Iterate on the replay details header spacing

### DIFF
--- a/static/app/components/idBadge/userBadge.tsx
+++ b/static/app/components/idBadge/userBadge.tsx
@@ -63,7 +63,7 @@ const StyledEmail = styled('div')`
   ${overflowEllipsis};
 `;
 
-const StyledName = styled('span')<{hideEmail: boolean}>`
+export const StyledName = styled('span')<{hideEmail: boolean}>`
   font-weight: ${p => (p.hideEmail ? 'inherit' : 'bold')};
   line-height: 1.15em;
   ${overflowEllipsis};

--- a/static/app/components/replays/keyMetrics.tsx
+++ b/static/app/components/replays/keyMetrics.tsx
@@ -36,7 +36,8 @@ export const KeyMetricData = ({keyName, value}: Props) => {
 
 const Key = styled('dt')`
   color: ${p => p.theme.subText};
-  font-weight: normal;
+  font-size: 14px;
+  font-weight: bold;
 `;
 
 const Value = styled('dt')`

--- a/static/app/views/replays/detail/detailLayout.tsx
+++ b/static/app/views/replays/detail/detailLayout.tsx
@@ -5,7 +5,7 @@ import Breadcrumbs from 'sentry/components/breadcrumbs';
 import Duration from 'sentry/components/duration';
 import FeatureBadge from 'sentry/components/featureBadge';
 import {FeatureFeedback} from 'sentry/components/featureFeedback';
-import UserBadge from 'sentry/components/idBadge/userBadge';
+import UserBadge, {StyledName} from 'sentry/components/idBadge/userBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {KeyMetricData, KeyMetrics} from 'sentry/components/replays/keyMetrics';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -25,6 +25,17 @@ type Props = {
 
 function DetailLayout({children, event, orgId, crumbs}: Props) {
   const title = event ? `${event.id} - Replays - ${orgId}` : `Replays - ${orgId}`;
+
+  const eventRow = event ? (
+    <React.Fragment>
+      <Layout.HeaderContent>
+        <EventHeader event={event} />
+      </Layout.HeaderContent>
+      <MetaDataColumn>
+        <EventMetaData event={event} crumbs={crumbs} />
+      </MetaDataColumn>
+    </React.Fragment>
+  ) : null;
 
   return (
     <SentryDocumentTitle title={title}>
@@ -48,7 +59,7 @@ function DetailLayout({children, event, orgId, crumbs}: Props) {
               ]}
             />
           </Layout.HeaderContent>
-          <ButtonWrapper>
+          <FeedbackButtonWrapper>
             <FeatureFeedback
               featureName="replay"
               feedbackTypes={[
@@ -58,13 +69,8 @@ function DetailLayout({children, event, orgId, crumbs}: Props) {
                 'Other reason',
               ]}
             />
-          </ButtonWrapper>
-          <Layout.HeaderContent>
-            <EventHeader event={event} />
-          </Layout.HeaderContent>
-          <Layout.HeaderActions>
-            <EventMetaData event={event} crumbs={crumbs} />
-          </Layout.HeaderActions>
+          </FeedbackButtonWrapper>
+          {eventRow}
         </Layout.Header>
         {children}
       </React.Fragment>
@@ -81,7 +87,7 @@ function EventHeader({event}: Pick<Props, 'event'>) {
   const pathname = getUrlPathname(urlTag?.value ?? '') ?? '';
 
   return (
-    <UserBadge
+    <BigNameUserBadge
       avatarSize={32}
       user={{
         username: event.user?.username ?? '',
@@ -95,6 +101,10 @@ function EventHeader({event}: Pick<Props, 'event'>) {
     />
   );
 }
+
+const MetaDataColumn = styled(Layout.HeaderActions)`
+  width: 325px;
+`;
 
 function EventMetaData({event, crumbs}: Pick<Props, 'event' | 'crumbs'>) {
   const {duration} = useReplayContext();
@@ -130,8 +140,16 @@ function msToSec(ms: number) {
   return ms / 1000;
 }
 
+const BigNameUserBadge = styled(UserBadge)`
+  align-items: flex-start;
+
+  ${StyledName} {
+    font-size: 26px;
+  }
+`;
+
 // TODO(replay); This could make a lot of sense to put inside HeaderActions by default
-const ButtonWrapper = styled(Layout.HeaderActions)`
+const FeedbackButtonWrapper = styled(Layout.HeaderActions)`
   align-items: end;
 `;
 


### PR DESCRIPTION
Iterate on the header spacing. It was off before.

**Before**
![old.png](https://graphite-user-uploaded-assets.s3.amazonaws.com/ck6V58zD6DexpsEB0MNr/9a4e71af-994f-4e7f-a300-67584a997123/old.png)

**After**
![fixed.png](https://graphite-user-uploaded-assets.s3.amazonaws.com/ck6V58zD6DexpsEB0MNr/d71a75c7-d84f-454b-aa34-0a0ceb889cd1/fixed.png)

When loading:

**Before**
There was too much space under the feedback button:
<img width="1389" alt="Screen Shot 2022-05-10 at 4 49 03 PM" src="https://user-images.githubusercontent.com/187460/167588774-85c6d749-acd6-4afd-b593-4048e5fb36cf.png">

**After**
<img width="1392" alt="Screen Shot 2022-05-10 at 4 48 56 PM" src="https://user-images.githubusercontent.com/187460/167588739-73914003-29f0-4b19-ad90-6cec4c07adbc.png">
