### PR TITLE
feat(profiling): make the drawer resizable

### DIFF
--- a/static/app/components/profiling/frameStack.tsx
+++ b/static/app/components/profiling/frameStack.tsx
@@ -310,19 +310,28 @@ function FrameStack(props: FrameStackProps) {
 
   const onMouseDown = useCallback((evt: React.MouseEvent<HTMLElement>) => {
     let startResizeVector = vec2.fromValues(evt.clientX, evt.clientY);
+    let rafId: number | undefined;
 
     function handleMouseMove(mvEvent: MouseEvent) {
-      const currentPositionVector = vec2.fromValues(mvEvent.clientX, mvEvent.clientY);
+      if (rafId !== undefined) {
+        window.cancelAnimationFrame(rafId);
+        rafId = undefined;
+      }
 
-      const distance = vec2.subtract(
-        vec2.fromValues(0, 0),
-        startResizeVector,
-        currentPositionVector
-      );
+      window.requestAnimationFrame(() => {
+        const currentPositionVector = vec2.fromValues(mvEvent.clientX, mvEvent.clientY);
 
-      startResizeVector = currentPositionVector;
+        const distance = vec2.subtract(
+          vec2.fromValues(0, 0),
+          startResizeVector,
+          currentPositionVector
+        );
 
-      setDrawerHeight(h => Math.max(MIN_DRAWER_HEIGHT_PX, h + distance[1]));
+        startResizeVector = currentPositionVector;
+
+        setDrawerHeight(h => Math.max(MIN_DRAWER_HEIGHT_PX, h + distance[1]));
+        rafId = undefined;
+      });
     }
 
     function handleMouseUp() {
@@ -334,6 +343,10 @@ function FrameStack(props: FrameStackProps) {
 
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
+
+      if (rafId !== undefined) {
+        window.cancelAnimationFrame(rafId);
+      }
     };
   }, []);
 

--- a/static/app/components/profiling/frameStack.tsx
+++ b/static/app/components/profiling/frameStack.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import {vec2} from 'gl-matrix';
 
 import Button from 'sentry/components/button';
 import {IconArrow} from 'sentry/icons';
@@ -284,10 +285,16 @@ interface FrameStackProps {
   flamegraphRenderer: FlamegraphRenderer;
 }
 
+const MIN_DRAWER_HEIGHT_PX = 30;
+
 function FrameStack(props: FrameStackProps) {
   const theme = useFlamegraphTheme();
   const {selectedNode} = useFlamegraphProfilesValue();
+
   const [tab, setTab] = useState<'bottom up' | 'call order'>('call order');
+  const [drawerHeight, setDrawerHeight] = useState(
+    (theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET + 2) * theme.SIZES.BAR_HEIGHT
+  );
 
   const roots = useMemo(() => {
     if (!selectedNode) {
@@ -301,10 +308,39 @@ function FrameStack(props: FrameStackProps) {
     return invertCallTree([selectedNode]);
   }, [selectedNode, tab]);
 
+  const onMouseDown = useCallback((evt: React.MouseEvent<HTMLElement>) => {
+    let startResizeVector = vec2.fromValues(evt.clientX, evt.clientY);
+
+    function handleMouseMove(mvEvent: MouseEvent) {
+      const currentPositionVector = vec2.fromValues(mvEvent.clientX, mvEvent.clientY);
+
+      const distance = vec2.subtract(
+        vec2.fromValues(0, 0),
+        startResizeVector,
+        currentPositionVector
+      );
+
+      startResizeVector = currentPositionVector;
+
+      setDrawerHeight(h => Math.max(MIN_DRAWER_HEIGHT_PX, h + distance[1]));
+    }
+
+    function handleMouseUp() {
+      document.removeEventListener('mousemove', handleMouseMove);
+    }
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+    };
+  }, []);
+
   return selectedNode ? (
     <FrameDrawer
       style={{
-        height: (theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET + 2) * theme.SIZES.BAR_HEIGHT,
+        height: drawerHeight,
       }}
     >
       <FrameTabs>
@@ -321,6 +357,7 @@ function FrameStack(props: FrameStackProps) {
             {t('Call Order')}
           </Button>
         </li>
+        <li style={{flex: '1 1 100%', cursor: 'ns-resize'}} onMouseDown={onMouseDown} />
       </FrameTabs>
       <FrameCallTreeStack {...props} roots={roots ?? []} referenceNode={selectedNode} />
     </FrameDrawer>
@@ -340,6 +377,7 @@ const FrameTabs = styled('ul')`
   margin: 0;
   border-top: 1px solid ${prop => prop.theme.border};
   background-color: ${props => props.theme.surface400};
+  user-select: none;
 
   > li {
     font-size: ${p => p.theme.fontSizeSmall};


### PR DESCRIPTION
Sometimes, users may want to prioritize looking a the call tree information, so we want to allow them to see a bigger part of it. We are not persisting the height anywhere for now, if user feedback is to add it, that shouldn't be too hard.

![CleanShot 2022-05-16 at 18 19 57](https://user-images.githubusercontent.com/9317857/168692017-1c90a8b8-2763-4a90-9806-9612f03f0113.gif)
