### PR TITLE
fix(widget-builder): Hook dependencies

### DIFF
--- a/static/app/views/dashboardsV2/create.tsx
+++ b/static/app/views/dashboardsV2/create.tsx
@@ -42,7 +42,7 @@ function CreateDashboard(props: Props) {
     if (constructedWidget) {
       browserHistory.replace(location.pathname);
     }
-  }, [location.pathname]);
+  }, [location.query, location.pathname]);
   return (
     <Feature
       features={['dashboards-edit']}


### PR DESCRIPTION
Fixes some widget builder hook dependencies because I noticed my PRs were failing due to eslint errors in CI. Mostly adds in the missing dependencies to the `useEffect` array, but two big changes:

- Moved the code responsible for setting the values for a widget that's being edited into the `useState` hook that sets the `state`. This had the benefit of reducing some of the missing dependencies, but more importantly renders the values right from the beginning (i.e. no flashing default table widget)
- Moved the function definition of `fetchDashboards` into the hook where it's being used, or else the hook re-triggers every render