### PR TITLE
feat(profiling): add timeline info to tooltip

### DIFF
--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -86,6 +86,7 @@ const Tooltip = styled('div')`
   user-select: none;
   border-radius: ${p => p.theme.borderRadius};
   padding: ${space(0.25)} ${space(1)};
+  border: 1px solid ${p => p.theme.border};
 `;
 
 export {BoundTooltip};

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {mat3, vec2} from 'gl-matrix';
 
 import {FrameStack} from 'sentry/components/profiling/frameStack';
+import space from 'sentry/styles/space';
 import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {DifferentialFlamegraph} from 'sentry/utils/profiling/differentialFlamegraph';
@@ -15,7 +16,7 @@ import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegrap
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
-import {Rect} from 'sentry/utils/profiling/gl/utils';
+import {formatColorForFrame, Rect} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 import {GridRenderer} from 'sentry/utils/profiling/renderers/gridRenderer';
 import {SelectedFrameRenderer} from 'sentry/utils/profiling/renderers/selectedFrameRenderer';
@@ -652,12 +653,22 @@ function FlamegraphZoomView({
             flamegraphCanvas={flamegraphCanvas}
             flamegraphView={flamegraphView}
           >
-            {flamegraphRenderer.flamegraph.formatter(hoveredNode.node.totalWeight)}{' '}
-            {formatWeightToProfileDuration(
-              hoveredNode.node,
-              flamegraphRenderer.flamegraph
-            )}{' '}
-            {hoveredNode.frame.name}
+            <HoveredFrameMainInfo>
+              <FrameColorIndicator
+                backgroundColor={formatColorForFrame(hoveredNode, flamegraphRenderer)}
+              />
+              {flamegraphRenderer.flamegraph.formatter(hoveredNode.node.totalWeight)}{' '}
+              {formatWeightToProfileDuration(
+                hoveredNode.node,
+                flamegraphRenderer.flamegraph
+              )}{' '}
+              {hoveredNode.frame.name}
+            </HoveredFrameMainInfo>
+            <HoveredFrameTimelineInfo>
+              {flamegraphRenderer.flamegraph.timelineFormatter(hoveredNode.start)}{' '}
+              {' \u2014 '}
+              {flamegraphRenderer.flamegraph.timelineFormatter(hoveredNode.end)}
+            </HoveredFrameTimelineInfo>
           </BoundTooltip>
         ) : null}
       </CanvasContainer>
@@ -670,6 +681,28 @@ function FlamegraphZoomView({
     </Fragment>
   );
 }
+
+const HoveredFrameTimelineInfo = styled('div')`
+  color: ${p => p.theme.subText};
+`;
+
+const HoveredFrameMainInfo = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const FrameColorIndicator = styled('div')<{
+  backgroundColor: React.CSSProperties['backgroundColor'];
+}>`
+  width: 12px;
+  height: 12px;
+  min-width: 12px;
+  min-height: 12px;
+  border-radius: 2px;
+  display: inline-block;
+  background-color: ${p => p.backgroundColor};
+  margin-right: ${space(1)};
+`;
 
 const CanvasContainer = styled('div')`
   display: flex;

--- a/static/app/components/profiling/frameStack.tsx
+++ b/static/app/components/profiling/frameStack.tsx
@@ -9,6 +9,7 @@ import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {useFlamegraphProfilesValue} from 'sentry/utils/profiling/flamegraph/useFlamegraphProfiles';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {formatColorForFrame} from 'sentry/utils/profiling/gl/utils';
 import {invertCallTree} from 'sentry/utils/profiling/profile/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 
@@ -18,21 +19,6 @@ function computeRelativeWeight(base: number, value: number) {
     return 0;
   }
   return (value / base) * 100;
-}
-
-function formatColorForFrame(
-  frame: FlamegraphFrame,
-  renderer: FlamegraphRenderer
-): string {
-  const color = renderer.getColorForFrame(frame);
-  if (color.length === 4) {
-    return `rgba(${color
-      .slice(0, 3)
-      .map(n => n * 255)
-      .join(',')}, ${color[3]})`;
-  }
-
-  return `rgba(${color.map(n => n * 255).join(',')}, 1.0)`;
 }
 
 function makeSortFunction(

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -1,5 +1,8 @@
 import {mat3, vec2} from 'gl-matrix';
 
+import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
+
 import {clamp} from '../colors/utils';
 
 export function createShader(
@@ -482,6 +485,21 @@ export function findRangeBinarySearch(
       high = mid;
     }
   }
+}
+
+export function formatColorForFrame(
+  frame: FlamegraphFrame,
+  renderer: FlamegraphRenderer
+): string {
+  const color = renderer.getColorForFrame(frame);
+  if (color.length === 4) {
+    return `rgba(${color
+      .slice(0, 3)
+      .map(n => n * 255)
+      .join(',')}, ${color[3]})`;
+  }
+
+  return `rgba(${color.map(n => n * 255).join(',')}, 1.0)`;
 }
 
 export const ELLIPSIS = '\u2026';


### PR DESCRIPTION
Add info about when on the profile timeline that frame occurred. Useful so that folks dont need to manually guesstimate by looking at the timeline.

![CleanShot 2022-05-16 at 15 39 28](https://user-images.githubusercontent.com/9317857/168669590-580c1ead-f74f-4616-854f-77e834f113bb.gif)
