### PR TITLE
feat(backend): adds a ADDITIONAL_SAMPLED_TASKS setting

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2580,6 +2580,9 @@ SAMPLED_DEFAULT_RATE = 1.0
 # A set of extra URLs to sample
 ADDITIONAL_SAMPLED_URLS = {}
 
+# A set of extra tasks to sample
+ADDITIONAL_SAMPLED_TASKS = {}
+
 # This controls whether Sentry is run in a demo mode.
 # Enabling this will allow users to create accounts without an email or password.
 DEMO_MODE = False

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -105,6 +105,9 @@ SAMPLED_TASKS = {
     "sentry.tasks.reports.deliver_organization_user_report": 0.01,
 }
 
+if settings.ADDITIONAL_SAMPLED_TASKS:
+    SAMPLED_TASKS.update(settings.ADDITIONAL_SAMPLED_TASKS)
+
 
 UNSAFE_TAG = "_unsafe"
 


### PR DESCRIPTION
This PR adds a `ADDITIONAL_SAMPLED_TASKS` setting so we can sample additional tasks in Getsentry