### PR TITLE
feat(metrics) - add mapping_meta and mapping_sources to ingest-metrics output

### DIFF
--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -452,7 +452,7 @@ def process_messages(
             tags = parsed_payload_value.get("tags", {})
             used_tags.add(metric_name)
 
-            new_tags: Mapping[int, int] = {}
+            new_tags: MutableMapping[int, int] = {}
             try:
                 for k, v in tags.items():
                     used_tags.update({k, v})

--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -468,6 +468,9 @@ def process_messages(
                     fetch_types_encountered.add(fetch_type)
                     output_message_meta[fetch_type.value][int_id] = tag
 
+            mapping_header_content = bytes(
+                "".join([t.value for t in fetch_types_encountered]), "utf-8"
+            )
             new_payload_value["tags"] = new_tags
             new_payload_value["metric_id"] = mapping[org_id][metric_name]
             new_payload_value["retention_days"] = 90
@@ -478,7 +481,10 @@ def process_messages(
             new_payload = KafkaPayload(
                 key=message.payload.key,
                 value=json.dumps(new_payload_value).encode(),
-                headers=message.payload.headers,
+                headers=[
+                    *message.payload.headers,
+                    ("mapping_sources", mapping_header_content),
+                ],
             )
             new_message = Message(
                 partition=message.partition,

--- a/src/sentry/sentry_metrics/multiprocess.py
+++ b/src/sentry/sentry_metrics/multiprocess.py
@@ -431,8 +431,9 @@ def process_messages(
 
     with metrics.timer("metrics_consumer.bulk_record"):
         record_result = indexer.bulk_record(org_strings)
-        mapping = record_result.get_mapped_results()
-        bulk_record_meta = record_result.get_fetch_metadata()
+
+    mapping = record_result.get_mapped_results()
+    bulk_record_meta = record_result.get_fetch_metadata()
 
     new_messages: List[Message[KafkaPayload]] = []
 

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Dict, List, Mapping, MutableMapping, Union
+from typing import Dict, List, Mapping, MutableMapping, Sequence, Union
 from unittest import mock
 from unittest.mock import Mock, call, patch
 
@@ -27,6 +27,34 @@ from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)
+
+
+def compare_messages_ignoring_mapping_metadata(actual: Message, expected: Message) -> None:
+    assert actual.offset == expected.offset
+    assert actual.partition == expected.partition
+    assert actual.timestamp == expected.timestamp
+
+    actual_payload: KafkaPayload = actual.payload
+    expected_payload: KafkaPayload = expected.payload
+
+    assert actual_payload.key == expected_payload.key
+
+    actual_headers_without_mapping_sources = [
+        (k, v) for k, v in actual_payload.headers if k != "mapping_sources"
+    ]
+    assert actual_headers_without_mapping_sources == expected_payload.headers
+
+    actual_deserialized = json.loads(actual_payload.value)
+    expected_deserialized = json.loads(expected_payload.value)
+    del actual_deserialized["mapping_meta"]
+    assert actual_deserialized == expected_deserialized
+
+
+def compare_message_batches_ignoring_metadata(
+    actual: Sequence[Message], expected: Sequence[Message]
+) -> None:
+    for (a, e) in zip(actual, expected):
+        compare_messages_ignoring_mapping_metadata(a, e)
 
 
 def _batch_message_set_up(next_step: Mock, max_batch_time: float = 100.0, max_batch_size: int = 2):
@@ -255,7 +283,7 @@ def test_process_messages(mock_indexer) -> None:
         )
         for i, m in enumerate(message_batch)
     ]
-    assert new_batch == expected_new_batch
+    compare_message_batches_ignoring_metadata(new_batch, expected_new_batch)
 
 
 invalid_payloads = [
@@ -330,7 +358,7 @@ def test_process_messages_invalid_messages(invalid_payload, error_text, caplog) 
             expected_msg.timestamp,
         )
     ]
-    assert new_batch == expected_new_batch
+    compare_message_batches_ignoring_metadata(new_batch, expected_new_batch)
     assert error_text in caplog.text
 
 


### PR DESCRIPTION
To allow the last_seen updater to do its work, this PR adds metadata about where tag keys/value/metric IDs were fetched from to the output of the indexer. The metadata header will be used by the last_seen_updater to ignore messages that have no impact on key TTL. The contents will be used so that the updater knows which specific keys may require a TTL update.

As a result of the fact that `bulk_record` is called for an incoming message batch for a collection of all contained tag keys/values but the output of fetch types needs to be presented individually, I had to change the internal structure of `KeyResults.meta` to index by key rather than by fetch type

mini-project plan: https://www.notion.so/sentry/Proposal-last_seen-updater-6f9171fe761b4423ab49f6e8807540fc