### PR TITLE
ref(replays): Remove extra "retry" state from useReplayData

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -90,7 +90,6 @@ function useReplayData({eventSlug, orgId}: Options): Result {
   const [projectId, eventId] = eventSlug.split(':');
 
   const api = useApi();
-  const [retry, setRetry] = useState(true);
   const [state, setState] = useState<State>(INITIAL_STATE);
 
   const fetchEvent = useCallback(() => {
@@ -172,24 +171,18 @@ function useReplayData({eventSlug, orgId}: Options): Result {
   );
 
   useEffect(() => {
-    if (retry) {
-      setRetry(false);
-      loadEvents();
-    }
-  }, [retry, loadEvents]);
+    loadEvents();
+  }, [loadEvents]);
 
-  const onRetry = useCallback(() => {
-    setRetry(true);
-  }, []);
-
-  const replay = useMemo(() => {
-    return ReplayReader.factory(state.event, state.rrwebEvents, state.replayEvents);
-  }, [state.event, state.rrwebEvents, state.replayEvents]);
+  const replay = useMemo(
+    () => ReplayReader.factory(state.event, state.rrwebEvents, state.replayEvents),
+    [state.event, state.rrwebEvents, state.replayEvents]
+  );
 
   return {
     fetchError: state.fetchError,
     fetching: state.fetching,
-    onRetry,
+    onRetry: loadEvents,
     replay,
   };
 }

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -140,35 +140,32 @@ function useReplayData({eventSlug, orgId}: Options): Result {
     );
   }, [api, eventId, orgId]);
 
-  const loadEvents = useCallback(
-    async function () {
-      setState(INITIAL_STATE);
+  const loadEvents = useCallback(async () => {
+    setState(INITIAL_STATE);
 
-      try {
-        const [event, rrwebEvents, replayEvents] = await Promise.all([
-          fetchEvent(),
-          fetchRRWebEvents(),
-          fetchReplayEvents(),
-        ]);
+    try {
+      const [event, rrwebEvents, replayEvents] = await Promise.all([
+        fetchEvent(),
+        fetchRRWebEvents(),
+        fetchReplayEvents(),
+      ]);
 
-        setState({
-          event,
-          fetchError: undefined,
-          fetching: false,
-          replayEvents,
-          rrwebEvents,
-        });
-      } catch (error) {
-        Sentry.captureException(error);
-        setState({
-          ...INITIAL_STATE,
-          fetchError: error,
-          fetching: false,
-        });
-      }
-    },
-    [fetchEvent, fetchRRWebEvents, fetchReplayEvents]
-  );
+      setState({
+        event,
+        fetchError: undefined,
+        fetching: false,
+        replayEvents,
+        rrwebEvents,
+      });
+    } catch (error) {
+      Sentry.captureException(error);
+      setState({
+        ...INITIAL_STATE,
+        fetchError: error,
+        fetching: false,
+      });
+    }
+  }, [fetchEvent, fetchRRWebEvents, fetchReplayEvents]);
 
   useEffect(() => {
     loadEvents();


### PR DESCRIPTION
Remove the `retry` state variable, we can simply pass `loadEvents` on down so children can load more data.

Setting the var was one way to debounce calls to `onRetry`, but really children can look at the `fetching` var to know if they should be calling `onRetry` or not at any given time. `loadEvents` could also look at `fetching` and have a guard, but none of this downstream stuff matters now anyway because nothing is misbehaving right now.