### PR TITLE
feat(replays): Fix errors not being treated as a breadcrumb

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/utils.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/utils.tsx
@@ -134,29 +134,17 @@ function getCrumbDescriptionAndColor(
   }
 }
 
-export function transformCrumbs(breadcrumbs: Array<RawCrumb>): Crumb[] {
-  return breadcrumbs.map((breadcrumb, index) => {
-    const convertedCrumbType = convertCrumbType(breadcrumb);
-    const {color, description} = getCrumbDescriptionAndColor(convertedCrumbType.type);
-    return {
-      ...convertedCrumbType,
-      id: index,
-      color,
-      description,
-      level: convertedCrumbType.level ?? BreadcrumbLevelType.UNDEFINED,
-    };
-  });
+export function transformCrumb(breadcrumb: RawCrumb, index: number): Crumb {
+  const convertedCrumbType = convertCrumbType(breadcrumb);
+  const {color, description} = getCrumbDescriptionAndColor(convertedCrumbType.type);
+  return {
+    ...convertedCrumbType,
+    id: index,
+    color,
+    description,
+    level: convertedCrumbType.level ?? BreadcrumbLevelType.UNDEFINED,
+  };
 }
-
-// In the future if we want to show more items at
-// the EventChapter, we should add to this array.
-const USER_ACTIONS = [
-  BreadcrumbType.USER,
-  BreadcrumbType.UI,
-  BreadcrumbType.ERROR,
-  BreadcrumbType.NAVIGATION,
-];
-
-export function onlyUserActions(crumbs: Crumb[]): Crumb[] {
-  return crumbs.filter(crumb => USER_ACTIONS.includes(crumb.type));
+export function transformCrumbs(breadcrumbs: Array<RawCrumb>): Crumb[] {
+  return breadcrumbs.map(transformCrumb);
 }

--- a/static/app/types/breadcrumbs.tsx
+++ b/static/app/types/breadcrumbs.tsx
@@ -28,7 +28,6 @@ export enum BreadcrumbType {
   SYSTEM = 'system',
   SESSION = 'session',
   TRANSACTION = 'transaction',
-  CONSOLE = 'console',
 }
 
 type BreadcrumbTypeBase = {
@@ -77,14 +76,6 @@ export type BreadcrumbTypeHTTP = {
     status_code?: number;
     url?: string;
   };
-} & BreadcrumbTypeBase;
-
-export type BreadcrumbTypeConsole = {
-  data: {
-    arguments: any[];
-    logger: string;
-  };
-  type: BreadcrumbType.CONSOLE;
 } & BreadcrumbTypeBase;
 
 export type BreadcrumbTypeDefault = {

--- a/static/app/utils/replays/isErrorCrumb.tsx
+++ b/static/app/utils/replays/isErrorCrumb.tsx
@@ -1,0 +1,11 @@
+import type {RawCrumb} from 'sentry/types/breadcrumbs';
+
+/**
+ * This is what we are assuming are exceptions in breadcrumbs. This differs from
+ * the treatment in the Breadcrumbs component in Issue Details because that
+ * component creates a crumb from the exception event itself and not from the
+ * raw breadcrumb.
+ */
+export default function isErrorCrumb(crumb: RawCrumb) {
+  return crumb.category === 'sentry.event' && crumb.level === 'error';
+}

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -5,6 +5,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import TagsTable from 'sentry/components/tagsTable';
 import type {Entry, Event} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
+import isErrorCrumb from 'sentry/utils/replays/isErrorCrumb';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -24,9 +25,9 @@ type Props = {
 
 const DEFAULT_TAB = ReplayTabs.PERFORMANCE;
 
-function getBreadcrumbsByCategory(breadcrumbEntry: Entry, categories: string[]) {
-  return breadcrumbEntry.data.values.filter(breadcrumb =>
-    categories.includes(breadcrumb.category)
+function getBreadcrumbsForConsole(breadcrumbEntry: Entry) {
+  return breadcrumbEntry.data.values.filter(
+    breadcrumb => breadcrumb.category === 'console' || isErrorCrumb(breadcrumb)
   );
 }
 
@@ -61,10 +62,8 @@ function ActiveTab({active, replay}: Props & {active: ReplayTabs}) {
   switch (active) {
     case 'console':
       const breadcrumbEntry = replay.getEntryType(EntryType.BREADCRUMBS);
-      const consoleMessages = getBreadcrumbsByCategory(breadcrumbEntry, [
-        'console',
-        'error',
-      ]);
+      const consoleMessages = getBreadcrumbsForConsole(breadcrumbEntry);
+
       return (
         <div id="console">
           <Console breadcrumbs={consoleMessages ?? []} orgSlug={organization.slug} />


### PR DESCRIPTION
Errors captured as a breadcrumb have a category of "sentry.event" with level of "error". This is different from Issue Details, where we create a fake "exception" crumb using the error event itself (not from breadcrumbs). I believe the difference here is also the crumb error is captured from client side, and the error event is our processed error from the backend. In the replays, it makes sense to show the client error.