### PR TITLE
ref: move conftest.py into tests/

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,9 @@
 import os
-import sys
 from collections import OrderedDict
 
 import pytest
 
 pytest_plugins = ["sentry.utils.pytest"]
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
 
 # XXX: The below code is vendored code from https://github.com/utgwkk/pytest-github-actions-annotate-failures


### PR DESCRIPTION
this removes two top-level files (conftest.py, \_\_pycache\_\_)

this is also a more common setup of pytest