### PR TITLE
ref: upgrade mistune to fix invalid escape SyntaxWarnings

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -28,7 +28,7 @@ google-crc32c==1.1.2
 jsonschema==3.2.0
 lxml==4.6.5
 maxminddb==2.0.3
-mistune==0.8.4
+mistune==2.0.2
 mmh3==3.0.0
 packaging==21.3
 parsimonious==0.8.0


### PR DESCRIPTION
the only usage appears in `src/sentry/integrations/vsts/issues.py` -- the `markdown(...)` api is largely unchanged between 0.8.4 and 2.0.2 (the breaking changes in between were around custom renderers and "internal" mechanisms)