### PR TITLE
fix(events): Check user_modified tag value against correct values

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -75,7 +75,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
 
         query_modified_by_user = request.GET.get("user_modified")
-        if query_modified_by_user in ["True", "False"]:
+        if query_modified_by_user in ["true", "false"]:
             sentry_sdk.set_tag("query.user_modified", query_modified_by_user)
         referrer = (
             referrer if referrer in ALLOWED_EVENTS_REFERRERS else "api.organization-events-v2"

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -157,7 +157,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
 
             query_modified_by_user = request.GET.get("user_modified")
-            if query_modified_by_user in ["True", "False"]:
+            if query_modified_by_user in ["true", "false"]:
                 sentry_sdk.set_tag("query.user_modified", query_modified_by_user)
 
         def get_event_stats(


### PR DESCRIPTION
Valid options are `["true", "false"]` since we're sending them from the client as booleans.
