### PR TITLE
fix(perf): Anchor links in span tree

### DIFF
--- a/static/app/views/performance/index.tsx
+++ b/static/app/views/performance/index.tsx
@@ -30,6 +30,7 @@ function PerformanceContainer({organization, children, location}: Props) {
             ...location.query,
             userModified: undefined,
           },
+          hash: location.hash,
         });
       }
     },


### PR DESCRIPTION
Within the event details page, the `hash` property was being used to determine which span is anchored. However, when navigating to new pages in Performance, the `hash` in `browserHistory` was not getting copied. This `useEffect` seems to trigger on refresh as well, so we need to copy the `hash` property too.


