### PR TITLE
feat(workflow): Remove platform icon next to error title

### DIFF
--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -149,18 +149,23 @@ class GroupHeader extends Component<Props, State> {
 
     const shortIdBreadCrumb = group.shortId && (
       <GuideAnchor target="issue_number" position="bottom">
-        <StyledTooltip
-          className="help-link"
-          title={t(
-            'This identifier is unique across your organization, and can be used to reference an issue in various places, like commit messages.'
-          )}
-          position="bottom"
-        >
-          <StyledShortId
-            shortId={group.shortId}
-            avatar={<StyledProjectBadge project={project} avatarSize={16} hideName />}
+        <IssueBreadcrumbWrapper>
+          <BreadcrumbProjectBadge
+            project={project}
+            avatarSize={16}
+            hideName
+            avatarProps={{hasTooltip: true, tooltip: project.slug}}
           />
-        </StyledTooltip>
+          <StyledTooltip
+            className="help-link"
+            title={t(
+              'This identifier is unique across your organization, and can be used to reference an issue in various places, like commit messages.'
+            )}
+            position="bottom"
+          >
+            <StyledShortId shortId={group.shortId} />
+          </StyledTooltip>
+        </IssueBreadcrumbWrapper>
       </GuideAnchor>
     );
 
@@ -178,12 +183,14 @@ class GroupHeader extends Component<Props, State> {
           <div className="row">
             <div className="col-sm-7">
               <TitleWrapper>
-                <StyledIdBadge
-                  project={project}
-                  avatarSize={24}
-                  hideName
-                  avatarProps={{hasTooltip: true, tooltip: project.slug}}
-                />
+                {!hasIssueIdBreadcrumbs && (
+                  <StyledIdBadge
+                    project={project}
+                    avatarSize={24}
+                    hideName
+                    avatarProps={{hasTooltip: true, tooltip: project.slug}}
+                  />
+                )}
                 <h3>
                   <EventOrGroupTitle hasGuideAnchor data={group} />
                 </h3>
@@ -431,6 +438,11 @@ const StyledBreadcrumbs = styled(Breadcrumbs)`
   margin-bottom: ${space(2)};
 `;
 
+const IssueBreadcrumbWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
 const StyledIdBadge = styled(IdBadge)`
   margin-right: ${space(1)};
 `;
@@ -478,6 +490,10 @@ const StyledListLink = styled(ListLink)`
 
 const StyledProjectBadge = styled(ProjectBadge)`
   flex-shrink: 0;
+`;
+
+const BreadcrumbProjectBadge = styled(StyledProjectBadge)`
+  margin-right: ${space(0.75)};
 `;
 
 const EventAnnotationWithSpace = styled(EventAnnotation)`


### PR DESCRIPTION
Remove platform icon next to the error title on the issue details page (in favor of the platform icon being in the breadcrumbs now with the short id). The platform icon in the breadcrumbs will also link to the project details page along with project name in the tooltip.

[FIXES WOR-1888
](https://getsentry.atlassian.net/browse/WOR-1888)

# Before
<img width="659" alt="Screen Shot 2022-05-19 at 3 36 50 PM" src="https://user-images.githubusercontent.com/20312973/169417938-3ea7bc38-1678-47ec-9a24-83e797138dfa.png">

# After
<img width="619" alt="Screen Shot 2022-05-19 at 3 41 50 PM" src="https://user-images.githubusercontent.com/20312973/169417953-16be0e7c-9965-4265-b9dd-0931df8c3d52.png">
<img width="216" alt="Screen Shot 2022-05-19 at 3 41 59 PM" src="https://user-images.githubusercontent.com/20312973/169417962-04ea3225-31d5-4670-af3a-649617721c82.png">
<img width="307" alt="Screen Shot 2022-05-19 at 3 42 04 PM" src="https://user-images.githubusercontent.com/20312973/169417967-a712e920-fc85-435d-a650-a0b57044459f.png">
