### PR TITLE
fix(rate limits): Add default concurrent rate limit

### DIFF
--- a/src/sentry/ratelimits/config.py
+++ b/src/sentry/ratelimits/config.py
@@ -22,9 +22,7 @@ HttpMethodName = str
 
 RateLimitOverrideDict = Mapping[HttpMethodName, Mapping[RateLimitCategory, RateLimit]]
 
-DEFAULT_RATELIMIT = RateLimit(
-    settings.SENTRY_RATELIMITER_DEFAULT, 1, settings.SENTRY_CONCURRENT_RATE_LIMIT_DEFAULT
-)
+DEFAULT_RATELIMIT = RateLimit(settings.SENTRY_RATELIMITER_DEFAULT, 1)
 SENTRY_RATELIMITER_GROUP_DEFAULTS: Mapping[GroupName, Mapping[RateLimitCategory, RateLimit]] = {
     "default": {category: DEFAULT_RATELIMIT for category in RateLimitCategory},
     "CLI": {

--- a/src/sentry/types/ratelimit.py
+++ b/src/sentry/types/ratelimit.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
 
+from django.conf import settings
+
 
 # Fixed set of rate limit categories
 class RateLimitCategory(str, Enum):
@@ -25,7 +27,7 @@ class RateLimit:
 
     limit: int
     window: int
-    concurrent_limit: Optional[int] = field(default=None)
+    concurrent_limit: Optional[int] = field(default=settings.SENTRY_CONCURRENT_RATE_LIMIT_DEFAULT)
 
 
 class RateLimitType(Enum):

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 from time import sleep, time
 from unittest import TestCase
 
+from django.conf import settings
 from freezegun import freeze_time
 
 from sentry.ratelimits import above_rate_limit_check, finish_request
@@ -27,8 +28,8 @@ class RatelimitMiddlewareTest(TestCase):
                 group=self.group,
                 reset_time=expected_reset_time,
                 remaining=9,
-                concurrent_limit=None,
-                concurrent_requests=None,
+                concurrent_limit=settings.SENTRY_CONCURRENT_RATE_LIMIT_DEFAULT,
+                concurrent_requests=1,
             )
             for i in range(10):
                 return_val = above_rate_limit_check(
@@ -42,7 +43,7 @@ class RatelimitMiddlewareTest(TestCase):
                 group=self.group,
                 reset_time=expected_reset_time,
                 remaining=0,
-                concurrent_limit=None,
+                concurrent_limit=settings.SENTRY_CONCURRENT_RATE_LIMIT_DEFAULT,
                 concurrent_requests=None,
             )
 


### PR DESCRIPTION
Endpoints that overrode the default rate limits such as the `ProjectGroupIndexEndpoint` always had the `X-Sentry-Rate-Limit-ConcurrentRemaining` and `X-Sentry-Rate-Limit-ConcurrentLimit` headers set to `None`. This PR sets a default value instead of `None` so we always apply the default concurrent rate limit. 