### PR TITLE
feat(alerts): Add analytics for alert wizard v3

### DIFF
--- a/src/sentry/analytics/events/alert_created.py
+++ b/src/sentry/analytics/events/alert_created.py
@@ -14,6 +14,7 @@ class AlertCreatedEvent(analytics.Event):
         # `alert_rule_ui_component` can be `alert-rule-action`
         analytics.Attribute("alert_rule_ui_component", required=False),
         analytics.Attribute("duplicate_rule", required=False),
+        analytics.Attribute("wizard_v3", required=False),
     )
 
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -114,6 +114,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 rule=rule, user=request.user, type=RuleActivityType.CREATED.value
             )
             duplicate_rule = request.query_params.get("duplicateRule")
+            wizard_v3 = request.query_params.get("wizardV3")
 
             self.create_audit_entry(
                 request=request,
@@ -131,6 +132,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 is_api_token=request.auth is not None,
                 alert_rule_ui_component=created_alert_rule_ui_component,
                 duplicate_rule=duplicate_rule,
+                wizard_v3=wizard_v3,
             )
 
             return Response(serialize(rule, request.user))

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -111,6 +111,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
                 referrer = request.query_params.get("referrer")
                 session_id = request.query_params.get("sessionId")
                 duplicate_rule = request.query_params.get("duplicateRule")
+                wizard_v3 = request.query_params.get("wizardV3")
                 alert_rule_created.send_robust(
                     user=request.user,
                     project=project,
@@ -121,6 +122,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
                     session_id=session_id,
                     is_api_token=request.auth is not None,
                     duplicate_rule=duplicate_rule,
+                    wizard_v3=wizard_v3,
                 )
                 return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -292,6 +292,7 @@ def record_alert_rule_created(
     session_id=None,
     alert_rule_ui_component=None,
     duplicate_rule=None,
+    wizard_v3=None,
     **kwargs,
 ):
     if rule_type == "issue" and rule.label == DEFAULT_RULE_LABEL and rule.data == DEFAULT_RULE_DATA:
@@ -320,6 +321,7 @@ def record_alert_rule_created(
         is_api_token=is_api_token,
         alert_rule_ui_component=alert_rule_ui_component,
         duplicate_rule=duplicate_rule,
+        wizard_v3=wizard_v3,
     )
 
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -85,7 +85,15 @@ inbound_filter_toggled = BetterSignal(providing_args=["project"])
 sso_enabled = BetterSignal(providing_args=["organization", "user", "provider"])
 data_scrubber_enabled = BetterSignal(providing_args=["organization"])
 alert_rule_created = BetterSignal(
-    providing_args=["project", "rule", "user", "rule_type", "is_api_token", "duplicate_rule"]
+    providing_args=[
+        "project",
+        "rule",
+        "user",
+        "rule_type",
+        "is_api_token",
+        "duplicate_rule",
+        "wizard_v3",
+    ]
 )
 alert_rule_edited = BetterSignal(
     providing_args=["project", "rule", "user", "rule_type", "is_api_token"]

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -49,6 +49,7 @@ export type TeamInsightsEventParameters = {
   'new_alert_rule.viewed': RuleViewed & {
     duplicate_rule: string;
     session_id: string;
+    wizard_v3: string;
   };
   'team_insights.viewed': {};
 };

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -96,12 +96,15 @@ class Create extends Component<Props, State> {
   componentDidMount() {
     const {organization, project} = this.props;
 
+    const hasAlertWizardV3 = organization.features.includes('alert-wizard-v3');
+
     trackAdvancedAnalyticsEvent('new_alert_rule.viewed', {
       organization,
       project_id: project.id,
       session_id: this.sessionId,
       alert_type: this.state.alertType,
       duplicate_rule: this.isDuplicateRule ? 'true' : 'false',
+      wizard_v3: hasAlertWizardV3 ? 'true' : 'false',
     });
   }
 


### PR DESCRIPTION
This adds the parameter `wizard_v3` to the `alert.created` analytics events to see the usage of the Alert Wizard V3.