### PR TITLE
fix(span-tree): Continuing tree depths visual bug

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -327,11 +327,15 @@ class SpanTreeModel {
     let descendants: EnhancedProcessedSpanType[];
 
     if (isAutogroupSiblingFeatureEnabled) {
-      let groupedDescendants: DescendantGroup[] = [];
+      const groupedDescendants: DescendantGroup[] = [];
       // Used to number sibling groups in case there are multiple groups with the same op and description
       const siblingGroupOccurrenceMap = {};
 
       const addGroupToMap = (prevSpanModel: SpanTreeModel, group: SpanTreeModel[]) => {
+        if (!group.length) {
+          return;
+        }
+
         const groupKey = `${prevSpanModel.span.op}.${prevSpanModel.span.description}`;
 
         if (!siblingGroupOccurrenceMap[groupKey]) {
@@ -379,8 +383,6 @@ class SpanTreeModel {
       } else if (descendantsSource.length >= 1) {
         groupedDescendants.push({group: descendantsSource});
       }
-
-      groupedDescendants = groupedDescendants.filter(g => g.group.length);
 
       descendants = (hideSpanTree ? [] : groupedDescendants).reduce(
         (

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -327,7 +327,7 @@ class SpanTreeModel {
     let descendants: EnhancedProcessedSpanType[];
 
     if (isAutogroupSiblingFeatureEnabled) {
-      const groupedDescendants: DescendantGroup[] = [];
+      let groupedDescendants: DescendantGroup[] = [];
       // Used to number sibling groups in case there are multiple groups with the same op and description
       const siblingGroupOccurrenceMap = {};
 
@@ -379,6 +379,8 @@ class SpanTreeModel {
       } else if (descendantsSource.length >= 1) {
         groupedDescendants.push({group: descendantsSource});
       }
+
+      groupedDescendants = groupedDescendants.filter(g => g.group.length);
 
       descendants = (hideSpanTree ? [] : groupedDescendants).reduce(
         (


### PR DESCRIPTION
Sometimes, the span tree would render an extra long connector bar that goes deeper than it should. This was due to groupedDescendants having empty groups, which would cause isLastSibling to be false in some cases when it should be true.

### Before
![image](https://user-images.githubusercontent.com/16740047/168651173-e5633ed4-aee8-4e88-9d9b-ee313fee77f5.png)

### After
![image](https://user-images.githubusercontent.com/16740047/168651276-1a6b5dd1-1b8f-4a28-927f-142b1dbbf858.png)


Fixes PERF-1550
