### PR TITLE
fix(dashboards): Widget Viewer fix equation alias breaking query

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -37,7 +37,11 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import {getUtcDateString} from 'sentry/utils/dates';
 import {TableDataRow, TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
-import {isAggregateField, isEquation} from 'sentry/utils/discover/fields';
+import {
+  isAggregateField,
+  isEquation,
+  isEquationAlias,
+} from 'sentry/utils/discover/fields';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {decodeInteger, decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
@@ -260,6 +264,7 @@ function WidgetViewerModal(props: Props) {
   if (
     widget.widgetType === WidgetType.DISCOVER &&
     orderby &&
+    !isEquationAlias(rawOrderby) &&
     !fields.includes(rawOrderby)
   ) {
     fields.push(rawOrderby);


### PR DESCRIPTION
fixes a case where widget viewer will add an invalid field that breaks the widget query if the orderby is an equation alias.
Check to see that the orderby is not an equation alias before adding it to fields.