### PR TITLE
feat(discover): Feature flags for frontend events endpoint usage

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -945,6 +945,8 @@ SENTRY_FEATURES = {
     "organizations:create": True,
     # Enable the 'discover' interface.
     "organizations:discover": False,
+    # Enables events endpoint usage on frontend
+    "organizations:discover-frontend-use-events-endpoint": False,
     # Enable duplicating alert rules.
     "organizations:duplicate-alert-rule": False,
     # Enable attaching arbitrary files to events.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -64,6 +64,9 @@ default_manager.add("organizations:dashboards-releases", OrganizationFeature, Tr
 default_manager.add("organizations:dashboards-template", OrganizationFeature, True)
 default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, True)
 default_manager.add("organizations:discover", OrganizationFeature)
+default_manager.add(
+    "organizations:discover-frontend-use-events-endpoint", OrganizationFeature, True
+)
 default_manager.add("organizations:duplicate-alert-rule", OrganizationFeature, True)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature)
 default_manager.add("organizations:filters-and-sampling", OrganizationFeature, True)


### PR DESCRIPTION
Creating a new feature flag to manage rolling out usage of the new `events` endpoint over the old `eventsv2` endpoint in the frontend.