### PR TITLE
Revert "ci: compile devservices args (#34891)"

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -23,10 +23,6 @@ inputs:
     description: 'Is chartcuterie required?'
     required: false
     default: 'false'
-  bigtable:
-    description: 'Is bigtable required?'
-    required: false
-    default: 'false'
   cache-files-hash:
     description: 'A single hash for a set of files. Used for caching.'
     required: false
@@ -72,6 +68,7 @@ runs:
     - name: Setup default environment variables
       shell: bash
       env:
+        NEED_KAFKA: ${{ inputs.kafka }}
         MATRIX_INSTANCE: ${{ matrix.instance }}
         # XXX: We should be using something like len(strategy.matrix.instance) (not possible atm)
         # If you have other things like python-version: [foo, bar, baz] then the sharding logic
@@ -115,6 +112,15 @@ runs:
         # This records failures on master to sentry in order to detect flakey tests, as it's
         # expected that people have failing tests on their PRs
         [ "$GITHUB_REF" = "refs/heads/master" ] && echo "PYTEST_SENTRY_ALWAYS_REPORT=1" >> $GITHUB_ENV || true
+
+        ### services configuration ###
+        echo "BIGTABLE_EMULATOR_HOST=localhost:8086" >> $GITHUB_ENV
+        # Note: some backend tests (e.g. tests/sentry/eventstream/kafka/test_consumer.py) will behave
+        # differently if these are set.
+        if [ "$NEED_KAFKA" = "true" ]; then
+          echo "SENTRY_KAFKA_HOSTS=127.0.0.1:9092" >> $GITHUB_ENV
+          echo "SENTRY_ZOOKEEPER_HOSTS=127.0.0.1:2181" >> $GITHUB_ENV
+        fi
 
     - name: Setup python
       id: setup-python
@@ -163,7 +169,6 @@ runs:
         NEED_KAFKA: ${{ inputs.kafka }}
         NEED_SNUBA: ${{ inputs.snuba }}
         NEED_CLICKHOUSE: ${{ inputs.clickhouse }}
-        NEED_BIGTABLE: ${{ inputs.bigtable }}
         NEED_CHARTCUTERIE: ${{ inputs.chartcuterie }}
         WORKDIR: ${{ inputs.workdir }}
         PG_VERSION: ${{ inputs.pg-version }}
@@ -171,26 +176,11 @@ runs:
         sentry init
 
         # redis, postgres are needed for almost every code path.
-        services='redis postgres'
+        sentry devservices up redis postgres
 
-        if [ "$NEED_CLICKHOUSE" = "true" ] || [ "$NEED_SNUBA" = "true" ]; then
-          services="${services} clickhouse"
+        if [ "$BIGTABLE_EMULATOR_HOST" ]; then
+          sentry devservices up --skip-only-if bigtable
         fi
-
-        if [ "$NEED_SNUBA" = "true" ]; then
-          services="${services} snuba"
-        fi
-
-        if [ "$NEED_BIGTABLE" = "true" ]; then
-          echo "BIGTABLE_EMULATOR_HOST=127.0.0.1:8086" >> $GITHUB_ENV
-          services="${services} bigtable"
-        fi
-
-        if [ "$NEED_CHARTCUTERIE" = "true" ]; then
-          services="${services} chartcuterie"
-        fi
-
-        sentry devservices up $services &
 
         # TODO: Use devservices kafka. See https://github.com/getsentry/sentry/pull/20986#issuecomment-704510570
         if [ "$NEED_KAFKA" = "true" ]; then
@@ -200,8 +190,7 @@ runs:
             --name sentry_zookeeper \
             -d --network host \
             -e ZOOKEEPER_CLIENT_PORT=2181 \
-            confluentinc/cp-zookeeper:4.1.0 \
-            &
+            confluentinc/cp-zookeeper:4.1.0
 
           # This is the production version; do not change w/o changing it there as well
           # https://github.com/getsentry/ops/blob/c823e62f930ecc6c97bb08898c71e49edc7232f6/cookbooks/getsentry/attributes/default.rb#L643
@@ -214,11 +203,20 @@ runs:
             -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \
             -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
             -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
-            confluentinc/cp-kafka:5.1.2 \
-            &
+            confluentinc/cp-kafka:5.1.2
         fi
 
-        wait
+        if [ "$NEED_SNUBA" = "true" ]; then
+          sentry devservices up clickhouse snuba
+        fi
+
+        if [ "$NEED_CLICKHOUSE" = "true" ]; then
+          sentry devservices up clickhouse
+        fi
+
+        if [ "$NEED_CHARTCUTERIE" = "true" ]; then
+          sentry devservices up --skip-only-if chartcuterie
+        fi
 
         docker ps -a
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -91,10 +91,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pip-cache-version: ${{ secrets.PIP_CACHE_VERSION }}
           snuba: true
-          # Right now, we run so few bigtable related tests that the
-          # overhead of running bigtable in all backend tests
-          # is way smaller than the time it would take to run in its own job.
-          bigtable: true
           pg-version: ${{ matrix.pg-version }}
 
       - name: Run backend test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1969,10 +1969,7 @@ SENTRY_DEVSERVICES = {
         {
             "image": "us.gcr.io/sentryio/cbtemulator:23c02d92c7a1747068eb1fc57dddbad23907d614",
             "ports": {"8086/tcp": 8086},
-            # NEED_BIGTABLE is set by CI so we don't have to pass
-            # --skip-only-if when compiling which services to run.
-            "only_if": os.environ.get("NEED_BIGTABLE", False)
-            or "bigtable" in settings.SENTRY_NODESTORE,
+            "only_if": "bigtable" in settings.SENTRY_NODESTORE,
         }
     ),
     "memcached": lambda settings, options: (
@@ -2013,9 +2010,7 @@ SENTRY_DEVSERVICES = {
                 "CHARTCUTERIE_CONFIG_POLLING": "true",
             },
             "ports": {"9090/tcp": 7901},
-            # NEED_CHARTCUTERIE is set by CI so we don't have to pass --skip-only-if when compiling which services to run.
-            "only_if": os.environ.get("NEED_CHARTCUTERIE", False)
-            or options.get("chart-rendering.enabled"),
+            "only_if": options.get("chart-rendering.enabled"),
         }
     ),
     "cdc": lambda settings, options: (

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1941,7 +1941,8 @@ SENTRY_DEVSERVICES = {
     ),
     "snuba": lambda settings, options: (
         {
-            "image": "getsentry/snuba:nightly" if not APPLE_ARM64
+            # snuba @ f063336085e7be0ccbdb52791aaf97882ba7a26f
+            "image": "getsentry/snuba:f063336085e7be0ccbdb52791aaf97882ba7a26f" if not APPLE_ARM64
             # We cross-build arm64 images on GH's Apple Intel runners
             else "ghcr.io/getsentry/snuba-arm64-dev:latest",
             "pull": True,


### PR DESCRIPTION
Since https://github.com/getsentry/sentry/pull/34891, various backend tests are now failing even though tests passed in the PR, weird. I attempted some fixes to partial success elsewhere, but I won't be able to fix in time by Monday, so tossing this revert up.