### PR TITLE
ref: explicitly test the warning raised from parsing a legacy version

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_sdk_updates.py
+++ b/tests/sentry/api/endpoints/test_organization_sdk_updates.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pytest
 from django.urls import reverse
 
 from sentry.sdk_updates import SdkIndexState
@@ -181,8 +182,16 @@ class OrganizationSdkUpdates(APITestCase, SnubaTestCase):
             assert_no_errors=False,
         )
 
-        with self.feature(self.features):
+        with self.feature(self.features), pytest.warns(DeprecationWarning) as warninfo:
             response = self.client.get(self.url)
 
         update_suggestions = response.data
         assert len(update_suggestions) == 0
+
+        # until it is turned into an error, we'll get a warning about parsing an invalid version
+        (warning,) = warninfo
+        (warn_msg,) = warning.message.args
+        assert (
+            warn_msg
+            == "Creating a LegacyVersion has been deprecated and will be removed in the next major release"
+        )


### PR DESCRIPTION
part of an effort to make tests warnings-clean

failure before this change (eventually we'll want to handle the _failure_ for parsing version, but at least we have a test demonstrating that until then):

```
Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/packaging/version.py", line 49, in parse
    return Version(version)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/packaging/version.py", line 266, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")
packaging.version.InvalidVersion: Invalid version: 'dev-master@32e5415'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/src/sentry/api/base.py", line 139, in handle_exception
    response = super().handle_exception(exc)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/rest_framework/views.py", line 465, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/rest_framework/views.py", line 476, in raise_uncaught_exception
    raise exc
  File "/Users/asottile/workspace/sentry/src/sentry/api/base.py", line 254, in dispatch
    response = handler(request, *args, **kwargs)
  File "/Users/asottile/workspace/sentry/src/sentry/api/endpoints/organization_sdk_updates.py", line 95, in get
    return Response(serialize(result["data"], projects))
  File "/Users/asottile/workspace/sentry/src/sentry/api/endpoints/organization_sdk_updates.py", line 42, in serialize
    updates_list = [
  File "/Users/asottile/workspace/sentry/src/sentry/api/endpoints/organization_sdk_updates.py", line 42, in <listcomp>
    updates_list = [
  File "/Users/asottile/workspace/sentry/src/sentry/api/endpoints/organization_sdk_updates.py", line 28, in <genexpr>
    [
  File "/Users/asottile/workspace/sentry/src/sentry/api/endpoints/organization_sdk_updates.py", line 32, in <listcomp>
    "sdkVersion": max((s["sdk.version"] for s in sdks), key=version.parse),
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/packaging/version.py", line 51, in parse
    return LegacyVersion(version)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/packaging/version.py", line 111, in __init__
    warnings.warn(
DeprecationWarning: Creating a LegacyVersion has been deprecated and will be removed in the next major release
```