### PR TITLE
ref(discover): Improve y-axis selector's UI & behavior

### DIFF
--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import FeatureBadge from 'sentry/components/featureBadge';
@@ -33,16 +33,26 @@ function OptionSelector({
   multiple,
   ...rest
 }: SingleProps | MultipleProps) {
-  const mappedOptions = options.map(opt => ({
-    ...opt,
-    label: <Truncate value={String(opt.label)} maxLength={60} expandDirection="left" />,
-  }));
+  const mappedOptions = useMemo(() => {
+    return options.map(opt => ({
+      ...opt,
+      label: <Truncate value={String(opt.label)} maxLength={60} expandDirection="left" />,
+    }));
+  }, [options]);
 
   function onValueChange(option) {
-    if (multiple && option.length > 3) {
-      return;
-    }
     onChange(multiple ? option.map(o => o.value) : option.value);
+  }
+
+  function isOptionDisabled(option) {
+    return (
+      // Option is explicitly marked as disabled
+      option.disabled ||
+      // The user has reached the maximum number of selections (3), and the option hasn't
+      // yet been selected. These options should be disabled to visually indicate that the
+      // user has reached the max.
+      (multiple && selected.length === 3 && !selected.includes(option.value))
+    );
   }
 
   return (
@@ -50,7 +60,7 @@ function OptionSelector({
       options={mappedOptions}
       value={selected}
       onChange={onValueChange}
-      isOptionDisabled={opt => opt.disabled}
+      isOptionDisabled={isOptionDisabled}
       multiple={multiple}
       triggerProps={{
         size: 'small',

--- a/static/app/views/eventsV2/chartFooter.tsx
+++ b/static/app/views/eventsV2/chartFooter.tsx
@@ -78,6 +78,10 @@ export default function ChartFooter({
         ) : (
           <OptionSelector
             multiple
+            isClearable
+            menuTitle={
+              yAxisOptions.length > 3 ? t('Select up to 3 options') : t('Y-axis')
+            }
             title={t('Y-Axis')}
             selected={yAxisValue}
             options={yAxisOptions}

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -81,12 +81,10 @@ function readShowTagsState() {
   return value === '1';
 }
 
-function getYAxis(location: Location, eventView: EventView, savedQuery?: SavedQuery) {
+function getYAxis(location: Location, savedQuery?: SavedQuery) {
   return location.query.yAxis
     ? decodeList(location.query.yAxis)
-    : savedQuery?.yAxis && savedQuery.yAxis.length > 0
-    ? decodeList(savedQuery?.yAxis)
-    : [eventView.getYAxis()];
+    : decodeList(savedQuery?.yAxis);
 }
 
 class Results extends Component<Props, State> {
@@ -133,12 +131,8 @@ class Results extends Component<Props, State> {
     this.checkEventView();
     const currentQuery = eventView.getEventsAPIPayload(location);
     const prevQuery = prevState.eventView.getEventsAPIPayload(prevProps.location);
-    const yAxisArray = getYAxis(location, eventView, savedQuery);
-    const prevYAxisArray = getYAxis(
-      prevProps.location,
-      prevState.eventView,
-      prevState.savedQuery
-    );
+    const yAxisArray = getYAxis(location, savedQuery);
+    const prevYAxisArray = getYAxis(prevProps.location, prevState.savedQuery);
 
     if (
       !isAPIPayloadSimilar(currentQuery, prevQuery) ||
@@ -485,7 +479,7 @@ class Results extends Component<Props, State> {
       : eventView.fields;
     const query = eventView.query;
     const title = this.getDocumentTitle();
-    const yAxisArray = getYAxis(location, eventView, savedQuery);
+    const yAxisArray = getYAxis(location, savedQuery);
 
     return (
       <SentryDocumentTitle title={title} orgSlug={organization.slug}>


### PR DESCRIPTION
Make it clearer that you can only select up to 3 y-axis options at a time, and fix a bug where the hover position gets reset after every selection.

**Before**
<img width="245" alt="Screen Shot 2022-05-10 at 12 38 46 PM" src="https://user-images.githubusercontent.com/44172267/167708651-58de087d-88a2-4037-8a1c-8575de6e1b8a.png">

**After**
<img width="245" alt="Screen Shot 2022-05-10 at 12 38 33 PM" src="https://user-images.githubusercontent.com/44172267/167708615-ba4d2580-8c6e-4634-80fc-d2eb058d9418.png">

