### PR TITLE
fix(replays): Render a placeholder for duration while data is loading

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -348,7 +348,7 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
   }
 
   const event = replay?.getEvent();
-  const duration = event ? (event.endTimestamp - event.startTimestamp) * 1000 : -1;
+  const duration = event ? (event.endTimestamp - event.startTimestamp) * 1000 : undefined;
 
   return (
     <ReplayPlayerContext.Provider


### PR DESCRIPTION
**Before:**

<img width="438" alt="Screen Shot 2022-05-18 at 5 05 05 PM" src="https://user-images.githubusercontent.com/187460/169001853-7dc8d1d0-4022-4ce5-97aa-585f647e2874.png">


**After:**

<img width="469" alt="Screen Shot 2022-05-18 at 5 03 57 PM" src="https://user-images.githubusercontent.com/187460/169001767-3654c7f9-9f5b-4ac5-9c76-a120d4c81a1c.png">

