### PR TITLE
feat(discover): adds a referrer for auth token requests

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -42,7 +42,7 @@ ALLOWED_EVENTS_GEO_REFERRERS = {
     "api.dashboards.worldmapwidget",
 }
 
-API_TOKEN_REFERRER = "api.auth-token"
+API_TOKEN_REFERRER = "api.auth-token.events"
 
 
 class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
@@ -156,14 +156,11 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
 
         sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
-        # Force the referrer to "api.auth-token" for events requests authorized through a bearer token
-        referrer = (
-            API_TOKEN_REFERRER
-            if request.auth
-            else referrer
-            if referrer in ALLOWED_EVENTS_REFERRERS
-            else "api.organization-events"
-        )
+        # Force the referrer to "api.auth-token.events" for events requests authorized through a bearer token
+        if request.auth:
+            referrer = API_TOKEN_REFERRER
+        elif referrer not in ALLOWED_EVENTS_REFERRERS:
+            referrer = "api.organization-events"
 
         def data_fn(offset, limit):
             query_details = {

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -9801,6 +9801,37 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         _, kwargs = mock.call_args
         self.assertEqual(kwargs["referrer"], self.referrer)
 
+    @mock.patch("sentry.snuba.discover.query")
+    def test_api_token_referrer(self, mock):
+        mock.return_value = {}
+        # Project ID cannot be inffered when using an org API key, so that must
+        # be passed in the parameters
+        api_key = ApiKey.objects.create(organization=self.organization, scope_list=["org:read"])
+
+        project = self.create_project()
+        data = load_data("transaction", timestamp=before_now(hours=1))
+        self.store_event(data=data, project_id=project.id)
+
+        query = {"field": ["project.name", "environment"], "project": [project.id]}
+
+        features = {"organizations:discover-basic": True}
+        features.update(self.features)
+        url = reverse(
+            self.viewname,
+            kwargs={"organization_slug": self.organization.slug},
+        )
+
+        with self.feature(features):
+            self.client.get(
+                url,
+                query,
+                format="json",
+                HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{api_key.key}:".encode()),
+            )
+
+        _, kwargs = mock.call_args
+        self.assertEqual(kwargs["referrer"], "api.auth-token")
+
     def test_limit_number_of_fields(self):
         self.create_project()
         for i in range(1, 25):

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -9830,7 +9830,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
             )
 
         _, kwargs = mock.call_args
-        self.assertEqual(kwargs["referrer"], "api.auth-token")
+        self.assertEqual(kwargs["referrer"], "api.auth-token.events")
 
     def test_limit_number_of_fields(self):
         self.create_project()


### PR DESCRIPTION
`events` requests authorized by an Auth Token are given an `api.auth-token` snuba referrer