### PR TITLE
feat(codeowners): add support for matching thread stack trace frames

### DIFF
--- a/src/sentry/grouping/fingerprinting.py
+++ b/src/sentry/grouping/fingerprinting.py
@@ -129,7 +129,6 @@ class EventAccess:
             self._frames = []
 
         find_stack_frames(self.event.data, self._push_frame)
-
         return self._frames
 
     def get_toplevel(self):

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping, MutableMapping, Sequence
+from copy import deepcopy
+from typing import Any, Callable, Mapping, MutableMapping, Optional, Sequence, Tuple, cast
 
 from sentry.utils.safe import PathSearchable, get_path
 
@@ -20,27 +21,50 @@ def get_crashing_thread(thread_frames: Sequence[Mapping[str, Any]]) -> Mapping[s
     return None
 
 
-def supplement_filename(platform: str, data_frames: Sequence[MutableMapping[str, Any]]) -> None:
-    # Java stackframes don't have an absolute path in the filename key.
-    # That property is usually just the basename of the file. In the future
-    # the Java SDK might generate better file paths, but for now we use the module
-    # path to approximate the file path so that we can intersect it with commit
-    # file paths.
-    if platform == "java":
-        for frame in data_frames:
-            if frame.get("filename") is None:
-                continue
-            if "/" not in str(frame.get("filename")) and frame.get("module"):
-                # Replace the last module segment with the filename, as the
-                # terminal element in a module path is the class
-                module = frame["module"].split(".")
-                module[-1] = frame["filename"]
-                frame["filename"] = "/".join(module)
+FrameMunger = Callable[[str, MutableMapping[str, Any]], bool]
+
+
+def java_frame_munger(key: str, frame: MutableMapping[str, Any]) -> bool:
+    if frame.get("filename") is None or frame.get("module") is None:
+        return False
+    if "/" not in str(frame.get("filename")) and frame.get("module"):
+        # Replace the last module segment with the filename, as the
+        # terminal element in a module path is the class
+        module = frame["module"].split(".")
+        module[-1] = frame["filename"]
+        frame[key] = "/".join(module)
+        return True
+    return False
+
+
+PLATFORM_FRAME_MUNGER: Mapping[str, FrameMunger] = {"java": java_frame_munger}
+
+
+def munged_filename_and_frames(
+    platform: str, data_frames: Sequence[Mapping[str, Any]], key: str = "munged_filename"
+) -> Optional[Tuple[str, Sequence[Mapping[str, Any]]]]:
+    """
+    Applies platform-specific frame munging for filename pathing.
+
+    Returns the key used to insert into the frames and a deepcopy of the input data_frames with munging applied,
+    otherwise returns None.
+    """
+    munger = PLATFORM_FRAME_MUNGER.get(platform)
+    if not munger:
+        return None
+
+    copy_frames: Sequence[MutableMapping[str, Any]] = cast(
+        Sequence[MutableMapping[str, Any]], deepcopy(data_frames)
+    )
+    frames_updated = False
+    for frame in copy_frames:
+        frames_updated |= munger(key, frame)
+    return (key, copy_frames) if frames_updated else None
 
 
 def find_stack_frames(
     event_data: PathSearchable, consume_frame: Callable[[Any], None] = lambda _: None
-) -> Sequence[MutableMapping[str, Any]]:
+) -> Sequence[Mapping[str, Any]]:
     """
     See: https://develop.sentry.dev/sdk/event-payloads/#core-interfaces for event data payload format.
 

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -40,7 +40,7 @@ def supplement_filename(platform: str, data_frames: Sequence[MutableMapping[str,
 
 def find_stack_frames(
     event_data: PathSearchable, consume_frame: Callable[[Any], None] = lambda _: None
-) -> Sequence[Mapping[str, Any]]:
+) -> Sequence[MutableMapping[str, Any]]:
     """
     See: https://develop.sentry.dev/sdk/event-payloads/#core-interfaces for event data payload format.
 

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -5,22 +5,6 @@ from typing import Any, Callable, Mapping, MutableMapping, Optional, Sequence, T
 
 from sentry.utils.safe import PathSearchable, get_path
 
-
-def get_crashing_thread(thread_frames: Sequence[Mapping[str, Any]]) -> Mapping[str, Any] | None:
-    if not thread_frames:
-        return None
-    if len(thread_frames) == 1:
-        return thread_frames[0]
-    filtered = [x for x in thread_frames if x and x.get("crashed")]
-    if len(filtered) == 1:
-        return filtered[0]
-    filtered = [x for x in thread_frames if x and x.get("current")]
-    if len(filtered) == 1:
-        return filtered[0]
-
-    return None
-
-
 FrameMunger = Callable[[str, MutableMapping[str, Any]], bool]
 
 
@@ -60,6 +44,21 @@ def munged_filename_and_frames(
     for frame in copy_frames:
         frames_updated |= munger(key, frame)
     return (key, copy_frames) if frames_updated else None
+
+
+def get_crashing_thread(thread_frames: Sequence[Mapping[str, Any]]) -> Mapping[str, Any] | None:
+    if not thread_frames:
+        return None
+    if len(thread_frames) == 1:
+        return thread_frames[0]
+    filtered = [x for x in thread_frames if x and x.get("crashed")]
+    if len(filtered) == 1:
+        return filtered[0]
+    filtered = [x for x in thread_frames if x and x.get("current")]
+    if len(filtered) == 1:
+        return filtered[0]
+
+    return None
 
 
 def find_stack_frames(

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -179,18 +179,11 @@ def test_matcher_test_threads():
         "threads": {
             "values": [
                 {
-                    "id": 0,
                     "stacktrace": {
                         "frames": [
-                            {
-                                # "function": "invoke0",
-                                "abs_path": "NativeMethodAccessorImpl.java",
-                                # "in_app": False,
-                                "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
-                                # "filename": "NativeMethodAccessorImpl.java",
-                            }
-                        ],
-                        "registers": {},
+                            {"filename": "foo/file.py"},
+                            {"abs_path": "/usr/local/src/other/app.py"},
+                        ]
                     },
                     "crashed": False,
                     "current": False,
@@ -199,9 +192,37 @@ def test_matcher_test_threads():
         }
     }
 
+    assert Matcher("path", "*.py").test(data)
+    assert Matcher("path", "foo/*.py").test(data)
+    assert Matcher("path", "/usr/local/src/*/app.py").test(data)
+    assert not Matcher("path", "*.js").test(data)
+    assert not Matcher("path", "*.jsx").test(data)
+    assert not Matcher("url", "*.py").test(data)
+    assert not Matcher("path", "*.py").test({})
+
+
+def test_matcher_test_platform_java_threads():
+    data = {
+        "platform": "java",
+        "threads": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
+                                "filename": "NativeMethodAccessorImpl.java",
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+
     assert Matcher("path", "*.java").test(data)
-    assert Matcher("path", "/jdk/internal/reflect/*.java").test(data)
-    # assert Matcher("path", "/jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
+    assert Matcher("path", "jdk/internal/reflect/*.java").test(data)
+    assert Matcher("path", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
     assert not Matcher("path", "*.js").test(data)
     assert not Matcher("path", "*.jsx").test(data)
     assert not Matcher("url", "*.py").test(data)

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -174,6 +174,40 @@ def test_matcher_test_stacktrace():
     assert not Matcher("path", "*.py").test({})
 
 
+def test_matcher_test_threads():
+    data = {
+        "threads": {
+            "values": [
+                {
+                    "id": 0,
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                # "function": "invoke0",
+                                "abs_path": "NativeMethodAccessorImpl.java",
+                                # "in_app": False,
+                                "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
+                                # "filename": "NativeMethodAccessorImpl.java",
+                            }
+                        ],
+                        "registers": {},
+                    },
+                    "crashed": False,
+                    "current": False,
+                }
+            ]
+        }
+    }
+
+    assert Matcher("path", "*.java").test(data)
+    assert Matcher("path", "/jdk/internal/reflect/*.java").test(data)
+    # assert Matcher("path", "/jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
+    assert not Matcher("path", "*.js").test(data)
+    assert not Matcher("path", "*.jsx").test(data)
+    assert not Matcher("url", "*.py").test(data)
+    assert not Matcher("path", "*.py").test({})
+
+
 def test_matcher_test_tags():
     data = {
         "tags": [["foo", "foo_value"], ["bar", "barval"]],

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -229,6 +229,36 @@ def test_matcher_test_platform_java_threads():
     assert not Matcher("path", "*.py").test({})
 
 
+def test_matcher_test_platform_none_threads():
+    data = {
+        "threads": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
+                                "filename": "NativeMethodAccessorImpl.java",
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+
+    # since no platform, we won't be able to fully-qualify(filename munge) based off module and filename
+    # matching will still work based on just the filename, but we won't be able to match on the src path
+    assert Matcher("path", "NativeMethodAccessorImpl.java").test(data)
+    assert Matcher("path", "*.java").test(data)
+    assert not Matcher("path", "jdk/internal/reflect/*.java").test(data)
+    assert not Matcher("path", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
+    assert not Matcher("path", "*.js").test(data)
+    assert not Matcher("path", "*.jsx").test(data)
+    assert not Matcher("url", "*.py").test(data)
+    assert not Matcher("path", "*.py").test({})
+
+
 def test_matcher_test_tags():
     data = {
         "tags": [["foo", "foo_value"], ["bar", "barval"]],

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -195,6 +195,9 @@ def test_matcher_test_threads():
     assert Matcher("path", "*.py").test(data)
     assert Matcher("path", "foo/*.py").test(data)
     assert Matcher("path", "/usr/local/src/*/app.py").test(data)
+    assert Matcher("codeowners", "*.py").test(data)
+    assert Matcher("codeowners", "foo/*.py").test(data)
+    assert Matcher("codeowners", "/usr/local/src/*/app.py").test(data)
     assert not Matcher("path", "*.js").test(data)
     assert not Matcher("path", "*.jsx").test(data)
     assert not Matcher("url", "*.py").test(data)
@@ -223,6 +226,9 @@ def test_matcher_test_platform_java_threads():
     assert Matcher("path", "*.java").test(data)
     assert Matcher("path", "jdk/internal/reflect/*.java").test(data)
     assert Matcher("path", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
+    assert Matcher("codeowners", "*.java").test(data)
+    assert Matcher("codeowners", "jdk/internal/reflect/*.java").test(data)
+    assert Matcher("codeowners", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
     assert not Matcher("path", "*.js").test(data)
     assert not Matcher("path", "*.jsx").test(data)
     assert not Matcher("url", "*.py").test(data)
@@ -251,10 +257,16 @@ def test_matcher_test_platform_none_threads():
     # matching will still work based on just the filename, but we won't be able to match on the src path
     assert Matcher("path", "NativeMethodAccessorImpl.java").test(data)
     assert Matcher("path", "*.java").test(data)
+    assert Matcher("codeowners", "NativeMethodAccessorImpl.java").test(data)
+    assert Matcher("codeowners", "*.java").test(data)
     assert not Matcher("path", "jdk/internal/reflect/*.java").test(data)
     assert not Matcher("path", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
     assert not Matcher("path", "*.js").test(data)
     assert not Matcher("path", "*.jsx").test(data)
+    assert not Matcher("codeowners", "jdk/internal/reflect/*.java").test(data)
+    assert not Matcher("codeowners", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
+    assert not Matcher("codeowners", "*.js").test(data)
+    assert not Matcher("codeowners", "*.jsx").test(data)
     assert not Matcher("url", "*.py").test(data)
     assert not Matcher("path", "*.py").test({})
 
@@ -653,8 +665,32 @@ def test_codeowners_match_backslash(path_details, expected):
         ),
     ],
 )
-def test_codeowners_match_fowardslash(path_details, expected):
+def test_codeowners_match_forwardslash(path_details, expected):
     _assert_matcher(Matcher("codeowners", "/"), path_details, expected)
+
+
+def test_codeowners_match_threads():
+    data = {
+        "threads": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {"filename": "foo/file.py"},
+                            {"abs_path": "/usr/local/src/other/app.py"},
+                        ]
+                    },
+                    "crashed": False,
+                    "current": False,
+                }
+            ]
+        }
+    }
+
+    assert Matcher("codeowners", "*.py").test(data)
+    assert Matcher("codeowners", "foo/file.py").test(data)
+    assert Matcher("codeowners", "/**/app.py").test(data)
+    assert Matcher("codeowners", "/usr/*/src/*/app.py").test(data)
 
 
 def test_parse_code_owners():


### PR DESCRIPTION
Previously, code owners didn't have support for matching on `path` patterns within thread stack frames(if present). This PR adds that support. 

This PR is also in preparations for adding support for mobile languages, which requires some stack frame transformations - that work will be in a later PR. 

Fixes: WOR-1801