### PR TITLE
feat(sampling): Change os.version to textarea [TET-82]

### DIFF
--- a/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
@@ -65,7 +65,6 @@ function Conditions({
           category === DynamicSamplingInnerName.EVENT_RELEASE ||
           category === DynamicSamplingInnerName.EVENT_TRANSACTION ||
           category === DynamicSamplingInnerName.EVENT_OS_NAME ||
-          category === DynamicSamplingInnerName.EVENT_OS_VERSION ||
           category === DynamicSamplingInnerName.EVENT_DEVICE_FAMILY ||
           category === DynamicSamplingInnerName.EVENT_DEVICE_NAME ||
           category === DynamicSamplingInnerName.EVENT_CUSTOM_TAG ||


### PR DESCRIPTION
This used to be autocomplete before, changing to textarea.
We do not want to support typeahead on this particular field.

![image](https://user-images.githubusercontent.com/9060071/167849800-eeb0553b-91e4-4194-b539-d24d8102846b.png)