### PR TITLE
fix(tests): Mock all discover unfurl query

### DIFF
--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -19,6 +19,8 @@ from sentry.testutils import TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.datetime import before_now, iso_format
 
+INTERVALS_PER_DAY = 288
+
 
 @pytest.mark.parametrize(
     "url,expected",
@@ -328,15 +330,17 @@ class UnfurlTest(TestCase):
         assert len(chart_data["sessionResponse"]["groups"]) >= 1
         assert len(chart_data["incidents"]) == 0
 
+    @patch(
+        "sentry.api.bases.organization_events.OrganizationEventsV2EndpointBase.get_event_stats_data",
+        return_value={
+            "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+            "end": 1652903400,
+            "isMetricsData": False,
+            "start": 1652817000,
+        },
+    )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
-    def test_unfurl_discover(self, mock_generate_chart):
-        min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
+    def test_unfurl_discover(self, mock_generate_chart, _):
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project={self.project.id}&query=&sort=-timestamp&statsPeriod=24h"
         link_type, args = match_link(url)
 
@@ -359,18 +363,19 @@ class UnfurlTest(TestCase):
         assert len(mock_generate_chart.mock_calls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
         assert chart_data["seriesName"] == "count()"
-        assert len(chart_data["stats"]["data"]) == 288
+        assert len(chart_data["stats"]["data"]) == INTERVALS_PER_DAY
 
+    @patch(
+        "sentry.api.bases.organization_events.OrganizationEventsV2EndpointBase.get_event_stats_data",
+        return_value={
+            "data": [(i * 300, [{"count": 0}]) for i in range(48)],
+            "end": 1652903400,
+            "isMetricsData": False,
+            "start": 1652817000,
+        },
+    )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
-    def test_unfurl_discover_previous_period(self, mock_generate_chart):
-        min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
-
+    def test_unfurl_discover_previous_period(self, mock_generate_chart, _):
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?display=previous&field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project={self.project.id}&query=&sort=-timestamp&statsPeriod=24h"
         link_type, args = match_link(url)
 
@@ -396,15 +401,27 @@ class UnfurlTest(TestCase):
         assert chart_data["seriesName"] == "count()"
         assert len(chart_data["stats"]["data"]) == 48
 
+    @patch(
+        "sentry.api.bases.organization_events.OrganizationEventsV2EndpointBase.get_event_stats_data",
+        return_value={
+            "count()": {
+                "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+                "end": 1652903400,
+                "isMetricsData": False,
+                "order": 1,
+                "start": 1652817000,
+            },
+            "count_unique(user)": {
+                "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+                "end": 1652903400,
+                "isMetricsData": False,
+                "order": 1,
+                "start": 1652817000,
+            },
+        },
+    )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
-    def test_unfurl_discover_multi_y_axis(self, mock_generate_chart):
-        min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
+    def test_unfurl_discover_multi_y_axis(self, mock_generate_chart, _):
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project={self.project.id}&query=&sort=-timestamp&statsPeriod=24h&yAxis=count_unique%28user%29&yAxis=count%28%29"
         link_type, args = match_link(url)
@@ -428,18 +445,21 @@ class UnfurlTest(TestCase):
         assert len(mock_generate_chart.mock_calls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
 
-        assert len(chart_data["stats"]["count()"]["data"]) == 288
-        assert len(chart_data["stats"]["count_unique(user)"]["data"]) == 288
+        assert len(chart_data["stats"]["count()"]["data"]) == INTERVALS_PER_DAY
+        assert len(chart_data["stats"]["count_unique(user)"]["data"]) == INTERVALS_PER_DAY
 
+    @patch(
+        "sentry.api.bases.organization_events.OrganizationEventsV2EndpointBase.get_event_stats_data",
+        return_value={
+            "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+            "end": 1652903400,
+            "isMetricsData": False,
+            "order": 1,
+            "start": 1652817000,
+        },
+    )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
-    def test_unfurl_discover_html_escaped(self, mock_generate_chart):
-        min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
+    def test_unfurl_discover_html_escaped(self, mock_generate_chart, _):
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?field=title&amp;field=event.type&amp;field=project&amp;field=user.display&amp;field=timestamp&amp;name=All+Events&amp;project={self.project.id}&amp;query=&amp;sort=-timestamp&amp;statsPeriod=24h"
         link_type, args = match_link(url)
@@ -463,10 +483,29 @@ class UnfurlTest(TestCase):
         assert len(mock_generate_chart.mock_calls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
         assert chart_data["seriesName"] == "count()"
-        assert len(chart_data["stats"]["data"]) == 288
+        assert len(chart_data["stats"]["data"]) == INTERVALS_PER_DAY
 
+    @patch(
+        "sentry.api.bases.organization_events.OrganizationEventsV2EndpointBase.get_event_stats_data",
+        return_value={
+            "default,first,capable-hagfish,None": {
+                "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+                "end": 1652903400,
+                "isMetricsData": False,
+                "order": 1,
+                "start": 1652817000,
+            },
+            "default,second,capable-hagfish,None": {
+                "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+                "end": 1652903400,
+                "isMetricsData": False,
+                "order": 1,
+                "start": 1652817000,
+            },
+        },
+    )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
-    def test_unfurl_discover_short_url(self, mock_generate_chart):
+    def test_unfurl_discover_short_url(self, mock_generate_chart, _):
         query = {
             "fields": ["message", "event.type", "project", "user.display", "count_unique(user)"],
             "query": "message:[first,second]",
@@ -482,16 +521,6 @@ class UnfurlTest(TestCase):
             version=2,
         )
         saved_query.set_projects([self.project.id])
-
-        min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={"message": "first", "fingerprint": ["group2"], "timestamp": min_ago},
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={"message": "second", "fingerprint": ["group2"], "timestamp": min_ago},
-            project_id=self.project.id,
-        )
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?id={saved_query.id}&statsPeriod=24h&project={self.project.id}"
         link_type, args = match_link(url)
@@ -526,10 +555,19 @@ class UnfurlTest(TestCase):
         # 2 + 1 cause of Other
         assert len(chart_data["stats"].keys()) == 2
         first_key = list(chart_data["stats"].keys())[0]
-        assert len(chart_data["stats"][first_key]["data"]) == 288
+        assert len(chart_data["stats"][first_key]["data"]) == INTERVALS_PER_DAY
 
+    @patch(
+        "sentry.api.bases.organization_events.OrganizationEventsV2EndpointBase.get_event_stats_data",
+        return_value={
+            "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+            "end": 1652903400,
+            "isMetricsData": False,
+            "start": 1652817000,
+        },
+    )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
-    def test_unfurl_correct_y_axis_for_saved_query(self, mock_generate_chart):
+    def test_unfurl_correct_y_axis_for_saved_query(self, mock_generate_chart, _):
         query = {
             "fields": [
                 "message",
@@ -547,16 +585,6 @@ class UnfurlTest(TestCase):
             version=2,
         )
         saved_query.set_projects([self.project.id])
-
-        min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={"message": "first", "fingerprint": ["group2"], "timestamp": min_ago},
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={"message": "second", "fingerprint": ["group2"], "timestamp": min_ago},
-            project_id=self.project.id,
-        )
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?id={saved_query.id}&statsPeriod=24h&project={self.project.id}"
         link_type, args = match_link(url)
@@ -587,19 +615,29 @@ class UnfurlTest(TestCase):
         assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_DISCOVER_TOTAL_PERIOD
         chart_data = mock_generate_chart.call_args[0][1]
         assert chart_data["seriesName"] == "p50(transaction.duration)"
-        assert len(chart_data["stats"]["data"]) == 288
+        assert len(chart_data["stats"]["data"]) == INTERVALS_PER_DAY
 
+    @patch(
+        "sentry.api.bases.organization_events.OrganizationEventsV2EndpointBase.get_event_stats_data",
+        return_value={
+            "default,first": {
+                "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+                "end": 1652903400,
+                "isMetricsData": False,
+                "order": 1,
+                "start": 1652817000,
+            },
+            "default,second": {
+                "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+                "end": 1652903400,
+                "isMetricsData": False,
+                "order": 1,
+                "start": 1652817000,
+            },
+        },
+    )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
-    def test_top_events_url_param(self, mock_generate_chart):
-        min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={"message": "first", "fingerprint": ["group1"], "timestamp": min_ago},
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={"message": "second", "fingerprint": ["group2"], "timestamp": min_ago},
-            project_id=self.project.id,
-        )
+    def test_top_events_url_param(self, mock_generate_chart, _):
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?field=message&field=event.type&field=count()&name=All+Events&query=message:[first,second]&sort=-count&statsPeriod=24h&display=top5&topEvents=2"
         link_type, args = match_link(url)
@@ -632,7 +670,7 @@ class UnfurlTest(TestCase):
         assert chart_data["seriesName"] == "count()"
         assert len(chart_data["stats"].keys()) == 2
         first_key = list(chart_data["stats"].keys())[0]
-        assert len(chart_data["stats"][first_key]["data"]) == 288
+        assert len(chart_data["stats"][first_key]["data"]) == INTERVALS_PER_DAY
 
     # patched return value determined by reading events stats output
     @patch(
@@ -701,8 +739,17 @@ class UnfurlTest(TestCase):
         # Two buckets
         assert len(chart_data["stats"][first_key]["data"]) == 2
 
+    @patch(
+        "sentry.api.bases.organization_events.OrganizationEventsV2EndpointBase.get_event_stats_data",
+        return_value={
+            "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+            "end": 1652903400,
+            "isMetricsData": False,
+            "start": 1652817000,
+        },
+    )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
-    def test_unfurl_discover_short_url_without_project_ids(self, mock_generate_chart):
+    def test_unfurl_discover_short_url_without_project_ids(self, mock_generate_chart, _):
         query = {
             "fields": ["title", "event.type", "project", "user.display", "timestamp"],
             "query": "",
@@ -716,14 +763,6 @@ class UnfurlTest(TestCase):
             version=2,
         )
         saved_query.set_projects([self.project.id])
-
-        min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?id={saved_query.id}&statsPeriod=24h"
         link_type, args = match_link(url)
@@ -754,17 +793,19 @@ class UnfurlTest(TestCase):
         assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_DISCOVER_TOTAL_PERIOD
         chart_data = mock_generate_chart.call_args[0][1]
         assert chart_data["seriesName"] == "count_unique(users)"
-        assert len(chart_data["stats"]["data"]) == 288
+        assert len(chart_data["stats"]["data"]) == INTERVALS_PER_DAY
 
+    @patch(
+        "sentry.api.bases.organization_events.OrganizationEventsV2EndpointBase.get_event_stats_data",
+        return_value={
+            "data": [(i * 300, [{"count": 0}]) for i in range(INTERVALS_PER_DAY)],
+            "end": 1652903400,
+            "isMetricsData": False,
+            "start": 1652817000,
+        },
+    )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
-    def test_unfurl_discover_without_project_ids(self, mock_generate_chart):
-        min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
-        self.store_event(
-            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
-        )
+    def test_unfurl_discover_without_project_ids(self, mock_generate_chart, _):
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&query=&sort=-timestamp&statsPeriod=24h"
         link_type, args = match_link(url)
@@ -793,27 +834,36 @@ class UnfurlTest(TestCase):
         assert len(mock_generate_chart.mock_calls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
         assert chart_data["seriesName"] == "count()"
-        assert len(chart_data["stats"]["data"]) == 288
+        assert len(chart_data["stats"]["data"]) == INTERVALS_PER_DAY
 
+    @patch(
+        "sentry.snuba.discover.query",
+        return_value={
+            "data": [
+                {"geo.country_code": "AU", "count": 2},
+                {"geo.country_code": "CA", "count": 2},
+            ],
+            "meta": {"geo.country_code": "string", "count": "integer"},
+            "profile": {"bytes": 64, "blocks": 1, "rows": 2, "elapsed": 0.009087800979614258},
+            "trace_output": "",
+            "timing": {
+                "timestamp": 1652998746,
+                "duration_ms": 32,
+                "marks_ms": {
+                    "cache_get": 1,
+                    "cache_set": 2,
+                    "execute": 9,
+                    "get_configs": 0,
+                    "prepare_query": 8,
+                    "rate_limit": 2,
+                    "validate_schema": 8,
+                },
+                "tags": {},
+            },
+        },
+    )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
-    def test_unfurl_world_map(self, mock_generate_chart):
-        min_ago = iso_format(before_now(minutes=1))
-        self.store_event(
-            data={
-                "fingerprint": ["group2"],
-                "timestamp": min_ago,
-                "user": {"geo": {"country_code": "CA", "region": "Canada"}},
-            },
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={
-                "fingerprint": ["group2"],
-                "timestamp": min_ago,
-                "user": {"geo": {"country_code": "AU", "region": "Australia"}},
-            },
-            project_id=self.project.id,
-        )
+    def test_unfurl_world_map(self, mock_generate_chart, _):
 
         url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?display=worldmap&field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project={self.project.id}&query=&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29"
         link_type, args = match_link(url)


### PR DESCRIPTION
Tests aren't testing snuba, or discover. This external dependecy was causing some test flakiness. This PR removes some of these dependencies by mocking
