### PR TITLE
fix(dashboard): Filter aggregate parameters to metric fields

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/yAxisStep/yAxisSelector/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/yAxisStep/yAxisSelector/index.tsx
@@ -94,11 +94,14 @@ export function YAxisSelector({
         return true;
       }
 
-      if (fieldValue.kind !== FieldValueKind.FUNCTION) {
-        return true;
+      if (isReleaseWidget) {
+        if (option.value.kind === FieldValueKind.METRICS) {
+          return true;
+        }
+        return false;
       }
 
-      if (isReleaseWidget || option.value.kind === FieldValueKind.METRICS) {
+      if (fieldValue.kind !== FieldValueKind.FUNCTION) {
         return true;
       }
 


### PR DESCRIPTION
Tags shouldn't show up in the parameters dropdown for aggregate
functions for RH. Affects the timeseries widget types.