### PR TITLE
feat(onboarding): update alert task for alerts

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -40,6 +40,16 @@ type Options = {
   projects?: Project[];
 };
 
+function getIssueAlertUrl({projects, organization}: Options) {
+  if (!projects || !projects.length) {
+    return `/organizations/${organization.slug}/alerts/rules/`;
+  }
+  // pick the first project with events if we have that, otherwise just pick the first project
+  const firstProjectWithEvents = projects.find(project => !!project.firstEvent);
+  const project = firstProjectWithEvents ?? projects[0];
+  return `/organizations/${organization.slug}/alerts/${project.slug}/wizard/`;
+}
+
 export function getOnboardingTasks({
   organization,
   projects,
@@ -194,14 +204,14 @@ export function getOnboardingTasks({
     },
     {
       task: OnboardingTaskKey.ALERT_RULE,
-      title: t('Get smarter alerts'),
+      title: t('Configure an Issue Alert'),
       description: t(
-        "Customize alerting rules by issue or metric. You'll get the exact information you need precisely when you need it."
+        'We all have issues. Get real-time error notifications by setting up alerts for issues that match your set criteria.'
       ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT],
       actionType: 'app',
-      location: `/organizations/${organization.slug}/alerts/rules/`,
+      location: getIssueAlertUrl({projects, organization}),
       display: true,
     },
   ];


### PR DESCRIPTION
This PR updates the copy and the link used for the alert task for onboarding. Note I will be adding a separate onboarding card for performance alerts soon.

![Screen Shot 2022-05-10 at 4 16 40 PM](https://user-images.githubusercontent.com/8533851/167739979-1b5ba64f-ba39-4e68-b883-e92c91f2ef54.png)