### PR TITLE
feat(alerts): read from query param to determine alert type

### DIFF
--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -56,10 +56,6 @@ class AlertWizard extends Component<Props, State> {
   };
 
   componentDidMount() {
-    // const {alert_option: alertOption} = this.props.location.query;
-    // this.state = {
-    //   alertOption: alertOption ?? DEFAULT_ALERT_OPTION,
-    // };
     // capture landing on the alert wizard page and viewing the issue alert by default
     this.trackView();
   }

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -49,10 +49,17 @@ const DEFAULT_ALERT_OPTION = 'issues';
 
 class AlertWizard extends Component<Props, State> {
   state: State = {
-    alertOption: DEFAULT_ALERT_OPTION,
+    alertOption:
+      this.props.location.query.alert_option in AlertWizardAlertNames
+        ? this.props.location.query.alert_option
+        : DEFAULT_ALERT_OPTION,
   };
 
   componentDidMount() {
+    // const {alert_option: alertOption} = this.props.location.query;
+    // this.state = {
+    //   alertOption: alertOption ?? DEFAULT_ALERT_OPTION,
+    // };
     // capture landing on the alert wizard page and viewing the issue alert by default
     this.trackView();
   }


### PR DESCRIPTION
This PR adds the ability to pre-select the alert type with the `alert_option` query parameter. We are going to leverage this for onboarding to pre-select options to reduce user friction.