### PR TITLE
feat(ownership): add support for kotlin stack frames

### DIFF
--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -14,11 +14,7 @@ from rest_framework.serializers import ValidationError
 
 from sentry.eventstore.models import EventSubjectTemplateData
 from sentry.models import ActorTuple, RepositoryProjectPathConfig
-<<<<<<< HEAD
 from sentry.utils.event_frames import find_stack_frames, munged_filename_and_frames
-=======
-from sentry.utils.event_frames import find_stack_frames, supplement_filename
->>>>>>> b975c7297b (add support for thread stack trace in code owners)
 from sentry.utils.glob import glob_match
 from sentry.utils.safe import PathSearchable, get_path
 
@@ -165,14 +161,6 @@ class Matcher(namedtuple("Matcher", "type pattern")):
             glob_match(val, pattern, ignorecase=True, path_normalize=True)
         ),
     ) -> bool:
-<<<<<<< HEAD
-=======
-        platform = data.get("platform")
-        frames = find_stack_frames(data)
-        if platform:
-            supplement_filename(platform, frames)
-
->>>>>>> b975c7297b (add support for thread stack trace in code owners)
         for frame in (f for f in frames if isinstance(f, Mapping)):
             for key in keys:
                 value = frame.get(key)

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -105,7 +105,6 @@ class Matcher(namedtuple("Matcher", "type pattern")):
 
     @staticmethod
     def munge_if_needed(data: PathSearchable) -> Tuple[Sequence[Mapping[str, Any]], Sequence[str]]:
-
         keys = ["filename", "abs_path"]
         platform = data.get("platform")
         frames = find_stack_frames(data)

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -105,6 +105,7 @@ class Matcher(namedtuple("Matcher", "type pattern")):
 
     @staticmethod
     def munge_if_needed(data: PathSearchable) -> Tuple[Sequence[Mapping[str, Any]], Sequence[str]]:
+
         keys = ["filename", "abs_path"]
         platform = data.get("platform")
         frames = find_stack_frames(data)

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -14,7 +14,11 @@ from rest_framework.serializers import ValidationError
 
 from sentry.eventstore.models import EventSubjectTemplateData
 from sentry.models import ActorTuple, RepositoryProjectPathConfig
+<<<<<<< HEAD
 from sentry.utils.event_frames import find_stack_frames, munged_filename_and_frames
+=======
+from sentry.utils.event_frames import find_stack_frames, supplement_filename
+>>>>>>> b975c7297b (add support for thread stack trace in code owners)
 from sentry.utils.glob import glob_match
 from sentry.utils.safe import PathSearchable, get_path
 
@@ -161,6 +165,14 @@ class Matcher(namedtuple("Matcher", "type pattern")):
             glob_match(val, pattern, ignorecase=True, path_normalize=True)
         ),
     ) -> bool:
+<<<<<<< HEAD
+=======
+        platform = data.get("platform")
+        frames = find_stack_frames(data)
+        if platform:
+            supplement_filename(platform, frames)
+
+>>>>>>> b975c7297b (add support for thread stack trace in code owners)
         for frame in (f for f in frames if isinstance(f, Mapping)):
             for key in keys:
                 value = frame.get(key)

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -140,7 +140,9 @@ def find_stack_frames(
         # potentially here for backwards compatibility
         frames = get_path(event_data, "stacktrace", "frames", filter=True) or []
         if not frames:
-            threads = get_path(event_data, "threads", "values", filter=True)
+            threads = get_path(event_data, "threads", "values", filter=True) or get_path(
+                event_data, "threads", filter=True
+            )
             thread = get_crashing_thread(threads)
             if thread is not None:
                 frames = get_path(thread, "stacktrace", "frames") or []

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -61,9 +61,6 @@ def get_crashing_thread(thread_frames: Sequence[Mapping[str, Any]]) -> Mapping[s
     return None
 
 
-FrameMunger = Callable[[str, MutableMapping[str, Any]], bool]
-
-
 def java_frame_munger(key: str, frame: MutableMapping[str, Any]) -> bool:
     if frame.get("filename") is None or frame.get("module") is None:
         return False
@@ -100,6 +97,21 @@ def munged_filename_and_frames(
     for frame in copy_frames:
         frames_updated |= munger(key, frame)
     return (key, copy_frames) if frames_updated else None
+
+
+def get_crashing_thread(thread_frames: Sequence[Mapping[str, Any]]) -> Mapping[str, Any] | None:
+    if not thread_frames:
+        return None
+    if len(thread_frames) == 1:
+        return thread_frames[0]
+    filtered = [x for x in thread_frames if x and x.get("crashed")]
+    if len(filtered) == 1:
+        return filtered[0]
+    filtered = [x for x in thread_frames if x and x.get("current")]
+    if len(filtered) == 1:
+        return filtered[0]
+
+    return None
 
 
 def find_stack_frames(

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -63,7 +63,7 @@ def get_crashing_thread(thread_frames: Sequence[Mapping[str, Any]]) -> Mapping[s
 
 def find_stack_frames(
     event_data: PathSearchable, consume_frame: Callable[[Any], None] = lambda _: None
-) -> Sequence[Mapping[str, Any]]:
+) -> Sequence[MutableMapping[str, Any]]:
     """
     See: https://develop.sentry.dev/sdk/event-payloads/#core-interfaces for event data payload format.
 

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -61,59 +61,6 @@ def get_crashing_thread(thread_frames: Sequence[Mapping[str, Any]]) -> Mapping[s
     return None
 
 
-def java_frame_munger(key: str, frame: MutableMapping[str, Any]) -> bool:
-    if frame.get("filename") is None or frame.get("module") is None:
-        return False
-    if "/" not in str(frame.get("filename")) and frame.get("module"):
-        # Replace the last module segment with the filename, as the
-        # terminal element in a module path is the class
-        module = frame["module"].split(".")
-        module[-1] = frame["filename"]
-        frame[key] = "/".join(module)
-        return True
-    return False
-
-
-PLATFORM_FRAME_MUNGER: Mapping[str, FrameMunger] = {"java": java_frame_munger}
-
-
-def munged_filename_and_frames(
-    platform: str, data_frames: Sequence[Mapping[str, Any]], key: str = "munged_filename"
-) -> Optional[Tuple[str, Sequence[Mapping[str, Any]]]]:
-    """
-    Applies platform-specific frame munging for filename pathing.
-
-    Returns the key used to insert into the frames and a deepcopy of the input data_frames with munging applied,
-    otherwise returns None.
-    """
-    munger = PLATFORM_FRAME_MUNGER.get(platform)
-    if not munger:
-        return None
-
-    copy_frames: Sequence[MutableMapping[str, Any]] = cast(
-        Sequence[MutableMapping[str, Any]], deepcopy(data_frames)
-    )
-    frames_updated = False
-    for frame in copy_frames:
-        frames_updated |= munger(key, frame)
-    return (key, copy_frames) if frames_updated else None
-
-
-def get_crashing_thread(thread_frames: Sequence[Mapping[str, Any]]) -> Mapping[str, Any] | None:
-    if not thread_frames:
-        return None
-    if len(thread_frames) == 1:
-        return thread_frames[0]
-    filtered = [x for x in thread_frames if x and x.get("crashed")]
-    if len(filtered) == 1:
-        return filtered[0]
-    filtered = [x for x in thread_frames if x and x.get("current")]
-    if len(filtered) == 1:
-        return filtered[0]
-
-    return None
-
-
 def find_stack_frames(
     event_data: PathSearchable, consume_frame: Callable[[Any], None] = lambda _: None
 ) -> Sequence[Mapping[str, Any]]:

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -221,34 +221,6 @@ def test_matcher_test_platform_java_threads():
         },
     }
 
-    assert Matcher("path", "*.py").test(data)
-    assert Matcher("path", "foo/*.py").test(data)
-    assert Matcher("path", "/usr/local/src/*/app.py").test(data)
-    assert not Matcher("path", "*.js").test(data)
-    assert not Matcher("path", "*.jsx").test(data)
-    assert not Matcher("url", "*.py").test(data)
-    assert not Matcher("path", "*.py").test({})
-
-
-def test_matcher_test_platform_java_threads():
-    data = {
-        "platform": "java",
-        "threads": {
-            "values": [
-                {
-                    "stacktrace": {
-                        "frames": [
-                            {
-                                "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
-                                "filename": "NativeMethodAccessorImpl.java",
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
-    }
-
     assert Matcher("path", "*.java").test(data)
     assert Matcher("path", "jdk/internal/reflect/*.java").test(data)
     assert Matcher("path", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -179,6 +179,7 @@ def test_matcher_test_threads():
         "threads": {
             "values": [
                 {
+<<<<<<< HEAD
                     "stacktrace": {
                         "frames": [
                             {"filename": "foo/file.py"},
@@ -216,6 +217,44 @@ def test_matcher_test_platform_java_threads():
                             }
                         ]
                     }
+=======
+                    "stacktrace": {
+                        "frames": [
+                            {"filename": "foo/file.py"},
+                            {"abs_path": "/usr/local/src/other/app.py"},
+                        ]
+                    },
+                    "crashed": False,
+                    "current": False,
+>>>>>>> b975c7297b (add support for thread stack trace in code owners)
+                }
+            ]
+        },
+    }
+
+    assert Matcher("path", "*.py").test(data)
+    assert Matcher("path", "foo/*.py").test(data)
+    assert Matcher("path", "/usr/local/src/*/app.py").test(data)
+    assert not Matcher("path", "*.js").test(data)
+    assert not Matcher("path", "*.jsx").test(data)
+    assert not Matcher("url", "*.py").test(data)
+    assert not Matcher("path", "*.py").test({})
+
+
+def test_matcher_test_platform_java_threads():
+    data = {
+        "platform": "java",
+        "threads": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
+                                "filename": "NativeMethodAccessorImpl.java",
+                            }
+                        ]
+                    }
                 }
             ]
         },
@@ -224,9 +263,12 @@ def test_matcher_test_platform_java_threads():
     assert Matcher("path", "*.java").test(data)
     assert Matcher("path", "jdk/internal/reflect/*.java").test(data)
     assert Matcher("path", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
+<<<<<<< HEAD
     assert Matcher("codeowners", "*.java").test(data)
     assert Matcher("codeowners", "jdk/internal/reflect/*.java").test(data)
     assert Matcher("codeowners", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
+=======
+>>>>>>> b975c7297b (add support for thread stack trace in code owners)
     assert not Matcher("path", "*.js").test(data)
     assert not Matcher("path", "*.jsx").test(data)
     assert not Matcher("url", "*.py").test(data)

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -184,9 +184,7 @@ def test_matcher_test_threads():
                             {"filename": "foo/file.py"},
                             {"abs_path": "/usr/local/src/other/app.py"},
                         ]
-                    },
-                    "crashed": False,
-                    "current": False,
+                    }
                 }
             ]
         }
@@ -267,8 +265,11 @@ def test_matcher_test_platform_none_threads():
     assert not Matcher("codeowners", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
     assert not Matcher("codeowners", "*.js").test(data)
     assert not Matcher("codeowners", "*.jsx").test(data)
-    assert not Matcher("url", "*.py").test(data)
-    assert not Matcher("path", "*.py").test({})
+    assert Matcher("path", "*.java").test(data)
+    assert Matcher("path", "/jdk/internal/reflect/*.java").test(data)
+    # assert Matcher("path", "/jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
+    assert not Matcher("path", "*.js").test(data)
+    assert not Matcher("path", "*.jsx").test(data)
 
 
 def test_matcher_test_tags():

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -179,7 +179,6 @@ def test_matcher_test_threads():
         "threads": {
             "values": [
                 {
-<<<<<<< HEAD
                     "stacktrace": {
                         "frames": [
                             {"filename": "foo/file.py"},
@@ -217,16 +216,6 @@ def test_matcher_test_platform_java_threads():
                             }
                         ]
                     }
-=======
-                    "stacktrace": {
-                        "frames": [
-                            {"filename": "foo/file.py"},
-                            {"abs_path": "/usr/local/src/other/app.py"},
-                        ]
-                    },
-                    "crashed": False,
-                    "current": False,
->>>>>>> b975c7297b (add support for thread stack trace in code owners)
                 }
             ]
         },
@@ -263,12 +252,9 @@ def test_matcher_test_platform_java_threads():
     assert Matcher("path", "*.java").test(data)
     assert Matcher("path", "jdk/internal/reflect/*.java").test(data)
     assert Matcher("path", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
-<<<<<<< HEAD
     assert Matcher("codeowners", "*.java").test(data)
     assert Matcher("codeowners", "jdk/internal/reflect/*.java").test(data)
     assert Matcher("codeowners", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
-=======
->>>>>>> b975c7297b (add support for thread stack trace in code owners)
     assert not Matcher("path", "*.js").test(data)
     assert not Matcher("path", "*.jsx").test(data)
     assert not Matcher("url", "*.py").test(data)
@@ -307,11 +293,8 @@ def test_matcher_test_platform_none_threads():
     assert not Matcher("codeowners", "jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
     assert not Matcher("codeowners", "*.js").test(data)
     assert not Matcher("codeowners", "*.jsx").test(data)
-    assert Matcher("path", "*.java").test(data)
-    assert Matcher("path", "/jdk/internal/reflect/*.java").test(data)
-    # assert Matcher("path", "/jdk/internal/*/NativeMethodAccessorImpl.java").test(data)
-    assert not Matcher("path", "*.js").test(data)
-    assert not Matcher("path", "*.jsx").test(data)
+    assert not Matcher("url", "*.py").test(data)
+    assert not Matcher("path", "*.py").test({})
 
 
 def test_matcher_test_tags():

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -281,6 +281,177 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
 
+    def test_kotlin_java_sdk_path_mangling(self):
+        event = self.store_event(
+            data={
+                "message": "Kaboom!",
+                "platform": "java",
+                "exception": {
+                    "values": [
+                        {
+                            "type": "RuntimeException",
+                            "value": "button clicked",
+                            "module": "java.lang",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "function": "main",
+                                        "module": "com.android.internal.os.ZygoteInit",
+                                        "filename": "ZygoteInit.java",
+                                        "abs_path": "ZygoteInit.java",
+                                        "lineno": 1003,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "run",
+                                        "module": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller",
+                                        "filename": "RuntimeInit.java",
+                                        "abs_path": "RuntimeInit.java",
+                                        "lineno": 548,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "invoke",
+                                        "module": "java.lang.reflect.Method",
+                                        "filename": "Method.java",
+                                        "abs_path": "Method.java",
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "main",
+                                        "module": "android.app.ActivityThread",
+                                        "filename": "ActivityThread.java",
+                                        "abs_path": "ActivityThread.java",
+                                        "lineno": 7842,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "loop",
+                                        "module": "android.os.Looper",
+                                        "filename": "Looper.java",
+                                        "abs_path": "Looper.java",
+                                        "lineno": 288,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "loopOnce",
+                                        "module": "android.os.Looper",
+                                        "filename": "Looper.java",
+                                        "abs_path": "Looper.java",
+                                        "lineno": 201,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "dispatchMessage",
+                                        "module": "android.os.Handler",
+                                        "filename": "Handler.java",
+                                        "abs_path": "Handler.java",
+                                        "lineno": 99,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "handleCallback",
+                                        "module": "android.os.Handler",
+                                        "filename": "Handler.java",
+                                        "abs_path": "Handler.java",
+                                        "lineno": 938,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "run",
+                                        "module": "android.view.View$PerformClick",
+                                        "filename": "View.java",
+                                        "abs_path": "View.java",
+                                        "lineno": 28810,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "access$3700",
+                                        "module": "android.view.View",
+                                        "filename": "View.java",
+                                        "abs_path": "View.java",
+                                        "lineno": 835,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "performClickInternal",
+                                        "module": "android.view.View",
+                                        "filename": "View.java",
+                                        "abs_path": "View.java",
+                                        "lineno": 7432,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "performClick",
+                                        "module": "com.google.android.material.button.MaterialButton",
+                                        "filename": "MaterialButton.java",
+                                        "abs_path": "MaterialButton.java",
+                                        "lineno": 1119,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "performClick",
+                                        "module": "android.view.View",
+                                        "filename": "View.java",
+                                        "abs_path": "View.java",
+                                        "lineno": 7455,
+                                        "in_app": False,
+                                    },
+                                    {
+                                        "function": "onClick",
+                                        "module": "com.jetbrains.kmm.androidApp.MainActivity$$ExternalSyntheticLambda0",
+                                        "lineno": 2,
+                                        "in_app": True,
+                                    },
+                                    {
+                                        "function": "$r8$lambda$hGNRcN3pFcj8CSoYZBi9fT_AXd0",
+                                        "module": "com.jetbrains.kmm.androidApp.MainActivity",
+                                        "lineno": 0,
+                                        "in_app": True,
+                                    },
+                                    {
+                                        "function": "onCreate$lambda-1",
+                                        "module": "com.jetbrains.kmm.androidApp.MainActivity",
+                                        "filename": "MainActivity.kt",
+                                        "abs_path": "MainActivity.kt",
+                                        "lineno": 55,
+                                        "in_app": True,
+                                    },
+                                ]
+                            },
+                            "thread_id": 2,
+                            "mechanism": {"type": "UncaughtExceptionHandler", "handled": False},
+                        }
+                    ]
+                },
+                "tags": {"sentry:release": self.release.version},
+            },
+            project_id=self.project.id,
+        )
+        self.release.set_commits(
+            [
+                {
+                    "id": "a" * 40,
+                    "repository": self.repo.name,
+                    "author_email": "bob@example.com",
+                    "author_name": "Bob",
+                    "message": "i fixed a bug",
+                    "patch_set": [
+                        {"path": "com.jetbrains.kmm.androidApp.MainActivity.kt", "type": "M"}
+                    ],
+                }
+            ]
+        )
+        GroupRelease.objects.create(
+            group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
+        )
+
+        result = get_serialized_event_file_committers(self.project, event)
+        assert len(result) == 1
+        assert "commits" in result[0]
+        assert len(result[0]["commits"]) == 1
+        assert result[0]["commits"][0]["id"] == "a" * 40
+
     def test_matching(self):
         event = self.store_event(
             data={

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -437,7 +437,7 @@ class GetEventFileCommitters(CommitTestCase):
                     "author_name": "Bob",
                     "message": "i fixed a bug",
                     "patch_set": [
-                        {"path": "com.jetbrains.kmm.androidApp.MainActivity.kt", "type": "M"}
+                        {"path": "com/jetbrains/kmm/androidApp/MainActivity.kt", "type": "M"}
                     ],
                 }
             ]

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -318,6 +318,37 @@ class WaterFallTestCase(TestCase):
         assert frames[0]["function"] == "invoke0"
         assert frames[0]["filename"] == "NativeMethodAccessorImpl.java"
 
+    def test_only_thread_interface_flattened(self):
+        event = self.store_event(
+            data={
+                "threads": [
+                    {
+                        "id": 0,
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "invoke0",
+                                    "abs_path": "NativeMethodAccessorImpl.java",
+                                    "in_app": False,
+                                    "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
+                                    "filename": "NativeMethodAccessorImpl.java",
+                                }
+                            ],
+                            "registers": {},
+                        },
+                        "crashed": False,
+                        "current": False,
+                    }
+                ]
+            },
+            project_id=self.project.id,
+        )
+
+        frames = find_stack_frames(event.data)
+        assert len(frames) == 1
+        assert frames[0]["function"] == "invoke0"
+        assert frames[0]["filename"] == "NativeMethodAccessorImpl.java"
+
     def test_exception_and_stacktrace_interfaces(self):
         exception_frame = {
             "function": "invoke0",

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -206,6 +206,10 @@ class FilenameMungingTestCase(unittest.TestCase):
         for z in zip(exception_frames, munged_frames):
             assert z[0].items() <= z[1].items()
 
+        has_munged = list(filter(lambda f: f.get("filename") and f.get("module"), munged_frames))
+        assert len(has_munged) == 14
+        assert all(str(x.get("munged_filename")).endswith(x.get("filename")) for x in has_munged)
+
 
 class WaterFallTestCase(TestCase):
     def test_only_exception_interface_with_no_stacktrace(self):

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -184,13 +184,13 @@ class FilenameMungingTestCase(unittest.TestCase):
                 "function": "onClick",
                 "module": "com.jetbrains.kmm.androidApp.MainActivity$$ExternalSyntheticLambda0",
                 "lineno": 2,
-                "in_app": False,
+                "in_app": True,
             },
             {
                 "function": "$r8$lambda$hGNRcN3pFcj8CSoYZBi9fT_AXd0",
                 "module": "com.jetbrains.kmm.androidApp.MainActivity",
                 "lineno": 0,
-                "in_app": False,
+                "in_app": True,
             },
             {
                 "function": "onCreate$lambda-1",
@@ -203,11 +203,8 @@ class FilenameMungingTestCase(unittest.TestCase):
         ]
         key, munged_frames = munged_filename_and_frames("java", exception_frames, "munged_filename")
         assert len(munged_frames) == 16
-        # assert munged_frames[0][key] == "jdk/internal/reflect/NativeMethodAccessorImpl.java"
-        # assert munged_frames[1][key] == "io/sentry/example/Application.java"
-        # assert munged_frames[2][key] == "io/sentry/example/Application.java"
-        # for z in zip(frames, munged_frames):
-        #     assert z[0].items() <= z[1].items()
+        for z in zip(exception_frames, munged_frames):
+            assert z[0].items() <= z[1].items()
 
 
 class WaterFallTestCase(TestCase):

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -75,6 +75,140 @@ class FilenameMungingTestCase(unittest.TestCase):
         no_munged = munged_filename_and_frames("java", [no_module])
         assert not no_munged
 
+    def test_platform_android_kotlin(self):
+        exception_frames = [
+            {
+                "function": "main",
+                "module": "com.android.internal.os.ZygoteInit",
+                "filename": "ZygoteInit.java",
+                "abs_path": "ZygoteInit.java",
+                "lineno": 1003,
+                "in_app": False,
+            },
+            {
+                "function": "run",
+                "module": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller",
+                "filename": "RuntimeInit.java",
+                "abs_path": "RuntimeInit.java",
+                "lineno": 548,
+                "in_app": False,
+            },
+            {
+                "function": "invoke",
+                "module": "java.lang.reflect.Method",
+                "filename": "Method.java",
+                "abs_path": "Method.java",
+                "in_app": False,
+            },
+            {
+                "function": "main",
+                "module": "android.app.ActivityThread",
+                "filename": "ActivityThread.java",
+                "abs_path": "ActivityThread.java",
+                "lineno": 7842,
+                "in_app": False,
+            },
+            {
+                "function": "loop",
+                "module": "android.os.Looper",
+                "filename": "Looper.java",
+                "abs_path": "Looper.java",
+                "lineno": 288,
+                "in_app": False,
+            },
+            {
+                "function": "loopOnce",
+                "module": "android.os.Looper",
+                "filename": "Looper.java",
+                "abs_path": "Looper.java",
+                "lineno": 201,
+                "in_app": False,
+            },
+            {
+                "function": "dispatchMessage",
+                "module": "android.os.Handler",
+                "filename": "Handler.java",
+                "abs_path": "Handler.java",
+                "lineno": 99,
+                "in_app": False,
+            },
+            {
+                "function": "handleCallback",
+                "module": "android.os.Handler",
+                "filename": "Handler.java",
+                "abs_path": "Handler.java",
+                "lineno": 938,
+                "in_app": False,
+            },
+            {
+                "function": "run",
+                "module": "android.view.View$PerformClick",
+                "filename": "View.java",
+                "abs_path": "View.java",
+                "lineno": 28810,
+                "in_app": False,
+            },
+            {
+                "function": "access$3700",
+                "module": "android.view.View",
+                "filename": "View.java",
+                "abs_path": "View.java",
+                "lineno": 835,
+                "in_app": False,
+            },
+            {
+                "function": "performClickInternal",
+                "module": "android.view.View",
+                "filename": "View.java",
+                "abs_path": "View.java",
+                "lineno": 7432,
+                "in_app": False,
+            },
+            {
+                "function": "performClick",
+                "module": "com.google.android.material.button.MaterialButton",
+                "filename": "MaterialButton.java",
+                "abs_path": "MaterialButton.java",
+                "lineno": 1119,
+                "in_app": False,
+            },
+            {
+                "function": "performClick",
+                "module": "android.view.View",
+                "filename": "View.java",
+                "abs_path": "View.java",
+                "lineno": 7455,
+                "in_app": False,
+            },
+            {
+                "function": "onClick",
+                "module": "com.jetbrains.kmm.androidApp.MainActivity$$ExternalSyntheticLambda0",
+                "lineno": 2,
+                "in_app": False,
+            },
+            {
+                "function": "$r8$lambda$hGNRcN3pFcj8CSoYZBi9fT_AXd0",
+                "module": "com.jetbrains.kmm.androidApp.MainActivity",
+                "lineno": 0,
+                "in_app": False,
+            },
+            {
+                "function": "onCreate$lambda-1",
+                "module": "com.jetbrains.kmm.androidApp.MainActivity",
+                "filename": "MainActivity.kt",
+                "abs_path": "MainActivity.kt",
+                "lineno": 55,
+                "in_app": True,
+            },
+        ]
+        key, munged_frames = munged_filename_and_frames("java", exception_frames, "munged_filename")
+        assert len(munged_frames) == 16
+        # assert munged_frames[0][key] == "jdk/internal/reflect/NativeMethodAccessorImpl.java"
+        # assert munged_frames[1][key] == "io/sentry/example/Application.java"
+        # assert munged_frames[2][key] == "io/sentry/example/Application.java"
+        # for z in zip(frames, munged_frames):
+        #     assert z[0].items() <= z[1].items()
+
 
 class WaterFallTestCase(TestCase):
     def test_only_exception_interface_with_no_stacktrace(self):


### PR DESCRIPTION
Kotlin uses `java` as a platform, so not much is needed to support that platform - we already had java path munging supported.

This PR mostly adds some tests specific to kotlin event generation.

Some sample event data from kotlin:
https://sentry.io/organizations/gilberts-garage/issues/3279595056/events/dd739735929c40f883bcc6e129b9eb4f/json/
https://sentry.io/organizations/gilberts-garage/issues/3279003045/events/c394c2469c4d45cdbc8cc69d369dc576/json/

I forked and modified a simple kotlin android app to do some manual testing, found here: https://github.com/barkbarkimashark/kmm-basic-sample


Fixes WOR-1802