### PR TITLE
ref(tests): Remove `get_valid_response()`

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -502,13 +502,6 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
 
         return getattr(self.client, method)(url, format="json", data=data, **headers)
 
-    def get_valid_response(self, *args, **params):
-        """Deprecated. Calls `get_response` (see above) and asserts a specific status code."""
-        status_code = params.pop("status_code", 200)
-        resp = self.get_response(*args, **params)
-        assert resp.status_code == status_code, (resp.status_code, resp.content)
-        return resp
-
     def get_success_response(self, *args, **params):
         """
         Call `get_response` (see above) and assert the response's status code.

--- a/tests/sentry/api/endpoints/test_api_authorizations.py
+++ b/tests/sentry/api/endpoints/test_api_authorizations.py
@@ -18,7 +18,7 @@ class ApiAuthorizationsListTest(ApiAuthorizationsTest):
             application=app, user=self.create_user("example@example.com")
         )
 
-        response = self.get_valid_response()
+        response = self.get_success_response()
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(auth.id)
 
@@ -31,6 +31,6 @@ class ApiAuthorizationsDeleteTest(ApiAuthorizationsTest):
         auth = ApiAuthorization.objects.create(application=app, user=self.user)
         token = ApiToken.objects.create(application=app, user=self.user)
 
-        self.get_valid_response(authorization=auth.id, status_code=204)
+        self.get_success_response(authorization=auth.id, status_code=204)
         assert not ApiAuthorization.objects.filter(id=auth.id).exists()
         assert not ApiToken.objects.filter(id=token.id).exists()

--- a/tests/sentry/api/endpoints/test_organization_environments.py
+++ b/tests/sentry/api/endpoints/test_organization_environments.py
@@ -20,18 +20,18 @@ class OrganizationEnvironmentsTest(APITestCase):
         prod = self.create_environment(name="production", project=self.project)
         staging = self.create_environment(name="staging", project=self.project)
 
-        response = self.get_valid_response(self.project.organization.slug)
+        response = self.get_success_response(self.project.organization.slug)
         assert response.data == serialize([prod, staging])
 
     def test_visibility(self):
         visible = self.create_environment(name="visible", project=self.project, is_hidden=False)
         hidden = self.create_environment(name="not visible", project=self.project, is_hidden=True)
         not_set = self.create_environment(name="null visible", project=self.project)
-        response = self.get_valid_response(self.project.organization.slug, visibility="visible")
+        response = self.get_success_response(self.project.organization.slug, visibility="visible")
         assert response.data == serialize([not_set, visible])
-        response = self.get_valid_response(self.project.organization.slug, visibility="hidden")
+        response = self.get_success_response(self.project.organization.slug, visibility="hidden")
         assert response.data == serialize([hidden])
-        response = self.get_valid_response(self.project.organization.slug, visibility="all")
+        response = self.get_success_response(self.project.organization.slug, visibility="all")
         assert response.data == serialize([hidden, not_set, visible])
 
     def test_project_filter(self):
@@ -39,15 +39,15 @@ class OrganizationEnvironmentsTest(APITestCase):
         project_env = self.create_environment(name="project", project=self.project)
         other_project_env = self.create_environment(name="other", project=other_project)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.project.organization.slug, project=[self.project.id]
         )
         assert response.data == serialize([project_env])
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.project.organization.slug, project=[other_project.id]
         )
         assert response.data == serialize([other_project_env])
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.project.organization.slug, project=[self.project.id, other_project.id]
         )
         assert response.data == serialize([other_project_env, project_env])

--- a/tests/sentry/api/endpoints/test_organization_pinned_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_pinned_searches.py
@@ -25,7 +25,7 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
         query = "test"
         search_type = SearchType.ISSUE.value
         sort = SortOptions.DATE
-        self.get_valid_response(type=search_type, query=query, sort=sort, status_code=201)
+        self.get_success_response(type=search_type, query=query, sort=sort, status_code=201)
         assert SavedSearch.objects.filter(
             organization=self.organization,
             name=PINNED_SEARCH_NAME,
@@ -36,7 +36,7 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
         ).exists()
 
         query = "test_2"
-        self.get_valid_response(type=search_type, query=query, sort=sort, status_code=201)
+        self.get_success_response(type=search_type, query=query, sort=sort, status_code=201)
         assert SavedSearch.objects.filter(
             organization=self.organization,
             name=PINNED_SEARCH_NAME,
@@ -46,7 +46,7 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             sort=sort,
         ).exists()
 
-        self.get_valid_response(type=SearchType.EVENT.value, query=query, status_code=201)
+        self.get_success_response(type=SearchType.EVENT.value, query=query, status_code=201)
         assert SavedSearch.objects.filter(
             organization=self.organization,
             name=PINNED_SEARCH_NAME,
@@ -63,7 +63,7 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
         ).exists()
 
         self.login_as(self.user)
-        self.get_valid_response(type=search_type, query=query, status_code=201)
+        self.get_success_response(type=search_type, query=query, status_code=201)
         assert SavedSearch.objects.filter(
             organization=self.organization,
             name=PINNED_SEARCH_NAME,
@@ -84,7 +84,7 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             organization=self.organization, name="foo", query="some test", date_added=timezone.now()
         )
         self.login_as(self.user)
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             type=org_search.type, query=org_search.query, status_code=201
         )
         assert resp.data["isPinned"]
@@ -95,7 +95,7 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             name="Global Query", query="global query", is_global=True, date_added=timezone.now()
         )
         self.login_as(self.user)
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             type=global_search.type, query=global_search.query, status_code=201
         )
         assert resp.data["isPinned"]
@@ -110,7 +110,7 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             query="wat",
         )
         self.login_as(self.user)
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             sort=SortOptions.DATE, type=saved_search.type, query=saved_search.query, status_code=201
         )
         assert resp.data["isPinned"]
@@ -151,13 +151,13 @@ class DeleteOrganizationPinnedSearchTest(APITestCase):
         )
 
         self.login_as(self.member)
-        self.get_valid_response(type=saved_search.type, status_code=204)
+        self.get_success_response(type=saved_search.type, status_code=204)
         assert not SavedSearch.objects.filter(id=saved_search.id).exists()
         assert SavedSearch.objects.filter(id=other_saved_search.id).exists()
 
         # Test calling multiple times works ok, doesn't cause other rows to
         # delete
-        self.get_valid_response(type=saved_search.type, status_code=204)
+        self.get_success_response(type=saved_search.type, status_code=204)
         assert SavedSearch.objects.filter(id=other_saved_search.id).exists()
 
     def test_invalid_type(self):

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -59,7 +59,7 @@ class OrganizationProjectsTest(OrganizationProjectsTestBase):
         self.check_valid_response(response, projects)
         assert "stats" not in response.data[0]
 
-        self.get_success_response(
+        self.get_error_response(
             self.organization.slug, qs_params={"statsPeriod": "48h"}, status_code=400
         )
 

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -36,36 +36,40 @@ class OrganizationProjectsTest(OrganizationProjectsTestBase):
     def test_simple(self):
         project = self.create_project(teams=[self.team])
 
-        response = self.get_valid_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
         self.check_valid_response(response, [project])
         assert self.client.session["activeorg"] == self.organization.slug
 
     def test_with_stats(self):
         projects = [self.create_project(teams=[self.team])]
 
-        response = self.get_valid_response(self.organization.slug, qs_params={"statsPeriod": "24h"})
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"statsPeriod": "24h"}
+        )
         self.check_valid_response(response, projects)
         assert "stats" in response.data[0]
 
-        response = self.get_valid_response(self.organization.slug, qs_params={"statsPeriod": "14d"})
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"statsPeriod": "14d"}
+        )
         self.check_valid_response(response, projects)
         assert "stats" in response.data[0]
 
-        response = self.get_valid_response(self.organization.slug, qs_params={"statsPeriod": ""})
+        response = self.get_success_response(self.organization.slug, qs_params={"statsPeriod": ""})
         self.check_valid_response(response, projects)
         assert "stats" not in response.data[0]
 
-        self.get_valid_response(
+        self.get_success_response(
             self.organization.slug, qs_params={"statsPeriod": "48h"}, status_code=400
         )
 
     def test_search(self):
         project = self.create_project(teams=[self.team], name="bar", slug="bar")
 
-        response = self.get_valid_response(self.organization.slug, qs_params={"query": "bar"})
+        response = self.get_success_response(self.organization.slug, qs_params={"query": "bar"})
         self.check_valid_response(response, [project])
 
-        response = self.get_valid_response(self.organization.slug, qs_params={"query": "baz"})
+        response = self.get_success_response(self.organization.slug, qs_params={"query": "baz"})
         self.check_valid_response(response, [])
 
     def test_search_by_ids(self):
@@ -73,12 +77,12 @@ class OrganizationProjectsTest(OrganizationProjectsTestBase):
         project_foo = self.create_project(teams=[self.team], name="foo", slug="foo")
         self.create_project(teams=[self.team], name="baz", slug="baz")
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, qs_params={"query": f"id:{project_foo.id}"}
         )
         self.check_valid_response(response, [project_foo])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, qs_params={"query": f"id:{project_bar.id} id:{project_foo.id}"}
         )
         self.check_valid_response(response, [project_bar, project_foo])
@@ -88,12 +92,12 @@ class OrganizationProjectsTest(OrganizationProjectsTestBase):
         project_foo = self.create_project(teams=[self.team], name="foo", slug="foo")
         self.create_project(teams=[self.team], name="baz", slug="baz")
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, qs_params={"query": f"slug:{project_foo.slug}"}
         )
         self.check_valid_response(response, [project_foo])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             qs_params={"query": f"slug:{project_bar.slug} slug:{project_foo.slug}"},
         )
@@ -105,26 +109,26 @@ class OrganizationProjectsTest(OrganizationProjectsTestBase):
         ]
         projects.sort(key=lambda project: project.slug)
 
-        response = self.get_valid_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
         self.check_valid_response(response, [project for project in projects])
 
-        response = self.get_valid_response(self.organization.slug, qs_params={"per_page": "2"})
+        response = self.get_success_response(self.organization.slug, qs_params={"per_page": "2"})
         self.check_valid_response(response, [project for project in projects[:2]])
 
         self.create_project_bookmark(projects[-1], user=self.user)
         # Move the bookmarked project to the front
         projects.insert(0, projects.pop())
-        response = self.get_valid_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
         self.check_valid_response(response, [project for project in projects])
 
         # Make sure that it's at the front when on the second page as well
-        response = self.get_valid_response(self.organization.slug, qs_params={"per_page": "2"})
+        response = self.get_success_response(self.organization.slug, qs_params={"per_page": "2"})
         self.check_valid_response(response, [project for project in projects[:2]])
 
         # Make sure that other user's bookmarks don't interfere with this user
         other_user = self.create_user()
         self.create_project_bookmark(projects[1], user=other_user)
-        response = self.get_valid_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
         self.check_valid_response(response, [project for project in projects])
 
     def test_team_filter(self):
@@ -134,12 +138,12 @@ class OrganizationProjectsTest(OrganizationProjectsTestBase):
         project_foo = self.create_project(teams=[other_team], name="foo", slug="foo")
         project_baz = self.create_project(teams=[other_team], name="baz", slug="baz")
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, qs_params={"query": f"team:{self.team.slug}"}
         )
         self.check_valid_response(response, [project_bar])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, qs_params={"query": f"!team:{self.team.slug}"}
         )
         self.check_valid_response(response, [project_baz, project_foo])
@@ -152,7 +156,7 @@ class OrganizationProjectsTest(OrganizationProjectsTestBase):
         project_baz = self.create_project(teams=[other_team], name="baz", slug="baz")
         sorted_projects = [project_bar, project_baz, project_foo]
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, qs_params={"all_projects": "1", "per_page": "1"}
         )
         # Verify all projects in the org are returned in sorted order
@@ -162,7 +166,7 @@ class OrganizationProjectsTest(OrganizationProjectsTestBase):
         project_bar = self.create_project(teams=[self.team], name="bar", slug="bar")
         sorted_projects = [project_bar]
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, qs_params={"all_projects": "1", "collapse": "latestDeploy"}
         )
         # Verify all projects in the org are returned in sorted order
@@ -184,7 +188,7 @@ class OrganizationProjectsTest(OrganizationProjectsTestBase):
 
         foo_user_projects = [project_bar]
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, qs_params={"query": "is_member:1"}
         )
         # Verify projects that were returned were foo_users projects
@@ -212,5 +216,5 @@ class OrganizationProjectsCountTest(APITestCase):
         # Make foo_user a part of the org and self.team
         self.create_member(organization=self.organization, user=self.foo_user, teams=[self.team])
 
-        response = self.get_valid_response(self.organization.slug, qs_params={"get_counts": "1"})
+        response = self.get_success_response(self.organization.slug, qs_params={"get_counts": "1"})
         assert response.data == {"allProjects": 6, "myProjects": 4}

--- a/tests/sentry/api/endpoints/test_organization_recent_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_recent_searches.py
@@ -22,7 +22,9 @@ class RecentSearchesListTest(APITestCase):
         kwargs = {}
         if query:
             kwargs["query"] = query
-        response = self.get_valid_response(self.organization.slug, type=search_type.value, **kwargs)
+        response = self.get_success_response(
+            self.organization.slug, type=search_type.value, **kwargs
+        )
         assert response.data == serialize(expected)
 
     def test_simple(self):

--- a/tests/sentry/api/endpoints/test_organization_relay_usage.py
+++ b/tests/sentry/api/endpoints/test_organization_relay_usage.py
@@ -82,7 +82,7 @@ class OrganizationRelayHistoryTest(APITestCase):
         """
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
         assert response.data == []
 
     @with_feature({"organizations:relay": False})
@@ -103,7 +103,7 @@ class OrganizationRelayHistoryTest(APITestCase):
         self.login_as(user=self.user)
         pks = self._public_keys()
         self._set_org_public_keys([pks[0], pks[1]])
-        response = self.get_valid_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
         data = response.data
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -94,7 +94,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         )
         release4.add_project(project3)
 
-        response = self.get_valid_response(org.slug)
+        response = self.get_success_response(org.slug)
         self.assert_expected_versions(response, [release4, release1, release3])
 
     def test_release_list_order_by_date_added(self):
@@ -140,7 +140,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         )
         release8.add_project(project)
 
-        response = self.get_valid_response(org.slug)
+        response = self.get_success_response(org.slug)
         self.assert_expected_versions(response, [release8, release7, release6])
 
     def test_release_list_order_by_sessions_empty(self):
@@ -153,7 +153,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         release_5 = self.create_release(version="5")
 
         #  Make sure ordering works fine when we have no session data at all
-        response = self.get_valid_response(self.organization.slug, sort="sessions", flatten="1")
+        response = self.get_success_response(self.organization.slug, sort="sessions", flatten="1")
         self.assert_expected_versions(
             response, [release_5, release_4, release_3, release_2, release_1]
         )
@@ -169,16 +169,16 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         release_5 = self.create_release(version="5")
         self.bulk_store_sessions([self.build_session(release=release_5) for _ in range(2)])
 
-        response = self.get_valid_response(self.organization.slug, sort="sessions", flatten="1")
+        response = self.get_success_response(self.organization.slug, sort="sessions", flatten="1")
         self.assert_expected_versions(
             response, [release_5, release_1, release_4, release_3, release_2]
         )
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, sort="sessions", flatten="1", per_page=1
         )
         self.assert_expected_versions(response, [release_5])
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="sessions",
             flatten="1",
@@ -186,7 +186,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
             cursor=self.get_cursor_headers(response)[1],
         )
         self.assert_expected_versions(response, [release_1])
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="sessions",
             flatten="1",
@@ -194,7 +194,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
             cursor=self.get_cursor_headers(response)[1],
         )
         self.assert_expected_versions(response, [release_4])
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="sessions",
             flatten="1",
@@ -202,7 +202,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
             cursor=self.get_cursor_headers(response)[1],
         )
         self.assert_expected_versions(response, [release_3])
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="sessions",
             flatten="1",
@@ -211,11 +211,11 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         )
         self.assert_expected_versions(response, [release_2])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, sort="sessions", flatten="1", per_page=3
         )
         self.assert_expected_versions(response, [release_5, release_1, release_4])
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="sessions",
             flatten="1",
@@ -232,7 +232,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         self.create_release(version="test@1.2")
         self.create_release(version="test@1.2+500alpha")
 
-        response = self.get_valid_response(self.organization.slug, sort="build")
+        response = self.get_success_response(self.organization.slug, sort="build")
         self.assert_expected_versions(response, [release_1, release_3, release_2])
 
     def test_release_list_order_by_semver(self):
@@ -247,7 +247,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         release_8 = self.create_release(version="test@some_thing")
         release_9 = self.create_release(version="random_junk")
 
-        response = self.get_valid_response(self.organization.slug, sort="semver")
+        response = self.get_success_response(self.organization.slug, sort="semver")
         self.assert_expected_versions(
             response,
             [
@@ -291,10 +291,10 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         )
         release2.add_project(project)
 
-        response = self.get_valid_response(org.slug, query="oob")
+        response = self.get_success_response(org.slug, query="oob")
         self.assert_expected_versions(response, [release])
 
-        response = self.get_valid_response(org.slug, query="baz")
+        response = self.get_success_response(org.slug, query="baz")
         self.assert_expected_versions(response, [])
 
     def test_release_filter(self):
@@ -325,17 +325,21 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         )
         release2.add_project(project)
 
-        response = self.get_valid_response(self.organization.slug, query=f"{RELEASE_ALIAS}:foobar")
+        response = self.get_success_response(
+            self.organization.slug, query=f"{RELEASE_ALIAS}:foobar"
+        )
         self.assert_expected_versions(response, [release])
 
-        response = self.get_valid_response(self.organization.slug, query=f"{RELEASE_ALIAS}:foo*")
+        response = self.get_success_response(self.organization.slug, query=f"{RELEASE_ALIAS}:foo*")
         self.assert_expected_versions(response, [release])
 
-        response = self.get_valid_response(self.organization.slug, query=f"{RELEASE_ALIAS}:baz")
+        response = self.get_success_response(self.organization.slug, query=f"{RELEASE_ALIAS}:baz")
         self.assert_expected_versions(response, [])
 
         # NOT release
-        response = self.get_valid_response(self.organization.slug, query=f"!{RELEASE_ALIAS}:foobar")
+        response = self.get_success_response(
+            self.organization.slug, query=f"!{RELEASE_ALIAS}:foobar"
+        )
         self.assert_expected_versions(response, [release2])
 
     def test_query_filter_suffix(self):
@@ -381,55 +385,57 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         release_3 = self.create_release(version="test2@1.2.5+125")
         release_4 = self.create_release(version="some.release")
 
-        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:>1.2.3")
+        response = self.get_success_response(self.organization.slug, query=f"{SEMVER_ALIAS}:>1.2.3")
         self.assert_expected_versions(response, [release_3, release_1])
 
-        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:>=1.2.3")
+        response = self.get_success_response(
+            self.organization.slug, query=f"{SEMVER_ALIAS}:>=1.2.3"
+        )
         self.assert_expected_versions(response, [release_3, release_2, release_1])
 
-        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:1.2.*")
+        response = self.get_success_response(self.organization.slug, query=f"{SEMVER_ALIAS}:1.2.*")
         self.assert_expected_versions(response, [release_3, release_2, release_1])
 
         # NOT semver version
-        response = self.get_valid_response(self.organization.slug, query=f"!{SEMVER_ALIAS}:1.2.3")
+        response = self.get_success_response(self.organization.slug, query=f"!{SEMVER_ALIAS}:1.2.3")
         self.assert_expected_versions(response, [release_4, release_3, release_1])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, query=f"{SEMVER_ALIAS}:>=1.2.3", sort="semver"
         )
         self.assert_expected_versions(response, [release_3, release_1, release_2])
 
-        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:2.2.1")
+        response = self.get_success_response(self.organization.slug, query=f"{SEMVER_ALIAS}:2.2.1")
         self.assert_expected_versions(response, [])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, query=f"{SEMVER_PACKAGE_ALIAS}:test2"
         )
         self.assert_expected_versions(response, [release_3])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, query=f"{SEMVER_PACKAGE_ALIAS}:test"
         )
         self.assert_expected_versions(response, [release_2, release_1])
 
         # NOT semver package
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, query=f"!{SEMVER_PACKAGE_ALIAS}:test2"
         )
         self.assert_expected_versions(response, [release_4, release_2, release_1])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, query=f"{SEMVER_BUILD_ALIAS}:>124"
         )
         self.assert_expected_versions(response, [release_3])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, query=f"{SEMVER_BUILD_ALIAS}:<125"
         )
         self.assert_expected_versions(response, [release_2, release_1])
 
         # NOT semver build
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, query=f"!{SEMVER_BUILD_ALIAS}:125"
         )
         self.assert_expected_versions(response, [release_4, release_2, release_1])
@@ -437,7 +443,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
     def test_release_stage_filter(self):
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:adopted",
             environment=self.environment.name,
@@ -466,21 +472,21 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
             environment_id=self.environment.id,
         )
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED}",
             environment=self.environment.name,
         )
         self.assert_expected_versions(response, [adopted_release])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION}",
             environment=self.environment.name,
         )
         self.assert_expected_versions(response, [not_adopted_release])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED}",
             environment=self.environment.name,
@@ -488,21 +494,21 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         self.assert_expected_versions(response, [replaced_release])
 
         # NOT release stage
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"!{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED}",
             environment=self.environment.name,
         )
         self.assert_expected_versions(response, [not_adopted_release, adopted_release])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED},{ReleaseStages.REPLACED}]",
             environment=self.environment.name,
         )
         self.assert_expected_versions(response, [adopted_release, replaced_release])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION}]",
             environment=self.environment.name,
@@ -510,7 +516,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
 
         self.assert_expected_versions(response, [not_adopted_release])
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="adoption",
         )
@@ -520,7 +526,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         adopted_rpe.update(adopted=timezone.now() - timedelta(minutes=15))
 
         # Replaced should come first now.
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="adoption",
         )
@@ -528,10 +534,10 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
             response, [replaced_release, adopted_release, not_adopted_release]
         )
 
-        response = self.get_valid_response(self.organization.slug, sort="adoption", per_page=1)
+        response = self.get_success_response(self.organization.slug, sort="adoption", per_page=1)
         self.assert_expected_versions(response, [replaced_release])
         next_cursor = self.get_cursor_headers(response)[1]
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="adoption",
             per_page=1,
@@ -539,7 +545,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         )
         self.assert_expected_versions(response, [adopted_release])
         next_cursor = self.get_cursor_headers(response)[1]
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="adoption",
             per_page=1,
@@ -547,7 +553,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         )
         prev_cursor = self.get_cursor_headers(response)[0]
         self.assert_expected_versions(response, [not_adopted_release])
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="adoption",
             per_page=1,
@@ -555,7 +561,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         )
         prev_cursor = self.get_cursor_headers(response)[0]
         self.assert_expected_versions(response, [adopted_release])
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             sort="adoption",
             per_page=1,
@@ -566,7 +572,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
 
         adopted_rpe.update(adopted=timezone.now() - timedelta(minutes=15))
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION},{ReleaseStages.REPLACED}]",
             sort="adoption",
@@ -621,7 +627,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         )
         release3.add_project(project1)
 
-        response = self.get_valid_response(org.slug)
+        response = self.get_success_response(org.slug)
         self.assert_expected_versions(response, [release1, release3])
 
     def test_all_projects_parameter(self):
@@ -649,7 +655,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         )
         release2.add_project(project2)
 
-        response = self.get_valid_response(org.slug, project=[-1])
+        response = self.get_success_response(org.slug, project=[-1])
         self.assert_expected_versions(response, [release2, release1])
 
     def test_new_org(self):
@@ -658,7 +664,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         team = self.create_team(organization=org)
         self.create_member(teams=[team], user=user, organization=org)
         self.login_as(user=user)
-        response = self.get_valid_response(org.slug)
+        response = self.get_success_response(org.slug)
         self.assert_expected_versions(response, [])
 
     def test_archive_release(self):
@@ -839,32 +845,34 @@ class OrganizationReleasesStatsTest(APITestCase):
         release_3 = self.create_release(version="test2@1.2.5")
         self.create_release(version="some.release")
 
-        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:>1.2.3")
+        response = self.get_success_response(self.organization.slug, query=f"{SEMVER_ALIAS}:>1.2.3")
         assert [r["version"] for r in response.data] == [release_3.version, release_1.version]
 
-        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:>=1.2.3")
+        response = self.get_success_response(
+            self.organization.slug, query=f"{SEMVER_ALIAS}:>=1.2.3"
+        )
         assert [r["version"] for r in response.data] == [
             release_3.version,
             release_2.version,
             release_1.version,
         ]
 
-        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:1.2.*")
+        response = self.get_success_response(self.organization.slug, query=f"{SEMVER_ALIAS}:1.2.*")
         assert [r["version"] for r in response.data] == [
             release_3.version,
             release_2.version,
             release_1.version,
         ]
 
-        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:2.2.1")
+        response = self.get_success_response(self.organization.slug, query=f"{SEMVER_ALIAS}:2.2.1")
         assert [r["version"] for r in response.data] == []
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, query=f"{SEMVER_PACKAGE_ALIAS}:test2"
         )
         assert [r["version"] for r in response.data] == [release_3.version]
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug, query=f"{SEMVER_PACKAGE_ALIAS}:test"
         )
         assert [r["version"] for r in response.data] == [release_2.version, release_1.version]
@@ -872,7 +880,7 @@ class OrganizationReleasesStatsTest(APITestCase):
     def test_release_stage_filter(self):
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:adopted",
             environment=self.environment.name,
@@ -901,28 +909,28 @@ class OrganizationReleasesStatsTest(APITestCase):
             environment_id=self.environment.id,
         )
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED}",
             environment=self.environment.name,
         )
         assert [r["version"] for r in response.data] == [adopted_release.version]
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION}",
             environment=self.environment.name,
         )
         assert [r["version"] for r in response.data] == [not_adopted_release.version]
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED}",
             environment=self.environment.name,
         )
         assert [r["version"] for r in response.data] == [replaced_release.version]
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED},{ReleaseStages.REPLACED}]",
             environment=self.environment.name,
@@ -932,7 +940,7 @@ class OrganizationReleasesStatsTest(APITestCase):
             replaced_release.version,
         ]
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION}]",
             environment=self.environment.name,
@@ -979,7 +987,7 @@ class OrganizationReleasesStatsTest(APITestCase):
         )
 
         # Filtering to self.environment.name and self.project with release.stage:adopted should NOT return multi_project_release.
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             project=self.project.id,
             environment=self.environment.name,
@@ -987,7 +995,7 @@ class OrganizationReleasesStatsTest(APITestCase):
         )
         assert [r["version"] for r in response.data] == [single_project_release.version]
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.organization.slug,
             environment=self.environment.name,
             query=f"{RELEASE_STAGE_ALIAS}:adopted",
@@ -1007,25 +1015,25 @@ class OrganizationReleasesStatsTest(APITestCase):
             self.project, version="sdfsdfsdf", date_added=datetime(2013, 8, 13, 3, 8, 24, 880386)
         )
 
-        response = self.get_valid_response(self.organization.slug, query="oob")
+        response = self.get_success_response(self.organization.slug, query="oob")
         assert [r["version"] for r in response.data] == [release.version]
 
-        response = self.get_valid_response(self.organization.slug, query="baz")
+        response = self.get_success_response(self.organization.slug, query="baz")
         assert [r["version"] for r in response.data] == []
 
-        response = self.get_valid_response(self.organization.slug, query="release:*oob*")
+        response = self.get_success_response(self.organization.slug, query="release:*oob*")
         assert [r["version"] for r in response.data] == [release.version]
 
-        response = self.get_valid_response(self.organization.slug, query="release:foob*")
+        response = self.get_success_response(self.organization.slug, query="release:foob*")
         assert [r["version"] for r in response.data] == [release.version]
 
-        response = self.get_valid_response(self.organization.slug, query="release:*bar")
+        response = self.get_success_response(self.organization.slug, query="release:*bar")
         assert [r["version"] for r in response.data] == [release.version]
 
-        response = self.get_valid_response(self.organization.slug, query="release:foobar")
+        response = self.get_success_response(self.organization.slug, query="release:foobar")
         assert [r["version"] for r in response.data] == [release.version]
 
-        response = self.get_valid_response(self.organization.slug, query="release:*baz*")
+        response = self.get_success_response(self.organization.slug, query="release:*baz*")
         assert [r["version"] for r in response.data] == []
 
 

--- a/tests/sentry/api/endpoints/test_organization_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_searches.py
@@ -66,7 +66,7 @@ class OrgLevelOrganizationSearchesListTest(APITestCase):
     def check_results(self, expected):
         self.login_as(user=self.user)
         expected.sort(key=lambda search: (not search.is_pinned, search.name.lower()))
-        response = self.get_valid_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
         assert response.data == serialize(expected)
 
     def test_simple(self):
@@ -116,7 +116,7 @@ class CreateOrganizationSearchesTest(APITestCase):
         name = "test"
         query = "hello"
         self.login_as(user=self.manager)
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             self.organization.slug, type=search_type, name=name, query=query
         )
         assert resp.data["name"] == name

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -157,14 +157,14 @@ class OrganizationTeamsCreateTest(APITestCase):
         user = self.create_user()
         self.login_as(user=user)
 
-        self.get_valid_response(self.organization.slug, status_code=403)
+        self.get_error_response(self.organization.slug, status_code=403)
 
     def test_missing_params(self):
-        resp = self.get_valid_response(self.organization.slug, status_code=400)
+        resp = self.get_error_response(self.organization.slug, status_code=400)
         assert b"Name or slug is required" in resp.content
 
     def test_valid_params(self):
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             self.organization.slug, name="hello world", slug="foobar", status_code=201
         )
 
@@ -180,27 +180,31 @@ class OrganizationTeamsCreateTest(APITestCase):
         ).exists()
 
     def test_without_slug(self):
-        resp = self.get_valid_response(self.organization.slug, name="hello world", status_code=201)
+        resp = self.get_success_response(
+            self.organization.slug, name="hello world", status_code=201
+        )
 
         team = Team.objects.get(id=resp.data["id"])
         assert team.slug == "hello-world"
 
     def test_without_name(self):
-        resp = self.get_valid_response(self.organization.slug, slug="example-slug", status_code=201)
+        resp = self.get_success_response(
+            self.organization.slug, slug="example-slug", status_code=201
+        )
 
         team = Team.objects.get(id=resp.data["id"])
         assert team.slug == "example-slug"
         assert team.name == "example-slug"
 
     def test_duplicate(self):
-        self.get_valid_response(
+        self.get_success_response(
             self.organization.slug, name="hello world", slug="foobar", status_code=201
         )
-        self.get_valid_response(
+        self.get_error_response(
             self.organization.slug, name="hello world", slug="foobar", status_code=409
         )
 
     def test_name_too_long(self):
-        self.get_valid_response(
+        self.get_error_response(
             self.organization.slug, name="x" * 65, slug="xxxxxxx", status_code=400
         )

--- a/tests/sentry/api/endpoints/test_organization_user_details.py
+++ b/tests/sentry/api/endpoints/test_organization_user_details.py
@@ -14,7 +14,7 @@ class OrganizationUserDetailsTest(APITestCase):
         self.login_as(user=self.owner_user)
 
     def test_gets_info_for_user_in_org(self):
-        response = self.get_valid_response(self.org.slug, self.user.id)
+        response = self.get_success_response(self.org.slug, self.user.id)
 
         assert response.data["id"] == str(self.user.id)
         assert response.data["email"] == self.user.email
@@ -22,4 +22,4 @@ class OrganizationUserDetailsTest(APITestCase):
     def test_cannot_access_info_if_user_not_in_org(self):
         user = self.create_user("meep@localhost", username="meep")
 
-        self.get_valid_response(self.org.slug, user.id, status_code=404)
+        self.get_error_response(self.org.slug, user.id, status_code=404)

--- a/tests/sentry/api/endpoints/test_organization_user_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_user_teams.py
@@ -19,7 +19,7 @@ class OrganizationUserTeamsTest(APITestCase):
     def test_simple(self):
         self.login_as(user=self.foo)
 
-        response = self.get_valid_response(self.org.slug)
+        response = self.get_success_response(self.org.slug)
 
         # Verify that only teams that the user is a member of, are returned
         assert len(response.data) == 2
@@ -37,7 +37,7 @@ class OrganizationUserTeamsTest(APITestCase):
     def test_super_user(self):
         self.login_as(user=self.bar, superuser=True)
 
-        response = self.get_valid_response(self.org.slug)
+        response = self.get_success_response(self.org.slug)
 
         # Verify that all teams are returned
         assert len(response.data) == 3

--- a/tests/sentry/api/endpoints/test_organization_users.py
+++ b/tests/sentry/api/endpoints/test_organization_users.py
@@ -24,7 +24,7 @@ class OrganizationMemberListTest(APITestCase):
 
     def test_simple(self):
         projects_ids = [self.project_1.id, self.project_2.id]
-        response = self.get_valid_response(self.org.slug, project=projects_ids)
+        response = self.get_success_response(self.org.slug, project=projects_ids)
         expected = serialize(
             list(
                 self.org.member_set.filter(user__in=[self.owner_user, self.user_2]).order_by(
@@ -37,7 +37,7 @@ class OrganizationMemberListTest(APITestCase):
         assert response.data == expected
 
         projects_ids = [self.project_2.id]
-        response = self.get_valid_response(self.org.slug, project=projects_ids)
+        response = self.get_success_response(self.org.slug, project=projects_ids)
         expected = serialize(
             list(self.org.member_set.filter(user__in=[self.user_2]).order_by("user__email")),
             self.user_2,

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -84,7 +84,7 @@ class ProjectDetailsTest(APITestCase):
         project = self.project  # force creation
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(project.organization.slug, project.slug)
+        response = self.get_success_response(project.organization.slug, project.slug)
         assert response.data["id"] == str(project.id)
 
     def test_numeric_org_slug(self):
@@ -105,7 +105,7 @@ class ProjectDetailsTest(APITestCase):
         self.create_group(project=project)
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             project.organization.slug, project.slug, qs_params={"include": "stats"}
         )
         assert response.data["stats"]["unresolved"] == 1
@@ -118,7 +118,7 @@ class ProjectDetailsTest(APITestCase):
         self.create_group(project=project)
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             project.organization.slug,
             project.slug,
             qs_params={"expand": "hasAlertIntegration"},
@@ -133,7 +133,7 @@ class ProjectDetailsTest(APITestCase):
         self.create_group(project=project)
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             project.organization.slug, project.slug, qs_params={"expand": "hasAlertIntegration"}
         )
         assert not response.data["hasAlertIntegrationInstalled"]
@@ -143,7 +143,7 @@ class ProjectDetailsTest(APITestCase):
         project.update_option("sentry:dynamic_sampling", _dyn_sampling_data())
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(project.organization.slug, project.slug)
+        response = self.get_success_response(project.organization.slug, project.slug)
         assert response.data["dynamicSampling"] == _dyn_sampling_data()
 
     def test_project_renamed_302(self):
@@ -151,11 +151,13 @@ class ProjectDetailsTest(APITestCase):
         self.login_as(user=self.user)
 
         # Rename the project
-        self.get_valid_response(
+        self.get_success_response(
             project.organization.slug, project.slug, method="put", slug="foobar"
         )
 
-        response = self.get_valid_response(project.organization.slug, project.slug, status_code=302)
+        response = self.get_success_response(
+            project.organization.slug, project.slug, status_code=302
+        )
         assert (
             AuditLogEntry.objects.get(
                 organization=project.organization, event=audit_log.get_event_id("PROJECT_EDIT")
@@ -189,7 +191,7 @@ class ProjectDetailsTest(APITestCase):
         ProjectRedirect.record(other_project, "old_slug")
         self.login_as(user=user)
 
-        self.get_valid_response(other_org.slug, "old_slug", status_code=403)
+        self.get_error_response(other_org.slug, "old_slug", status_code=403)
 
 
 class ProjectUpdateTest(APITestCase):
@@ -206,11 +208,11 @@ class ProjectUpdateTest(APITestCase):
         project = Project.objects.get(id=self.project.id)
         options = {"mail:subject_prefix": "[Sentry]"}
 
-        self.get_valid_response(self.org_slug, self.proj_slug, options=options)
+        self.get_success_response(self.org_slug, self.proj_slug, options=options)
         assert project.get_option("mail:subject_prefix") == "[Sentry]"
 
         options["mail:subject_prefix"] = ""
-        self.get_valid_response(self.org_slug, self.proj_slug, options=options)
+        self.get_success_response(self.org_slug, self.proj_slug, options=options)
         assert project.get_option("mail:subject_prefix") == ""
 
     def test_simple_member_restriction(self):
@@ -224,7 +226,7 @@ class ProjectUpdateTest(APITestCase):
         )
         self.login_as(user)
 
-        self.get_valid_response(
+        self.get_error_response(
             self.org_slug,
             self.proj_slug,
             slug="zzz",
@@ -244,7 +246,7 @@ class ProjectUpdateTest(APITestCase):
         )
         self.login_as(user=user)
 
-        self.get_valid_response(
+        self.get_error_response(
             self.org_slug,
             self.proj_slug,
             slug="zzz",
@@ -257,12 +259,12 @@ class ProjectUpdateTest(APITestCase):
         assert not ProjectBookmark.objects.filter(user=user, project_id=project.id).exists()
 
     def test_name(self):
-        self.get_valid_response(self.org_slug, self.proj_slug, name="hello world")
+        self.get_success_response(self.org_slug, self.proj_slug, name="hello world")
         project = Project.objects.get(id=self.project.id)
         assert project.name == "hello world"
 
     def test_slug(self):
-        self.get_valid_response(self.org_slug, self.proj_slug, slug="foobar")
+        self.get_success_response(self.org_slug, self.proj_slug, slug="foobar")
         project = Project.objects.get(id=self.project.id)
         assert project.slug == "foobar"
         assert ProjectRedirect.objects.filter(project=self.project, redirect_slug=self.proj_slug)
@@ -272,7 +274,7 @@ class ProjectUpdateTest(APITestCase):
 
     def test_invalid_slug(self):
         new_project = self.create_project()
-        self.get_valid_response(
+        self.get_error_response(
             self.org_slug,
             self.proj_slug,
             slug=new_project.slug,
@@ -282,7 +284,7 @@ class ProjectUpdateTest(APITestCase):
         assert project.slug != new_project.slug
 
     def test_reserved_slug(self):
-        self.get_valid_response(
+        self.get_error_response(
             self.org_slug,
             self.proj_slug,
             slug=list(RESERVED_PROJECT_SLUGS)[0],
@@ -290,12 +292,12 @@ class ProjectUpdateTest(APITestCase):
         )
 
     def test_platform(self):
-        self.get_valid_response(self.org_slug, self.proj_slug, platform="python")
+        self.get_success_response(self.org_slug, self.proj_slug, platform="python")
         project = Project.objects.get(id=self.project.id)
         assert project.platform == "python"
 
     def test_platform_invalid(self):
-        self.get_valid_response(self.org_slug, self.proj_slug, platform="lol", status_code=400)
+        self.get_error_response(self.org_slug, self.proj_slug, platform="lol", status_code=400)
 
     def test_options(self):
         options = {
@@ -321,7 +323,7 @@ class ProjectUpdateTest(APITestCase):
             "sentry:verify_ssl": False,
         }
         with self.feature("projects:custom-inbound-filters"):
-            self.get_valid_response(self.org_slug, self.proj_slug, options=options)
+            self.get_success_response(self.org_slug, self.proj_slug, options=options)
 
         project = Project.objects.get(id=self.project.id)
         assert project.get_option("sentry:origins", []) == options["sentry:origins"].split("\n")
@@ -406,13 +408,13 @@ class ProjectUpdateTest(APITestCase):
         ).exists()
 
     def test_bookmarks(self):
-        self.get_valid_response(self.org_slug, self.proj_slug, isBookmarked="false")
+        self.get_success_response(self.org_slug, self.proj_slug, isBookmarked="false")
         assert not ProjectBookmark.objects.filter(
             project_id=self.project.id, user=self.user
         ).exists()
 
     def test_subscription(self):
-        self.get_valid_response(self.org_slug, self.proj_slug, isSubscribed="true")
+        self.get_success_response(self.org_slug, self.proj_slug, isSubscribed="true")
         value0 = NotificationSetting.objects.get_settings(
             provider=ExternalProviders.EMAIL,
             type=NotificationSettingTypes.ISSUE_ALERTS,
@@ -421,7 +423,7 @@ class ProjectUpdateTest(APITestCase):
         )
         assert value0 == NotificationSettingOptionValues.ALWAYS
 
-        self.get_valid_response(self.org_slug, self.proj_slug, isSubscribed="false")
+        self.get_success_response(self.org_slug, self.proj_slug, isSubscribed="false")
         value1 = NotificationSetting.objects.get_settings(
             provider=ExternalProviders.EMAIL,
             type=NotificationSettingTypes.ISSUE_ALERTS,
@@ -431,72 +433,72 @@ class ProjectUpdateTest(APITestCase):
         assert value1 == NotificationSettingOptionValues.NEVER
 
     def test_security_token(self):
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, securityToken="fizzbuzz")
+        resp = self.get_success_response(self.org_slug, self.proj_slug, securityToken="fizzbuzz")
         assert self.project.get_security_token() == "fizzbuzz"
         assert resp.data["securityToken"] == "fizzbuzz"
 
         # can delete
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, securityToken="")
+        resp = self.get_success_response(self.org_slug, self.proj_slug, securityToken="")
         assert self.project.get_security_token() == ""
         assert resp.data["securityToken"] == ""
 
     def test_security_token_header(self):
         value = "X-Hello-World"
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, securityTokenHeader=value)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, securityTokenHeader=value)
         assert self.project.get_option("sentry:token_header") == "X-Hello-World"
         assert resp.data["securityTokenHeader"] == "X-Hello-World"
 
         # can delete
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, securityTokenHeader="")
+        resp = self.get_success_response(self.org_slug, self.proj_slug, securityTokenHeader="")
         assert self.project.get_option("sentry:token_header") == ""
         assert resp.data["securityTokenHeader"] == ""
 
     def test_verify_ssl(self):
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, verifySSL=False)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, verifySSL=False)
         assert self.project.get_option("sentry:verify_ssl") is False
         assert resp.data["verifySSL"] is False
 
     def test_scrub_ip_address(self):
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, scrubIPAddresses=True)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, scrubIPAddresses=True)
         assert self.project.get_option("sentry:scrub_ip_address") is True
         assert resp.data["scrubIPAddresses"] is True
 
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, scrubIPAddresses=False)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, scrubIPAddresses=False)
         assert self.project.get_option("sentry:scrub_ip_address") is False
         assert resp.data["scrubIPAddresses"] is False
 
     def test_scrape_javascript(self):
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, scrapeJavaScript=False)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, scrapeJavaScript=False)
         assert self.project.get_option("sentry:scrape_javascript") is False
         assert resp.data["scrapeJavaScript"] is False
 
     def test_default_environment(self):
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, defaultEnvironment="dev")
+        resp = self.get_success_response(self.org_slug, self.proj_slug, defaultEnvironment="dev")
         assert self.project.get_option("sentry:default_environment") == "dev"
         assert resp.data["defaultEnvironment"] == "dev"
 
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, defaultEnvironment="")
+        resp = self.get_success_response(self.org_slug, self.proj_slug, defaultEnvironment="")
         assert self.project.get_option("sentry:default_environment") == ""
         assert resp.data["defaultEnvironment"] == ""
 
     def test_resolve_age(self):
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, resolveAge=5)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, resolveAge=5)
         assert self.project.get_option("sentry:resolve_age") == 5
         assert resp.data["resolveAge"] == 5
 
         # can set to 0 or delete
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, resolveAge="")
+        resp = self.get_success_response(self.org_slug, self.proj_slug, resolveAge="")
         assert self.project.get_option("sentry:resolve_age") == 0
         assert resp.data["resolveAge"] == 0
 
     def test_allowed_domains(self):
         value = ["foobar.com", "https://example.com"]
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, allowedDomains=value)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, allowedDomains=value)
         assert self.project.get_option("sentry:origins") == ["foobar.com", "https://example.com"]
         assert resp.data["allowedDomains"] == ["foobar.com", "https://example.com"]
 
         # cannot be empty
-        resp = self.get_valid_response(
+        resp = self.get_error_response(
             self.org_slug, self.proj_slug, allowedDomains="", status_code=400
         )
         assert self.project.get_option("sentry:origins") == ["foobar.com", "https://example.com"]
@@ -504,7 +506,7 @@ class ProjectUpdateTest(APITestCase):
             "Empty value will block all requests, use * to accept from all domains"
         ]
 
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             self.org_slug,
             self.proj_slug,
             allowedDomains=["*", ""],
@@ -514,7 +516,7 @@ class ProjectUpdateTest(APITestCase):
 
     def test_safe_fields(self):
         value = ["foobar.com", "https://example.com"]
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, safeFields=value)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, safeFields=value)
         assert self.project.get_option("sentry:safe_fields") == [
             "foobar.com",
             "https://example.com",
@@ -522,7 +524,7 @@ class ProjectUpdateTest(APITestCase):
         assert resp.data["safeFields"] == ["foobar.com", "https://example.com"]
 
     def test_store_crash_reports(self):
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, storeCrashReports=10)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, storeCrashReports=10)
         assert self.project.get_option("sentry:store_crash_reports") == 10
         assert resp.data["storeCrashReports"] == 10
 
@@ -536,13 +538,13 @@ class ProjectUpdateTest(APITestCase):
 
     def test_relay_pii_config(self):
         value = '{"applications": {"freeform": []}}'
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, relayPiiConfig=value)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, relayPiiConfig=value)
         assert self.project.get_option("sentry:relay_pii_config") == value
         assert resp.data["relayPiiConfig"] == value
 
     def test_sensitive_fields(self):
         value = ["foobar.com", "https://example.com"]
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, sensitiveFields=value)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, sensitiveFields=value)
         assert self.project.get_option("sentry:sensitive_fields") == [
             "foobar.com",
             "https://example.com",
@@ -550,34 +552,34 @@ class ProjectUpdateTest(APITestCase):
         assert resp.data["sensitiveFields"] == ["foobar.com", "https://example.com"]
 
     def test_data_scrubber(self):
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, dataScrubber=False)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, dataScrubber=False)
         assert self.project.get_option("sentry:scrub_data") is False
         assert resp.data["dataScrubber"] is False
 
     def test_data_scrubber_defaults(self):
-        resp = self.get_valid_response(self.org_slug, self.proj_slug, dataScrubberDefaults=False)
+        resp = self.get_success_response(self.org_slug, self.proj_slug, dataScrubberDefaults=False)
         assert self.project.get_option("sentry:scrub_defaults") is False
         assert resp.data["dataScrubberDefaults"] is False
 
     def test_digests_delay(self):
-        self.get_valid_response(self.org_slug, self.proj_slug, digestsMinDelay=1000)
+        self.get_success_response(self.org_slug, self.proj_slug, digestsMinDelay=1000)
         assert self.project.get_option("digests:mail:minimum_delay") == 1000
 
-        self.get_valid_response(self.org_slug, self.proj_slug, digestsMaxDelay=1200)
+        self.get_success_response(self.org_slug, self.proj_slug, digestsMaxDelay=1200)
         assert self.project.get_option("digests:mail:maximum_delay") == 1200
 
-        self.get_valid_response(
+        self.get_success_response(
             self.org_slug, self.proj_slug, digestsMinDelay=300, digestsMaxDelay=600
         )
         assert self.project.get_option("digests:mail:minimum_delay") == 300
         assert self.project.get_option("digests:mail:maximum_delay") == 600
 
     def test_digests_min_without_max(self):
-        self.get_valid_response(self.org_slug, self.proj_slug, digestsMinDelay=1200)
+        self.get_success_response(self.org_slug, self.proj_slug, digestsMinDelay=1200)
         assert self.project.get_option("digests:mail:minimum_delay") == 1200
 
     def test_digests_max_without_min(self):
-        self.get_valid_response(self.org_slug, self.proj_slug, digestsMaxDelay=1200)
+        self.get_success_response(self.org_slug, self.proj_slug, digestsMaxDelay=1200)
         assert self.project.get_option("digests:mail:maximum_delay") == 1200
 
     def test_invalid_digests_min_delay(self):
@@ -585,8 +587,8 @@ class ProjectUpdateTest(APITestCase):
 
         self.project.update_option("digests:mail:minimum_delay", min_delay)
 
-        self.get_valid_response(self.org_slug, self.proj_slug, digestsMinDelay=59, status_code=400)
-        self.get_valid_response(
+        self.get_error_response(self.org_slug, self.proj_slug, digestsMinDelay=59, status_code=400)
+        self.get_error_response(
             self.org_slug, self.proj_slug, digestsMinDelay=3601, status_code=400
         )
 
@@ -599,26 +601,26 @@ class ProjectUpdateTest(APITestCase):
         self.project.update_option("digests:mail:minimum_delay", min_delay)
         self.project.update_option("digests:mail:maximum_delay", max_delay)
 
-        self.get_valid_response(self.org_slug, self.proj_slug, digestsMaxDelay=59, status_code=400)
-        self.get_valid_response(
+        self.get_error_response(self.org_slug, self.proj_slug, digestsMaxDelay=59, status_code=400)
+        self.get_error_response(
             self.org_slug, self.proj_slug, digestsMaxDelay=3601, status_code=400
         )
 
         assert self.project.get_option("digests:mail:maximum_delay") == max_delay
 
         # test sending only max
-        self.get_valid_response(self.org_slug, self.proj_slug, digestsMaxDelay=100, status_code=400)
+        self.get_error_response(self.org_slug, self.proj_slug, digestsMaxDelay=100, status_code=400)
         assert self.project.get_option("digests:mail:maximum_delay") == max_delay
 
         # test sending min + invalid max
-        self.get_valid_response(
+        self.get_error_response(
             self.org_slug, self.proj_slug, digestsMinDelay=120, digestsMaxDelay=100, status_code=400
         )
         assert self.project.get_option("digests:mail:minimum_delay") == min_delay
         assert self.project.get_option("digests:mail:maximum_delay") == max_delay
 
     def test_dynamic_sampling_requires_feature_enabled(self):
-        self.get_valid_response(
+        self.get_error_response(
             self.org_slug, self.proj_slug, dynamicSampling=_dyn_sampling_data(), status_code=403
         )
 
@@ -627,7 +629,7 @@ class ProjectUpdateTest(APITestCase):
         Test that we can set sampling rules
         """
         with Feature({"organizations:filters-and-sampling": True}):
-            self.get_valid_response(
+            self.get_success_response(
                 self.org_slug, self.proj_slug, dynamicSampling=_dyn_sampling_data()
             )
         original_config = _dyn_sampling_data()
@@ -651,8 +653,8 @@ class ProjectUpdateTest(APITestCase):
         """
         data = _dyn_sampling_data()
         with Feature({"organizations:filters-and-sampling": True}):
-            self.get_valid_response(self.org_slug, self.proj_slug, dynamicSampling=data)
-            response = self.get_valid_response(self.org_slug, self.proj_slug, method="get")
+            self.get_success_response(self.org_slug, self.proj_slug, dynamicSampling=data)
+            response = self.get_success_response(self.org_slug, self.proj_slug, method="get")
         saved_config = _remove_ids_from_dynamic_rules(response.data["dynamicSampling"])
         original_data = _remove_ids_from_dynamic_rules(data)
         assert saved_config == original_data
@@ -699,8 +701,8 @@ class ProjectUpdateTest(APITestCase):
             ]
         }
         with Feature({"organizations:filters-and-sampling": True}):
-            self.get_valid_response(self.org_slug, self.proj_slug, dynamicSampling=config)
-        response = self.get_valid_response(self.org_slug, self.proj_slug, method="get")
+            self.get_success_response(self.org_slug, self.proj_slug, dynamicSampling=config)
+        response = self.get_success_response(self.org_slug, self.proj_slug, method="get")
         saved_config = response.data["dynamicSampling"]
         next_id = saved_config["next_id"]
         id1 = saved_config["rules"][0]["id"]
@@ -745,8 +747,8 @@ class ProjectUpdateTest(APITestCase):
             # turn it back from ordered dict to dict (both main obj and rules)
             saved_config = dict(saved_config)
             saved_config["rules"] = [dict(rule) for rule in saved_config["rules"]]
-            self.get_valid_response(self.org_slug, self.proj_slug, dynamicSampling=saved_config)
-        response = self.get_valid_response(self.org_slug, self.proj_slug, method="get")
+            self.get_success_response(self.org_slug, self.proj_slug, dynamicSampling=saved_config)
+        response = self.get_success_response(self.org_slug, self.proj_slug, method="get")
         saved_config = response.data["dynamicSampling"]
         new_ids = [rule["id"] for rule in saved_config["rules"]]
         # first rule is new, second rule got a new id because it is changed,
@@ -762,20 +764,20 @@ class ProjectUpdateTest(APITestCase):
         assert response.status_code == 400
 
         expiry = int(now + 3600 * 24 * 1)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.org_slug, self.proj_slug, secondaryGroupingExpiry=expiry
         )
         assert response.data["secondaryGroupingExpiry"] == expiry
 
         expiry = int(now + 3600 * 24 * 89)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.org_slug, self.proj_slug, secondaryGroupingExpiry=expiry
         )
         assert response.data["secondaryGroupingExpiry"] == expiry
 
         # Larger timestamps are capped to 91 days:
         expiry = int(now + 3600 * 24 * 365)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.org_slug, self.proj_slug, secondaryGroupingExpiry=expiry
         )
         expiry = response.data["secondaryGroupingExpiry"]
@@ -798,7 +800,7 @@ class ProjectUpdateTest(APITestCase):
                 "username": "honkhonk",
                 "password": "beepbeep",
             }
-            self.get_valid_response(
+            self.get_success_response(
                 self.org_slug, self.proj_slug, symbolSources=json.dumps([config])
             )
             config["id"] = first_symbol_source_id(self.project.get_option("sentry:symbol_sources"))
@@ -814,7 +816,7 @@ class ProjectUpdateTest(APITestCase):
             call = faux.faux(create_audit_entry)
             assert call.kwarg_equals("data", {"sentry:symbol_sources": [redacted_source]})
 
-            self.get_valid_response(
+            self.get_success_response(
                 self.org_slug, self.proj_slug, symbolSources=json.dumps([redacted_source])
             )
             # on save the magic object should be replaced with the previously set password
@@ -837,7 +839,7 @@ class ProjectUpdateTest(APITestCase):
                 "username": "honkhonk",
                 "password": "beepbeep",
             }
-            self.get_valid_response(
+            self.get_success_response(
                 self.org_slug, self.proj_slug, symbolSources=json.dumps([config])
             )
             config["id"] = first_symbol_source_id(self.project.get_option("sentry:symbol_sources"))
@@ -990,7 +992,7 @@ class CopyProjectSettingsTest(APITestCase):
 
     def test_simple(self):
         project = self.create_project()
-        self.get_valid_response(
+        self.get_success_response(
             project.organization.slug, project.slug, copy_from_project=self.other_project.id
         )
         self.assert_settings_copied(project)
@@ -1005,7 +1007,7 @@ class CopyProjectSettingsTest(APITestCase):
             "sentry:scrub_data": True,
             "sentry:scrub_defaults": True,
         }
-        self.get_valid_response(project.organization.slug, project.slug, **data)
+        self.get_success_response(project.organization.slug, project.slug, **data)
         self.assert_settings_copied(project)
         self.assert_other_project_settings_not_changed()
 
@@ -1014,7 +1016,7 @@ class CopyProjectSettingsTest(APITestCase):
         other_project = self.create_project(
             organization=self.create_organization(), fire_project_created=True
         )
-        resp = self.get_valid_response(
+        resp = self.get_error_response(
             project.organization.slug,
             project.slug,
             copy_from_project=other_project.id,
@@ -1026,7 +1028,7 @@ class CopyProjectSettingsTest(APITestCase):
 
     def test_project_does_not_exist(self):
         project = self.create_project(fire_project_created=True)
-        resp = self.get_valid_response(
+        resp = self.get_error_response(
             project.organization.slug, project.slug, copy_from_project=1234567890, status_code=400
         )
         assert resp.data == {"copy_from_project": ["Project to copy settings from not found."]}
@@ -1043,7 +1045,7 @@ class CopyProjectSettingsTest(APITestCase):
 
         self.organization.flags.allow_joinleave = False
         self.organization.save()
-        resp = self.get_valid_response(
+        resp = self.get_error_response(
             project.organization.slug,
             project.slug,
             copy_from_project=self.other_project.id,
@@ -1074,7 +1076,7 @@ class CopyProjectSettingsTest(APITestCase):
         self.organization.flags.allow_joinleave = False
         self.organization.save()
 
-        resp = self.get_valid_response(
+        resp = self.get_error_response(
             project.organization.slug,
             project.slug,
             copy_from_project=self.other_project.id,
@@ -1093,7 +1095,7 @@ class CopyProjectSettingsTest(APITestCase):
     def test_copy_project_settings_fails(self, mock_copy_settings_from):
         mock_copy_settings_from.return_value = False
         project = self.create_project(fire_project_created=True)
-        resp = self.get_valid_response(
+        resp = self.get_error_response(
             project.organization.slug,
             project.slug,
             copy_from_project=self.other_project.id,
@@ -1116,7 +1118,7 @@ class ProjectDeleteTest(APITestCase):
         self.login_as(user=self.user)
 
         with self.settings(SENTRY_PROJECT=0):
-            self.get_valid_response(project.organization.slug, project.slug, status_code=204)
+            self.get_success_response(project.organization.slug, project.slug, status_code=204)
 
         assert ScheduledDeletion.objects.filter(model_name="Project", object_id=project.id).exists()
 
@@ -1136,7 +1138,7 @@ class ProjectDeleteTest(APITestCase):
         self.login_as(user=self.user)
 
         with self.settings(SENTRY_PROJECT=project.id):
-            self.get_valid_response(project.organization.slug, project.slug, status_code=403)
+            self.get_error_response(project.organization.slug, project.slug, status_code=403)
 
         assert not ScheduledDeletion.objects.filter(
             model_name="Project", object_id=project.id

--- a/tests/sentry/api/endpoints/test_project_filter_details.py
+++ b/tests/sentry/api/endpoints/test_project_filter_details.py
@@ -15,7 +15,7 @@ class ProjectFilterDetailsTest(APITestCase):
         project = self.create_project(name="Bar", slug="bar", teams=[team])
 
         project.update_option("filters:browser-extensions", "0")
-        self.get_valid_response(
+        self.get_success_response(
             org.slug, project.slug, "browser-extensions", active=True, status_code=201
         )
 

--- a/tests/sentry/api/endpoints/test_project_filters.py
+++ b/tests/sentry/api/endpoints/test_project_filters.py
@@ -14,6 +14,6 @@ class ProjectFiltersTest(APITestCase):
         project = self.create_project(name="Bar", slug="bar", teams=[team])
 
         project.update_option("filters:browser-extension", "0")
-        response = self.get_valid_response(org.slug, project.slug)
+        response = self.get_success_response(org.slug, project.slug)
 
         self.insta_snapshot(response.data)

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -20,7 +20,7 @@ class ProjectsListTest(APITestCase):
 
         self.login_as(user=user, superuser=True)
 
-        response = self.get_valid_response()
+        response = self.get_success_response()
         assert len(response.data) == 1
 
         assert response.data[0]["id"] == str(project.id)
@@ -38,7 +38,7 @@ class ProjectsListTest(APITestCase):
         self.create_project(organization=org2)
 
         self.login_as(user=user, superuser=True)
-        response = self.get_valid_response(qs_params={"show": "all"})
+        response = self.get_success_response(qs_params={"show": "all"})
         assert len(response.data) == 2
 
     def test_show_all_without_superuser(self):
@@ -53,7 +53,7 @@ class ProjectsListTest(APITestCase):
         self.create_project(organization=org2)
 
         self.login_as(user=user)
-        response = self.get_valid_response()
+        response = self.get_success_response()
         assert len(response.data) == 0
 
     def test_status_filter(self):
@@ -67,11 +67,11 @@ class ProjectsListTest(APITestCase):
 
         self.login_as(user=user)
 
-        response = self.get_valid_response(qs_params={"status": "active"})
+        response = self.get_success_response(qs_params={"status": "active"})
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(project1.id)
 
-        response = self.get_valid_response(qs_params={"status": "deleted"})
+        response = self.get_success_response(qs_params={"status": "deleted"})
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(project2.id)
 
@@ -86,11 +86,11 @@ class ProjectsListTest(APITestCase):
 
         self.login_as(user=user)
 
-        response = self.get_valid_response(qs_params={"query": "foo"})
+        response = self.get_success_response(qs_params={"query": "foo"})
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(project1.id)
 
-        response = self.get_valid_response(qs_params={"query": "baz"})
+        response = self.get_success_response(qs_params={"query": "baz"})
         assert len(response.data) == 0
 
     def test_slug_query(self):
@@ -104,11 +104,11 @@ class ProjectsListTest(APITestCase):
 
         self.login_as(user=user)
 
-        response = self.get_valid_response(qs_params={"query": "slug:foo"})
+        response = self.get_success_response(qs_params={"query": "slug:foo"})
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(project1.id)
 
-        response = self.get_valid_response(qs_params={"query": "slug:baz"})
+        response = self.get_success_response(qs_params={"query": "slug:baz"})
         assert len(response.data) == 0
 
     def test_id_query(self):
@@ -122,11 +122,11 @@ class ProjectsListTest(APITestCase):
 
         self.login_as(user=user)
 
-        response = self.get_valid_response(qs_params={"query": f"id:{project1.id}"})
+        response = self.get_success_response(qs_params={"query": f"id:{project1.id}"})
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(project1.id)
 
-        response = self.get_valid_response(qs_params={"query": "id:-1"})
+        response = self.get_success_response(qs_params={"query": "id:-1"})
         assert len(response.data) == 0
 
     def test_valid_with_internal_integration(self):

--- a/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
+++ b/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
@@ -49,7 +49,7 @@ class ProjectIssuesResolvedInReleaseEndpointTest(APITestCase):
         )
 
     def run_test(self, expected_groups):
-        response = self.get_valid_response(self.org.slug, self.project.slug, self.release.version)
+        response = self.get_success_response(self.org.slug, self.project.slug, self.release.version)
         assert len(response.data) == len(expected_groups)
         expected = set(map(str, [g.id for g in expected_groups]))
         assert {item["id"] for item in response.data} == expected

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -21,7 +21,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         project1 = self.create_project(teams=[team], name="foo")
         self.create_project(teams=[team], name="baz")
 
-        response = self.get_valid_response(self.organization.slug, project1.slug)
+        response = self.get_success_response(self.organization.slug, project1.slug)
         assert len(response.data["actions"]) == 7
         assert len(response.data["conditions"]) == 7
         assert len(response.data["filters"]) == 7
@@ -45,7 +45,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         if not rules:
             rules = self.rules
         with patch("sentry.api.endpoints.project_rules_configuration.rules", rules):
-            response = self.get_valid_response(
+            response = self.get_success_response(
                 self.organization.slug, self.project.slug, qs_params=querystring_params
             )
 
@@ -86,7 +86,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         self.run_mock_rules_test(0, {}, rules=rules)
 
     def test_available_actions(self):
-        response = self.get_valid_response(self.organization.slug, self.project.slug)
+        response = self.get_success_response(self.organization.slug, self.project.slug)
 
         action_ids = [action["id"] for action in response.data["actions"]]
         assert EMAIL_ACTION in action_ids
@@ -94,7 +94,7 @@ class ProjectRuleConfigurationTest(APITestCase):
 
     def test_ticket_rules_not_in_available_actions(self):
         with self.feature({"organizations:integrations-ticket-rules": False}):
-            response = self.get_valid_response(self.organization.slug, self.project.slug)
+            response = self.get_success_response(self.organization.slug, self.project.slug)
             action_ids = [action["id"] for action in response.data["actions"]]
             assert EMAIL_ACTION in action_ids
             assert JIRA_ACTION not in action_ids
@@ -112,7 +112,7 @@ class ProjectRuleConfigurationTest(APITestCase):
             slug=sentry_app.slug, organization=self.organization, user=self.user
         )
 
-        response = self.get_valid_response(self.organization.slug, project1.slug)
+        response = self.get_success_response(self.organization.slug, project1.slug)
 
         assert len(response.data["actions"]) == 8
         assert {
@@ -142,7 +142,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         install = self.create_sentry_app_installation(
             slug=sentry_app.slug, organization=self.organization, user=self.user
         )
-        response = self.get_valid_response(self.organization.slug, project1.slug)
+        response = self.get_success_response(self.organization.slug, project1.slug)
 
         assert len(response.data["actions"]) == 8
         assert {

--- a/tests/sentry/api/endpoints/test_project_team_details.py
+++ b/tests/sentry/api/endpoints/test_project_team_details.py
@@ -17,14 +17,16 @@ class ProjectTeamDetailsPostTest(ProjectTeamDetailsTest):
         project = self.create_project()
         team = self.create_team()
 
-        self.get_valid_response(project.organization.slug, project.slug, team.slug, status_code=201)
+        self.get_success_response(
+            project.organization.slug, project.slug, team.slug, status_code=201
+        )
 
         assert ProjectTeam.objects.filter(project=project, team=team).exists()
 
     def test_add_team_not_found(self):
         project = self.create_project()
 
-        self.get_valid_response(
+        self.get_success_response(
             project.organization.slug, project.slug, "not-a-team", status_code=404
         )
 
@@ -54,7 +56,7 @@ class ProjectTeamDetailsDeleteTest(ProjectTeamDetailsTest):
 
         assert r1.owner == r2.owner == ar1.owner == ar2.owner == team.actor
 
-        self.get_valid_response(project.organization.slug, project.slug, team.slug)
+        self.get_success_response(project.organization.slug, project.slug, team.slug)
         assert not ProjectTeam.objects.filter(project=project, team=team).exists()
 
         r1.refresh_from_db()
@@ -65,7 +67,7 @@ class ProjectTeamDetailsDeleteTest(ProjectTeamDetailsTest):
         assert r1.owner == ar1.owner is None
         assert r2.owner == ar2.owner == team.actor
 
-        self.get_valid_response(project.organization.slug, another_project.slug, team.slug)
+        self.get_success_response(project.organization.slug, another_project.slug, team.slug)
 
         r1.refresh_from_db()
         r2.refresh_from_db()
@@ -77,6 +79,6 @@ class ProjectTeamDetailsDeleteTest(ProjectTeamDetailsTest):
     def test_remove_team_not_found(self):
         project = self.create_project()
 
-        self.get_valid_response(
+        self.get_success_response(
             project.organization.slug, project.slug, "not-a-team", status_code=404
         )

--- a/tests/sentry/api/endpoints/test_project_team_details.py
+++ b/tests/sentry/api/endpoints/test_project_team_details.py
@@ -26,7 +26,7 @@ class ProjectTeamDetailsPostTest(ProjectTeamDetailsTest):
     def test_add_team_not_found(self):
         project = self.create_project()
 
-        self.get_success_response(
+        self.get_error_response(
             project.organization.slug, project.slug, "not-a-team", status_code=404
         )
 
@@ -79,6 +79,6 @@ class ProjectTeamDetailsDeleteTest(ProjectTeamDetailsTest):
     def test_remove_team_not_found(self):
         project = self.create_project()
 
-        self.get_success_response(
+        self.get_error_response(
             project.organization.slug, project.slug, "not-a-team", status_code=404
         )

--- a/tests/sentry/api/endpoints/test_project_teams.py
+++ b/tests/sentry/api/endpoints/test_project_teams.py
@@ -12,7 +12,7 @@ class ProjectTeamsTest(APITestCase):
         team = self.create_team()
         project = self.create_project(teams=[team])
 
-        response = self.get_valid_response(project.organization.slug, project.slug)
+        response = self.get_success_response(project.organization.slug, project.slug)
 
         assert len(response.data) == 1
         assert response.data[0]["slug"] == team.slug

--- a/tests/sentry/api/endpoints/test_project_user_details.py
+++ b/tests/sentry/api/endpoints/test_project_user_details.py
@@ -18,7 +18,7 @@ class ProjectUserDetailsTest(APITestCase):
 
     def test_simple(self):
         self.login_as(user=self.user)
-        response = self.get_valid_response(self.org.slug, self.project.slug, self.euser.hash)
+        response = self.get_success_response(self.org.slug, self.project.slug, self.euser.hash)
         assert response.data["id"] == str(self.euser.id)
 
     def test_delete_event_user(self):

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -31,7 +31,7 @@ class SentryAppComponentsTest(APITestCase):
         self.login_as(user=self.user)
 
     def test_retrieves_all_components(self):
-        response = self.get_valid_response(self.sentry_app.slug)
+        response = self.get_success_response(self.sentry_app.slug)
 
         assert response.data[0] == {
             "uuid": str(self.component.uuid),
@@ -88,7 +88,9 @@ class OrganizationSentryAppComponentsTest(APITestCase):
 
     @patch("sentry.mediators.sentry_app_components.Preparer.run")
     def test_retrieves_all_components_for_installed_apps(self, run):
-        response = self.get_valid_response(self.org.slug, qs_params={"projectId": self.project.id})
+        response = self.get_success_response(
+            self.org.slug, qs_params={"projectId": self.project.id}
+        )
 
         assert self.component3.uuid not in [d["uuid"] for d in response.data]
         components = {d["uuid"]: d for d in response.data}
@@ -142,7 +144,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
 
         component = sentry_app.components.first()
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             self.org.slug, qs_params={"projectId": self.project.id, "filter": "alert-rule"}
         )
 
@@ -162,7 +164,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
 
     @patch("sentry.mediators.sentry_app_components.Preparer.run")
     def test_prepares_each_component(self, run):
-        self.get_valid_response(self.org.slug, qs_params={"projectId": self.project.id})
+        self.get_success_response(self.org.slug, qs_params={"projectId": self.project.id})
 
         calls = [
             call(component=self.component1, install=self.install1, project=self.project),
@@ -175,7 +177,9 @@ class OrganizationSentryAppComponentsTest(APITestCase):
     def test_component_prep_errors_are_isolated(self, run):
         run.side_effect = [APIError(), self.component2]
 
-        response = self.get_valid_response(self.org.slug, qs_params={"projectId": self.project.id})
+        response = self.get_success_response(
+            self.org.slug, qs_params={"projectId": self.project.id}
+        )
 
         # Does not include self.component1 data, because it raised an exception
         # during preparation.

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_details.py
@@ -31,11 +31,11 @@ class SentryAppInstallationExternalIssueDetailsEndpointTest(APITestCase):
 
     def test_deletes_external_issue(self):
         assert PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()
-        self.get_valid_response(self.install.uuid, self.external_issue.id, status_code=204)
+        self.get_success_response(self.install.uuid, self.external_issue.id, status_code=204)
         assert not PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()
 
     def test_handles_non_existing_external_issue(self):
-        self.get_valid_response(self.install.uuid, 999999, status_code=404)
+        self.get_error_response(self.install.uuid, 999999, status_code=404)
 
     def test_handles_issue_from_wrong_org(self):
         """
@@ -55,5 +55,5 @@ class SentryAppInstallationExternalIssueDetailsEndpointTest(APITestCase):
             organization=evil_org, slug=evil_sentry_app.slug, user=evil_user
         )
 
-        self.get_valid_response(evil_install.uuid, self.external_issue.id, status_code=404)
+        self.get_error_response(evil_install.uuid, self.external_issue.id, status_code=404)
         assert PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -58,7 +58,7 @@ class TeamDetailsTest(TeamDetailsTestBase):
     def test_simple(self):
         team = self.team  # force creation
 
-        response = self.get_valid_response(team.organization.slug, team.slug)
+        response = self.get_success_response(team.organization.slug, team.slug)
         assert response.data["id"] == str(team.id)
 
 
@@ -68,7 +68,7 @@ class TeamUpdateTest(TeamDetailsTestBase):
     def test_simple(self):
         team = self.team  # force creation
 
-        self.get_valid_response(
+        self.get_success_response(
             team.organization.slug, team.slug, name="hello world", slug="foobar"
         )
 
@@ -90,7 +90,7 @@ class TeamDeleteTest(TeamDetailsTestBase):
 
         self.login_as(admin_user)
 
-        self.get_valid_response(team.organization.slug, team.slug, status_code=204)
+        self.get_success_response(team.organization.slug, team.slug, status_code=204)
 
         original_slug = team.slug
         team.refresh_from_db()
@@ -107,7 +107,7 @@ class TeamDeleteTest(TeamDetailsTestBase):
 
         self.login_as(admin_user)
 
-        self.get_valid_response(team.organization.slug, team.slug, status_code=204)
+        self.get_success_response(team.organization.slug, team.slug, status_code=204)
 
         team.refresh_from_db()
         self.assert_team_deleted(team.id)
@@ -131,14 +131,14 @@ class TeamDeleteTest(TeamDetailsTestBase):
         self.login_as(admin_user)
 
         # first, try deleting the team with open membership off
-        self.get_valid_response(team.organization.slug, team.slug, status_code=403)
+        self.get_error_response(team.organization.slug, team.slug, status_code=403)
         self.assert_team_not_deleted(team.id)
 
         # now, with open membership on
         org.flags.allow_joinleave = True
         org.save()
 
-        self.get_valid_response(team.organization.slug, team.slug, status_code=204)
+        self.get_success_response(team.organization.slug, team.slug, status_code=204)
         self.assert_team_deleted(team.id)
 
     def test_cannot_remove_as_member(self):
@@ -157,5 +157,5 @@ class TeamDeleteTest(TeamDetailsTestBase):
 
         self.login_as(member_user)
 
-        self.get_valid_response(team.organization.slug, team.slug, status_code=403)
+        self.get_error_response(team.organization.slug, team.slug, status_code=403)
         self.assert_team_not_deleted(team.id)

--- a/tests/sentry/api/endpoints/test_team_release_count.py
+++ b/tests/sentry/api/endpoints/test_team_release_count.py
@@ -48,7 +48,7 @@ class TeamReleaseCountTest(APITestCase):
             organization_id=org.id, version="5", date_added=before_now(days=5)
         )
         release5.add_project(project3)
-        response = self.get_valid_response(org.slug, team1.slug)
+        response = self.get_success_response(org.slug, team1.slug)
 
         assert len(response.data) == 3
         assert len(response.data["release_counts"]) == 90
@@ -63,7 +63,7 @@ class TeamReleaseCountTest(APITestCase):
 
         release4.add_project(project1)  # up the last week total for project1 by 1
 
-        response = self.get_valid_response(org.slug, team1.slug)
+        response = self.get_success_response(org.slug, team1.slug)
         assert len(response.data) == 3
         assert len(response.data["release_counts"]) == 90
         assert len(response.data["project_avgs"]) == 2
@@ -92,7 +92,7 @@ class TeamReleaseCountTest(APITestCase):
         release1.add_project(project1)
         release1.add_project(project2)
 
-        response = self.get_valid_response(org.slug, team1.slug)
+        response = self.get_success_response(org.slug, team1.slug)
 
         assert project2.id not in response.data["project_avgs"]
 
@@ -139,7 +139,7 @@ class TeamReleaseCountTest(APITestCase):
             organization_id=org.id, version="5", date_added=before_now(days=5)
         )
         release5.add_project(project3)
-        response = self.get_valid_response(org.slug, team1.slug)
+        response = self.get_success_response(org.slug, team1.slug)
 
         assert len(response.data) == 3
         assert len(response.data["release_counts"]) == 90

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -22,10 +22,10 @@ class UserDetailsGetTest(UserDetailsTest):
     # TODO(dcramer): theres currently no way to look up other users
     def test_look_up_other_user(self):
         user2 = self.create_user(email="b@example.com")
-        self.get_valid_response(user2.id, status_code=403)
+        self.get_error_response(user2.id, status_code=403)
 
     def test_lookup_self(self):
-        resp = self.get_valid_response("me")
+        resp = self.get_success_response("me")
 
         assert resp.data["id"] == str(self.user.id)
         assert resp.data["options"]["theme"] == "light"
@@ -38,7 +38,7 @@ class UserDetailsGetTest(UserDetailsTest):
         superuser = self.create_user(email="b@example.com", is_superuser=True)
         self.login_as(user=superuser, superuser=True)
 
-        resp = self.get_valid_response(self.user.id)
+        resp = self.get_success_response(self.user.id)
 
         assert resp.data["id"] == str(self.user.id)
         assert "identities" in resp.data
@@ -49,7 +49,7 @@ class UserDetailsGetTest(UserDetailsTest):
         self.add_user_permission(superuser, "users.admin")
         self.login_as(user=superuser, superuser=True)
 
-        resp = self.get_valid_response(superuser.id)
+        resp = self.get_success_response(superuser.id)
 
         assert resp.data["id"] == str(superuser.id)
         assert "permissions" in resp.data
@@ -58,7 +58,7 @@ class UserDetailsGetTest(UserDetailsTest):
         role = UserRole.objects.create(name="test", permissions=["broadcasts.admin"])
         role.users.add(superuser)
 
-        resp = self.get_valid_response(superuser.id)
+        resp = self.get_success_response(superuser.id)
         assert resp.data["permissions"] == ["broadcasts.admin", "users.admin"]
 
 
@@ -66,7 +66,7 @@ class UserDetailsUpdateTest(UserDetailsTest):
     method = "put"
 
     def test_simple(self):
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             "me",
             name="hello world",
             options={
@@ -109,7 +109,7 @@ class UserDetailsUpdateTest(UserDetailsTest):
     def test_managed_fields(self):
         assert self.user.name == "example name"
         with self.settings(SENTRY_MANAGED_USER_FIELDS=("name",)):
-            self.get_valid_response("me", name="new name")
+            self.get_success_response("me", name="new name")
 
             # name remains unchanged
             user = User.objects.get(id=self.user.id)
@@ -120,7 +120,7 @@ class UserDetailsUpdateTest(UserDetailsTest):
         user = self.create_user(email="c@example.com", username="diff@example.com")
         self.login_as(user=user, superuser=False)
 
-        self.get_valid_response("me", username="new@example.com")
+        self.get_success_response("me", username="new@example.com")
 
         user = User.objects.get(id=user.id)
 
@@ -133,7 +133,7 @@ class UserDetailsUpdateTest(UserDetailsTest):
         user = self.create_user(email="c@example.com", username="c@example.com")
         self.login_as(user=user)
 
-        self.get_valid_response("me", username="new@example.com")
+        self.get_success_response("me", username="new@example.com")
 
         user = User.objects.get(id=user.id)
 
@@ -148,7 +148,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
         superuser = self.create_user(email="b@example.com", is_superuser=True)
         self.login_as(user=superuser, superuser=True)
 
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             self.user.id,
             isActive="false",
         )
@@ -162,7 +162,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
         UserPermission.objects.create(user=superuser, permission="users.admin")
         self.login_as(user=superuser, superuser=True)
 
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             self.user.id,
             isActive="false",
         )
@@ -175,7 +175,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
         superuser = self.create_user(email="b@example.com", is_superuser=True)
         self.login_as(user=superuser, superuser=True)
 
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             self.user.id,
             isSuperuser="true",
         )
@@ -189,7 +189,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
         superuser = self.create_user(email="b@example.com", is_superuser=True)
         self.login_as(user=superuser, superuser=True)
 
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             self.user.id,
             isStaff="true",
         )
@@ -203,7 +203,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
         UserPermission.objects.create(user=superuser, permission="users.admin")
         self.login_as(user=superuser, superuser=True)
 
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             self.user.id,
             isSuperuser="true",
         )
@@ -217,7 +217,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
         UserPermission.objects.create(user=superuser, permission="users.admin")
         self.login_as(user=superuser, superuser=True)
 
-        resp = self.get_valid_response(
+        resp = self.get_success_response(
             self.user.id,
             isStaff="true",
         )
@@ -241,11 +241,11 @@ class UserDetailsDeleteTest(UserDetailsTest):
         self.create_member(user=self.user, organization=org_as_other_owner, role="owner")
 
         # test validations
-        self.get_valid_response(self.user.id, status_code=400)
-        self.get_valid_response(self.user.id, organizations=None, status_code=400)
+        self.get_error_response(self.user.id, status_code=400)
+        self.get_error_response(self.user.id, organizations=None, status_code=400)
 
         # test actual delete
-        self.get_valid_response(
+        self.get_success_response(
             self.user.id,
             organizations=[
                 org_with_other_owner.slug,
@@ -286,7 +286,7 @@ class UserDetailsDeleteTest(UserDetailsTest):
         self.create_member(user=user2, organization=org_with_other_owner, role="owner")
         self.create_member(user=self.user, organization=org_as_other_owner, role="owner")
 
-        self.get_valid_response(self.user.id, organizations=[], status_code=204)
+        self.get_success_response(self.user.id, organizations=[], status_code=204)
 
         # deletes org_single_owner even though it wasn't specified in array
         # because it has a single owner
@@ -302,19 +302,19 @@ class UserDetailsDeleteTest(UserDetailsTest):
 
     def test_cannot_hard_delete_self(self):
         # Cannot hard delete your own account
-        self.get_valid_response(self.user.id, hardDelete=True, organizations=[], status_code=403)
+        self.get_error_response(self.user.id, hardDelete=True, organizations=[], status_code=403)
 
     def test_hard_delete_account_without_permission(self):
         self.user.update(is_superuser=True)
         user2 = self.create_user(email="user2@example.com")
 
         # failed authorization, user does not have permissions to delete another user
-        self.get_valid_response(user2.id, hardDelete=True, organizations=[], status_code=403)
+        self.get_error_response(user2.id, hardDelete=True, organizations=[], status_code=403)
 
         # Reauthenticate as super user to hard delete an account
         self.login_as(user=self.user, superuser=True)
 
-        self.get_valid_response(user2.id, hardDelete=True, organizations=[], status_code=403)
+        self.get_error_response(user2.id, hardDelete=True, organizations=[], status_code=403)
 
         assert User.objects.filter(id=user2.id).exists()
 
@@ -323,12 +323,12 @@ class UserDetailsDeleteTest(UserDetailsTest):
         user2 = self.create_user(email="user2@example.com")
 
         # failed authorization, user does not have permissions to delete another user
-        self.get_valid_response(user2.id, hardDelete=True, organizations=[], status_code=403)
+        self.get_error_response(user2.id, hardDelete=True, organizations=[], status_code=403)
 
         # Reauthenticate as super user to hard delete an account
         UserPermission.objects.create(user=self.user, permission="users.admin")
         self.login_as(user=self.user, superuser=True)
 
-        self.get_valid_response(user2.id, hardDelete=True, organizations=[], status_code=204)
+        self.get_success_response(user2.id, hardDelete=True, organizations=[], status_code=204)
 
         assert not User.objects.filter(id=user2.id).exists()

--- a/tests/sentry/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/api/endpoints/test_user_emails_confirm.py
@@ -17,7 +17,7 @@ class UserEmailsConfirmTest(APITestCase):
         email = UserEmail.objects.create(email="bar@example.com", is_verified=False, user=self.user)
         email.save()
 
-        self.get_valid_response(self.user.id, email="bar@example.com", status_code=204)
+        self.get_success_response(self.user.id, email="bar@example.com", status_code=204)
         send_confirm_email.assert_called_once_with(UserEmail.objects.get(email="bar@example.com"))
 
     @mock.patch("sentry.models.User.send_confirm_email_singular")
@@ -25,7 +25,7 @@ class UserEmailsConfirmTest(APITestCase):
         email = UserEmail.objects.create(email="Bar@example.com", is_verified=False, user=self.user)
         email.save()
 
-        self.get_valid_response(self.user.id, email="Bar@example.com", status_code=204)
+        self.get_success_response(self.user.id, email="Bar@example.com", status_code=204)
         send_confirm_email.assert_called_once_with(UserEmail.objects.get(email="Bar@example.com"))
 
     @mock.patch("sentry.models.User.send_confirm_email_singular")
@@ -33,10 +33,10 @@ class UserEmailsConfirmTest(APITestCase):
         email = UserEmail.objects.create(email="bar@example.com", is_verified=True, user=self.user)
         email.save()
 
-        self.get_valid_response(self.user.id, email="bar@example.com", status_code=400)
+        self.get_error_response(self.user.id, email="bar@example.com", status_code=400)
         assert send_confirm_email.call_count == 0
 
     @mock.patch("sentry.models.User.send_confirm_email_singular")
     def test_validate_email(self, send_confirm_email):
-        self.get_valid_response(self.user.id, email="", status_code=400)
+        self.get_error_response(self.user.id, email="", status_code=400)
         assert send_confirm_email.call_count == 0

--- a/tests/sentry/api/endpoints/test_user_identity.py
+++ b/tests/sentry/api/endpoints/test_user_identity.py
@@ -20,5 +20,5 @@ class UserIdentityTest(APITestCase):
             scopes=[],
         )
 
-        response = self.get_valid_response(self.user.id)
+        response = self.get_success_response(self.user.id)
         assert response.data[0]["identityProvider"]["type"] == "slack"

--- a/tests/sentry/api/endpoints/test_user_identity_details.py
+++ b/tests/sentry/api/endpoints/test_user_identity_details.py
@@ -20,6 +20,6 @@ class DeleteUserIdentityTest(APITestCase):
             user=self.user,
         )
 
-        self.get_valid_response(self.user.id, auth_identity.id, status_code=204)
+        self.get_success_response(self.user.id, auth_identity.id, status_code=204)
 
         assert not AuthIdentity.objects.filter(id=auth_identity.id).exists()

--- a/tests/sentry/api/endpoints/test_user_index.py
+++ b/tests/sentry/api/endpoints/test_user_index.py
@@ -14,41 +14,41 @@ class UserListTest(APITestCase):
 
     def test_superuser_only(self):
         self.login_as(self.normal_user)
-        self.get_valid_response(status_code=403)
+        self.get_error_response(status_code=403)
 
     def test_simple(self):
-        response = self.get_valid_response()
+        response = self.get_success_response()
         assert len(response.data) == 2
 
     def test_generic_query(self):
-        response = self.get_valid_response(qs_params={"query": "@example.com"})
+        response = self.get_success_response(qs_params={"query": "@example.com"})
         assert len(response.data) == 2
 
-        response = self.get_valid_response(qs_params={"query": "bar"})
+        response = self.get_success_response(qs_params={"query": "bar"})
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(self.superuser.id)
 
-        response = self.get_valid_response(qs_params={"query": "foobar"})
+        response = self.get_success_response(qs_params={"query": "foobar"})
         assert len(response.data) == 0
 
     def test_superuser_query(self):
-        response = self.get_valid_response(qs_params={"query": "is:superuser"})
+        response = self.get_success_response(qs_params={"query": "is:superuser"})
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(self.superuser.id)
 
     def test_email_query(self):
-        response = self.get_valid_response(qs_params={"query": "email:bar@example.com"})
+        response = self.get_success_response(qs_params={"query": "email:bar@example.com"})
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(self.superuser.id)
 
-        response = self.get_valid_response(qs_params={"query": "email:foobar"})
+        response = self.get_success_response(qs_params={"query": "email:foobar"})
         assert len(response.data) == 0
 
     def test_basic_query(self):
         UserPermission.objects.create(user=self.superuser, permission="broadcasts.admin")
 
-        response = self.get_valid_response(qs_params={"query": "permission:broadcasts.admin"})
+        response = self.get_success_response(qs_params={"query": "permission:broadcasts.admin"})
         assert len(response.data) == 1
 
-        response = self.get_valid_response(qs_params={"query": "permission:foobar"})
+        response = self.get_success_response(qs_params={"query": "permission:foobar"})
         assert len(response.data) == 0

--- a/tests/sentry/api/endpoints/test_user_ips.py
+++ b/tests/sentry/api/endpoints/test_user_ips.py
@@ -29,7 +29,7 @@ class UserEmailsTest(APITestCase):
             last_seen=datetime(2013, 4, 10, 3, 29, 45, tzinfo=timezone.utc),
         )
 
-        response = self.get_valid_response("me")
+        response = self.get_success_response("me")
         assert len(response.data) == 2
 
         assert response.data[0]["ipAddress"] == "127.0.0.1"

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -13,18 +13,18 @@ class UserNotificationDetailsTestBase(APITestCase):
 
 class UserNotificationDetailsGetTest(UserNotificationDetailsTestBase):
     def test_lookup_self(self):
-        self.get_valid_response("me")
+        self.get_success_response("me")
 
     def test_lookup_other_user(self):
         user_b = self.create_user(email="b@example.com")
-        self.get_valid_response(user_b.id, status_code=403)
+        self.get_error_response(user_b.id, status_code=403)
 
     def test_superuser(self):
         superuser = self.create_user(email="b@example.com", is_superuser=True)
 
         self.login_as(user=superuser, superuser=True)
 
-        self.get_valid_response(self.user.id)
+        self.get_success_response(self.user.id)
 
     def test_returns_correct_defaults(self):
         """
@@ -49,7 +49,7 @@ class UserNotificationDetailsGetTest(UserNotificationDetailsTestBase):
             organization=self.organization,
         )
 
-        response = self.get_valid_response("me")
+        response = self.get_success_response("me")
 
         assert response.data.get("deployNotifications") == 3
         assert response.data.get("personalActivityNotifications") is False
@@ -69,7 +69,7 @@ class UserNotificationDetailsGetTest(UserNotificationDetailsTestBase):
             user=self.user,
         )
 
-        response = self.get_valid_response("me")
+        response = self.get_success_response("me")
         assert response.data.get("subscribeByDefault") is False
 
 
@@ -82,7 +82,7 @@ class UserNotificationDetailsPutTest(UserNotificationDetailsTestBase):
             "personalActivityNotifications": True,
             "selfAssignOnResolve": True,
         }
-        response = self.get_valid_response("me", **data)
+        response = self.get_success_response("me", **data)
 
         assert response.data.get("deployNotifications") == 2
         assert response.data.get("personalActivityNotifications") is True
@@ -106,7 +106,7 @@ class UserNotificationDetailsPutTest(UserNotificationDetailsTestBase):
             organization=self.organization,
         )
 
-        response = self.get_valid_response("me", **{"deployNotifications": 2})
+        response = self.get_success_response("me", **{"deployNotifications": 2})
         assert response.data.get("deployNotifications") == 2
 
         value1 = NotificationSetting.objects.get_settings(
@@ -125,4 +125,4 @@ class UserNotificationDetailsPutTest(UserNotificationDetailsTestBase):
         assert value2 == NotificationSettingOptionValues.ALWAYS
 
     def test_reject_invalid_values(self):
-        self.get_valid_response("me", status_code=400, **{"deployNotifications": 6})
+        self.get_error_response("me", status_code=400, **{"deployNotifications": 6})

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -17,7 +17,7 @@ class UserNotificationFineTuningTestBase(APITestCase):
 
     def test_invalid_notification_type(self):
         """This is run twice because of inheritance."""
-        self.get_valid_response("me", "invalid", status_code=404)
+        self.get_error_response("me", "invalid", status_code=404)
 
 
 class UserNotificationFineTuningGetTest(UserNotificationFineTuningTestBase):
@@ -29,7 +29,7 @@ class UserNotificationFineTuningGetTest(UserNotificationFineTuningTestBase):
             user=self.user,
             project=self.project,
         )
-        response = self.get_valid_response("me", "alerts")
+        response = self.get_success_response("me", "alerts")
         assert response.data.get(self.project.id) == "1"
 
         NotificationSetting.objects.update_settings(
@@ -39,7 +39,7 @@ class UserNotificationFineTuningGetTest(UserNotificationFineTuningTestBase):
             user=self.user,
             organization=self.organization,
         )
-        response = self.get_valid_response("me", "deploy")
+        response = self.get_success_response("me", "deploy")
         assert response.data.get(self.organization.id) == "2"
 
         UserOption.objects.create(
@@ -48,7 +48,7 @@ class UserNotificationFineTuningGetTest(UserNotificationFineTuningTestBase):
             key="reports:disabled-organizations",
             value=[self.organization.id],
         )
-        response = self.get_valid_response("me", "reports")
+        response = self.get_success_response("me", "reports")
         assert response.data.get(self.organization.id) == "0"
 
 
@@ -56,14 +56,14 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
     method = "put"
 
     def test_update_invalid_project(self):
-        self.get_valid_response("me", "alerts", status_code=403, **{"123": 1})
+        self.get_error_response("me", "alerts", status_code=403, **{"123": 1})
 
     def test_invalid_id_value(self):
-        self.get_valid_response("me", "alerts", status_code=400, **{"nope": 1})
+        self.get_error_response("me", "alerts", status_code=400, **{"nope": 1})
 
     def test_saves_and_returns_alerts(self):
         data = {str(self.project.id): 1, str(self.project2.id): 0}
-        self.get_valid_response("me", "alerts", status_code=204, **data)
+        self.get_success_response("me", "alerts", status_code=204, **data)
 
         value1 = NotificationSetting.objects.get_settings(
             provider=ExternalProviders.EMAIL,
@@ -84,7 +84,7 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
 
         # Can return to default
         data = {str(self.project.id): -1}
-        self.get_valid_response("me", "alerts", status_code=204, **data)
+        self.get_success_response("me", "alerts", status_code=204, **data)
 
         value1 = NotificationSetting.objects.get_settings(
             provider=ExternalProviders.EMAIL,
@@ -104,7 +104,7 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
 
     def test_saves_and_returns_workflow(self):
         data = {str(self.project.id): 1, str(self.project2.id): 2}
-        self.get_valid_response("me", "workflow", status_code=204, **data)
+        self.get_success_response("me", "workflow", status_code=204, **data)
 
         value = NotificationSetting.objects.get_settings(
             provider=ExternalProviders.EMAIL,
@@ -124,7 +124,7 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
 
         # Can return to default
         data = {str(self.project.id): -1}
-        self.get_valid_response("me", "workflow", status_code=204, **data)
+        self.get_success_response("me", "workflow", status_code=204, **data)
 
         value1 = NotificationSetting.objects.get_settings(
             provider=ExternalProviders.EMAIL,
@@ -147,7 +147,7 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
         email = self.user.email
 
         data = {str(self.project.id): email, str(self.project2.id): "alias@example.com"}
-        self.get_valid_response("me", "email", status_code=204, **data)
+        self.get_success_response("me", "email", status_code=204, **data)
 
         value1 = UserOption.objects.get(
             user=self.user, project=self.project, key="mail:email"
@@ -165,18 +165,18 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
         ).save()
 
         data = {str(self.project.id): "alias@example.com"}
-        self.get_valid_response("me", "email", status_code=400, **data)
+        self.get_error_response("me", "email", status_code=400, **data)
 
     def test_email_routing_emails_must_be_valid(self):
         new_user = self.create_user(email="b@example.com")
         UserEmail.objects.create(user=new_user, email="alias2@example.com", is_verified=True).save()
 
         data = {str(self.project2.id): "alias2@example.com"}
-        self.get_valid_response("me", "email", status_code=400, **data)
+        self.get_error_response("me", "email", status_code=400, **data)
 
     def test_saves_and_returns_deploy(self):
         data = {str(self.organization.id): 4}
-        self.get_valid_response("me", "deploy", status_code=204, **data)
+        self.get_success_response("me", "deploy", status_code=204, **data)
 
         value = NotificationSetting.objects.get_settings(
             provider=ExternalProviders.EMAIL,
@@ -187,7 +187,7 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
         assert value == NotificationSettingOptionValues.NEVER
 
         data = {str(self.organization.id): 2}
-        self.get_valid_response("me", "deploy", status_code=204, **data)
+        self.get_success_response("me", "deploy", status_code=204, **data)
 
         value = NotificationSetting.objects.get_settings(
             provider=ExternalProviders.EMAIL,
@@ -198,7 +198,7 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
         assert value == NotificationSettingOptionValues.ALWAYS
 
         data = {str(self.organization.id): -1}
-        self.get_valid_response("me", "deploy", status_code=204, **data)
+        self.get_success_response("me", "deploy", status_code=204, **data)
 
         value = NotificationSetting.objects.get_settings(
             provider=ExternalProviders.EMAIL,
@@ -210,27 +210,27 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
 
     def test_saves_and_returns_weekly_reports(self):
         data = {str(self.organization.id): 0, str(self.organization2.id): "0"}
-        self.get_valid_response("me", "reports", status_code=204, **data)
+        self.get_success_response("me", "reports", status_code=204, **data)
 
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
         ) == {self.organization.id, self.organization2.id}
 
         data = {str(self.organization.id): 1}
-        self.get_valid_response("me", "reports", status_code=204, **data)
+        self.get_success_response("me", "reports", status_code=204, **data)
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
         ) == {self.organization2.id}
 
         data = {str(self.organization.id): 0}
-        self.get_valid_response("me", "reports", status_code=204, **data)
+        self.get_success_response("me", "reports", status_code=204, **data)
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
         ) == {self.organization.id, self.organization2.id}
 
     def test_enable_weekly_reports_from_default_setting(self):
         data = {str(self.organization.id): 1, str(self.organization2.id): "1"}
-        self.get_valid_response("me", "reports", status_code=204, **data)
+        self.get_success_response("me", "reports", status_code=204, **data)
 
         assert (
             set(UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value)
@@ -239,14 +239,14 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
 
         # can disable
         data = {str(self.organization.id): 0}
-        self.get_valid_response("me", "reports", status_code=204, **data)
+        self.get_success_response("me", "reports", status_code=204, **data)
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
         ) == {self.organization.id}
 
         # re-enable
         data = {str(self.organization.id): 1}
-        self.get_valid_response("me", "reports", status_code=204, **data)
+        self.get_success_response("me", "reports", status_code=204, **data)
         assert (
             set(UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value)
             == set()
@@ -261,14 +261,14 @@ class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
         )
 
         data = {str(new_org.id): 0}
-        self.get_valid_response("me", "reports", status_code=403, **data)
+        self.get_error_response("me", "reports", status_code=403, **data)
 
         assert not UserOption.objects.filter(
             user=self.user, organization=new_org, key="reports"
         ).exists()
 
         data = {str(new_project.id): 1}
-        self.get_valid_response("me", "alerts", status_code=403, **data)
+        self.get_error_response("me", "alerts", status_code=403, **data)
 
         value = NotificationSetting.objects.get_settings(
             ExternalProviders.EMAIL,

--- a/tests/sentry/api/endpoints/test_user_organizationintegration.py
+++ b/tests/sentry/api/endpoints/test_user_organizationintegration.py
@@ -17,5 +17,5 @@ class UserOrganizationIntegationTest(APITestCase):
             organization_id=self.organization.id, integration_id=integration.id
         )
 
-        response = self.get_valid_response(self.user.id)
+        response = self.get_success_response(self.user.id)
         assert response.data[0]["organizationId"] == self.organization.id

--- a/tests/sentry/api/endpoints/test_user_organizations.py
+++ b/tests/sentry/api/endpoints/test_user_organizations.py
@@ -11,6 +11,6 @@ class UserOrganizationsTest(APITestCase):
     def test_simple(self):
         organization_id = self.organization.id  # force creation
 
-        response = self.get_valid_response("me")
+        response = self.get_success_response("me")
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(organization_id)

--- a/tests/sentry/api/endpoints/test_user_password.py
+++ b/tests/sentry/api/endpoints/test_user_password.py
@@ -18,7 +18,7 @@ class UserPasswordTest(APITestCase):
 
     def test_change_password(self):
         old_password = self.user.password
-        self.get_valid_response(
+        self.get_success_response(
             "me",
             status_code=204,
             **{
@@ -37,7 +37,7 @@ class UserPasswordTest(APITestCase):
         mock.Mock(return_value=[MinimumLengthValidator(min_length=6)]),
     )
     def test_password_too_short(self):
-        self.get_valid_response(
+        self.get_error_response(
             "me",
             status_code=400,
             **{
@@ -48,11 +48,11 @@ class UserPasswordTest(APITestCase):
         )
 
     def test_no_password(self):
-        self.get_valid_response("me", status_code=400, **{"password": "helloworld!"})
-        self.get_valid_response("me", status_code=400)
+        self.get_error_response("me", status_code=400, **{"password": "helloworld!"})
+        self.get_error_response("me", status_code=400)
 
     def test_require_current_password(self):
-        self.get_valid_response(
+        self.get_error_response(
             "me",
             status_code=400,
             **{
@@ -63,7 +63,7 @@ class UserPasswordTest(APITestCase):
         )
 
     def test_verifies_mismatch_password(self):
-        self.get_valid_response(
+        self.get_error_response(
             "me",
             status_code=400,
             **{
@@ -77,7 +77,7 @@ class UserPasswordTest(APITestCase):
         user = self.create_user(email="new@example.com", is_managed=True)
         self.login_as(user)
 
-        self.get_valid_response(
+        self.get_error_response(
             user.id,
             status_code=400,
             **{"passwordNew": "newpassword", "passwordVerify": "newpassword"},
@@ -89,7 +89,7 @@ class UserPasswordTest(APITestCase):
         user.save()
         self.login_as(user)
 
-        self.get_valid_response(
+        self.get_error_response(
             user.id,
             status_code=400,
             **{"passwordNew": "newpassword", "passwordVerify": "newpassword"},
@@ -99,7 +99,7 @@ class UserPasswordTest(APITestCase):
         user = self.create_user(email="new@example.com", is_superuser=False)
         self.login_as(user)
 
-        self.get_valid_response(
+        self.get_error_response(
             self.user.id,
             status_code=403,
             **{
@@ -113,7 +113,7 @@ class UserPasswordTest(APITestCase):
         user = self.create_user(email="new@example.com", is_superuser=True)
         self.login_as(user, superuser=True)
 
-        self.get_valid_response(
+        self.get_success_response(
             self.user.id,
             status_code=204,
             **{

--- a/tests/sentry/api/endpoints/test_user_social_identities_index.py
+++ b/tests/sentry/api/endpoints/test_user_social_identities_index.py
@@ -12,6 +12,6 @@ class UserSocialIdentitiesIndexTest(APITestCase):
     def test_simple(self):
         UserSocialAuth.create_social_auth(self.user, "1234", "github")
 
-        response = self.get_valid_response(self.user.id)
+        response = self.get_success_response(self.user.id)
         assert len(response.data) == 1
         assert response.data[0]["provider"] == "github"

--- a/tests/sentry/api/endpoints/test_user_social_identity_details.py
+++ b/tests/sentry/api/endpoints/test_user_social_identity_details.py
@@ -13,10 +13,10 @@ class UserSocialIdentityDetailsEndpointTest(APITestCase):
         auth = UserSocialAuth.create_social_auth(self.user, "1234", "github")
 
         with self.settings(GITHUB_APP_ID="app-id", GITHUB_API_SECRET="secret"):
-            self.get_valid_response(self.user.id, auth.id, status_code=204)
+            self.get_success_response(self.user.id, auth.id, status_code=204)
             assert not len(UserSocialAuth.objects.filter(user=self.user))
 
     def test_disconnect_id_not_found(self):
         with self.settings(GITHUB_APP_ID="app-id", GITHUB_API_SECRET="secret"):
-            self.get_valid_response(self.user.id, 999, status_code=404)
+            self.get_error_response(self.user.id, 999, status_code=404)
             assert not len(UserSocialAuth.objects.filter(user=self.user))

--- a/tests/sentry/api/endpoints/test_user_subscriptions.py
+++ b/tests/sentry/api/endpoints/test_user_subscriptions.py
@@ -25,10 +25,10 @@ class UserSubscriptionsNewsletterTest(APITestCase):
         newsletter.backend.enable()
 
     def test_get_subscriptions(self):
-        self.get_valid_response(self.user.id, method="get")
+        self.get_success_response(self.user.id, method="get")
 
     def test_subscribe(self):
-        self.get_valid_response(self.user.id, listId="123", subscribed=True, status_code=204)
+        self.get_success_response(self.user.id, listId="123", subscribed=True, status_code=204)
         results = newsletter.get_subscriptions(self.user)["subscriptions"]
         assert len(results) == 1
         assert results[0].list_id == 123
@@ -36,14 +36,14 @@ class UserSubscriptionsNewsletterTest(APITestCase):
         assert results[0].verified
 
     def test_requires_subscribed(self):
-        self.get_valid_response(self.user.id, listId="123", status_code=400)
+        self.get_error_response(self.user.id, listId="123", status_code=400)
 
     def test_unverified_emails(self):
         UserEmail.objects.get(email=self.user.email).update(is_verified=False)
-        self.get_valid_response(self.user.id, listId="123", subscribed=True, status_code=204)
+        self.get_success_response(self.user.id, listId="123", subscribed=True, status_code=204)
 
     def test_unsubscribe(self):
-        self.get_valid_response(self.user.id, listId="123", subscribed=False, status_code=204)
+        self.get_success_response(self.user.id, listId="123", subscribed=False, status_code=204)
         results = newsletter.get_subscriptions(self.user)["subscriptions"]
         assert len(results) == 1
         assert results[0].list_id == 123
@@ -51,7 +51,7 @@ class UserSubscriptionsNewsletterTest(APITestCase):
         assert results[0].verified
 
     def test_default_subscription(self):
-        self.get_valid_response(self.user.id, method="post", subscribed=True, status_code=204)
+        self.get_success_response(self.user.id, method="post", subscribed=True, status_code=204)
         results = newsletter.get_subscriptions(self.user)["subscriptions"]
         assert len(results) == 1
         assert results[0].list_id == newsletter.get_default_list_id()

--- a/tests/sentry/data_export/endpoints/test_data_export_details.py
+++ b/tests/sentry/data_export/endpoints/test_data_export_details.py
@@ -24,7 +24,7 @@ class DataExportDetailsTest(APITestCase):
 
     def test_content(self):
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, self.data_export.id)
+            response = self.get_success_response(self.organization.slug, self.data_export.id)
         assert response.data["id"] == self.data_export.id
         assert response.data["user"] == {
             "id": str(self.user.id),
@@ -39,7 +39,7 @@ class DataExportDetailsTest(APITestCase):
 
     def test_early(self):
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, self.data_export.id)
+            response = self.get_success_response(self.organization.slug, self.data_export.id)
         assert response.data["dateFinished"] is None
         assert response.data["dateExpired"] is None
         assert response.data["status"] == ExportStatus.Early
@@ -50,7 +50,7 @@ class DataExportDetailsTest(APITestCase):
             date_expired=timezone.now() + timedelta(weeks=1),
         )
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, self.data_export.id)
+            response = self.get_success_response(self.organization.slug, self.data_export.id)
         assert response.data["dateFinished"] is not None
         assert response.data["dateFinished"] == self.data_export.date_finished
         assert response.data["dateExpired"] is not None
@@ -63,7 +63,7 @@ class DataExportDetailsTest(APITestCase):
             date_expired=timezone.now() - timedelta(weeks=1),
         )
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, self.data_export.id)
+            response = self.get_success_response(self.organization.slug, self.data_export.id)
         assert response.data["dateFinished"] is not None
         assert response.data["dateFinished"] == self.data_export.date_finished
         assert response.data["dateExpired"] is not None
@@ -72,7 +72,7 @@ class DataExportDetailsTest(APITestCase):
 
     def test_no_file(self):
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, self.data_export.id)
+            response = self.get_success_response(self.organization.slug, self.data_export.id)
         assert response.data["checksum"] is None
         assert response.data["fileName"] is None
 
@@ -84,7 +84,7 @@ class DataExportDetailsTest(APITestCase):
         file.putfile(BytesIO(contents))
         self.data_export.update(file_id=file.id)
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, self.data_export.id)
+            response = self.get_success_response(self.organization.slug, self.data_export.id)
         assert response.data["checksum"] == sha1(contents).hexdigest()
         assert response.data["fileName"] == "test.csv"
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -47,7 +47,7 @@ class AlertRuleDetailsBase(AlertRuleBase):
         self.endpoint = "sentry-api-0-organization-alert-rules"
         self.method = "get"
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug)
+            resp = self.get_success_response(self.organization.slug)
             assert len(resp.data) >= 1
             serialized_alert_rule = resp.data[0]
             if serialized_alert_rule["environment"]:
@@ -94,7 +94,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug, self.alert_rule.id)
+            resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
 
         assert resp.data == serialize(self.alert_rule, serializer=DetailedAlertRuleSerializer())
 
@@ -109,10 +109,10 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
             status=IncidentStatus.CRITICAL.value,
         )
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.alert_rule.id, expand=["latestIncident"]
             )
-            no_expand_resp = self.get_valid_response(self.organization.slug, self.alert_rule.id)
+            no_expand_resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
 
         assert resp.data["latestIncident"] is not None
         assert resp.data["latestIncident"]["id"] == str(incident.id)
@@ -186,7 +186,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["name"] = "what"
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -219,7 +219,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         }
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -239,7 +239,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule = self.get_serialized_alert_rule()
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -266,13 +266,13 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["triggers"][0]["label"] = "goodbye"
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_error_response(
                 self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
             )
             assert resp.data == {"nonFieldErrors": ['Trigger 1 must be labeled "critical"']}
             serialized_alert_rule["triggers"][0]["label"] = "critical"
             serialized_alert_rule["triggers"][1]["label"] = "goodbye"
-            resp = self.get_valid_response(
+            resp = self.get_error_response(
                 self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
             )
             assert resp.data == {"nonFieldErrors": ['Trigger 2 must be labeled "warning"']}
@@ -291,7 +291,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["name"] = "AUniqueName"
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -314,7 +314,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["name"] = "AUniqueName"
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -337,7 +337,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["name"] = "AUniqueName"
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
         assert resp.data["name"] == "AUniqueName"
@@ -356,7 +356,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["triggers"].pop(1)
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -375,7 +375,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["triggers"][1]["actions"].pop(1)
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -385,7 +385,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["triggers"][1]["actions"].pop()
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -407,7 +407,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["triggers"][0]["actions"][0]["targetIdentifier"] = self.user.id
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -433,7 +433,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["triggers"][0]["alertThreshold"] = 50  # Invalid
         serialized_alert_rule.pop("resolveThreshold")
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_error_response(
                 self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
             )
 
@@ -451,7 +451,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         alert_rule.save()
 
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_error_response(
                 self.organization.slug, alert_rule.id, status_code=404, **serialized_alert_rule
             )
 
@@ -467,7 +467,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule["owner"] = None
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -496,7 +496,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.status_code == 403
         self.create_team_membership(team=self.team, member=om)
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
 
@@ -514,7 +514,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
         self.login_as(self.user)
 
         with self.feature("organizations:incidents"):
-            self.get_valid_response(self.organization.slug, self.alert_rule.id, status_code=204)
+            self.get_success_response(self.organization.slug, self.alert_rule.id, status_code=204)
 
         assert not AlertRule.objects.filter(id=self.alert_rule.id).exists()
         assert not AlertRule.objects_with_snapshots.filter(name=self.alert_rule.name).exists()
@@ -531,7 +531,9 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
             incident = self.create_incident(alert_rule=self.alert_rule)
 
             with self.feature("organizations:incidents"):
-                self.get_valid_response(self.organization.slug, self.alert_rule.id, status_code=204)
+                self.get_success_response(
+                    self.organization.slug, self.alert_rule.id, status_code=204
+                )
 
             alert_rule = AlertRule.objects_with_snapshots.get(id=self.alert_rule.id)
 
@@ -561,4 +563,4 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.status_code == 403
         self.create_team_membership(team=self.team, member=om)
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug, alert_rule.id, status_code=204)
+            resp = self.get_success_response(self.organization.slug, alert_rule.id, status_code=204)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -79,7 +79,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, APITestCase):
 
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug)
+            resp = self.get_success_response(self.organization.slug)
 
         assert resp.data == serialize([alert_rule])
 
@@ -104,7 +104,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
 
     def test_simple(self):
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, status_code=201, **deepcopy(self.alert_rule_dict)
             )
         assert "id" in resp.data
@@ -135,7 +135,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
         }
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, status_code=201, **valid_alert_rule
             )
         assert "id" in resp.data
@@ -162,7 +162,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
         }
 
         with self.feature("organizations:incidents"):
-            self.get_valid_response(self.organization.slug, status_code=400, **valid_alert_rule)
+            self.get_error_response(self.organization.slug, status_code=400, **valid_alert_rule)
 
     def test_invalid_sentry_app(self):
         valid_alert_rule = deepcopy(self.alert_rule_dict)
@@ -175,7 +175,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
         }
 
         with self.feature("organizations:incidents"):
-            self.get_valid_response(self.organization.slug, status_code=400, **valid_alert_rule)
+            self.get_error_response(self.organization.slug, status_code=400, **valid_alert_rule)
 
     def test_no_label(self):
         rule_one_trigger_no_label = {
@@ -198,7 +198,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
         }
 
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_error_response(
                 self.organization.slug, status_code=400, **rule_one_trigger_no_label
             )
 
@@ -223,7 +223,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
             ],
         }
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, status_code=201, **rule_one_trigger_only_critical
             )
         assert "id" in resp.data
@@ -242,7 +242,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
         }
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_error_response(
                 self.organization.slug, status_code=400, **rule_no_triggers
             )
             assert resp.data == {"triggers": ["This field is required."]}
@@ -269,7 +269,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
         }
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_error_response(
                 self.organization.slug, status_code=400, **rule_one_trigger_only_warning
             )
             assert resp.data == {"nonFieldErrors": ['Trigger 1 must be labeled "critical"']}
@@ -288,7 +288,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
         }
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, status_code=201, **rule_one_trigger_only_critical_no_action
             )
         assert "id" in resp.data
@@ -297,7 +297,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
 
     def test_invalid_projects(self):
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_error_response(
                 self.organization.slug,
                 status_code=400,
                 projects=[
@@ -353,7 +353,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
         }
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug, status_code=201, **rule_data)
+            resp = self.get_success_response(self.organization.slug, status_code=201, **rule_data)
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         assert resp.data == serialize(alert_rule, self.user)
@@ -368,11 +368,11 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug)
+            resp = self.get_success_response(self.organization.slug)
             assert perf_alert_rule.id not in [x["id"] for x in list(resp.data)]
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(self.organization.slug)
+            resp = self.get_success_response(self.organization.slug)
             assert perf_alert_rule.id in [int(x["id"]) for x in list(resp.data)]
 
     def setup_project_and_rules(self):

--- a/tests/sentry/incidents/endpoints/test_organization_incident_activity_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_activity_index.py
@@ -62,10 +62,12 @@ class OrganizationIncidentActivityIndexTest(APITestCase):
         expected = serialize(activities, user=self.user)
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(incident.organization.slug, incident.identifier, desc=0)
+            resp = self.get_success_response(
+                incident.organization.slug, incident.identifier, desc=0
+            )
         assert resp.data == expected
 
         expected.reverse()
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(incident.organization.slug, incident.identifier)
+            resp = self.get_success_response(incident.organization.slug, incident.identifier)
         assert resp.data == expected

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
@@ -4,7 +4,7 @@ from sentry.incidents.models import IncidentActivity, IncidentActivityType
 from sentry.testutils import APITestCase
 
 
-class BaseIncidentCommentDetailsTest:
+class BaseIncidentCommentDetailsTest(APITestCase):
     endpoint = "sentry-api-0-organization-incident-comment-details"
 
     def setUp(self):
@@ -41,7 +41,7 @@ class BaseIncidentCommentDetailsTest:
     def test_not_found(self):
         comment = "hello"
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_error_response(
                 self.organization.slug,
                 self.incident.identifier,
                 123,
@@ -52,7 +52,7 @@ class BaseIncidentCommentDetailsTest:
     def test_non_comment_type(self):
         comment = "hello"
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_error_response(
                 self.organization.slug,
                 self.incident.identifier,
                 self.detected_activity.id,
@@ -61,13 +61,13 @@ class BaseIncidentCommentDetailsTest:
             )
 
 
-class OrganizationIncidentCommentUpdateEndpointTest(BaseIncidentCommentDetailsTest, APITestCase):
+class OrganizationIncidentCommentUpdateEndpointTest(BaseIncidentCommentDetailsTest):
     method = "put"
 
     def test_simple(self):
         comment = "hello"
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_success_response(
                 self.organization.slug,
                 self.incident.identifier,
                 self.activity.id,
@@ -81,7 +81,7 @@ class OrganizationIncidentCommentUpdateEndpointTest(BaseIncidentCommentDetailsTe
 
     def test_cannot_edit_others_comment(self):
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_error_response(
                 self.organization.slug,
                 self.incident.identifier,
                 self.user2_activity.id,
@@ -96,7 +96,7 @@ class OrganizationIncidentCommentUpdateEndpointTest(BaseIncidentCommentDetailsTe
         edited_comment = "this comment has been edited"
 
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_success_response(
                 self.organization.slug,
                 self.incident.identifier,
                 self.user2_activity.id,
@@ -108,19 +108,19 @@ class OrganizationIncidentCommentUpdateEndpointTest(BaseIncidentCommentDetailsTe
         assert activity.comment == edited_comment
 
 
-class OrganizationIncidentCommentDeleteEndpointTest(BaseIncidentCommentDetailsTest, APITestCase):
+class OrganizationIncidentCommentDeleteEndpointTest(BaseIncidentCommentDetailsTest):
     method = "delete"
 
     def test_simple(self):
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_success_response(
                 self.organization.slug, self.incident.identifier, self.activity.id, status_code=204
             )
         assert not IncidentActivity.objects.filter(id=self.activity.id).exists()
 
     def test_cannot_delete_others_comments(self):
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_error_response(
                 self.organization.slug,
                 self.incident.identifier,
                 self.user2_activity.id,
@@ -132,7 +132,7 @@ class OrganizationIncidentCommentDeleteEndpointTest(BaseIncidentCommentDetailsTe
         self.user.save()
 
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_success_response(
                 self.organization.slug,
                 self.incident.identifier,
                 self.user2_activity.id,

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_index.py
@@ -29,7 +29,7 @@ class OrganizationIncidentCommentCreateEndpointTest(APITestCase):
         comment = "hello"
         incident = self.create_incident()
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, incident.identifier, comment=comment, status_code=201
             )
         activity = IncidentActivity.objects.get(id=resp.data["id"])
@@ -50,7 +50,7 @@ class OrganizationIncidentCommentCreateEndpointTest(APITestCase):
         comment = "hello **@%s**" % mentioned_member.username
         incident = self.create_incident()
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug,
                 incident.identifier,
                 comment=comment,

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -48,7 +48,7 @@ class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest, APITestCase):
 
         incident = self.create_incident(seen_by=[self.user])
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(incident.organization.slug, incident.identifier)
+            resp = self.get_success_response(incident.organization.slug, incident.identifier)
 
         expected = serialize(incident)
 
@@ -67,14 +67,14 @@ class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest, APITestCase):
 class OrganizationIncidentUpdateStatusTest(BaseIncidentDetailsTest, APITestCase):
     method = "put"
 
-    def get_valid_response(self, *args, **params):
+    def get_success_response(self, *args, **params):
         params.setdefault("status", IncidentStatus.CLOSED.value)
-        return super().get_valid_response(*args, **params)
+        return super().get_success_response(*args, **params)
 
     def test_simple(self):
         incident = self.create_incident()
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_success_response(
                 incident.organization.slug, incident.identifier, status=IncidentStatus.CLOSED.value
             )
 
@@ -95,7 +95,7 @@ class OrganizationIncidentUpdateStatusTest(BaseIncidentDetailsTest, APITestCase)
         status = IncidentStatus.CLOSED.value
         comment = "fixed"
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_success_response(
                 incident.organization.slug, incident.identifier, status=status, comment=comment
             )
 

--- a/tests/sentry/incidents/endpoints/test_organization_incident_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_index.py
@@ -32,7 +32,7 @@ class IncidentListEndpointTest(APITestCase):
 
         self.login_as(self.user)
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(self.organization.slug)
+            resp = self.get_success_response(self.organization.slug)
 
         assert resp.data == serialize([other_incident, incident])
 
@@ -43,8 +43,8 @@ class IncidentListEndpointTest(APITestCase):
         self.login_as(self.user)
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp_closed = self.get_valid_response(self.organization.slug, status="closed")
-            resp_open = self.get_valid_response(self.organization.slug, status="open")
+            resp_closed = self.get_success_response(self.organization.slug, status="closed")
+            resp_open = self.get_success_response(self.organization.slug, status="open")
 
         assert len(resp_closed.data) == 1
         assert len(resp_open.data) == 1
@@ -62,8 +62,10 @@ class IncidentListEndpointTest(APITestCase):
         self.login_as(self.user)
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp_filter_env = self.get_valid_response(self.organization.slug, environment=env.name)
-            resp_no_env_filter = self.get_valid_response(self.organization.slug)
+            resp_filter_env = self.get_success_response(
+                self.organization.slug, environment=env.name
+            )
+            resp_no_env_filter = self.get_success_response(self.organization.slug)
 
         # The alert without an environment assigned should not be selected
         assert len(resp_filter_env.data) == 1
@@ -88,11 +90,11 @@ class IncidentListEndpointTest(APITestCase):
 
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug)
+            resp = self.get_success_response(self.organization.slug)
             assert resp.data == serialize([incident])
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(self.organization.slug)
+            resp = self.get_success_response(self.organization.slug)
             assert resp.data == serialize([incident, perf_incident])
 
     def test_filter_start_end_times(self):
@@ -111,13 +113,13 @@ class IncidentListEndpointTest(APITestCase):
         )
         self.login_as(self.user)
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp_all = self.get_valid_response(self.organization.slug)
-            resp_new = self.get_valid_response(
+            resp_all = self.get_success_response(self.organization.slug)
+            resp_new = self.get_success_response(
                 self.organization.slug,
                 start=(timezone.now() - timedelta(hours=12)).isoformat(),
                 end=timezone.now().isoformat(),
             )
-            resp_old = self.get_valid_response(
+            resp_old = self.get_success_response(
                 self.organization.slug,
                 start=(timezone.now() - timedelta(hours=36)).isoformat(),
                 end=(timezone.now() - timedelta(hours=24)).isoformat(),
@@ -133,8 +135,8 @@ class IncidentListEndpointTest(APITestCase):
         self.login_as(self.user)
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            results = self.get_valid_response(self.organization.slug, title="yet")
-            no_results = self.get_valid_response(self.organization.slug, title="no results")
+            results = self.get_success_response(self.organization.slug, title="yet")
+            no_results = self.get_success_response(self.organization.slug, title="no results")
 
         assert len(results.data) == 1
         assert len(no_results.data) == 0
@@ -166,20 +168,17 @@ class IncidentListEndpointTest(APITestCase):
         self.login_as(self.user)
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            results = self.get_valid_response(self.organization.slug, project=[self.project.id])
-        assert results.status_code == 200
+            results = self.get_success_response(self.organization.slug, project=[self.project.id])
         assert len(results.data) == 3
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            results = self.get_valid_response(
+            results = self.get_success_response(
                 self.organization.slug, project=[self.project.id], team=[team.id]
             )
-        assert results.status_code == 200
         assert len(results.data) == 1
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            results = self.get_valid_response(
+            results = self.get_success_response(
                 self.organization.slug, project=[self.project.id], team=[team.id, other_team.id]
             )
-        assert results.status_code == 200
         assert len(results.data) == 2

--- a/tests/sentry/incidents/endpoints/test_organization_incident_subscription_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_subscription_index.py
@@ -46,7 +46,7 @@ class OrganizationIncidentSubscribeEndpointTest(
         self.login_as(self.user)
         incident = self.create_incident()
         with self.feature("organizations:incidents"):
-            self.get_valid_response(self.organization.slug, incident.identifier, status_code=201)
+            self.get_success_response(self.organization.slug, incident.identifier, status_code=201)
         sub = IncidentSubscription.objects.filter(incident=incident, user=self.user).get()
         assert sub.incident == incident
         assert sub.user == self.user
@@ -65,5 +65,5 @@ class OrganizationIncidentUnsubscribeEndpointTest(
         incident = self.create_incident()
         subscribe_to_incident(incident, self.user)
         with self.feature("organizations:incidents"):
-            self.get_valid_response(self.organization.slug, incident.identifier, status_code=200)
+            self.get_success_response(self.organization.slug, incident.identifier, status_code=200)
         assert not IncidentSubscription.objects.filter(incident=incident, user=self.user).exists()

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -16,7 +16,7 @@ from sentry.models import AuditLogEntry, Integration
 from sentry.testutils import APITestCase
 
 
-class AlertRuleDetailsBase:
+class AlertRuleDetailsBase(APITestCase):
     endpoint = "sentry-api-0-project-alert-rule-details"
 
     def setUp(self):
@@ -74,7 +74,7 @@ class AlertRuleDetailsBase:
         self.endpoint = "sentry-api-0-organization-alert-rules"
         self.method = "get"
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug)
+            resp = self.get_success_response(self.organization.slug)
             assert len(resp.data) >= 1
             serialized_alert_rule = resp.data[0]
         self.endpoint = original_endpoint
@@ -101,11 +101,11 @@ class AlertRuleDetailsBase:
         assert resp.status_code == 404
 
 
-class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
+class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
     def test_simple(self):
         self.login_as(self.member_user)
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id
             )
 
@@ -115,12 +115,14 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
         self.login_as(self.owner_user)
         alert_rule = self.create_alert_rule(aggregate="count_unique(tags[sentry:user])")
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug, self.project.slug, alert_rule.id)
+            resp = self.get_success_response(
+                self.organization.slug, self.project.slug, alert_rule.id
+            )
             assert resp.data["aggregate"] == "count_unique(user)"
             assert alert_rule.snuba_query.aggregate == "count_unique(tags[sentry:user])"
 
 
-class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
+class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
     method = "put"
 
     def setUp(self):
@@ -133,7 +135,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         test_params.update({"name": "what"})
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
             )
 
@@ -154,7 +156,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         test_params["aggregate"] = self.alert_rule.snuba_query.aggregate
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
             )
 
@@ -178,7 +180,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         alert_rule.save()
 
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
                 alert_rule.id,
@@ -381,7 +383,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         test_params["owner"] = None
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, alert_rule.id, **test_params
             )
 
@@ -413,7 +415,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             ],
         }
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            self.get_valid_response(
+            self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
                 self.alert_rule.id,
@@ -467,7 +469,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         ]
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            self.get_valid_response(
+            self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
                 self.alert_rule.id,
@@ -531,7 +533,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert error_message in resp.data["sentry_app"]
 
 
-class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
+class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
     method = "delete"
 
     def setUp(self):
@@ -540,7 +542,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
 
     def test_simple(self):
         with self.feature("organizations:incidents"):
-            self.get_valid_response(
+            self.get_success_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, status_code=204
             )
 
@@ -559,7 +561,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
             incident = self.create_incident(alert_rule=self.alert_rule)
 
             with self.feature("organizations:incidents"):
-                self.get_valid_response(
+                self.get_success_response(
                     self.organization.slug, self.project.slug, self.alert_rule.id, status_code=204
                 )
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -45,7 +45,7 @@ class AlertRuleListEndpointTest(APITestCase):
 
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug, self.project.slug)
+            resp = self.get_success_response(self.organization.slug, self.project.slug)
 
         assert resp.data == serialize([alert_rule])
 
@@ -55,11 +55,11 @@ class AlertRuleListEndpointTest(APITestCase):
         perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug, self.project.slug)
+            resp = self.get_success_response(self.organization.slug, self.project.slug)
             assert resp.data == serialize([alert_rule])
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(self.organization.slug, self.project.slug)
+            resp = self.get_success_response(self.organization.slug, self.project.slug)
             assert resp.data == serialize([perf_alert_rule, alert_rule])
 
     def test_no_feature(self):
@@ -113,7 +113,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
 
     def test_simple(self):
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule
             )
         assert "id" in resp.data
@@ -128,7 +128,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
     @override_settings(MAX_QUERY_SUBSCRIPTIONS_PER_ORG=1)
     def test_enforce_max_subscriptions(self):
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule
             )
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
@@ -189,7 +189,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
             ],
         }
         with self.feature(["organizations:incidents"]):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=202, **valid_alert_rule
             )
         resp.data["uuid"] = "abc123"
@@ -210,7 +210,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         }
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=201, **rule_data
             )
         assert "id" in resp.data
@@ -349,7 +349,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
             ],
         }
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            self.get_valid_response(
+            self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=201, **alert_rule
             )
 
@@ -401,7 +401,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         }
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            self.get_valid_response(
+            self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=201, **alert_rule
             )
 
@@ -470,11 +470,11 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
         perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug, self.project.slug)
+            resp = self.get_success_response(self.organization.slug, self.project.slug)
             assert perf_alert_rule.id not in [x["id"] for x in list(resp.data)]
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(self.organization.slug, self.project.slug)
+            resp = self.get_success_response(self.organization.slug, self.project.slug)
             assert perf_alert_rule.id in [int(x["id"]) for x in list(resp.data)]
 
     def setup_project_and_rules(self):
@@ -714,7 +714,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
 
     def test_simple_crash_rate_alerts_for_sessions(self):
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule
             )
         assert "id" in resp.data
@@ -728,7 +728,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
             }
         )
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule
             )
         assert "id" in resp.data
@@ -738,7 +738,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
     def test_simple_crash_rate_alerts_for_sessions_drops_event_types(self):
         self.valid_alert_rule["eventTypes"] = ["sessions", "events"]
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule
             )
         assert "id" in resp.data
@@ -748,7 +748,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
     def test_simple_crash_rate_alerts_for_sessions_with_invalid_time_window(self):
         self.valid_alert_rule["timeWindow"] = "90"
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(
+            resp = self.get_error_response(
                 self.organization.slug, self.project.slug, status_code=400, **self.valid_alert_rule
             )
         assert (
@@ -760,7 +760,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
     def test_simple_crash_rate_alerts_for_non_supported_aggregate(self):
         self.valid_alert_rule.update({"aggregate": "count(sessions)"})
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(
+            resp = self.get_error_response(
                 self.organization.slug, self.project.slug, status_code=400, **self.valid_alert_rule
             )
         assert (
@@ -801,7 +801,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
             },
         ]
         with self.feature(["organizations:incidents"]):
-            resp = self.get_valid_response(
+            resp = self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=202, **self.valid_alert_rule
             )
         resp.data["uuid"] = "abc123"

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -84,7 +84,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         group = event.group
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(sort_by="date", query="is:unresolved")
+        response = self.get_success_response(sort_by="date", query="is:unresolved")
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(group.id)
 
@@ -127,7 +127,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             sort="trend",
             query="is:unresolved",
             limit=1,
@@ -139,7 +139,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         header_links = parse_link_header(response["Link"])
         cursor = [link for link in header_links.values() if link["rel"] == "next"][0]["cursor"]
-        response = self.get_valid_response(
+        response = self.get_success_response(
             sort="trend",
             query="is:unresolved",
             limit=1,
@@ -171,7 +171,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         inbox_2.update(date_added=inbox_1.date_added - timedelta(hours=1))
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             sort="inbox", query="is:unresolved is:for_review", limit=1
         )
         assert len(response.data) == 1
@@ -262,7 +262,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         GroupAssignee.objects.assign(unowned_assigned_to_other, other_user)
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             sort="inbox",
             query="is:unresolved is:for_review assigned_or_suggested:[me, none]",
             limit=10,
@@ -289,7 +289,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             sort_by="date", query="is:unresolved trace:a7d67cf796774551a95be6543cacd459"
         )
         assert len(response.data) == 1
@@ -314,7 +314,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         with self.feature("organizations:global-views"):
-            response = self.get_valid_response(project_id=[-1])
+            response = self.get_success_response(project_id=[-1])
             assert response.status_code == 200
 
     def test_boolean_search_feature_flag(self):
@@ -370,7 +370,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
         group2 = event2.group
         self.login_as(user=self.user)
-        response = self.get_valid_response(sort_by="date", limit=1)
+        response = self.get_success_response(sort_by="date", limit=1)
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(group2.id)
 
@@ -398,9 +398,9 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        self.get_valid_response(groupStatsPeriod="24h")
-        self.get_valid_response(groupStatsPeriod="14d")
-        self.get_valid_response(groupStatsPeriod="")
+        self.get_success_response(groupStatsPeriod="24h")
+        self.get_success_response(groupStatsPeriod="14d")
+        self.get_success_response(groupStatsPeriod="")
         response = self.get_response(groupStatsPeriod="48h")
         assert response.status_code == 400
 
@@ -424,7 +424,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(environment="production")
+        response = self.get_success_response(environment="production")
         assert len(response.data) == 1
 
         response = self.get_response(environment="garbage")
@@ -444,7 +444,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         group2 = event2.group
 
         self.login_as(user=self.user)
-        response = self.get_valid_response()
+        response = self.get_success_response()
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(group2.id)
 
@@ -459,7 +459,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(query="c" * 32)
+        response = self.get_success_response(query="c" * 32)
         assert response["X-Sentry-Direct-Hit"] == "1"
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(event.group.id)
@@ -482,7 +482,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.login_as(user=user)
 
         with self.feature("organizations:global-views"):
-            response = self.get_valid_response(query=event_id, project=[other_project.id])
+            response = self.get_success_response(query=event_id, project=[other_project.id])
         assert response["X-Sentry-Direct-Hit"] == "1"
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(event.group.id)
@@ -498,7 +498,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(query="  {}  ".format("c" * 32))
+        response = self.get_success_response(query="  {}  ".format("c" * 32))
         assert response["X-Sentry-Direct-Hit"] == "1"
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(event.group.id)
@@ -511,7 +511,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.create_group()
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(query="c" * 32)
+        response = self.get_success_response(query="c" * 32)
         assert len(response.data) == 0
 
     def test_lookup_by_short_id(self):
@@ -519,7 +519,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         short_id = group.qualified_short_id
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(query=short_id, shortIdLookup=1)
+        response = self.get_success_response(query=short_id, shortIdLookup=1)
         assert len(response.data) == 1
 
     def test_lookup_by_short_id_ignores_project_list(self):
@@ -534,7 +534,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             organization.slug, project=project.id, query=short_id, shortIdLookup=1
         )
         assert len(response.data) == 1
@@ -550,16 +550,16 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=user)
 
-        response = self.get_valid_response(organization.slug, query=short_id, shortIdLookup=1)
+        response = self.get_success_response(organization.slug, query=short_id, shortIdLookup=1)
         assert len(response.data) == 0
 
     def test_lookup_by_group_id(self):
         self.login_as(user=self.user)
-        response = self.get_valid_response(group=self.group.id)
+        response = self.get_success_response(group=self.group.id)
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(self.group.id)
         group_2 = self.create_group()
-        response = self.get_valid_response(group=[self.group.id, group_2.id])
+        response = self.get_success_response(group=[self.group.id, group_2.id])
         assert {g["id"] for g in response.data} == {str(self.group.id), str(group_2.id)}
 
     def test_lookup_by_group_id_no_perms(self):
@@ -589,7 +589,9 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
 
         with self.feature("organizations:global-views"):
-            response = self.get_valid_response(**{"query": 'first-release:"%s"' % release.version})
+            response = self.get_success_response(
+                **{"query": 'first-release:"%s"' % release.version}
+            )
         issues = json.loads(response.content)
         assert len(issues) == 2
         assert int(issues[0]["id"]) == event2.group.id
@@ -608,7 +610,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        response = self.get_valid_response(release=release.version)
+        response = self.get_success_response(release=release.version)
         issues = json.loads(response.content)
         assert len(issues) == 1
         assert int(issues[0]["id"]) == event.group.id
@@ -626,7 +628,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        response = self.get_valid_response(release=release.version[:3] + "*")
+        response = self.get_success_response(release=release.version[:3] + "*")
         issues = json.loads(response.content)
         assert len(issues) == 1
         assert int(issues[0]["id"]) == event.group.id
@@ -643,7 +645,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
         record_group_history(event.group, GroupHistoryStatus.REGRESSED, release=release)
-        response = self.get_valid_response(query=f"regressed_in_release:{release.version}")
+        response = self.get_success_response(query=f"regressed_in_release:{release.version}")
         issues = json.loads(response.content)
         assert [int(issue["id"]) for issue in issues] == [event.group.id]
 
@@ -666,7 +668,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response()
+        response = self.get_success_response()
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(events[1].group.id)
 
@@ -676,7 +678,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.create_group(last_seen=timezone.now() - timedelta(days=2))
 
         with self.options({"system.event-retention-days": 1}):
-            response = self.get_valid_response()
+            response = self.get_success_response()
 
         assert len(response.data) == 0
 
@@ -698,11 +700,11 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
             self.login_as(user=self.user)
 
-            response = self.get_valid_response(statsPeriod="6h")
+            response = self.get_success_response(statsPeriod="6h")
             assert len(response.data) == 1
             assert response.data[0]["id"] == str(group.id)
 
-            response = self.get_valid_response(statsPeriod="1h")
+            response = self.get_success_response(statsPeriod="1h")
             assert len(response.data) == 0
 
     @patch("sentry.analytics.record")
@@ -1809,7 +1811,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"status": "unresolved", "project": self.project.id}, status="resolved"
         )
         assert response.data == {"status": "resolved", "statusDetails": {}, "inbox": None}
@@ -1863,7 +1865,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=member)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"status": "unresolved", "project": self.project.id}, status="resolved"
         )
         assert response.data == {"status": "resolved", "statusDetails": {}, "inbox": None}
@@ -1881,13 +1883,13 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
                 project_id=self.project.id,
             )
 
-        response = self.get_valid_response(query="is:unresolved", sort_by="date", method="get")
+        response = self.get_success_response(query="is:unresolved", sort_by="date", method="get")
         assert len(response.data) == 100
 
-        response = self.get_valid_response(qs_params={"status": "unresolved"}, status="resolved")
+        response = self.get_success_response(qs_params={"status": "unresolved"}, status="resolved")
         assert response.data == {"status": "resolved", "statusDetails": {}, "inbox": None}
 
-        response = self.get_valid_response(query="is:unresolved", sort_by="date", method="get")
+        response = self.get_success_response(query="is:unresolved", sort_by="date", method="get")
         assert len(response.data) == 0
 
     @patch("sentry.integrations.example.integration.ExampleIntegration.sync_status_outbound")
@@ -1926,12 +1928,12 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             relationship=GroupLink.Relationship.references,
         )[0]
 
-        response = self.get_valid_response(sort_by="date", query="is:unresolved", method="get")
+        response = self.get_success_response(sort_by="date", query="is:unresolved", method="get")
         assert len(response.data) == 1
 
         with self.tasks():
             with self.feature({"organizations:integrations-issue-sync": True}):
-                response = self.get_valid_response(
+                response = self.get_success_response(
                     qs_params={"status": "unresolved"}, status="resolved"
                 )
                 group = Group.objects.get(id=group.id)
@@ -1942,7 +1944,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
                     external_issue, True, group.project_id
                 )
 
-        response = self.get_valid_response(sort_by="date", query="is:unresolved", method="get")
+        response = self.get_success_response(sort_by="date", query="is:unresolved", method="get")
         assert len(response.data) == 0
 
     @patch("sentry.integrations.example.integration.ExampleIntegration.sync_status_outbound")
@@ -1980,7 +1982,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         with self.tasks():
             with self.feature({"organizations:integrations-issue-sync": True}):
-                response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
+                response = self.get_success_response(
+                    qs_params={"id": group.id}, status="unresolved"
+                )
                 assert response.status_code == 200
                 assert response.data == {"status": "unresolved", "statusDetails": {}}
 
@@ -2003,7 +2007,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         uo1 = UserOption.objects.create(key="self_assign_issue", value="1", project=None, user=user)
 
         self.login_as(user=user)
-        response = self.get_valid_response(qs_params={"id": group.id}, status="resolved")
+        response = self.get_success_response(qs_params={"id": group.id}, status="resolved")
         assert response.data["assignedTo"]["id"] == str(user.id)
         assert response.data["assignedTo"]["type"] == "user"
         assert response.data["status"] == "resolved"
@@ -2026,7 +2030,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="resolvedInNextRelease"
         )
         assert response.data["status"] == "resolved"
@@ -2076,7 +2080,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="resolvedInNextRelease"
         )
         assert response.data["status"] == "resolved"
@@ -2137,7 +2141,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="resolvedInNextRelease"
         )
         assert response.data["status"] == "resolved"
@@ -2201,7 +2205,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         # is set to its default of `True`
         assert Group.objects.get(id=group.id).get_last_release() == release_1.version
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="resolvedInNextRelease"
         )
         assert response.data["status"] == "resolved"
@@ -2242,7 +2246,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="resolvedInNextRelease"
         )
         assert response.data["status"] == "resolved"
@@ -2276,7 +2280,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
         with self.feature("organizations:global-views"):
-            response = self.get_valid_response(
+            response = self.get_success_response(
                 qs_params={"id": [group1.id, group2.id], "group4": group4.id}, status="resolved"
             )
         assert response.data == {"status": "resolved", "statusDetails": {}, "inbox": None}
@@ -2309,7 +2313,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="resolved", statusDetails={"inRelease": "latest"}
         )
         assert response.data["status"] == "resolved"
@@ -2345,7 +2349,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id},
             status="resolved",
             statusDetails={"inRelease": release.version},
@@ -2387,7 +2391,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id},
             status="resolved",
             statusDetails={"inRelease": release_1.version},
@@ -2424,7 +2428,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="resolved", statusDetails={"inNextRelease": True}
         )
         assert response.data["status"] == "resolved"
@@ -2456,7 +2460,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="resolvedInNextRelease"
         )
         assert response.data["status"] == "resolved"
@@ -2490,7 +2494,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id},
             status="resolved",
             statusDetails={"inCommit": {"commit": commit.key, "repository": repo.name}},
@@ -2527,7 +2531,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id},
             status="resolved",
             statusDetails={"inCommit": {"commit": commit.key, "repository": repo.name}},
@@ -2587,7 +2591,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
+        response = self.get_success_response(qs_params={"id": group.id}, status="unresolved")
         assert response.data == {"status": "unresolved", "statusDetails": {}}
 
         group = Group.objects.get(id=group.id)
@@ -2609,7 +2613,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
+        response = self.get_success_response(qs_params={"id": group.id}, status="unresolved")
         assert response.data == {"status": "unresolved", "statusDetails": {}}
 
         group = Group.objects.get(id=group.id)
@@ -2627,7 +2631,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.IGNORED
         ).exists()
-        response = self.get_valid_response(qs_params={"id": group.id}, status="ignored")
+        response = self.get_success_response(qs_params={"id": group.id}, status="ignored")
         # existing snooze objects should be cleaned up
         assert not GroupSnooze.objects.filter(id=snooze.id).exists()
 
@@ -2642,7 +2646,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="ignored", ignoreDuration=30
         )
         snooze = GroupSnooze.objects.get(group=group)
@@ -2674,7 +2678,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="ignored", ignoreCount=100
         )
         snooze = GroupSnooze.objects.get(group=group)
@@ -2711,7 +2715,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": group.id}, status="ignored", ignoreUserCount=10
         )
         snooze = GroupSnooze.objects.get(group=group)
@@ -2741,7 +2745,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
         with self.feature("organizations:global-views"):
-            response = self.get_valid_response(
+            response = self.get_success_response(
                 qs_params={"id": [group1.id, group2.id], "group4": group4.id}, isBookmarked="true"
             )
         assert response.data == {"isBookmarked": True}
@@ -2774,7 +2778,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
         with self.feature("organizations:global-views"):
-            response = self.get_valid_response(
+            response = self.get_success_response(
                 qs_params={"id": [group1.id, group2.id], "group4": group4.id}, isSubscribed="true"
             )
         assert response.data == {"isSubscribed": True, "subscriptionDetails": {"reason": "unknown"}}
@@ -2796,7 +2800,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         group2 = self.create_group()
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": [group1.id, group2.id]}, isPublic="true"
         )
         assert response.data["isPublic"] is True
@@ -2818,7 +2822,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             assert bool(g.get_share_id())
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": [group1.id, group2.id]}, isPublic="false"
         )
         assert response.data == {"isPublic": False, "shareId": None}
@@ -2840,7 +2844,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
         with self.feature("organizations:global-views"):
-            response = self.get_valid_response(
+            response = self.get_success_response(
                 qs_params={"id": [group1.id, group2.id], "group4": group4.id}, hasSeen="true"
             )
         assert response.data == {"hasSeen": True}
@@ -2871,7 +2875,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         self.create_group()
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": [group1.id, group2.id, group3.id]}, merge="1"
         )
         assert response.data["merge"]["parent"] == str(group2.id)
@@ -2897,7 +2901,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         user = self.user
 
         self.login_as(user=user)
-        response = self.get_valid_response(qs_params={"id": group1.id}, assignedTo=user.username)
+        response = self.get_success_response(qs_params={"id": group1.id}, assignedTo=user.username)
         assert response.data["assignedTo"]["id"] == str(user.id)
         assert response.data["assignedTo"]["type"] == "user"
         assert GroupAssignee.objects.filter(group=group1, user=user).exists()
@@ -2911,7 +2915,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         assert GroupSubscription.objects.filter(user=user, group=group1, is_active=True).exists()
 
-        response = self.get_valid_response(qs_params={"id": group1.id}, assignedTo="")
+        response = self.get_success_response(qs_params={"id": group1.id}, assignedTo="")
         assert response.data["assignedTo"] is None
 
         assert not GroupAssignee.objects.filter(group=group1, user=user).exists()
@@ -2947,7 +2951,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group, status=GroupHistoryStatus.ASSIGNED
         ).exists()
 
-        response = self.get_valid_response(qs_params={"id": group.id}, assignedTo=f"team:{team.id}")
+        response = self.get_success_response(
+            qs_params={"id": group.id}, assignedTo=f"team:{team.id}"
+        )
         assert response.data["assignedTo"]["id"] == str(team.id)
         assert response.data["assignedTo"]["type"] == "team"
         assert GroupHistory.objects.filter(group=group, status=GroupHistoryStatus.ASSIGNED).exists()
@@ -2957,7 +2963,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         assert GroupSubscription.objects.filter(group=group, is_active=True).count() == 2
 
-        response = self.get_valid_response(qs_params={"id": group.id}, assignedTo="")
+        response = self.get_success_response(qs_params={"id": group.id}, assignedTo="")
         assert response.data["assignedTo"] is None
         assert GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.UNASSIGNED
@@ -2999,7 +3005,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         group2 = self.create_group()
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(qs_params={"id": [group1.id, group2.id]}, inbox="true")
+        response = self.get_success_response(qs_params={"id": [group1.id, group2.id]}, inbox="true")
         assert response.data == {"inbox": True}
         assert GroupInbox.objects.filter(group=group1).exists()
         assert GroupInbox.objects.filter(group=group2).exists()
@@ -3010,7 +3016,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group2, status=GroupHistoryStatus.REVIEWED
         ).exists()
 
-        response = self.get_valid_response(qs_params={"id": [group2.id]}, inbox="false")
+        response = self.get_success_response(qs_params={"id": [group2.id]}, inbox="false")
         assert response.data == {"inbox": False}
         assert GroupInbox.objects.filter(group=group1).exists()
         assert not GroupHistory.objects.filter(
@@ -3026,14 +3032,14 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         group2 = self.create_group()
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(
+        response = self.get_success_response(
             qs_params={"id": [group1.id, group2.id]}, status="resolved"
         )
         assert response.data["inbox"] is None
         assert not GroupInbox.objects.filter(group=group1).exists()
         assert not GroupInbox.objects.filter(group=group2).exists()
 
-        self.get_valid_response(qs_params={"id": [group2.id]}, status="unresolved")
+        self.get_success_response(qs_params={"id": [group2.id]}, status="unresolved")
         assert not GroupInbox.objects.filter(group=group1).exists()
         assert not GroupInbox.objects.filter(group=group2).exists()
         assert not GroupHistory.objects.filter(

--- a/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
+++ b/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
@@ -61,7 +61,7 @@ class OrganizationIssuesResolvedInReleaseEndpointTest(APITestCase, SnubaTestCase
         if environment_names:
             params["environment"] = environment_names
 
-        response = self.get_valid_response(self.org.slug, self.release.version, **params)
+        response = self.get_success_response(self.org.slug, self.release.version, **params)
         assert len(response.data) == len(expected_groups)
         expected = set(map(str, [g.id for g in expected_groups]))
         assert {item["id"] for item in response.data} == expected

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -26,7 +26,7 @@ class OrganizationTagKeyTestCase(APITestCase, SnubaTestCase):
         return super().get_response(self.org.slug, key, **kwargs)
 
     def run_test(self, key, expected, **kwargs):
-        response = self.get_valid_response(key, **kwargs)
+        response = self.get_success_response(key, **kwargs)
         assert [(val["value"], val["count"]) for val in response.data] == expected
 
     @fixture

--- a/tests/snuba/api/endpoints/test_project_tags.py
+++ b/tests/snuba/api/endpoints/test_project_tags.py
@@ -22,7 +22,7 @@ class ProjectTagsTest(APITestCase, SnubaTestCase):
             project_id=self.project.id,
         )
 
-        response = self.get_valid_response(self.project.organization.slug, self.project.slug)
+        response = self.get_success_response(self.project.organization.slug, self.project.slug)
 
         data = {v["key"]: v for v in response.data}
         assert len(data) == 3


### PR DESCRIPTION
The `get_valid_response()` helper is deprecated in favor of the more specific `get_success_response()` and `get_error_response()`. This PR is just a global replace via regex plus deleting the deprecated method.