### PR TITLE
ref: patch the non-deprecated github settings under test

### DIFF
--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -163,8 +163,8 @@ def pytest_configure(config):
     settings.ASANA_CLIENT_SECRET = "123"
     settings.BITBUCKET_CONSUMER_KEY = "abc"
     settings.BITBUCKET_CONSUMER_SECRET = "123"
-    settings.GITHUB_APP_ID = "abc"
-    settings.GITHUB_API_SECRET = "123"
+    settings.SENTRY_OPTIONS["github-login.client-id"] = "abc"
+    settings.SENTRY_OPTIONS["github-login.client-secret"] = "123"
     # this isn't the real secret
     settings.SENTRY_OPTIONS["github.integration-hook-secret"] = "b3002c3e321d4b7880360d397db2ccfd"
 


### PR DESCRIPTION
this removes 4 lines of warning noise from every test run:

```
/Users/asottile/workspace/sentry/src/sentry/runner/initializer.py:186: DeprecatedSettingWarning: The GITHUB_APP_ID setting is deprecated. Please use SENTRY_OPTIONS['github-login.client-id'] instead.
  warnings.warn(DeprecatedSettingWarning(options_mapper[k], "SENTRY_OPTIONS['%s']" % k))
/Users/asottile/workspace/sentry/src/sentry/runner/initializer.py:186: DeprecatedSettingWarning: The GITHUB_API_SECRET setting is deprecated. Please use SENTRY_OPTIONS['github-login.client-secret'] instead.
  warnings.warn(DeprecatedSettingWarning(options_mapper[k], "SENTRY_OPTIONS['%s']" % k))
```