### PR TITLE
Add internal flag to dataset selector in Performance

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/metricEvents/metricsEventsDropdown.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/metricEvents/metricsEventsDropdown.tsx
@@ -25,7 +25,7 @@ const autoTextMap: Record<AutoSampleState, string> = {
 
 function getOptions(mepContext: MetricsEnhancedSettingContext): MetricsEventsOption[] {
   const autoText = autoTextMap[mepContext.autoSampleState];
-  const prefix = t('Sample');
+  const prefix = t('Sample (Internal)');
 
   return [
     {


### PR DESCRIPTION
This selector will only ever be internal to the Performance team to ensure data quality with the upcoming Metrics Enhanced Performance. This label just clarifies that.