### PR TITLE
feat(replays): Chapters disappear when browser window > 900 & < 1200

### DIFF
--- a/static/app/views/replays/detail/userActionsNavigator.tsx
+++ b/static/app/views/replays/detail/userActionsNavigator.tsx
@@ -134,8 +134,10 @@ const Panel = styled(BasePanel)`
   grid-template-rows: auto 1fr;
   height: 0;
   min-height: 100%;
-  @media only screen and (max-width: ${p => p.theme.breakpoints[1]}) {
-    min-height: 450px;
+  @media only screen and (max-width: ${p => p.theme.breakpoints[2]}) {
+    height: fit-content;
+    max-height: 400px;
+    margin-top: ${space(2)};
   }
 `;
 


### PR DESCRIPTION
### Description

Chapters component disappears when the browser window is narrow.

Ex. Browser window > 900 || window < 1200

Fixes #34483 

### Screenshots

<img width="929" alt="image" src="https://user-images.githubusercontent.com/14813235/168345656-130c523f-4bb4-482d-a572-39541fc680aa.png">

---
