### PR TITLE
ref: add pyproject.toml to "backend" files

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -41,10 +41,11 @@ backend_dependencies: &backend_dependencies
   - 'requirements-*.txt'
 
 backend_build_changes: &backend_build_changes
-  - 'Makefile'
-  - '.pre-commit-config.yaml'
-  - '.github/workflows/!(frontend)'
   - '.github/actions/setup-sentry/action.yml'
+  - '.github/workflows/!(frontend)'
+  - '.pre-commit-config.yaml'
+  - 'Makefile'
+  - 'pyproject.toml'
 
 backend: &backend
   - *backend_build_changes


### PR DESCRIPTION
without this (for example) changes to pytest's configuration could cause a primary-branch breakage as tests are skipped

I also `:sort`ed the `backend_build_changes` list