### PR TITLE
ref(settings): Adjust font sizes and paddings

### DIFF
--- a/static/app/components/forms/field/fieldHelp.tsx
+++ b/static/app/components/forms/field/fieldHelp.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import space from 'sentry/styles/space';
 
 const FieldHelp = styled('div')<{inline?: boolean; stacked?: boolean}>`
-  color: ${p => p.theme.gray300};
-  font-size: 14px;
-  margin-top: ${p => (p.stacked && !p.inline ? 0 : space(1))};
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeSmall};
+  margin-top: ${p => (p.stacked && !p.inline ? 0 : space(0.5))};
   line-height: 1.4;
 `;
 

--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -231,7 +231,6 @@ const EditAndDelete = styled('div')`
 `;
 
 const RepositoryTitle = styled('div')`
-  margin-bottom: ${space(1)};
   /* accommodate cancel button height */
   line-height: 26px;
 `;

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -389,6 +389,7 @@ class AbstractIntegrationDetailedView<
 
 const Flex = styled('div')`
   display: flex;
+  align-items: center;
 `;
 
 const FlexContainer = styled('div')`
@@ -417,7 +418,7 @@ const NameContainer = styled('div')`
 const Name = styled('div')`
   font-weight: bold;
   font-size: 1.4em;
-  margin-bottom: ${space(1)};
+  margin-bottom: ${space(0.5)};
 `;
 
 const IconCloseCircle = styled(IconClose)`
@@ -473,9 +474,8 @@ const ExternalLinkContainer = styled('div')`
 `;
 
 const StatusWrapper = styled('div')`
-  margin-bottom: ${space(1)};
+  margin-bottom: ${space(0.5)};
   padding-left: ${space(2)};
-  line-height: 1.5em;
 `;
 
 const DisableWrapper = styled('div')`

--- a/static/app/views/organizationIntegrations/integrationItem.tsx
+++ b/static/app/views/organizationIntegrations/integrationItem.tsx
@@ -37,6 +37,7 @@ export default class IntegrationItem extends Component<Props> {
 
 const Flex = styled('div')`
   display: flex;
+  align-items: center;
 `;
 type StyledProps = Pick<Props, 'compact'>;
 const Labels = styled('div')<StyledProps>`
@@ -50,18 +51,18 @@ const Labels = styled('div')<StyledProps>`
 `;
 
 const IntegrationName = styled('div')`
-  font-size: 1rem;
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: bold;
 `;
 
 // Not using the overflowEllipsis style import here
 // as it sets width 100% which causes layout issues in the
 // integration list.
 const DomainName = styled('div')<StyledProps>`
-  color: ${p => (p.compact ? p.theme.gray200 : p.theme.gray400)};
+  color: ${p => p.theme.subText};
   margin-left: ${p => (p.compact ? space(1) : 'inherit')};
-  margin-top: ${p => (!p.compact ? space(0.25) : 'inherit')};
-  font-size: 0.875rem;
-  line-height: 1.2;
+  margin-top: ${p => (!p.compact ? 0 : 'inherit')};
+  font-size: ${p => p.theme.fontSizeSmall};
   overflow: hidden;
   text-overflow: ellipsis;
 `;

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -181,8 +181,7 @@ const IntegrationName = styled(Link)`
 const IntegrationDetails = styled('div')`
   display: flex;
   align-items: center;
-  margin-top: 6px;
-  font-size: 0.8em;
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const StyledLink = styled(Link)`

--- a/static/app/views/settings/account/accountSubscriptions.tsx
+++ b/static/app/views/settings/account/accountSubscriptions.tsx
@@ -188,16 +188,16 @@ const SubscriptionDetails = styled('div')`
 `;
 
 const SubscriptionName = styled('div')`
-  font-size: ${p => p.theme.fontSizeExtraLarge};
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 const Description = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  margin-top: ${space(0.75)};
   color: ${p => p.theme.subText};
+  margin-top: ${space(0.5)};
 `;
 
 const SubscribedDescription = styled(Description)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;
 
 export default AccountSubscriptions;

--- a/static/app/views/settings/account/apiApplications/row.tsx
+++ b/static/app/views/settings/account/apiApplications/row.tsx
@@ -99,14 +99,12 @@ const ApplicationNameWrapper = styled('div')`
 `;
 
 const ApplicationName = styled(Link)`
-  font-size: ${p => p.theme.headerFontSize};
-  font-weight: bold;
-  margin-bottom: ${space(0.5)};
+  margin-bottom: ${space(1)};
 `;
 
 const ClientId = styled('div')`
-  color: ${p => p.theme.gray200};
-  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 export default Row;

--- a/static/app/views/settings/components/emptyMessage.tsx
+++ b/static/app/views/settings/components/emptyMessage.tsx
@@ -50,7 +50,7 @@ const EmptyMessage = styled(
   flex-direction: column;
   color: ${p => p.theme.textColor};
   font-size: ${p =>
-    p.size && p.size === 'large' ? p.theme.fontSizeExtraLarge : p.theme.fontSizeLarge};
+    p.size && p.size === 'large' ? p.theme.fontSizeExtraLarge : p.theme.fontSizeMedium};
 `;
 
 const IconWrapper = styled('div')`

--- a/static/app/views/settings/components/settingsWrapper.tsx
+++ b/static/app/views/settings/components/settingsWrapper.tsx
@@ -23,9 +23,9 @@ export default SettingsWrapper;
 const StyledSettingsWrapper = styled('div')`
   display: flex;
   flex: 1;
-  font-size: ${p => p.theme.fontSizeLarge};
+  font-size: ${p => p.theme.fontSizeMedium};
+  line-height: ${p => p.theme.text.lineHeightBody};
   color: ${p => p.theme.textColor};
-  line-height: 1;
 
   .messages-container {
     margin: 0;

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -166,8 +166,8 @@ const ProviderName = styled('div')`
 `;
 
 const ProviderDescription = styled('div')`
-  margin-top: ${space(0.75)};
-  font-size: 0.8em;
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
 `;
 
 const FeatureBadge = styled('div')`

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -264,14 +264,14 @@ const MemberDescription = styled(Link)`
 
 const UserName = styled('div')`
   display: block;
-  font-size: ${p => p.theme.fontSizeLarge};
   overflow: hidden;
+  font-size: ${p => p.theme.fontSizeMedium};
   text-overflow: ellipsis;
 `;
 
 const Email = styled('div')`
-  color: ${p => p.theme.textColor};
-  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeSmall};
   overflow: hidden;
   text-overflow: ellipsis;
 `;


### PR DESCRIPTION
Use a smaller base font size of `14px` instead of `16px` (since this is the new base in our design system), and adjust paddings accordingly.

Before-after screenshots are available below in the comments.

**Before**
<img width="1182" alt="Screen Shot 2022-05-11 at 4 39 57 PM" src="https://user-images.githubusercontent.com/44172267/167964595-02ebb4dc-4fc0-4214-bc82-8cbe1f11b34c.png">

**After**
<img width="1182" alt="Screen Shot 2022-05-11 at 4 41 27 PM" src="https://user-images.githubusercontent.com/44172267/167964704-aceb8d78-ab87-44d5-aecf-9d2efcdbb654.png">

