### PR TITLE
fix(discoverChart): Set default for Y-axis

### DIFF
--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -81,10 +81,16 @@ function readShowTagsState() {
   return value === '1';
 }
 
-function getYAxis(location: Location, savedQuery?: SavedQuery) {
-  return location.query.yAxis
-    ? decodeList(location.query.yAxis)
-    : decodeList(savedQuery?.yAxis);
+function getYAxis(location: Location, eventView: EventView, savedQuery?: SavedQuery) {
+  if (location.query.yAxis) {
+    return decodeList(location.query.yAxis);
+  }
+  if (location.query.yAxis === null) {
+    return [];
+  }
+  return savedQuery?.yAxis && savedQuery?.yAxis.length > 0
+    ? decodeList(savedQuery?.yAxis)
+    : [eventView.getYAxis()];
 }
 
 class Results extends Component<Props, State> {
@@ -131,8 +137,8 @@ class Results extends Component<Props, State> {
     this.checkEventView();
     const currentQuery = eventView.getEventsAPIPayload(location);
     const prevQuery = prevState.eventView.getEventsAPIPayload(prevProps.location);
-    const yAxisArray = getYAxis(location, savedQuery);
-    const prevYAxisArray = getYAxis(prevProps.location, prevState.savedQuery);
+    const yAxisArray = getYAxis(location, eventView, savedQuery);
+    const prevYAxisArray = getYAxis(prevProps.location, eventView, prevState.savedQuery);
 
     if (
       !isAPIPayloadSimilar(currentQuery, prevQuery) ||
@@ -320,7 +326,7 @@ class Results extends Component<Props, State> {
 
     const newQuery = {
       ...location.query,
-      yAxis: value,
+      yAxis: value.length > 0 ? value : [null],
       // If using Multi Y-axis and not in a supported display, change to the default display mode
       display:
         value.length > 1 && !isDisplayMultiYAxisSupported
@@ -479,7 +485,7 @@ class Results extends Component<Props, State> {
       : eventView.fields;
     const query = eventView.query;
     const title = this.getDocumentTitle();
-    const yAxisArray = getYAxis(location, savedQuery);
+    const yAxisArray = getYAxis(location, eventView, savedQuery);
 
     return (
       <SentryDocumentTitle title={title} orgSlug={organization.slug}>


### PR DESCRIPTION
When there is no `yAxis` parameter in the URL, use a default value for the y-axis dropdown, while still allowing users to clear all values.

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/44172267/168169858-375e7085-d7e9-47f5-8ce6-55f24be001b2.png">
