### PR TITLE
feat(sampling): Submit rule modal with enter [TET-80]

### DIFF
--- a/static/app/views/settings/project/filtersAndSampling/modal/ruleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/ruleModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment, KeyboardEvent, useEffect, useState} from 'react';
 import {components, createFilter} from 'react-select';
 import styled from '@emotion/styled';
 
@@ -80,6 +80,7 @@ function RuleModal({
   rule,
 }: Props) {
   const [data, setData] = useState<State>(getInitialState());
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     setData(d => {
@@ -134,6 +135,7 @@ function RuleModal({
   const {errors, conditions, sampleRate} = data;
 
   async function submitRules(newRules: DynamicSamplingRules, currentRuleIndex: number) {
+    setIsSaving(true);
     try {
       const newProjectDetails = await api.requestPromise(
         `/projects/${organization.slug}/${project.slug}/`,
@@ -149,6 +151,7 @@ function RuleModal({
     } catch (error) {
       convertRequestErrorResponse(getErrorMessage(error, currentRuleIndex));
     }
+    setIsSaving(false);
   }
 
   function convertRequestErrorResponse(error: ReturnType<typeof getErrorMessage>) {
@@ -333,6 +336,11 @@ function RuleModal({
             onChange={value => {
               setData({...data, sampleRate: !!value ? Number(value) : null});
             }}
+            onKeyDown={(_value: string, e: KeyboardEvent) => {
+              if (e.key === 'Enter') {
+                onSubmit({conditions, sampleRate, submitRules});
+              }
+            }}
             placeholder={'\u0025'}
             value={sampleRate}
             inline={false}
@@ -351,7 +359,7 @@ function RuleModal({
             priority="primary"
             onClick={() => onSubmit({conditions, sampleRate, submitRules})}
             title={submitDisabled ? t('Required fields must be filled out') : undefined}
-            disabled={submitDisabled}
+            disabled={isSaving || submitDisabled}
           >
             {t('Save Rule')}
           </Button>


### PR DESCRIPTION
Hitting Enter while inside sampling rate field will submit the rule modal.

Added the isLoading boolean, so that the feedback is instant and it also prevents spamming the button many times in quick succession.