### PR TITLE
ref(compactSelect): Use translucent border on menu header

### DIFF
--- a/static/app/components/forms/compactSelect.tsx
+++ b/static/app/components/forms/compactSelect.tsx
@@ -333,10 +333,12 @@ const Overlay = styled('div')<{minWidth?: number}>`
 `;
 
 const MenuHeader = styled('div')`
+  position: relative;
   display: flex;
   justify-content: space-between;
   padding: ${space(0.25)} ${space(1)} ${space(0.25)} ${space(1.5)};
-  border-bottom: solid 1px ${p => p.theme.innerBorder};
+  box-shadow: 0 1px 0 ${p => p.theme.translucentInnerBorder};
+  z-index: 1;
 `;
 
 const MenuTitle = styled('span')`

--- a/static/app/components/forms/selectControl.tsx
+++ b/static/app/components/forms/selectControl.tsx
@@ -183,11 +183,13 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
         boxShadow: 'none',
         cursor: 'initial',
         minHeight: 'none',
-        ...(!isSearchable && {
-          height: 0,
-          padding: 0,
-          overflow: 'hidden',
-        }),
+        ...(isSearchable
+          ? {marginTop: 1}
+          : {
+              height: 0,
+              padding: 0,
+              overflow: 'hidden',
+            }),
       }),
     }),
 


### PR DESCRIPTION
**Before**
<img width="209" alt="image" src="https://user-images.githubusercontent.com/44172267/167929402-562291a0-668d-464e-a242-933b1c32b203.png">


**After**
<img width="210" alt="image" src="https://user-images.githubusercontent.com/44172267/167929350-6b209b0b-63ce-4d31-841d-348853c7b1d2.png">
