### PR TITLE
ref: upgrade unidiff to fix invalid escape SyntaxWarnings

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ symbolic==8.7.1
 toronado==0.1.0
 typing-extensions==3.10.0.2
 ua-parser==0.10.0
-unidiff==0.6.0
+unidiff==0.7.3
 urllib3[brotli]==1.25.11
 brotlipy==0.7.0
 # See if we can remove LDFLAGS from lib.sh


### PR DESCRIPTION
only usages are in these files:

```
src/sentry/integrations/bitbucket/client.py
src/sentry_plugins/bitbucket/client.py
```

we only use the `PatchSet` api which remains unchanged between the previous version -- the main updates between the version we're on and latest involve adding type hinting (0.7.0)