### PR TITLE
fix(alerts): Metric alert rule save error msg when missing rule name

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -476,7 +476,13 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     }
 
     if (!validRule || !validTriggers) {
-      addErrorMessage(t('Alert not valid'));
+      const missingFields = [
+        !validRule && t('name'),
+        !validRule && !validTriggers && t('and'),
+        !validTriggers && t('critical threshold'),
+      ].filter(x => x);
+
+      addErrorMessage(t(`Alert not valid: missing %s`, missingFields.join(' ')));
       return;
     }
 

--- a/static/app/views/alerts/rules/metric/ruleNameOwnerForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleNameOwnerForm.tsx
@@ -29,7 +29,7 @@ export default function RuleNameOwnerForm({disabled, project, hasAlertWizardV3}:
         hasAlertWizardV3 ? t('Enter Alert Name') : t('Something really bad happened')
       }
       required
-      hideControlState
+      flexibleControlStateSize
     />
   );
 
@@ -41,7 +41,7 @@ export default function RuleNameOwnerForm({disabled, project, hasAlertWizardV3}:
       label={hasAlertWizardV3 ? null : t('Team')}
       help={hasAlertWizardV3 ? null : t('The team that can edit this alert.')}
       disabled={disabled}
-      hideControlState
+      flexibleControlStateSize
     >
       {({model}) => {
         const owner = model.getValue('owner');

--- a/static/app/views/alerts/rules/metric/triggers/form.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/form.tsx
@@ -157,6 +157,11 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
   };
 
   getThresholdUnits(aggregate: string, comparisonType: AlertRuleComparisonType) {
+    // cls is a number not a measurement of time
+    if (aggregate.includes('measurements.cls')) {
+      return '';
+    }
+
     if (aggregate.includes('duration') || aggregate.includes('measurements')) {
       return 'ms';
     }


### PR DESCRIPTION
This restores the control state to alert rule name in the metric alert rule editor. Updates the error message with the missing fields. Also removes the `ms` from the Cumulative Layout Shift error trigger thresholds.

V3 metric example:
![v3-metric](https://user-images.githubusercontent.com/15015880/168956790-b26783d1-704d-42bb-8b5a-5cac26557a45.png)

non-V3 metric example:
![non-v3-metric](https://user-images.githubusercontent.com/15015880/168956802-bd971906-2895-430c-8f02-394df1e5a8e3.png)

Error messages:
![Screen Shot 2022-05-17 at 9 22 35 PM](https://user-images.githubusercontent.com/15015880/168956844-7aca0b7c-7562-42b1-9b7f-df6d8ee4cb1d.png)
![Screen Shot 2022-05-17 at 9 22 46 PM](https://user-images.githubusercontent.com/15015880/168956847-aba1360b-84d5-4acc-9553-70f204f78ce8.png)
![Screen Shot 2022-05-17 at 9 23 08 PM](https://user-images.githubusercontent.com/15015880/168956849-9e26b584-f063-487a-ad12-767f7f6fd762.png)


