### PR TITLE
chore: Update OrganizationSerializer to use self.validated_data in favour of self.initial_data

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -346,50 +346,52 @@ class OrganizationSerializer(serializers.Serializer):
         if not hasattr(org, "__data"):
             update_tracked_data(org)
 
+        data = self.validated_data
+
         for key, option, type_, default_value in ORG_OPTIONS:
-            if key not in self.initial_data:
+            if key not in data:
                 continue
             try:
                 option_inst = OrganizationOption.objects.get(organization=org, key=option)
                 update_tracked_data(option_inst)
             except OrganizationOption.DoesNotExist:
                 OrganizationOption.objects.set_value(
-                    organization=org, key=option, value=type_(self.initial_data[key])
+                    organization=org, key=option, value=type_(data[key])
                 )
 
-                if self.initial_data[key] != default_value:
-                    changed_data[key] = f"to {self.initial_data[key]}"
+                if data[key] != default_value:
+                    changed_data[key] = f"to {data[key]}"
             else:
-                option_inst.value = self.initial_data[key]
+                option_inst.value = data[key]
                 # check if ORG_OPTIONS changed
                 if has_changed(option_inst, "value"):
                     old_val = old_value(option_inst, "value")
                     changed_data[key] = f"from {old_val} to {option_inst.value}"
                 option_inst.save()
 
-        trusted_relay_info = self.validated_data.get("trustedRelays")
+        trusted_relay_info = data.get("trustedRelays")
         if trusted_relay_info is not None:
             self.save_trusted_relays(trusted_relay_info, changed_data, org)
 
-        if "openMembership" in self.initial_data:
-            org.flags.allow_joinleave = self.initial_data["openMembership"]
-        if "allowSharedIssues" in self.initial_data:
-            org.flags.disable_shared_issues = not self.initial_data["allowSharedIssues"]
-        if "enhancedPrivacy" in self.initial_data:
-            org.flags.enhanced_privacy = self.initial_data["enhancedPrivacy"]
-        if "isEarlyAdopter" in self.initial_data:
-            org.flags.early_adopter = self.initial_data["isEarlyAdopter"]
-        if "require2FA" in self.initial_data:
-            org.flags.require_2fa = self.initial_data["require2FA"]
+        if "openMembership" in data:
+            org.flags.allow_joinleave = data["openMembership"]
+        if "allowSharedIssues" in data:
+            org.flags.disable_shared_issues = not data["allowSharedIssues"]
+        if "enhancedPrivacy" in data:
+            org.flags.enhanced_privacy = data["enhancedPrivacy"]
+        if "isEarlyAdopter" in data:
+            org.flags.early_adopter = data["isEarlyAdopter"]
+        if "require2FA" in data:
+            org.flags.require_2fa = data["require2FA"]
         if (
             features.has("organizations:required-email-verification", org)
-            and "requireEmailVerification" in self.initial_data
+            and "requireEmailVerification" in data
         ):
-            org.flags.require_email_verification = self.initial_data["requireEmailVerification"]
-        if "name" in self.initial_data:
-            org.name = self.initial_data["name"]
-        if "slug" in self.validated_data:
-            org.slug = self.validated_data["slug"]
+            org.flags.require_email_verification = data["requireEmailVerification"]
+        if "name" in data:
+            org.name = data["name"]
+        if "slug" in data:
+            org.slug = data["slug"]
 
         org_tracked_field = {
             "name": org.name,
@@ -418,18 +420,18 @@ class OrganizationSerializer(serializers.Serializer):
 
         org.save()
 
-        if "avatar" in self.initial_data or "avatarType" in self.initial_data:
+        if "avatar" in data or "avatarType" in data:
             OrganizationAvatar.save_avatar(
                 relation={"organization": org},
-                type=self.initial_data.get("avatarType", "upload"),
-                avatar=self.initial_data.get("avatar"),
+                type=data.get("avatarType", "upload"),
+                avatar=data.get("avatar"),
                 filename=f"{org.slug}.png",
             )
-        if self.initial_data.get("require2FA") is True:
+        if data.get("require2FA") is True:
             org.handle_2fa_required(self.context["request"])
         if (
             features.has("organizations:required-email-verification", org)
-            and self.initial_data.get("requireEmailVerification") is True
+            and data.get("requireEmailVerification") is True
         ):
             org.handle_email_verification_required(self.context["request"])
         return org, changed_data
@@ -442,9 +444,10 @@ class OwnerOrganizationSerializer(OrganizationSerializer):
     def save(self, *args, **kwargs):
         org = self.context["organization"]
         update_tracked_data(org)
-        cancel_deletion = "cancelDeletion" in self.initial_data and org.status in DELETION_STATUSES
-        if "defaultRole" in self.initial_data:
-            org.default_role = self.initial_data["defaultRole"]
+        data = self.validated_data
+        cancel_deletion = "cancelDeletion" in data and org.status in DELETION_STATUSES
+        if "defaultRole" in data:
+            org.default_role = data["defaultRole"]
         if cancel_deletion:
             org.status = OrganizationStatus.VISIBLE
         return super().save(*args, **kwargs)


### PR DESCRIPTION


Follow up to https://github.com/getsentry/sentry/pull/34575 to swap `self.initial_data` in favour of `self.validated_data` for `OrganizationSerializer` and `OwnerOrganizationSerializer` classes. 

This should increase confidence that we're using the validated user provided data to save into the database.

With this change, I expect no breakage in any of our tests