### PR TITLE
feat(onboarding): Customized cards

### DIFF
--- a/static/app/components/onboardingWizard/sidebar.tsx
+++ b/static/app/components/onboardingWizard/sidebar.tsx
@@ -96,10 +96,10 @@ function OnboardingWizardSidebar({
 
   const {allTasks, customTasks, active, upcoming, complete} = useMemo(() => {
     const all = getMergedTasks({organization, projects}).filter(task => task.display);
-    const tasks = all.filter(task => !task.render);
+    const tasks = all.filter(task => !task.renderCard);
     return {
       allTasks: all,
-      customTasks: all.filter(task => task.render),
+      customTasks: all.filter(task => task.renderCard),
       active: tasks.filter(findActiveTasks),
       upcoming: tasks.filter(findUpcomingTasks),
       complete: tasks.filter(findCompleteTasks),
@@ -165,16 +165,14 @@ function OnboardingWizardSidebar({
 
   const [onboardingState, setOnboardingState] = usePersistedOnboardingState();
   const customizedCards = customTasks
-    .map(
-      task =>
-        task.render &&
-        task.render({
-          organization,
-          task,
-          onboardingState,
-          setOnboardingState,
-          projects,
-        })
+    .map(task =>
+      task.renderCard?.({
+        organization,
+        task,
+        onboardingState,
+        setOnboardingState,
+        projects,
+      })
     )
     .filter(card => !!card);
 

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -1,4 +1,7 @@
+import {OnboardingState} from 'sentry/views/onboarding/targetedOnboarding/types';
+
 import type {AvatarUser} from './user';
+import {Organization, Project} from '.';
 
 export enum OnboardingTaskKey {
   FIRST_PROJECT = 'create_project',
@@ -16,6 +19,14 @@ export enum OnboardingTaskKey {
 
 export type OnboardingSupplementComponentProps = {
   onCompleteTask: () => void;
+  task: OnboardingTask;
+};
+
+export type OnboardingCustomComponentProps = {
+  onboardingState: OnboardingState | null;
+  organization: Organization;
+  projects: Project[];
+  setOnboardingState: (state: OnboardingState | null) => void;
   task: OnboardingTask;
 };
 
@@ -40,6 +51,14 @@ export type OnboardingTaskDescriptor = {
    * An extra component that may be rendered within the onboarding task item.
    */
   SupplementComponent?: React.ComponentType<OnboardingSupplementComponentProps>;
+  /**
+   * If a render function was provided, it will be used to render the entire card,
+   * and the card will be rendered before any other cards regardless of completion status.
+   * the render function is therefore responsible for determining the completion status
+   * of the card by returning null when it's completed. Note that this is not a functional
+   * component so you can't use react hooks in here.
+   */
+  render?: (props: OnboardingCustomComponentProps) => JSX.Element | null;
 } & (
   | {
       actionType: 'app' | 'external';
@@ -55,7 +74,7 @@ export type OnboardingTaskStatus = {
   status: 'skipped' | 'pending' | 'complete';
   task: OnboardingTaskKey;
   completionSeen?: string;
-  data?: object;
+  data?: {[key: string]: string};
   dateCompleted?: string;
   user?: AvatarUser | null;
 };

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -1,7 +1,7 @@
+import {Organization, Project} from 'sentry/types';
 import {OnboardingState} from 'sentry/views/onboarding/targetedOnboarding/types';
 
 import type {AvatarUser} from './user';
-import {Organization, Project} from '.';
 
 export enum OnboardingTaskKey {
   FIRST_PROJECT = 'create_project',
@@ -55,10 +55,11 @@ export type OnboardingTaskDescriptor = {
    * If a render function was provided, it will be used to render the entire card,
    * and the card will be rendered before any other cards regardless of completion status.
    * the render function is therefore responsible for determining the completion status
-   * of the card by returning null when it's completed. Note that this is not a functional
-   * component so you can't use react hooks in here.
+   * of the card by returning null when it's completed.
+   *
+   * Note that this should not be given a react component.
    */
-  render?: (props: OnboardingCustomComponentProps) => JSX.Element | null;
+  renderCard?: (props: OnboardingCustomComponentProps) => JSX.Element | null;
 } & (
   | {
       actionType: 'app' | 'external';


### PR DESCRIPTION
<img width="503" alt="image" src="https://user-images.githubusercontent.com/8980455/168387190-0e24c274-bf8e-438d-a69f-149796b0dc5d.png">

This combines the "hacked" onboarding project selection cards and the new integration selection cards into a new category of onboarding cards. When you specify "customized: true" on the OnboardingDescriptor, you're allowed to take over the rendering of the card entirely and decide if you would to show the card or now by returning null in the custom component.

Note that the component must be a functional component and you can't call any hooks inside it. This might change if we convert `OnboardingWizardSidebar` into a functional component in the future.