### PR TITLE
fix(ui): Update Issue ID fontsize in breadcrumbs

### DIFF
--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -441,6 +441,7 @@ const StyledTooltip = styled(Tooltip)`
 
 const StyledShortId = styled(ShortId)`
   font-family: ${p => p.theme.text.family};
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const StatsWrapper = styled('div')`


### PR DESCRIPTION
Update Issue ID fontsize in breadcrumbs.

# Before
<img width="287" alt="Screen Shot 2022-05-17 at 1 25 33 PM" src="https://user-images.githubusercontent.com/20312973/168904610-e063b46f-1b1a-4cda-9569-6e422556bef7.png">

# After
<img width="269" alt="Screen Shot 2022-05-17 at 1 27 28 PM" src="https://user-images.githubusercontent.com/20312973/168904634-681ea8c2-01e6-47f4-be40-3586082aed30.png">

