### PR TITLE
feat(alerts): Add Mobile Vitals to alerts

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -277,7 +277,12 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
+        columnTypes: validateForNumericAggregate([
+          'duration',
+          'number',
+          'percentage',
+          'integer',
+        ]),
         required: true,
         defaultValue: 'transaction.duration',
       },
@@ -304,7 +309,12 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
+        columnTypes: validateForNumericAggregate([
+          'duration',
+          'number',
+          'percentage',
+          'integer',
+        ]),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -318,7 +328,12 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
+        columnTypes: validateForNumericAggregate([
+          'duration',
+          'number',
+          'percentage',
+          'integer',
+        ]),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -332,7 +347,12 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
+        columnTypes: validateForNumericAggregate([
+          'duration',
+          'number',
+          'percentage',
+          'integer',
+        ]),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -347,7 +367,12 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
+        columnTypes: validateForNumericAggregate([
+          'duration',
+          'number',
+          'percentage',
+          'integer',
+        ]),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -361,7 +386,12 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
+        columnTypes: validateForNumericAggregate([
+          'duration',
+          'number',
+          'percentage',
+          'integer',
+        ]),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -375,7 +405,12 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
+        columnTypes: validateForNumericAggregate([
+          'duration',
+          'number',
+          'percentage',
+          'integer',
+        ]),
         defaultValue: 'transaction.duration',
         required: true,
       },
@@ -395,7 +430,12 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
+        columnTypes: validateForNumericAggregate([
+          'duration',
+          'number',
+          'percentage',
+          'integer',
+        ]),
         defaultValue: 'transaction.duration',
         required: true,
       },

--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -1,7 +1,10 @@
 import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import {AggregationKey, LooseFieldKey} from 'sentry/utils/discover/fields';
-import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
+import {
+  MOBILE_VITAL_DETAILS,
+  WEB_VITAL_DETAILS,
+} from 'sentry/utils/performance/vitals/constants';
 import {
   AlertRuleThresholdType,
   AlertRuleTriggerType,
@@ -120,7 +123,10 @@ export function getWizardAlertFieldConfig(
   return {
     aggregations,
     fields: ['transaction.duration'],
-    measurementKeys: Object.keys(WEB_VITAL_DETAILS),
+    measurementKeys: [
+      ...Object.keys(WEB_VITAL_DETAILS),
+      ...Object.keys(MOBILE_VITAL_DETAILS),
+    ],
   };
 }
 

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -22,7 +22,8 @@ export type AlertType =
   | 'crash_free_users'
   // Mobile vitals
   | 'app_start_cold'
-  | 'app_start_warm';
+  | 'app_start_warm'
+  | 'frames_slow';
 
 export type MetricAlertType = Exclude<AlertType, 'issues'>;
 
@@ -42,6 +43,7 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   crash_free_users: t('Crash Free User Rate'),
   app_start_cold: t('App Cold Start'),
   app_start_warm: t('App Warm Start'),
+  frames_slow: t('Slow Frames'),
 };
 
 type AlertWizardCategory = {
@@ -73,6 +75,7 @@ export const getAlertWizardCategories = (org: Organization): AlertWizardCategory
       'cls',
       'app_start_cold',
       'app_start_warm',
+      'frames_slow',
     ],
   },
   {
@@ -163,6 +166,11 @@ export const AlertWizardRuleTemplates: Record<
     dataset: Dataset.TRANSACTIONS,
     eventTypes: EventTypes.TRANSACTION,
   },
+  frames_slow: {
+    aggregate: 'p75(measurements.frames_slow)',
+    dataset: Dataset.TRANSACTIONS,
+    eventTypes: EventTypes.TRANSACTION,
+  },
 };
 
 export const DEFAULT_WIZARD_TEMPLATE = AlertWizardRuleTemplates.num_errors;
@@ -184,6 +192,7 @@ export const hideParameterSelectorSet = new Set<AlertType>([
   'cls',
   'app_start_cold',
   'app_start_warm',
+  'frames_slow',
 ]);
 
 export function getFunctionHelpText(alertType: AlertType): {

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -21,7 +21,8 @@ export type AlertType =
   | 'crash_free_sessions'
   | 'crash_free_users'
   // Mobile vitals
-  | 'app_start_cold';
+  | 'app_start_cold'
+  | 'app_start_warm';
 
 export type MetricAlertType = Exclude<AlertType, 'issues'>;
 
@@ -40,6 +41,7 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   crash_free_sessions: t('Crash Free Session Rate'),
   crash_free_users: t('Crash Free User Rate'),
   app_start_cold: t('App Cold Start'),
+  app_start_warm: t('App Warm Start'),
 };
 
 type AlertWizardCategory = {
@@ -70,6 +72,7 @@ export const getAlertWizardCategories = (org: Organization): AlertWizardCategory
       'fid',
       'cls',
       'app_start_cold',
+      'app_start_warm',
     ],
   },
   {
@@ -155,6 +158,11 @@ export const AlertWizardRuleTemplates: Record<
     dataset: Dataset.TRANSACTIONS,
     eventTypes: EventTypes.TRANSACTION,
   },
+  app_start_warm: {
+    aggregate: 'p75(measurements.app_start_warm)',
+    dataset: Dataset.TRANSACTIONS,
+    eventTypes: EventTypes.TRANSACTION,
+  },
 };
 
 export const DEFAULT_WIZARD_TEMPLATE = AlertWizardRuleTemplates.num_errors;
@@ -175,6 +183,7 @@ export const hideParameterSelectorSet = new Set<AlertType>([
   'fid',
   'cls',
   'app_start_cold',
+  'app_start_warm',
 ]);
 
 export function getFunctionHelpText(alertType: AlertType): {

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -23,7 +23,8 @@ export type AlertType =
   // Mobile vitals
   | 'app_start_cold'
   | 'app_start_warm'
-  | 'frames_slow';
+  | 'frames_slow'
+  | 'frames_frozen';
 
 export type MetricAlertType = Exclude<AlertType, 'issues'>;
 
@@ -44,6 +45,7 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   app_start_cold: t('App Cold Start'),
   app_start_warm: t('App Warm Start'),
   frames_slow: t('Slow Frames'),
+  frames_frozen: t('Frozen Frames'),
 };
 
 type AlertWizardCategory = {
@@ -76,6 +78,7 @@ export const getAlertWizardCategories = (org: Organization): AlertWizardCategory
       'app_start_cold',
       'app_start_warm',
       'frames_slow',
+      'frames_frozen',
     ],
   },
   {
@@ -171,6 +174,11 @@ export const AlertWizardRuleTemplates: Record<
     dataset: Dataset.TRANSACTIONS,
     eventTypes: EventTypes.TRANSACTION,
   },
+  frames_frozen: {
+    aggregate: 'p75(measurements.frames_frozen)',
+    dataset: Dataset.TRANSACTIONS,
+    eventTypes: EventTypes.TRANSACTION,
+  },
 };
 
 export const DEFAULT_WIZARD_TEMPLATE = AlertWizardRuleTemplates.num_errors;
@@ -193,6 +201,7 @@ export const hideParameterSelectorSet = new Set<AlertType>([
   'app_start_cold',
   'app_start_warm',
   'frames_slow',
+  'frames_frozen',
 ]);
 
 export function getFunctionHelpText(alertType: AlertType): {

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -24,7 +24,10 @@ export type AlertType =
   | 'app_start_cold'
   | 'app_start_warm'
   | 'frames_slow'
-  | 'frames_frozen';
+  | 'frames_frozen'
+  | 'stall_longest_time'
+  | 'stall_total_time'
+  | 'stall_count';
 
 export type MetricAlertType = Exclude<AlertType, 'issues'>;
 
@@ -46,6 +49,9 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   app_start_warm: t('App Warm Start'),
   frames_slow: t('Slow Frames'),
   frames_frozen: t('Frozen Frames'),
+  stall_longest_time: t('Longest Stall Time'),
+  stall_total_time: t('Total Stall Time'),
+  stall_count: t('Stall Count'),
 };
 
 type AlertWizardCategory = {
@@ -79,6 +85,9 @@ export const getAlertWizardCategories = (org: Organization): AlertWizardCategory
       'app_start_warm',
       'frames_slow',
       'frames_frozen',
+      'stall_longest_time',
+      'stall_total_time',
+      'stall_count',
     ],
   },
   {
@@ -179,6 +188,21 @@ export const AlertWizardRuleTemplates: Record<
     dataset: Dataset.TRANSACTIONS,
     eventTypes: EventTypes.TRANSACTION,
   },
+  stall_longest_time: {
+    aggregate: 'p75(measurements.stall_longest_time)',
+    dataset: Dataset.TRANSACTIONS,
+    eventTypes: EventTypes.TRANSACTION,
+  },
+  stall_total_time: {
+    aggregate: 'p75(measurements.stall_total_time)',
+    dataset: Dataset.TRANSACTIONS,
+    eventTypes: EventTypes.TRANSACTION,
+  },
+  stall_count: {
+    aggregate: 'p75(measurements.stall_count)',
+    dataset: Dataset.TRANSACTIONS,
+    eventTypes: EventTypes.TRANSACTION,
+  },
 };
 
 export const DEFAULT_WIZARD_TEMPLATE = AlertWizardRuleTemplates.num_errors;
@@ -202,6 +226,9 @@ export const hideParameterSelectorSet = new Set<AlertType>([
   'app_start_warm',
   'frames_slow',
   'frames_frozen',
+  'stall_longest_time',
+  'stall_total_time',
+  'stall_count',
 ]);
 
 export function getFunctionHelpText(alertType: AlertType): {

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -19,7 +19,9 @@ export type AlertType =
   | 'cls'
   | 'custom'
   | 'crash_free_sessions'
-  | 'crash_free_users';
+  | 'crash_free_users'
+  // Mobile vitals
+  | 'app_start_cold';
 
 export type MetricAlertType = Exclude<AlertType, 'issues'>;
 
@@ -37,6 +39,7 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   custom: t('Custom Metric'),
   crash_free_sessions: t('Crash Free Session Rate'),
   crash_free_users: t('Crash Free User Rate'),
+  app_start_cold: t('App Cold Start'),
 };
 
 type AlertWizardCategory = {
@@ -66,6 +69,7 @@ export const getAlertWizardCategories = (org: Organization): AlertWizardCategory
       'lcp',
       'fid',
       'cls',
+      'app_start_cold',
     ],
   },
   {
@@ -146,6 +150,11 @@ export const AlertWizardRuleTemplates: Record<
     dataset: Dataset.SESSIONS,
     eventTypes: EventTypes.USER,
   },
+  app_start_cold: {
+    aggregate: 'p75(measurements.app_start_cold)',
+    dataset: Dataset.TRANSACTIONS,
+    eventTypes: EventTypes.TRANSACTION,
+  },
 };
 
 export const DEFAULT_WIZARD_TEMPLATE = AlertWizardRuleTemplates.num_errors;
@@ -165,6 +174,7 @@ export const hideParameterSelectorSet = new Set<AlertType>([
   'lcp',
   'fid',
   'cls',
+  'app_start_cold',
 ]);
 
 export function getFunctionHelpText(alertType: AlertType): {

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -183,4 +183,13 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     ],
     illustration: diagramCustom,
   },
+  frames_frozen: {
+    description: t('Frozen frames are frames that take longer than 700 ms to render.'),
+    examples: [
+      t(
+        'For Apple, the frame rate can be higher, especially as 120 fps displays are becoming more popular. For these apps, Sentry detects the frame rate and adjusts the slow frame calculation accordingly.'
+      ),
+    ],
+    illustration: diagramCustom,
+  },
 };

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -173,4 +173,14 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     ],
     illustration: diagramCustom,
   },
+  frames_slow: {
+    description: t(
+      'Using 60 fps, slow frames are frames that take more time than necessary to render.'
+    ),
+    examples: [
+      t('On iOS, a slow frame occurs when a frame renders after 16.67 ms.'),
+      t('On Android, a slow frame occurs when a frame renders after 16 ms.'),
+    ],
+    illustration: diagramCustom,
+  },
 };

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -159,4 +159,18 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     ],
     illustration: diagramCustom,
   },
+  app_start_warm: {
+    description: t(
+      'App warm start metric track when your app takes does not too long to launch.'
+    ),
+    examples: [
+      t(
+        'On iOS, Apple recommends your app take at most 400ms to render the first frame.'
+      ),
+      t(
+        'On Android, the Google Play console warns you when a cold start takes longer than five seconds or a warm start longer than two seconds.'
+      ),
+    ],
+    illustration: diagramCustom,
+  },
 };

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -147,4 +147,16 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     ],
     illustration: diagramCrashFreeUsers,
   },
+  app_start_cold: {
+    description: t('App cold start metric track when your app takes too long to launch.'),
+    examples: [
+      t(
+        'On iOS, Apple recommends your app take at most 400ms to render the first frame.'
+      ),
+      t(
+        'On Android, the Google Play console warns you when a cold start takes longer than five seconds or a warm start longer than two seconds.'
+      ),
+    ],
+    illustration: diagramCustom,
+  },
 };

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -192,4 +192,19 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     ],
     illustration: diagramCustom,
   },
+  stall_longest_time: {
+    description: t('The time, in milliseconds, of the longest event loop stall.'),
+    examples: [t('stall_longest_time example here')],
+    illustration: diagramCustom,
+  },
+  stall_total_time: {
+    description: t('The total combined time, in milliseconds, of all stalls.'),
+    examples: [t('stall_total_time example here')],
+    illustration: diagramCustom,
+  },
+  stall_count: {
+    description: t('The total number of stalls that occurred during the transaction.'),
+    examples: [t('stall_count example here')],
+    illustration: diagramCustom,
+  },
 };

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -17,6 +17,7 @@ const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> 
     fid: 'measurements.fid',
     cls: 'measurements.cls',
     app_start_cold: 'measurements.app_start_cold',
+    app_start_warm: 'measurements.app_start_warm',
   },
   [Dataset.SESSIONS]: {
     crash_free_sessions: SessionsAggregate.CRASH_FREE_SESSIONS,

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -16,6 +16,7 @@ const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> 
     lcp: 'measurements.lcp',
     fid: 'measurements.fid',
     cls: 'measurements.cls',
+    app_start_cold: 'measurements.app_start_cold',
   },
   [Dataset.SESSIONS]: {
     crash_free_sessions: SessionsAggregate.CRASH_FREE_SESSIONS,

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -18,6 +18,7 @@ const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> 
     cls: 'measurements.cls',
     app_start_cold: 'measurements.app_start_cold',
     app_start_warm: 'measurements.app_start_warm',
+    frames_slow: 'measurements.frames_slow',
   },
   [Dataset.SESSIONS]: {
     crash_free_sessions: SessionsAggregate.CRASH_FREE_SESSIONS,

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -20,6 +20,9 @@ const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> 
     app_start_warm: 'measurements.app_start_warm',
     frames_slow: 'measurements.frames_slow',
     frames_frozen: 'measurements.frames_frozen',
+    stall_longest_time: 'measurements.stall_longest_time',
+    stall_total_time: 'measurements.stall_total_time',
+    stall_count: 'measurements.stall_count',
   },
   [Dataset.SESSIONS]: {
     crash_free_sessions: SessionsAggregate.CRASH_FREE_SESSIONS,

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -19,6 +19,7 @@ const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> 
     app_start_cold: 'measurements.app_start_cold',
     app_start_warm: 'measurements.app_start_warm',
     frames_slow: 'measurements.frames_slow',
+    frames_frozen: 'measurements.frames_frozen',
   },
   [Dataset.SESSIONS]: {
     crash_free_sessions: SessionsAggregate.CRASH_FREE_SESSIONS,


### PR DESCRIPTION
Adding alert options for the following mobile vital measurements:

- `measurements.app_start_cold`
- `measurements.app_start_warm`
- `measurements.frames_slow`
- `measurements.frames_frozen`
- `measurements.stall_longest_time`
- `measurements.stall_total_time`
- `measurements.stall_count`

### TODO

- [ ] add support for wizard v3
- [ ] Illustrations to be provided by @robinrendle 