### PR TITLE
fix(profiling): Always set content type for proxied profiling responses

### DIFF
--- a/src/sentry/utils/profiling.py
+++ b/src/sentry/utils/profiling.py
@@ -46,10 +46,13 @@ def proxy_profiling_service(
     response = StreamingHttpResponse(
         streaming_content=stream(),
         status=profiling_response.status_code,
+        content_type=profiling_response.headers.get("Content_type", "application/json"),
     )
-    for h in ["Content-Type", "Content-Encoding", "Vary"]:
+
+    for h in ["Content-Encoding", "Vary"]:
         if h in profiling_response.headers:
             response[h] = profiling_response.headers[h]
+
     return response
 
 


### PR DESCRIPTION
When returning a StreamingHttpResponse, an appropriate content type should be
set so that it is not treated as HTML error in ViewAsRenderMiddleware.

Fixes SENTRY-V18