### PR TITLE
ci: compile devservices args

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -194,11 +194,6 @@ runs:
 
         # TODO: Use devservices kafka. See https://github.com/getsentry/sentry/pull/20986#issuecomment-704510570
         if [ "$NEED_KAFKA" = "true" ]; then
-          # Note: some backend tests (e.g. tests/sentry/eventstream/kafka/test_consumer.py) will behave
-          # differently if these are set.
-          echo "SENTRY_KAFKA_HOSTS=127.0.0.1:9092" >> $GITHUB_ENV
-          echo "SENTRY_ZOOKEEPER_HOSTS=127.0.0.1:2181" >> $GITHUB_ENV
-
           # This is *not* the production version. Unclear reason as to why this was chosen
           # https://github.com/getsentry/ops/blob/c823e62f930ecc6c97bb08898c71e49edc7232f6/cookbooks/getsentry/attributes/default.rb#L631
           docker run \

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Is chartcuterie required?'
     required: false
     default: 'false'
+  bigtable:
+    description: 'Is bigtable required?'
+    required: false
+    default: 'false'
   cache-files-hash:
     description: 'A single hash for a set of files. Used for caching.'
     required: false
@@ -68,7 +72,6 @@ runs:
     - name: Setup default environment variables
       shell: bash
       env:
-        NEED_KAFKA: ${{ inputs.kafka }}
         MATRIX_INSTANCE: ${{ matrix.instance }}
         # XXX: We should be using something like len(strategy.matrix.instance) (not possible atm)
         # If you have other things like python-version: [foo, bar, baz] then the sharding logic
@@ -112,15 +115,6 @@ runs:
         # This records failures on master to sentry in order to detect flakey tests, as it's
         # expected that people have failing tests on their PRs
         [ "$GITHUB_REF" = "refs/heads/master" ] && echo "PYTEST_SENTRY_ALWAYS_REPORT=1" >> $GITHUB_ENV || true
-
-        ### services configuration ###
-        echo "BIGTABLE_EMULATOR_HOST=localhost:8086" >> $GITHUB_ENV
-        # Note: some backend tests (e.g. tests/sentry/eventstream/kafka/test_consumer.py) will behave
-        # differently if these are set.
-        if [ "$NEED_KAFKA" = "true" ]; then
-          echo "SENTRY_KAFKA_HOSTS=127.0.0.1:9092" >> $GITHUB_ENV
-          echo "SENTRY_ZOOKEEPER_HOSTS=127.0.0.1:2181" >> $GITHUB_ENV
-        fi
 
     - name: Setup python
       id: setup-python
@@ -169,6 +163,7 @@ runs:
         NEED_KAFKA: ${{ inputs.kafka }}
         NEED_SNUBA: ${{ inputs.snuba }}
         NEED_CLICKHOUSE: ${{ inputs.clickhouse }}
+        NEED_BIGTABLE: ${{ inputs.bigtable }}
         NEED_CHARTCUTERIE: ${{ inputs.chartcuterie }}
         WORKDIR: ${{ inputs.workdir }}
         PG_VERSION: ${{ inputs.pg-version }}
@@ -176,21 +171,42 @@ runs:
         sentry init
 
         # redis, postgres are needed for almost every code path.
-        sentry devservices up redis postgres
+        services='redis postgres'
 
-        if [ "$BIGTABLE_EMULATOR_HOST" ]; then
-          sentry devservices up --skip-only-if bigtable
+        if [ "$NEED_CLICKHOUSE" = "true" ] || [ "$NEED_SNUBA" = "true" ]; then
+          services="${services} clickhouse"
         fi
+
+        if [ "$NEED_SNUBA" = "true" ]; then
+          services="${services} snuba"
+        fi
+
+        if [ "$NEED_BIGTABLE" = "true" ]; then
+          echo "BIGTABLE_EMULATOR_HOST=127.0.0.1:8086" >> $GITHUB_ENV
+          services="${services} bigtable"
+        fi
+
+        if [ "$NEED_CHARTCUTERIE" = "true" ]; then
+          services="${services} chartcuterie"
+        fi
+
+        sentry devservices up $services &
 
         # TODO: Use devservices kafka. See https://github.com/getsentry/sentry/pull/20986#issuecomment-704510570
         if [ "$NEED_KAFKA" = "true" ]; then
+          # Note: some backend tests (e.g. tests/sentry/eventstream/kafka/test_consumer.py) will behave
+          # differently if these are set.
+          echo "SENTRY_KAFKA_HOSTS=127.0.0.1:9092" >> $GITHUB_ENV
+          echo "SENTRY_ZOOKEEPER_HOSTS=127.0.0.1:2181" >> $GITHUB_ENV
+
           # This is *not* the production version. Unclear reason as to why this was chosen
           # https://github.com/getsentry/ops/blob/c823e62f930ecc6c97bb08898c71e49edc7232f6/cookbooks/getsentry/attributes/default.rb#L631
           docker run \
             --name sentry_zookeeper \
             -d --network host \
             -e ZOOKEEPER_CLIENT_PORT=2181 \
-            confluentinc/cp-zookeeper:4.1.0
+            confluentinc/cp-zookeeper:4.1.0 \
+            &
 
           # This is the production version; do not change w/o changing it there as well
           # https://github.com/getsentry/ops/blob/c823e62f930ecc6c97bb08898c71e49edc7232f6/cookbooks/getsentry/attributes/default.rb#L643
@@ -203,20 +219,11 @@ runs:
             -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \
             -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
             -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
-            confluentinc/cp-kafka:5.1.2
+            confluentinc/cp-kafka:5.1.2 \
+            &
         fi
 
-        if [ "$NEED_SNUBA" = "true" ]; then
-          sentry devservices up clickhouse snuba
-        fi
-
-        if [ "$NEED_CLICKHOUSE" = "true" ]; then
-          sentry devservices up clickhouse
-        fi
-
-        if [ "$NEED_CHARTCUTERIE" = "true" ]; then
-          sentry devservices up --skip-only-if chartcuterie
-        fi
+        wait
 
         docker ps -a
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -91,6 +91,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pip-cache-version: ${{ secrets.PIP_CACHE_VERSION }}
           snuba: true
+          # Right now, we run so few bigtable related tests that the
+          # overhead of running bigtable in all backend tests
+          # is way smaller than the time it would take to run in its own job.
+          bigtable: true
           pg-version: ${{ matrix.pg-version }}
 
       - name: Run backend test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1969,7 +1969,10 @@ SENTRY_DEVSERVICES = {
         {
             "image": "us.gcr.io/sentryio/cbtemulator:23c02d92c7a1747068eb1fc57dddbad23907d614",
             "ports": {"8086/tcp": 8086},
-            "only_if": "bigtable" in settings.SENTRY_NODESTORE,
+            # NEED_BIGTABLE is set by CI so we don't have to pass
+            # --skip-only-if when compiling which services to run.
+            "only_if": os.environ.get("NEED_BIGTABLE", False)
+            or "bigtable" in settings.SENTRY_NODESTORE,
         }
     ),
     "memcached": lambda settings, options: (
@@ -2010,7 +2013,9 @@ SENTRY_DEVSERVICES = {
                 "CHARTCUTERIE_CONFIG_POLLING": "true",
             },
             "ports": {"9090/tcp": 7901},
-            "only_if": options.get("chart-rendering.enabled"),
+            # NEED_CHARTCUTERIE is set by CI so we don't have to pass --skip-only-if when compiling which services to run.
+            "only_if": os.environ.get("NEED_CHARTCUTERIE", False)
+            or options.get("chart-rendering.enabled"),
         }
     ),
     "cdc": lambda settings, options: (

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -163,9 +163,9 @@ def test_consumer_start_from_committed_offset(requires_kafka):
 
         assert producer.flush(5) == 0, "producer did not successfully flush queue"
 
-        Consumer(
-            {"bootstrap.servers": SENTRY_KAFKA_HOSTS, "group.id": consumer_group}
-        ).commit(message=messages_delivered[topic][0], asynchronous=False)
+        Consumer({"bootstrap.servers": SENTRY_KAFKA_HOSTS, "group.id": consumer_group}).commit(
+            message=messages_delivered[topic][0], asynchronous=False
+        )
 
         # Create the synchronized consumer.
         consumer = SynchronizedConsumer(
@@ -374,9 +374,7 @@ def test_consumer_rebalance_from_committed_offset(requires_kafka):
 
         assert producer.flush(5) == 0, "producer did not successfully flush queue"
 
-        Consumer(
-            {"bootstrap.servers": SENTRY_KAFKA_HOSTS, "group.id": consumer_group}
-        ).commit(
+        Consumer({"bootstrap.servers": SENTRY_KAFKA_HOSTS, "group.id": consumer_group}).commit(
             offsets=[
                 TopicPartition(message.topic(), message.partition(), message.offset() + 1)
                 for message in messages_delivered[topic][:2]

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -24,21 +24,21 @@ except ImportError:
 
 from django.conf import settings
 
-settings.KAFKA_CLUSTERS["default"] = {
-    "common": {"bootstrap.servers": os.environ.get("SENTRY_KAFKA_HOSTS", "127.0.0.1:9092")}
-}
+SENTRY_KAFKA_HOSTS = os.environ.get("SENTRY_KAFKA_HOSTS", "127.0.0.1:9092")
+SENTRY_ZOOKEEPER_HOSTS = os.environ.get("SENTRY_ZOOKEEPER_HOSTS", "127.0.0.1:2181")
+settings.KAFKA_CLUSTERS["default"] = {"common": {"bootstrap.servers": SENTRY_KAFKA_HOSTS}}
 
 
 @contextmanager
 def create_topic(partitions=1, replication_factor=1):
     command = ["docker", "exec", "sentry_kafka", "kafka-topics"] + [
         "--zookeeper",
-        os.environ["SENTRY_ZOOKEEPER_HOSTS"],
+        SENTRY_ZOOKEEPER_HOSTS,
     ]
     topic = f"test-{uuid.uuid1().hex}"
     subprocess.check_call(
         command
-        + [
+        + (
             "--create",
             "--topic",
             topic,
@@ -46,12 +46,12 @@ def create_topic(partitions=1, replication_factor=1):
             f"{partitions}",
             "--replication-factor",
             f"{replication_factor}",
-        ]
+        )
     )
     try:
         yield topic
     finally:
-        subprocess.check_call(command + ["--delete", "--topic", topic])
+        subprocess.check_call(command + ("--delete", "--topic", topic))
 
 
 def test_consumer_start_from_partition_start(requires_kafka):
@@ -65,7 +65,7 @@ def test_consumer_start_from_partition_start(requires_kafka):
 
     producer = Producer(
         {
-            "bootstrap.servers": os.environ["SENTRY_KAFKA_HOSTS"],
+            "bootstrap.servers": SENTRY_KAFKA_HOSTS,
             "on_delivery": record_message_delivered,
         }
     )
@@ -150,7 +150,7 @@ def test_consumer_start_from_committed_offset(requires_kafka):
 
     producer = Producer(
         {
-            "bootstrap.servers": os.environ["SENTRY_KAFKA_HOSTS"],
+            "bootstrap.servers": SENTRY_KAFKA_HOSTS,
             "on_delivery": record_message_delivered,
         }
     )
@@ -164,7 +164,7 @@ def test_consumer_start_from_committed_offset(requires_kafka):
         assert producer.flush(5) == 0, "producer did not successfully flush queue"
 
         Consumer(
-            {"bootstrap.servers": os.environ["SENTRY_KAFKA_HOSTS"], "group.id": consumer_group}
+            {"bootstrap.servers": SENTRY_KAFKA_HOSTS, "group.id": consumer_group}
         ).commit(message=messages_delivered[topic][0], asynchronous=False)
 
         # Create the synchronized consumer.
@@ -247,7 +247,7 @@ def test_consumer_rebalance_from_partition_start(requires_kafka):
 
     producer = Producer(
         {
-            "bootstrap.servers": os.environ["SENTRY_KAFKA_HOSTS"],
+            "bootstrap.servers": SENTRY_KAFKA_HOSTS,
             "on_delivery": record_message_delivered,
         }
     )
@@ -361,7 +361,7 @@ def test_consumer_rebalance_from_committed_offset(requires_kafka):
 
     producer = Producer(
         {
-            "bootstrap.servers": os.environ["SENTRY_KAFKA_HOSTS"],
+            "bootstrap.servers": SENTRY_KAFKA_HOSTS,
             "on_delivery": record_message_delivered,
         }
     )
@@ -375,7 +375,7 @@ def test_consumer_rebalance_from_committed_offset(requires_kafka):
         assert producer.flush(5) == 0, "producer did not successfully flush queue"
 
         Consumer(
-            {"bootstrap.servers": os.environ["SENTRY_KAFKA_HOSTS"], "group.id": consumer_group}
+            {"bootstrap.servers": SENTRY_KAFKA_HOSTS, "group.id": consumer_group}
         ).commit(
             offsets=[
                 TopicPartition(message.topic(), message.partition(), message.offset() + 1)
@@ -524,7 +524,7 @@ def test_consumer_rebalance_from_uncommitted_offset(requires_kafka):
 
     producer = Producer(
         {
-            "bootstrap.servers": os.environ["SENTRY_KAFKA_HOSTS"],
+            "bootstrap.servers": SENTRY_KAFKA_HOSTS,
             "on_delivery": record_message_delivered,
         }
     )


### PR DESCRIPTION
Consistent ~45 second speedup for setup-sentry action by:

- compiling args for a single sentry devservices up (which was recently made multithreaded by yours truly)
- docker run for kafka+zookeeper also done in parallel
- bigtable emulator removed from all but backend tests
- bonus: cleaned up some kafka test stuff

```
20c2d20e3e3c   getsentry/snuba:nightly              "./docker_entrypoint…"   Less than a second ago   Up Less than a second   127.0.0.1:1218->1218/tcp                                                       sentry_snuba
27e2e75891a3   yandex/clickhouse-server:20.3.9.70   "/entrypoint.sh"         2 seconds ago            Up 1 second             127.0.0.1:8123->8123/tcp, 127.0.0.1:9000->9000/tcp, 127.0.0.1:9009->9009/tcp   sentry_clickhouse
7e025778337b   confluentinc/cp-kafka:5.1.2          "/etc/confluent/dock…"   7 seconds ago            Up 7 seconds                                                                                           sentry_kafka
c30215bc464d   confluentinc/cp-zookeeper:4.1.0      "/etc/confluent/dock…"   7 seconds ago            Up 7 seconds                                                                                           sentry_zookeeper
fcc02e34e331   postgres:9.6-alpine                  "docker-entrypoint.s…"   13 seconds ago           Up 12 seconds           127.0.0.1:5432->5432/tcp                                                       sentry_postgres
4cdb48e6b2d4   redis:5.0-alpine                     "docker-entrypoint.s…"   14 seconds ago           Up 13 seconds           127.0.0.1:6379->6379/tcp                                                       sentry_redis
```

```
e5ec77ea3523   getsentry/snuba:nightly                                                   "./docker_entrypoint…"   1 second ago     Up Less than a second   127.0.0.1:1218->1218/tcp                                                       sentry_snuba
95529104919b   yandex/clickhouse-server:20.3.9.70                                        "/entrypoint.sh"         2 seconds ago    Up Less than a second   127.0.0.1:8123->8123/tcp, 127.0.0.1:9000->9000/tcp, 127.0.0.1:9009->9009/tcp   sentry_clickhouse
5a73ee2c125b   confluentinc/cp-kafka:5.1.2                                               "/etc/confluent/dock…"   24 seconds ago   Up 23 seconds                                                                                          sentry_kafka
fca9025f729b   confluentinc/cp-zookeeper:4.1.0                                           "/etc/confluent/dock…"   39 seconds ago   Up 38 seconds                                                                                          sentry_zookeeper
a2d9dc8ed7a1   us.gcr.io/sentryio/cbtemulator:23c02d92c7a1747068eb1fc57dddbad23907d614   "/bin/cbtemulator -h…"   52 seconds ago   Up 51 seconds           127.0.0.1:8086->8086/tcp                                                       sentry_bigtable
582157f3a883   redis:5.0-alpine                                                          "docker-entrypoint.s…"   58 seconds ago   Up 56 seconds           127.0.0.1:6379->6379/tcp                                                       sentry_redis
b8b4fb8ef6c2   postgres:9.6-alpine                                                       "docker-entrypoint.s…"   58 seconds ago   Up 56 seconds           127.0.0.1:5432->5432/tcp                                                       sentry_postgres
```