### PR TITLE
fix(createProject): Add space before create team button

### DIFF
--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -356,6 +356,7 @@ const ProjectNameInput = styled('div')`
 
 const TeamSelectInput = styled('div')`
   display: grid;
+  gap: ${space(1)};
   grid-template-columns: 1fr min-content;
   align-items: center;
 `;


### PR DESCRIPTION
**Before**
<img width="305" alt="Screen Shot 2022-05-13 at 4 09 24 PM" src="https://user-images.githubusercontent.com/44172267/168400000-0123e1e6-fc19-43a0-bbab-10428d038bea.png">


**After**
<img width="305" alt="Screen Shot 2022-05-13 at 4 06 28 PM" src="https://user-images.githubusercontent.com/44172267/168399822-f6ca1b3f-7b87-4367-8f70-5461252a6d41.png">

Ideally we should probably move the create team button inside the dropdown. But we'll need to implement footer actions in `SelectControl` first before that can happen.