### PR TITLE
feat(alerts): Add analytics for alert wizard v3 FE

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -49,6 +49,7 @@ export type TeamInsightsEventParameters = {
   'new_alert_rule.viewed': RuleViewed & {
     duplicate_rule: string;
     session_id: string;
+    wizard_v3: string;
   };
   'team_insights.viewed': {};
 };

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -96,12 +96,15 @@ class Create extends Component<Props, State> {
   componentDidMount() {
     const {organization, project} = this.props;
 
+    const hasAlertWizardV3 = organization.features.includes('alert-wizard-v3');
+
     trackAdvancedAnalyticsEvent('new_alert_rule.viewed', {
       organization,
       project_id: project.id,
       session_id: this.sessionId,
       alert_type: this.state.alertType,
       duplicate_rule: this.isDuplicateRule ? 'true' : 'false',
+      wizard_v3: hasAlertWizardV3 ? 'true' : 'false',
     });
   }
 


### PR DESCRIPTION
This adds the parameter `wizard_v3` to the `new_alert_rule.viewed` analytics events to see the usage of the Alert Wizard V3.