### PR TITLE
fix(replays): Set event.startTimestamp based on the earliest of span/breadcrumb/rrweb data

### DIFF
--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -185,8 +185,6 @@ export function flattenSpans(rawSpans: RawSpanType[]): FlattenedSpanRange[] {
     } as FlattenedSpanRange;
   });
 
-  // might need to make sure we've sorted by startTimestamp
-
   const [firstSpan, ...restSpans] = spans;
   const flatSpans = [firstSpan];
 

--- a/static/app/utils/replays/mergeBreadcrumbEntries.tsx
+++ b/static/app/utils/replays/mergeBreadcrumbEntries.tsx
@@ -14,6 +14,8 @@ export default function mergeBreadcrumbEntries(events: Event[]): Entry {
   const deduped = Array.from(new Set(stringified));
   const values = deduped.map(value => JSON.parse(value));
 
+  values.sort((a, b) => +new Date(a?.timestamp || 0) - +new Date(b?.timestamp || 0));
+
   return {
     type: EntryType.BREADCRUMBS,
     data: {

--- a/static/app/utils/replays/mergeSpanEntries.tsx
+++ b/static/app/utils/replays/mergeSpanEntries.tsx
@@ -11,5 +11,7 @@ export default function mergeSpanEntries(events: Event[]): Entry {
     )
   );
 
+  spans.sort((a, b) => a.start_timestamp - b.start_timestamp);
+
   return {type: EntryType.SPANS, data: spans};
 }


### PR DESCRIPTION
Just like with the end-time, the start time depends on the earliest data that we've grabbed. During pageload we can grab span data before rrweb does an html snapshot. So we need to adjust `startTimestamp` as well the rrweb events to account for that earlier timestamp.

**Before**
before we had 2 seconds of span data that was rendered outside the Timeline component. Here you can see a sliver of data poking out, but actually more is hidden behind the Left Nav:
<img width="328" alt="Screen Shot 2022-05-12 at 8 30 12 PM" src="https://user-images.githubusercontent.com/187460/168075098-890402b9-6416-43a7-9c36-3f0b86034513.png">


**After**
The duration of the replay is actually 2seconds longer (from 30 to 32s) because of the pageload span data.
Those extra 2 seconds mean that the first click happens at about `t=9` instead of `t=7`

<img width="377" alt="Screen Shot 2022-05-12 at 8 28 11 PM" src="https://user-images.githubusercontent.com/187460/168074909-2bc5a906-b4df-43c2-9eae-850960852b94.png">


Fixes https://github.com/getsentry/sentry/issues/34489
