### PR TITLE
feat(events): Set a tag when user_modified param is sent

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -74,7 +74,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
 
         query_modified_by_user = request.GET.get("user_modified")
-        if query_modified_by_user is in ["True", "False"]:
+        if query_modified_by_user in ["True", "False"]:
             sentry_sdk.set_tag("query.user_modified", query_modified_by_user)
         referrer = (
             referrer if referrer in ALLOWED_EVENTS_V2_REFERRERS else "api.organization-events-v2"

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -72,6 +72,10 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
 
         sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
+
+        query_modified_by_user = request.GET.get("user_modified")
+        if query_modified_by_user is not None:
+            sentry_sdk.set_tag("query.user_modified", query_modified_by_user)
         referrer = (
             referrer if referrer in ALLOWED_EVENTS_V2_REFERRERS else "api.organization-events-v2"
         )

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -74,7 +74,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
 
         query_modified_by_user = request.GET.get("user_modified")
-        if query_modified_by_user is not None:
+        if query_modified_by_user is in ["True", "False"]:
             sentry_sdk.set_tag("query.user_modified", query_modified_by_user)
         referrer = (
             referrer if referrer in ALLOWED_EVENTS_V2_REFERRERS else "api.organization-events-v2"

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -156,6 +156,10 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
             allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
 
+            query_modified_by_user = request.GET.get("user_modified")
+            if query_modified_by_user is not None:
+                sentry_sdk.set_tag("query.user_modified", query_modified_by_user)
+
         def get_event_stats(
             query_columns: Sequence[str],
             query: str,

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -157,7 +157,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
 
             query_modified_by_user = request.GET.get("user_modified")
-            if query_modified_by_user is not None:
+            if query_modified_by_user in ["True", "False"]:
                 sentry_sdk.set_tag("query.user_modified", query_modified_by_user)
 
         def get_event_stats(


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR adds a feature for `eventsV2` and `events-stats` endpoints where if a client sends `user_modified` parameter in the payload, then a tag `query.user_modified` is set to the value of the provided param. If no param was sent, then no tag is set. This will give us a better insight into how/when users modify search queries so we can improve searching experience.

Fixes PERF-1562
