### PR TITLE
fix(profiling): Should quote transaction name in functions query

### DIFF
--- a/static/app/views/profiling/functions/index.tsx
+++ b/static/app/views/profiling/functions/index.tsx
@@ -146,7 +146,7 @@ function fetchFunctions(
       method: 'GET',
       includeAllArgs: false,
       query: {
-        query: `transaction_name:${transaction} version:"${version}"`,
+        query: `transaction_name:"${transaction}" version:"${version}"`,
       },
     }
   );


### PR DESCRIPTION
Transaction names can contain spaces, make sure to quote it so it's parsed properly.