### PR TITLE
build(py): Update sentry-relay to 0.8.11

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,7 @@ rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
 sentry-arroyo==0.0.16
-sentry-relay==0.8.10
+sentry-relay==0.8.11
 sentry-sdk>=1.4.3,<1.6.0
 snuba-sdk==1.0.0
 simplejson==3.17.2

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -205,10 +205,10 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
             ]
             assert raw_event["breakdowns"] == {
                 "span_ops": {
-                    "ops.browser": {"value": pytest.approx(200)},
-                    "ops.resource": {"value": pytest.approx(200)},
-                    "ops.http": {"value": pytest.approx(200)},
-                    "ops.db": {"value": pytest.approx(200)},
-                    "total.time": {"value": pytest.approx(1050)},
+                    "ops.browser": {"unit": "millisecond", "value": pytest.approx(200)},
+                    "ops.resource": {"unit": "millisecond", "value": pytest.approx(200)},
+                    "ops.http": {"unit": "millisecond", "value": pytest.approx(200)},
+                    "ops.db": {"unit": "millisecond", "value": pytest.approx(200)},
+                    "total.time": {"unit": "millisecond", "value": pytest.approx(1050)},
                 }
             }


### PR DESCRIPTION
This version introduces a new data category for profiling.

