### PR TITLE
fix(widget-builder): Should not inject orderby in alias form into fields

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -17,7 +17,7 @@ import {
 } from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {TableData, TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
-import {isEquation} from 'sentry/utils/discover/fields';
+import {getAggregateAlias, isEquation} from 'sentry/utils/discover/fields';
 import {
   DiscoverQueryRequestParams,
   doDiscoverQuery,
@@ -454,7 +454,9 @@ class WidgetQueries extends Component<Props, State> {
           // the orderby selected
           if (
             query.orderby &&
-            !requestData.field.includes(trimStart(query.orderby, '-'))
+            !requestData.field
+              .map(getAggregateAlias)
+              .includes(getAggregateAlias(trimStart(query.orderby, '-')))
           ) {
             requestData.field.push(trimStart(query.orderby, '-'));
           }


### PR DESCRIPTION
The Widget Viewer currently applies a sort in the alias format, this PR converts the fields and orderby into the alias format to properly check if the orderby is included (e.g. without the alias conversion, checking `['project', 'count()'].includes('count')` would result in adding the field "count" to the field array, which we do not want.

If we can make the widget viewer applying the sort in the field format then this PR might not be necessary. Ideally we sort using the field value, but since widget viewer changes are not saved to the widget, then I think it's fine to account for it here for the time being.

Tagging @edwardgou-sentry to see if this could help or not.