### PR TITLE
fix(alerts): Add missing v3 param to alert create request for analytics events

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1138,7 +1138,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                     <PanelBody>{this.renderActionInterval(disabled)}</PanelBody>
                   </Panel>
                 )}
-                {hasAlertWizardV3 && (
+                {this.hasAlertWizardV3 && (
                   <Fragment>
                     <StyledListItem>{t('Establish ownership')}</StyledListItem>
                     {this.renderRuleName(disabled)}

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -149,6 +149,10 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     );
   }
 
+  get hasAlertWizardV3(): boolean {
+    return this.props.organization.features.includes('alert-wizard-v3');
+  }
+
   componentWillUnmount() {
     window.clearTimeout(this.pollingTimeout);
   }
@@ -358,6 +362,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
         data: rule,
         query: {
           duplicateRule: this.isDuplicateRule ? 'true' : 'false',
+          wizardV3: this.hasAlertWizardV3 ? 'true' : 'false',
         },
       });
 
@@ -618,27 +623,27 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     );
   }
 
-  renderRuleName(disabled: boolean, hasAlertWizardV3: boolean) {
+  renderRuleName(disabled: boolean) {
     const {rule, detailedError} = this.state;
     const {name} = rule || {};
 
     return (
       <StyledField
-        hasAlertWizardV3={hasAlertWizardV3}
-        label={hasAlertWizardV3 ? null : t('Alert name')}
-        help={hasAlertWizardV3 ? null : t('Add a name for this alert')}
+        hasAlertWizardV3={this.hasAlertWizardV3}
+        label={this.hasAlertWizardV3 ? null : t('Alert name')}
+        help={this.hasAlertWizardV3 ? null : t('Add a name for this alert')}
         error={detailedError?.name?.[0]}
         disabled={disabled}
         required
         stacked
-        flexibleControlStateSize={hasAlertWizardV3 ? true : undefined}
+        flexibleControlStateSize={this.hasAlertWizardV3 ? true : undefined}
       >
         <Input
           type="text"
           name="name"
           value={name}
           data-test-id="alert-name"
-          placeholder={hasAlertWizardV3 ? t('Enter Alert Name') : t('My Rule Name')}
+          placeholder={this.hasAlertWizardV3 ? t('Enter Alert Name') : t('My Rule Name')}
           onChange={(event: ChangeEvent<HTMLInputElement>) =>
             this.handleChange('name', event.target.value)
           }
@@ -649,18 +654,18 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     );
   }
 
-  renderTeamSelect(disabled: boolean, hasAlertWizardV3: boolean) {
+  renderTeamSelect(disabled: boolean) {
     const {rule, project} = this.state;
     const ownerId = rule?.owner?.split(':')[1];
 
     return (
       <StyledField
-        hasAlertWizardV3={hasAlertWizardV3}
+        hasAlertWizardV3={this.hasAlertWizardV3}
         extraMargin
-        label={hasAlertWizardV3 ? null : t('Team')}
-        help={hasAlertWizardV3 ? null : t('The team that can edit this alert.')}
+        label={this.hasAlertWizardV3 ? null : t('Team')}
+        help={this.hasAlertWizardV3 ? null : t('The team that can edit this alert.')}
         disabled={disabled}
-        flexibleControlStateSize={hasAlertWizardV3 ? true : undefined}
+        flexibleControlStateSize={this.hasAlertWizardV3 ? true : undefined}
       >
         <TeamSelector
           value={this.getTeamId()}
@@ -784,16 +789,16 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     );
   }
 
-  renderActionInterval(disabled: boolean, hasAlertWizardV3: boolean) {
+  renderActionInterval(disabled: boolean) {
     const {rule} = this.state;
     const {frequency} = rule || {};
 
     return (
       <StyledSelectField
-        hasAlertWizardV3={hasAlertWizardV3}
-        label={hasAlertWizardV3 ? null : t('Action Interval')}
+        hasAlertWizardV3={this.hasAlertWizardV3}
+        label={this.hasAlertWizardV3 ? null : t('Action Interval')}
         help={
-          hasAlertWizardV3
+          this.hasAlertWizardV3
             ? null
             : t('Perform these actions once this often for an issue')
         }
@@ -805,7 +810,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
         options={FREQUENCY_OPTIONS}
         onChange={val => this.handleChange('frequency', val)}
         disabled={disabled}
-        flexibleControlStateSize={hasAlertWizardV3 ? true : undefined}
+        flexibleControlStateSize={this.hasAlertWizardV3 ? true : undefined}
       />
     );
   }
@@ -814,7 +819,6 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     const {organization} = this.props;
     const {environments, project, rule, detailedError, loading} = this.state;
     const {actions, filters, conditions, frequency} = rule || {};
-    const hasAlertWizardV3 = organization.features.includes('alert-wizard-v3');
 
     const environmentOptions = [
       {
@@ -870,10 +874,10 @@ class IssueRuleEditor extends AsyncView<Props, State> {
               <List symbol="colored-numeric">
                 {loading && <SemiTransparentLoadingMask data-test-id="loading-mask" />}
                 <StyledListItem>{t('Add alert settings')}</StyledListItem>
-                {hasAlertWizardV3 ? (
+                {this.hasAlertWizardV3 ? (
                   <SettingsContainer>
                     <StyledSelectField
-                      hasAlertWizardV3={hasAlertWizardV3}
+                      hasAlertWizardV3={this.hasAlertWizardV3}
                       className={classNames({
                         error: this.hasError('environment'),
                       })}
@@ -904,8 +908,8 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                         disabled={disabled}
                       />
 
-                      {this.renderTeamSelect(disabled, hasAlertWizardV3)}
-                      {this.renderRuleName(disabled, hasAlertWizardV3)}
+                      {this.renderTeamSelect(disabled)}
+                      {this.renderRuleName(disabled)}
                     </PanelBody>
                   </Panel>
                 )}
@@ -1127,20 +1131,18 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                     {t('Perform the actions above once this often for an issue')}
                   </StyledFieldHelp>
                 </StyledListItem>
-                {hasAlertWizardV3 ? (
-                  this.renderActionInterval(disabled, hasAlertWizardV3)
+                {this.hasAlertWizardV3 ? (
+                  this.renderActionInterval(disabled)
                 ) : (
                   <Panel>
-                    <PanelBody>
-                      {this.renderActionInterval(disabled, hasAlertWizardV3)}
-                    </PanelBody>
+                    <PanelBody>{this.renderActionInterval(disabled)}</PanelBody>
                   </Panel>
                 )}
                 {hasAlertWizardV3 && (
                   <Fragment>
                     <StyledListItem>{t('Establish ownership')}</StyledListItem>
-                    {this.renderRuleName(disabled, hasAlertWizardV3)}
-                    {this.renderTeamSelect(disabled, hasAlertWizardV3)}
+                    {this.renderRuleName(disabled)}
+                    {this.renderTeamSelect(disabled)}
                   </Fragment>
                 )}
               </List>

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -109,6 +109,14 @@ const isEmpty = (str: unknown): boolean => str === '' || !defined(str);
 class RuleFormContainer extends AsyncComponent<Props, State> {
   pollingTimeout: number | undefined = undefined;
 
+  get isDuplicateRule(): boolean {
+    return Boolean(this.props.isDuplicateRule);
+  }
+
+  get hasAlertWizardV3(): boolean {
+    return this.props.organization.features.includes('alert-wizard-v3');
+  }
+
   componentDidMount() {
     const {organization} = this.props;
     const {project} = this.state;
@@ -532,7 +540,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
           aggregate,
         },
         {
-          duplicateRule: this.props.isDuplicateRule ? 'true' : 'false',
+          duplicateRule: this.isDuplicateRule ? 'true' : 'false',
+          wizardV3: this.hasAlertWizardV3 ? 'true' : 'false',
           referrer: location?.query?.referrer,
           sessionId,
         }
@@ -718,8 +727,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       />
     );
 
-    const hasAlertWizardV3 = organization.features.includes('alert-wizard-v3');
-
     const triggerForm = (disabled: boolean) => (
       <Triggers
         disabled={disabled}
@@ -735,7 +742,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         organization={organization}
         ruleId={ruleId}
         availableActions={this.state.availableActions}
-        hasAlertWizardV3={hasAlertWizardV3}
+        hasAlertWizardV3={this.hasAlertWizardV3}
         onChange={this.handleChangeTriggers}
         onThresholdTypeChange={this.handleThresholdTypeChange}
         onThresholdPeriodChange={this.handleThresholdPeriodChange}
@@ -747,7 +754,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       <RuleNameOwnerForm
         disabled={disabled}
         project={project}
-        hasAlertWizardV3={hasAlertWizardV3}
+        hasAlertWizardV3={this.hasAlertWizardV3}
       />
     );
 
@@ -761,7 +768,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         }
         onComparisonTypeChange={this.handleComparisonTypeChange}
         organization={organization}
-        hasAlertWizardV3={hasAlertWizardV3}
+        hasAlertWizardV3={this.hasAlertWizardV3}
         comparisonDelta={comparisonDelta}
       />
     );
@@ -825,7 +832,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                     alertType === 'custom' || dataset === Dataset.ERRORS
                   }
                   alertType={alertType}
-                  hasAlertWizardV3={hasAlertWizardV3}
+                  hasAlertWizardV3={this.hasAlertWizardV3}
                   dataset={dataset}
                   timeWindow={timeWindow}
                   comparisonType={comparisonType}
@@ -837,13 +844,13 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                     this.handleFieldChange('timeWindow', value)
                   }
                 />
-                {!hasAlertWizardV3 && thresholdTypeForm(disabled)}
+                {!this.hasAlertWizardV3 && thresholdTypeForm(disabled)}
                 <AlertListItem>
-                  {hasAlertWizardV3
+                  {this.hasAlertWizardV3
                     ? t('Set thresholds')
                     : t('Set thresholds to trigger alert')}
                 </AlertListItem>
-                {hasAlertWizardV3 && thresholdTypeForm(disabled)}
+                {this.hasAlertWizardV3 && thresholdTypeForm(disabled)}
                 {triggerForm(disabled)}
                 {ruleNameOwnerForm(disabled)}
               </List>


### PR DESCRIPTION
This adds the missing `wizardV3` query param to alert creation requests. Also changed the `hasAlertWizardV3` and `isDuplicateRule` checks to getters.