### PR TITLE
ref(tests): Infer `status_code` from `method`

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -59,6 +59,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from exam import Exam, before, fixture
 from pkg_resources import iter_entry_points
+from rest_framework import status
 from rest_framework.test import APITestCase as BaseAPITestCase
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 
@@ -516,11 +517,23 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
         if status_code and status_code >= 400:
             raise Exception("status_code must be < 400")
 
-        response = self.get_response(*args, **params)
+        method = params.pop("method", self.method).lower()
+
+        response = self.get_response(*args, method=method, **params)
 
         if status_code:
             assert_status_code(response, status_code)
+        elif method == "get":
+            assert_status_code(response, status.HTTP_200_OK)
+        # TODO(mgaeta): Add the other methods.
+        # elif method == "post":
+        #     assert_status_code(response, status.HTTP_201_CREATED)
+        elif method == "put":
+            assert_status_code(response, status.HTTP_200_OK)
+        elif method == "delete":
+            assert_status_code(response, status.HTTP_204_NO_CONTENT)
         else:
+            # TODO(mgaeta): Add other methods.
             assert_status_code(response, 200, 300)
 
         return response

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -5,6 +5,7 @@ from dateutil.parser import parse as parse_date
 from django.core import mail
 from django.utils import timezone
 from pytz import UTC
+from rest_framework import status
 
 from sentry import audit_log
 from sentry.api.endpoints.organization_details import ERR_NO_2FA, ERR_SSO_ENABLED
@@ -638,7 +639,7 @@ class OrganizationDeleteTest(OrganizationDetailsTestBase):
         assert len(owners) > 0
 
         with self.tasks():
-            self.get_success_response(self.organization.slug, status_code=202)
+            self.get_success_response(self.organization.slug, status_code=status.HTTP_202_ACCEPTED)
 
         org = Organization.objects.get(id=self.organization.id)
 
@@ -682,7 +683,7 @@ class OrganizationDeleteTest(OrganizationDetailsTestBase):
         org = self.create_organization(owner=self.user)
         ScheduledDeletion.schedule(org, days=1)
 
-        self.get_success_response(org.slug)
+        self.get_success_response(org.slug, status_code=status.HTTP_202_ACCEPTED)
 
         org = Organization.objects.get(id=org.id)
         assert org.status == OrganizationStatus.PENDING_DELETION

--- a/tests/sentry/api/endpoints/test_project_team_details.py
+++ b/tests/sentry/api/endpoints/test_project_team_details.py
@@ -80,7 +80,12 @@ class ProjectTeamDetailsDeleteTest(ProjectTeamDetailsTest):
         assert r1.owner == ar1.owner is None
         assert r2.owner == ar2.owner == team.actor
 
-        self.get_success_response(project.organization.slug, another_project.slug, team.slug)
+        self.get_success_response(
+            project.organization.slug,
+            another_project.slug,
+            team.slug,
+            status_code=status.HTTP_200_OK,
+        )
 
         r1.refresh_from_db()
         r2.refresh_from_db()

--- a/tests/sentry/api/endpoints/test_project_team_details.py
+++ b/tests/sentry/api/endpoints/test_project_team_details.py
@@ -1,3 +1,5 @@
+from rest_framework import status
+
 from sentry.models import ProjectTeam, Rule
 from sentry.testutils import APITestCase
 
@@ -18,7 +20,10 @@ class ProjectTeamDetailsPostTest(ProjectTeamDetailsTest):
         team = self.create_team()
 
         self.get_success_response(
-            project.organization.slug, project.slug, team.slug, status_code=201
+            project.organization.slug,
+            project.slug,
+            team.slug,
+            status_code=status.HTTP_201_CREATED,
         )
 
         assert ProjectTeam.objects.filter(project=project, team=team).exists()
@@ -27,7 +32,10 @@ class ProjectTeamDetailsPostTest(ProjectTeamDetailsTest):
         project = self.create_project()
 
         self.get_error_response(
-            project.organization.slug, project.slug, "not-a-team", status_code=404
+            project.organization.slug,
+            project.slug,
+            "not-a-team",
+            status_code=status.HTTP_404_NOT_FOUND,
         )
 
 
@@ -56,7 +64,12 @@ class ProjectTeamDetailsDeleteTest(ProjectTeamDetailsTest):
 
         assert r1.owner == r2.owner == ar1.owner == ar2.owner == team.actor
 
-        self.get_success_response(project.organization.slug, project.slug, team.slug)
+        self.get_success_response(
+            project.organization.slug,
+            project.slug,
+            team.slug,
+            status_code=status.HTTP_200_OK,
+        )
         assert not ProjectTeam.objects.filter(project=project, team=team).exists()
 
         r1.refresh_from_db()
@@ -80,5 +93,8 @@ class ProjectTeamDetailsDeleteTest(ProjectTeamDetailsTest):
         project = self.create_project()
 
         self.get_error_response(
-            project.organization.slug, project.slug, "not-a-team", status_code=404
+            project.organization.slug,
+            project.slug,
+            "not-a-team",
+            status_code=status.HTTP_404_NOT_FOUND,
         )

--- a/tests/sentry/api/endpoints/test_team_notification_settings.py
+++ b/tests/sentry/api/endpoints/test_team_notification_settings.py
@@ -1,3 +1,5 @@
+from rest_framework import status
+
 from sentry.models import NotificationSetting
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import APITestCase
@@ -8,23 +10,23 @@ class TeamNotificationSettingsTestBase(APITestCase):
     endpoint = "sentry-api-0-team-notification-settings"
 
     def setUp(self):
+        super().setUp()
         self.login_as(self.user)
-        self.org = self.organization  # Force creation.
-        _ = self.project  # Force creation.
 
 
 class TeamNotificationSettingsGetTest(TeamNotificationSettingsTestBase):
     def test_simple(self):
-        response = self.get_success_response(self.org.slug, self.team.slug)
+        _ = self.project  # HACK to force creation.
+        response = self.get_success_response(self.organization.slug, self.team.slug)
 
         # Spot check.
         assert response.data["alerts"]["project"][self.project.id]["email"] == "default"
-        assert response.data["deploy"]["organization"][self.org.id]["email"] == "default"
+        assert response.data["deploy"]["organization"][self.organization.id]["email"] == "default"
         assert response.data["workflow"]["project"][self.project.id]["slack"] == "default"
 
     def test_type_querystring(self):
         response = self.get_success_response(
-            self.org.slug, self.team.slug, qs_params={"type": "workflow"}
+            self.organization.slug, self.team.slug, qs_params={"type": "workflow"}
         )
 
         assert "alerts" not in response.data
@@ -32,17 +34,24 @@ class TeamNotificationSettingsGetTest(TeamNotificationSettingsTestBase):
 
     def test_invalid_querystring(self):
         self.get_error_response(
-            self.org.slug, self.team.slug, qs_params={"type": "invalid"}, status_code=400
+            self.organization.slug,
+            self.team.slug,
+            qs_params={"type": "invalid"},
+            status_code=status.HTTP_400_BAD_REQUEST,
         )
 
     def test_invalid_team_slug(self):
-        self.get_error_response(self.org.slug, "invalid", status_code=404)
+        self.get_error_response(
+            self.organization.slug, "invalid", status_code=status.HTTP_404_NOT_FOUND
+        )
 
     def test_wrong_team_slug(self):
         other_org = self.create_organization()
         other_team = self.create_team(organization=other_org, name="Tesla Motors")
 
-        self.get_error_response(other_org.slug, other_team.slug, status_code=403)
+        self.get_error_response(
+            other_org.slug, other_team.slug, status_code=status.HTTP_403_FORBIDDEN
+        )
 
 
 class TeamNotificationSettingsTest(TeamNotificationSettingsTestBase):
@@ -60,9 +69,10 @@ class TeamNotificationSettingsTest(TeamNotificationSettingsTestBase):
         )
 
         self.get_success_response(
-            self.org.slug,
+            self.organization.slug,
             self.team.slug,
-            **{"alerts": {"project": {self.project.id: {"email": "always", "slack": "always"}}}},
+            alerts={"project": {self.project.id: {"email": "always", "slack": "always"}}},
+            status_code=status.HTTP_204_NO_CONTENT,
         )
 
         assert (
@@ -76,7 +86,16 @@ class TeamNotificationSettingsTest(TeamNotificationSettingsTestBase):
         )
 
     def test_empty_payload(self):
-        self.get_error_response(self.org.slug, self.team.slug, **{}, status_code=400)
+        self.get_error_response(
+            self.organization.slug,
+            self.team.slug,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
 
     def test_invalid_payload(self):
-        self.get_error_response(self.org.slug, self.team.slug, **{"invalid": 1}, status_code=400)
+        self.get_error_response(
+            self.organization.slug,
+            self.team.slug,
+            invalid=1,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )


### PR DESCRIPTION
My vision for `get_success_reponse()` is that it should be inferring `method`, `url`, and `status_code` from class variables. For example:

```py
class ExampleTest(APITestCase):
    def test_simple(self):
        ...
        url = reverse("sentry-api-0-sentry-app-requests", args=[self.published_app.slug])
        response = self.client.delete(url, format="json")
        assert response.status_code == 204
```
would be:
```py
class ExampleTest(APITestCase):
    endpoint = "sentry-api-0-sentry-app-requests"
    method = "delete"

    def test_simple(self):
        ...
        response = self.get_success_response(self.published_app.slug)
```
But where the API is returning an unexpected `status_code`, it would have to be explicitly set.

Broken tests by method

|method|count|
|------|-----|
|GET|0|
|POST|~400|
|PUT|6|
|DELETE|1|

It's going to take a significant refactor to get this working for POST.
