### PR TITLE
fix(dev): skip patching selenium files when they do not exist

### DIFF
--- a/tools/patch_selenium.py
+++ b/tools/patch_selenium.py
@@ -33,6 +33,10 @@ PATCH_FILE_PATTERN = (
 
 def main() -> int:
     for patch, filename, pattern in PATCH_FILE_PATTERN:
+        if not os.path.exists(filename):
+            print(f"patch_selenium: ignoring {filename} (does not exist)")
+            continue
+
         with open(filename) as f:
             for line in f:
                 if pattern.search(line):


### PR DESCRIPTION
this happens from `getsentry` in CI when the sentry `Makefile` is invoked

before:

```
Traceback (most recent call last):
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/runner/work/getsentry/getsentry/sentry/tools/patch_selenium.py", line 53, in <module>
    raise SystemExit(main())
  File "/Users/runner/work/getsentry/getsentry/sentry/tools/patch_selenium.py", line 36, in main
    with open(filename) as f:
FileNotFoundError: [Errno 2] No such file or directory: '.venv/lib/python3.8/site-packages/selenium/webdriver/chrome/options.py'
```

testing done:
- simulated getsentry locally, it skips the files rather than erroring as before