### PR TITLE
feat(perf): Add transaction name only search feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1087,6 +1087,8 @@ SENTRY_FEATURES = {
     "organizations:performance-onboarding-checklist": False,
     # Enable automatic horizontal scrolling on the span tree
     "organizations:performance-span-tree-autoscroll": False,
+    # Enable transaction name only search on performance landing page
+    "organizations:performance-transaction-name-only-search": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable usage of external relays, for use with Relay. See

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1087,7 +1087,7 @@ SENTRY_FEATURES = {
     "organizations:performance-onboarding-checklist": False,
     # Enable automatic horizontal scrolling on the span tree
     "organizations:performance-span-tree-autoscroll": False,
-    # Enable transaction name only search on performance landing page
+    # Enable transaction name only search
     "organizations:performance-transaction-name-only-search": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -109,6 +109,9 @@ default_manager.add("organizations:performance-onboarding-checklist", Organizati
 default_manager.add("organizations:performance-use-metrics", OrganizationFeature, True)
 default_manager.add("organizations:performance-dry-run-mep", OrganizationFeature, True)
 default_manager.add("organizations:performance-span-tree-autoscroll", OrganizationFeature, True)
+default_manager.add(
+    "organizations:performance-transaction-name-only-search", OrganizationFeature, True
+)
 default_manager.add("organizations:profiling", OrganizationFeature, True)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)
 default_manager.add("organizations:related-events", OrganizationFeature)


### PR DESCRIPTION
Add a flag that would make the search bar on the performance landing page transaction name search only. We will run an experiment to see if transaction name search is sufficient to cover all users' searching needs.

Fixes PERF-1554
