### PR TITLE
feat(onboarding): create ui element for metric alert onboarding

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -236,7 +236,7 @@ export function getOnboardingTasks({
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_TRANSACTION],
       actionType: 'app',
       location: getMetricAlertUrl({projects, organization}),
-      display: organization.features.includes('incidents'),
+      display: organization.features?.includes('incidents'),
     },
   ];
 }

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -228,7 +228,7 @@ export function getOnboardingTasks({
     },
     {
       task: OnboardingTaskKey.METRIC_ALERT,
-      title: t('Create a Metric Alert'),
+      title: t('Create a Performance Alert'),
       description: t(
         'No one likes crashes and frozen frames. Define thresholds for metrics that trigger alerts for when your application’s performance is degrading.'
       ),

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -50,6 +50,18 @@ function getIssueAlertUrl({projects, organization}: Options) {
   return `/organizations/${organization.slug}/alerts/${project.slug}/wizard/`;
 }
 
+function getMetricAlertUrl({projects, organization}: Options) {
+  if (!projects || !projects.length) {
+    return `/organizations/${organization.slug}/alerts/rules/`;
+  }
+  // pick the first project with transaction events if we have that, otherwise just pick the first project
+  const firstProjectWithEvents = projects.find(
+    project => !!project.firstTransactionEvent
+  );
+  const project = firstProjectWithEvents ?? projects[0];
+  return `/organizations/${organization.slug}/alerts/${project.slug}/wizard/?alert_option=trans_duration`;
+}
+
 export function getOnboardingTasks({
   organization,
   projects,
@@ -213,6 +225,18 @@ export function getOnboardingTasks({
       actionType: 'app',
       location: getIssueAlertUrl({projects, organization}),
       display: true,
+    },
+    {
+      task: OnboardingTaskKey.METRIC_ALERT,
+      title: t('Create a Metric Alert'),
+      description: t(
+        'No one likes crashes and frozen frames. Define thresholds for metrics that trigger alerts for when your application’s performance is degrading.'
+      ),
+      skippable: true,
+      requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_TRANSACTION],
+      actionType: 'app',
+      location: getMetricAlertUrl({projects, organization}),
+      display: organization.features.includes('incidents'),
     },
   ];
 }

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -15,6 +15,7 @@ export enum OnboardingTaskKey {
   ISSUE_TRACKER = 'setup_issue_tracker',
   ALERT_RULE = 'setup_alert_rules',
   FIRST_TRANSACTION = 'setup_transactions',
+  METRIC_ALERT = 'setup_metric_alert_rules',
 }
 
 export type OnboardingSupplementComponentProps = {


### PR DESCRIPTION
This PR adds the new onboarding task for creating metric alerts

![Screen Shot 2022-05-16 at 10 48 30 AM](https://user-images.githubusercontent.com/8533851/168652756-8c04f105-6054-44c9-af92-07ae9646428a.png)

Only shows up if you sent a first transaction and you have metric alerts supported by your plan