### PR TITLE
fix(ci): separate backend test job for tests that require kafka

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -106,6 +106,51 @@ jobs:
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
 
+  kafka:
+    if: needs.files-changed.outputs.backend == 'true'
+    needs: files-changed
+    name: backend kafka test
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    strategy:
+      # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
+      # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
+      fail-fast: false
+      matrix:
+        python-version: [3.8.12]
+        # XXX: When updating this, make sure you also update MATRIX_INSTANCE_TOTAL.
+        instance: [0]
+        pg-version: ['9.6']
+
+    env:
+      # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
+      MATRIX_INSTANCE_TOTAL: 1
+      MIGRATIONS_TEST_MIGRATE: 1
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Avoid codecov error message related to SHA resolution:
+          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
+          fetch-depth: '2'
+
+      - name: Setup sentry env (python ${{ matrix.python-version }})
+        uses: ./.github/actions/setup-sentry
+        id: setup
+        with:
+          python-version: ${{ matrix.python-version }}
+          pip-cache-version: ${{ secrets.PIP_CACHE_VERSION }}
+          snuba: true
+          kafka: true
+          pg-version: ${{ matrix.pg-version }}
+
+      - name: Run backend kafka test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
+        run: |
+          make test-kafka
+
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts
+
   cli:
     if: needs.files-changed.outputs.backend == 'true'
     needs: files-changed

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -91,6 +91,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pip-cache-version: ${{ secrets.PIP_CACHE_VERSION }}
           snuba: true
+          kafka: true
           # Right now, we run so few bigtable related tests that the
           # overhead of running bigtable in all backend tests
           # is way smaller than the time it would take to run in its own job.

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -91,7 +91,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pip-cache-version: ${{ secrets.PIP_CACHE_VERSION }}
           snuba: true
-          kafka: true
           # Right now, we run so few bigtable related tests that the
           # overhead of running bigtable in all backend tests
           # is way smaller than the time it would take to run in its own job.

--- a/Makefile
+++ b/Makefile
@@ -122,14 +122,23 @@ test-python:
 	# This gets called by getsentry
 	pytest tests/integration tests/sentry
 
+# TODO: need a better way of marking tests as kafka or snuba
+#       than keeping these ignores synced
 test-python-ci:
 	make build-platform-assets
-	@echo "--> Running backend tests, except those that require Kafka"
+	@echo "--> Running backend tests"
 	pytest tests/integration tests/sentry \
 		--ignore tests/sentry/eventstream/kafka \
 		--ignore tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
-		--cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
+		--ignore tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py \
+		--ignore tests/sentry/incidents/endpoints/test_project_alert_rule_index.py \
+		--ignore tests/sentry/incidents/test_subscription_processor.py \
+		\
+		--ignore tests/sentry/snuba \
+		--ignore tests/sentry/search/events
 	@echo ""
+
+#       --cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
 
 test-kafka:
 	@echo "--> Running backend tests that require Kafka"
@@ -137,13 +146,19 @@ test-kafka:
 	pytest \
 		tests/sentry/eventstream/kafka \
 		tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
-		--cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
+		tests/sentry/incidents/endpoints/test_project_alert_rule_index.py \
+		tests/sentry/incidents/test_subscription_processor.py \
 	@echo ""
 
+#       --cov . --cov-report="xml:.artifacts/kafka.coverage.xml" --junit-xml=".artifacts/kafka.junit.xml" || exit 1
+
+# TODO: remove kafka from snuba tests and see if there's more to be moved over
+#       otherwise just move kafka tests into snuba
 test-snuba:
 	@echo "--> Running snuba tests"
-	pytest tests/snuba tests/sentry/eventstream/kafka tests/sentry/snuba/test_discover.py tests/sentry/search/events -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml" --junit-xml=".artifacts/snuba.junit.xml"
+	pytest tests/snuba tests/sentry/snuba tests/sentry/search/events
 	@echo ""
+#		-vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml" --junit-xml=".artifacts/snuba.junit.xml"
 
 test-tools:
 	@echo "--> Running tools tests"

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,20 @@ test-python:
 
 test-python-ci:
 	make build-platform-assets
-	@echo "--> Running CI Python tests"
-	pytest tests/integration tests/sentry --cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
+	@echo "--> Running backend tests, except those that require Kafka"
+	pytest tests/integration tests/sentry \
+		--ignore tests/sentry/eventstream/kafka \
+		--ignore tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
+		--cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
+	@echo ""
+
+test-kafka:
+	@echo "--> Running backend tests that require Kafka"
+	# This needs to be synced with the --ignores above in test-python-ci.
+	pytest \
+		tests/sentry/eventstream/kafka \
+		tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
+		--cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
 	@echo ""
 
 test-snuba:

--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,6 @@ test-python-ci:
 	pytest tests/integration tests/sentry \
 		--ignore tests/sentry/eventstream/kafka \
 		--ignore tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
-		--ignore tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py \
-		--ignore tests/sentry/incidents/endpoints/test_project_alert_rule_index.py \
-		--ignore tests/sentry/incidents/test_subscription_processor.py \
 		\
 		--ignore tests/sentry/snuba \
 		--ignore tests/sentry/search/events
@@ -145,9 +142,7 @@ test-kafka:
 	# This needs to be synced with the --ignores above in test-python-ci.
 	pytest \
 		tests/sentry/eventstream/kafka \
-		tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
-		tests/sentry/incidents/endpoints/test_project_alert_rule_index.py \
-		tests/sentry/incidents/test_subscription_processor.py \
+		tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
 	@echo ""
 
 #       --cov . --cov-report="xml:.artifacts/kafka.coverage.xml" --junit-xml=".artifacts/kafka.junit.xml" || exit 1

--- a/src/sentry/utils/pytest/kafka.py
+++ b/src/sentry/utils/pytest/kafka.py
@@ -99,14 +99,6 @@ def kafka_topics_setter():
     return set_test_kafka_settings
 
 
-@pytest.fixture
-def requires_kafka():
-    pytest.importorskip("confluent_kafka")
-
-    if "SENTRY_KAFKA_HOSTS" not in os.environ:
-        pytest.xfail("test requires SENTRY_KAFKA_HOSTS environment variable which is not set")
-
-
 @pytest.fixture(scope="session")
 def scope_consumers():
     """

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -38,7 +38,7 @@ def create_topic(partitions=1, replication_factor=1):
     topic = f"test-{uuid.uuid1().hex}"
     subprocess.check_call(
         command
-        + (
+        + [
             "--create",
             "--topic",
             topic,
@@ -46,12 +46,12 @@ def create_topic(partitions=1, replication_factor=1):
             f"{partitions}",
             "--replication-factor",
             f"{replication_factor}",
-        )
+        ]
     )
     try:
         yield topic
     finally:
-        subprocess.check_call(command + ("--delete", "--topic", topic))
+        subprocess.check_call(command + ["--delete", "--topic", topic])
 
 
 def test_consumer_start_from_partition_start():

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -54,7 +54,7 @@ def create_topic(partitions=1, replication_factor=1):
         subprocess.check_call(command + ("--delete", "--topic", topic))
 
 
-def test_consumer_start_from_partition_start(requires_kafka):
+def test_consumer_start_from_partition_start():
     synchronize_commit_group = f"consumer-{uuid.uuid1().hex}"
 
     messages_delivered = defaultdict(list)
@@ -138,7 +138,7 @@ def test_consumer_start_from_partition_start(requires_kafka):
         assert consumer.poll(1) is None
 
 
-def test_consumer_start_from_committed_offset(requires_kafka):
+def test_consumer_start_from_committed_offset():
     consumer_group = f"consumer-{uuid.uuid1().hex}"
     synchronize_commit_group = f"consumer-{uuid.uuid1().hex}"
 
@@ -235,7 +235,7 @@ def test_consumer_start_from_committed_offset(requires_kafka):
         assert consumer.poll(1) is None
 
 
-def test_consumer_rebalance_from_partition_start(requires_kafka):
+def test_consumer_rebalance_from_partition_start():
     consumer_group = f"consumer-{uuid.uuid1().hex}"
     synchronize_commit_group = f"consumer-{uuid.uuid1().hex}"
 
@@ -349,7 +349,7 @@ def test_consumer_rebalance_from_partition_start(requires_kafka):
             assert consumer.poll(1) is None
 
 
-def test_consumer_rebalance_from_committed_offset(requires_kafka):
+def test_consumer_rebalance_from_committed_offset():
     consumer_group = f"consumer-{uuid.uuid1().hex}"
     synchronize_commit_group = f"consumer-{uuid.uuid1().hex}"
 
@@ -510,7 +510,7 @@ def collect_messages_received(count):
     reason="assignment during rebalance requires partition rollback to last committed offset",
     run=False,
 )
-def test_consumer_rebalance_from_uncommitted_offset(requires_kafka):
+def test_consumer_rebalance_from_uncommitted_offset():
     consumer_group = f"consumer-{uuid.uuid1().hex}"
     synchronize_commit_group = f"consumer-{uuid.uuid1().hex}"
 
@@ -635,7 +635,6 @@ def kafka_message_payload():
     ]
 
 
-@pytest.mark.usefixtures("requires_kafka")
 class BatchedConsumerTest(TestCase):
     def _get_producer(self, topic):
         cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -88,7 +88,6 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
     task_runner,
     kafka_producer,
     kafka_admin,
-    requires_kafka,
     default_project,
     get_test_message,
     random_group_id,
@@ -138,7 +137,7 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
 
 
 def test_ingest_consumer_fails_when_not_autocreating_topics(
-    kafka_admin, requires_kafka, random_group_id
+    kafka_admin, random_group_id
 ):
     topic_event_name = ConsumerType.get_topic_name(ConsumerType.Events)
 
@@ -165,7 +164,6 @@ def test_ingest_consumer_fails_when_not_autocreating_topics(
 def test_ingest_topic_can_be_overridden(
     task_runner,
     kafka_admin,
-    requires_kafka,
     random_group_id,
     default_project,
     get_test_message,

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -136,9 +136,7 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
     assert transaction_message.data["contexts"]["trace"]
 
 
-def test_ingest_consumer_fails_when_not_autocreating_topics(
-    kafka_admin, random_group_id
-):
+def test_ingest_consumer_fails_when_not_autocreating_topics(kafka_admin, random_group_id):
     topic_event_name = ConsumerType.get_topic_name(ConsumerType.Events)
 
     admin = kafka_admin(settings)


### PR DESCRIPTION
Since https://github.com/getsentry/sentry/pull/34891, various backend tests are now failing even though tests passed in the PR, weird.

I was going to add kafka to all backend testing as a hotfix but thought might as well just separate backend tests that require kafka to their own testing matrix.

This PR also prefixes NEEDS_CHARTCUTERIE et al with CI. (TODO)