### PR TITLE
feat(ui): Use AutoComplete with TextField

### DIFF
--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -196,6 +196,9 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
   makeHandleInputChange<E extends HTMLInputElement>(
     onChange: GetInputArgs<E>['onChange']
   ) {
+    // Some inputs (e.g. input) pass in only the event to the onChange listener and
+    // others (e.g. TextField) pass in both the value and the event to the onChange listener.
+    // This returned function is to accomodate both kinds of input components.
     return (
       valueOrEvent: string | React.ChangeEvent<E>,
       event?: React.ChangeEvent<E>

--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -196,10 +196,16 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
   makeHandleInputChange<E extends HTMLInputElement>(
     onChange: GetInputArgs<E>['onChange']
   ) {
-    return (maybeValue: string | React.ChangeEvent<E>, e?: React.ChangeEvent<E>) => {
-      const value: string = e === undefined ? (maybeValue as string) : e.target.value;
+    return (
+      valueOrEvent: string | React.ChangeEvent<E>,
+      event?: React.ChangeEvent<E>
+    ) => {
+      const value: string =
+        event === undefined
+          ? (valueOrEvent as React.ChangeEvent<E>).target.value
+          : (valueOrEvent as string);
       const changeEvent: React.ChangeEvent<E> =
-        e === undefined ? (maybeValue as React.ChangeEvent<E>) : e;
+        event === undefined ? (valueOrEvent as React.ChangeEvent<E>) : event;
 
       // We force `isOpen: true` here because:
       // 1) it's possible to have menu closed but input with focus (i.e. hitting "Esc")

--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -196,8 +196,11 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
   makeHandleInputChange<E extends HTMLInputElement>(
     onChange: GetInputArgs<E>['onChange']
   ) {
-    return (maybeValue: any, e?: React.ChangeEvent<E>) => {
-      const value = e !== undefined ? e.target.value : maybeValue;
+    return (maybeValue: string | React.ChangeEvent<E>, e?: React.ChangeEvent<E>) => {
+      const value: string = e === undefined ? (maybeValue as string) : e.target.value;
+      const changeEvent: React.ChangeEvent<E> =
+        e === undefined ? (maybeValue as React.ChangeEvent<E>) : e;
+
       // We force `isOpen: true` here because:
       // 1) it's possible to have menu closed but input with focus (i.e. hitting "Esc")
       // 2) you select an item, input still has focus, and then change input
@@ -206,7 +209,7 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
         inputValue: value,
       });
 
-      onChange?.(e ?? maybeValue);
+      onChange?.(changeEvent);
     };
   }
 

--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -196,9 +196,8 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
   makeHandleInputChange<E extends HTMLInputElement>(
     onChange: GetInputArgs<E>['onChange']
   ) {
-    return (e: React.ChangeEvent<E>) => {
-      const value = e.target.value;
-
+    return (maybeValue: any, e?: React.ChangeEvent<E>) => {
+      const value = e !== undefined ? e.target.value : maybeValue;
       // We force `isOpen: true` here because:
       // 1) it's possible to have menu closed but input with focus (i.e. hitting "Esc")
       // 2) you select an item, input still has focus, and then change input
@@ -207,7 +206,7 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
         inputValue: value,
       });
 
-      onChange?.(e);
+      onChange?.(e ?? maybeValue);
     };
   }
 


### PR DESCRIPTION
Allow AutoComplete to be used with inputs that pass a value and event to the onChange listener