### PR TITLE
fix: Remove return from constructor in CamelSnakeModelSerializer

### DIFF
--- a/src/sentry/api/serializers/rest_framework/base.py
+++ b/src/sentry/api/serializers/rest_framework/base.py
@@ -65,7 +65,7 @@ class CamelSnakeModelSerializer(ModelSerializer):
     def __init__(self, instance=None, data=empty, **kwargs):
         if data is not empty:
             data = convert_dict_key_case(data, camel_to_snake_case)
-        return super().__init__(instance=instance, data=data, **kwargs)
+        super().__init__(instance=instance, data=data, **kwargs)
 
     @property
     def errors(self):

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -466,7 +466,7 @@ def from_member(
     return OrganizationMemberAccess(member, scopes, permissions)
 
 
-def from_auth(auth, organization: Organization, scopes=[]) -> Access:
+def from_auth(auth, organization: Organization) -> Access:
     if is_system_auth(auth):
         return SystemAccess()
     if auth.organization_id == organization.id:

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -466,7 +466,7 @@ def from_member(
     return OrganizationMemberAccess(member, scopes, permissions)
 
 
-def from_auth(auth, organization: Organization) -> Access:
+def from_auth(auth, organization: Organization, scopes=[]) -> Access:
     if is_system_auth(auth):
         return SystemAccess()
     if auth.organization_id == organization.id:


### PR DESCRIPTION


<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
