### PR TITLE
ref(slack): Link to docs for Slack metric alert action

### DIFF
--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -359,18 +359,20 @@ function RuleNode({
 
     if (data.id === 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction') {
       return (
-        <MarginlessAlert type="warning">
-          {tct(
-            'Having rate limiting problems? Enter a channel or user ID. Read more [rateLimiting].',
-            {
-              rateLimiting: (
-                <ExternalLink href="https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error">
-                  {t('here')}
-                </ExternalLink>
-              ),
+          <MarginlessAlert
+            type="info"
+            showIcon
+            trailingItems={
+              <Button
+                href={"https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error"}
+                size="xsmall"
+              >
+                {t('Learn More')}
+              </Button>
             }
-          )}
-        </MarginlessAlert>
+          >
+            {t('Having rate limiting problems? Enter a channel or user ID.')}
+          </MarginlessAlert>
       );
     }
 

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -359,20 +359,20 @@ function RuleNode({
 
     if (data.id === 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction') {
       return (
-          <MarginlessAlert
-            type="info"
-            showIcon
-            trailingItems={
-              <Button
-                href={"https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error"}
-                size="xsmall"
-              >
-                {t('Learn More')}
-              </Button>
-            }
-          >
-            {t('Having rate limiting problems? Enter a channel or user ID.')}
-          </MarginlessAlert>
+        <MarginlessAlert
+          type="info"
+          showIcon
+          trailingItems={
+            <Button
+              href="https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error"
+              size="xsmall"
+            >
+              {t('Learn More')}
+            </Button>
+          }
+        >
+          {t('Having rate limiting problems? Enter a channel or user ID.')}
+        </MarginlessAlert>
       );
     }
 

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -147,20 +147,20 @@ class ActionsPanel extends PureComponent<Props> {
       return null;
     }
     return (
-          <MarginlessAlert
-            type="info"
-            showIcon
-            trailingItems={
-              <Button
-                href={"https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error"}
-                size="xsmall"
-              >
-                {t('Learn More')}
-              </Button>
-            }
+      <MarginlessAlert
+        type="info"
+        showIcon
+        trailingItems={
+          <Button
+            href="https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error"
+            size="xsmall"
           >
-            {t('Having rate limiting problems? Enter a channel or user ID.')}
-          </MarginlessAlert>
+            {t('Learn More')}
+          </Button>
+        }
+      >
+        {t('Having rate limiting problems? Enter a channel or user ID.')}
+      </MarginlessAlert>
     );
   }
 

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -4,13 +4,15 @@ import * as Sentry from '@sentry/react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
+import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import SelectControl from 'sentry/components/forms/selectControl';
+import ExternalLink from 'sentry/components/links/externalLink';
 import ListItem from 'sentry/components/list/listItem';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {PanelItem} from 'sentry/components/panels';
 import {IconAdd, IconSettings} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project, SelectValue} from 'sentry/types';
 import {uniqueId} from 'sentry/utils/guid';
@@ -136,6 +138,29 @@ class ActionsPanel extends PureComponent<Props> {
     };
 
     onChange(triggerIndex, triggers, replaceAtArrayIndex(actions, index, newAction));
+  }
+
+  conditionallyRenderHelpfulBanner(triggerIndex: number, index: number) {
+    const {triggers} = this.props;
+    const {actions} = triggers[triggerIndex];
+    const newAction = {...actions[index]};
+    if (newAction.type === 'slack') {
+      return (
+        <MarginlessAlert type="warning">
+          {tct(
+            'Having rate limiting problems? Enter a channel or user ID. Read more [rateLimiting].',
+            {
+              rateLimiting: (
+                <ExternalLink href="https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error">
+                  {t('here')}
+                </ExternalLink>
+              ),
+            }
+          )}
+        </MarginlessAlert>
+      );
+    }
+    return null;
   }
 
   handleAddAction = () => {
@@ -414,6 +439,7 @@ class ActionsPanel extends PureComponent<Props> {
                   />
                 </PanelItemGrid>
               </RuleRowContainer>
+              {this.conditionallyRenderHelpfulBanner(triggerIndex, actionIdx)}
             </div>
           );
         })}
@@ -481,6 +507,16 @@ const StyledListItem = styled(ListItem)`
 const PerformActionsListItem = styled(StyledListItem)`
   margin-bottom: 0;
   line-height: 1.3;
+`;
+
+const MarginlessAlert = styled(Alert)`
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-width: 0;
+  border-top: 1px ${p => p.theme.innerBorder} solid;
+  margin: 0;
+  padding: ${space(1)} ${space(1)};
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 export default withOrganization(ActionsPanelWithSpace);

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -144,23 +144,21 @@ class ActionsPanel extends PureComponent<Props> {
     const {triggers} = this.props;
     const {actions} = triggers[triggerIndex];
     const newAction = {...actions[index]};
-    if (newAction.type === 'slack') {
-      return (
-        <MarginlessAlert type="warning">
-          {tct(
-            'Having rate limiting problems? Enter a channel or user ID. Read more [rateLimiting].',
-            {
-              rateLimiting: (
-                <ExternalLink href="https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error">
-                  {t('here')}
-                </ExternalLink>
-              ),
-            }
-          )}
-        </MarginlessAlert>
-      );
+    if (newAction.type !== 'slack') {
+      return null;
     }
-    return null;
+    return (
+      <MarginlessAlert type="warning">
+        {tct(
+          'Having rate limiting problems? Enter a channel or user ID. Read more [rateLimiting:here].',
+          {
+            rateLimiting: (
+              <ExternalLink href="https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error" />
+            ),
+          }
+        )}
+      </MarginlessAlert>
+    );
   }
 
   handleAddAction = () => {

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -7,12 +7,11 @@ import {openModal} from 'sentry/actionCreators/modal';
 import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import SelectControl from 'sentry/components/forms/selectControl';
-import ExternalLink from 'sentry/components/links/externalLink';
 import ListItem from 'sentry/components/list/listItem';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {PanelItem} from 'sentry/components/panels';
 import {IconAdd, IconSettings} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project, SelectValue} from 'sentry/types';
 import {uniqueId} from 'sentry/utils/guid';
@@ -148,16 +147,20 @@ class ActionsPanel extends PureComponent<Props> {
       return null;
     }
     return (
-      <MarginlessAlert type="warning">
-        {tct(
-          'Having rate limiting problems? Enter a channel or user ID. Read more [rateLimiting:here].',
-          {
-            rateLimiting: (
-              <ExternalLink href="https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error" />
-            ),
-          }
-        )}
-      </MarginlessAlert>
+          <MarginlessAlert
+            type="info"
+            showIcon
+            trailingItems={
+              <Button
+                href={"https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error"}
+                size="xsmall"
+              >
+                {t('Learn More')}
+              </Button>
+            }
+          >
+            {t('Having rate limiting problems? Enter a channel or user ID.')}
+          </MarginlessAlert>
     );
   }
 

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -493,8 +493,11 @@ const PanelItemSelects = styled('div')`
 
 const RuleRowContainer = styled('div')`
   background-color: ${p => p.theme.backgroundSecondary};
-  border-radius: ${p => p.theme.borderRadius};
   border: 1px ${p => p.theme.border} solid;
+  border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
+  &:last-child {
+    border-radius: ${p => p.theme.borderRadius};
+  }
 `;
 
 const StyledListItem = styled(ListItem)`
@@ -508,10 +511,9 @@ const PerformActionsListItem = styled(StyledListItem)`
 `;
 
 const MarginlessAlert = styled(Alert)`
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  border-width: 0;
-  border-top: 1px ${p => p.theme.innerBorder} solid;
+  border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
+  border: 1px ${p => p.theme.border} solid;
+  border-top-width: 0;
   margin: 0;
   padding: ${space(1)} ${space(1)};
   font-size: ${p => p.theme.fontSizeSmall};


### PR DESCRIPTION
Add a little banner with a link to the Slack docs to let users know they can enter the channel or user ID in a metric alert action. We already have this for issue alerts: https://github.com/getsentry/sentry/pull/29125 and 6 months later I'm adding it for metric alerts too. I also updated the issue alerts banner to match this one.

### Metric Alert Action

**Before**
<img width="1025" alt="Screen Shot 2022-05-16 at 11 21 45 AM" src="https://user-images.githubusercontent.com/29959063/168657788-c07e5303-9c4e-41af-b264-cc008dceadc4.png">

**After**
<img width="1044" alt="Screen Shot 2022-05-25 at 2 59 37 PM" src="https://user-images.githubusercontent.com/29959063/170375541-0b981afb-0e71-4530-bac2-7d51b27d8ef0.png">

### Issue Alert Action
**Before**
<img width="983" alt="Screen Shot 2022-05-25 at 3 13 19 PM" src="https://user-images.githubusercontent.com/29959063/170376019-7148d806-00ea-4c58-99a5-21edc7271616.png">


**After**
<img width="984" alt="Screen Shot 2022-05-25 at 3 07 07 PM" src="https://user-images.githubusercontent.com/29959063/170375655-7dc0e2f2-0bae-4266-b9a3-60acdaeda685.png">
