### PR TITLE
chore(deps): Bump qrcode.react

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "process": "^0.11.10",
     "prop-types": "^15.8.1",
     "pyright": "1.1.229",
-    "qrcode.react": "^1.0.1",
+    "qrcode.react": "^3.0.2",
     "query-string": "7.0.1",
     "react": "17.0.2",
     "react-aria": "^3.12.0",

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
-import QRCode from 'qrcode.react';
+import {QRCodeCanvas} from 'qrcode.react';
 
 import {
   addErrorMessage,
@@ -434,7 +434,7 @@ const Actions = styled(PanelItem)`
   justify-content: flex-end;
 `;
 
-const StyledQRCode = styled(QRCode)`
+const StyledQRCode = styled(QRCodeCanvas)`
   background: white;
   padding: ${space(2)};
 `;

--- a/tests/js/spec/views/accountSecurityEnroll.spec.jsx
+++ b/tests/js/spec/views/accountSecurityEnroll.spec.jsx
@@ -47,7 +47,7 @@ describe('AccountSecurityEnroll', function () {
     });
 
     it('has qrcode component', function () {
-      expect(wrapper.find('QRCode')).toHaveLength(1);
+      expect(wrapper.find('QRCodeCanvas')).toHaveLength(1);
     });
 
     it('can enroll', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12871,19 +12871,10 @@ pyright@1.1.229:
   resolved "https://registry.yarnpkg.com/pyright/-/pyright-1.1.229.tgz#c48e4425b2fd7c13221d094693282ffa4bf9862a"
   integrity sha512-eEmhg/8zJRf9a4EHkchxce/ihuL7FBd5Nk3O1Y3MRjUfrZwwyNNCgHYHIFi/OYajodlNhg3GJjSc6+1poZ3vvg==
 
-qr.js@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"
-  integrity sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8=
-
-qrcode.react@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-1.0.1.tgz#2834bb50e5e275ffe5af6906eff15391fe9e38a5"
-  integrity sha512-8d3Tackk8IRLXTo67Y+c1rpaiXjoz/Dd2HpcMdW//62/x8J1Nbho14Kh8x974t9prsLHN6XqVgcnRiBGFptQmg==
-  dependencies:
-    loose-envify "^1.4.0"
-    prop-types "^15.6.0"
-    qr.js "0.0.0"
+qrcode.react@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-3.0.2.tgz#7ceaea165aa7066253ef670a25bf238eaec4eb9e"
+  integrity sha512-8F3SGxSkNb3fMIHdlseqjFjLbsPrF3WvF/1MOboSUUHytT537W8f/FtbdA3XFIHDrc+TrRBjTI/QLmwhAIGWWw==
 
 qs@6.7.0:
   version "6.7.0"


### PR DESCRIPTION
The default previously was to render a `QRCodeCanvas`, but the default
export of `QRCode` is now deprecated. So we can just import the
`QRCodeCanvas`.

https://github.com/zpao/qrcode.react/blob/b6951e3270786f694dd083fd35c674449312f354/src/index.tsx#L360-L371