### PR TITLE
ref: rely on django's global settings inheritance rather than a `*` import

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -12,8 +12,6 @@ import tempfile
 from datetime import timedelta
 from urllib.parse import urlparse
 
-from django.conf.global_settings import *  # NOQA
-
 import sentry
 from sentry.utils.celery import crontab_with_minute_jitter
 from sentry.utils.types import type_from_value


### PR DESCRIPTION
from https://docs.djangoproject.com/en/2.2/topics/settings/#default-settings

> Note that a settings file should _not_ import from **global_settings**, because that’s redundant.

___

this removes two lines of warning noise from every test run:

```
/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/django/conf/__init__.py:181: RemovedInDjango31Warning: The FILE_CHARSET setting is deprecated. Starting with Django 3.1, all files read from disk must be UTF-8 encoded.
  warnings.warn(FILE_CHARSET_DEPRECATED_MSG, RemovedInDjango31Warning)
```