### PR TITLE
feat(metrics): Support project slug filters in metrics API [TET-87]

### DIFF
--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -20,6 +20,7 @@ from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Project
 from sentry.search.events.builder import UnresolvedQuery
+from sentry.search.events.filter import get_filter
 from sentry.sentry_metrics.utils import (
     STRING_NOT_FOUND,
     resolve_tag_key,
@@ -174,7 +175,7 @@ def resolve_tags(org_id: int, input_: Any) -> Any:
     raise InvalidParams("Unable to resolve conditions")
 
 
-def parse_query(query_string: str) -> Sequence[Condition]:
+def parse_query(query_string: str, projects) -> Sequence[Condition]:
     """Parse given filter query into a list of snuba conditions"""
     # HACK: Parse a sessions query, validate / transform afterwards.
     # We will want to write our own grammar + interpreter for this later.
@@ -185,13 +186,35 @@ def parse_query(query_string: str) -> Sequence[Condition]:
         query_builder = UnresolvedQuery(
             Dataset.Sessions,
             params={
-                "project_id": 0,
+                "project_id": projects,
             },
         )
         where, _ = query_builder.resolve_conditions(query_string, use_aggregate_conditions=True)
+
+        # XXX(ahmed): Hack to accept project:slug filter as we are no longer maintaining the
+        # metrics API.
+        # Essentially prior to this change `project` slug query filters were treated as `tags[
+        # project]` filters, so I loop over the where list and when its found it popped out of
+        # the list and replaced with the appropriate `project_id` filter.
+        for idx, condition in enumerate(list(where)):
+            if condition.lhs == Function("ifNull", parameters=[Column("tags[project]"), ""]):
+                del where[idx]
+
+                snuba_filter_conditions = get_filter(
+                    query_string, {"project_id": [p.id for p in projects]}
+                ).conditions
+                for snuba_condition in snuba_filter_conditions:
+                    if snuba_condition[0] == "project_id":
+                        where.append(
+                            Condition(
+                                Column(snuba_condition[0]),
+                                Op(snuba_condition[1]),
+                                snuba_condition[2],
+                            )
+                        )
+
     except InvalidSearchQuery as e:
         raise InvalidParams(f"Failed to parse query: {e}")
-
     return where
 
 
@@ -210,7 +233,8 @@ class APIQueryDefinition:
         paginator_kwargs = paginator_kwargs or {}
 
         self.query = query_params.get("query", "")
-        self.parsed_query = parse_query(self.query) if self.query else None
+        self.parsed_query = parse_query(self.query, projects) if self.query else None
+
         raw_fields = query_params.getlist("field", [])
         self.groupby = query_params.getlist("groupBy", [])
 

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -197,7 +197,9 @@ def parse_query(query_string: str, projects: Sequence[Project]) -> Sequence[Cond
         # project]` filters, so I loop over the where list and when its found it popped out of
         # the list and replaced with the appropriate `project_id` filter.
         for idx, condition in enumerate(list(where)):
-            if condition.lhs == Function("ifNull", parameters=[Column("tags[project]"), ""]):
+            if isinstance(condition, Condition) and condition.lhs == Function(
+                "ifNull", parameters=[Column("tags[project]"), ""]
+            ):
                 del where[idx]
 
                 snuba_filter_conditions = get_filter(

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -175,7 +175,7 @@ def resolve_tags(org_id: int, input_: Any) -> Any:
     raise InvalidParams("Unable to resolve conditions")
 
 
-def parse_query(query_string: str, projects) -> Sequence[Condition]:
+def parse_query(query_string: str, projects: Sequence[Project]) -> Sequence[Condition]:
     """Parse given filter query into a list of snuba conditions"""
     # HACK: Parse a sessions query, validate / transform afterwards.
     # We will want to write our own grammar + interpreter for this later.
@@ -186,7 +186,7 @@ def parse_query(query_string: str, projects) -> Sequence[Condition]:
         query_builder = UnresolvedQuery(
             Dataset.Sessions,
             params={
-                "project_id": projects,
+                "project_id": 0,
             },
         )
         where, _ = query_builder.resolve_conditions(query_string, use_aggregate_conditions=True)

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -136,6 +136,52 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         )
         assert response.status_code == 400
 
+    def test_filter_by_project_slug(self):
+        p = self.create_project(name="sentry2")
+        p2 = self.create_project(name="sentry3")
+
+        for minute in range(2):
+            self.store_session(
+                self.build_session(
+                    project_id=self.project.id,
+                    started=(time.time() // 60 - minute) * 60,
+                    status="ok",
+                )
+            )
+        for minute in range(3):
+            self.store_session(
+                self.build_session(
+                    project_id=p.id,
+                    started=(time.time() // 60 - minute) * 60,
+                    status="ok",
+                )
+            )
+        for minute in range(5):
+            self.store_session(
+                self.build_session(
+                    project_id=p2.id,
+                    started=(time.time() // 60 - minute) * 60,
+                    status="ok",
+                )
+            )
+
+        response = self.get_response(
+            self.project.organization.slug,
+            field=["sum(sentry.sessions.session)"],
+            project=[p.id, p2.id, self.project.id],
+            query="project:[sentry2,sentry3]",
+            interval="24h",
+            statsPeriod="24h",
+        )
+        assert response.status_code == 200
+        assert response.data["groups"] == [
+            {
+                "by": {},
+                "totals": {"sum(sentry.sessions.session)": 8},
+                "series": {"sum(sentry.sessions.session)": [8]},
+            }
+        ]
+
     def test_pagination_limit_without_orderby(self):
         """
         Test that ensures a successful response is returned even when sending a per_page

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -195,7 +195,7 @@ def test_parse_query(monkeypatch, query_string, expected):
         # will be values 10000, 10001 respectively
         local_indexer.record(org_id, s)
     monkeypatch.setattr("sentry.sentry_metrics.indexer.resolve", local_indexer.resolve)
-    parsed = resolve_tags(org_id, parse_query(query_string))
+    parsed = resolve_tags(org_id, parse_query(query_string, []))
     assert parsed == expected
 
 
@@ -209,7 +209,7 @@ def test_parse_query(monkeypatch, query_string, expected):
 )
 def test_parse_query_invalid(query_string):
     with pytest.raises(InvalidParams):
-        parse_query(query_string)
+        parse_query(query_string, projects=[])
 
 
 @freeze_time("2018-12-11 03:21:00")


### PR DESCRIPTION
Adds support for project slug filters in
the metrics API as they `project` filter
was previously treated as a tag by the
metrics API
