### PR TITLE
feat(proj-config): Add v3 of proj config endpoint [INGEST-1324 INGEST-1325]

### DIFF
--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -72,19 +72,18 @@ class RelayProjectConfigsEndpoint(Endpoint):
     def _post_or_schedule_by_key(self, request: Request):
         public_keys = set(request.relay_request_data.get("publicKeys") or ())
 
-        configs = {}
+        proj_configs = {}
         pending = []
         for key in public_keys:
             computed = self._get_cached_or_schedule(key)
             if not computed:
                 pending.append(key)
             else:
-                configs[key] = computed
+                proj_configs[key] = computed
 
-        if len(pending) > 0:
-            configs["pending"] = pending
+        res = {"configs": proj_configs, "pending": pending}
 
-        return Response(configs, status=200)
+        return Response(res, status=200)
 
     def _get_cached_or_schedule(self, public_key) -> Optional[dict]:
         """

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -103,6 +103,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
             public_key=public_key,
             update_reason="project_config.post_v3",
         )
+        return None
 
     def _post_by_key(self, request: Request, full_config_requested):
         public_keys = request.relay_request_data.get("publicKeys")

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from typing import Optional
 
 from django.conf import settings
 from rest_framework.request import Request
@@ -82,10 +83,10 @@ class RelayProjectConfigsEndpoint(Endpoint):
 
         return Response(configs, status=200)
 
-    def _get_cached_or_schedule(self, public_key):
+    def _get_cached_or_schedule(self, public_key) -> Optional[dict]:
         """
         Returns the config of a project if it's in the cache; else, schedules a
-        task to compute and write it into the cache, and returns False.
+        task to compute and write it into the cache.
 
         Debouncing of the project happens after the task has been scheduled.
         """
@@ -95,7 +96,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         if projectconfig_debounce_cache.is_debounced(
             public_key=public_key, project_id=None, organization_id=None
         ):
-            return False
+            return
 
         update_config_cache.delay(
             generate=True,
@@ -113,7 +114,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         projectconfig_debounce_cache.debounce(
             public_key=public_key, project_id=None, organization_id=None
         )
-        return False
+        return
 
     def _post_by_key(self, request: Request, full_config_requested):
         public_keys = request.relay_request_data.get("publicKeys")

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -48,12 +48,15 @@ class RelayProjectConfigsEndpoint(Endpoint):
         version = request.GET.get("version") or "1"
         set_tag("relay_protocol_version", version)
 
-        if version == "3":
+        no_cache = request.relay_request_data.get("no_cache") or False
+        set_tag("relay_no_cache", no_cache)
+
+        if version == "3" and not no_cache:
             # Always compute the full config. It's invalid to send partial
             # configs to processing relays, and these validate the requests they
             # get with permissions and trim configs down accordingly.
             return self._post_or_schedule_by_key(request)
-        elif version == "2":
+        elif version in ["2", "3"]:
             return self._post_by_key(
                 request=request,
                 full_config_requested=full_config_requested,

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -66,7 +66,6 @@ class RelayProjectConfigsEndpoint(Endpoint):
             return Response("Unsupported version, we only support versions 1 to 3.", 400)
 
     def _post_or_schedule_by_key(self, request: Request):
-        request.relay_request_data.get("publicKeys")
         public_keys = set(request.relay_request_data.get("publicKeys") or ())
 
         configs = {}

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -71,7 +71,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         configs = {}
         pending = []
         for key in public_keys:
-            computed = self._compute_proj_config(key)
+            computed = self._get_cached_or_schedule(key)
             if not computed:
                 pending.append(key)
             else:
@@ -82,7 +82,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
 
         return Response(configs, status=200)
 
-    def _compute_proj_config(self, public_key):
+    def _get_cached_or_schedule(self, public_key):
         """
         Returns the config of a project if it's in the cache; else, schedules a
         task to compute and write it into the cache, and returns False.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1356,12 +1356,12 @@ SENTRY_QUOTAS = "sentry.quotas.Quota"
 SENTRY_QUOTA_OPTIONS = {}
 
 # Cache for Relay project configs
-SENTRY_RELAY_PROJECTCONFIG_CACHE = "sentry.relay.projectconfig_cache.base.ProjectConfigCache"
+SENTRY_RELAY_PROJECTCONFIG_CACHE = "sentry.relay.projectconfig_cache.redis.RedisProjectConfigCache"
 SENTRY_RELAY_PROJECTCONFIG_CACHE_OPTIONS = {}
 
 # Which cache to use for debouncing cache updates to the projectconfig cache
 SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE = (
-    "sentry.relay.projectconfig_debounce_cache.base.ProjectConfigDebounceCache"
+    "sentry.relay.projectconfig_debounce_cache.redis.RedisProjectConfigDebounceCache"
 )
 SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE_OPTIONS = {}
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1361,7 +1361,7 @@ SENTRY_RELAY_PROJECTCONFIG_CACHE_OPTIONS = {}
 
 # Which cache to use for debouncing cache updates to the projectconfig cache
 SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE = (
-    "sentry.relay.projectconfig_debounce_cache.redis.RedisProjectConfigDebounceCache"
+    "sentry.relay.projectconfig_debounce_cache.base.ProjectConfigDebounceCache"
 )
 SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE_OPTIONS = {}
 

--- a/src/sentry/relay/projectconfig_debounce_cache/base.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/base.py
@@ -47,3 +47,4 @@ class ProjectConfigDebounceCache(Service):
 
         Returns 1 if the task was removed, 0 if it wasn't.
         """
+        return 1

--- a/src/sentry/relay/projectconfig_debounce_cache/base.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/base.py
@@ -44,4 +44,6 @@ class ProjectConfigDebounceCache(Service):
         """
         Mark a task done such that `check_is_debounced` starts emitting False
         for the given parameters.
+
+        Returns 1 if the task was removed, 0 if it wasn't.
         """

--- a/src/sentry/relay/projectconfig_debounce_cache/redis.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/redis.py
@@ -52,4 +52,4 @@ class RedisProjectConfigDebounceCache(ProjectConfigDebounceCache):
     def mark_task_done(self, public_key, project_id, organization_id):
         key = _get_redis_key(public_key, project_id, organization_id)
         client = self.__get_redis_client(key)
-        client.delete(key)
+        return client.delete(key)

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -32,11 +32,6 @@ def update_config_cache(
     from sentry.relay import projectconfig_cache
     from sentry.relay.config import get_project_config
 
-    if not should_update_cache(
-        organization_id=organization_id, project_id=project_id, public_key=public_key
-    ):
-        return
-
     if project_id:
         set_current_event_project(project_id)
 
@@ -50,6 +45,13 @@ def update_config_cache(
 
     sentry_sdk.set_tag("update_reason", update_reason)
     sentry_sdk.set_tag("generate", generate)
+
+    # Not running this at the beginning of the task to add tags in case there's
+    # something wrong going on.
+    if not should_update_cache(
+        organization_id=organization_id, project_id=project_id, public_key=public_key
+    ):
+        return
 
     if organization_id:
         projects = list(Project.objects.filter(organization_id=organization_id))

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -64,13 +64,13 @@ def update_config_cache(
             keys = [ProjectKey.objects.get(public_key=public_key)]
         except ProjectKey.DoesNotExist:
             # In this particular case, where a project key got deleted and
-            # triggered an update, we at least know the public key that needs
-            # to be deleted from cache.
+            # triggered an update, we know that key doesn't exist and we want to
+            # avoid creating more tasks for it.
             #
             # In other similar cases, like an org being deleted, we potentially
             # cannot find any keys anymore, so we don't know which cache keys
             # to delete.
-            projectconfig_cache.delete_many([public_key])
+            projectconfig_cache.set_many({public_key: {"disabled": True}})
             return
 
     else:

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -51,6 +51,9 @@ def update_config_cache(
     if not should_update_cache(
         organization_id=organization_id, project_id=project_id, public_key=public_key
     ):
+        # XXX(iker): this approach doesn't work with celery's ack_late enabled.
+        # If ack_late is enabled and the task fails after being marked as done,
+        # the second attempt will exit early and not compute the project config.
         return
 
     if organization_id:

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -32,6 +32,23 @@ def update_config_cache(
     from sentry.relay import projectconfig_cache
     from sentry.relay.config import get_project_config
 
+    # At this point, we haven't marked the task as completed, so it should be
+    # debounced. If it isn't, another worker has picked a task for the same
+    # public key and marked it as done. Since we want to avoid recomputation,
+    # exit the current task.
+    if not projectconfig_debounce_cache.is_debounced(
+        public_key=public_key, project_id=None, organization_id=None
+    ):
+        return
+
+    # Delete key before generating configs such that we never have an outdated
+    # but valid cache.
+    #
+    # If this was running at the end of the task, it would be more effective
+    # against bursts of updates, but introduces a different race where an
+    # outdated cache may be used.
+    projectconfig_debounce_cache.mark_task_done(public_key, project_id, organization_id)
+
     if project_id:
         set_current_event_project(project_id)
 
@@ -45,14 +62,6 @@ def update_config_cache(
 
     sentry_sdk.set_tag("update_reason", update_reason)
     sentry_sdk.set_tag("generate", generate)
-
-    # Delete key before generating configs such that we never have an outdated
-    # but valid cache.
-    #
-    # If this was running at the end of the task, it would be more effective
-    # against bursts of updates, but introduces a different race where an
-    # outdated cache may be used.
-    projectconfig_debounce_cache.mark_task_done(public_key, project_id, organization_id)
 
     if organization_id:
         projects = list(Project.objects.filter(organization_id=organization_id))

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -376,15 +376,3 @@ def test_exposes_features(call_endpoint, task_runner):
         for config in result["configs"].values():
             config = config["config"]
             assert config["sessionMetrics"] == {"version": 1, "drop": False}
-
-
-@pytest.mark.django_db
-def test_v3(call_endpoint):
-    # For now v2 and v3 are supposed to be identical, the payload is backwards compatible if
-    # there are no pending configs and we never generate pending configs currently.
-    # with task_runner():
-    result, status_code = call_endpoint(full_config=False, version=3)
-
-    assert status_code < 400
-    assert result.get("configs")
-    assert not result.get("pending")

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -140,7 +140,10 @@ def test_return_full_config_if_in_cache(
 ):
     result, status_code = call_endpoint(full_config=True)
     assert status_code < 400
-    assert result == {default_projectkey.public_key: {"is_mock_config": True}}
+    assert result == {
+        "configs": {default_projectkey.public_key: {"is_mock_config": True}},
+        "pending": [],
+    }
 
 
 @pytest.mark.django_db
@@ -151,7 +154,11 @@ def test_return_partial_config_if_in_cache(
     # configs.
     result, status_code = call_endpoint(full_config=False)
     assert status_code < 400
-    assert result == {default_projectkey.public_key: {"is_mock_config": True}}
+    expected = {
+        "configs": {default_projectkey.public_key: {"is_mock_config": True}},
+        "pending": [],
+    }
+    assert result == expected
 
 
 @pytest.mark.django_db
@@ -163,7 +170,7 @@ def test_proj_in_cache_and_another_pending(
     )
     assert status_code < 400
     assert result == {
-        "must_exist": {"is_mock_config": True},
+        "configs": {"must_exist": {"is_mock_config": True}},
         "pending": [default_projectkey.public_key],
     }
 
@@ -180,7 +187,7 @@ def test_enqueue_task_if_config_not_cached_not_queued(
 ):
     result, status_code = call_endpoint(full_config=True)
     assert status_code < 400
-    assert result == {"pending": [default_projectkey.public_key]}
+    assert result == {"configs": {}, "pending": [default_projectkey.public_key]}
     assert schedule_mock.call_count == 1
 
 
@@ -196,7 +203,7 @@ def test_debounce_task_if_proj_config_not_cached_already_enqueued(
 ):
     result, status_code = call_endpoint(full_config=True)
     assert status_code < 400
-    assert result == {"pending": [default_projectkey.public_key]}
+    assert result == {"configs": {}, "pending": [default_projectkey.public_key]}
     assert task_mock.call_count == 0
 
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -1,0 +1,222 @@
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from django.urls import reverse
+from sentry_relay.auth import generate_key_pair
+
+from sentry.models.relay import Relay
+from sentry.relay.config import ProjectConfig
+from sentry.tasks.relay import update_config_cache
+from sentry.utils import json
+
+
+@pytest.fixture
+def key_pair():
+    return generate_key_pair()
+
+
+@pytest.fixture
+def public_key(key_pair):
+    return key_pair[1]
+
+
+@pytest.fixture
+def private_key(key_pair):
+    return key_pair[0]
+
+
+@pytest.fixture
+def relay_id():
+    return str(uuid4())
+
+
+@pytest.fixture
+def relay(relay_id, public_key):
+    return Relay.objects.create(relay_id=relay_id, public_key=str(public_key), is_internal=True)
+
+
+@pytest.fixture
+def call_endpoint(client, relay, private_key, default_projectkey):
+    def inner(full_config, public_keys=None):
+        path = reverse("sentry-api-0-relay-projectconfigs") + "?version=3"
+
+        if public_keys is None:
+            public_keys = [str(default_projectkey.public_key)]
+
+        if full_config is None:
+            raw_json, signature = private_key.pack({"publicKeys": public_keys})
+        else:
+            raw_json, signature = private_key.pack(
+                {"publicKeys": public_keys, "fullConfig": full_config}
+            )
+
+        resp = client.post(
+            path,
+            data=raw_json,
+            content_type="application/json",
+            HTTP_X_SENTRY_RELAY_ID=relay.relay_id,
+            HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
+        )
+
+        return json.loads(resp.content), resp.status_code
+
+    return inner
+
+
+@pytest.fixture
+def projectconfig_cache_get_no_config(monkeypatch):
+    monkeypatch.setattr("sentry.relay.projectconfig_cache.get", lambda *args, **kwargs: None)
+
+
+@pytest.fixture
+def projectconfig_cache_get_mock_config(monkeypatch):
+    monkeypatch.setattr(
+        "sentry.relay.projectconfig_cache.get", lambda *args, **kwargs: {"is_mock_config": True}
+    )
+
+
+@pytest.fixture
+def single_mock_proj_cached(monkeypatch):
+    def cache_get(*args, **kwargs):
+        if args[0] == "must_exist":
+            return {"is_mock_config": True}
+        return None
+
+    monkeypatch.setattr("sentry.relay.projectconfig_cache.get", cache_get)
+
+
+@pytest.fixture
+def projectconfig_debounced_cache(monkeypatch):
+    monkeypatch.setattr(
+        "sentry.relay.projectconfig_debounce_cache.is_debounced", lambda *args, **kargs: True
+    )
+
+
+@pytest.fixture
+def projectconfig_isnt_debounced(monkeypatch):
+    monkeypatch.setattr(
+        "sentry.relay.projectconfig_debounce_cache.is_debounced",
+        lambda *args, **kwargs: False,
+    )
+
+
+@pytest.fixture
+def projectconfig_mark_task_done(monkeypatch):
+    monkeypatch.setattr(
+        "sentry.relay.projectconfig_debounce_cache.mark_task_done", lambda *args, **kwargs: False
+    )
+
+
+@pytest.fixture
+def project_config_get_mock(monkeypatch):
+    monkeypatch.setattr(
+        "sentry.relay.config.get_project_config",
+        lambda *args, **kwargs: ProjectConfig("mock_project", is_mock_config=True),
+    )
+
+
+@pytest.mark.django_db
+def test_return_full_config_if_in_cache(
+    call_endpoint, default_projectkey, projectconfig_cache_get_mock_config
+):
+    result, status_code = call_endpoint(full_config=True)
+    assert status_code < 400
+    assert result == {default_projectkey.public_key: {"is_mock_config": True}}
+
+
+@pytest.mark.django_db
+def test_return_partial_config_if_in_cache(
+    call_endpoint, default_projectkey, projectconfig_cache_get_mock_config
+):
+    # Partial configs aren't supported, but the endpoint must always return full
+    # configs.
+    result, status_code = call_endpoint(full_config=False)
+    assert status_code < 400
+    assert result == {default_projectkey.public_key: {"is_mock_config": True}}
+
+
+@pytest.mark.django_db
+def test_proj_in_cache_and_another_pending(
+    call_endpoint, default_projectkey, single_mock_proj_cached
+):
+    result, status_code = call_endpoint(
+        full_config=True, public_keys=["must_exist", default_projectkey.public_key]
+    )
+    assert status_code < 400
+    assert result == {
+        "must_exist": {"is_mock_config": True},
+        "pending": [default_projectkey.public_key],
+    }
+
+
+@patch("sentry.tasks.relay.update_config_cache.delay")
+@patch("sentry.relay.projectconfig_debounce_cache.debounce")
+@pytest.mark.django_db
+def test_enqueue_task_if_config_not_cached_not_queued(
+    task_mock,
+    cache_debounce_mock,
+    call_endpoint,
+    default_projectkey,
+    projectconfig_cache_get_no_config,
+    projectconfig_isnt_debounced,
+):
+    result, status_code = call_endpoint(full_config=True)
+    assert status_code < 400
+    assert result == {"pending": [default_projectkey.public_key]}
+    assert task_mock.call_count == 1
+    assert cache_debounce_mock.call_count == 1
+
+
+@patch("sentry.tasks.relay.update_config_cache.delay")
+@pytest.mark.django_db
+def test_debounce_task_if_proj_config_not_cached_already_enqueued(
+    task_mock,
+    call_endpoint,
+    default_projectkey,
+    projectconfig_cache_get_no_config,
+    projectconfig_debounced_cache,
+):
+    result, status_code = call_endpoint(full_config=True)
+    assert status_code < 400
+    assert result == {"pending": [default_projectkey.public_key]}
+    assert task_mock.call_count == 0
+
+
+@patch("sentry.relay.projectconfig_debounce_cache.mark_task_done")
+@pytest.mark.django_db
+def test_task_doesnt_run_if_not_debounced(
+    mark_task_done_mock, default_projectkey, projectconfig_isnt_debounced
+):
+    update_config_cache(
+        generate=True,
+        organization_id=None,
+        project_id=None,
+        public_key=default_projectkey.public_key,
+        update_reason="test",
+    )
+    assert mark_task_done_mock.call_count == 0
+
+
+@patch("sentry.relay.projectconfig_cache.set_many")
+@pytest.mark.django_db
+def test_task_writes_config_into_cache(
+    cache_set_many_mock,
+    default_projectkey,
+    projectconfig_debounced_cache,
+    projectconfig_mark_task_done,
+    project_config_get_mock,
+):
+    update_config_cache(
+        generate=True,
+        organization_id=None,
+        project_id=None,
+        public_key=default_projectkey.public_key,
+        update_reason="test",
+    )
+
+    assert cache_set_many_mock.call_count == 1
+    # Using a tuple because that's the format `.args` uses
+    assert cache_set_many_mock.call_args.args == (
+        {default_projectkey.public_key: {"is_mock_config": True}},
+    )

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -45,10 +45,10 @@ def call_endpoint(client, relay, private_key, default_projectkey):
             public_keys = [str(default_projectkey.public_key)]
 
         if full_config is None:
-            raw_json, signature = private_key.pack({"publicKeys": public_keys})
+            raw_json, signature = private_key.pack({"publicKeys": public_keys, "no_cache": False})
         else:
             raw_json, signature = private_key.pack(
-                {"publicKeys": public_keys, "fullConfig": full_config}
+                {"publicKeys": public_keys, "fullConfig": full_config, "no_cache": False}
             )
 
         resp = client.post(

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -216,10 +216,7 @@ def test_projectkeys(default_project, task_runner, redis_cache):
         pk.save()
 
     for key in deleted_pks:
-        # XXX: Ideally we would write `{"disabled": True}` into Redis, however
-        # it's fine if we don't and instead Relay starts hitting the endpoint
-        # which will write this for us.
-        assert not redis_cache.get(key.public_key)
+        assert redis_cache.get(key.public_key) == {"disabled": True}
 
     (pk_json,) = redis_cache.get(pk.public_key)["publicKeys"]
     assert pk_json["publicKey"] == pk.public_key
@@ -233,7 +230,7 @@ def test_projectkeys(default_project, task_runner, redis_cache):
     with task_runner():
         pk.delete()
 
-    assert not redis_cache.get(pk.public_key)
+    assert redis_cache.get(pk.public_key) == {"disabled": True}
 
     for key in ProjectKey.objects.filter(project_id=default_project.id):
         assert not redis_cache.get(key.public_key)

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -37,29 +37,23 @@ def redis_cache(monkeypatch):
 def debounce_cache(monkeypatch):
     debounce_cache = RedisProjectConfigDebounceCache()
     monkeypatch.setattr(
-        "sentry.relay.projectconfig_debounce_cache.mark_task_done", debounce_cache.mark_task_done
+        "sentry.relay.projectconfig_debounce_cache.mark_task_done",
+        debounce_cache.mark_task_done,
     )
     monkeypatch.setattr(
         "sentry.relay.projectconfig_debounce_cache.check_is_debounced",
         debounce_cache.check_is_debounced,
     )
     monkeypatch.setattr(
-        "sentry.relay.projectconfig_debounce_cache.debounce", debounce_cache.debounce
+        "sentry.relay.projectconfig_debounce_cache.debounce",
+        debounce_cache.debounce,
     )
     monkeypatch.setattr(
-        "sentry.relay.projectconfig_debounce_cache.is_debounced", debounce_cache.is_debounced
+        "sentry.relay.projectconfig_debounce_cache.is_debounced",
+        debounce_cache.is_debounced,
     )
 
     return debounce_cache
-
-
-@pytest.mark.django_db
-def test_no_cache(monkeypatch, default_project):
-    def apply_async(*a, **kw):
-        assert False
-
-    monkeypatch.setattr("sentry.tasks.relay.update_config_cache.apply_async", apply_async)
-    schedule_update_config_cache(generate=True, project_id=default_project.id)
 
 
 @pytest.fixture
@@ -72,9 +66,7 @@ def test_debounce(
     monkeypatch,
     default_project,
     default_organization,
-    redis_cache,
     debounce_cache,
-    always_update_cache,
 ):
     tasks = []
 
@@ -84,9 +76,11 @@ def test_debounce(
 
     monkeypatch.setattr("sentry.tasks.relay.update_config_cache.apply_async", apply_async)
 
+    debounce_cache.mark_task_done(None, default_project.id, None)
     schedule_update_config_cache(generate=True, project_id=default_project.id)
     schedule_update_config_cache(generate=False, project_id=default_project.id)
 
+    debounce_cache.mark_task_done(None, None, default_organization.id)
     schedule_update_config_cache(generate=True, organization_id=default_organization.id)
     schedule_update_config_cache(generate=False, organization_id=default_organization.id)
 

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -30,6 +30,11 @@ def redis_cache(monkeypatch):
         "sentry.relay.projectconfig_debounce_cache.redis.RedisProjectConfigDebounceCache",
     )
 
+    return cache
+
+
+@pytest.fixture
+def debounce_cache(monkeypatch):
     debounce_cache = RedisProjectConfigDebounceCache()
     monkeypatch.setattr(
         "sentry.relay.projectconfig_debounce_cache.mark_task_done", debounce_cache.mark_task_done
@@ -45,7 +50,7 @@ def redis_cache(monkeypatch):
         "sentry.relay.projectconfig_debounce_cache.is_debounced", debounce_cache.is_debounced
     )
 
-    return cache
+    return debounce_cache
 
 
 @pytest.mark.django_db
@@ -64,7 +69,12 @@ def always_update_cache(monkeypatch):
 
 @pytest.mark.django_db
 def test_debounce(
-    monkeypatch, default_project, default_organization, redis_cache, always_update_cache
+    monkeypatch,
+    default_project,
+    default_organization,
+    redis_cache,
+    debounce_cache,
+    always_update_cache,
 ):
     tasks = []
 


### PR DESCRIPTION
This new version of the endpoint doesn't perform any computation on the
project configs. Instead, it performs computation async, as follows:

- If a requested project config exists in the cache, the endpoint
  returns it.
- If a requested project config doesn't exist in the cache, the endpoint
  schedules a new task to compute that config, and returns a pending
  response.
- If a requested project config doesn't exist in the cache, but a task
  is already scheduled, the endpoint returns a pending request.

Tasks are debounced based on the public key of the project. Pending
projects are returned as a list part of the config in the response, for
example:

```
{
    proj1_key: { proj1_config },
    proj2_key: { proj2_config },
    pending: [proj3_key, proj4_key]
}
```

The `pending` entry only exists if there is at least one pending
project.

**Redis cache changes**
Redis is now a requirement for the project configs cache, since the endpoint can't operate without redis anymore. On the other hand, the debouncing cache hasn't been updated because it's not needed for local development (requests will never be debounced and always processed).