### PR TITLE
chore(deps): Bump style-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "screenfull": "^6.0.1",
     "scroll-to-element": "^2.0.0",
     "sprintf-js": "1.0.3",
-    "style-loader": "^3.0.0",
+    "style-loader": "^3.3.1",
     "ts-node": "^10.7.0",
     "tslib": "^2.3.1",
     "typescript": "^4.6.2",
@@ -203,7 +203,7 @@
     "dotenv-webpack": "^7.1.0",
     "html-webpack-plugin": "^5.0.0",
     "less-loader": "^11.0.0",
-    "style-loader": "^2.0.0",
+    "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.1.4",
     "webpack-virtual-modules": "^0.4.3",
     "colors": "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14625,18 +14625,10 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-style-loader@^1.3.0, style-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-2.0.0.tgz#9669602fd4690740eaaec137799a03addbbc393c"
-  integrity sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
-style-loader@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.0.0.tgz#2eafcd0dbe70b07438e0256a9714ea94dd63cbe0"
-  integrity sha512-pqJTDiCtLr8D2eyVWXPiwNkLsAMDuvPHnu+Z/Edo9hu+DzdJwdO5eZv9zUBF6tWI8GJGhAkenWJaVjXI+sHnuQ==
+style-loader@^1.3.0, style-loader@^2.0.0, style-loader@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
+  integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
 
 style-search@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Changelog here: https://github.com/webpack-contrib/style-loader/blob/master/CHANGELOG.md#300-2021-06-24

> minimum supported Node.js version is 12.13.0
> minimum supported webpack version is 5.0.0
>
> the styleTag value of the injectType (default value) option earlier uses singleton style tag by default for IE8-IE9 due limitations (more information), in this release we have disabled this behavior, because these versions of IE are outdated, if you don't support these browsers this change does not affect you, if you require to support IE8-IE9, you can return old behaviour by setting autoStyleTag value for the injectType option (do the same for lazyStyleTag, i.e. change it to lazyAutoStyleTag)

Pretty much nothing