### PR TITLE
feat(onboarding): make new performance alert onboarding task

### DIFF
--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -25,7 +25,7 @@ class OnboardingTask:
     ISSUE_TRACKER = 9
     ALERT_RULE = 10
     FIRST_TRANSACTION = 11
-    PERFORMANCE_ALERT = 12
+    METRIC_ALERT = 12
 
 
 class OnboardingTaskStatus:
@@ -88,7 +88,7 @@ class OrganizationOnboardingTask(Model):
         (OnboardingTask.ISSUE_TRACKER, "setup_issue_tracker"),
         (OnboardingTask.ALERT_RULE, "setup_alert_rules"),
         (OnboardingTask.FIRST_TRANSACTION, "setup_transactions"),
-        (OnboardingTask.PERFORMANCE_ALERT, "setup_performance_alert_rules"),
+        (OnboardingTask.METRIC_ALERT, "setup_metric_alert_rules"),
     )
 
     STATUS_CHOICES = (
@@ -119,7 +119,7 @@ class OrganizationOnboardingTask(Model):
             OnboardingTask.ISSUE_TRACKER,
             OnboardingTask.ALERT_RULE,
             OnboardingTask.FIRST_TRANSACTION,
-            OnboardingTask.PERFORMANCE_ALERT,
+            OnboardingTask.METRIC_ALERT,
         ]
     )
 
@@ -134,7 +134,7 @@ class OrganizationOnboardingTask(Model):
             OnboardingTask.ISSUE_TRACKER,
             OnboardingTask.ALERT_RULE,
             OnboardingTask.FIRST_TRANSACTION,
-            OnboardingTask.PERFORMANCE_ALERT,
+            OnboardingTask.METRIC_ALERT,
         ]
     )
 

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -25,6 +25,7 @@ class OnboardingTask:
     ISSUE_TRACKER = 9
     ALERT_RULE = 10
     FIRST_TRANSACTION = 11
+    PERFORMANCE_ALERT = 12
 
 
 class OnboardingTaskStatus:
@@ -87,6 +88,7 @@ class OrganizationOnboardingTask(Model):
         (OnboardingTask.ISSUE_TRACKER, "setup_issue_tracker"),
         (OnboardingTask.ALERT_RULE, "setup_alert_rules"),
         (OnboardingTask.FIRST_TRANSACTION, "setup_transactions"),
+        (OnboardingTask.PERFORMANCE_ALERT, "setup_performance_alert_rules"),
     )
 
     STATUS_CHOICES = (
@@ -117,6 +119,7 @@ class OrganizationOnboardingTask(Model):
             OnboardingTask.ISSUE_TRACKER,
             OnboardingTask.ALERT_RULE,
             OnboardingTask.FIRST_TRANSACTION,
+            OnboardingTask.PERFORMANCE_ALERT,
         ]
     )
 
@@ -131,6 +134,7 @@ class OrganizationOnboardingTask(Model):
             OnboardingTask.ISSUE_TRACKER,
             OnboardingTask.ALERT_RULE,
             OnboardingTask.FIRST_TRANSACTION,
+            OnboardingTask.PERFORMANCE_ALERT,
         ]
     )
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -367,7 +367,7 @@ def record_plugin_enabled(plugin, project, user, **kwargs):
 
 @alert_rule_created.connect(weak=False)
 def record_alert_rule_created(user, project, rule, rule_type, **kwargs):
-    task = OnboardingTask.PERFORMANCE_ALERT if rule_type == "metric" else OnboardingTask.ALERT_RULE
+    task = OnboardingTask.METRIC_ALERT if rule_type == "metric" else OnboardingTask.ALERT_RULE
     rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
         organization_id=project.organization_id,
         task=task,

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -366,10 +366,11 @@ def record_plugin_enabled(plugin, project, user, **kwargs):
 
 
 @alert_rule_created.connect(weak=False)
-def record_alert_rule_created(user, project, rule, **kwargs):
+def record_alert_rule_created(user, project, rule, rule_type, **kwargs):
+    task = OnboardingTask.PERFORMANCE_ALERT if rule_type == "metric" else OnboardingTask.ALERT_RULE
     rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
         organization_id=project.organization_id,
-        task=OnboardingTask.ALERT_RULE,
+        task=task,
         values={
             "status": OnboardingTaskStatus.COMPLETE,
             "user": user,

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -305,6 +305,22 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         assert task is not None
 
+    def test_metric_added(self):
+        alert_rule_created.send(
+            rule=Rule(id=1),
+            project=self.project,
+            user=self.user,
+            rule_type="metric",
+            sender=type(Rule),
+            is_api_token=False,
+        )
+        task = OrganizationOnboardingTask.objects.get(
+            organization=self.organization,
+            task=OnboardingTask.PERFORMANCE_ALERT,
+            status=OnboardingTaskStatus.COMPLETE,
+        )
+        assert task is not None
+
     def test_onboarding_complete(self):
         now = timezone.now()
         user = self.create_user(email="test@example.org")
@@ -381,6 +397,14 @@ class OrganizationOnboardingTaskTest(TestCase):
             project=self.project,
             user=self.user,
             rule_type="issue",
+            sender=type(Rule),
+            is_api_token=False,
+        )
+        alert_rule_created.send(
+            rule=Rule(id=1),
+            project=self.project,
+            user=self.user,
+            rule_type="metric",
             sender=type(Rule),
             is_api_token=False,
         )

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -316,7 +316,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         task = OrganizationOnboardingTask.objects.get(
             organization=self.organization,
-            task=OnboardingTask.PERFORMANCE_ALERT,
+            task=OnboardingTask.METRIC_ALERT,
             status=OnboardingTaskStatus.COMPLETE,
         )
         assert task is not None


### PR DESCRIPTION
This PR makes a new alert rule task specifically for metric/performance alerts. An upcoming PR will start using it in the UI.