### PR TITLE
feat(flamegraphzoomview): add back total weight and 

### DIFF
--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -2,6 +2,7 @@ import {useLayoutEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
 
+import space from 'sentry/styles/space';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
@@ -91,7 +92,6 @@ function BoundTooltip({
   let cursorHorizontalPosition = logicalSpaceCursor[0];
   // Move the tooltip just beneath the cursor so that the text isn't covered.
   const cursorVerticalPosition = logicalSpaceCursor[1] + 8;
-
   const mid = bounds.width / 2;
 
   // If users screen is on right half of the screen, then we have more space to position on the left and vice versa
@@ -101,6 +101,7 @@ function BoundTooltip({
     cursorHorizontalPosition -= tooltipBounds.width;
   }
 
+  const PADDING = 24;
   return (
     <Tooltip
       ref={tooltipRef}
@@ -109,7 +110,9 @@ function BoundTooltip({
         fontFamily: flamegraphTheme.FONTS.FONT,
         left: cursorHorizontalPosition,
         top: cursorVerticalPosition,
-        width: Math.min(tooltipRect.width, bounds.width - cursorHorizontalPosition - 2),
+        width:
+          Math.min(tooltipRect.width, bounds.width - cursorHorizontalPosition - 2) +
+          PADDING,
       }}
     >
       {children}
@@ -125,6 +128,8 @@ const Tooltip = styled('div')`
   overflow: hidden;
   pointer-events: none;
   user-select: none;
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${space(0.25)} ${space(1)};
 `;
 
 export {BoundTooltip};

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -2,6 +2,7 @@ import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react
 import styled from '@emotion/styled';
 import {mat3, vec2} from 'gl-matrix';
 
+import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {DifferentialFlamegraph} from 'sentry/utils/profiling/differentialFlamegraph';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
@@ -25,6 +26,10 @@ import {
   FlamegraphOptionsContextMenu,
   useContextMenu,
 } from './flamegraphOptionsContextMenu';
+
+function formatWeightToProfileDuration(frame: CallTreeNode, flamegraph: Flamegraph) {
+  return `(${Math.round((frame.totalWeight / flamegraph.profile.duration) * 100)}%)`;
+}
 
 interface FlamegraphZoomViewProps {
   canvasBounds: Rect;
@@ -634,13 +639,18 @@ function FlamegraphZoomView({
           contextMenuProps={contextMenuProps}
         />
       ) : null}
-      {flamegraphCanvas && flamegraphView && hoveredNode?.frame?.name ? (
+      {flamegraphCanvas &&
+      flamegraphRenderer &&
+      flamegraphView &&
+      hoveredNode?.frame?.name ? (
         <BoundTooltip
           bounds={canvasBounds}
           cursor={configSpaceCursor}
           flamegraphCanvas={flamegraphCanvas}
           flamegraphView={flamegraphView}
         >
+          {flamegraphRenderer.flamegraph.formatter(hoveredNode.node.totalWeight)}{' '}
+          {formatWeightToProfileDuration(hoveredNode.node, flamegraphRenderer.flamegraph)}{' '}
           {hoveredNode.frame.name}
         </BoundTooltip>
       ) : null}


### PR DESCRIPTION
Adds total frame weight to the flamegraph tooltip and it's relative size expressed in % of the total profile duration.

<img width="666" alt="CleanShot 2022-05-13 at 13 14 57@2x" src="https://user-images.githubusercontent.com/9317857/168334697-e98495b4-1d33-43e2-bd63-384bbea1cfe3.png">