### PR TITLE
ref(tooltip): Improve arrow css

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -356,63 +356,62 @@ const TooltipContent = styled(motion.div, {
 `;
 
 const TooltipArrow = styled('span')`
-  position: absolute;
-  width: 6px;
-  height: 6px;
-  border: solid 6px transparent;
   pointer-events: none;
+  position: absolute;
+  width: 12px;
+  height: 12px;
 
-  &::before {
+  &::before,
+  &::after {
     content: '';
     display: block;
     position: absolute;
-    width: 0;
-    height: 0;
+    height: 12px;
+    width: 12px;
     border: solid 6px transparent;
-    z-index: -1;
   }
 
-  &[data-placement*='bottom'] {
-    top: 0;
-    margin-top: -12px;
-    border-bottom-color: ${p => p.theme.backgroundElevated};
+  &[data-placement|='bottom'] {
+    top: -12px;
     &::before {
-      bottom: -5px;
-      left: -6px;
+      bottom: 1px;
       border-bottom-color: ${p => p.theme.translucentBorder};
     }
+    &::after {
+      border-bottom-color: ${p => p.theme.backgroundElevated};
+    }
   }
 
-  &[data-placement*='top'] {
-    bottom: 0;
-    margin-bottom: -12px;
-    border-top-color: ${p => p.theme.backgroundElevated};
+  &[data-placement|='top'] {
+    bottom: -12px;
     &::before {
-      top: -5px;
-      left: -6px;
+      top: 1px;
       border-top-color: ${p => p.theme.translucentBorder};
     }
-  }
-
-  &[data-placement*='right'] {
-    left: 0;
-    margin-left: -12px;
-    border-right-color: ${p => p.theme.backgroundElevated};
-    &::before {
-      top: -6px;
-      right: -5px;
-      border-right-color: ${p => p.theme.translucentBorder};
+    &::after {
+      border-top-color: ${p => p.theme.backgroundElevated};
     }
   }
 
-  &[data-placement*='left'] {
-    right: 0;
-    margin-right: -12px;
-    border-left-color: ${p => p.theme.backgroundElevated};
+  &[data-placement|='right'] {
+    left: -12px;
     &::before {
-      top: -6px;
-      left: -5px;
+      right: 1px;
+      border-right-color: ${p => p.theme.translucentBorder};
+    }
+    &::after {
+      border-right-color: ${p => p.theme.backgroundElevated};
+    }
+  }
+
+  &[data-placement|='left'] {
+    right: -12px;
+    &::before {
+      left: 1px;
       border-left-color: ${p => p.theme.translucentBorder};
+    }
+    &::after {
+      border-left-color: ${p => p.theme.backgroundElevated};
     }
   }
 `;


### PR DESCRIPTION
I am upgrading popper, which uses `transform: translate(...)` to move the tooltip arrow into position. Unfortuantely this put's the arrow in a different stacking context, which breaks the current approach