### PR TITLE
fix(team-store): Reset team store when loading org details

### DIFF
--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -119,6 +119,7 @@ export async function fetchOrganizationDetails(
   if (!silent) {
     OrganizationActions.reset();
     ProjectActions.reset();
+    TeamActions.reset();
     PageFiltersActions.reset();
   }
 

--- a/static/app/actions/teamActions.tsx
+++ b/static/app/actions/teamActions.tsx
@@ -15,6 +15,7 @@ const TeamActions = createActions([
   'removeTeam',
   'removeTeamError',
   'removeTeamSuccess',
+  'reset',
   'update',
   'updateError',
   'updateSuccess',

--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -63,6 +63,7 @@ const teamStoreConfig: TeamStoreDefinition = {
     this.unsubscribeListeners.push(
       this.listenTo(TeamActions.updateSuccess, this.onUpdateSuccess)
     );
+    this.unsubscribeListeners.push(this.listenTo(TeamActions.reset, this.reset));
   },
 
   reset() {


### PR DESCRIPTION
When loading org details, we need to reset the team store when silent is off.
This corresponds to when we need to do a full update like when changing
organizations.