### PR TITLE
dev(eslint): Make `react-hooks/exhaustive-deps` not error in CI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,9 +4,10 @@
 const process = require('process');
 
 const isRelaxed = !!process.env.SENTRY_ESLINT_RELAXED;
+const isCi = !!process.env.CI;
 
 // Strict ruleset that runs on pre-commit and in local environments
-const strictRules = {
+const strictRulesNotCi = {
   'react-hooks/exhaustive-deps': ['error'],
 };
 
@@ -23,7 +24,7 @@ module.exports = {
   },
 
   rules: {
-    ...(!isRelaxed ? strictRules : {}),
+    ...(!isRelaxed && !isCi ? strictRulesNotCi : {}),
   },
 
   overrides: [


### PR DESCRIPTION
Follow-up to #34436 - I forgot we actually run strict mode on CI for PRs for changed files only (we run relaxed on master where it lints the entire codebase). Lets not run this specific rule in CI and if we dont see much hook fixing, we can slap it back into CI.