### PR TITLE
fix(profiling): Rename the key instead of copying its value

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -114,8 +114,8 @@ def _symbolicate(profile: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
     # remove debug information we don't need anymore
     profile.pop("debug_meta")
 
-    # save the symbolicated frames on the profile
-    profile["profile"] = profile["sampled_profile"]
+    # rename the profile key to suggest it has been processed
+    profile["profile"] = profile.pop("sampled_profile")
 
     return profile
 


### PR DESCRIPTION
We were copying the value to another key in the `dict` instead of renaming it, creating a bigger than needed payload to push to Kafka. This PR fixes this issue.