### PR TITLE
fix(replay): Use `AbortController` to prevent extra state updates after the mouse has left the tracking component

### DIFF
--- a/static/app/components/replays/player/horizontalMouseTracking.tsx
+++ b/static/app/components/replays/player/horizontalMouseTracking.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useRef} from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 
@@ -26,6 +26,7 @@ function getBoundingRect(elem: Element): Promise<DOMRectReadOnly> {
 function HorizontalMouseTracking({children}: Props) {
   const elem = useRef<HTMLDivElement>(null);
   const {duration, setCurrentHoverTime} = useReplayContext();
+  const [isEntered, setIsEntered] = useState(false);
 
   const onMouseMove = useCallback(
     async (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
@@ -35,6 +36,10 @@ function HorizontalMouseTracking({children}: Props) {
       }
 
       const rect = await getBoundingRect(elem.current);
+
+      if (!isEntered) {
+        return;
+      }
       const left = e.clientX - rect.left;
       if (left >= 0) {
         const percent = left / rect.width;
@@ -44,17 +49,26 @@ function HorizontalMouseTracking({children}: Props) {
         setCurrentHoverTime(undefined);
       }
     },
-    [duration, setCurrentHoverTime]
+    [isEntered, duration, setCurrentHoverTime]
+  );
+
+  const onMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      setIsEntered(true);
+      onMouseMove(e);
+    },
+    [onMouseMove]
   );
 
   const onMouseLeave = useCallback(() => {
+    setIsEntered(false);
     setCurrentHoverTime(undefined);
   }, [setCurrentHoverTime]);
 
   return (
     <div
       ref={elem}
-      onMouseEnter={onMouseMove}
+      onMouseEnter={onMouseEnter}
       onMouseMove={onMouseMove}
       onMouseLeave={onMouseLeave}
     >

--- a/static/app/components/replays/player/horizontalMouseTracking.tsx
+++ b/static/app/components/replays/player/horizontalMouseTracking.tsx
@@ -12,9 +12,12 @@ class AbortError extends Error {}
 /**
  * Replace `elem.getBoundingClientRect()` which is too laggy for onMouseMove
  */
-function getBoundingRect(elem: Element, {signal}): Promise<DOMRectReadOnly> {
+function getBoundingRect(
+  elem: Element,
+  {signal}: {signal: AbortSignal}
+): Promise<DOMRectReadOnly> {
   return new Promise((resolve, reject) => {
-    if (signal.abort) {
+    if (signal.aborted) {
       reject(new AbortError());
     }
 
@@ -50,7 +53,7 @@ function HorizontalMouseTracking({children}: Props) {
 
       try {
         const rect = await getBoundingRect(elem.current, {
-          signal: controller.current?.signal,
+          signal: controller.current.signal,
         });
         const left = e.clientX - rect.left;
         if (left >= 0) {

--- a/static/app/components/replays/player/horizontalMouseTracking.tsx
+++ b/static/app/components/replays/player/horizontalMouseTracking.tsx
@@ -72,13 +72,6 @@ function HorizontalMouseTracking({children}: Props) {
     [controller, duration, setCurrentHoverTime]
   );
 
-  const onMouseEnter = useCallback(
-    (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-      onMouseMove(e);
-    },
-    [onMouseMove]
-  );
-
   const onMouseLeave = useCallback(() => {
     if (controller.current) {
       controller.current.abort();
@@ -91,7 +84,7 @@ function HorizontalMouseTracking({children}: Props) {
   return (
     <div
       ref={elem}
-      onMouseEnter={onMouseEnter}
+      onMouseEnter={onMouseMove}
       onMouseMove={onMouseMove}
       onMouseLeave={onMouseLeave}
     >


### PR DESCRIPTION
I'm not sure if this is working better or not.

I tried to find a way to lag out the page reliably and make the hover stuff janky, it's not reliable but playing a complex replay video helps. And then even with this code it's still janky.
