### PR TITLE
ref: fix deprecated django postgresql_psycopg2 imports

### DIFF
--- a/src/bitfield/types.py
+++ b/src/bitfield/types.py
@@ -246,7 +246,7 @@ from django.core.exceptions import ImproperlyConfigured
 # We need to register adapters in Django 1.8 in order to prevent
 # "ProgrammingError: can't adapt type"
 try:
-    from django.db.backends.postgresql_psycopg2.base import Database
+    from django.db.backends.postgresql.base import Database
 
     Database.extensions.register_adapter(Bit, lambda x: Database.extensions.AsIs(int(x)))
     Database.extensions.register_adapter(BitHandler, lambda x: Database.extensions.AsIs(int(x)))

--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -2,7 +2,7 @@ import psycopg2 as Database
 
 # Some of these imports are unused, but they are inherited from other engines
 # and should be available as part of the backend ``base.py`` namespace.
-from django.db.backends.postgresql_psycopg2.base import DatabaseWrapper
+from django.db.backends.postgresql.base import DatabaseWrapper
 
 from sentry.utils.strings import strip_lone_surrogates
 

--- a/src/sentry/db/postgres/operations.py
+++ b/src/sentry/db/postgres/operations.py
@@ -1,4 +1,4 @@
-from django.db.backends.postgresql_psycopg2.base import DatabaseOperations
+from django.db.backends.postgresql.base import DatabaseOperations
 
 
 class DatabaseOperations(DatabaseOperations):


### PR DESCRIPTION
the current imported module just forwards to backends.postgresql


this partially fixes warning noise of this variety in `getsentry`:

```
/Users/asottile/workspace/sentry/src/sentry/db/postgres/operations.py:1: RemovedInDjango30Warning: The django.db.backends.postgresql_psycopg2 module is deprecated in favor of django.db.backends.postgresql.
  from django.db.backends.postgresql_psycopg2.base import DatabaseOperations
```