### PR TITLE
fix(widget-builder): seriesName can be undefined when checking for Other

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -429,8 +429,8 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
           }
 
           const otherRegex = new RegExp(`(?:.* : ${OTHER}$)|^${OTHER}$`);
-          const shouldColorOther = timeseriesResults?.some(({seriesName}) =>
-            seriesName.match(otherRegex)
+          const shouldColorOther = timeseriesResults?.some(
+            ({seriesName}) => seriesName && seriesName.match(otherRegex)
           );
           const colors = timeseriesResults
             ? theme.charts.getColorPalette(


### PR DESCRIPTION
The `seriesName` can be undefined when there isn't a `yAxis` sent in the request to `events-stats`. The default data that comes back is `count()`. We should still investigate how a user ends up in a state where `yAxis` is not defined in the request, but this patches the widget from error-ing out.

Fixes JAVASCRIPT-276Q