### PR TITLE
fix(profiling): Do not mutate profiles list

### DIFF
--- a/static/app/components/profiling/threadSelector.tsx
+++ b/static/app/components/profiling/threadSelector.tsx
@@ -25,7 +25,7 @@ function ThreadMenuSelector<OptionType extends GeneralSelectValue = GeneralSelec
   profileGroup,
 }: ThreadSelectorProps) {
   const options: SelectValue<number>[] = useMemo(() => {
-    return profileGroup.profiles.sort(compareProfiles).map(profile => ({
+    return [...profileGroup.profiles].sort(compareProfiles).map(profile => ({
       label: profile.name
         ? `tid (${profile.threadId}): ${profile.name}`
         : `tid (${profile.threadId})`,


### PR DESCRIPTION
Calling .sort will mutate the original list. This has the unintended side effect
of causing the profile indices to mismatch. Make a shallow copy of the list
before sorting.