### PR TITLE
ref(apidocs): Leverage inheritance to consolidate repeated fields

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -10,7 +10,7 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import (
-    OrganizationProjectResponseDict,
+    OrganizationProjectResponse,
     ProjectSummarySerializer,
 )
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOTFOUND, RESPONSE_UNAUTHORIZED
@@ -32,7 +32,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         request=None,
         responses={
             200: inline_sentry_response_serializer(
-                "OrganizationProjectResponseDict", List[OrganizationProjectResponseDict]
+                "OrganizationProjectResponseDict", List[OrganizationProjectResponse]
             ),
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -165,23 +165,32 @@ def get_features_for_projects(
     return features_by_project
 
 
-class ProjectSerializerResponse(TypedDict):
+class _ProjectSerializerOptionalBaseResponse(TypedDict, total=False):
+    stats: Any
+    transactionStats: Any
+    sessionStats: Any
+
+
+class ProjectSerializerBaseResponse(_ProjectSerializerOptionalBaseResponse):
     id: str
-    slug: str
     name: str  # TODO: add deprecation about this field (not used in app)
-    isPublic: bool
+    slug: str
     isBookmarked: bool
-    color: str
-    dateCreated: datetime
-    firstEvent: datetime
-    firstTransactionEvent: bool
-    hasSessions: bool
-    features: List[str]
-    status: str  # TODO enum/literal
-    platform: str
-    isInternal: bool
     isMember: bool
     hasAccess: bool
+    dateCreated: datetime
+    features: List[str]
+    firstTransactionEvent: bool
+    hasSessions: bool
+    platform: Optional[str]
+    firstEvent: Optional[datetime]
+
+
+class ProjectSerializerResponse(ProjectSerializerBaseResponse):
+    isPublic: bool
+    color: str
+    status: str  # TODO enum/literal
+    isInternal: bool
     avatar: Any  # TODO: use Avatar type from other serializers
 
 
@@ -494,31 +503,18 @@ class LatestReleaseDict(TypedDict):
     version: str
 
 
-class _OrganizationProjectResponseDictOptional(TypedDict, total=False):
+class _OrganizationProjectOptionalResponse(TypedDict, total=False):
     latestDeploys: Optional[Dict[str, Dict[str, str]]]
-    stats: Any
-    transactionStats: Any
-    sessionStats: Any
 
 
-class OrganizationProjectResponseDict(_OrganizationProjectResponseDictOptional):
+class OrganizationProjectResponse(
+    _OrganizationProjectOptionalResponse, ProjectSerializerBaseResponse
+):
     team: Optional[TeamResponseDict]
     teams: List[TeamResponseDict]
-    id: str
-    name: str
-    slug: str
-    isBookmarked: bool
-    isMember: bool
-    hasAccess: bool
-    dateCreated: str
     eventProcessing: EventProcessingDict
-    features: List[str]
-    firstTransactionEvent: bool
-    hasSessions: bool
-    platform: Optional[str]
     platforms: List[str]
     hasUserReports: bool
-    firstEvent: Optional[str]
     environments: List[str]
     latestRelease: Optional[LatestReleaseDict]
 
@@ -620,8 +616,8 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
 
         return attrs
 
-    def serialize(self, obj, attrs, user) -> OrganizationProjectResponseDict:  # type: ignore
-        context = OrganizationProjectResponseDict(
+    def serialize(self, obj, attrs, user) -> OrganizationProjectResponse:  # type: ignore
+        context = OrganizationProjectResponse(
             team=attrs["teams"][0] if attrs["teams"] else None,
             teams=attrs["teams"],
             id=str(obj.id),


### PR DESCRIPTION
`ProjectSerializerResponse` and `OrganizationProjectResponse` had a lot of overlapping fields, and two nearly identical typeddicts. I consolidated the typedicts and renamed some classes for consistency
