### PR TITLE
fix(ci): Do not skip acceptance collector job if there are FE changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -56,6 +56,7 @@ backend: &backend
   - 'migrations_lockfile.txt'
   - 'config/**/*'
 
+# This is the ultimate controller for acceptance.yml
 acceptance: &acceptance
   - *backend
   - *frontend

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -309,7 +309,7 @@ jobs:
         if: needs.files-changed.outputs.backend == 'true'
 
   visual-diff:
-    if: needs.files-changed.outputs.backend_any_type == 'true'
+    if: needs.files-changed.outputs.acceptance == 'true'
     # This guarantees that we will only schedule Visual Snapshots if all
     # workflows that generate artifacts succeed
     needs: [acceptance, frontend, chartcuterie]
@@ -337,7 +337,7 @@ jobs:
   fake-visual-snapshot:
     name: Visual Snapshot
     # Opposite condition to "triggers visual snapshot" required check
-    if: needs.files-changed.outputs.backend_any_type != 'true'
+    if: needs.files-changed.outputs.acceptance != 'true'
     runs-on: ubuntu-20.04
     steps:
       - name: Sentaur attack


### PR DESCRIPTION
This is a fallout from #34004.

This got noticed in [this run](https://github.com/getsentry/sentry/runs/6379373504?check_suite_focus=true) were an FE check failed yet the collector job got skipped instead.