### PR TITLE
feat(charts): Decrease size of chartcuterie charts in slack

### DIFF
--- a/static/app/chartcuterie/slack.tsx
+++ b/static/app/chartcuterie/slack.tsx
@@ -10,8 +10,8 @@ export const DEFAULT_FONT_FAMILY = 'sans-serif';
  * Size configuration for SLACK_* type charts
  */
 export const slackChartSize = {
-  height: 200,
-  width: 600,
+  height: 150,
+  width: 450,
 };
 
 export const slackGeoChartSize = {


### PR DESCRIPTION
Reverts getsentry/sentry#34807

This was a mistake, its too big.