### PR TITLE
feat(discover): Add both events endpoints to sampling

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -49,6 +49,9 @@ SAMPLED_URL_NAMES = {
     # notification platform
     "sentry-api-0-user-notification-settings": settings.SAMPLED_DEFAULT_RATE,
     "sentry-api-0-team-notification-settings": settings.SAMPLED_DEFAULT_RATE,
+    # events
+    "sentry-api-0-organization-eventsv2": 0.01,
+    "sentry-api-0-organization-events": 0.01,
     # releases
     "sentry-api-0-organization-releases": settings.SAMPLED_DEFAULT_RATE,
     "sentry-api-0-organization-release-details": settings.SAMPLED_DEFAULT_RATE,


### PR DESCRIPTION
- Starting real low at 1% to get an idea of overall throughput change,
  will increase based on this
- This is so we can get an idea of non sentry.io usage of the events API
