### PR TITLE
Revert "fix(workflow): Handle filtering release list by date"

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -82,17 +82,13 @@ class ReleasesList extends AsyncView<Props, State> {
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {organization, location} = this.props;
-    const {statsPeriod, start, end, utc} = location.query;
+    const {statsPeriod} = location.query;
     const activeSort = this.getSort();
     const activeStatus = this.getStatus();
 
     const query = {
       ...pick(location.query, ['project', 'environment', 'cursor', 'query', 'sort']),
       summaryStatsPeriod: statsPeriod,
-      statsPeriod,
-      start,
-      end,
-      utc,
       per_page: 20,
       flatten: activeSort === ReleasesSortOption.DATE ? 0 : 1,
       adoptionStages: 1,


### PR DESCRIPTION
Reverts getsentry/sentry#33752

Its filtering releases in a way that people don't expect, we'll need to take statsPeriod and date filtering and separate them. People want a stats period of 24hrs but not to limit the releases for released within the last 24 hours. We used to not filter it by date released at all by default.