### PR TITLE
ref: remove unneeded map compat imports

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -25,7 +25,6 @@ from sentry.models import (
     ReleaseProject,
 )
 from sentry.utils import auth
-from sentry.utils.compat import map
 from sentry.utils.hashlib import hash_values
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.sdk import bind_organization_context

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -39,7 +39,6 @@ from sentry.search.snuba.backend import assigned_or_suggested_filter
 from sentry.search.snuba.executors import get_search_filter
 from sentry.snuba import discover
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.utils.compat import map
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.validators import normalize_event_id
 

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -10,7 +10,6 @@ from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.models import Group
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.utils.compat import map
 
 
 class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -4,7 +4,6 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import Project
-from sentry.utils.compat import map
 
 
 class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -6,7 +6,6 @@ from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models import Environment, Project, Team
-from sentry.utils.compat import map
 
 
 class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMixin):

--- a/src/sentry/auth/providers/google/views.py
+++ b/src/sentry/auth/providers/google/views.py
@@ -5,7 +5,6 @@ from rest_framework.response import Response
 
 from sentry.auth.view import AuthView, ConfigureView
 from sentry.utils import json
-from sentry.utils.compat import map
 from sentry.utils.signing import urlsafe_b64decode
 
 from .constants import DOMAIN_BLOCKLIST, ERR_INVALID_DOMAIN, ERR_INVALID_RESPONSE

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -14,7 +14,6 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Environment
 from sentry.search.events.builder import QueryBuilder
 from sentry.utils import metrics
-from sentry.utils.compat import map
 from sentry.utils.snuba import MAX_FIELDS, Dataset
 
 from ..base import ExportQueryType

--- a/src/sentry/debug/utils/packages.py
+++ b/src/sentry/debug/utils/packages.py
@@ -1,7 +1,5 @@
 import sys
 
-from sentry.utils.compat import map
-
 try:
     import pkg_resources
 except ImportError:

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -13,7 +13,6 @@ from sentry.api.paginator import GenericOffsetPaginator
 from sentry.discover.utils import transform_aliases_and_query
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import snuba
-from sentry.utils.compat import map
 
 from .serializers import DiscoverQuerySerializer
 

--- a/src/sentry/identity/google/provider.py
+++ b/src/sentry/identity/google/provider.py
@@ -3,7 +3,6 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.provider import MigratingIdentityId
 from sentry.identity.oauth2 import OAuth2Provider
 from sentry.utils import json
-from sentry.utils.compat import map
 from sentry.utils.signing import urlsafe_b64decode
 
 # When no hosted domain is in use for the authenticated user, we default to the

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -5,7 +5,6 @@ from symbolic import parse_addr
 from sentry.constants import NATIVE_UNKNOWN_STRING
 from sentry.interfaces.exception import upgrade_legacy_mechanism
 from sentry.lang.native.utils import image_name
-from sentry.utils.compat import map
 from sentry.utils.safe import get_path
 
 REPORT_VERSION = "104"

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -7,7 +7,6 @@ import click
 import sentry_sdk
 
 import sentry
-from sentry.utils.compat import map
 from sentry.utils.imports import import_string
 
 # We need to run this here because of a concurrency bug in Python's locale

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -6,7 +6,6 @@ import pytz
 from dateutil.parser import parse
 
 from sentry.runner.decorators import configuration
-from sentry.utils.compat import map
 from sentry.utils.iterators import chunked
 
 

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -6,7 +6,6 @@ import click
 from django.conf import settings
 
 from sentry.utils import metrics, warnings
-from sentry.utils.compat import map
 from sentry.utils.sdk import configure_sdk
 from sentry.utils.warnings import DeprecatedSettingWarning
 

--- a/src/sentry/similarity/encoder.py
+++ b/src/sentry/similarity/encoder.py
@@ -1,7 +1,5 @@
 from collections.abc import Mapping, Sequence, Set
 
-from sentry.utils.compat import map
-
 
 class Encoder:
     try:

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -3,7 +3,6 @@ from collections import Counter, defaultdict
 from django.utils import timezone
 
 from sentry.tsdb.base import BaseTSDB
-from sentry.utils.compat import map
 from sentry.utils.dates import to_datetime, to_timestamp
 
 

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -13,7 +13,6 @@ from django.utils.html import escape
 from PIL import Image  # type: ignore
 
 from sentry.http import safe_urlopen
-from sentry.utils.compat import map
 from sentry.utils.hashlib import md5_text
 
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -20,7 +20,6 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
-from sentry.utils.compat import map
 from sentry.utils.retries import TimedRetryPolicy
 
 logger = logging.getLogger("sentry.testutils")

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -7,8 +7,6 @@ import zlib
 
 from django.utils.encoding import force_text, smart_text
 
-from sentry.utils.compat import map
-
 _word_sep_re = re.compile(r"[\s.;,_-]+", re.UNICODE)
 _camelcase_re = re.compile(r"(?:[A-Z]{2,}(?=[A-Z]))|(?:[A-Z][a-z0-9]+)|(?:[a-z0-9]+)")
 _letters_re = re.compile(r"[A-Z]+")

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -2,7 +2,6 @@ from django.utils.encoding import force_text, python_2_unicode_compatible
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import warnings
-from sentry.utils.compat import map
 
 
 @python_2_unicode_compatible

--- a/src/social_auth/__init__.py
+++ b/src/social_auth/__init__.py
@@ -1,5 +1,3 @@
-from sentry.utils.compat import map
-
 version = (0, 7, 28)
 
 __version__ = ".".join(map(str, version))

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -23,7 +23,6 @@ from django.utils.crypto import constant_time_compare, get_random_string
 from requests_oauthlib import OAuth1
 
 from sentry.utils import json
-from sentry.utils.compat import map
 from social_auth.exceptions import (
     AuthCanceled,
     AuthFailed,


### PR DESCRIPTION
I audited each of these callsites and verified that the map result was immediately serialized to another type or passed to max(...)

___

I did not fix all of `compat.map(...)`, there are many uses which utilize the python 2.x behaviour that will need to be fixed individually