### PR TITLE
test(workflow): Add tests for incident date range

### DIFF
--- a/static/app/views/alerts/list/row.tsx
+++ b/static/app/views/alerts/list/row.tsx
@@ -14,40 +14,10 @@ import TeamStore from 'sentry/stores/teamStore';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
 import {Actor, Organization, Project} from 'sentry/types';
-import {getUtcDateString} from 'sentry/utils/dates';
 import getDynamicText from 'sentry/utils/getDynamicText';
 
-import {
-  API_INTERVAL_POINTS_LIMIT,
-  API_INTERVAL_POINTS_MIN,
-} from '../rules/details/constants';
 import {Incident, IncidentStatus} from '../types';
 import {alertDetailsLink} from '../utils';
-
-/**
- * Retrieve the start/end for showing the graph of the metric
- * Will show at least 150 and no more than 10,000 data points
- */
-export const makeRuleDetailsQuery = (
-  incident: Incident
-): {end: string; start: string} => {
-  const {timeWindow} = incident.alertRule;
-  const timeWindowMillis = timeWindow * 60 * 1000;
-  const minRange = timeWindowMillis * API_INTERVAL_POINTS_MIN;
-  const maxRange = timeWindowMillis * API_INTERVAL_POINTS_LIMIT;
-  const now = moment.utc();
-  const startDate = moment.utc(incident.dateStarted);
-  // make a copy of now since we will modify endDate and use now for comparing
-  const endDate = incident.dateClosed ? moment.utc(incident.dateClosed) : moment(now);
-  const incidentRange = Math.max(endDate.diff(startDate), 3 * timeWindowMillis);
-  const range = Math.min(maxRange, Math.max(minRange, incidentRange));
-  const halfRange = moment.duration(range / 2);
-
-  return {
-    start: getUtcDateString(startDate.subtract(halfRange)),
-    end: getUtcDateString(moment.min(endDate.add(halfRange), now)),
-  };
-};
 
 type Props = {
   incident: Incident;

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -17,14 +17,17 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import withApi from 'sentry/utils/withApi';
 import withProjects from 'sentry/utils/withProjects';
 import {IncidentRule, TimePeriod} from 'sentry/views/alerts/incidentRules/types';
-import {makeRuleDetailsQuery} from 'sentry/views/alerts/list/row';
-
-import {Incident} from '../../types';
-import {fetchAlertRule, fetchIncident, fetchIncidentsForRule} from '../../utils/apiCalls';
+import type {Incident} from 'sentry/views/alerts/types';
+import {
+  fetchAlertRule,
+  fetchIncident,
+  fetchIncidentsForRule,
+} from 'sentry/views/alerts/utils/apiCalls';
 
 import DetailsBody from './body';
 import {TIME_OPTIONS, TIME_WINDOWS, TimePeriodType} from './constants';
 import DetailsHeader from './header';
+import {buildIncidentGraphDateRange} from './utils';
 
 interface Props extends RouteComponentProps<{orgId: string; ruleId: string}, {}> {
   api: Client;
@@ -98,7 +101,7 @@ class MetricAlertDetails extends Component<Props, State> {
     }
 
     if (location.query.alert && selectedIncident) {
-      const {start, end} = makeRuleDetailsQuery(selectedIncident);
+      const {start, end} = buildIncidentGraphDateRange(selectedIncident);
       return {
         start,
         end,

--- a/static/app/views/alerts/rules/details/utils.tsx
+++ b/static/app/views/alerts/rules/details/utils.tsx
@@ -1,0 +1,31 @@
+import moment from 'moment';
+
+import {getUtcDateString} from 'sentry/utils/dates';
+import type {Incident} from 'sentry/views/alerts/types';
+
+import {API_INTERVAL_POINTS_LIMIT, API_INTERVAL_POINTS_MIN} from './constants';
+
+/**
+ * Retrieve start/end date of a metric alert incident for the events graph
+ * Will show at least 150 and no more than 10,000 data points
+ */
+export function buildIncidentGraphDateRange(incident: Incident): {
+  end: string;
+  start: string;
+} {
+  const timeWindowMillis = incident.alertRule.timeWindow * 60 * 1000;
+  const minRange = timeWindowMillis * API_INTERVAL_POINTS_MIN;
+  const maxRange = timeWindowMillis * API_INTERVAL_POINTS_LIMIT;
+  const now = moment.utc();
+  const startDate = moment.utc(incident.dateStarted);
+  // make a copy of now since we will modify endDate and use now for comparing
+  const endDate = incident.dateClosed ? moment.utc(incident.dateClosed) : moment(now);
+  const incidentRange = Math.max(endDate.diff(startDate), 3 * timeWindowMillis);
+  const range = Math.min(maxRange, Math.max(minRange, incidentRange));
+  const halfRange = moment.duration(range / 2);
+
+  return {
+    start: getUtcDateString(startDate.subtract(halfRange)),
+    end: getUtcDateString(moment.min(endDate.add(halfRange), now)),
+  };
+}

--- a/tests/fixtures/js-stubs/incident.js
+++ b/tests/fixtures/js-stubs/incident.js
@@ -13,7 +13,7 @@ export function Incident(params = {}) {
     status: 0,
     projects: [],
     isSubscribed: true,
-    alertRule: IncidentRule(),
+    alertRule: IncidentRule(params.alertRule),
     activities: [
       {
         id: '78',

--- a/tests/js/spec/views/alerts/rules/utils.spec.tsx
+++ b/tests/js/spec/views/alerts/rules/utils.spec.tsx
@@ -15,8 +15,8 @@ describe('buildIncidentGraphDateRange', () => {
 
   it('should use current date for an active alert', () => {
     const incident = TestStubs.Incident({
-      dateClosed: null,
       dateStarted: '2022-05-16T18:55:00Z',
+      dateClosed: null,
       alertRule: {timeWindow: 1},
     });
     const result = buildIncidentGraphDateRange(incident);
@@ -26,8 +26,8 @@ describe('buildIncidentGraphDateRange', () => {
 
   it('should use current date for a recently closed alert', () => {
     const incident = TestStubs.Incident({
-      dateClosed: '2022-05-16T18:57:00Z',
       dateStarted: '2022-05-16T18:55:00Z',
+      dateClosed: '2022-05-16T18:57:00Z',
       alertRule: {timeWindow: 1},
     });
     const result = buildIncidentGraphDateRange(incident);
@@ -38,8 +38,8 @@ describe('buildIncidentGraphDateRange', () => {
   it('should use a past date for an older alert', () => {
     // Incident is from over a week ago
     const incident = TestStubs.Incident({
-      dateClosed: '2022-05-04T18:57:00Z',
       dateStarted: '2022-05-04T18:55:00Z',
+      dateClosed: '2022-05-04T18:57:00Z',
       alertRule: {timeWindow: 1},
     });
     const result = buildIncidentGraphDateRange(incident);
@@ -49,8 +49,8 @@ describe('buildIncidentGraphDateRange', () => {
 
   it('should handle large time windows', () => {
     const incident = TestStubs.Incident({
-      dateClosed: null,
       dateStarted: '2022-04-20T20:28:00Z',
+      dateClosed: null,
       // 1 day time window
       alertRule: {timeWindow: 1440},
     });

--- a/tests/js/spec/views/alerts/rules/utils.spec.tsx
+++ b/tests/js/spec/views/alerts/rules/utils.spec.tsx
@@ -1,0 +1,61 @@
+import MockDate from 'mockdate';
+import moment from 'moment';
+
+import {buildIncidentGraphDateRange} from 'sentry/views/alerts/rules/details/utils';
+
+describe('buildIncidentGraphDateRange', () => {
+  const now = '2022-05-16T20:00:00';
+  beforeAll(() => {
+    MockDate.set(`${now}Z`);
+  });
+  afterAll(() => {
+    // reset mock date
+    MockDate.set(new Date(1508208080000));
+  });
+
+  it('should use current date for an active alert', () => {
+    const incident = TestStubs.Incident({
+      dateClosed: null,
+      dateStarted: '2022-05-16T18:55:00Z',
+      timeWindow: {timeWindow: 1},
+    });
+    const result = buildIncidentGraphDateRange(incident);
+    expect(result).toEqual({start: '2022-05-13T15:55:00', end: now});
+    expect(moment(result.end).diff(moment(result.start), 'minutes')).toBe(4565);
+  });
+
+  it('should use current date for a recently closed alert', () => {
+    const incident = TestStubs.Incident({
+      dateClosed: '2022-05-16T18:57:00Z',
+      dateStarted: '2022-05-16T18:55:00Z',
+      timeWindow: {timeWindow: 1},
+    });
+    const result = buildIncidentGraphDateRange(incident);
+    expect(result).toEqual({start: '2022-05-13T15:55:00', end: now});
+    expect(moment(result.end).diff(moment(result.start), 'minutes')).toBe(4565);
+  });
+
+  it('should use a past date for an older alert', () => {
+    // Incident is from over a week ago
+    const incident = TestStubs.Incident({
+      dateClosed: '2022-05-04T18:57:00Z',
+      dateStarted: '2022-05-04T18:55:00Z',
+      timeWindow: {timeWindow: 1},
+    });
+    const result = buildIncidentGraphDateRange(incident);
+    expect(result).toEqual({start: '2022-05-01T15:55:00', end: '2022-05-07T21:57:00'});
+    expect(moment(result.end).diff(moment(result.start), 'minutes')).toBe(9002);
+  });
+
+  it('should handle large time windows', () => {
+    const incident = TestStubs.Incident({
+      dateClosed: null,
+      dateStarted: '2022-04-20T20:28:00Z',
+      // 1 day time window
+      timeWindow: {timeWindow: 1440},
+    });
+    const result = buildIncidentGraphDateRange(incident);
+    expect(result).toEqual({start: '2022-04-07T20:42:00', end: now});
+    expect(moment(result.end).diff(moment(result.start), 'days')).toBe(38);
+  });
+});

--- a/tests/js/spec/views/alerts/rules/utils.spec.tsx
+++ b/tests/js/spec/views/alerts/rules/utils.spec.tsx
@@ -17,22 +17,22 @@ describe('buildIncidentGraphDateRange', () => {
     const incident = TestStubs.Incident({
       dateClosed: null,
       dateStarted: '2022-05-16T18:55:00Z',
-      timeWindow: {timeWindow: 1},
+      alertRule: {timeWindow: 1},
     });
     const result = buildIncidentGraphDateRange(incident);
-    expect(result).toEqual({start: '2022-05-13T15:55:00', end: now});
-    expect(moment(result.end).diff(moment(result.start), 'minutes')).toBe(4565);
+    expect(result).toEqual({start: '2022-05-16T17:40:00', end: now});
+    expect(moment(result.end).diff(moment(result.start), 'minutes')).toBe(140);
   });
 
   it('should use current date for a recently closed alert', () => {
     const incident = TestStubs.Incident({
       dateClosed: '2022-05-16T18:57:00Z',
       dateStarted: '2022-05-16T18:55:00Z',
-      timeWindow: {timeWindow: 1},
+      alertRule: {timeWindow: 1},
     });
     const result = buildIncidentGraphDateRange(incident);
-    expect(result).toEqual({start: '2022-05-13T15:55:00', end: now});
-    expect(moment(result.end).diff(moment(result.start), 'minutes')).toBe(4565);
+    expect(result).toEqual({start: '2022-05-16T17:40:00', end: now});
+    expect(moment(result.end).diff(moment(result.start), 'minutes')).toBe(140);
   });
 
   it('should use a past date for an older alert', () => {
@@ -40,11 +40,11 @@ describe('buildIncidentGraphDateRange', () => {
     const incident = TestStubs.Incident({
       dateClosed: '2022-05-04T18:57:00Z',
       dateStarted: '2022-05-04T18:55:00Z',
-      timeWindow: {timeWindow: 1},
+      alertRule: {timeWindow: 1},
     });
     const result = buildIncidentGraphDateRange(incident);
-    expect(result).toEqual({start: '2022-05-01T15:55:00', end: '2022-05-07T21:57:00'});
-    expect(moment(result.end).diff(moment(result.start), 'minutes')).toBe(9002);
+    expect(result).toEqual({end: '2022-05-04T20:12:00', start: '2022-05-04T17:40:00'});
+    expect(moment(result.end).diff(moment(result.start), 'minutes')).toBe(152);
   });
 
   it('should handle large time windows', () => {
@@ -52,10 +52,10 @@ describe('buildIncidentGraphDateRange', () => {
       dateClosed: null,
       dateStarted: '2022-04-20T20:28:00Z',
       // 1 day time window
-      timeWindow: {timeWindow: 1440},
+      alertRule: {timeWindow: 1440},
     });
     const result = buildIncidentGraphDateRange(incident);
-    expect(result).toEqual({start: '2022-04-07T20:42:00', end: now});
-    expect(moment(result.end).diff(moment(result.start), 'days')).toBe(38);
+    expect(result).toEqual({start: '2022-02-04T20:28:00', end: now});
+    expect(moment(result.end).diff(moment(result.start), 'days')).toBe(100);
   });
 });


### PR DESCRIPTION
Because I have to re-create this function on the backend to build the chartcuterie chart, pull this into a file that makes more sense and add some unit tests.