### PR TITLE
fix(discover): Fix bug preventing saving queries with equation

### DIFF
--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -9,6 +9,7 @@ from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers.rest_framework import ListField
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.constants import ALL_ACCESS_PROJECTS
+from sentry.discover.arithmetic import categorize_columns
 from sentry.discover.models import MAX_TEAM_KEY_TRANSACTIONS, TeamKeyTransaction
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Team
@@ -218,11 +219,13 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
 
         if "query" in query:
             try:
+                equations, columns = categorize_columns(query["fields"])
                 builder = QueryBuilder(
                     dataset=Dataset.Discover,
                     params=self.context["params"],
                     query=query["query"],
-                    selected_columns=query["fields"],
+                    selected_columns=columns,
+                    equations=equations,
                     orderby=query.get("orderby"),
                 )
                 builder.get_snql_query().validate()

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -576,6 +576,28 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert response.status_code == 400, response.content
         assert not DiscoverSavedQuery.objects.filter(name="project query").exists()
 
+    def test_save_with_equation(self):
+        with self.feature(self.feature_name):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Equation query",
+                    "projects": [-1],
+                    "fields": [
+                        "title",
+                        "equation|count_if(measurements.lcp,greater,4000) / count()",
+                        "count()",
+                        "count_if(measurements.lcp,greater,4000)",
+                    ],
+                    "orderby": "equation[0]",
+                    "range": "24h",
+                    "query": "title:1",
+                    "version": 2,
+                },
+            )
+        assert response.status_code == 201, response.content
+        assert DiscoverSavedQuery.objects.filter(name="Equation query").exists()
+
     def test_save_invalid_query(self):
         with self.feature(self.feature_name):
             response = self.client.post(


### PR DESCRIPTION
- This fixes a bug where queries without equations couldn't be saved,
  which was caused because equations were being passed as part of
  selected columns and wasn't being categorized first