### PR TITLE
ref(relay-redis): Separate debouncing and checking [INGEST-1329]

### DIFF
--- a/src/sentry/relay/projectconfig_debounce_cache/base.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/base.py
@@ -22,13 +22,22 @@ class ProjectConfigDebounceCache(Service):
 
     def check_is_debounced(self, public_key, project_id, organization_id):
         """
-        Check if the given project/organization should be debounced.
+        Check if the given project/organization should be debounced, and
+        debounces when it isn't.
 
         It's fine to erroneously return false, it's not fine to erroneously
         return true.
         """
 
         return False
+
+    def is_debounced(self, public_key, project_id, organization_id):
+        """Checks if the given project/organization should be debounced."""
+
+    def debounce(self, public_key, project_id, organization_id):
+        """
+        Debounces the given project/organization, without performing any checks.
+        """
 
     def mark_task_done(self, public_key, project_id, organization_id):
         """

--- a/src/sentry/relay/projectconfig_debounce_cache/base.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/base.py
@@ -33,6 +33,7 @@ class ProjectConfigDebounceCache(Service):
 
     def is_debounced(self, public_key, project_id, organization_id):
         """Checks if the given project/organization should be debounced."""
+        return False
 
     def debounce(self, public_key, project_id, organization_id):
         """

--- a/src/sentry/relay/projectconfig_debounce_cache/base.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/base.py
@@ -15,7 +15,7 @@ class ProjectConfigDebounceCache(Service):
     going to cut it.
     """
 
-    __all__ = ("check_is_debounced", "mark_task_done")
+    __all__ = ("check_is_debounced", "is_debounced", "debounce", "mark_task_done")
 
     def __init__(self, **options):
         pass

--- a/src/sentry/relay/projectconfig_debounce_cache/redis.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/redis.py
@@ -32,11 +32,21 @@ class RedisProjectConfigDebounceCache(ProjectConfigDebounceCache):
             return self.cluster.get_local_client_for_key(routing_key)
 
     def check_is_debounced(self, public_key, project_id, organization_id):
+        if self.is_debounced(public_key, project_id, organization_id):
+            return True
+        self.debounce(public_key, project_id, organization_id)
+        return False
+
+    def is_debounced(self, public_key, project_id, organization_id):
         key = _get_redis_key(public_key, project_id, organization_id)
         client = self.__get_redis_client(key)
         if client.get(key):
             return True
+        return False
 
+    def debounce(self, public_key, project_id, organization_id):
+        key = _get_redis_key(public_key, project_id, organization_id)
+        client = self.__get_redis_client(key)
         client.setex(key, REDIS_CACHE_TIMEOUT, 1)
         return False
 

--- a/src/sentry/relay/projectconfig_debounce_cache/redis.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/redis.py
@@ -48,7 +48,6 @@ class RedisProjectConfigDebounceCache(ProjectConfigDebounceCache):
         key = _get_redis_key(public_key, project_id, organization_id)
         client = self.__get_redis_client(key)
         client.setex(key, REDIS_CACHE_TIMEOUT, 1)
-        return False
 
     def mark_task_done(self, public_key, project_id, organization_id):
         key = _get_redis_key(public_key, project_id, organization_id)


### PR DESCRIPTION
`check_is_debounced` sets the state of scheduling a task before
scheduling it. Since running both operations isn't atomic, it's possible
that the process gets killed after setting the state to scheduled and
before scheduling a task. This makes the cache to be stale for 1h
(current TTL).

This PR splits both operations into different methods, so that they can
be used independently. The behavior of `check_is_debounced` hasn't been
modified.

h/t to @jjbayer for coming up with this issue.

This is required for future work on coming soon.