### PR TITLE
ref(ts): Remove unused types for Breadcrumbs

### DIFF
--- a/static/app/types/breadcrumbs.tsx
+++ b/static/app/types/breadcrumbs.tsx
@@ -28,7 +28,6 @@ export enum BreadcrumbType {
   SYSTEM = 'system',
   SESSION = 'session',
   TRANSACTION = 'transaction',
-  CONSOLE = 'console',
   INIT = 'init',
 }
 
@@ -78,14 +77,6 @@ export type BreadcrumbTypeHTTP = {
     status_code?: number;
     url?: string;
   };
-} & BreadcrumbTypeBase;
-
-export type BreadcrumbTypeConsole = {
-  data: {
-    arguments: any[];
-    logger: string;
-  };
-  type: BreadcrumbType.CONSOLE;
 } & BreadcrumbTypeBase;
 
 export type BreadcrumbTypeDefault = {


### PR DESCRIPTION
Added in #34197, but 1) was incorrect and 2) unused.