### PR TITLE
feat(profiling): add table sorting

### DIFF
--- a/static/app/components/profiling/frameStack.tsx
+++ b/static/app/components/profiling/frameStack.tsx
@@ -117,7 +117,7 @@ function FrameCallTreeStack({
           <tr>
             <th>
               <TableHeaderButton onClick={() => onSortChange('self weight')}>
-                {t('Self Time')}{' '}
+                {t('Self Time ')}
                 {sort === 'self weight' ? (
                   <IconArrow direction={direction === 'desc' ? 'down' : 'up'} />
                 ) : null}

--- a/static/app/components/profiling/frameStack.tsx
+++ b/static/app/components/profiling/frameStack.tsx
@@ -83,7 +83,7 @@ function FrameCallTreeStack({
   roots,
   referenceNode,
 }: FrameCallTreeStackProps) {
-  const [sort, setSort] = useState<'total weight' | 'self weight' | 'name' | null>(
+  const [sort, setSort] = useState<'total weight' | 'self weight' | 'name'>(
     'total weight'
   );
   const [direction, setDirection] = useState<'asc' | 'desc'>('desc');

--- a/static/app/components/profiling/frameStack.tsx
+++ b/static/app/components/profiling/frameStack.tsx
@@ -36,10 +36,15 @@ function formatColorForFrame(
 
 interface FrameCallTreeStackProps {
   flamegraphRenderer: FlamegraphRenderer;
+  referenceNode: FlamegraphFrame;
   roots: FlamegraphFrame[];
 }
 
-function FrameCallTreeStack({flamegraphRenderer, roots}: FrameCallTreeStackProps) {
+function FrameCallTreeStack({
+  flamegraphRenderer,
+  roots,
+  referenceNode,
+}: FrameCallTreeStackProps) {
   return (
     <FrameBar>
       <FrameCallersTable>
@@ -59,7 +64,7 @@ function FrameCallTreeStack({flamegraphRenderer, roots}: FrameCallTreeStackProps
                   key={r.key}
                   depth={0}
                   frame={r}
-                  referenceNode={r}
+                  referenceNode={referenceNode}
                   flamegraphRenderer={flamegraphRenderer}
                 />
               );
@@ -170,9 +175,9 @@ interface FrameStackProps {
 }
 
 function FrameStack(props: FrameStackProps) {
-  const [tab, setTab] = useState<'bottom up' | 'call order'>('call order');
   const theme = useFlamegraphTheme();
   const {selectedNode} = useFlamegraphProfilesValue();
+  const [tab, setTab] = useState<'bottom up' | 'call order'>('call order');
 
   const roots = useMemo(() => {
     if (!selectedNode) {
@@ -208,7 +213,7 @@ function FrameStack(props: FrameStackProps) {
         </li>
       </FrameTabs>
 
-      <FrameCallTreeStack {...props} roots={roots ?? []} />
+      <FrameCallTreeStack {...props} roots={roots ?? []} referenceNode={selectedNode} />
     </FrameDrawer>
   ) : null;
 }

--- a/static/app/components/profiling/frameStack.tsx
+++ b/static/app/components/profiling/frameStack.tsx
@@ -2,6 +2,7 @@ import {Fragment, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
+import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
@@ -34,6 +35,43 @@ function formatColorForFrame(
   return `rgba(${color.map(n => n * 255).join(',')}, 1.0)`;
 }
 
+function makeSortFunction(
+  property: 'total weight' | 'self weight' | 'name',
+  direction: 'asc' | 'desc'
+) {
+  if (property === 'total weight') {
+    return direction === 'desc'
+      ? (a: FlamegraphFrame, b: FlamegraphFrame) => {
+          return b.node.totalWeight - a.node.totalWeight;
+        }
+      : (a: FlamegraphFrame, b: FlamegraphFrame) => {
+          return a.node.totalWeight - b.node.totalWeight;
+        };
+  }
+
+  if (property === 'self weight') {
+    return direction === 'desc'
+      ? (a: FlamegraphFrame, b: FlamegraphFrame) => {
+          return b.node.selfWeight - a.node.selfWeight;
+        }
+      : (a: FlamegraphFrame, b: FlamegraphFrame) => {
+          return a.node.selfWeight - b.node.selfWeight;
+        };
+  }
+
+  if (property === 'name') {
+    return direction === 'desc'
+      ? (a: FlamegraphFrame, b: FlamegraphFrame) => {
+          return a.frame.name.localeCompare(b.frame.name);
+        }
+      : (a: FlamegraphFrame, b: FlamegraphFrame) => {
+          return b.frame.name.localeCompare(a.frame.name);
+        };
+  }
+
+  throw new Error(`Unknown sort property ${property}`);
+}
+
 interface FrameCallTreeStackProps {
   flamegraphRenderer: FlamegraphRenderer;
   referenceNode: FlamegraphFrame;
@@ -45,30 +83,77 @@ function FrameCallTreeStack({
   roots,
   referenceNode,
 }: FrameCallTreeStackProps) {
+  const [sort, setSort] = useState<'total weight' | 'self weight' | 'name' | null>(
+    'total weight'
+  );
+  const [direction, setDirection] = useState<'asc' | 'desc'>('desc');
+
+  const sortFunction: FrameRowProps['sortFunction'] = useMemo(() => {
+    if (sort === null) {
+      return () => 0;
+    }
+    return makeSortFunction(sort, direction);
+  }, [sort, direction]);
+
+  const onSortChange = useCallback(
+    (newSort: 'total weight' | 'self weight' | 'name') => {
+      // If sort is the same, just invert the direction
+      if (newSort === sort) {
+        setDirection(direction === 'asc' ? 'desc' : 'asc');
+        return;
+      }
+
+      // Else set the new sort and default to descending order
+      setSort(newSort);
+      setDirection('desc');
+    },
+    [sort, direction]
+  );
+
   return (
     <FrameBar>
       <FrameCallersTable>
         <FrameCallersTableHeader>
           <tr>
-            <th>{t('Self Time')}</th>
-            <th>{t('Total Time')}</th>
-            <th colSpan={100}>{t('Frame')}</th>
+            <th>
+              <TableHeaderButton onClick={() => onSortChange('self weight')}>
+                {t('Self Time')}{' '}
+                {sort === 'self weight' ? (
+                  <IconArrow direction={direction === 'desc' ? 'down' : 'up'} />
+                ) : null}
+              </TableHeaderButton>
+            </th>
+            <th>
+              <TableHeaderButton onClick={() => onSortChange('total weight')}>
+                {t('Total Time')}{' '}
+                {sort === 'total weight' ? (
+                  <IconArrow direction={direction === 'desc' ? 'down' : 'up'} />
+                ) : null}
+              </TableHeaderButton>
+            </th>
+            <th colSpan={100}>
+              <TableHeaderButton onClick={() => onSortChange('name')}>
+                {t('Frame')}{' '}
+                {sort === 'name' ? (
+                  <IconArrow direction={direction === 'desc' ? 'down' : 'up'} />
+                ) : null}
+              </TableHeaderButton>
+            </th>
           </tr>
         </FrameCallersTableHeader>
         <tbody>
-          {roots
-            .sort((a, b) => b.node.selfWeight - a.node.selfWeight)
-            .map(r => {
-              return (
-                <FrameRow
-                  key={r.key}
-                  depth={0}
-                  frame={r}
-                  referenceNode={referenceNode}
-                  flamegraphRenderer={flamegraphRenderer}
-                />
-              );
-            })}
+          {roots.sort(sortFunction).map(r => {
+            return (
+              <FrameRow
+                key={r.key}
+                depth={0}
+                frame={r}
+                sortFunction={sortFunction}
+                referenceNode={referenceNode}
+                flamegraphRenderer={flamegraphRenderer}
+              />
+            );
+          })}
           {/* We add a row at the end with rowSpan so that we can have that nice border-right stretched over the entire table */}
           <tr>
             <FrameCallersTableCell rowSpan={100} />
@@ -81,11 +166,32 @@ function FrameCallTreeStack({
   );
 }
 
+const TableHeaderButton = styled('button')`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 ${space(1)};
+  border: none;
+  background-color: ${props => props.theme.surface400};
+  transition: background-color 100ms ease-in-out;
+
+  &:hover {
+    background-color: #edecee;
+  }
+
+  svg {
+    width: 10px;
+    height: 10px;
+  }
+`;
+
 interface FrameRowProps {
   depth: number;
   flamegraphRenderer: FlamegraphRenderer;
   frame: FlamegraphFrame;
   referenceNode: FlamegraphFrame;
+  sortFunction: (a: FlamegraphFrame, b: FlamegraphFrame) => number;
   initialOpen?: boolean;
 }
 
@@ -94,6 +200,7 @@ function FrameRow({
   frame,
   flamegraphRenderer,
   referenceNode,
+  sortFunction,
   initialOpen,
 }: FrameRowProps) {
   const [open, setOpen] = useState<boolean>(initialOpen ?? false);
@@ -154,16 +261,19 @@ function FrameRow({
         </FrameCallersTableCell>
       </FrameCallersRow>
       {open
-        ? frame.children.map(c => (
-            <FrameRow
-              key={c.key}
-              frame={c}
-              referenceNode={referenceNode}
-              initialOpen={forceOpenChildren ? open : undefined}
-              flamegraphRenderer={flamegraphRenderer}
-              depth={depth + 1}
-            />
-          ))
+        ? frame.children
+            .sort(sortFunction)
+            .map(c => (
+              <FrameRow
+                key={c.key}
+                frame={c}
+                referenceNode={referenceNode}
+                initialOpen={forceOpenChildren ? open : undefined}
+                flamegraphRenderer={flamegraphRenderer}
+                sortFunction={sortFunction}
+                depth={depth + 1}
+              />
+            ))
         : null}
     </Fragment>
   );
@@ -230,6 +340,7 @@ const FrameTabs = styled('ul')`
   padding: 0 ${space(1)};
   margin: 0;
   border-top: 1px solid ${prop => prop.theme.border};
+  background-color: ${props => props.theme.surface400};
 
   > li {
     font-size: ${p => p.theme.fontSizeSmall};
@@ -337,9 +448,8 @@ const FrameCallersTableHeader = styled('thead')`
   th {
     position: relative;
     border-bottom: 1px solid ${p => p.theme.border};
-    background-color: ${p => p.theme.surface100};
+    background-color: ${p => p.theme.surface400};
     white-space: nowrap;
-    padding: 0 ${space(1)};
 
     &:first-child,
     &:nth-child(2) {

--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -1,6 +1,7 @@
 import {Span} from '@sentry/types';
 
 import {defined} from 'sentry/utils';
+import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {Frame} from 'sentry/utils/profiling/frame';
 import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
@@ -179,3 +180,82 @@ export function getSlowestProfileCallsFromProfileGroup(profileGroup: ProfileGrou
     slowestSystemCalls: systemCalls,
   };
 }
+
+function indexNodeToParents(
+  roots: FlamegraphFrame[],
+  map: Record<string, FlamegraphFrame[]>,
+  leafs: FlamegraphFrame[]
+) {
+  // Index each child node to its parent
+  function indexNode(node: FlamegraphFrame, parent: FlamegraphFrame) {
+    if (!map[node.key]) {
+      map[node.key] = [];
+    }
+
+    map[node.key].push(parent);
+
+    if (!node.children.length) {
+      leafs.push(node);
+      return;
+    }
+
+    for (let i = 0; i < node.children.length; i++) {
+      indexNode(node.children[i], node);
+    }
+  }
+
+  // Begin in each root node
+  for (let i = 0; i < roots.length; i++) {
+    leafs.push(roots[i]);
+
+    // If the root has no children, continue
+    if (!roots[i].children?.length) {
+      continue;
+    }
+
+    // Init the map for the root in case we havent yet
+    if (!map[roots[i].key]) {
+      map[roots[i].key] = [];
+    }
+
+    // descend down to each child and index them
+    for (let j = 0; j < roots[i].children.length; j++) {
+      indexNode(roots[i].children[j], roots[i]);
+    }
+  }
+}
+
+function reverseTrail(
+  nodes: FlamegraphFrame[],
+  parentMap: Record<string, FlamegraphFrame[]>
+): FlamegraphFrame[] {
+  const splits: FlamegraphFrame[] = [];
+
+  for (const n of nodes) {
+    const nc = {
+      ...n,
+      parent: null as FlamegraphFrame | null,
+      children: [] as FlamegraphFrame[],
+    };
+
+    if (!parentMap[n.key]) {
+      continue;
+    }
+
+    for (const parent of parentMap[n.key]) {
+      nc.children.push(...reverseTrail([parent], parentMap));
+    }
+    splits.push(nc);
+  }
+
+  return splits;
+}
+
+export const invertCallTree = (roots: FlamegraphFrame[]): FlamegraphFrame[] => {
+  const nodeToParentIndex: Record<string, FlamegraphFrame[]> = {};
+  const leafNodes: FlamegraphFrame[] = [];
+
+  indexNodeToParents(roots, nodeToParentIndex, leafNodes);
+  const reversed = reverseTrail(leafNodes, nodeToParentIndex);
+  return reversed;
+};


### PR DESCRIPTION
Allow users to sort the table in asc/desc order. Note that this sorts at node level, so it preserves the hierarchy.

![CleanShot 2022-05-13 at 10 52 11](https://user-images.githubusercontent.com/9317857/168310702-f0adb3db-6a9a-402f-9497-a96a8f7f6c65.gif)
