### PR TITLE
ref: use builtins for map/filter/zip when iterable is immediately used

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -14,7 +14,6 @@ from sentry import options
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
 from sentry.models import FileBlob
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.utils.compat import zip
 from sentry.utils.files import get_max_file_size
 
 MAX_CHUNKS_PER_REQUEST = 64

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -8,7 +8,6 @@ from sentry import similarity
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import Group
-from sentry.utils.compat import zip
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/api/endpoints/organization_member_unreleased_commits.py
+++ b/src/sentry/api/endpoints/organization_member_unreleased_commits.py
@@ -3,7 +3,6 @@ from django.db import connections
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import Commit, Repository, UserEmail
-from sentry.utils.compat import zip
 
 # TODO(dcramer): once LatestRepoReleaseEnvironment is backfilled, change this query to use the new
 # schema [performance]

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -43,7 +43,6 @@ from sentry.search.events.filter import handle_operator_negation, parse_semver
 from sentry.signals import release_created
 from sentry.snuba.sessions import STATS_PERIODS
 from sentry.utils.cache import cache
-from sentry.utils.compat import zip as izip
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
 ERR_INVALID_STATS_PERIOD = "Invalid %s. Valid choices are %s"
@@ -149,7 +148,7 @@ def debounce_update_release_health_data(organization, project_ids):
     should_update = {}
     cache_keys = ["debounce-health:%d" % id for id in project_ids]
     cache_data = cache.get_many(cache_keys)
-    for project_id, cache_key in izip(project_ids, cache_keys):
+    for project_id, cache_key in zip(project_ids, cache_keys):
         if cache_data.get(cache_key) is None:
             should_update[project_id] = cache_key
 
@@ -200,7 +199,7 @@ def debounce_update_release_health_data(organization, project_ids):
             release.add_project(project)
 
     # Debounce updates for a minute
-    cache.set_many(dict(izip(should_update.values(), [True] * len(should_update))), 60)
+    cache.set_many(dict(zip(should_update.values(), [True] * len(should_update))), 60)
 
 
 class OrganizationReleasesEndpoint(

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -16,7 +16,6 @@ from sentry.models import Environment, Group, Organization, Project, Release, Us
 from sentry.models.group import looks_like_short_id
 from sentry.signals import advanced_search_feature_gated
 from sentry.utils import metrics
-from sentry.utils.compat import zip
 from sentry.utils.cursors import Cursor, CursorResult
 
 from . import SEARCH_MAX_HITS

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -10,7 +10,6 @@ from django.db.models.functions import Lower
 from django.db.models.sql.datastructures import EmptyResultSet
 from django.utils import timezone
 
-from sentry.utils.compat import map, zip
 from sentry.utils.cursors import Cursor, CursorResult, build_cursor
 
 quote_name = connections["default"].ops.quote_name

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -2,7 +2,6 @@ import functools
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import Activity, Commit, Group, PullRequest
-from sentry.utils.compat import zip
 from sentry.utils.functional import apply_values
 
 

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -23,7 +23,6 @@ from sentry.models import (
     actor_type_to_string,
 )
 from sentry.snuba.models import SnubaQueryEventType
-from sentry.utils.compat import zip
 
 
 @register(AlertRule)

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -9,7 +9,6 @@ from sentry.incidents.models import (
     AlertRuleTriggerAction,
     AlertRuleTriggerExclusion,
 )
-from sentry.utils.compat import zip
 
 
 @register(AlertRuleTrigger)

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -8,7 +8,6 @@ from sentry.eventstore.models import Event
 from sentry.models import EventAttachment, EventError, Release, UserReport
 from sentry.sdk_updates import SdkSetupState, get_suggested_updates
 from sentry.search.utils import convert_user_tag_to_query
-from sentry.utils.compat import zip
 from sentry.utils.json import prune_empty_keys
 from sentry.utils.safe import get_path
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -59,7 +59,6 @@ from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tsdb.snuba import SnubaTSDB
 from sentry.utils import metrics
 from sentry.utils.cache import cache
-from sentry.utils.compat import zip
 from sentry.utils.hashlib import hash_values
 from sentry.utils.json import JSONData
 from sentry.utils.safe import safe_execute

--- a/src/sentry/api/serializers/models/grouprelease.py
+++ b/src/sentry/api/serializers/models/grouprelease.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.app import tsdb
 from sentry.models import GroupRelease, Release
-from sentry.utils.compat import zip
 
 StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 

--- a/src/sentry/api/serializers/models/grouptombstone.py
+++ b/src/sentry/api/serializers/models/grouptombstone.py
@@ -1,7 +1,6 @@
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.constants import LOG_LEVELS
 from sentry.models import GroupTombstone, User
-from sentry.utils.compat import zip
 
 
 @register(GroupTombstone)

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -48,7 +48,6 @@ from sentry.notifications.types import NotificationSettingOptionValues, Notifica
 from sentry.snuba import discover
 from sentry.tasks.symbolication import should_demote_symbolication
 from sentry.utils import json
-from sentry.utils.compat import zip
 
 STATUS_LABELS = {
     ProjectStatus.VISIBLE: "active",

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -21,7 +21,6 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.utils import metrics
-from sentry.utils.compat import zip
 from sentry.utils.hashlib import md5_text
 
 

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -35,7 +35,6 @@ from sentry.models import (
     User,
 )
 from sentry.scim.endpoints.constants import SCIM_SCHEMA_GROUP
-from sentry.utils.compat import zip
 from sentry.utils.query import RangeQuerySetWrapper
 
 if TYPE_CHECKING:

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -1,6 +1,5 @@
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import EventUser, Group, UserReport
-from sentry.utils.compat import zip
 
 
 @register(UserReport)

--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -5,8 +5,6 @@ from uuid import uuid4
 from django.db import connections, router
 from django.utils import timezone
 
-from sentry.utils.compat import zip
-
 
 class BulkDeleteQuery:
     def __init__(self, model, project_id=None, dtfield=None, days=None, order_by=None):

--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -14,7 +14,6 @@ from sentry.db.models.manager import M, make_key
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.db.models.query import create_or_update
 from sentry.utils.cache import cache
-from sentry.utils.compat import zip
 from sentry.utils.hashlib import md5_text
 
 logger = logging.getLogger("sentry")

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -20,7 +20,6 @@ from sentry.spans.grouping.api import load_span_grouping_config
 from sentry.utils import json
 from sentry.utils.cache import memoize
 from sentry.utils.canonical import CanonicalKeyView
-from sentry.utils.compat import zip
 from sentry.utils.safe import get_path, trim
 from sentry.utils.strings import truncatechars
 

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -30,7 +30,6 @@ from sentry.snuba.entity_subscription import get_entity_subscription_for_dataset
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
 from sentry.snuba.tasks import build_snuba_filter
 from sentry.utils import json
-from sentry.utils.compat import zip
 from sentry.utils.snuba import raw_snql_query
 
 from . import CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS, DATASET_VALID_EVENT_TYPES, UNSUPPORTED_QUERIES

--- a/src/sentry/integrations/jira/webhooks/search.py
+++ b/src/sentry/integrations/jira/webhooks/search.py
@@ -5,7 +5,6 @@ from rest_framework.response import Response
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.models import Integration
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
-from sentry.utils.compat import filter
 
 from ..utils import build_user_choice
 

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -9,7 +9,6 @@ from sentry.integrations.utils import where_should_sync
 from sentry.models import ExternalIssue, GroupLink, User, UserOption
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.tasks.integrations import sync_status_inbound as sync_status_inbound_task
-from sentry.utils.compat import filter
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
 

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -4,7 +4,6 @@ import logging
 from sentry.incidents.models import IncidentStatus
 from sentry.models import Integration
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils.compat import filter
 
 from .client import MsTeamsClient, MsTeamsPreInstallClient, get_token_data
 

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -20,7 +20,6 @@ from sentry.lang.native.utils import (
 from sentry.models import EventError, Project
 from sentry.stacktraces.functions import trim_function_name
 from sentry.stacktraces.processing import find_stacktraces_in_data
-from sentry.utils.compat import zip
 from sentry.utils.in_app import is_known_third_party, is_optional_package
 from sentry.utils.safe import get_path, set_path, setdefault_path, trim
 

--- a/src/sentry/management/commands/collectstatic.py
+++ b/src/sentry/management/commands/collectstatic.py
@@ -6,8 +6,6 @@ from operator import itemgetter
 from click import echo
 from django.contrib.staticfiles.management.commands.collectstatic import Command as BaseCommand
 
-from sentry.utils.compat import map, zip
-
 BUFFER_SIZE = 65536
 VERSION_PATH = "version"
 

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -6,7 +6,6 @@ from django.db.models.signals import pre_save
 from rest_framework import serializers
 
 from sentry.db.models import Model
-from sentry.utils.compat import filter
 
 if TYPE_CHECKING:
     from sentry.models import Team, User

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -6,7 +6,6 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.db.models import FlexibleForeignKey, Model
-from sentry.utils.compat import filter
 
 
 class GroupOwnerType(Enum):

--- a/src/sentry/runner/importer.py
+++ b/src/sentry/runner/importer.py
@@ -1,8 +1,7 @@
 import sys
+import types
 
 import click
-
-from sentry.utils.compat import new_module
 
 
 def install(name, config_path, default_settings, callback=None):
@@ -64,7 +63,7 @@ class Importer:
         else:
             default_settings_mod = None
 
-        settings_mod = new_module(self.name)
+        settings_mod = types.ModuleType(self.name)
 
         # Django doesn't play too nice without the config file living as a real
         # file, so let's fake it.
@@ -83,7 +82,7 @@ class Importer:
 
 def load_settings(mod_or_filename, settings, silent=False):
     if isinstance(mod_or_filename, str):
-        conf = new_module("temp_config")
+        conf = types.ModuleType("temp_config")
         conf.__file__ = mod_or_filename
 
         try:

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.core.cache import cache
 
 from sentry.tasks.release_registry import SDK_INDEX_CACHE_KEY
-from sentry.utils.compat import zip
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -41,7 +41,6 @@ from sentry.search.events.constants import (
 )
 from sentry.search.events.types import NormalizedArg, ParamsType
 from sentry.search.utils import InvalidQuery, parse_duration
-from sentry.utils.compat import zip
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.snuba import (
     SESSIONS_SNUBA_MAP,

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -27,7 +27,6 @@ from sentry.search.events.fields import (
 )
 from sentry.search.events.types import HistogramParams, ParamsType
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT
-from sentry.utils.compat import filter
 from sentry.utils.dates import to_timestamp
 from sentry.utils.math import nice_int
 from sentry.utils.snuba import (

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -24,7 +24,6 @@ from sentry.models.integrations.sentry_app import VALID_EVENTS, track_response_c
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
-from sentry.utils.compat import filter
 from sentry.utils.http import absolute_uri
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import responses
 
-from sentry.utils.compat import zip
-
 __all__ = (
     "TestCase",
     "TransactionTestCase",

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -7,7 +7,6 @@ from sentry.constants import DataCategory
 from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.tsdb.base import BaseTSDB, TSDBModel
 from sentry.utils import outcomes, snuba
-from sentry.utils.compat import map, zip
 from sentry.utils.dates import to_datetime
 
 SnubaModelQuerySettings = namedtuple(

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -25,7 +25,6 @@ from sentry.api.serializers.models.release import Author
 from sentry.eventstore.models import Event
 from sentry.models import Commit, CommitFileChange, Group, Project, Release, ReleaseCommit
 from sentry.utils import metrics
-from sentry.utils.compat import zip
 from sentry.utils.hashlib import hash_values
 from sentry.utils.safe import PathSearchable, get_path
 

--- a/src/sentry/utils/compat/__init__.py
+++ b/src/sentry/utils/compat/__init__.py
@@ -42,10 +42,3 @@ from binascii import crc32 as _crc32
 def crc32(*args):
     rt = _crc32(*args)
     return rt - ((rt & 0x80000000) << 1)
-
-
-import types
-
-
-def new_module(name):
-    return types.ModuleType(name)

--- a/src/sentry/utils/functional.py
+++ b/src/sentry/utils/functional.py
@@ -1,7 +1,5 @@
 from django.utils.functional import empty
 
-from sentry.utils.compat import zip
-
 
 def extract_lazy_object(lo):
     """

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -7,7 +7,6 @@ from django.conf import settings
 
 from sentry import options
 from sentry.utils import json
-from sentry.utils.compat import filter, map
 
 ParsedUriMatch = namedtuple("ParsedUriMatch", ["scheme", "domain", "path"])
 

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -10,7 +10,6 @@ from django.utils.translation import ugettext_lazy as _
 import sentry
 from sentry.integrations import FeatureDescription, IntegrationFeatures
 from sentry.plugins.bases.notify import NotificationPlugin
-from sentry.utils.compat import filter, map
 from sentry_plugins.base import CorePluginMixin
 
 from .client import TwilioApiClient


### PR DESCRIPTION
this removes imports to our python 2 wrappers which serialize immediately to list

similar to https://github.com/getsentry/sentry/pull/34557