### PR TITLE
fix(identity): Prevent KeyError for "access_token"

### DIFF
--- a/src/sentry/identity/github_enterprise/provider.py
+++ b/src/sentry/identity/github_enterprise/provider.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import PermissionDenied
+
 from sentry import http
 from sentry.identity.oauth2 import OAuth2Provider
 
@@ -24,8 +26,12 @@ class GitHubEnterpriseIdentityProvider(OAuth2Provider):
 
     def build_identity(self, data):
         data = data["data"]
+        access_token = data.get("access_token")
+        if not access_token:
+            raise PermissionDenied()
+
         # todo(meredith): this doesn't work yet, need to pass in the base url
-        user = get_user_info(data["access_token"])
+        user = get_user_info(access_token)
 
         return {
             "type": "github_enterprise",

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import PermissionDenied
 from rest_framework.request import Request
 
 from sentry import http, options
@@ -95,7 +96,10 @@ class VSTSIdentityProvider(OAuth2Provider):
 
     def build_identity(self, data):
         data = data["data"]
-        user = get_user_info(data["access_token"])
+        access_token = data.get("access_token")
+        if not access_token:
+            raise PermissionDenied()
+        user = get_user_info(access_token)
 
         return {
             "type": "vsts",


### PR DESCRIPTION
Fixes [SENTRY-RWR](https://sentry.io/organizations/sentry/issues/2554576838/events/4196a89f60dc4930a60fc31f2deeacaa/).

Just imitates what's being done at

https://github.com/getsentry/sentry/blob/c0ff66b0afedf1515ec88b85d311db54897b1d17/src/sentry/identity/github/provider.py#L43-L46

I considered factoring the duplicated code up into `OAuth2Provider`, but there's larger duplications that should probably be refactored all at once.