### PR TITLE
Revert "Revert "ref: rely on django's global settings inheritance rather than a `*` import (#34811)""

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -12,8 +12,6 @@ import tempfile
 from datetime import timedelta
 from urllib.parse import urlparse
 
-from django.conf.global_settings import *  # NOQA
-
 import sentry
 from sentry.utils.celery import crontab_with_minute_jitter
 from sentry.utils.types import type_from_value


### PR DESCRIPTION
re-apply of #34811 now that https://github.com/getsentry/getsentry/pull/7531 has landed

testing done:

(in getsentry):

```console
$ pytest tests/getsentry/utils/test_math.py 

...

=============================== test session starts ===============================
platform darwin -- Python 3.8.13, pytest-6.1.0, py-1.11.0, pluggy-0.13.1
rootdir: /Users/asottile/workspace/getsentry, configfile: pyproject.toml
plugins: rerunfailures-9.1.1, cov-2.11.1, django-3.10.0, sentry-0.1.9
collected 1 item                                                                  

tests/getsentry/utils/test_math.py .                                        [100%]

================================ 1 passed in 0.05s ================================
```