### PR TITLE
debug(tests): Debug flaky unfurl test

### DIFF
--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -429,15 +429,15 @@ class UnfurlTest(TestCase):
     def test_top_daily_events_renders_bar_chart(self, mock_generate_chart):
         min_ago = iso_format(before_now(minutes=1))
         self.store_event(
-            data={"message": "first", "fingerprint": ["group1"], "timestamp": min_ago},
+            data={"message": "top_daily_first", "fingerprint": ["group1"], "timestamp": min_ago},
             project_id=self.project.id,
         )
         self.store_event(
-            data={"message": "second", "fingerprint": ["group2"], "timestamp": min_ago},
+            data={"message": "top_daily_second", "fingerprint": ["group2"], "timestamp": min_ago},
             project_id=self.project.id,
         )
 
-        url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?field=message&field=event.type&field=count()&name=All+Events&query=message:[first,second]&sort=-count&statsPeriod=24h&display=dailytop5&topEvents=2"
+        url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?field=message&field=event.type&field=count()&name=All+Events&query=message:[top_daily_first,top_daily_second]&sort=-count&statsPeriod=24h&display=dailytop5&topEvents=2"
         link_type, args = match_link(url)
 
         if not args or not link_type:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -428,16 +428,16 @@ class UnfurlTest(TestCase):
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
     def test_top_daily_events_renders_bar_chart(self, mock_generate_chart):
         min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={"message": "top_daily_first", "fingerprint": ["group1"], "timestamp": min_ago},
+        first_event = self.store_event(
+            data={"message": "first", "fingerprint": ["group1"], "timestamp": min_ago},
             project_id=self.project.id,
         )
-        self.store_event(
-            data={"message": "top_daily_second", "fingerprint": ["group2"], "timestamp": min_ago},
+        second_event = self.store_event(
+            data={"message": "second", "fingerprint": ["group2"], "timestamp": min_ago},
             project_id=self.project.id,
         )
 
-        url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?field=message&field=event.type&field=count()&name=All+Events&query=message:[top_daily_first,top_daily_second]&sort=-count&statsPeriod=24h&display=dailytop5&topEvents=2"
+        url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?field=message&field=event.type&field=count()&name=All+Events&query=message:[{first_event.message},{second_event.message}]&sort=-count&statsPeriod=24h&display=dailytop5&topEvents=2"
         link_type, args = match_link(url)
 
         if not args or not link_type:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -436,6 +436,8 @@ class UnfurlTest(TestCase):
             data={"message": "second", "fingerprint": ["group2"], "timestamp": min_ago},
             project_id=self.project.id,
         )
+        debug_first_event = first_event.event_id  # noqa: F841
+        debug_second_event = second_event.event_id  # noqa: F841
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?field=message&field=event.type&field=count()&name=All+Events&query=message:[{first_event.message},{second_event.message}]&sort=-count&statsPeriod=24h&display=dailytop5&topEvents=2"
         link_type, args = match_link(url)


### PR DESCRIPTION
My working theory is that the store_event function isn't consistently storing the event. When only one event is found, the number of keys are 4 instead of 2. 

I'm want to see what items are inside the event objects created. If the event isn't created, is everything still populated?
