### PR TITLE
fix: Disallow whitespace in org slugs

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1,5 +1,4 @@
 import logging
-import string
 from copy import copy
 from datetime import datetime
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1,4 +1,5 @@
 import logging
+import string
 from copy import copy
 from datetime import datetime
 
@@ -186,6 +187,12 @@ class OrganizationSerializer(serializers.Serializer):
         qs = Organization.objects.filter(slug=value).exclude(id=self.context["organization"].id)
         if qs.exists():
             raise serializers.ValidationError(f'The slug "{value}" is already in use.')
+
+        contains_whitespace = True in [c in self.initial_data["slug"] for c in string.whitespace]
+        if contains_whitespace:
+            raise serializers.ValidationError(
+                f'The slug "{value}" should not contain any whitespace.'
+            )
         return value
 
     def validate_relayPiiConfig(self, value):
@@ -382,8 +389,8 @@ class OrganizationSerializer(serializers.Serializer):
             org.flags.require_email_verification = self.initial_data["requireEmailVerification"]
         if "name" in self.initial_data:
             org.name = self.initial_data["name"]
-        if "slug" in self.initial_data:
-            org.slug = self.initial_data["slug"]
+        if "slug" in self.validated_data:
+            org.slug = self.validated_data["slug"]
 
         org_tracked_field = {
             "name": org.name,

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -188,7 +188,7 @@ class OrganizationSerializer(serializers.Serializer):
         if qs.exists():
             raise serializers.ValidationError(f'The slug "{value}" is already in use.')
 
-        contains_whitespace = any(c in self.initial_data["slug"] for c in string.whitespace)
+        contains_whitespace = any(c.isspace() for c in self.initial_data["slug"])
         if contains_whitespace:
             raise serializers.ValidationError(
                 f'The slug "{value}" should not contain any whitespace.'

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -188,7 +188,7 @@ class OrganizationSerializer(serializers.Serializer):
         if qs.exists():
             raise serializers.ValidationError(f'The slug "{value}" is already in use.')
 
-        contains_whitespace = True in [c in self.initial_data["slug"] for c in string.whitespace]
+        contains_whitespace = any(c in self.initial_data["slug"] for c in string.whitespace)
         if contains_whitespace:
             raise serializers.ValidationError(
                 f'The slug "{value}" should not contain any whitespace.'

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -208,6 +208,11 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         illegal_slug = list(RESERVED_ORGANIZATION_SLUGS)[0]
         self.get_error_response(self.organization.slug, slug=illegal_slug, status_code=400)
 
+    def test_invalid_slug(self):
+        self.get_error_response(self.organization.slug, slug=" i have whitespace ", status_code=400)
+        self.get_error_response(self.organization.slug, slug="foo-bar ", status_code=400)
+        self.get_error_response(self.organization.slug, slug="bird-company!", status_code=400)
+
     def test_upload_avatar(self):
         data = {"avatarType": "upload", "avatar": b64encode(self.load_fixture("avatar.jpg"))}
         self.get_success_response(self.organization.slug, **data)


### PR DESCRIPTION
There is an organization that managed to update their org slug to include a whitespace; which is disallowed. For example: `"foo-bar "` (note the whitespace at the end).

 The `slug = serializers.RegexField(r"^[a-z0-9_\-]+$", max_length=50)` serializer is supposed to validate this; but I'm unsure why the regex isn't treating the last whitespace character as non-matching. 

With the extra validation:

![Screen Shot 2022-05-12 at 5 46 13 PM](https://user-images.githubusercontent.com/139499/168173416-e954d165-44c0-4117-b98d-e85f6af9ea83.png)
