### PR TITLE
feat(replays): use postMessage to sync replays across multiple browser windows

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -14,7 +14,7 @@ type RootElem = null | HTMLDivElement;
 // Important: Don't allow context Consumers to access `Replayer` directly.
 // It has state that, when changed, will not trigger a react render.
 // Instead only expose methods that wrap `Replayer` and manage state.
-type ReplayPlayerContextProps = {
+export type ReplayPlayerContextProps = {
   /**
    * The time, in milliseconds, where the user focus is.
    * The user focus can be reported by any collaborating object, usually on

--- a/static/app/components/replays/useCrossWindowSync.tsx
+++ b/static/app/components/replays/useCrossWindowSync.tsx
@@ -1,0 +1,81 @@
+import {useCallback, useEffect, useRef} from 'react';
+
+import type {ReplayPlayerContextProps} from 'sentry/components/replays/replayContext';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import type {EventTransaction} from 'sentry/types/event';
+
+type Options = {
+  childWindow: Window | null;
+};
+
+type ReplayStateChange = {
+  payload: {
+    currentHoverTime: ReplayPlayerContextProps['currentHoverTime'];
+    currentTime: ReplayPlayerContextProps['currentTime'];
+    eventId: EventTransaction['id'];
+  };
+  source: 'replay-window-sync';
+};
+
+function useCrossWindowSync({childWindow}: Options) {
+  const {currentHoverTime, currentTime, replay, setCurrentHoverTime, setCurrentTime} =
+    useReplayContext();
+
+  const eventId = replay?.getEvent().id;
+
+  const handleMessage = useCallback(
+    (event: MessageEvent<ReplayStateChange>) => {
+      if (event.origin !== window.location.origin) {
+        return;
+      }
+
+      const {source, payload} = event.data;
+
+      if (source !== 'replay-window-sync') {
+        return;
+      }
+
+      if (payload.eventId === eventId) {
+        setCurrentTime(payload.currentTime);
+        setCurrentHoverTime(payload.currentHoverTime);
+      }
+    },
+    [eventId, setCurrentTime, setCurrentHoverTime]
+  );
+
+  useEffect(() => {
+    if (document.visibilityState === 'visible' && childWindow) {
+      const stateChange = {
+        source: 'replay-window-sync',
+        payload: {
+          currentHoverTime,
+          currentTime,
+          eventId,
+        },
+      } as ReplayStateChange;
+      childWindow.postMessage(stateChange, window.location.origin);
+    }
+  }, [eventId, currentTime, currentHoverTime, childWindow]);
+
+  useEffect(() => {
+    window.addEventListener('message', handleMessage, false);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [handleMessage]);
+}
+
+export default useCrossWindowSync;
+
+type Props = {};
+
+export function CrossWindowSync(_props: Props) {
+  const devtoolsWinRef = useRef<Window | null>(null);
+
+  useCrossWindowSync({childWindow: devtoolsWinRef.current});
+
+  const handleClick = useCallback(() => {
+    devtoolsWinRef.current = window.open(window.location.href);
+  }, []);
+  return <button onClick={handleClick}>Pop out devtools</button>;
+}

--- a/static/app/components/replays/useCrossWindowSync.tsx
+++ b/static/app/components/replays/useCrossWindowSync.tsx
@@ -1,7 +1,9 @@
 import {useCallback, useEffect, useRef} from 'react';
 
+import Button from 'sentry/components/button';
 import type {ReplayPlayerContextProps} from 'sentry/components/replays/replayContext';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {IconOpen} from 'sentry/icons';
 import type {EventTransaction} from 'sentry/types/event';
 
 type Options = {
@@ -69,13 +71,18 @@ export default useCrossWindowSync;
 
 type Props = {};
 
-export function CrossWindowSync(_props: Props) {
-  const devtoolsWinRef = useRef<Window | null>(null);
+export function CrossWindowSyncButton(_props: Props) {
+  const devtoolsWinRef = useRef<ReturnType<typeof window.open> | null>(null);
 
   useCrossWindowSync({childWindow: devtoolsWinRef.current});
 
   const handleClick = useCallback(() => {
-    devtoolsWinRef.current = window.open(window.location.href);
+    devtoolsWinRef.current = window.open(window.location.href, undefined, 'popup=1');
   }, []);
-  return <button onClick={handleClick}>Pop out devtools</button>;
+
+  return (
+    <Button icon={<IconOpen color="gray500" size="sm" />} onClick={handleClick}>
+      Undock devtools
+    </Button>
+  );
 }

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -7,7 +7,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayView from 'sentry/components/replays/replayView';
-import {CrossWindowSync} from 'sentry/components/replays/useCrossWindowSync';
+import {CrossWindowSyncButton} from 'sentry/components/replays/useCrossWindowSync';
 import useFullscreen from 'sentry/components/replays/useFullscreen';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
@@ -78,7 +78,7 @@ function ReplayDetails() {
         orgId={orgId}
         crumbs={replay?.getRawCrumbs()}
       >
-        <CrossWindowSync />
+        <CrossWindowSyncButton />
         <Layout.Body>
           <Layout.Main ref={fullscreenRef}>
             <ReplayView toggleFullscreen={toggleFullscreen} isFullscreen={isFullscreen} />

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -7,6 +7,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayView from 'sentry/components/replays/replayView';
+import {CrossWindowSync} from 'sentry/components/replays/useCrossWindowSync';
 import useFullscreen from 'sentry/components/replays/useFullscreen';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
@@ -77,6 +78,7 @@ function ReplayDetails() {
         orgId={orgId}
         crumbs={replay?.getRawCrumbs()}
       >
+        <CrossWindowSync />
         <Layout.Body>
           <Layout.Main ref={fullscreenRef}>
             <ReplayView toggleFullscreen={toggleFullscreen} isFullscreen={isFullscreen} />


### PR DESCRIPTION
This is a proof of concept:
- There's a new button on the details page which spawns a popup window, which also shows the details page
- This `window.open` call gives us a reference to the popup
- We can call `postMessage` and send a message from the original page, to the popup, keeping the state in sync

Still TODO:
- [ ] Use `window.opener` or `event.source` in popup to send it's messages back to the 1st window
- [ ] Payload shape and handler that can better sync play/pause state and the results of all the function calls
- [ ] Trigger `postMessage` whenever play/pause, setSpeed, etc are called
- [ ] Button needs a home in the UI
- [ ] Better page/layout for the popup

Fixes #35047
