### PR TITLE
feat(sampling): Change custom tag payload [TET-23]

### DIFF
--- a/static/app/types/dynamicSampling.tsx
+++ b/static/app/types/dynamicSampling.tsx
@@ -72,7 +72,7 @@ export enum DynamicSamplingInnerName {
   EVENT_LEGACY_BROWSER = 'event.legacy_browser',
   EVENT_ERROR_MESSAGES = 'event.error_messages',
   EVENT_CSP = 'event.csp',
-  EVENT_CUSTOM_TAG = 'event.custom_tag',
+  EVENT_CUSTOM_TAG = 'event.custom_tag', // used for the fresh new custom tag condition (gets replaced once you choose tag key)
 }
 
 export enum LegacyBrowser {
@@ -96,7 +96,8 @@ type DynamicSamplingConditionLogicalInnerGlob = {
     | DynamicSamplingInnerName.EVENT_OS_VERSION
     | DynamicSamplingInnerName.EVENT_DEVICE_FAMILY
     | DynamicSamplingInnerName.EVENT_DEVICE_NAME
-    | DynamicSamplingInnerName.EVENT_CUSTOM_TAG;
+    | DynamicSamplingInnerName.EVENT_CUSTOM_TAG
+    | string; // for custom tags
   op: DynamicSamplingInnerOperator.GLOB_MATCH;
   value: Array<string>;
 };
@@ -140,20 +141,12 @@ type DynamicSamplingConditionLogicalInnerCustomLegacyBrowser = {
   value: Array<LegacyBrowser>;
 };
 
-export type DynamicSamplingConditionLogicalInnerCustomTag = {
-  name: DynamicSamplingInnerName.EVENT_CUSTOM_TAG;
-  op: DynamicSamplingInnerOperator.GLOB_MATCH;
-  tagKey: string;
-  value: Array<string>;
-};
-
 export type DynamicSamplingConditionLogicalInner =
   | DynamicSamplingConditionLogicalInnerGlob
   | DynamicSamplingConditionLogicalInnerEq
   | DynamicSamplingConditionLogicalInnerEqBoolean
   | DynamicSamplingConditionLogicalInnerCustom
-  | DynamicSamplingConditionLogicalInnerCustomLegacyBrowser
-  | DynamicSamplingConditionLogicalInnerCustomTag;
+  | DynamicSamplingConditionLogicalInnerCustomLegacyBrowser;
 
 export type DynamicSamplingCondition = {
   inner: Array<DynamicSamplingConditionLogicalInner>;

--- a/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
@@ -87,6 +87,11 @@ function Conditions({
                     onChange(index, 'category', addCustomTagPrefix(value))
                   }
                   value={stripCustomTagPrefix(category)}
+                  disabledOptions={conditions
+                    .filter(
+                      cond => isCustomTagName(cond.category) && cond.category !== category
+                    )
+                    .map(cond => stripCustomTagPrefix(cond.category))}
                 />
               ) : (
                 <span>

--- a/static/app/views/settings/project/filtersAndSampling/modal/tagKeyAutocomplete.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/tagKeyAutocomplete.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import SelectField from 'sentry/components/forms/selectField';
 import {t} from 'sentry/locale';
 import {Organization, Project, Tag} from 'sentry/types';
+import {DynamicSamplingInnerName} from 'sentry/types/dynamicSampling';
 import useApi from 'sentry/utils/useApi';
 
 type Props = {
@@ -17,7 +18,7 @@ type Props = {
  * This component is used for the autocomplete of custom tag key
  */
 function TagKeyAutocomplete({onChange, orgSlug, projectSlug, value}: Props) {
-  const [tags, setTags] = useState<Tag[]>(value ? [{key: value, name: value}] : []);
+  const [tags, setTags] = useState<Tag[]>([]);
   const api = useApi();
 
   const fetchProjectTags = useCallback(async () => {
@@ -36,11 +37,21 @@ function TagKeyAutocomplete({onChange, orgSlug, projectSlug, value}: Props) {
     fetchProjectTags();
   }, [fetchProjectTags]);
 
+  // select doesn't play nicely with selected values that are not in the listed options
+  const options = tags.map(({key}) => ({value: key, label: key}));
+  if (
+    value &&
+    value !== DynamicSamplingInnerName.EVENT_CUSTOM_TAG &&
+    !tags.some(({key}) => key === value)
+  ) {
+    options.push({value, label: value});
+  }
+
   return (
     <Wrapper>
       <SelectField
         name="customTagKey"
-        options={tags.map(({key}) => ({value: key, label: key}))}
+        options={options}
         inline={false}
         stacked
         hideControlState

--- a/static/app/views/settings/project/filtersAndSampling/modal/tagKeyAutocomplete.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/tagKeyAutocomplete.tsx
@@ -8,6 +8,7 @@ import {DynamicSamplingInnerName} from 'sentry/types/dynamicSampling';
 import useApi from 'sentry/utils/useApi';
 
 type Props = {
+  disabledOptions: string[];
   onChange: (value: string) => void;
   orgSlug: Organization['slug'];
   projectSlug: Project['slug'];
@@ -17,7 +18,13 @@ type Props = {
 /**
  * This component is used for the autocomplete of custom tag key
  */
-function TagKeyAutocomplete({onChange, orgSlug, projectSlug, value}: Props) {
+function TagKeyAutocomplete({
+  onChange,
+  orgSlug,
+  projectSlug,
+  value,
+  disabledOptions,
+}: Props) {
   const [tags, setTags] = useState<Tag[]>([]);
   const api = useApi();
 
@@ -52,6 +59,7 @@ function TagKeyAutocomplete({onChange, orgSlug, projectSlug, value}: Props) {
       <SelectField
         name="customTagKey"
         options={options}
+        isOptionDisabled={option => disabledOptions.includes(option.value)}
         inline={false}
         stacked
         hideControlState

--- a/static/app/views/settings/project/filtersAndSampling/modal/tagValueAutocomplete.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/tagValueAutocomplete.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useEffect, useState} from 'react';
 import {components, MultiValueProps, OptionProps} from 'react-select';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import SelectField from 'sentry/components/forms/selectField';
@@ -31,7 +30,8 @@ type Props = {
     | DynamicSamplingInnerName.EVENT_CUSTOM_TAG
     | DynamicSamplingInnerName.TRACE_ENVIRONMENT
     | DynamicSamplingInnerName.TRACE_RELEASE
-    | DynamicSamplingInnerName.TRACE_TRANSACTION;
+    | DynamicSamplingInnerName.TRACE_TRANSACTION
+    | string;
   onChange: (value: string) => void;
   orgSlug: Organization['slug'];
   projectId: Project['id'];
@@ -69,13 +69,10 @@ function TagValueAutocomplete({
         return t('Search or add a device family');
       case DynamicSamplingInnerName.EVENT_DEVICE_NAME:
         return t('Search or add a device name');
-      case DynamicSamplingInnerName.EVENT_CUSTOM_TAG:
-        return t('Search or add tag values');
+
       default:
-        Sentry.captureException(
-          new Error('Unknown dynamic sampling condition inner name')
-        );
-        return ''; // this shall never happen
+        // custom tags
+        return t('Search or add tag values');
     }
   }
 

--- a/static/app/views/settings/project/filtersAndSampling/rules/rule/conditions.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/rules/rule/conditions.tsx
@@ -10,8 +10,7 @@ import {
   DynamicSamplingConditionOperator,
 } from 'sentry/types/dynamicSampling';
 
-import {isInnerCustomTag} from '../../modal/utils';
-import {getCustomTagLabel, getInnerNameLabel, LEGACY_BROWSER_LIST} from '../../utils';
+import {getInnerNameLabel, LEGACY_BROWSER_LIST} from '../../utils';
 
 type Props = {
   condition: DynamicSamplingCondition;
@@ -46,11 +45,7 @@ function Conditions({condition}: Props) {
         <Wrapper>
           {inner.map((innerItem, index) => (
             <div key={index}>
-              <Label>
-                {isInnerCustomTag(innerItem)
-                  ? getCustomTagLabel(innerItem.tagKey)
-                  : getInnerNameLabel(innerItem.name)}
-              </Label>
+              <Label>{getInnerNameLabel(innerItem.name)}</Label>
               {getConvertedValue(innerItem.value)}
             </div>
           ))}

--- a/static/app/views/settings/project/filtersAndSampling/utils.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/utils.tsx
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/react';
-
 import {t} from 'sentry/locale';
 import {DynamicSamplingInnerName, LegacyBrowser} from 'sentry/types/dynamicSampling';
 
@@ -42,7 +40,7 @@ export const LEGACY_BROWSER_LIST = {
   },
 };
 
-export function getInnerNameLabel(name: DynamicSamplingInnerName) {
+export function getInnerNameLabel(name: DynamicSamplingInnerName | string) {
   switch (name) {
     case DynamicSamplingInnerName.TRACE_ENVIRONMENT:
     case DynamicSamplingInnerName.EVENT_ENVIRONMENT:
@@ -84,13 +82,32 @@ export function getInnerNameLabel(name: DynamicSamplingInnerName) {
     case DynamicSamplingInnerName.EVENT_CUSTOM_TAG:
       return t('Custom Tag');
 
-    default: {
-      Sentry.captureException(new Error('Unknown dynamic sampling condition inner name'));
-      return ''; // this shall never happen
-    }
+    default:
+      return `${stripCustomTagPrefix(name)} - ${t('Custom')}`;
   }
 }
 
-export function getCustomTagLabel(tagKey: string) {
-  return `${tagKey} - ${t('Custom')}`;
+const CUSTOM_TAG_PREFIX = 'event.tags.';
+
+export function isCustomTagName(name: DynamicSamplingInnerName | string): boolean {
+  return (
+    name === DynamicSamplingInnerName.EVENT_CUSTOM_TAG ||
+    name.startsWith(CUSTOM_TAG_PREFIX)
+  );
+}
+
+export function stripCustomTagPrefix(name: string): string {
+  if (name.startsWith(CUSTOM_TAG_PREFIX)) {
+    return name.replace(CUSTOM_TAG_PREFIX, '');
+  }
+
+  return name;
+}
+
+export function addCustomTagPrefix(name: string): string {
+  if (name.startsWith(CUSTOM_TAG_PREFIX)) {
+    return name;
+  }
+
+  return `${CUSTOM_TAG_PREFIX}${name}`;
 }


### PR DESCRIPTION
Based on this PR: https://github.com/getsentry/relay/pull/1268 we are slightly changing the payload for custom tag rules.

We are going from:
```
{"dynamicSampling":{"rules":[{"id":0,"type":"error","condition":{"op":"and","inner":[{"op":"glob","name":"event.custom_tag",tagKey:"browser","value":["Chrome 101.0.4951"]}]},"sampleRate":0.1}]}}
```
to:
```
{"dynamicSampling":{"rules":[{"id":0,"type":"error","condition":{"op":"and","inner":[{"op":"glob","name":"event.tags.browser","value":["Chrome 101.0.4951"]}]},"sampleRate":0.1}]}}
```

This PR also adds tag field validation, and displays custom tags in condition selector.

https://user-images.githubusercontent.com/9060071/168092875-cbb50285-4dec-459e-9dbc-04384bf758b8.mp4
