### PR TITLE
fix(ci): various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,12 +125,16 @@ test-python:
 test-python-ci:
 	make build-platform-assets
 	@echo "--> Running CI Python tests"
-	pytest tests/integration tests/sentry --cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
+	pytest tests/integration tests/sentry \
+		--ignore tests/sentry/eventstream/kafka \
+		--ignore tests/sentry/snuba \
+		--ignore tests/sentry/search/events \
+		--cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
 	@echo ""
 
 test-snuba:
 	@echo "--> Running snuba tests"
-	pytest tests/snuba tests/sentry/eventstream/kafka tests/sentry/snuba/test_discover.py tests/sentry/search/events -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml" --junit-xml=".artifacts/snuba.junit.xml"
+	pytest tests/snuba tests/sentry/eventstream/kafka tests/sentry/snuba tests/sentry/search/events -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml" --junit-xml=".artifacts/snuba.junit.xml"
 	@echo ""
 
 test-tools:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1941,7 +1941,7 @@ SENTRY_DEVSERVICES = {
     ),
     "snuba": lambda settings, options: (
         {
-            "image": "getsentry/snuba:nightly" if not APPLE_ARM64
+            "image": "getsentry/snuba:f063336085e7be0ccbdb52791aaf97882ba7a26f" if not APPLE_ARM64
             # We cross-build arm64 images on GH's Apple Intel runners
             else "ghcr.io/getsentry/snuba-arm64-dev:latest",
             "pull": True,

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -38,7 +38,7 @@ def create_topic(partitions=1, replication_factor=1):
     topic = f"test-{uuid.uuid1().hex}"
     subprocess.check_call(
         command
-        + (
+        + [
             "--create",
             "--topic",
             topic,
@@ -46,12 +46,12 @@ def create_topic(partitions=1, replication_factor=1):
             f"{partitions}",
             "--replication-factor",
             f"{replication_factor}",
-        )
+        ]
     )
     try:
         yield topic
     finally:
-        subprocess.check_call(command + ("--delete", "--topic", topic))
+        subprocess.check_call(command + ["--delete", "--topic", topic])
 
 
 def test_consumer_start_from_partition_start(requires_kafka):


### PR DESCRIPTION
The recent test fails (like in `tests/sentry/incidents/test_subscription_processor.py`) on the merge commit for https://github.com/getsentry/sentry/pull/34891 are not only a result of some changes there but are also due to a snuba release that occured after tests passed (to be able to merge that branch) but before CI kicked off for the merge commit.

This temporarily pins snuba to f063336085e7be0ccbdb52791aaf97882ba7a26f, cc @getsentry/owners-snuba. I don't know which is exactly the bad commit, but 3cacc16753696de0953e80af5dcdabefc65d370e for sure is, and the two before seemed related.

Also, I removed some overlap between test-python-ci and test-snuba.