### PR TITLE
fix(ui): Remove "required" from textarea to prevent html required

### DIFF
--- a/static/app/components/forms/controls/input.tsx
+++ b/static/app/components/forms/controls/input.tsx
@@ -9,11 +9,9 @@ export interface InputProps
   type?: React.HTMLInputTypeAttribute;
 }
 
-/**
- * Do not forward required to `input` to avoid default browser behavior
- */
 const Input = styled('input', {
   shouldForwardProp: prop =>
+    // Do not forward required to `input` to avoid default browser behavior
     typeof prop === 'string' && isPropValid(prop) && prop !== 'required',
 })<InputProps>`
   ${inputStyles};

--- a/static/app/components/forms/textareaField.tsx
+++ b/static/app/components/forms/textareaField.tsx
@@ -19,7 +19,8 @@ export default function TextareaField({
       field={fieldProps => (
         <Textarea
           {...{monospace, rows, autosize}}
-          {...omit(fieldProps, ['onKeyDown', 'children'])}
+          // Do not forward required to `textarea` to avoid default browser behavior
+          {...omit(fieldProps, ['onKeyDown', 'children', 'required'])}
         />
       )}
     />


### PR DESCRIPTION
We remove required from the input field, do the same with textarea.