### PR TITLE
ref(span-tree): Remove No Children button from spanDetail

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -92,11 +92,7 @@ class SpanDetail extends Component<Props, State> {
     }
 
     if (this.props.childTransactions.length <= 0) {
-      return (
-        <StyledDiscoverButton size="xsmall" disabled>
-          {t('No Children')}
-        </StyledDiscoverButton>
-      );
+      return null;
     }
 
     const {span, trace, event, organization} = this.props;


### PR DESCRIPTION
When clicking on a span to open the span's details, by default, there would always be a disabled 'No Children' button, unless the span has an embedded transaction. After some discussion, we decided it's better to just not show this button for regular spans.

Fixes PERF-1551