### PR TITLE
dev(eslint): Make `react-hooks/exhaustive-deps` error on pre-commit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,11 @@ const process = require('process');
 
 const isRelaxed = !!process.env.SENTRY_ESLINT_RELAXED;
 
+// Strict ruleset that runs on pre-commit and in local environments
+const strictRules = {
+  'react-hooks/exhaustive-deps': ['error'],
+};
+
 module.exports = {
   extends: [isRelaxed ? 'sentry-app' : 'sentry-app/strict'],
   globals: {
@@ -17,7 +22,9 @@ module.exports = {
     jest: true,
   },
 
-  rules: {},
+  rules: {
+    ...(!isRelaxed ? strictRules : {}),
+  },
 
   overrides: [
     {


### PR DESCRIPTION
Adds a new "strict" rule for `react-hooks/exhaustive-deps`. This will be used everywhere except CI where it will remain a warning (e.g. pre-commit, editors). This will give devs the proper feedback on their commits and allows us to start reducing the number of warnings from this rule.