### PR TITLE
feat(perf): Add entity count for span details page

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import {setTag} from '@sentry/react';
 import {Location} from 'history';
 
 import Feature from 'sentry/components/acl/feature';
@@ -85,6 +86,14 @@ export default function SpanDetailsContentWrapper(props: Props) {
             {({tableData}) => {
               const totalCount: number | null =
                 (tableData?.data?.[0]?.count as number) ?? null;
+
+              if (totalCount) {
+                setTag('spans.totalCount', totalCount);
+                const countGroup = [
+                  1, 5, 10, 20, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000,
+                ].find(n => totalCount <= n);
+                setTag('spans.totalCount.grouped', `<=${countGroup}`);
+              }
 
               return (
                 <SuspectSpansQuery


### PR DESCRIPTION
### Summary
This is a quick tag to help us find performance issues or look at high 'n' performance on the span detail page.
