### PR TITLE
feat(replays): Make the ReplayCurrentUrl area appear disabled when loading

### DIFF
--- a/static/app/components/forms/textCopyInput.tsx
+++ b/static/app/components/forms/textCopyInput.tsx
@@ -44,6 +44,7 @@ type Props = {
    */
   children: string;
   className?: string;
+  disabled?: boolean;
   onCopy?: (value: string, event: React.MouseEvent) => void;
   /**
    * Always show the ending of a long overflowing text in input
@@ -93,7 +94,7 @@ class TextCopyInput extends Component<Props> {
   };
 
   render() {
-    const {className, style, children, rtl} = this.props;
+    const {className, disabled, style, children, rtl} = this.props;
 
     /**
      * We are using direction: rtl; to always show the ending of a long overflowing text in input.
@@ -110,6 +111,7 @@ class TextCopyInput extends Component<Props> {
         <OverflowContainer>
           <StyledInput
             readOnly
+            disabled={disabled}
             ref={this.textRef}
             style={style}
             value={inputValue}
@@ -118,7 +120,11 @@ class TextCopyInput extends Component<Props> {
           />
         </OverflowContainer>
         <Clipboard hideUnsupported value={children}>
-          <StyledCopyButton type="button" onClick={this.handleCopyClick}>
+          <StyledCopyButton
+            type="button"
+            disabled={disabled}
+            onClick={this.handleCopyClick}
+          >
             <IconCopy />
           </StyledCopyButton>
         </Clipboard>

--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -12,25 +12,27 @@ import getCurrentUrl from 'sentry/utils/replays/getCurrentUrl';
 function ReplayCurrentUrl() {
   const {currentTime, replay} = useReplayContext();
   if (!replay) {
-    return null;
+    return <UrlCopyInput disabled>{''}</UrlCopyInput>;
   }
 
   return <UrlCopyInput>{getCurrentUrl(replay, currentTime)}</UrlCopyInput>;
 }
 
-const UrlCopyInput = styled(TextCopyInput)`
+const UrlCopyInput = styled(TextCopyInput)<{disabled?: boolean}>`
   ${StyledInput} {
     background: white;
     border: none;
     padding: 0 ${space(0.75)};
     font-size: ${p => p.theme.fontSizeMedium};
     border-bottom-left-radius: 0;
+    ${p => (p.disabled ? 'pointer-events: none;' : '')}
   }
 
   ${StyledCopyButton} {
     border-top: none;
     border-right: none;
     border-bottom: none;
+    ${p => (p.disabled ? 'pointer-events: none;' : '')}
   }
 `;
 

--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -31,7 +31,6 @@ const UrlCopyInput = styled(TextCopyInput)<{disabled?: boolean}>`
           pointer-events: none;
           background: ${p.theme.backgroundSecondary};
           color: ${p.theme.gray300};
-          border: 1px solid ${p.theme.border};
           cursor: not-allowed;
         `
         : ''}

--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -18,29 +18,22 @@ function ReplayCurrentUrl() {
   return <UrlCopyInput>{getCurrentUrl(replay, currentTime)}</UrlCopyInput>;
 }
 
-const UrlCopyInput = styled(TextCopyInput)<{disabled?: boolean}>`
+const UrlCopyInput = styled(TextCopyInput)`
   ${StyledInput} {
-    background: 'white';
+    background: ${p => p.theme.white};
     border: none;
     padding: 0 ${space(0.75)};
     font-size: ${p => p.theme.fontSizeMedium};
     border-bottom-left-radius: 0;
-    ${p =>
-      p.disabled
-        ? `
-          pointer-events: none;
-          background: ${p.theme.backgroundSecondary};
-          color: ${p.theme.gray300};
-          cursor: not-allowed;
-        `
-        : ''}
+  }
+  ${StyledInput}[disabled] {
+    border: none;
   }
 
   ${StyledCopyButton} {
     border-top: none;
     border-right: none;
     border-bottom: none;
-    ${p => (p.disabled ? 'pointer-events: none;' : '')}
   }
 `;
 

--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -20,12 +20,21 @@ function ReplayCurrentUrl() {
 
 const UrlCopyInput = styled(TextCopyInput)<{disabled?: boolean}>`
   ${StyledInput} {
-    background: white;
+    background: 'white';
     border: none;
     padding: 0 ${space(0.75)};
     font-size: ${p => p.theme.fontSizeMedium};
     border-bottom-left-radius: 0;
-    ${p => (p.disabled ? 'pointer-events: none;' : '')}
+    ${p =>
+      p.disabled
+        ? `
+          pointer-events: none;
+          background: ${p.theme.backgroundSecondary};
+          color: ${p.theme.gray300};
+          border: 1px solid ${p.theme.border};
+          cursor: not-allowed;
+        `
+        : ''}
   }
 
   ${StyledCopyButton} {


### PR DESCRIPTION
**Before:**
The CurrentUrl area is missing, and there's an extra thick line at the top of the player area:

<img width="743" alt="Screen Shot 2022-05-23 at 8 26 39 PM" src="https://user-images.githubusercontent.com/187460/169819423-67c5a54a-15ab-4915-b6ef-b3fa02173e63.png">


**After:**
We get the textbox & button displayed and disabled, no tooltip appears for the button.

<img width="730" alt="Screen Shot 2022-05-25 at 1 10 40 AM" src="https://user-images.githubusercontent.com/187460/170093691-33d0fb26-b48a-4241-8b3e-54106dc9fe78.png">


