### PR TITLE
feat(digest): New Digest notification title

### DIFF
--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -165,7 +165,7 @@ def _notify_recipient(
             "link_names": 1,
             "unfurl_links": False,
             "unfurl_media": False,
-            "text": notification.get_subject(shared_context),
+            "text": notification.get_notification_title(shared_context),
             "attachments": json.dumps(local_attachments),
         }
 

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -144,6 +144,7 @@ def _notify_recipient(
     attachments: List[SlackAttachment],
     channel: str,
     integration: Integration,
+    shared_context: Mapping[str, Any],
 ) -> None:
     with sentry_sdk.start_span(op="notification.send_slack", description="notify_recipient"):
         # Make a local copy to which we can append.
@@ -164,7 +165,7 @@ def _notify_recipient(
             "link_names": 1,
             "unfurl_links": False,
             "unfurl_media": False,
-            "text": notification.get_notification_title(),
+            "text": notification.get_subject(shared_context),
             "attachments": json.dumps(local_attachments),
         }
 
@@ -213,6 +214,7 @@ def send_notification_as_slack(
                     attachments=attachments,
                     channel=channel,
                     integration=integration,
+                    shared_context=shared_context,
                 )
 
     metrics.incr(

--- a/src/sentry/notifications/notifications/activity/assigned.py
+++ b/src/sentry/notifications/notifications/activity/assigned.py
@@ -61,7 +61,7 @@ class AssignedActivityNotification(GroupActivityNotification):
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} assigned {an issue} to {assignee}", {"assignee": self.get_assignee()}, {}
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         assignee = self.get_assignee()
 
         if not self.activity.user:

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -131,7 +131,7 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
             "referrer": self.__class__.__name__,
         }
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         description, params, _ = self.get_description()
         return self.description_as_text(description, params, True)
 

--- a/src/sentry/notifications/notifications/activity/new_processing_issues.py
+++ b/src/sentry/notifications/notifications/activity/new_processing_issues.py
@@ -54,7 +54,7 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
     def title(self) -> str:
         return self.get_subject()
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         project_url = absolute_uri(
             f"/settings/{self.organization.slug}/projects/{self.project.slug}/processing-issues/"
         )

--- a/src/sentry/notifications/notifications/activity/note.py
+++ b/src/sentry/notifications/notifications/activity/note.py
@@ -21,7 +21,7 @@ class NoteActivityNotification(GroupActivityNotification):
         author = self.activity.user.get_display_name()
         return f"New comment by {author}"
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         return self.title
 
     def get_message_description(self, recipient: Team | User) -> Any:

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -34,7 +34,7 @@ class RegressionActivityNotification(GroupActivityNotification):
 
         return message, params, html_params
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         text = "Issue marked as regression"
         if self.version:
             text += f" in release {self.version_parsed}"

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -134,7 +134,7 @@ class ReleaseActivityNotification(ActivityNotification):
     def title(self) -> str:
         return self.get_subject()
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         projects_text = ""
         if len(self.projects) == 1:
             projects_text = " for this project"

--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -31,7 +31,7 @@ class ResolvedInReleaseActivityNotification(GroupActivityNotification):
             )
         return "{author} marked {an issue} as resolved in an upcoming release", {}, {}
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         data = self.activity.data
         author = self.activity.user.get_display_name()
         release = data["version"] if data.get("version") else "an upcoming release"

--- a/src/sentry/notifications/notifications/activity/unassigned.py
+++ b/src/sentry/notifications/notifications/activity/unassigned.py
@@ -12,7 +12,7 @@ class UnassignedActivityNotification(GroupActivityNotification):
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} unassigned {an issue}", {}, {}
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         user = self.activity.user
         if user:
             author = user.name or user.email

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -80,7 +80,8 @@ class BaseNotification(abc.ABC):
         # Basically a noop.
         return {**extra_context}
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
+        """The subject line when sending this notifications as a chat notification."""
         raise NotImplementedError
 
     def get_title_link(self, recipient: Team | User) -> str | None:

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -62,9 +62,8 @@ class DigestNotification(ProjectNotification):
             return "Digest Report"
         return get_digest_subject(context["group"], context["counts"], context["start"])
 
-    def get_notification_title(self) -> str:
-        # This shouldn't be possible but adding a message just in case.
-        return self.get_subject()
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
+        return self.get_subject(context)
 
     def get_title_link(self, recipient: Team | User) -> str | None:
         return None

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -29,6 +29,7 @@ from sentry.notifications.utils.digest import (
     should_send_as_alert_notification,
 )
 from sentry.types.integrations import ExternalProviders
+from sentry.utils.dates import to_timestamp
 
 if TYPE_CHECKING:
     from sentry.models import Organization, Project, Team, User
@@ -60,10 +61,17 @@ class DigestNotification(ProjectNotification):
         if not context:
             # This shouldn't be possible but adding a message just in case.
             return "Digest Report"
+
         return get_digest_subject(context["group"], context["counts"], context["start"])
 
     def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
-        return self.get_subject(context)
+        return "<!date^{:.0f}^{count} {noun} detected in {project} {date} | Digest Report".format(
+            to_timestamp(context["start"]),
+            count=len(context["counts"]),
+            noun="issue" if len(context["counts"]) == 1 else "issues",
+            project=context["group"].project.name,
+            date="{date_pretty}",
+        )
 
     def get_title_link(self, recipient: Team | User) -> str | None:
         return None

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -65,6 +65,9 @@ class DigestNotification(ProjectNotification):
         return get_digest_subject(context["group"], context["counts"], context["start"])
 
     def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
+        if not context:
+            return "Digest Report"
+
         return "<!date^{:.0f}^{count} {noun} detected in {project} {date} | Digest Report".format(
             to_timestamp(context["start"]),
             count=len(context["counts"]),

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -64,7 +64,7 @@ class DigestNotification(ProjectNotification):
 
     def get_notification_title(self) -> str:
         # This shouldn't be possible but adding a message just in case.
-        return "Digest Report"
+        return self.get_subject()
 
     def get_title_link(self, recipient: Team | User) -> str | None:
         return None

--- a/src/sentry/notifications/notifications/integration_nudge.py
+++ b/src/sentry/notifications/notifications/integration_nudge.py
@@ -87,7 +87,7 @@ class IntegrationNudgeNotification(BaseNotification):
     def get_context(self) -> MutableMapping[str, Any]:
         return {}
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         return ""
 
     def get_title_link(self, recipient: Team | User) -> str | None:

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 import logging
-from typing import TYPE_CHECKING, Any, Iterable, MutableMapping, Type
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Type
 
 from sentry.db.models import Model
 from sentry.models import Team
@@ -38,7 +38,7 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
     def determine_recipients(self) -> Iterable[Team | User]:
         return self.role_based_recipient_strategy.determine_recipients()
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         # purposely use empty string for the notification title
         return ""
 

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -72,7 +72,7 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return f"Your team member requested the {self.provider_name} integration on Sentry"
 
-    def get_notification_title(self) -> str:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         return self.get_subject()
 
     def build_attachment_title(self, recipient: Team | User) -> str:

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -104,7 +104,7 @@ class AlertRuleNotification(ProjectNotification):
 
         return context
 
-    def get_notification_title(self) -> Any:
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         from sentry.integrations.slack.message_builder.issues import build_rule_url
 
         title_str = "Alert triggered"

--- a/src/sentry/notifications/notifications/user_report.py
+++ b/src/sentry/notifications/notifications/user_report.py
@@ -44,9 +44,8 @@ class UserReportNotification(ProjectNotification):
         message = force_text(message)
         return message
 
-    def get_notification_title(self) -> str:
-        # This shouldn't be possible but adding a message just in case.
-        return self.get_subject()
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
+        return self.get_subject(context)
 
     @property
     def reference(self) -> Model | None:

--- a/src/sentry/notifications/utils/digest.py
+++ b/src/sentry/notifications/utils/digest.py
@@ -4,21 +4,22 @@ import itertools
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Counter, Mapping
 
-from django.utils import dateformat
-
 from sentry.notifications.types import ActionTargetType
 from sentry.plugins.base import Notification
+from sentry.utils.dates import to_timestamp
 
 if TYPE_CHECKING:
     from sentry.models import Group
 
 
 def get_digest_subject(group: Group, counts: Counter[Group], date: datetime) -> str:
-    return "{short_id} - {count} new {noun} since {date}".format(
-        short_id=group.qualified_short_id,
+
+    return "<!date^{:.0f}^{count} {noun} detected in {project} {date} | Digest Report".format(
+        to_timestamp(date),
         count=len(counts),
-        noun="alert" if len(counts) == 1 else "alerts",
-        date=dateformat.format(date, "N j, Y, P e"),
+        noun="issue" if len(counts) == 1 else "issues",
+        project=group.project.name,
+        date="{date_pretty}",
     )
 
 

--- a/src/sentry/notifications/utils/digest.py
+++ b/src/sentry/notifications/utils/digest.py
@@ -4,22 +4,21 @@ import itertools
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Counter, Mapping
 
+from django.utils import dateformat
+
 from sentry.notifications.types import ActionTargetType
 from sentry.plugins.base import Notification
-from sentry.utils.dates import to_timestamp
 
 if TYPE_CHECKING:
     from sentry.models import Group
 
 
 def get_digest_subject(group: Group, counts: Counter[Group], date: datetime) -> str:
-
-    return "<!date^{:.0f}^{count} {noun} detected in {project} {date} | Digest Report".format(
-        to_timestamp(date),
+    return "{short_id} - {count} new {noun} since {date}".format(
+        short_id=group.qualified_short_id,
         count=len(counts),
-        noun="issue" if len(counts) == 1 else "issues",
-        project=group.project.name,
-        date="{date_pretty}",
+        noun="alert" if len(counts) == 1 else "alerts",
+        date=dateformat.format(date, "N j, Y, P e"),
     )
 
 

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -23,7 +23,7 @@ class DummyNotification(BaseNotification):
     def get_title_link(self, *args):
         return None
 
-    def get_notification_title(self, *args):
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         return "Notification Title"
 
     def record_notification_sent(self, *args):

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -1,15 +1,21 @@
+from unittest import mock
 from unittest.mock import patch
+from urllib.parse import parse_qs
 
+import responses
 from django.core import mail
 
 import sentry
 from sentry.digests.backends.base import Backend
 from sentry.digests.backends.redis import RedisBackend
 from sentry.digests.notifications import event_to_record
-from sentry.models.rule import Rule
+from sentry.models import Rule
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils import TestCase
+from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.slack import send_notification
+from sentry.utils import json
 
 USER_COUNT = 2
 
@@ -59,3 +65,54 @@ class DigestNotificationTest(TestCase):
 
         # It is an alert rule notification, not a digest
         assert "new alerts since" not in mail.outbox[0].subject
+
+
+class DigestSlackNotification(SlackActivityNotificationTest):
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    @mock.patch.object(sentry, "digests")
+    def test_slack_digest_notification(self, digests, mock_func):
+        """
+        Test that with digests enabled, but Slack notification settings
+        (and not email settings), we send a Slack notification
+        """
+        backend = RedisBackend()
+        digests.digest = backend.digest
+        digests.enabled.return_value = True
+        timestamp = "2022-05-19T16:22:18"
+        key = f"slack:p:{self.project.id}"
+        rule = Rule.objects.create(project=self.project, label="my rule")
+        event = self.store_event(
+            data={
+                "timestamp": timestamp,
+                "message": "Hello world",
+                "level": "error",
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+
+        event2 = self.store_event(
+            data={
+                "timestamp": timestamp,
+                "message": "Goodbye world",
+                "level": "error",
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        )
+        backend.add(key, event_to_record(event, [rule]), increment_delay=0, maximum_delay=0)
+        backend.add(key, event_to_record(event2, [rule]), increment_delay=0, maximum_delay=0)
+        with self.tasks():
+            deliver_digest(key)
+
+        assert len(responses.calls) >= 1
+        data = parse_qs(responses.calls[0].request.body)
+        assert "text" in data
+        assert "attachments" in data
+        attachments = json.loads(data["attachments"][0])
+        assert (
+            data["text"][0]
+            == "<!date^1652977338^2 issues detected in Bar {date_pretty} | Digest Report"
+        )
+        assert len(attachments) == 2


### PR DESCRIPTION
## Objective:
We want a more descriptive title than `Digest Report`. Also wrote a test for Digest Notifications in Slack. 

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
