### PR TITLE
fix(release-health): Interval errors in line and area chart

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -28,7 +28,7 @@ import {FlatValidationError, ValidationError} from '../utils';
 
 // Used in the widget builder to limit the number of lines plotted in the chart
 export const DEFAULT_RESULTS_LIMIT = 5;
-const RESULTS_LIMIT = 10;
+export const MAX_RESULTS_LIMIT = 10;
 
 // Both dashboards and widgets use the 'new' keyword when creating
 export const NEW_DASHBOARD_ID = 'new';
@@ -362,7 +362,7 @@ export function getResultsLimit(numQueries: number, numYAxes: number) {
     return DEFAULT_RESULTS_LIMIT;
   }
 
-  return Math.floor(RESULTS_LIMIT / (numQueries * numYAxes));
+  return Math.floor(MAX_RESULTS_LIMIT / (numQueries * numYAxes));
 }
 
 export function getIsTimeseriesChart(displayType: DisplayType) {

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -91,7 +91,7 @@ import {
 } from './utils';
 import {WidgetLibrary} from './widgetLibrary';
 
-function getDataSetQuery(widgetBuilderNewDesign: boolean): Record<DataSet, WidgetQuery> {
+function getDataSetQuery(hasOrderby: boolean): Record<DataSet, WidgetQuery> {
   return {
     [DataSet.EVENTS]: {
       name: '',
@@ -100,7 +100,7 @@ function getDataSetQuery(widgetBuilderNewDesign: boolean): Record<DataSet, Widge
       fieldAliases: [],
       aggregates: ['count()'],
       conditions: '',
-      orderby: widgetBuilderNewDesign ? '-count()' : '',
+      orderby: hasOrderby ? '-count()' : '',
     },
     [DataSet.ISSUES]: {
       name: '',
@@ -109,7 +109,7 @@ function getDataSetQuery(widgetBuilderNewDesign: boolean): Record<DataSet, Widge
       fieldAliases: [],
       aggregates: [],
       conditions: '',
-      orderby: widgetBuilderNewDesign ? IssueSortOptions.DATE : '',
+      orderby: hasOrderby ? IssueSortOptions.DATE : '',
     },
     [DataSet.RELEASES]: {
       name: '',
@@ -118,7 +118,7 @@ function getDataSetQuery(widgetBuilderNewDesign: boolean): Record<DataSet, Widge
       fieldAliases: [],
       aggregates: [`crash_free_rate(${SessionField.SESSION})`],
       conditions: '',
-      orderby: widgetBuilderNewDesign ? `-crash_free_rate(${SessionField.SESSION})` : '',
+      orderby: hasOrderby ? `-crash_free_rate(${SessionField.SESSION})` : '',
     },
   };
 }
@@ -278,7 +278,11 @@ function WidgetBuilder({
       }
     } else {
       defaultState.queries = [
-        {...getDataSetQuery(widgetBuilderNewDesign)[DataSet.EVENTS]},
+        {
+          ...getDataSetQuery(defaultState.displayType === DisplayType.TABLE)[
+            DataSet.EVENTS
+          ],
+        },
       ];
     }
 
@@ -462,7 +466,7 @@ function WidgetBuilder({
           'queries',
           normalizeQueries({
             displayType: newDisplayType,
-            queries: [{...getDataSetQuery(widgetBuilderNewDesign)[DataSet.EVENTS]}],
+            queries: [{...getDataSetQuery(isTabularChart)[DataSet.EVENTS]}],
             widgetType: WidgetType.DISCOVER,
             widgetBuilderNewDesign,
           })
@@ -599,7 +603,7 @@ function WidgetBuilder({
         ...(widgetToBeUpdated?.widgetType &&
         WIDGET_TYPE_TO_DATA_SET[widgetToBeUpdated.widgetType] === newDataSet
           ? widgetToBeUpdated.queries
-          : [{...getDataSetQuery(widgetBuilderNewDesign)[newDataSet]}])
+          : [{...getDataSetQuery(isTabularChart)[newDataSet]}])
       );
 
       set(newState, 'userHasModified', true);
@@ -610,7 +614,7 @@ function WidgetBuilder({
   function handleAddSearchConditions() {
     setState(prevState => {
       const newState = cloneDeep(prevState);
-      const query = cloneDeep(getDataSetQuery(widgetBuilderNewDesign)[prevState.dataSet]);
+      const query = cloneDeep(getDataSetQuery(isTabularChart)[prevState.dataSet]);
       query.fields = prevState.queries[0].fields;
       query.aggregates = prevState.queries[0].aggregates;
       query.columns = prevState.queries[0].columns;

--- a/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
@@ -226,7 +226,7 @@ class ReleaseWidgetQueries extends Component<Props, State> {
       case DisplayType.BIG_NUMBER:
         return 1;
       default:
-        return limit ?? 20; // TODO(dam): Can be changed to undefined once [INGEST-1079] is resolved
+        return limit ?? 10; // TODO(dam): Can be changed to undefined once [INGEST-1079] is resolved
     }
   }
 
@@ -302,7 +302,7 @@ class ReleaseWidgetQueries extends Component<Props, State> {
           end,
           environment: environments,
           groupBy: columns.map(fieldsToDerivedMetrics),
-          limit: unsupportedOrderby || rawOrderby === '' ? undefined : this.limit,
+          limit: unsupportedOrderby || rawOrderby === '' ? 10 : this.limit,
           orderBy: unsupportedOrderby
             ? ''
             : isDescending

--- a/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
@@ -29,6 +29,7 @@ import {
   FIELD_TO_METRICS_EXPRESSION,
   METRICS_EXPRESSION_TO_FIELD,
 } from '../widgetBuilder/releaseWidget/fields';
+import {MAX_RESULTS_LIMIT} from '../widgetBuilder/utils';
 
 import {transformSessionsResponseToSeries} from './transformSessionsResponseToSeries';
 import {transformSessionsResponseToTable} from './transformSessionsResponseToTable';
@@ -226,7 +227,7 @@ class ReleaseWidgetQueries extends Component<Props, State> {
       case DisplayType.BIG_NUMBER:
         return 1;
       default:
-        return limit ?? 10; // TODO(dam): Can be changed to undefined once [INGEST-1079] is resolved
+        return limit ?? MAX_RESULTS_LIMIT; // TODO(dam): Can be changed to undefined once [INGEST-1079] is resolved
     }
   }
 
@@ -302,7 +303,7 @@ class ReleaseWidgetQueries extends Component<Props, State> {
           end,
           environment: environments,
           groupBy: columns.map(fieldsToDerivedMetrics),
-          limit: unsupportedOrderby || rawOrderby === '' ? 10 : this.limit,
+          limit: unsupportedOrderby || rawOrderby === '' ? MAX_RESULTS_LIMIT : this.limit,
           orderBy: unsupportedOrderby
             ? ''
             : isDescending

--- a/tests/js/spec/views/dashboardsV2/releaseWidgetQueries.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/releaseWidgetQueries.spec.tsx
@@ -536,6 +536,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
           interval: '30m',
           project: [1],
           statsPeriod: '14d',
+          per_page: 10,
         },
       })
     );
@@ -551,6 +552,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
           project: [1],
           query: 'environment:prod',
           statsPeriod: '14d',
+          per_page: 10,
         },
       })
     );


### PR DESCRIPTION
When requesting data from `.../metrics/data` without a limit, the backend would apply a default limit of 50 resulting series/groups. This does not apply to the number of results in that series (that's determined by the interval requested). The frontend would supply a limit of 20 which causes an interval error when requesting an interval of `5m`.

Since we never want to show more than 10 lines, I changed the default to `10` instead of `20` and that is enough to avoid the interval error.

Also fixes a bug where we would set a sort in timeseries charts which would make the first chart render fine (e.g. line) but switching to area would throw the interval error. The fix was to only provide the default sort if we're in a table.

To reproduce the bug in prod:
1. Go to the widget builder and select Releases as your data set and a Line chart
2. Check that your page filter is set to 24hrs
3. Change the chart type to Area
4. You should see an error saying:
```
Requested interval of timedelta of 0:05:00 with statsPeriod timedelta of 1 day, 0:00:00 is too granular for a per_page of 51 elements. Increase your interval, decrease your statsPeriod, or decrease your per_page parameter.
```

You will see similar errors when changing the page filter time range.