### PR TITLE
fix(profiling): Flamegraph minimap should render config space

### DIFF
--- a/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
@@ -89,7 +89,7 @@ function FlamegraphZoomViewMinimap({
 
     const drawRectangles = () => {
       flamegraphMiniMapRenderer.draw(
-        flamegraphMiniMapView.fromConfigView(flamegraphMiniMapCanvas.physicalSpace)
+        flamegraphMiniMapView.fromConfigSpace(flamegraphMiniMapCanvas.physicalSpace)
       );
     };
 


### PR DESCRIPTION
The flamegraph minimap should be using the config space to render the full
flamegraph and only use the config view for the position renderer.