### PR TITLE
fix(onboarding): setting up a plugin should not mark the alert rule task as complete

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -14,7 +14,6 @@ from sentry.models import (
     Project,
 )
 from sentry.plugins.bases import IssueTrackingPlugin, IssueTrackingPlugin2
-from sentry.plugins.bases.notify import NotificationPlugin
 from sentry.signals import (
     alert_rule_created,
     event_processed,
@@ -343,9 +342,6 @@ def record_plugin_enabled(plugin, project, user, **kwargs):
     if isinstance(plugin, IssueTrackingPlugin) or isinstance(plugin, IssueTrackingPlugin2):
         task = OnboardingTask.ISSUE_TRACKER
         status = OnboardingTaskStatus.PENDING
-    elif isinstance(plugin, NotificationPlugin):
-        task = OnboardingTask.ALERT_RULE
-        status = OnboardingTaskStatus.COMPLETE
     else:
         return
 


### PR DESCRIPTION
Setting up a plugin is not the same as setting up an alert rule