### PR TITLE
feat(replays): Use new `sentry/replay` plugin instead of `sentry/rrweb`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@sentry/node": "7.0.0-beta.1",
     "@sentry/react": "7.0.0-beta.1",
     "@sentry/release-parser": "^1.3.0",
-    "@sentry/rrweb": "^0.3.1",
+    "@sentry/replay": "^0.2.0-0",
     "@sentry/tracing": "7.0.0-beta.1",
     "@sentry/utils": "7.0.0-beta.1",
     "@testing-library/jest-dom": "^5.16.1",

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -98,7 +98,7 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       transport: Sentry.makeFetchTransport,
       stackParser: Sentry.defaultStackParser,
       tracesSampleRate,
-      integrations: [replay],
+      integrations: [...Sentry.defaultIntegrations, replay],
     });
     // `bindClient` will setup integrations
     hub.bindClient(client);

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -157,6 +157,7 @@ export interface Config {
     latest: string;
     upgradeAvailable: boolean;
   };
+  sentryReplaysDsn?: string;
   statuspage?: {
     api_host: string;
     id: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2921,10 +2921,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-1.3.0.tgz#8175b835bede83346728e329bf226d80c1063653"
   integrity sha512-m6yuQTI8XiT+L7ELbCzqPRhBvSQ5Go3YTPzj2socm9Aekp3Jcze0ZlNJIqvuPPmuysmF+SOM849WYN47kM9ERg==
 
-"@sentry/rrweb@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@sentry/rrweb/-/rrweb-0.3.1.tgz#a0f7496e086a30679d7af227d62ab76cfd5ed934"
-  integrity sha512-AJIy2yqjtgpcow3L1gyxxr6x+rqLN9HXMlsNNmLeUKlPBxaSMP47lM6aexI3V+XkKnRmOW05H21cLimyuM+59Q==
+"@sentry/replay@^0.2.0-0":
+  version "0.2.0-0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-0.2.0-0.tgz#a805f6c91291e728cec1d51144ab4c1bd06a13bb"
+  integrity sha512-A0dFi0hEiyUTRV5khV5n2HiLZbxMpYSA4LZ3eI/89pIkv6E9GqeCZ+qMVgv3VNR9xITzVAvzYIMYvCd5bnlKBw==
 
 "@sentry/tracing@7.0.0-beta.1":
   version "7.0.0-beta.1"


### PR DESCRIPTION
Updated to use new `sentry/replay` plugin for staff (when replay-specific DSN is available). Note that `sentry/rrweb` has been broken due to v7 of sentry sdk.