### PR TITLE
fix(tests): make test_tasks consistent by adjusting event timing

### DIFF
--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -38,7 +38,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             data={
                 "tags": {"foo": "bar"},
                 "fingerprint": ["group-1"],
-                "timestamp": iso_format(before_now(minutes=1)),
+                "timestamp": iso_format(before_now(minutes=3)),
                 "environment": "dev",
             },
             project_id=self.project.id,
@@ -47,7 +47,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             data={
                 "tags": {"foo": "bar2"},
                 "fingerprint": ["group-1"],
-                "timestamp": iso_format(before_now(minutes=1)),
+                "timestamp": iso_format(before_now(minutes=2)),
                 "environment": "prod",
             },
             project_id=self.project.id,


### PR DESCRIPTION
if all three of the events were created at the same timestamp then two tests failed

here's a diff which forced that race condition:

```diff
diff --git a/tests/sentry/data_export/test_tasks.py b/tests/sentry/data_export/test_tasks.py
index 3e777d900d..e11d7f7e97 100644
--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -34,11 +34,12 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
         self.user = self.create_user()
         self.org = self.create_organization()
         self.project = self.create_project(organization=self.org)
+        ts = iso_format(before_now(minutes=1))
         self.event = self.store_event(
             data={
                 "tags": {"foo": "bar"},
                 "fingerprint": ["group-1"],
-                "timestamp": iso_format(before_now(minutes=1)),
+                "timestamp": ts,
                 "environment": "dev",
             },
             project_id=self.project.id,
@@ -47,7 +48,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             data={
                 "tags": {"foo": "bar2"},
                 "fingerprint": ["group-1"],
-                "timestamp": iso_format(before_now(minutes=1)),
+                "timestamp": ts,
                 "environment": "prod",
             },
             project_id=self.project.id,
@@ -56,7 +57,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             data={
                 "tags": {"foo": "bar2"},
                 "fingerprint": ["group-1"],
-                "timestamp": iso_format(before_now(minutes=1)),
+                "timestamp": ts,
                 "environment": "prod",
             },
             project_id=self.project.id,
```

and the failed output in that situation:

```console
$ pytest tests/sentry/data_export/test_tasks.py
/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/django/conf/__init__.py:181: RemovedInDjango31Warning: The FILE_CHARSET setting is deprecated. Starting with Django 3.1, all files read from disk must be UTF-8 encoded.
  warnings.warn(FILE_CHARSET_DEPRECATED_MSG, RemovedInDjango31Warning)
/Users/asottile/workspace/sentry/src/sentry/runner/initializer.py:186: DeprecatedSettingWarning: The GITHUB_APP_ID setting is deprecated. Please use SENTRY_OPTIONS['github-login.client-id'] instead.
  warnings.warn(DeprecatedSettingWarning(options_mapper[k], "SENTRY_OPTIONS['%s']" % k))
/Users/asottile/workspace/sentry/src/sentry/runner/initializer.py:186: DeprecatedSettingWarning: The GITHUB_API_SECRET setting is deprecated. Please use SENTRY_OPTIONS['github-login.client-secret'] instead.
  warnings.warn(DeprecatedSettingWarning(options_mapper[k], "SENTRY_OPTIONS['%s']" % k))
19:48:29 [WARNING] sentry.utils.geo: settings.GEOIP_PATH_MMDB not configured.
19:48:31 [INFO] sentry.plugins.github: apps-not-configured
======================================= test session starts ========================================
platform darwin -- Python 3.8.13, pytest-6.1.0, py-1.11.0, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: rerunfailures-9.1.1, cov-2.11.1, django-3.10.0, sentry-0.1.9
collected 22 items                                                                                 

tests/sentry/data_export/test_tasks.py ............F....F....                                [100%]

============================================= FAILURES =============================================
__________________________ AssembleDownloadTest.test_issue_by_tag_batched __________________________
tests/sentry/data_export/test_tasks.py:93: in test_issue_by_tag_batched
    assert raw1.startswith(b"bar,1,")
E   AssertionError: assert False
E    +  where False = <built-in method startswith of bytes object at 0x11c8de270>(b'bar,1,')
E    +    where <built-in method startswith of bytes object at 0x11c8de270> = b'bar2,2,2022-05-17T19:47:40.000000Z,2022-05-17T19:47:40.000000Z'.startswith
--------------------------------------- Captured stdout call ---------------------------------------
19:48:40 [WARNING] sentry: Cannot record first event for organization (26) due to missing owners
19:48:40 [INFO] sentry.data_export.tasks: dataexport.start (data_export_id=13)
19:48:40 [INFO] sentry.data_export.tasks: dataexport.run (data_export_id=13 offset=0)
19:48:40 [INFO] sentry.data_export.tasks: dataexport.end (data_export_id=13)
--------------------------------------- Captured stderr call ---------------------------------------
Exception ignored in: <_io.FileIO name='/tmp/sentry-files/ae/d2e7/a6ea044db390ef19c258a2b618' mode='rb' closefd=True>
Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/src/sentry/data_export/tasks.py", line 346, in merge_export_blobs
    for chunk in blob.getfile().chunks():
ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/sentry-files/ae/d2e7/a6ea044db390ef19c258a2b618'>
---------------------------------------- Captured log call -----------------------------------------
WARNING  sentry:onboarding.py:137 Cannot record first event for organization (26) due to missing owners
INFO     sentry.data_export.tasks:tasks.py:66 dataexport.start
INFO     sentry.data_export.tasks:tasks.py:70 dataexport.run
INFO     sentry.data_export.tasks:tasks.py:368 dataexport.end
___________________________ AssembleDownloadTest.test_no_error_on_retry ____________________________
tests/sentry/data_export/test_tasks.py:125: in test_no_error_on_retry
    assert raw1.startswith(b"bar,1,")
E   AssertionError: assert False
E    +  where False = <built-in method startswith of bytes object at 0x11cf76d50>(b'bar,1,')
E    +    where <built-in method startswith of bytes object at 0x11cf76d50> = b'bar2,2,2022-05-17T19:47:42.000000Z,2022-05-17T19:47:42.000000Z'.startswith
--------------------------------------- Captured stdout call ---------------------------------------
19:48:42 [WARNING] sentry: Cannot record first event for organization (36) due to missing owners
19:48:42 [INFO] sentry.data_export.tasks: dataexport.start (data_export_id=18)
19:48:42 [INFO] sentry.data_export.tasks: dataexport.run (data_export_id=18 offset=0)
19:48:43 [INFO] sentry.data_export.tasks: dataexport.end (data_export_id=18)
19:48:43 [INFO] sentry.data_export.tasks: dataexport.start (data_export_id=18)
19:48:43 [INFO] sentry.data_export.tasks: dataexport.run (data_export_id=18 offset=0)
19:48:43 [INFO] sentry.data_export.tasks: dataexport.end (data_export_id=18)
--------------------------------------- Captured stderr call ---------------------------------------
Exception ignored in: <_io.FileIO name='/tmp/sentry-files/5c/98d2/149bf74b62b08474f5a0ee3dd7' mode='rb' closefd=True>
Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/src/sentry/data_export/tasks.py", line 346, in merge_export_blobs
    for chunk in blob.getfile().chunks():
ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/sentry-files/5c/98d2/149bf74b62b08474f5a0ee3dd7'>
Exception ignored in: <_io.FileIO name='/tmp/sentry-files/5c/98d2/149bf74b62b08474f5a0ee3dd7' mode='rb' closefd=True>
Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/src/sentry/data_export/tasks.py", line 346, in merge_export_blobs
    for chunk in blob.getfile().chunks():
ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/sentry-files/5c/98d2/149bf74b62b08474f5a0ee3dd7'>
---------------------------------------- Captured log call -----------------------------------------
WARNING  sentry:onboarding.py:137 Cannot record first event for organization (36) due to missing owners
INFO     sentry.data_export.tasks:tasks.py:66 dataexport.start
INFO     sentry.data_export.tasks:tasks.py:70 dataexport.run
INFO     sentry.data_export.tasks:tasks.py:368 dataexport.end
INFO     sentry.data_export.tasks:tasks.py:66 dataexport.start
INFO     sentry.data_export.tasks:tasks.py:70 dataexport.run
INFO     sentry.data_export.tasks:tasks.py:368 dataexport.end
===================================== short test summary info ======================================
FAILED tests/sentry/data_export/test_tasks.py::AssembleDownloadTest::test_issue_by_tag_batched - ...
FAILED tests/sentry/data_export/test_tasks.py::AssembleDownloadTest::test_no_error_on_retry - Ass...
================================== 2 failed, 20 passed in 15.02s ===================================
%4|1652816926.383|TERMINATE|rdkafka#producer-1| [thrd:app]: Producer terminating with 110 messages (20094 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
```

by forcing the timestamps to be different, this forces the sorting to be consistent