### PR TITLE
feat(replays): Add Tooltip to each item in the Chapters list with basic info

### DIFF
--- a/static/app/components/replays/actionCategory.tsx
+++ b/static/app/components/replays/actionCategory.tsx
@@ -12,8 +12,8 @@ type Props = {
 };
 
 type actionCategoryInfo = {
-  description?: string;
-  title?: string;
+  description: string;
+  title: string;
 };
 
 function getActionCategoryInfo(crumb: RawCrumb): actionCategoryInfo {

--- a/static/app/components/replays/actionCategory.tsx
+++ b/static/app/components/replays/actionCategory.tsx
@@ -3,68 +3,52 @@ import styled from '@emotion/styled';
 
 import Tooltip from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
-import {
-  BreadcrumbType,
-  BreadcrumbTypeHTTP,
-  BreadcrumbTypeNavigation,
-  RawCrumb,
-} from 'sentry/types/breadcrumbs';
+import {BreadcrumbType, RawCrumb} from 'sentry/types/breadcrumbs';
 
 import {convertCrumbType} from '../events/interfaces/breadcrumbs/utils';
 
 type Props = {
-  category: RawCrumb;
-  description?: BreadcrumbTypeNavigation | BreadcrumbTypeHTTP;
+  action: RawCrumb;
 };
 
-function getActionCategoryDescription(crumb: RawCrumb): string {
+type actionCategoryInfo = {
+  description?: string;
+  title?: string;
+};
+
+function getActionCategoryInfo(crumb: RawCrumb): actionCategoryInfo {
   switch (crumb.type) {
     case BreadcrumbType.USER:
     case BreadcrumbType.UI:
-      return t('UI Click');
-    case BreadcrumbType.HTTP:
-      return t('Fetch');
+      return {
+        title: t('UI Click'),
+        description: `${crumb.category}: ${crumb.message}`,
+      };
     case BreadcrumbType.NAVIGATION:
-      return t('Navigation');
+      return {
+        title: t('Navigation'),
+        description: `${crumb.category}: ${crumb.data?.from} => ${crumb.data?.to}`,
+      };
     case BreadcrumbType.ERROR:
-      return t('Error');
+      return {title: t('Error'), description: `${crumb.category}: ${crumb.message}`};
     default:
-      return '';
+      return {
+        title: '',
+        description: '',
+      };
   }
 }
 
-const ActionCategory = memo(function Category({category, description}: Props) {
-  const title = getActionCategoryDescription(convertCrumbType(category));
+const ActionCategory = memo(function Category({action}: Props) {
+  const {title, description} = getActionCategoryInfo(convertCrumbType(action));
 
   return (
-    <Wrapper>
-      <Tooltip
-        title={description}
-        disabled={!description}
-        skipWrapper
-        disableForVisualTest
-      >
-        <Value>{title}</Value>
-      </Tooltip>
-    </Wrapper>
+    <Tooltip title={description} disabled={!description} skipWrapper disableForVisualTest>
+      <Value>{title}</Value>
+    </Tooltip>
   );
 });
 
-const Wrapper = styled('div')`
-  display: flex;
-  justify-content: center;
-  position: relative;
-  :before {
-    content: '';
-    display: block;
-    width: 1px;
-    top: 0;
-    bottom: 0;
-    left: 50%;
-    transform: translate(-50%);
-    position: absolute;
-  }
-`;
 const Value = styled('div')`
   color: ${p => p.theme.headingColor};
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/components/replays/actionCategory.tsx
+++ b/static/app/components/replays/actionCategory.tsx
@@ -27,7 +27,9 @@ function getActionCategoryInfo(crumb: RawCrumb): actionCategoryInfo {
     case BreadcrumbType.NAVIGATION:
       return {
         title: t('Navigation'),
-        description: `${crumb.category}: ${crumb.data?.from} => ${crumb.data?.to}`,
+        description: `${crumb.category}: ${(crumb.data && crumb.data?.from) || ''} => ${
+          (crumb.data && crumb.data?.to) || ''
+        }`,
       };
     case BreadcrumbType.ERROR:
       return {title: t('Error'), description: `${crumb.category}: ${crumb.message}`};

--- a/static/app/components/replays/actionCategory.tsx
+++ b/static/app/components/replays/actionCategory.tsx
@@ -3,12 +3,10 @@ import styled from '@emotion/styled';
 
 import Tooltip from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
-import {BreadcrumbType, RawCrumb} from 'sentry/types/breadcrumbs';
-
-import {convertCrumbType} from '../events/interfaces/breadcrumbs/utils';
+import {BreadcrumbType, Crumb} from 'sentry/types/breadcrumbs';
 
 type Props = {
-  action: RawCrumb;
+  action: Crumb;
 };
 
 type actionCategoryInfo = {
@@ -16,7 +14,7 @@ type actionCategoryInfo = {
   title: string;
 };
 
-function getActionCategoryInfo(crumb: RawCrumb): actionCategoryInfo {
+function getActionCategoryInfo(crumb: Crumb): actionCategoryInfo {
   switch (crumb.type) {
     case BreadcrumbType.USER:
     case BreadcrumbType.UI:
@@ -41,8 +39,8 @@ function getActionCategoryInfo(crumb: RawCrumb): actionCategoryInfo {
   }
 }
 
-const ActionCategory = memo(function Category({action}: Props) {
-  const {title, description} = getActionCategoryInfo(convertCrumbType(action));
+const ActionCategory = memo(({action}: Props) => {
+  const {title, description} = getActionCategoryInfo(action);
 
   return (
     <Tooltip title={description} disabled={!description} skipWrapper disableForVisualTest>

--- a/static/app/components/replays/actionCategory.tsx
+++ b/static/app/components/replays/actionCategory.tsx
@@ -9,12 +9,12 @@ type Props = {
   action: Crumb;
 };
 
-type actionCategoryInfo = {
+type ActionCategoryInfo = {
   description: string;
   title: string;
 };
 
-function getActionCategoryInfo(crumb: Crumb): actionCategoryInfo {
+function getActionCategoryInfo(crumb: Crumb): ActionCategoryInfo {
   switch (crumb.type) {
     case BreadcrumbType.USER:
     case BreadcrumbType.UI:
@@ -25,12 +25,15 @@ function getActionCategoryInfo(crumb: Crumb): actionCategoryInfo {
     case BreadcrumbType.NAVIGATION:
       return {
         title: t('Navigation'),
-description: `${crumb.category}: ${crumb.data?.from ?? ''} => ${crumb.data?.to ?? ''}`
-          (crumb.data && crumb.data?.to) || ''
+        description: `${crumb.category}: ${crumb.data?.from ?? ''} => ${
+          crumb.data?.to ?? ''
         }`,
       };
     case BreadcrumbType.ERROR:
-      return {title: t('Error'), description: `${crumb.category}: ${crumb.message}`};
+      return {
+        title: t('Error'),
+        description: `${crumb.category}: ${crumb.message}`,
+      };
     default:
       return {
         title: t('Default'),

--- a/static/app/components/replays/actionCategory.tsx
+++ b/static/app/components/replays/actionCategory.tsx
@@ -33,7 +33,7 @@ function getActionCategoryInfo(crumb: Crumb): actionCategoryInfo {
       return {title: t('Error'), description: `${crumb.category}: ${crumb.message}`};
     default:
       return {
-        title: '',
+        title: t('Default'),
         description: '',
       };
   }

--- a/static/app/components/replays/actionCategory.tsx
+++ b/static/app/components/replays/actionCategory.tsx
@@ -25,7 +25,7 @@ function getActionCategoryInfo(crumb: Crumb): actionCategoryInfo {
     case BreadcrumbType.NAVIGATION:
       return {
         title: t('Navigation'),
-        description: `${crumb.category}: ${(crumb.data && crumb.data?.from) || ''} => ${
+description: `${crumb.category}: ${crumb.data?.from ?? ''} => ${crumb.data?.to ?? ''}`
           (crumb.data && crumb.data?.to) || ''
         }`,
       };

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -125,7 +125,7 @@ function UserActionsNavigator({event, crumbs}: Props) {
                     color={item.color}
                     description={item.description}
                   />
-                  <ActionCategory category={item} />
+                  <ActionCategory action={item} />
                 </Wrapper>
                 <PlayerRelativeTime
                   relativeTime={startTimestamp}


### PR DESCRIPTION
### Description

The existing breadcrumb component has many columns of data: type, category, description, level & time. This is too much data for us to show.

But we do want to give people an idea when they're looking at the Chapters.

Therefore, we want to show some metadata so people know more than just what type of action has happened.

Closes #34226 
Closes #34700 

### Screenshots
<img width="896" alt="image" src="https://user-images.githubusercontent.com/14813235/167916222-670f70ea-0835-464e-b649-da3fdaf7b277.png">

---