### PR TITLE
ref(profiling): Lift and unify config views

### DIFF
--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -33,17 +33,17 @@ const useCachedMeasure = (string: string, font: string): Rect => {
 
 interface BoundTooltipProps {
   bounds: Rect;
-  canvas: FlamegraphCanvas;
   cursor: vec2 | null;
-  view: FlamegraphView;
+  flamegraphCanvas: FlamegraphCanvas;
+  flamegraphView: FlamegraphView;
   children?: React.ReactNode;
 }
 
 function BoundTooltip({
   bounds,
-  canvas,
+  flamegraphCanvas,
   cursor,
-  view,
+  flamegraphView,
   children,
 }: BoundTooltipProps): React.ReactElement | null {
   const tooltipRef = useRef<HTMLDivElement>(null);
@@ -79,13 +79,13 @@ function BoundTooltip({
   const physicalSpaceCursor = vec2.transformMat3(
     vec2.create(),
     cursor,
-    view.fromConfigView(canvas.physicalSpace)
+    flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
   );
 
   const logicalSpaceCursor = vec2.transformMat3(
     vec2.create(),
     physicalSpaceCursor,
-    canvas.physicalToLogicalSpace
+    flamegraphCanvas.physicalToLogicalSpace
   );
 
   let cursorHorizontalPosition = logicalSpaceCursor[0];

--- a/static/app/components/profiling/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph.tsx
@@ -193,26 +193,32 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
       return undefined;
     }
 
-    const observer = watchForResize(
-      [
-        flamegraphCanvasRef,
-        flamegraphOverlayCanvasRef,
-        flamegraphMiniMapCanvasRef,
-        flamegraphMiniMapOverlayCanvasRef,
-      ],
+    const flamegraphObserver = watchForResize(
+      [flamegraphCanvasRef, flamegraphOverlayCanvasRef],
       () => {
         const bounds = flamegraphCanvasRef.getBoundingClientRect();
         setCanvasBounds(new Rect(bounds.x, bounds.y, bounds.width, bounds.height));
 
-        flamegraphCanvas.resizePhysicalSpace();
-        flamegraphMiniMapCanvas.resizePhysicalSpace();
+        flamegraphCanvas.initPhysicalSpace();
         flamegraphView.resizeConfigSpace(flamegraphCanvas);
 
         canvasPoolManager.drawSync();
       }
     );
 
-    return () => observer.disconnect();
+    const flamegraphMiniMapObserver = watchForResize(
+      [flamegraphMiniMapCanvasRef, flamegraphMiniMapOverlayCanvasRef],
+      () => {
+        flamegraphMiniMapCanvas.initPhysicalSpace();
+
+        canvasPoolManager.drawSync();
+      }
+    );
+
+    return () => {
+      flamegraphObserver.disconnect();
+      flamegraphMiniMapObserver.disconnect();
+    };
   }, [
     canvasPoolManager,
     flamegraphCanvas,
@@ -254,28 +260,28 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
       <FlamegraphZoomViewMinimapContainer height={flamegraphTheme.SIZES.MINIMAP_HEIGHT}>
         <FlamegraphZoomViewMinimap
-          canvas={flamegraphMiniMapCanvas}
           canvasPoolManager={canvasPoolManager}
           flamegraph={flamegraph}
+          flamegraphMiniMapCanvas={flamegraphMiniMapCanvas}
           flamegraphMiniMapCanvasRef={flamegraphMiniMapCanvasRef}
           flamegraphMiniMapOverlayCanvasRef={flamegraphMiniMapOverlayCanvasRef}
+          flamegraphMiniMapView={flamegraphView}
           setFlamegraphMiniMapCanvasRef={setFlamegraphMiniMapCanvasRef}
           setFlamegraphMiniMapOverlayCanvasRef={setFlamegraphMiniMapOverlayCanvasRef}
-          view={flamegraphView}
         />
       </FlamegraphZoomViewMinimapContainer>
       <FlamegraphZoomViewContainer>
         <ProfileDragDropImport onImport={props.onImport}>
           <FlamegraphZoomView
-            canvas={flamegraphCanvas}
             canvasBounds={canvasBounds}
             canvasPoolManager={canvasPoolManager}
             flamegraph={flamegraph}
+            flamegraphCanvas={flamegraphCanvas}
             flamegraphCanvasRef={flamegraphCanvasRef}
             flamegraphOverlayCanvasRef={flamegraphOverlayCanvasRef}
+            flamegraphView={flamegraphView}
             setFlamegraphCanvasRef={setFlamegraphCanvasRef}
             setFlamegraphOverlayCanvasRef={setFlamegraphOverlayCanvasRef}
-            view={flamegraphView}
           />
         </ProfileDragDropImport>
       </FlamegraphZoomViewContainer>

--- a/static/app/components/profiling/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph.tsx
@@ -1,5 +1,6 @@
-import {Fragment, ReactElement, useMemo} from 'react';
+import {Fragment, ReactElement, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import {mat3, vec2} from 'gl-matrix';
 
 import {FlamegraphOptionsMenu} from 'sentry/components/profiling/flamegraphOptionsMenu';
 import {FlamegraphSearch} from 'sentry/components/profiling/flamegraphSearch';
@@ -12,15 +13,20 @@ import {
   ProfileDragDropImportProps,
 } from 'sentry/components/profiling/profileDragDropImport';
 import {ThreadMenuSelector} from 'sentry/components/profiling/threadSelector';
-import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {Flamegraph as FlamegraphModel} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/useFlamegraphPreferences';
 import {useFlamegraphProfiles} from 'sentry/utils/profiling/flamegraph/useFlamegraphProfiles';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
-import {Rect} from 'sentry/utils/profiling/gl/utils';
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
+import {Rect, watchForResize} from 'sentry/utils/profiling/gl/utils';
 import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
+import {useDevicePixelRatio} from 'sentry/utils/useDevicePixelRatio';
+import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
 
 function getTransactionConfigSpace(profiles: Profile[]): Rect {
   const startedAt = Math.min(...profiles.map(p => p.startedAt));
@@ -33,11 +39,27 @@ interface FlamegraphProps {
 }
 
 function Flamegraph(props: FlamegraphProps): ReactElement {
+  const devicePixelRatio = useDevicePixelRatio();
+
   const flamegraphTheme = useFlamegraphTheme();
   const [{sorting, view, xAxis}, dispatch] = useFlamegraphPreferences();
   const [{threadId}, dispatchThreadId] = useFlamegraphProfiles();
 
+  const [canvasBounds, setCanvasBounds] = useState<Rect>(Rect.Empty());
+
+  const [flamegraphCanvasRef, setFlamegraphCanvasRef] =
+    useState<HTMLCanvasElement | null>(null);
+  const [flamegraphOverlayCanvasRef, setFlamegraphOverlayCanvasRef] =
+    useState<HTMLCanvasElement | null>(null);
+
+  const [flamegraphMiniMapCanvasRef, setFlamegraphMiniMapCanvasRef] =
+    useState<HTMLCanvasElement | null>(null);
+  const [flamegraphMiniMapOverlayCanvasRef, setFlamegraphMiniMapOverlayCanvasRef] =
+    useState<HTMLCanvasElement | null>(null);
+
   const canvasPoolManager = useMemo(() => new CanvasPoolManager(), []);
+
+  const scheduler = useMemo(() => new CanvasScheduler(), []);
 
   const flamegraph = useMemo(() => {
     if (typeof threadId !== 'number') {
@@ -59,7 +81,149 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
           ? getTransactionConfigSpace(props.profiles.profiles)
           : undefined,
     });
-  }, [props.profiles, threadId, sorting, xAxis, view]);
+  }, [props.profiles, sorting, threadId, view, xAxis]);
+
+  const flamegraphCanvas = useMemo(() => {
+    if (!flamegraphCanvasRef) {
+      return null;
+    }
+    return new FlamegraphCanvas(
+      flamegraphCanvasRef,
+      vec2.fromValues(0, flamegraphTheme.SIZES.TIMELINE_HEIGHT * devicePixelRatio)
+    );
+  }, [devicePixelRatio, flamegraphCanvasRef, flamegraphTheme]);
+
+  const flamegraphMiniMapCanvas = useMemo(() => {
+    if (!flamegraphMiniMapCanvasRef) {
+      return null;
+    }
+    return new FlamegraphCanvas(flamegraphMiniMapCanvasRef, vec2.fromValues(0, 0));
+  }, [flamegraphMiniMapCanvasRef]);
+
+  const flamegraphView = useMemoWithPrevious<FlamegraphView | null>(
+    previousView => {
+      if (!flamegraphCanvas) {
+        return null;
+      }
+
+      const newView = new FlamegraphView({
+        canvas: flamegraphCanvas,
+        flamegraph,
+        theme: flamegraphTheme,
+      });
+
+      // if the profile we're rendering as a flamegraph has changed, we do not
+      // want to persist the config view
+      if (previousView?.flamegraph.profile === newView.flamegraph.profile) {
+        // if we're still looking at the same profile but only a preference other than
+        // left heavy has changed, we do want to persist the config view
+        if (previousView.flamegraph.leftHeavy === newView.flamegraph.leftHeavy) {
+          newView.setConfigView(
+            previousView.configView.withHeight(newView.configView.height)
+          );
+        }
+      }
+
+      return newView;
+    },
+    [flamegraph, flamegraphCanvas, flamegraphTheme]
+  );
+
+  useEffect(() => {
+    if (!flamegraphCanvas || !flamegraphView) {
+      return undefined;
+    }
+
+    const onConfigViewChange = (rect: Rect) => {
+      flamegraphView.setConfigView(rect);
+      canvasPoolManager.draw();
+    };
+
+    const onTransformConfigView = (mat: mat3) => {
+      flamegraphView.transformConfigView(mat);
+      canvasPoolManager.draw();
+    };
+
+    const onResetZoom = () => {
+      flamegraphView.resetConfigView(flamegraphCanvas);
+      canvasPoolManager.draw();
+    };
+
+    const onZoomIntoFrame = (frame: FlamegraphFrame) => {
+      flamegraphView.setConfigView(
+        new Rect(
+          frame.start,
+          frame.depth,
+          frame.end - frame.start,
+          flamegraphView.configView.height
+        )
+      );
+
+      canvasPoolManager.draw();
+    };
+
+    scheduler.on('setConfigView', onConfigViewChange);
+    scheduler.on('transformConfigView', onTransformConfigView);
+    scheduler.on('resetZoom', onResetZoom);
+    scheduler.on('zoomIntoFrame', onZoomIntoFrame);
+
+    return () => {
+      scheduler.off('setConfigView', onConfigViewChange);
+      scheduler.off('transformConfigView', onTransformConfigView);
+      scheduler.off('resetZoom', onResetZoom);
+      scheduler.off('zoomIntoFrame', onZoomIntoFrame);
+    };
+  }, [canvasPoolManager, flamegraphCanvas, flamegraphView, scheduler]);
+
+  useEffect(() => {
+    canvasPoolManager.registerScheduler(scheduler);
+    return () => canvasPoolManager.unregisterScheduler(scheduler);
+  }, [canvasPoolManager, scheduler]);
+
+  useEffect(() => {
+    if (
+      !flamegraphView ||
+      !flamegraphCanvas ||
+      !flamegraphMiniMapCanvas ||
+      !flamegraphCanvasRef ||
+      !flamegraphOverlayCanvasRef ||
+      !flamegraphMiniMapCanvasRef ||
+      !flamegraphMiniMapOverlayCanvasRef
+    ) {
+      return undefined;
+    }
+
+    const observer = watchForResize(
+      [
+        flamegraphCanvasRef,
+        flamegraphOverlayCanvasRef,
+        flamegraphMiniMapCanvasRef,
+        flamegraphMiniMapOverlayCanvasRef,
+      ],
+      () => {
+        const bounds = flamegraphCanvasRef.getBoundingClientRect();
+        setCanvasBounds(new Rect(bounds.x, bounds.y, bounds.width, bounds.height));
+
+        flamegraphCanvas.resizePhysicalSpace();
+        flamegraphMiniMapCanvas.resizePhysicalSpace();
+        flamegraphView.resizeConfigSpace(flamegraphCanvas);
+
+        canvasPoolManager.drawSync();
+      }
+    );
+
+    return () => observer.disconnect();
+  }, [
+    canvasPoolManager,
+    flamegraphCanvas,
+    flamegraphCanvasRef,
+    flamegraphMiniMapCanvas,
+    flamegraphMiniMapCanvasRef,
+    flamegraphMiniMapOverlayCanvasRef,
+    flamegraphOverlayCanvasRef,
+    flamegraphView,
+    setCanvasBounds,
+  ]);
 
   return (
     <Fragment>
@@ -90,15 +254,28 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
       <FlamegraphZoomViewMinimapContainer height={flamegraphTheme.SIZES.MINIMAP_HEIGHT}>
         <FlamegraphZoomViewMinimap
-          flamegraph={flamegraph}
+          canvas={flamegraphMiniMapCanvas}
           canvasPoolManager={canvasPoolManager}
+          flamegraph={flamegraph}
+          flamegraphMiniMapCanvasRef={flamegraphMiniMapCanvasRef}
+          flamegraphMiniMapOverlayCanvasRef={flamegraphMiniMapOverlayCanvasRef}
+          setFlamegraphMiniMapCanvasRef={setFlamegraphMiniMapCanvasRef}
+          setFlamegraphMiniMapOverlayCanvasRef={setFlamegraphMiniMapOverlayCanvasRef}
+          view={flamegraphView}
         />
       </FlamegraphZoomViewMinimapContainer>
       <FlamegraphZoomViewContainer>
         <ProfileDragDropImport onImport={props.onImport}>
           <FlamegraphZoomView
-            flamegraph={flamegraph}
+            canvas={flamegraphCanvas}
+            canvasBounds={canvasBounds}
             canvasPoolManager={canvasPoolManager}
+            flamegraph={flamegraph}
+            flamegraphCanvasRef={flamegraphCanvasRef}
+            flamegraphOverlayCanvasRef={flamegraphOverlayCanvasRef}
+            setFlamegraphCanvasRef={setFlamegraphCanvasRef}
+            setFlamegraphOverlayCanvasRef={setFlamegraphOverlayCanvasRef}
+            view={flamegraphView}
           />
         </ProfileDragDropImport>
       </FlamegraphZoomViewContainer>

--- a/static/app/utils/profiling/canvasScheduler.tsx
+++ b/static/app/utils/profiling/canvasScheduler.tsx
@@ -153,4 +153,16 @@ export class CanvasPoolManager {
       this.schedulers.delete(scheduler);
     }
   }
+
+  drawSync(): void {
+    for (const scheduler of this.schedulers) {
+      scheduler.drawSync();
+    }
+  }
+
+  draw(): void {
+    for (const scheduler of this.schedulers) {
+      scheduler.draw();
+    }
+  }
 }

--- a/static/app/utils/profiling/flamegraphCanvas.tsx
+++ b/static/app/utils/profiling/flamegraphCanvas.tsx
@@ -41,7 +41,4 @@ export class FlamegraphCanvas {
       this.logicalSpace
     );
   }
-
-  // alias provided for convenience
-  resizePhysicalSpace = this.initPhysicalSpace;
 }

--- a/static/app/utils/profiling/flamegraphCanvas.tsx
+++ b/static/app/utils/profiling/flamegraphCanvas.tsx
@@ -1,0 +1,47 @@
+import {mat3, vec2} from 'gl-matrix';
+
+import {Rect, Transform} from 'sentry/utils/profiling/gl/utils';
+
+export class FlamegraphCanvas {
+  canvas: HTMLCanvasElement;
+  origin: vec2;
+
+  physicalSpace: Rect = Rect.Empty();
+  logicalSpace: Rect = Rect.Empty();
+
+  physicalToLogicalSpace: mat3 = mat3.create();
+  logicalToPhysicalSpace: mat3 = mat3.create();
+
+  constructor(canvas: HTMLCanvasElement, origin: vec2) {
+    this.canvas = canvas;
+    this.origin = origin;
+    this.initPhysicalSpace();
+  }
+
+  initPhysicalSpace() {
+    this.physicalSpace = new Rect(
+      this.origin[0],
+      this.origin[1],
+      this.canvas.width - this.origin[0],
+      this.canvas.height - this.origin[1]
+    );
+
+    this.logicalSpace = this.physicalSpace.scale(
+      1 / window.devicePixelRatio,
+      1 / window.devicePixelRatio
+    );
+
+    this.logicalToPhysicalSpace = Transform.transformMatrixBetweenRect(
+      this.logicalSpace,
+      this.physicalSpace
+    );
+
+    this.physicalToLogicalSpace = Transform.transformMatrixBetweenRect(
+      this.physicalSpace,
+      this.logicalSpace
+    );
+  }
+
+  // alias provided for convenience
+  resizePhysicalSpace = this.initPhysicalSpace;
+}

--- a/static/app/utils/profiling/flamegraphView.tsx
+++ b/static/app/utils/profiling/flamegraphView.tsx
@@ -1,0 +1,149 @@
+import {mat3, vec2} from 'gl-matrix';
+
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {computeClampedConfigView, Rect, Transform} from 'sentry/utils/profiling/gl/utils';
+
+export class FlamegraphView {
+  flamegraph: Flamegraph;
+  theme: FlamegraphTheme;
+
+  configView: Rect = Rect.Empty();
+  configSpace: Rect = Rect.Empty();
+
+  constructor({
+    canvas,
+    flamegraph,
+    theme,
+  }: {
+    canvas: FlamegraphCanvas;
+    flamegraph: Flamegraph;
+    theme: FlamegraphTheme;
+  }) {
+    this.flamegraph = flamegraph;
+    this.theme = theme;
+    this.initConfigSpace(canvas);
+  }
+
+  private _initConfigSpace(canvas: FlamegraphCanvas): void {
+    const BAR_HEIGHT = this.theme.SIZES.BAR_HEIGHT * window.devicePixelRatio;
+
+    this.configSpace = new Rect(
+      0,
+      0,
+      this.flamegraph.configSpace.width,
+      Math.max(
+        this.flamegraph.depth + this.theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET + 1,
+        canvas.physicalSpace.height / BAR_HEIGHT
+      )
+    );
+  }
+
+  private _initConfigView(canvas: FlamegraphCanvas, space: Rect): void {
+    const BAR_HEIGHT = this.theme.SIZES.BAR_HEIGHT * window.devicePixelRatio;
+
+    this.configView = Rect.From(space).withHeight(
+      canvas.physicalSpace.height / BAR_HEIGHT
+    );
+  }
+
+  initConfigSpace(canvas: FlamegraphCanvas): void {
+    this._initConfigSpace(canvas);
+    this._initConfigView(canvas, this.configSpace);
+  }
+
+  resizeConfigSpace(canvas: FlamegraphCanvas): void {
+    this._initConfigSpace(canvas);
+    this._initConfigView(canvas, this.configView);
+  }
+
+  resetConfigView(canvas: FlamegraphCanvas): void {
+    this._initConfigView(canvas, this.configSpace);
+  }
+
+  setConfigView(configView: Rect) {
+    this.configView = computeClampedConfigView(configView, {
+      width: {
+        min: this.flamegraph.profile.minFrameDuration,
+        max: this.configSpace.width,
+      },
+      height: {
+        min: 0,
+        max: this.configSpace.height,
+      },
+    });
+  }
+
+  transformConfigView(transformation: mat3) {
+    this.setConfigView(this.configView.transformRect(transformation));
+  }
+
+  toConfigSpace(space: Rect): mat3 {
+    const toConfigSpace = Transform.transformMatrixBetweenRect(space, this.configSpace);
+
+    if (this.flamegraph.inverted) {
+      mat3.multiply(toConfigSpace, this.configSpace.invertYTransform(), toConfigSpace);
+    }
+
+    return toConfigSpace;
+  }
+
+  toConfigView(space: Rect): mat3 {
+    const toConfigView = Transform.transformMatrixBetweenRect(space, this.configView);
+
+    if (this.flamegraph.inverted) {
+      mat3.multiply(toConfigView, this.configView.invertYTransform(), toConfigView);
+    }
+
+    return toConfigView;
+  }
+
+  fromConfigSpace(space: Rect): mat3 {
+    const fromConfigSpace = Transform.transformMatrixBetweenRect(this.configSpace, space);
+
+    if (this.flamegraph.inverted) {
+      mat3.multiply(fromConfigSpace, space.invertYTransform(), fromConfigSpace);
+    }
+
+    return fromConfigSpace;
+  }
+
+  fromConfigView(space: Rect): mat3 {
+    const fromConfigView = Transform.transformMatrixBetweenRect(this.configView, space);
+
+    if (this.flamegraph.inverted) {
+      mat3.multiply(fromConfigView, space.invertYTransform(), fromConfigView);
+    }
+
+    return fromConfigView;
+  }
+
+  getConfigSpaceCursor(logicalSpaceCursor: vec2, canvas: FlamegraphCanvas): vec2 {
+    const physicalSpaceCursor = vec2.transformMat3(
+      vec2.create(),
+      logicalSpaceCursor,
+      canvas.logicalToPhysicalSpace
+    );
+
+    return vec2.transformMat3(
+      vec2.create(),
+      physicalSpaceCursor,
+      this.toConfigSpace(canvas.physicalSpace)
+    );
+  }
+
+  getConfigViewCursor(logicalSpaceCursor: vec2, canvas: FlamegraphCanvas): vec2 {
+    const physicalSpaceCursor = vec2.transformMat3(
+      vec2.create(),
+      logicalSpaceCursor,
+      canvas.logicalToPhysicalSpace
+    );
+
+    return vec2.transformMat3(
+      vec2.create(),
+      physicalSpaceCursor,
+      this.toConfigView(canvas.physicalSpace)
+    );
+  }
+}

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -5,14 +5,12 @@ import {FlamegraphTheme} from '../flamegraph/flamegraphTheme';
 import {FlamegraphFrame} from '../flamegraphFrame';
 import {Frame} from '../frame';
 import {
-  computeClampedConfigView,
   createProgram,
   createShader,
   getContext,
   makeProjectionMatrix,
   Rect,
   resizeCanvasToDisplaySize,
-  Transform,
 } from '../gl/utils';
 
 import {fragment, vertex} from './shaders';
@@ -25,7 +23,6 @@ class FlamegraphRenderer {
   program: WebGLProgram | null = null;
 
   theme: FlamegraphTheme;
-  origin: vec2;
   frames: ReadonlyArray<FlamegraphFrame> = [];
   roots: ReadonlyArray<FlamegraphFrame> = [];
 
@@ -35,15 +32,6 @@ class FlamegraphRenderer {
   colors: Array<number> = [];
 
   colorMap: Map<string | number, number[]> = new Map();
-
-  logicalSpace: Rect = Rect.Empty();
-  logicalToPhysicalSpace: mat3 = mat3.create();
-
-  physicalSpace: Rect = new Rect(0, 0, 0, 0);
-  physicalToLogicalSpace: mat3 = mat3.create();
-
-  configSpace: Rect = new Rect(0, 0, 0, 0);
-  configView: Rect = new Rect(0, 0, 0, 0);
 
   lastDragPosition: vec2 | null = null;
 
@@ -79,13 +67,11 @@ class FlamegraphRenderer {
     canvas: HTMLCanvasElement,
     flamegraph: Flamegraph,
     theme: FlamegraphTheme,
-    origin: vec2 = vec2.fromValues(0, 0),
     options: {draw_border: boolean} = {draw_border: false}
   ) {
     this.flamegraph = flamegraph;
     this.canvas = canvas;
     this.theme = theme;
-    this.origin = origin;
     this.options = options;
 
     this.init();
@@ -109,129 +95,8 @@ class FlamegraphRenderer {
     this.colors = colorBuffer;
 
     this.initCanvasContext();
-    this.initPhysicalSpace();
-    this.initConfigSpace();
     this.initVertices();
     this.initShaders();
-  }
-
-  initPhysicalSpace(): void {
-    if (!this.gl) {
-      throw new Error('Uninitialized WebGL context');
-    }
-
-    // Setup physical space which may differ depending on device px ratio
-    this.physicalSpace = new Rect(
-      this.origin[0],
-      this.origin[1],
-      this.gl.canvas.width - this.origin[0],
-      this.gl.canvas.height - this.origin[1]
-    );
-    this.logicalSpace = this.physicalSpace.scale(
-      1 / window.devicePixelRatio,
-      1 / window.devicePixelRatio
-    );
-
-    this.logicalToPhysicalSpace = Transform.transformMatrixBetweenRect(
-      this.logicalSpace,
-      this.physicalSpace
-    );
-    this.physicalToLogicalSpace = mat3.invert(mat3.create(), this.logicalToPhysicalSpace);
-  }
-
-  get logicalSpaceToConfigView(): mat3 {
-    const logicalSpaceToConfigView = Transform.transformMatrixBetweenRect(
-      this.logicalSpace,
-      this.configView
-    );
-
-    if (this.flamegraph.inverted) {
-      mat3.multiply(
-        logicalSpaceToConfigView,
-        this.configSpace.invertYTransform(),
-        logicalSpaceToConfigView
-      );
-    }
-
-    return logicalSpaceToConfigView;
-  }
-
-  get configSpaceToPhysicalSpace(): mat3 {
-    const configSpaceToPhysicalSpace = Transform.transformMatrixBetweenRect(
-      this.configSpace,
-      this.physicalSpace
-    );
-
-    if (this.flamegraph.inverted) {
-      mat3.multiply(
-        configSpaceToPhysicalSpace,
-        this.physicalSpace.invertYTransform(),
-        configSpaceToPhysicalSpace
-      );
-    }
-
-    return configSpaceToPhysicalSpace;
-  }
-
-  get configViewToPhysicalSpace(): mat3 {
-    const configViewToPhysicalSpace = Transform.transformMatrixBetweenRect(
-      this.configView,
-      this.physicalSpace
-    );
-
-    if (this.flamegraph.inverted) {
-      mat3.multiply(
-        configViewToPhysicalSpace,
-        this.physicalSpace.invertYTransform(),
-        configViewToPhysicalSpace
-      );
-    }
-
-    return configViewToPhysicalSpace;
-  }
-
-  initConfigSpace(): void {
-    const BAR_HEIGHT = this.theme.SIZES.BAR_HEIGHT * window.devicePixelRatio;
-
-    this.configSpace = new Rect(
-      0,
-      0,
-      this.flamegraph.configSpace.width,
-      Math.max(
-        this.flamegraph.depth + this.theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET + 1,
-        this.physicalSpace.height / BAR_HEIGHT
-      )
-    );
-
-    this.resetConfigView();
-  }
-
-  resetConfigView(): void {
-    const BAR_HEIGHT = this.theme.SIZES.BAR_HEIGHT * window.devicePixelRatio;
-
-    this.configView = Rect.From(this.configSpace).withHeight(
-      this.physicalSpace.height / BAR_HEIGHT
-    );
-  }
-
-  onResizeUpdateSpace(): void {
-    this.initPhysicalSpace();
-
-    const BAR_HEIGHT = this.theme.SIZES.BAR_HEIGHT * window.devicePixelRatio;
-
-    this.configSpace = new Rect(
-      0,
-      0,
-      this.flamegraph.configSpace.width,
-      Math.max(
-        this.flamegraph.depth + this.theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET + 1,
-        this.physicalSpace.height / BAR_HEIGHT
-      )
-    );
-
-    this.configView = Rect.From(this.configView).withHeight(
-      this.physicalSpace.height / BAR_HEIGHT
-    );
   }
 
   initVertices(): void {
@@ -290,6 +155,10 @@ class FlamegraphRenderer {
     }
     // Setup webgl canvas context
     this.gl = getContext(this.canvas, 'webgl');
+
+    if (!this.gl) {
+      throw new Error('Uninitialized WebGL context');
+    }
 
     this.gl.enable(this.gl.BLEND);
     this.gl.blendFuncSeparate(
@@ -479,53 +348,8 @@ class FlamegraphRenderer {
     this.gl.useProgram(this.program);
   }
 
-  setConfigView(configView: Rect): Rect {
-    this.configView = computeClampedConfigView(configView, {
-      width: {
-        min: this.flamegraph.profile.minFrameDuration,
-        max: this.configSpace.width,
-      },
-      height: {
-        min: 0,
-        max: this.configSpace.height,
-      },
-    });
-    return this.configView;
-  }
-
-  transformConfigView(transformation: mat3): Rect {
-    const newConfigView = this.configView.transformRect(transformation);
-
-    this.configView = computeClampedConfigView(newConfigView, {
-      width: {
-        min: this.flamegraph.profile.minFrameDuration,
-        max: this.configSpace.width,
-      },
-      height: {
-        min: 0,
-        max: this.configSpace.height,
-      },
-    });
-
-    return this.configView;
-  }
-
   getColorForFrame(frame: Frame): number[] {
     return this.colorMap.get(frame.key) ?? this.theme.COLORS.FRAME_FALLBACK_COLOR;
-  }
-
-  getConfigSpaceCursor(
-    logicalSpaceCursor: vec2,
-    configViewToPhysicalSpace: mat3 = this.configViewToPhysicalSpace
-  ): vec2 {
-    const physicalSpaceCursor = vec2.transformMat3(
-      vec2.create(),
-      logicalSpaceCursor,
-      this.logicalToPhysicalSpace
-    );
-
-    const physicalToConfig = mat3.invert(mat3.create(), configViewToPhysicalSpace);
-    return vec2.transformMat3(vec2.create(), physicalSpaceCursor, physicalToConfig);
   }
 
   getHoveredNode(configSpaceCursor: vec2): FlamegraphFrame | null {
@@ -566,8 +390,8 @@ class FlamegraphRenderer {
   }
 
   draw(
-    searchResults: Record<FlamegraphFrame['frame']['key'], FlamegraphFrame> | null,
-    configViewToPhysicalSpace = this.configViewToPhysicalSpace
+    configViewToPhysicalSpace: mat3,
+    searchResults: Record<FlamegraphFrame['frame']['key'], FlamegraphFrame> | null = null
   ): void {
     if (!this.gl) {
       throw new Error('Uninitialized WebGL context');

--- a/tests/js/sentry-test/profiling/utils.tsx
+++ b/tests/js/sentry-test/profiling/utils.tsx
@@ -1,0 +1,84 @@
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {EventedProfile} from 'sentry/utils/profiling/profile/eventedProfile';
+import {createFrameIndex} from 'sentry/utils/profiling/profile/utils';
+
+export const makeContextMock = (
+  partialMock: Partial<WebGLRenderingContext> = {}
+): WebGLRenderingContext => {
+  const context: Partial<WebGLRenderingContext> = {
+    attachShader: jest.fn(),
+    bufferData: jest.fn(),
+    blendFuncSeparate: jest.fn(),
+    bindBuffer: jest.fn(),
+    clearColor: jest.fn(),
+    clear: jest.fn(),
+    createShader: jest.fn().mockReturnValue({}),
+    createProgram: jest.fn().mockReturnValue({}),
+    createBuffer: jest.fn().mockReturnValue([]),
+    compileShader: jest.fn(),
+    drawArrays: jest.fn(),
+    enable: jest.fn(),
+    enableVertexAttribArray: jest.fn(),
+    getShaderParameter: jest.fn().mockReturnValue(1),
+    getProgramParameter: jest.fn().mockReturnValue({}),
+    getUniformLocation: jest.fn().mockReturnValue({}),
+    getAttribLocation: jest.fn().mockReturnValue({}),
+    linkProgram: jest.fn(),
+    shaderSource: jest.fn(),
+    uniformMatrix3fv: jest.fn(),
+    uniform1i: jest.fn(),
+    uniform2f: jest.fn(),
+    useProgram: jest.fn(),
+    vertexAttribPointer: jest.fn(),
+    viewport: jest.fn(),
+
+    // @ts-ignore
+    canvas: {
+      width: 1000,
+      height: 1000,
+    },
+    ...partialMock,
+  };
+
+  return context as WebGLRenderingContext;
+};
+
+export const makeCanvasMock = (
+  partialMock: Partial<HTMLCanvasElement> = {}
+): HTMLCanvasElement => {
+  const canvas: Partial<HTMLCanvasElement> = {
+    getContext: jest.fn().mockReturnValue(makeContextMock()),
+    height: 1000,
+    width: 1000,
+    ...partialMock,
+  };
+
+  return canvas as HTMLCanvasElement;
+};
+
+const base: Profiling.EventedProfile = {
+  name: 'profile',
+  startValue: 0,
+  endValue: 10,
+  unit: 'milliseconds',
+  type: 'evented',
+  threadID: 0,
+  events: [
+    {type: 'O', at: 0, frame: 0},
+    {type: 'C', at: 10, frame: 0},
+  ],
+};
+
+export const makeFlamegraph = (
+  trace?: Partial<Profiling.EventedProfile>,
+  frames?: Profiling.Schema['shared']['frames']
+): Flamegraph => {
+  return new Flamegraph(
+    EventedProfile.FromProfile(
+      trace ? {...base, ...trace} : base,
+      createFrameIndex(frames ?? [{name: 'f0'}])
+    ),
+    0,
+    {inverted: false, leftHeavy: false}
+  );
+};

--- a/tests/js/spec/utils/profiling/flamegraphCanvas.spec.tsx
+++ b/tests/js/spec/utils/profiling/flamegraphCanvas.spec.tsx
@@ -52,6 +52,21 @@ describe('flamegraphCanvas', () => {
     );
   });
 
+  it('initializes physicalToLogicalSpace', () => {
+    window.devicePixelRatio = 2;
+    // @ts-ignore partial mock
+    const context = makeContextMock({canvas: {width: 100, height: 100}});
+    const canvas = makeCanvasMock({
+      getContext: jest.fn().mockReturnValue(context),
+    });
+
+    const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(10, 10));
+
+    expect(flamegraphCanvas.physicalToLogicalSpace).toEqual(
+      mat3.fromScaling(mat3.create(), vec2.fromValues(0.5, 0.5))
+    );
+  });
+
   it('handles resize events by updating space', () => {
     // @ts-ignore partial canvas mock
     const canvas = makeCanvasMock({
@@ -62,10 +77,11 @@ describe('flamegraphCanvas', () => {
     const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
 
     expect(flamegraphCanvas.physicalSpace).toEqual(new Rect(0, 0, 100, 100));
+
     canvas.width = 200;
     canvas.height = 200;
+    flamegraphCanvas.initPhysicalSpace();
 
-    flamegraphCanvas.resizePhysicalSpace();
     expect(flamegraphCanvas.physicalSpace).toEqual(new Rect(0, 0, 200, 200));
   });
 });

--- a/tests/js/spec/utils/profiling/flamegraphCanvas.spec.tsx
+++ b/tests/js/spec/utils/profiling/flamegraphCanvas.spec.tsx
@@ -1,0 +1,71 @@
+import {mat3, vec2} from 'gl-matrix';
+
+import {makeCanvasMock, makeContextMock} from 'sentry-test/profiling/utils';
+
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {Rect} from 'sentry/utils/profiling/gl/utils';
+
+describe('flamegraphCanvas', () => {
+  beforeEach(() => {
+    // We simulate regular screens unless differently specified
+    window.devicePixelRatio = 1;
+  });
+
+  it('initializes physical space', () => {
+    const canvas = makeCanvasMock();
+    const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+    expect(flamegraphCanvas.physicalSpace).toEqual(new Rect(0, 0, 1000, 1000));
+  });
+
+  it('initializes physical space with origin', () => {
+    const canvas = makeCanvasMock();
+    const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(10, 10));
+    expect(flamegraphCanvas.physicalSpace).toEqual(new Rect(10, 10, 990, 990));
+  });
+
+  it('initializes logical space', () => {
+    window.devicePixelRatio = 2;
+    const canvas = makeCanvasMock();
+    const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+    expect(flamegraphCanvas.logicalSpace).toEqual(new Rect(0, 0, 500, 500));
+  });
+
+  it('initializes logical space with origin', () => {
+    window.devicePixelRatio = 2;
+    const canvas = makeCanvasMock();
+    const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(10, 10));
+    expect(flamegraphCanvas.logicalSpace).toEqual(new Rect(5, 5, 495, 495));
+  });
+
+  it('initializes logicalToPhysicalSpace', () => {
+    window.devicePixelRatio = 2;
+    // @ts-ignore partial mock
+    const context = makeContextMock({canvas: {width: 100, height: 100}});
+    const canvas = makeCanvasMock({
+      getContext: jest.fn().mockReturnValue(context),
+    });
+
+    const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(10, 10));
+
+    expect(flamegraphCanvas.logicalToPhysicalSpace).toEqual(
+      mat3.fromScaling(mat3.create(), vec2.fromValues(2, 2))
+    );
+  });
+
+  it('handles resize events by updating space', () => {
+    // @ts-ignore partial canvas mock
+    const canvas = makeCanvasMock({
+      width: 100,
+      height: 100,
+    });
+
+    const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+
+    expect(flamegraphCanvas.physicalSpace).toEqual(new Rect(0, 0, 100, 100));
+    canvas.width = 200;
+    canvas.height = 200;
+
+    flamegraphCanvas.resizePhysicalSpace();
+    expect(flamegraphCanvas.physicalSpace).toEqual(new Rect(0, 0, 200, 200));
+  });
+});

--- a/tests/js/spec/utils/profiling/flamegraphView.spec.tsx
+++ b/tests/js/spec/utils/profiling/flamegraphView.spec.tsx
@@ -1,0 +1,189 @@
+import {vec2} from 'gl-matrix';
+
+import {
+  makeCanvasMock,
+  makeContextMock,
+  makeFlamegraph,
+} from 'sentry-test/profiling/utils';
+
+import {LightFlamegraphTheme as theme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
+import {Rect} from 'sentry/utils/profiling/gl/utils';
+
+describe('flamegraphView', () => {
+  beforeEach(() => {
+    // We simulate regular screens unless differently specified
+    window.devicePixelRatio = 1;
+  });
+
+  describe('initializes', () => {
+    it('initializes config space', () => {
+      const canvas = makeCanvasMock();
+      const flamegraph = makeFlamegraph();
+      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+      const flamegraphView = new FlamegraphView({
+        canvas: flamegraphCanvas,
+        flamegraph,
+        theme,
+      });
+      expect(flamegraphView.configSpace).toEqual(new Rect(0, 0, 10, 50));
+    });
+
+    it('initializes config view', () => {
+      const canvas = makeCanvasMock();
+      const flamegraph = makeFlamegraph();
+      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+      const flamegraphView = new FlamegraphView({
+        canvas: flamegraphCanvas,
+        flamegraph,
+        theme,
+      });
+      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 50));
+    });
+
+    it('initializes config view with insufficient height', () => {
+      const canvas = makeCanvasMock({width: 1000, height: 100});
+      const flamegraph = makeFlamegraph();
+      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+      const flamegraphView = new FlamegraphView({
+        canvas: flamegraphCanvas,
+        flamegraph,
+        theme,
+      });
+      // 20 pixels tall each, and canvas is 100 pixels tall
+      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 5));
+    });
+  });
+
+  describe('getConfigSpaceCursor', () => {
+    it('when view is not zoomed', () => {
+      const canvas = makeCanvasMock({
+        getContext: jest
+          .fn()
+          // @ts-ignore
+          .mockReturnValue(makeContextMock({canvas: {width: 1000, height: 2000}})),
+      });
+
+      const flamegraph = makeFlamegraph({startValue: 0, endValue: 100});
+
+      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+      const flamegraphView = new FlamegraphView({
+        canvas: flamegraphCanvas,
+        flamegraph,
+        theme,
+      });
+
+      // x=250 is 1/4 of the width of the viewport, so it should map to flamegraph duration / 4
+      // y=250 is at 1/8th the height of the viewport, so it should map to view height / 8
+      const cursor = flamegraphView.getConfigSpaceCursor(
+        vec2.fromValues(250, 250),
+        flamegraphCanvas
+      );
+      expect(cursor).toEqual(vec2.fromValues(25, 2000 / theme.SIZES.BAR_HEIGHT / 8));
+    });
+  });
+
+  describe('setConfigView', () => {
+    const canvas = makeCanvasMock();
+    const flamegraph = makeFlamegraph(
+      {
+        startValue: 0,
+        endValue: 1000,
+        events: [
+          {type: 'O', frame: 0, at: 0},
+          {type: 'C', frame: 0, at: 500},
+        ],
+      },
+      [{name: 'f0'}]
+    );
+
+    it('does not allow zooming in more than the min width of a frame', () => {
+      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+      const flamegraphView = new FlamegraphView({
+        canvas: flamegraphCanvas,
+        flamegraph,
+        theme,
+      });
+
+      flamegraphView.setConfigView(new Rect(0, 0, 10, 50));
+      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 500, 50));
+    });
+
+    it('does not allow zooming out more than the duration of a profile', () => {
+      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+      const flamegraphView = new FlamegraphView({
+        canvas: flamegraphCanvas,
+        flamegraph,
+        theme,
+      });
+
+      flamegraphView.setConfigView(new Rect(0, 0, 2000, 50));
+      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
+    });
+
+    describe('edge detection on X axis', () => {
+      it('is not zoomed in', () => {
+        const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+        const flamegraphView = new FlamegraphView({
+          canvas: flamegraphCanvas,
+          flamegraph,
+          theme,
+        });
+
+        // Check that we cant go negative X from start of profile
+        flamegraphView.setConfigView(new Rect(-100, 0, 1000, 50));
+        expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
+
+        // Check that we cant go over X from end of profile
+        flamegraphView.setConfigView(new Rect(2000, 0, 1000, 50));
+        expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
+      });
+
+      it('is zoomed in', () => {
+        const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+        const flamegraphView = new FlamegraphView({
+          canvas: flamegraphCanvas,
+          flamegraph,
+          theme,
+        });
+
+        // Duration is is 1000, so we can't go over the end of the profile
+        flamegraphView.setConfigView(new Rect(600, 0, 500, 50));
+        expect(flamegraphView.configView).toEqual(new Rect(500, 0, 500, 50));
+      });
+    });
+
+    describe('edge detection on Y axis', () => {
+      it('is not zoomed in', () => {
+        const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+        const flamegraphView = new FlamegraphView({
+          canvas: flamegraphCanvas,
+          flamegraph,
+          theme,
+        });
+
+        // Check that we cant go under stack height
+        flamegraphView.setConfigView(new Rect(0, -50, 1000, 50));
+        expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
+
+        // Check that we cant go over stack height
+        flamegraphView.setConfigView(new Rect(0, 50, 1000, 50));
+        expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
+      });
+
+      it('is zoomed in', () => {
+        const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+        const flamegraphView = new FlamegraphView({
+          canvas: flamegraphCanvas,
+          flamegraph,
+          theme,
+        });
+
+        // Check that we cant go over stack height
+        flamegraphView.setConfigView(new Rect(0, 50, 1000, 25));
+        expect(flamegraphView.configView).toEqual(new Rect(0, 25, 1000, 25));
+      });
+    });
+  });
+});

--- a/tests/js/spec/utils/profiling/flamegraphView.spec.tsx
+++ b/tests/js/spec/utils/profiling/flamegraphView.spec.tsx
@@ -6,10 +6,26 @@ import {
   makeFlamegraph,
 } from 'sentry-test/profiling/utils';
 
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {LightFlamegraphTheme as theme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
+
+const makeCanvasAndView = (
+  canvas: HTMLCanvasElement,
+  flamegraph: Flamegraph,
+  origin: vec2 = vec2.fromValues(0, 0)
+) => {
+  const flamegraphCanvas = new FlamegraphCanvas(canvas, origin);
+  const flamegraphView = new FlamegraphView({
+    canvas: flamegraphCanvas,
+    flamegraph,
+    theme,
+  });
+
+  return {flamegraphCanvas, flamegraphView};
+};
 
 describe('flamegraphView', () => {
   beforeEach(() => {
@@ -21,38 +37,50 @@ describe('flamegraphView', () => {
     it('initializes config space', () => {
       const canvas = makeCanvasMock();
       const flamegraph = makeFlamegraph();
-      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-      const flamegraphView = new FlamegraphView({
-        canvas: flamegraphCanvas,
-        flamegraph,
-        theme,
-      });
+      const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
       expect(flamegraphView.configSpace).toEqual(new Rect(0, 0, 10, 50));
     });
 
     it('initializes config view', () => {
       const canvas = makeCanvasMock();
       const flamegraph = makeFlamegraph();
-      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-      const flamegraphView = new FlamegraphView({
-        canvas: flamegraphCanvas,
-        flamegraph,
-        theme,
-      });
+      const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
       expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 50));
     });
 
     it('initializes config view with insufficient height', () => {
-      const canvas = makeCanvasMock({width: 1000, height: 100});
+      const canvas = makeCanvasMock({height: 100});
       const flamegraph = makeFlamegraph();
-      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-      const flamegraphView = new FlamegraphView({
-        canvas: flamegraphCanvas,
-        flamegraph,
-        theme,
-      });
+      const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
       // 20 pixels tall each, and canvas is 100 pixels tall
       expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 5));
+    });
+
+    it('resizes config space and config view', () => {
+      const canvas = makeCanvasMock({width: 200, height: 200});
+      const flamegraph = makeFlamegraph();
+      const {flamegraphCanvas, flamegraphView} = makeCanvasAndView(canvas, flamegraph);
+
+      expect(flamegraphView.configSpace).toEqual(new Rect(0, 0, 10, 13));
+      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 10));
+
+      // make it smaller
+      canvas.width = 100;
+      canvas.height = 100;
+      flamegraphCanvas.initPhysicalSpace();
+      flamegraphView.resizeConfigSpace(flamegraphCanvas);
+
+      expect(flamegraphView.configSpace).toEqual(new Rect(0, 0, 10, 13));
+      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 5));
+
+      // make it bigger
+      canvas.width = 1000;
+      canvas.height = 1000;
+      flamegraphCanvas.initPhysicalSpace();
+      flamegraphView.resizeConfigSpace(flamegraphCanvas);
+
+      expect(flamegraphView.configSpace).toEqual(new Rect(0, 0, 10, 50));
+      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 50));
     });
   });
 
@@ -67,12 +95,7 @@ describe('flamegraphView', () => {
 
       const flamegraph = makeFlamegraph({startValue: 0, endValue: 100});
 
-      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-      const flamegraphView = new FlamegraphView({
-        canvas: flamegraphCanvas,
-        flamegraph,
-        theme,
-      });
+      const {flamegraphCanvas, flamegraphView} = makeCanvasAndView(canvas, flamegraph);
 
       // x=250 is 1/4 of the width of the viewport, so it should map to flamegraph duration / 4
       // y=250 is at 1/8th the height of the viewport, so it should map to view height / 8
@@ -99,37 +122,20 @@ describe('flamegraphView', () => {
     );
 
     it('does not allow zooming in more than the min width of a frame', () => {
-      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-      const flamegraphView = new FlamegraphView({
-        canvas: flamegraphCanvas,
-        flamegraph,
-        theme,
-      });
-
+      const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
       flamegraphView.setConfigView(new Rect(0, 0, 10, 50));
       expect(flamegraphView.configView).toEqual(new Rect(0, 0, 500, 50));
     });
 
     it('does not allow zooming out more than the duration of a profile', () => {
-      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-      const flamegraphView = new FlamegraphView({
-        canvas: flamegraphCanvas,
-        flamegraph,
-        theme,
-      });
-
+      const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
       flamegraphView.setConfigView(new Rect(0, 0, 2000, 50));
       expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
     });
 
     describe('edge detection on X axis', () => {
       it('is not zoomed in', () => {
-        const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-        const flamegraphView = new FlamegraphView({
-          canvas: flamegraphCanvas,
-          flamegraph,
-          theme,
-        });
+        const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
 
         // Check that we cant go negative X from start of profile
         flamegraphView.setConfigView(new Rect(-100, 0, 1000, 50));
@@ -141,12 +147,7 @@ describe('flamegraphView', () => {
       });
 
       it('is zoomed in', () => {
-        const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-        const flamegraphView = new FlamegraphView({
-          canvas: flamegraphCanvas,
-          flamegraph,
-          theme,
-        });
+        const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
 
         // Duration is is 1000, so we can't go over the end of the profile
         flamegraphView.setConfigView(new Rect(600, 0, 500, 50));
@@ -156,12 +157,7 @@ describe('flamegraphView', () => {
 
     describe('edge detection on Y axis', () => {
       it('is not zoomed in', () => {
-        const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-        const flamegraphView = new FlamegraphView({
-          canvas: flamegraphCanvas,
-          flamegraph,
-          theme,
-        });
+        const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
 
         // Check that we cant go under stack height
         flamegraphView.setConfigView(new Rect(0, -50, 1000, 50));
@@ -173,12 +169,7 @@ describe('flamegraphView', () => {
       });
 
       it('is zoomed in', () => {
-        const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-        const flamegraphView = new FlamegraphView({
-          canvas: flamegraphCanvas,
-          flamegraph,
-          theme,
-        });
+        const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
 
         // Check that we cant go over stack height
         flamegraphView.setConfigView(new Rect(0, 50, 1000, 25));

--- a/tests/js/spec/utils/profiling/renderers/flamegraphRenderer.spec.tsx
+++ b/tests/js/spec/utils/profiling/renderers/flamegraphRenderer.spec.tsx
@@ -1,94 +1,18 @@
-import {mat3, vec2} from 'gl-matrix';
+import {vec2} from 'gl-matrix';
 
-import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
-import {LightFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {
+  makeCanvasMock,
+  makeContextMock,
+  makeFlamegraph,
+} from 'sentry-test/profiling/utils';
+
+import {LightFlamegraphTheme as theme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Frame} from 'sentry/utils/profiling/frame';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
-import {EventedProfile} from 'sentry/utils/profiling/profile/eventedProfile';
-import {createFrameIndex} from 'sentry/utils/profiling/profile/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
-
-const base: Profiling.EventedProfile = {
-  name: 'profile',
-  startValue: 0,
-  endValue: 10,
-  unit: 'milliseconds',
-  type: 'evented',
-  threadID: 0,
-  events: [
-    {type: 'O', at: 0, frame: 0},
-    {type: 'C', at: 10, frame: 0},
-  ],
-};
-
-const makeFlamegraph = (
-  trace?: Partial<Profiling.EventedProfile>,
-  frames?: Profiling.Schema['shared']['frames']
-): Flamegraph => {
-  return new Flamegraph(
-    EventedProfile.FromProfile(
-      trace ? {...base, ...trace} : base,
-      createFrameIndex(frames ?? [{name: 'f0'}])
-    ),
-    0,
-    {inverted: false, leftHeavy: false}
-  );
-};
-
-const makeContextMock = (
-  partialMock: Partial<WebGLRenderingContext> = {}
-): WebGLRenderingContext => {
-  const context: Partial<WebGLRenderingContext> = {
-    attachShader: jest.fn(),
-    bufferData: jest.fn(),
-    blendFuncSeparate: jest.fn(),
-    bindBuffer: jest.fn(),
-    clearColor: jest.fn(),
-    clear: jest.fn(),
-    createShader: jest.fn().mockReturnValue({}),
-    createProgram: jest.fn().mockReturnValue({}),
-    createBuffer: jest.fn().mockReturnValue([]),
-    compileShader: jest.fn(),
-    drawArrays: jest.fn(),
-    enable: jest.fn(),
-    enableVertexAttribArray: jest.fn(),
-    getShaderParameter: jest.fn().mockReturnValue(1),
-    getProgramParameter: jest.fn().mockReturnValue({}),
-    getUniformLocation: jest.fn().mockReturnValue({}),
-    getAttribLocation: jest.fn().mockReturnValue({}),
-    linkProgram: jest.fn(),
-    shaderSource: jest.fn(),
-    uniformMatrix3fv: jest.fn(),
-    uniform1i: jest.fn(),
-    uniform2f: jest.fn(),
-    useProgram: jest.fn(),
-    vertexAttribPointer: jest.fn(),
-    viewport: jest.fn(),
-
-    // @ts-ignore
-    canvas: {
-      width: 1000,
-      height: 1000,
-    },
-    ...partialMock,
-  };
-
-  return context as WebGLRenderingContext;
-};
-
-const makeCanvasMock = (
-  partialMock: Partial<HTMLCanvasElement> = {}
-): HTMLCanvasElement => {
-  const canvas: Partial<HTMLCanvasElement> = {
-    getContext: jest.fn().mockReturnValue(makeContextMock()),
-    height: 1000,
-    width: 1000,
-    ...partialMock,
-  };
-
-  return canvas as HTMLCanvasElement;
-};
 
 const originalDpr = window.devicePixelRatio;
 
@@ -112,9 +36,9 @@ describe('flamegraphRenderer', () => {
         canvas as HTMLCanvasElement,
         flamegraph,
         {
-          ...LightFlamegraphTheme,
+          ...theme,
           COLORS: {
-            ...LightFlamegraphTheme.COLORS,
+            ...theme.COLORS,
             // @ts-ignore overridee the colors implementation
             STACK_TO_COLOR: () => {
               const colorMap = new Map<string, number[]>([['f0', [1, 0, 0, 1]]]);
@@ -139,8 +63,7 @@ describe('flamegraphRenderer', () => {
     const renderer = new FlamegraphRenderer(
       canvas as HTMLCanvasElement,
       flamegraph,
-      LightFlamegraphTheme,
-      vec2.fromValues(0, 0)
+      theme
     );
 
     // Helper rect for the only frame in our flamegraph
@@ -157,6 +80,7 @@ describe('flamegraphRenderer', () => {
     expect(renderer.positions.slice(8, 10)).toEqual([rect.right, rect.top]);
     expect(renderer.positions.slice(10, 12)).toEqual([rect.right, rect.bottom]);
   });
+
   it('inits shaders', () => {
     const VERTEX = `void main() { gl_Position = vec4(pos, 0.0, 1.0); }`;
     const FRAGMENT = `void main() { gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0); }`;
@@ -174,8 +98,7 @@ describe('flamegraphRenderer', () => {
     const _renderer = new FlamegraphRenderer(
       canvas as HTMLCanvasElement,
       flamegraph,
-      LightFlamegraphTheme,
-      vec2.fromValues(0, 0)
+      theme
     );
 
     expect(context.createShader).toHaveBeenCalledTimes(2);
@@ -185,118 +108,6 @@ describe('flamegraphRenderer', () => {
     expect(context.getShaderParameter.mock.calls[0][0]).toEqual(VERTEX);
     // @ts-ignore this is a mock
     expect(context.getShaderParameter.mock.calls[1][0]).toEqual(FRAGMENT);
-  });
-  it('inits config space', () => {
-    const context = makeContextMock();
-    const canvas = makeCanvasMock({
-      getContext: jest.fn().mockReturnValue(context),
-    });
-
-    const flamegraph = makeFlamegraph();
-
-    const renderer = new FlamegraphRenderer(
-      canvas as HTMLCanvasElement,
-      flamegraph,
-      LightFlamegraphTheme,
-      vec2.fromValues(0, 0)
-    );
-
-    expect(
-      // Config height is basically many flamegraph rectangles can fit into
-      // the viewport vertically and config width is the duration of the flamegraph
-      renderer.configSpace.equals(
-        new Rect(0, 0, 10, context.canvas.height / LightFlamegraphTheme.SIZES.BAR_HEIGHT)
-      )
-    ).toBe(true);
-  });
-  it('inits physical space', () => {
-    const context = makeContextMock();
-    const canvas = makeCanvasMock({
-      getContext: jest.fn().mockReturnValue(context),
-    });
-
-    const flamegraph = makeFlamegraph();
-
-    const renderer = new FlamegraphRenderer(
-      canvas as HTMLCanvasElement,
-      flamegraph,
-      LightFlamegraphTheme,
-      vec2.fromValues(0, 0)
-    );
-
-    expect(
-      // Config height is basically many flamegraph rectangles can fit into
-      // the viewport vertically and config width is the duration of the flamegraph
-      renderer.physicalSpace.equals(
-        new Rect(0, 0, context.canvas.width, context.canvas.height)
-      )
-    ).toBe(true);
-  });
-  it('inits logical space', () => {
-    // @ts-ignore partial canvas mock
-    const context = makeContextMock({canvas: {width: 100, height: 100}});
-    const canvas = makeCanvasMock({
-      getContext: jest.fn().mockReturnValue(context),
-    });
-
-    const flamegraph = makeFlamegraph();
-
-    const renderer = new FlamegraphRenderer(
-      canvas as HTMLCanvasElement,
-      flamegraph,
-      LightFlamegraphTheme,
-      vec2.fromValues(0, 0)
-    );
-
-    expect(renderer.logicalSpace).toEqual(new Rect(0, 0, 100, 100));
-  });
-  it('inits logicalToPhysicalSpace', () => {
-    window.devicePixelRatio = 2;
-    // @ts-ignore partial mock
-    const context = makeContextMock({canvas: {width: 100, height: 100}});
-    const canvas = makeCanvasMock({
-      getContext: jest.fn().mockReturnValue(context),
-    });
-
-    const flamegraph = makeFlamegraph();
-
-    const renderer = new FlamegraphRenderer(
-      canvas as HTMLCanvasElement,
-      flamegraph,
-      LightFlamegraphTheme,
-      vec2.fromValues(0, 0)
-    );
-
-    expect(renderer.logicalToPhysicalSpace).toEqual(
-      mat3.fromScaling(mat3.create(), vec2.fromValues(2, 2))
-    );
-  });
-
-  it('handles resize events by updating space', () => {
-    const canvasMock = {canvas: {width: 100, height: 100}};
-
-    // @ts-ignore partial canvas mock
-    const context = makeContextMock(canvasMock);
-    // @ts-ignore partial canvas mock
-    const canvas = makeCanvasMock({
-      getContext: jest.fn().mockReturnValue(context),
-    });
-
-    const flamegraph = makeFlamegraph();
-
-    const renderer = new FlamegraphRenderer(
-      canvas as HTMLCanvasElement,
-      flamegraph,
-      LightFlamegraphTheme,
-      vec2.fromValues(0, 0)
-    );
-
-    expect(renderer.physicalSpace).toEqual(new Rect(0, 0, 100, 100));
-    canvasMock.canvas.width = 200;
-    canvasMock.canvas.height = 200;
-
-    renderer.onResizeUpdateSpace();
-    expect(renderer.physicalSpace).toEqual(new Rect(0, 0, 200, 200));
   });
 
   it('getColorForFrame', () => {
@@ -309,41 +120,15 @@ describe('flamegraphRenderer', () => {
     const renderer = new FlamegraphRenderer(
       canvas as HTMLCanvasElement,
       flamegraph,
-      LightFlamegraphTheme,
-      vec2.fromValues(0, 0)
+      theme
     );
 
     expect(renderer.getColorForFrame(flamegraph.frames[0].frame)).toEqual([
       0.9750000000000001, 0.7250000000000001, 0.7250000000000001,
     ]);
     expect(renderer.getColorForFrame(new Frame({key: 20, name: 'Unknown'}))).toEqual(
-      LightFlamegraphTheme.COLORS.FRAME_FALLBACK_COLOR
+      theme.COLORS.FRAME_FALLBACK_COLOR
     );
-  });
-  describe('getConfigSpaceCursor', () => {
-    it('when view is not zoomed', () => {
-      const canvas = makeCanvasMock({
-        getContext: jest
-          .fn()
-          // @ts-ignore
-          .mockReturnValue(makeContextMock({canvas: {width: 1000, height: 2000}})),
-      });
-
-      const flamegraph = makeFlamegraph({startValue: 0, endValue: 100});
-
-      const renderer = new FlamegraphRenderer(
-        canvas as HTMLCanvasElement,
-        flamegraph,
-        LightFlamegraphTheme,
-        vec2.fromValues(0, 0)
-      );
-
-      // x=250 is 1/4 of the width of the viewport, so it should map to flamegraph duration / 4
-      // y=250 is at 1/8th the height of the viewport, so it should map to view height / 8
-      expect(renderer.getConfigSpaceCursor(vec2.fromValues(250, 250))).toEqual(
-        vec2.fromValues(25, 2000 / LightFlamegraphTheme.SIZES.BAR_HEIGHT / 8)
-      );
-    });
   });
 
   it('getHoveredNode', () => {
@@ -370,112 +155,13 @@ describe('flamegraphRenderer', () => {
     const renderer = new FlamegraphRenderer(
       makeCanvasMock() as HTMLCanvasElement,
       flamegraph,
-      LightFlamegraphTheme,
-      vec2.fromValues(0, 0)
+      theme
     );
 
     expect(renderer.getHoveredNode(vec2.fromValues(-1, 0))).toBeNull();
     expect(renderer.getHoveredNode(vec2.fromValues(-1, 0))).toBeNull();
     expect(renderer.getHoveredNode(vec2.fromValues(0, 0))?.frame?.name).toBe('f0');
     expect(renderer.getHoveredNode(vec2.fromValues(5, 2))?.frame?.name).toBe('f3');
-  });
-
-  describe('setConfigView', () => {
-    const makeRenderer = () => {
-      const flamegraph = makeFlamegraph(
-        {
-          startValue: 0,
-          endValue: 1000,
-          events: [
-            {type: 'O', frame: 0, at: 0},
-            {type: 'C', frame: 0, at: 500},
-          ],
-        },
-        [{name: 'f0'}]
-      );
-
-      return new FlamegraphRenderer(
-        makeCanvasMock() as HTMLCanvasElement,
-        flamegraph,
-        LightFlamegraphTheme,
-        vec2.fromValues(0, 0)
-      );
-    };
-
-    it('does not allow zooming in more than the min width of a frame', () => {
-      const renderer = makeRenderer();
-      expect(
-        renderer.setConfigView(new Rect(0, 0, 10, 50)).equals(new Rect(0, 0, 500, 50))
-      ).toBe(true);
-    });
-
-    it('does not allow zooming out more than the duration of a profile', () => {
-      const renderer = makeRenderer();
-      expect(
-        renderer.setConfigView(new Rect(0, 0, 2000, 50)).equals(new Rect(0, 0, 1000, 50))
-      ).toBe(true);
-    });
-
-    describe('edge detection on X axis', () => {
-      it('is not zoomed in', () => {
-        const renderer = makeRenderer();
-
-        // Check that we cant go negative X from start of profile
-        expect(
-          renderer
-            .setConfigView(new Rect(-100, 0, 1000, 50))
-            .equals(new Rect(0, 0, 1000, 50))
-        ).toBe(true);
-        // Check that we cant go over X from end of profile
-        expect(
-          renderer
-            .setConfigView(new Rect(2000, 0, 1000, 50))
-            .equals(new Rect(0, 0, 1000, 50))
-        ).toBe(true);
-      });
-
-      it('is zoomed in', () => {
-        const renderer = makeRenderer();
-
-        // Duration is is 1000, so we can't go over the end of the profile
-        expect(
-          renderer
-            .setConfigView(new Rect(600, 0, 500, 50))
-            .equals(new Rect(500, 0, 500, 50))
-        ).toBe(true);
-      });
-    });
-
-    describe('edge detection on Y axis', () => {
-      it('is not zoomed in', () => {
-        const renderer = makeRenderer();
-
-        // Check that we cant go under stack height
-        expect(
-          renderer
-            .setConfigView(new Rect(0, -50, 1000, 50))
-            .equals(new Rect(0, 0, 1000, 50))
-        ).toBe(true);
-
-        // Check that we cant go over stack height
-        expect(
-          renderer
-            .setConfigView(new Rect(0, 50, 1000, 50))
-            .equals(new Rect(0, 0, 1000, 50))
-        ).toBe(true);
-      });
-
-      it('is zoomed in', () => {
-        const renderer = makeRenderer();
-
-        // Check that we cant go over stack height
-        expect(
-          renderer
-            .setConfigView(new Rect(0, 50, 1000, 25))
-            .equals(new Rect(0, 25, 1000, 25))
-        ).toBe(true);
-      });
-    });
   });
 
   describe('draw', () => {
@@ -519,17 +205,22 @@ describe('flamegraphRenderer', () => {
         [{name: 'f0'}, {name: 'f1'}]
       );
 
-      const renderer = new FlamegraphRenderer(
-        canvas,
+      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+      const flamegraphView = new FlamegraphView({
+        canvas: flamegraphCanvas,
         flamegraph,
-        LightFlamegraphTheme,
-        vec2.fromValues(0, 0)
-      );
+        theme,
+      });
+      const renderer = new FlamegraphRenderer(canvas, flamegraph, theme);
 
-      renderer.draw(results, renderer.configViewToPhysicalSpace);
+      renderer.draw(
+        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace),
+        results
+      );
       expect(context.uniform1i).toHaveBeenCalledTimes(3);
       expect(context.drawArrays).toHaveBeenCalledTimes(2);
     });
+
     it('draws all frames', () => {
       const context = makeContextMock();
       const canvas = makeCanvasMock({
@@ -566,14 +257,15 @@ describe('flamegraphRenderer', () => {
         [{name: 'f0'}, {name: 'f1'}]
       );
 
-      const renderer = new FlamegraphRenderer(
-        canvas,
+      const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
+      const flamegraphView = new FlamegraphView({
+        canvas: flamegraphCanvas,
         flamegraph,
-        LightFlamegraphTheme,
-        vec2.fromValues(0, 0)
-      );
+        theme,
+      });
+      const renderer = new FlamegraphRenderer(canvas, flamegraph, theme);
 
-      renderer.draw(null, renderer.configViewToPhysicalSpace);
+      renderer.draw(flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace));
       expect(context.drawArrays).toHaveBeenCalledTimes(2);
     });
   });


### PR DESCRIPTION
Previously, we had 2 separate config space/views that had to be kept in sync so
that the flamegraph and the minimap were rendered correctly. This change lifts
the state into the parent component to reduce complexity.