### PR TITLE
feat(profiling): invert call tree

### DIFF
--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -1,6 +1,7 @@
 import {Span} from '@sentry/types';
 
 import {defined} from 'sentry/utils';
+import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {Frame} from 'sentry/utils/profiling/frame';
 import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
@@ -179,3 +180,82 @@ export function getSlowestProfileCallsFromProfileGroup(profileGroup: ProfileGrou
     slowestSystemCalls: systemCalls,
   };
 }
+
+function indexNodeToParents(
+  roots: FlamegraphFrame[],
+  map: Record<string, FlamegraphFrame[]>,
+  leafs: FlamegraphFrame[]
+) {
+  // Index each child node to its parent
+  function indexNode(node: FlamegraphFrame, parent: FlamegraphFrame) {
+    if (!map[node.key]) {
+      map[node.key] = [];
+    }
+
+    map[node.key].push(parent);
+
+    if (!node.children.length) {
+      leafs.push(node);
+      return;
+    }
+
+    for (let i = 0; i < node.children.length; i++) {
+      indexNode(node.children[i], node);
+    }
+  }
+
+  // Begin in each root node
+  for (let i = 0; i < roots.length; i++) {
+    leafs.push(roots[i]);
+
+    // If the root has no children, continue
+    if (!roots[i].children?.length) {
+      continue;
+    }
+
+    // Init the map for the root in case we havent yet
+    if (!map[roots[i].key]) {
+      map[roots[i].key] = [];
+    }
+
+    // descend down to each child and index them
+    for (let j = 0; j < roots[i].children.length; j++) {
+      indexNode(roots[i].children[j], roots[i]);
+    }
+  }
+}
+
+function reverseTrail(
+  nodes: FlamegraphFrame[],
+  parentMap: Record<string, FlamegraphFrame[]>
+): FlamegraphFrame[] {
+  const splits: FlamegraphFrame[] = [];
+
+  for (const n of nodes) {
+    const nc = {
+      ...n,
+      parent: null as FlamegraphFrame | null,
+      children: [] as FlamegraphFrame[],
+    };
+
+    if (!parentMap[n.key]) {
+      continue;
+    }
+
+    for (const parent of parentMap[n.key]) {
+      nc.children.push(...reverseTrail([parent], parentMap));
+    }
+    splits.push(nc);
+  }
+
+  return splits;
+}
+
+export const invertCallTree = (roots: FlamegraphFrame[]): FlamegraphFrame[] => {
+  const nodeToParentIndex: Record<string, FlamegraphFrame[]> = {};
+  const leafNodes: FlamegraphFrame[] = [];
+
+  indexNodeToParents(roots, nodeToParentIndex, leafNodes);
+  const reversed = reverseTrail(leafNodes, nodeToParentIndex);
+  return reversed;
+};


### PR DESCRIPTION
Alternative representation that represents the currently selected part of the tree in a "leaf first" approach. This is useful for finding frames with large self times and working your way up to see why they were called

![CleanShot 2022-05-13 at 08 25 49](https://user-images.githubusercontent.com/9317857/168283420-8d2315ba-b650-4363-bf49-4469c536c13a.gif)
.