### PR TITLE
feat(charts): Increase size of chartcuterie charts in slack

### DIFF
--- a/static/app/chartcuterie/slack.tsx
+++ b/static/app/chartcuterie/slack.tsx
@@ -10,8 +10,8 @@ export const DEFAULT_FONT_FAMILY = 'sans-serif';
  * Size configuration for SLACK_* type charts
  */
 export const slackChartSize = {
-  height: 150,
-  width: 450,
+  height: 200,
+  width: 600,
 };
 
 export const slackGeoChartSize = {


### PR DESCRIPTION
Increase the size of discover and metric alert charts, this size is a bit closer to what we have in the frontend. It takes 50px more of vertical space. This also helps with the size needed for adding the chart to emails. Another possible option is to pass the size of the chart on request w/ a default.

example before after
![image](https://user-images.githubusercontent.com/1400464/169376641-96272065-1add-4dfa-b861-1f473417d52c.png)
