### PR TITLE
feat(replays): Update hover timestamp when hovering a Chapter

### DIFF
--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -77,7 +77,9 @@ function UserActionsNavigator({event, crumbs}: Props) {
 
   const onMouseEnter = useCallback(
     (item: Crumb) => {
-      setCurrentHoverTime(relativeTimeInMs(item.timestamp ?? '', startTimestamp));
+      if (startTimestamp) {
+        setCurrentHoverTime(relativeTimeInMs(item.timestamp ?? '', startTimestamp));
+      }
     },
     [setCurrentHoverTime, startTimestamp]
   );

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -96,10 +96,6 @@ function UserActionsNavigator({event, crumbs}: Props) {
     getClosestUserAction(currentHoverTime);
   }, [getClosestUserAction, currentHoverTime]);
 
-  if (!event) {
-    return null;
-  }
-
   return (
     <Panel>
       <PanelHeader>{t('Event Chapters')}</PanelHeader>

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -50,7 +50,7 @@ type ContainerProps = {
 };
 
 function UserActionsNavigator({event, crumbs}: Props) {
-  const {setCurrentTime, currentHoverTime} = useReplayContext();
+  const {setCurrentTime, setCurrentHoverTime, currentHoverTime} = useReplayContext();
   const [currentUserAction, setCurrentUserAction] = useState<Crumb>();
   const [closestUserAction, setClosestUserAction] = useState<Crumb>();
 
@@ -83,6 +83,18 @@ function UserActionsNavigator({event, crumbs}: Props) {
     getClosestUserAction(currentHoverTime);
   }, [getClosestUserAction, currentHoverTime]);
 
+  if (!event) {
+    return null;
+  }
+
+  function onMouseEnter(item: Crumb) {
+    setCurrentHoverTime(relativeTimeInMs(item.timestamp ?? '', startTimestamp));
+  }
+
+  function onMouseLeave() {
+    setCurrentHoverTime(undefined);
+  }
+
   return (
     <Panel>
       <PanelHeader>{t('Event Chapters')}</PanelHeader>
@@ -93,6 +105,8 @@ function UserActionsNavigator({event, crumbs}: Props) {
           userActionCrumbs.map(item => (
             <PanelItemCenter
               key={item.id}
+              onMouseEnter={() => onMouseEnter(item)}
+              onMouseLeave={() => onMouseLeave()}
               onClick={() => {
                 setCurrentUserAction(item);
                 item.timestamp

--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -75,6 +75,17 @@ function UserActionsNavigator({event, crumbs}: Props) {
     [closestUserAction?.timestamp, startTimestamp, userActionCrumbs]
   );
 
+  const onMouseEnter = useCallback(
+    (item: Crumb) => {
+      setCurrentHoverTime(relativeTimeInMs(item.timestamp ?? '', startTimestamp));
+    },
+    [setCurrentHoverTime, startTimestamp]
+  );
+
+  const onMouseLeave = useCallback(() => {
+    setCurrentHoverTime(undefined);
+  }, [setCurrentHoverTime]);
+
   useEffect(() => {
     if (!currentHoverTime) {
       setClosestUserAction(undefined);
@@ -85,14 +96,6 @@ function UserActionsNavigator({event, crumbs}: Props) {
 
   if (!event) {
     return null;
-  }
-
-  function onMouseEnter(item: Crumb) {
-    setCurrentHoverTime(relativeTimeInMs(item.timestamp ?? '', startTimestamp));
-  }
-
-  function onMouseLeave() {
-    setCurrentHoverTime(undefined);
   }
 
   return (


### PR DESCRIPTION
### Description

- Hovering over a Chapter should update the hover timestamp and highlight it in scrubbers

Closes #34408 

### Screenshots

<img width="960" alt="image" src="https://user-images.githubusercontent.com/14813235/167932868-ebc2bfe3-7d9b-418c-85e6-4d1d536c278d.png">




---
