### PR TITLE
ref: improve error message for running migrations tests locally

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1546,9 +1546,13 @@ class TestMigrations(TransactionTestCase):
         self.migrate_to = [(self.app, self.migrate_to)]
 
         executor = MigrationExecutor(connection)
-        self.current_migration = [
-            max(filter(lambda m: m[0] == self.app, executor.loader.applied_migrations))
-        ]
+        matching_migrations = [m for m in executor.loader.applied_migrations if m[0] == self.app]
+        if not matching_migrations:
+            raise AssertionError(
+                "no migrations detected!\n\n"
+                "try running this test with `MIGRATIONS_TEST_MIGRATE=1 pytest ...`"
+            )
+        self.current_migration = [max(matching_migrations)]
         old_apps = executor.loader.project_state(self.migrate_from).apps
 
         # Reverse to the original migration


### PR DESCRIPTION
error message before:

```
___________________________ TestConvertDashboardWidgetQueryOrderby.test ____________________________
src/sentry/testutils/cases.py:1555: in setUp
    max(filter(lambda m: m[0] == self.app, executor.loader.applied_migrations))
E   ValueError: max() arg is an empty sequence
```

error message after:

```
___________________________ TestConvertDashboardWidgetQueryOrderby.test ____________________________
src/sentry/testutils/cases.py:1551: in setUp
    raise AssertionError(
E   AssertionError: no migrations detected!
E   
E   try running this test with `MIGRATIONS_TEST_MIGRATE=1 pytest ...`
```

passing:

```console
$ MIGRATIONS_TEST_MIGRATE=1 pytest tests/sentry/migrations/test_0289_dashboardwidgetquery_convert_orderby_to_field.py::TestConvertDashboardWidgetQueryOrderby::test

...

======================================= test session starts ========================================
platform darwin -- Python 3.8.13, pytest-6.1.0, py-1.11.0, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: rerunfailures-9.1.1, cov-2.11.1, django-3.10.0, sentry-0.1.9
collected 1 item                                                                                   

tests/sentry/migrations/test_0289_dashboardwidgetquery_convert_orderby_to_field.py .         [100%]

======================================== 1 passed in 21.23s ========================================
```