### PR TITLE
feat(ratelimits): Group CLI endpoints together

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from sentry import options
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
 from sentry.models import FileBlob
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.utils.compat import zip
 from sentry.utils.files import get_max_file_size
 
@@ -41,6 +42,7 @@ class GzipChunk(BytesIO):
 
 class ChunkUploadEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationReleasePermission,)
+    rate_limits = RateLimitConfig(group="CLI")
 
     def get(self, request: Request, organization) -> Response:
         """

--- a/src/sentry/api/endpoints/organization_release_previous_commits.py
+++ b/src/sentry/api/endpoints/organization_release_previous_commits.py
@@ -6,9 +6,12 @@ from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models import Release
+from sentry.ratelimits.config import RateLimitConfig
 
 
 class OrganizationReleasePreviousCommitsEndpoint(OrganizationReleasesBaseEndpoint):
+    rate_limits = RateLimitConfig(group="CLI")
+
     def get(self, request: Request, organization, version) -> Response:
         """
         Retrieve an Organization's Most Recent Release with Commits

--- a/src/sentry/api/endpoints/organization_repositories.py
+++ b/src/sentry/api/endpoints/organization_repositories.py
@@ -8,6 +8,7 @@ from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.models import Integration, Repository
 from sentry.plugins.base import bindings
+from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
 from sentry.utils.sdk import capture_exception
 
 UNMIGRATABLE_PROVIDERS = ("bitbucket", "github")
@@ -15,6 +16,9 @@ UNMIGRATABLE_PROVIDERS = ("bitbucket", "github")
 
 class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission,)
+    rate_limits = RateLimitConfig(
+        group="CLI", limit_overrides={"POST": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}
+    )
 
     def get(self, request: Request, organization) -> Response:
         """

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -15,6 +15,7 @@ from sentry.api.serializers import serialize
 from sentry.constants import MAX_RELEASE_FILES_OFFSET
 from sentry.models import Distribution, File, Release, ReleaseFile
 from sentry.models.releasefile import read_artifact_index
+from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
 from sentry.utils.db import atomic_transaction
 
 ERR_FILE_EXISTS = "A file matching this name already exists for the given release"
@@ -208,6 +209,9 @@ def pseudo_releasefile(url, info, dist):
 
 class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
     permission_classes = (ProjectReleasePermission,)
+    rate_limits = RateLimitConfig(
+        group="CLI", limit_overrides={"GET": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}
+    )
 
     def get(self, request: Request, project, version) -> Response:
         """

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -19,7 +19,7 @@ from sentry.utils.sdk import bind_organization_context, configure_scope
 class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
     permission_classes = (ProjectReleasePermission,)
     rate_limits = RateLimitConfig(
-        group="CLI", limit_overrides={"POST": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}
+        group="CLI", limit_overrides={"GET": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}
     )
 
     def get(self, request: Request, project) -> Response:

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -11,12 +11,16 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ReleaseWithVersionSerializer
 from sentry.models import Activity, Environment, Release, ReleaseStatus
 from sentry.plugins.interfaces.releasehook import ReleaseHook
+from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
 from sentry.signals import release_created
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
 
 class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
     permission_classes = (ProjectReleasePermission,)
+    rate_limits = RateLimitConfig(
+        group="CLI", limit_overrides={"POST": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}
+    )
 
     def get(self, request: Request, project) -> Response:
         """


### PR DESCRIPTION
The following endpoints are called frequently by the CLI.

- `(POST) sentry.api.endpoints.project_releases.ProjectReleasesEndpoint`
- `(POST) sentry.api.endpoints.project_release_files.ProjectReleaseFilesEndpoint`
- `(GET, POST) sentry.api.endpoints.chunk.ChunkUploadEndpoint`
- `(GET) sentry.api.endpoints.organization_repositories.OrganizationRepositoriesEndpoint`
- `(POST) sentry.api.endpoints.release_deploys.ReleaseDeploysEndpoint`
- `(GET) sentry.api.endpoints.organization_release_previous_commits.OrganizationReleasePreviousCommitsEndpoint`

This PR categorizes all these endpoints as `CLI` so that they can use its default ratelimit.

#sync-getsentry