### PR TITLE
ref: upgrade boto* packages to fix conflicts

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.7.1
-boto3==1.13.16
-botocore==1.16.16
+boto3==1.22.12
+botocore==1.25.12
 celery==4.4.7
 click==8.0.4
 # See if we can remove CPATH from lib.sh


### PR DESCRIPTION
while attempting to upgrade `selenium` the first issue hit is a conflict between botocore<->urllib3<->selenium