### PR TITLE
fix(alerts): Disable project selector on alert rule edit

### DIFF
--- a/static/app/views/alerts/rules/metric/edit.tsx
+++ b/static/app/views/alerts/rules/metric/edit.tsx
@@ -101,6 +101,7 @@ class MetricRulesEdit extends AsyncView<Props, State> {
         ruleId={ruleId}
         rule={rule}
         onSubmitSuccess={this.handleSubmitSuccess}
+        disableProjectSelector
       />
     );
   }

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -71,6 +71,7 @@ type Props = {
   timeWindow: number;
   allowChangeEventTypes?: boolean;
   comparisonDelta?: number;
+  disableProjectSelector?: boolean;
   loadingProjects?: boolean;
 };
 
@@ -263,7 +264,13 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   renderProjectSelector() {
-    const {project: _selectedProject, projects, disabled, organization} = this.props;
+    const {
+      project: _selectedProject,
+      projects,
+      disabled,
+      organization,
+      disableProjectSelector,
+    } = this.props;
     const hasOpenMembership = organization.features.includes('open-membership');
     const myProjects = projects.filter(project => project.hasAccess && project.isMember);
     const allProjects = projects.filter(
@@ -314,7 +321,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
 
           return (
             <SelectControl
-              isDisabled={disabled}
+              isDisabled={disabled || disableProjectSelector}
               value={selectedProject.id}
               options={projectOptions}
               onChange={({value}: {value: Project['id']}) => {

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -74,6 +74,7 @@ type Props = {
   routes: PlainRoute[];
   rule: MetricRule;
   userTeamIds: string[];
+  disableProjectSelector?: boolean;
   isCustomMetric?: boolean;
   isDuplicateRule?: boolean;
   ruleId?: string;
@@ -673,7 +674,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {organization, ruleId, rule, onSubmitSuccess, router} = this.props;
+    const {organization, ruleId, rule, onSubmitSuccess, router, disableProjectSelector} =
+      this.props;
     const {
       query,
       project,
@@ -843,6 +845,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                   onTimeWindowChange={value =>
                     this.handleFieldChange('timeWindow', value)
                   }
+                  disableProjectSelector={disableProjectSelector}
                 />
                 {!this.hasAlertWizardV3 && thresholdTypeForm(disabled)}
                 <AlertListItem>


### PR DESCRIPTION
This disables the project selector when you are editing an alert rule (in alert-wizard-v3) since api will throw a non-descript error for PUT on alert rules endpoint with changed project, in short you can't change projects.

Before:
![Screen Shot 2022-05-17 at 3 00 36 PM](https://user-images.githubusercontent.com/15015880/168917460-474494bb-01d2-4a1e-af7d-2531bf7848d1.png)


After:
![Screen Shot 2022-05-17 at 3 00 44 PM](https://user-images.githubusercontent.com/15015880/168917471-743e9f5d-aa18-421f-b3d6-bda3f672fc77.png)


