### PR TITLE
feat (replays): added a placeholder to the issues tab on replay details

### DIFF
--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -19,6 +19,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
+import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
 
 type Props = {
   projectId: string;
@@ -156,9 +157,12 @@ function IssueList(props: Props) {
       limit={15}
     >
       {data => {
-        return (
+        return data.tableData?.data.length === 0 ? (
+          <Placeholder height="200px">
+            <EmptyMessage title={`${t('No issues for replay event.')}`} />
+          </Placeholder>
+        ) : (
           <StyledPanelTable
-            isEmpty={data.tableData?.data.length === 0}
             isLoading={data.isLoading}
             headers={
               isScreenLarge ? columns : columns.filter(column => column !== t('Graph'))

--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -159,7 +159,7 @@ function IssueList(props: Props) {
         return (
           <StyledPanelTable
             isEmpty={data.tableData?.data.length === 0}
-            emptyMessage={`${t('No related Issues found.')}`}
+            emptyMessage={t('No related Issues found.')}
             isLoading={data.isLoading}
             headers={
               isScreenLarge ? columns : columns.filter(column => column !== t('Graph'))

--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -159,7 +159,7 @@ function IssueList(props: Props) {
         return (
           <StyledPanelTable
             isEmpty={data.tableData?.data.length === 0}
-            emptyMessage={`${t('Good News! There are no processing issues.')}`}
+            emptyMessage={`${t('No related Issues found.')}`}
             isLoading={data.isLoading}
             headers={
               isScreenLarge ? columns : columns.filter(column => column !== t('Graph'))

--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -19,7 +19,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
-import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
 
 type Props = {
   projectId: string;
@@ -157,12 +156,10 @@ function IssueList(props: Props) {
       limit={15}
     >
       {data => {
-        return data.tableData?.data.length === 0 ? (
-          <Placeholder height="200px">
-            <EmptyMessage title={`${t('No issues for replay event.')}`} />
-          </Placeholder>
-        ) : (
+        return (
           <StyledPanelTable
+            isEmpty={data.tableData?.data.length === 0}
+            emptyMessage={`${t('Good News! There are no processing issues.')}`}
             isLoading={data.isLoading}
             headers={
               isScreenLarge ? columns : columns.filter(column => column !== t('Graph'))


### PR DESCRIPTION
Closes #34435 
This replaces the empty table that was there previously. I went ahead and added an empty message too since a placeholder with nothing in it doesn't seem immediately obvious regarding what's up.

<img width="1704" alt="image" src="https://user-images.githubusercontent.com/7014871/168824320-84b7b393-0e60-4f07-8bba-e5642db121d3.png">





<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
