### PR TITLE
ui(profiling): Include thread ID in profile thread selector

### DIFF
--- a/static/app/components/profiling/threadSelector.tsx
+++ b/static/app/components/profiling/threadSelector.tsx
@@ -26,7 +26,9 @@ function ThreadMenuSelector<OptionType extends GeneralSelectValue = GeneralSelec
 }: ThreadSelectorProps) {
   const options: SelectValue<number>[] = useMemo(() => {
     return profileGroup.profiles.sort(compareProfiles).map(profile => ({
-      label: profile.name ? profile.name : `tid (${profile.threadId})`,
+      label: profile.name
+        ? `tid (${profile.threadId}): ${profile.name}`
+        : `tid (${profile.threadId})`,
       value: profile.threadId,
       details: (
         <ThreadLabelDetails


### PR DESCRIPTION
Threads can have identical names, so we need to include the thread ID to
distinguish between them.