### PR TITLE
feat(replay): Make `<Timeline>` and `<Tabs>` sticky at the top of the browser window

### DIFF
--- a/static/app/views/replays/detail/focusTabs.tsx
+++ b/static/app/views/replays/detail/focusTabs.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
 import NavTabs from 'sentry/components/navTabs';
 import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
 
 import useActiveTabFromLocation from './useActiveTabFromLocation';
 
@@ -21,19 +19,14 @@ const TABS = [
 function FocusTabs({}: Props) {
   const active = useActiveTabFromLocation();
   return (
-    <FullBleedNavTabs underlined>
+    <NavTabs underlined>
       {TABS.map(tab => (
         <li key={tab} className={active === tab.toLowerCase() ? 'active' : ''}>
           <a href={`#${tab.toLowerCase()}`}>{tab}</a>
         </li>
       ))}
-    </FullBleedNavTabs>
+    </NavTabs>
   );
 }
-
-const FullBleedNavTabs = styled(NavTabs)`
-  margin-inline: -${space(4)};
-  padding-inline: ${space(4)};
-`;
 
 export default FocusTabs;

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from '@emotion/styled';
 
 import DetailedError from 'sentry/components/errors/detailedError';
 import NotFound from 'sentry/components/errors/notFound';
@@ -10,6 +11,7 @@ import ReplayView from 'sentry/components/replays/replayView';
 import useFullscreen from 'sentry/components/replays/useFullscreen';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
+import space from 'sentry/styles/space';
 import useReplayData from 'sentry/utils/replays/useReplayData';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
@@ -93,9 +95,13 @@ function ReplayDetails() {
               event={replay.getEvent()}
             />
           </Layout.Side>
-          <Layout.Main fullWidth>
+
+          <StickyMain fullWidth>
             <ReplayTimeline />
             <FocusTabs />
+          </StickyMain>
+
+          <Layout.Main fullWidth>
             <FocusArea replay={replay} />
           </Layout.Main>
         </Layout.Body>
@@ -103,5 +109,17 @@ function ReplayDetails() {
     </ReplayContextProvider>
   );
 }
+
+const StickyMain = styled(Layout.Main)`
+  position: sticky;
+  top: 0;
+  z-index: ${p => p.theme.zIndex.header};
+
+  /* Make this component full-bleed, so the background covers everything underneath it */
+  margin: -${space(1.5)} -${space(4)} -${space(3)};
+  padding: ${space(1.5)} ${space(4)} 0;
+  max-width: none;
+  background: ${p => p.theme.background};
+`;
 
 export default ReplayDetails;


### PR DESCRIPTION

<img width="1234" alt="Screen Shot 2022-05-11 at 9 43 46 PM" src="https://user-images.githubusercontent.com/187460/167864429-9c58f7d8-fce3-49bf-a8cf-3349a9ccf494.png">

