### PR TITLE
fix(alerts): Add message for alerts not yet triggered

### DIFF
--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -64,7 +64,7 @@ function RuleListRow({
   function renderLastIncidentDate(): React.ReactNode {
     if (isIssueAlert(rule)) {
       if (!rule.lastTriggered) {
-        return t('Alert not triggered yet.');
+        return t('Alerts not triggered yet.');
       }
       return (
         <div>
@@ -75,7 +75,7 @@ function RuleListRow({
     }
 
     if (!rule.latestIncident) {
-      return t('Alert not triggered yet.');
+      return t('Alerts not triggered yet.');
     }
 
     if (activeIncident) {

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -64,7 +64,7 @@ function RuleListRow({
   function renderLastIncidentDate(): React.ReactNode {
     if (isIssueAlert(rule)) {
       if (!rule.lastTriggered) {
-        return '-';
+        return t('Alert not triggered yet.');
       }
       return (
         <div>
@@ -75,7 +75,7 @@ function RuleListRow({
     }
 
     if (!rule.latestIncident) {
-      return '-';
+      return t('Alert not triggered yet.');
     }
 
     if (activeIncident) {

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -64,7 +64,7 @@ function RuleListRow({
   function renderLastIncidentDate(): React.ReactNode {
     if (isIssueAlert(rule)) {
       if (!rule.lastTriggered) {
-        return t('Alerts not triggered yet.');
+        return t('Alerts not triggered yet');
       }
       return (
         <div>
@@ -75,7 +75,7 @@ function RuleListRow({
     }
 
     if (!rule.latestIncident) {
-      return t('Alerts not triggered yet.');
+      return t('Alerts not triggered yet');
     }
 
     if (activeIncident) {


### PR DESCRIPTION
This adds a message for alerts that haven't triggered yet in the alert list.

After:
![Screen Shot 2022-05-19 at 4 08 36 PM](https://user-images.githubusercontent.com/15015880/169418731-948eef58-28dc-48ca-ae39-9459f1ac9cc6.png)



Before:
![Screen Shot 2022-05-19 at 4 08 48 PM](https://user-images.githubusercontent.com/15015880/169418712-535aeeaf-f871-4535-8454-ea861ac8701c.png)


JIRA: [WOR-1847](https://getsentry.atlassian.net/browse/WOR-1847)
