### PR TITLE
feat(replay): Set a fixed height for the replay view depending on browser window size

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -10,9 +10,10 @@ import FastForwardBadge from './player/fastForwardBadge';
 
 interface Props {
   className?: string;
+  height?: number;
 }
 
-function BasePlayerRoot({className}: Props) {
+function BasePlayerRoot({className, height = Infinity}: Props) {
   const {
     initRoot,
     dimensions: videoDimensions,
@@ -54,9 +55,11 @@ function BasePlayerRoot({className}: Props) {
   // Update the scale of the view whenever dimensions have changed.
   useEffect(() => {
     if (viewEl.current) {
+      const windowHeight = height === Infinity ? windowDimensions.height : height;
+
       const scale = Math.min(
         windowDimensions.width / videoDimensions.width,
-        windowDimensions.height / videoDimensions.height,
+        windowHeight / videoDimensions.height,
         1
       );
       if (scale) {
@@ -66,10 +69,10 @@ function BasePlayerRoot({className}: Props) {
         viewEl.current.style.height = `${videoDimensions.height * scale}px`;
       }
     }
-  }, [windowDimensions, videoDimensions]);
+  }, [windowDimensions, videoDimensions, height]);
 
   return (
-    <SizingWindow ref={windowEl} className="sr-block">
+    <SizingWindow ref={windowEl} className="sr-block" minHeight={height}>
       <div ref={viewEl} className={className} />
       {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
       {isBuffering ? <PositionedBuffering /> : null}
@@ -80,14 +83,31 @@ function BasePlayerRoot({className}: Props) {
 // Center the viewEl inside the windowEl.
 // This is useful when the window is inside a container that has large fixed
 // dimensions, like when in fullscreen mode.
-const SizingWindow = styled('div')`
+const SizingWindow = styled('div')<{minHeight: number}>`
   width: 100%;
   height: 100%;
+  ${p => (p.minHeight !== Infinity ? `min-height: ${p.minHeight}px !important;` : '')}
 
   display: flex;
   justify-content: center;
   align-items: center;
   position: relative;
+
+  background-color: ${p => p.theme.backgroundSecondary};
+  background-image: repeating-linear-gradient(
+      -145deg,
+      transparent,
+      transparent 8px,
+      ${p => p.theme.backgroundSecondary} 8px,
+      ${p => p.theme.backgroundSecondary} 11px
+    ),
+    repeating-linear-gradient(
+      -45deg,
+      transparent,
+      transparent 15px,
+      ${p => p.theme.gray100} 15px,
+      ${p => p.theme.gray100} 16px
+    );
 `;
 
 const PositionedFastForward = styled(FastForwardBadge)`

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import debounce from 'lodash/debounce';
 
 import {Panel, PanelBody, PanelHeader as _PanelHeader} from 'sentry/components/panels';
 import HorizontalMouseTracking from 'sentry/components/replays/player/horizontalMouseTracking';
@@ -8,21 +9,48 @@ import ReplayController from 'sentry/components/replays/replayController';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 
+// How much to reveal under the player, so people can see the 'pagefold' and
+// know that they can scroll the page.
+const BOTTOM_REVEAL_PIXELS = 70;
+
 type Props = {
   isFullscreen: boolean;
   toggleFullscreen: () => void;
 };
 
 function ReplayView({isFullscreen, toggleFullscreen}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const playerRef = useRef<HTMLDivElement>(null);
+
+  const [windowInnerHeight, setWindowInnerHeight] = useState(window.innerHeight);
+  const [playerHeight, setPlayerHeight] = useState(0);
+
+  useEffect(() => {
+    const onResize = debounce(() => {
+      setWindowInnerHeight(window.innerHeight);
+    });
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+    };
+  }, []);
+
+  useEffect(() => {
+    const containerBottom =
+      (containerRef.current?.offsetTop || 0) + (containerRef.current?.offsetHeight || 0);
+    const playerOffsetHeight = playerRef.current?.offsetHeight || 0;
+    const calc =
+      windowInnerHeight - (containerBottom - playerOffsetHeight) - BOTTOM_REVEAL_PIXELS;
+    setPlayerHeight(Math.max(200, calc));
+  }, [windowInnerHeight]);
+
   return (
-    <PanelNoMargin isFullscreen={isFullscreen}>
+    <PanelNoMargin ref={containerRef} isFullscreen={isFullscreen}>
       <PanelHeader>
         <ReplayCurrentUrl />
       </PanelHeader>
-      <PanelHeader disablePadding noBorder>
-        <ManualResize isFullscreen={isFullscreen}>
-          <ReplayPlayer />
-        </ManualResize>
+      <PanelHeader ref={playerRef} disablePadding noBorder>
+        <ReplayPlayer height={isFullscreen ? Infinity : playerHeight} />
       </PanelHeader>
       <HorizontalMouseTracking>
         <PlayerScrubber />
@@ -50,21 +78,6 @@ const PanelHeader = styled(_PanelHeader)<{noBorder?: boolean}>`
   display: block;
   padding: 0;
   ${p => (p.noBorder ? 'border-bottom: none;' : '')}
-`;
-
-const ManualResize = styled('div')<{isFullscreen: boolean}>`
-  resize: vertical;
-  overflow: auto;
-  max-width: 100%;
-
-  ${p =>
-    p.isFullscreen
-      ? `resize: none;
-      /* use !important to override html attrs set by resize:vertical */
-      width: auto !important;
-      height: 100% !important;
-      `
-      : ''}
 `;
 
 export default ReplayView;


### PR DESCRIPTION
Resizes the Player based on the window width/height.

When the pageloads the player viewport will expand to be most of the size of the window, leaving half of the `<Timeline>` visible 'above the fold'.
Depending on the widht/height ratio of the captured page: you'll see empty space either on the sides, or above/below. 
The empty space has a subtle repeating background to make it easier to tell the edges of the captured page.
The whole Player section resizes if the browser window changes sizes, including in fullscreen mode.

The video will more than likely be scaled somewhat with this resize/scale feature. Going to fullscreen is the best chance to watch the replay at full resolution.

<img width="1315" alt="Screen Shot 2022-05-11 at 11 29 26 PM" src="https://user-images.githubusercontent.com/187460/167888695-1958db96-5f6e-4c93-b421-c4869de7cdca.png">
<img width="1315" alt="Screen Shot 2022-05-11 at 11 29 27 PM" src="https://user-images.githubusercontent.com/187460/167888735-e7d933d4-afba-403d-ad8b-e5b59da04856.png">

**Test Plan**

I was testing by loading up these pages: 
- https://dev.getsentry.net:7999/organizations/sentry-emerging-tech/replays/sourcemapsio-replays:0229ffafea534bb7b26c72907cef6c66/
- https://dev.getsentry.net:7999/organizations/sentry-emerging-tech/replays/dublin-test-project:4d512725a28346a0a2e1a5947c66a72c/#performance

One capture has a portrait orientation, and the other is horizontal. Then I adjust my window to different sizes and loaded each page. Also changed window sizes with the pages loaded, and going in/out of fullscreen.