### PR TITLE
feat(discover): Transform equation alias back to field name

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -272,6 +272,8 @@ def query(
                 translated_columns.get(column): function_details
                 for column, function_details in builder.function_alias_map.items()
             }
+            for index, equation in enumerate(equations):
+                translated_columns[f"equation[{index}]"] = f"equation|{equation}"
         result = transform_results(
             result,
             function_alias_map,

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -10400,12 +10400,13 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
                 "organizations:discover-basic": True,
             },
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         assert (
-            response.data["data"][0]["equation[0]"]
+            response.data["data"][0]["equation|spans.http / 3"]
             == event_data["breakdowns"]["span_ops"]["ops.http"]["value"] / 3
         )
+        assert response.data["meta"]["equation|spans.http / 3"] == "number"
 
     def test_equation_sort(self):
         event_data = load_data("transaction", timestamp=before_now(minutes=1))
@@ -10419,7 +10420,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         query = {
             "field": ["spans.http", "equation|spans.http / 3"],
             "project": [self.project.id],
-            "orderby": "equation[0]",
+            "orderby": "equation|spans.http / 3",
             "query": "event.type:transaction",
         }
         response = self.do_request(
@@ -10428,14 +10429,14 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
                 "organizations:discover-basic": True,
             },
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 2
         assert (
-            response.data["data"][0]["equation[0]"]
+            response.data["data"][0]["equation|spans.http / 3"]
             == event_data["breakdowns"]["span_ops"]["ops.http"]["value"] / 3
         )
         assert (
-            response.data["data"][1]["equation[0]"]
+            response.data["data"][1]["equation|spans.http / 3"]
             == event_data2["breakdowns"]["span_ops"]["ops.http"]["value"] / 3
         )
 


### PR DESCRIPTION
- This changes how return equations from the alias we use for querying
  - eg. `equation[0]` back to what they were queried with like `equation|a + b`
- This only does this change for the new events endpoint