### PR TITLE
Revert "Revert "fix(notifications): Use `metrics_key` (#34572)""

### DIFF
--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -19,9 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_headers(notification: BaseNotification) -> Mapping[str, Any]:
-    headers = {
-        "X-SMTPAPI": json.dumps({"category": notification.get_category()}),
-    }
+    headers = {"X-SMTPAPI": json.dumps({"category": notification.metrics_key})}
     if isinstance(notification, ProjectNotification):
         headers["X-Sentry-Project"] = notification.project.slug
 
@@ -154,7 +152,7 @@ def get_builder_args_from_context(
         "html_template": f"{notification.template_path}.html",
         "headers": get_headers(notification),
         "reference": notification.reference,
-        "type": notification.get_type(),
+        "type": notification.metrics_key,
     }
     # add in optinal fields
     from_email = notification.from_email

--- a/src/sentry/notifications/notifications/activity/assigned.py
+++ b/src/sentry/notifications/notifications/activity/assigned.py
@@ -48,17 +48,14 @@ def get_assignee_str(activity: Activity, organization: Organization) -> str:
 
 
 class AssignedActivityNotification(GroupActivityNotification):
+    metrics_key = "assigned_activity"
     title = "Assigned"
-    referrer_base = "assigned-activity"
 
     def get_assignee(self) -> str:
         return get_assignee_str(self.activity, self.organization)
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} assigned {an issue} to {assignee}", {"assignee": self.get_assignee()}, {}
-
-    def get_category(self) -> str:
-        return "assigned_activity_email"
 
     def get_notification_title(self) -> str:
         assignee = self.get_assignee()

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -21,9 +21,9 @@ if TYPE_CHECKING:
 
 
 class ActivityNotification(ProjectNotification, abc.ABC):
+    metrics_key = "activity"
     notification_setting_type = NotificationSettingTypes.WORKFLOW
     template_path = "sentry/emails/activity/generic"
-    metrics_key = "activity"
 
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity.project)
@@ -55,9 +55,6 @@ class ActivityNotification(ProjectNotification, abc.ABC):
     @property
     def reference(self) -> Model | None:
         return self.activity
-
-    def get_type(self) -> str:
-        return f"notify.activity.{self.activity.get_type_display()}"
 
     @abc.abstractmethod
     def get_context(self) -> MutableMapping[str, Any]:

--- a/src/sentry/notifications/notifications/activity/new_processing_issues.py
+++ b/src/sentry/notifications/notifications/activity/new_processing_issues.py
@@ -12,7 +12,7 @@ from .base import ActivityNotification
 
 
 class NewProcessingIssuesActivityNotification(ActivityNotification):
-    referrer_base = "new-processing-issues-activity"
+    metrics_key = "new_processing_issues_activity"
     template_path = "sentry/emails/activity/new_processing_issues"
 
     def __init__(self, activity: Activity) -> None:
@@ -53,9 +53,6 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
     @property
     def title(self) -> str:
         return self.get_subject()
-
-    def get_category(self) -> str:
-        return "new_processing_issues_activity_email"
 
     def get_notification_title(self) -> str:
         project_url = absolute_uri(

--- a/src/sentry/notifications/notifications/activity/note.py
+++ b/src/sentry/notifications/notifications/activity/note.py
@@ -10,14 +10,11 @@ if TYPE_CHECKING:
 
 class NoteActivityNotification(GroupActivityNotification):
     message_builder = "SlackNotificationsMessageBuilder"
-    referrer_base = "note-activity"
+    metrics_key = "note_activity"
     template_path = "sentry/emails/activity/note"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return str(self.activity.data["text"]), {}, {}
-
-    def get_category(self) -> str:
-        return "note_activity_email"
 
     @property
     def title(self) -> str:

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -12,8 +12,8 @@ from .base import GroupActivityNotification
 
 
 class RegressionActivityNotification(GroupActivityNotification):
+    metrics_key = "regression_activity"
     title = "Regression"
-    referrer_base = "regression-activity"
 
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity)
@@ -33,9 +33,6 @@ class RegressionActivityNotification(GroupActivityNotification):
             html_params["version"] = f'<a href="{version_url}">{escape(self.version_parsed)}</a>'
 
         return message, params, html_params
-
-    def get_category(self) -> str:
-        return "regression_activity_email"
 
     def get_notification_title(self) -> str:
         text = "Issue marked as regression"

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -32,7 +32,7 @@ from .base import ActivityNotification
 
 
 class ReleaseActivityNotification(ActivityNotification):
-    referrer_base = "release-activity"
+    metrics_key = "release_activity"
     notification_setting_type = NotificationSettingTypes.DEPLOY
     template_path = "sentry/emails/activity/release"
 
@@ -141,9 +141,6 @@ class ReleaseActivityNotification(ActivityNotification):
         elif len(self.projects) > 1:
             projects_text = " for these projects"
         return f"Release {self.version_parsed} was deployed to {self.environment}{projects_text}"
-
-    def get_category(self) -> str:
-        return "release_activity_email"
 
     def get_message_actions(self, recipient: Team | User) -> Sequence[MessageAction]:
         if self.release:

--- a/src/sentry/notifications/notifications/activity/resolved.py
+++ b/src/sentry/notifications/notifications/activity/resolved.py
@@ -6,11 +6,8 @@ from .base import GroupActivityNotification
 
 
 class ResolvedActivityNotification(GroupActivityNotification):
+    metrics_key = "resolved_activity"
     title = "Resolved Issue"
-    referrer_base = "resolved-activity"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} marked {an issue} as resolved", {}, {}
-
-    def get_category(self) -> str:
-        return "resolved_activity_email"

--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -9,8 +9,8 @@ from .base import GroupActivityNotification
 
 
 class ResolvedInReleaseActivityNotification(GroupActivityNotification):
+    metrics_key = "resolved_in_release_activity"
     title = "Resolved Issue"
-    referrer_base = "resolved-in-release-activity"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         data = self.activity.data
@@ -30,9 +30,6 @@ class ResolvedInReleaseActivityNotification(GroupActivityNotification):
                 },
             )
         return "{author} marked {an issue} as resolved in an upcoming release", {}, {}
-
-    def get_category(self) -> str:
-        return "resolved_in_release_activity_email"
 
     def get_notification_title(self) -> str:
         data = self.activity.data

--- a/src/sentry/notifications/notifications/activity/unassigned.py
+++ b/src/sentry/notifications/notifications/activity/unassigned.py
@@ -6,14 +6,11 @@ from .base import GroupActivityNotification
 
 
 class UnassignedActivityNotification(GroupActivityNotification):
+    metrics_key = "unassigned_activity"
     title = "Unassigned"
-    referrer_base = "unassigned-activity"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} unassigned {an issue}", {}, {}
-
-    def get_category(self) -> str:
-        return "unassigned_activity_email"
 
     def get_notification_title(self) -> str:
         user = self.activity.user

--- a/src/sentry/notifications/notifications/codeowners_auto_sync.py
+++ b/src/sentry/notifications/notifications/codeowners_auto_sync.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 
 class AutoSyncNotification(ProjectNotification):
+    metrics_key = "auto_sync"
     notification_setting_type = NotificationSettingTypes.DEPLOY
     template_path = "sentry/emails/codeowners-auto-sync-failure"
 
@@ -47,9 +48,3 @@ class AutoSyncNotification(ProjectNotification):
             )
         )
         return context
-
-    def get_type(self) -> str:
-        return "deploy.auto-sync"
-
-    def get_category(self) -> str:
-        return "auto-sync"

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 class DigestNotification(ProjectNotification):
     message_builder = "DigestNotificationMessageBuilder"
-    referrer_base = "digest"
+    metrics_key = "digest"
     template_path = "sentry/emails/digests/body"
 
     def __init__(
@@ -52,12 +52,6 @@ class DigestNotification(ProjectNotification):
         self.digest = digest
         self.target_type = target_type
         self.target_identifier = target_identifier
-
-    def get_category(self) -> str:
-        return "digest_email"
-
-    def get_type(self) -> str:
-        return "notify.digest"
 
     def get_unsubscribe_key(self) -> tuple[str, int, str | None] | None:
         return "project", self.project.id, "alert_digest"

--- a/src/sentry/notifications/notifications/integration_nudge.py
+++ b/src/sentry/notifications/notifications/integration_nudge.py
@@ -42,7 +42,7 @@ MESSAGE_LIBRARY = [
 
 
 class IntegrationNudgeNotification(BaseNotification):
-    category = "integration_nudge"
+    metrics_key = "integration_nudge"
     template_path = "integration-nudge"
     type = "integration.nudge"
 
@@ -94,12 +94,6 @@ class IntegrationNudgeNotification(BaseNotification):
         return None
 
     def build_attachment_title(self, recipient: Team | User) -> str:
-        return ""
-
-    def get_category(self) -> str:
-        return ""
-
-    def get_type(self) -> str:
         return ""
 
     def build_notification_footer(self, recipient: Team | User) -> str:

--- a/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
@@ -26,12 +26,6 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification, abc.ABC
         super().__init__(pending_member.organization, requester)
         self.pending_member = pending_member
 
-    def get_type(self) -> str:
-        return "organization.invite-request"
-
-    def get_category(self) -> str:
-        return "organization_invite_request"
-
     @property
     def members_url(self) -> str:
         url: str = absolute_uri(

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 
 class OrganizationRequestNotification(BaseNotification, abc.ABC):
     notification_setting_type = NotificationSettingTypes.APPROVAL
-    referrer_base: str = ""
     RoleBasedRecipientStrategyClass: Type[RoleBasedRecipientStrategy]
 
     def __init__(self, organization: Organization, requester: User) -> None:

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -38,7 +38,7 @@ def get_url(organization: Organization, provider_type: str, provider_slug: str) 
 class IntegrationRequestNotification(OrganizationRequestNotification):
     # TODO: switch to a strategy based on the integration write scope
     RoleBasedRecipientStrategyClass = OwnerRecipientStrategy
-    referrer_base = "integration-request"
+    metrics_key = "integration_request"
     template_path = "sentry/emails/requests/organization-integration"
 
     def __init__(
@@ -69,17 +69,11 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
             "message": self.message,
         }
 
-    def get_category(self) -> str:
-        return "integration_request"
-
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return f"Your team member requested the {self.provider_name} integration on Sentry"
 
     def get_notification_title(self) -> str:
         return self.get_subject()
-
-    def get_type(self) -> str:
-        return "organization.integration.request"
 
     def build_attachment_title(self, recipient: Team | User) -> str:
         return "Request to Install"

--- a/src/sentry/notifications/notifications/organization_request/invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/invite_request.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 @register()
 class InviteRequestNotification(AbstractInviteRequestNotification):
     analytics_event = "invite_request.sent"
-    referrer_base = "invite_request"
+    metrics_key = "invite_request"
     template_path = "sentry/emails/organization-invite-request"
 
     def build_attachment_title(self, recipient: Team | User) -> str:

--- a/src/sentry/notifications/notifications/organization_request/join_request.py
+++ b/src/sentry/notifications/notifications/organization_request/join_request.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 @register()
 class JoinRequestNotification(AbstractInviteRequestNotification):
     analytics_event = "join_request.sent"
-    referrer_base = "join_request"
+    metrics_key = "join_request"
     template_path = "sentry/emails/organization-join-request"
 
     def build_attachment_title(self, recipient: Team | User) -> str:

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -28,9 +28,8 @@ logger = logging.getLogger(__name__)
 
 class AlertRuleNotification(ProjectNotification):
     message_builder = "IssueNotificationMessageBuilder"
-    notification_setting_type = NotificationSettingTypes.ISSUE_ALERTS
     metrics_key = "issue_alert"
-    referrer_base = "alert-rule"
+    notification_setting_type = NotificationSettingTypes.ISSUE_ALERTS
     template_path = "sentry/emails/error"
 
     def __init__(
@@ -56,9 +55,6 @@ class AlertRuleNotification(ProjectNotification):
             target_identifier=self.target_identifier,
             event=self.event,
         )
-
-    def get_category(self) -> str:
-        return "issue_alert_email"
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return str(self.event.get_email_subject())
@@ -121,9 +117,6 @@ class AlertRuleNotification(ProjectNotification):
                 title_str += f" (+{len(self.rules) - 1} other)"
 
         return title_str
-
-    def get_type(self) -> str:
-        return "notify.error"
 
     def send(self) -> None:
         from sentry.notifications.notify import notify

--- a/src/sentry/notifications/notifications/user_report.py
+++ b/src/sentry/notifications/notifications/user_report.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class UserReportNotification(ProjectNotification):
-    referrer_base = "user-report"
+    metrics_key = "user_report"
     template_path = "sentry/emails/activity/new-user-feedback"
 
     def __init__(self, project: Project, report: Mapping[str, Any]) -> None:
@@ -37,12 +37,6 @@ class UserReportNotification(ProjectNotification):
             for provider, data in data_by_provider.items()
             if provider in [ExternalProviders.EMAIL]
         }
-
-    def get_category(self) -> str:
-        return "user_report_email"
-
-    def get_type(self) -> str:
-        return "notify.user-report"
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         # Explicitly typing to satisfy mypy.

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -1,8 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from sentry.models import Team, User
 from sentry.notifications.notifications.base import BaseNotification
 
 
 class DummyNotification(BaseNotification):
     template_path = ""
+    metrics_key = "dummy"
+    reference = None
+
+    def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
+        pass
+
+    def determine_recipients(self) -> Iterable[Team | User]:
+        return []
 
     def build_attachment_title(self, *args):
         return "My Title"

--- a/tests/fixtures/emails/assigned.txt
+++ b/tests/fixtures/emails/assigned.txt
@@ -7,7 +7,7 @@ foo@example.com assigned PROJECT-1 to foo@example.com
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=assigned-activity-email
+http://testserver/organizations/organization/issues/1/?referrer=assigned_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/assigned_self.txt
+++ b/tests/fixtures/emails/assigned_self.txt
@@ -7,7 +7,7 @@ foo@example.com assigned PROJECT-1 to themselves
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=assigned-activity-email
+http://testserver/organizations/organization/issues/1/?referrer=assigned_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/note.txt
+++ b/tests/fixtures/emails/note.txt
@@ -9,6 +9,6 @@ sincerely gobbler epic immensely katydid beloved stunning falcon mainly actively
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/activity/?referrer=note-activity-email
+http://testserver/organizations/organization/issues/1/activity/?referrer=note_activity-email
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/regression.txt
+++ b/tests/fixtures/emails/regression.txt
@@ -7,7 +7,7 @@ Sentry marked PROJECT-1 as a regression
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=regression-activity-email
+http://testserver/organizations/organization/issues/1/?referrer=regression_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/regression_with_version.txt
+++ b/tests/fixtures/emails/regression_with_version.txt
@@ -7,7 +7,7 @@ Sentry marked PROJECT-1 as a regression in abcdef
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=regression-activity-email
+http://testserver/organizations/organization/issues/1/?referrer=regression_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/resolved.txt
+++ b/tests/fixtures/emails/resolved.txt
@@ -7,7 +7,7 @@ Sentry marked PROJECT-1 as resolved
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=resolved-activity-email
+http://testserver/organizations/organization/issues/1/?referrer=resolved_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/resolved_in_release.txt
+++ b/tests/fixtures/emails/resolved_in_release.txt
@@ -7,7 +7,7 @@ Sentry marked PROJECT-1 as resolved in abcdef
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=resolved-in-release-activity-email
+http://testserver/organizations/organization/issues/1/?referrer=resolved_in_release_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/resolved_in_release_upcoming.txt
+++ b/tests/fixtures/emails/resolved_in_release_upcoming.txt
@@ -7,7 +7,7 @@ Sentry marked PROJECT-1 as resolved in an upcoming release
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=resolved-in-release-activity-email
+http://testserver/organizations/organization/issues/1/?referrer=resolved_in_release_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/unassigned.txt
+++ b/tests/fixtures/emails/unassigned.txt
@@ -7,7 +7,7 @@ foo@example.com unassigned PROJECT-1
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=unassigned-activity-email
+http://testserver/organizations/organization/issues/1/?referrer=unassigned_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -142,7 +142,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest):
         assert attachment["title"] == self.group.title
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user|Notification Settings>"
         )
 
     def test_automatic_assignment(self):

--- a/tests/sentry/integrations/slack/notifications/test_deploy.py
+++ b/tests/sentry/integrations/slack/notifications/test_deploy.py
@@ -65,5 +65,5 @@ class SlackDeployNotificationTest(SlackActivityNotificationTest):
         assert (
             attachment["footer"]
             == f"{first_project.slug} | <http://testserver/settings/account/notifications/"
-            f"deploy/?referrer=release-activity-slack-user|Notification Settings>"
+            f"deploy/?referrer=release_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -70,7 +70,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
         assert attachment["title"] == "Hello world"
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=alert-rule-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user|Notification Settings>"
         )
 
     @responses.activate
@@ -141,7 +141,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
         assert attachment["title"] == "Hello world"
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=alert-rule-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user|Notification Settings>"
         )
 
     @responses.activate
@@ -231,7 +231,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
         assert attachments[0]["title"] == "Hello world"
         assert (
             attachments[0]["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=alert-rule-slack-team|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team|Notification Settings>"
         )
 
     @responses.activate
@@ -397,7 +397,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
         assert attachments[0]["title"] == "Hello world"
         assert (
             attachments[0]["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=alert-rule-slack-team|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team|Notification Settings>"
         )
 
     @responses.activate
@@ -476,7 +476,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
         assert attachments[0]["title"] == "Hello world"
         assert (
             attachments[0]["footer"]
-            == f"{self.project.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=alert-rule-slack-team|Notification Settings>"
+            == f"{self.project.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team|Notification Settings>"
         )
 
     @responses.activate
@@ -556,7 +556,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
         assert attachments[0]["title"] == "Hello world"
         assert (
             attachments[0]["footer"]
-            == f"{project2.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=alert-rule-slack-team|Notification Settings>"
+            == f"{project2.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team|Notification Settings>"
         )
 
     @responses.activate
@@ -664,7 +664,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
         assert attachments[0]["title"] == "Hello world"
         assert (
             attachments[0]["footer"]
-            == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=alert-rule-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user|Notification Settings>"
         )
 
         # check that user2 got a notification as well
@@ -675,7 +675,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
         assert attachments[0]["title"] == "Hello world"
         assert (
             attachments[0]["footer"]
-            == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=alert-rule-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user|Notification Settings>"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
+++ b/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
@@ -43,5 +43,5 @@ class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
         )
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=new-processing-issues-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=new_processing_issues_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -34,10 +34,10 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest):
         assert attachment["title"] == f"{self.group.title}"
         assert (
             attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note-activity-slack"
+            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note_activity-slack"
         )
         assert attachment["text"] == notification.activity.data["text"]
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -32,5 +32,5 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest):
         assert text == "Issue marked as regression"
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -35,5 +35,5 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest):
         )
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -33,5 +33,5 @@ class SlackResolvedInReleaseNotificationTest(SlackActivityNotificationTest):
         assert text == f"Issue marked as resolved in {release_name} by {self.name}"
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved-in-release-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -33,5 +33,5 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest):
         assert attachment["title"] == self.group.title
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/notifications/notifications/test_organization_request.py
+++ b/tests/sentry/notifications/notifications/test_organization_request.py
@@ -14,6 +14,7 @@ class DummyRoleBasedRecipientStrategy(RoleBasedRecipientStrategy):
 
 
 class DummyRequestNotification(OrganizationRequestNotification):
+    metrics_key = "dummy"
     template_path = ""
     RoleBasedRecipientStrategyClass = DummyRoleBasedRecipientStrategy
 

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -119,12 +119,12 @@ class ActivityNotificationTest(APITestCase):
         assert attachment["title"] == f"{self.group.title}"
         assert (
             attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note-activity-slack"
+            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note_activity-slack"
         )
         assert attachment["text"] == "blah blah"
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user|Notification Settings>"
         )
 
     @responses.activate
@@ -151,7 +151,7 @@ class ActivityNotificationTest(APITestCase):
         assert attachment["title"] == self.group.title
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user|Notification Settings>"
         )
 
     @responses.activate
@@ -180,7 +180,7 @@ class ActivityNotificationTest(APITestCase):
         assert attachment["title"] == self.group.title
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user|Notification Settings>"
         )
 
     @responses.activate
@@ -209,7 +209,7 @@ class ActivityNotificationTest(APITestCase):
         assert attachment["title"] == self.group.title
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user|Notification Settings>"
         )
 
     @responses.activate
@@ -249,7 +249,7 @@ class ActivityNotificationTest(APITestCase):
         )
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/deploy/?referrer=release-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/deploy/?referrer=release_activity-slack-user|Notification Settings>"
         )
 
     @responses.activate
@@ -288,7 +288,7 @@ class ActivityNotificationTest(APITestCase):
         assert text == "Issue marked as regression"
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user|Notification Settings>"
         )
 
     @responses.activate
@@ -323,7 +323,7 @@ class ActivityNotificationTest(APITestCase):
         assert attachment["title"] == self.group.title
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved-in-release-activity-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user|Notification Settings>"
         )
 
     @responses.activate
@@ -383,5 +383,5 @@ class ActivityNotificationTest(APITestCase):
         assert attachment["title"] == "Hello world"
         assert (
             attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=alert-rule-slack-user|Notification Settings>"
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user|Notification Settings>"
         )


### PR DESCRIPTION
The PR https://github.com/getsentry/sentry/pull/34572 was failing a getsentry test.
This reverts commit 04f013dd203f286aaf27b1c887bb72a2e24a498e.
