### PR TITLE
test(metrics): Remove init tag for rh user metric in tests

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1637,7 +1637,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     "project_id": self.project.id,
                     "metric_id": self.session_user_metric,
                     "timestamp": user_ts,
-                    "tags": {self.session_status_tag: indexer.record(self.organization.id, "init")},
+                    "tags": {},
                     "type": "s",
                     "value": [1, 2, 4],
                     "retention_days": 90,
@@ -1676,7 +1676,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     "project_id": self.project.id,
                     "metric_id": self.session_user_metric,
                     "timestamp": user_ts,
-                    "tags": {self.session_status_tag: indexer.record(self.organization.id, "init")},
+                    "tags": {},
                     "type": "s",
                     "value": [1, 2, 4, 7, 9],
                     "retention_days": 90,
@@ -1705,7 +1705,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     "metric_id": self.session_user_metric,
                     "timestamp": user_ts,
                     "tags": {
-                        self.session_status_tag: indexer.record(self.organization.id, "init"),
                         self.release_tag: indexer.record(org_id, "foobar@1.0"),
                     },
                     "type": "s",
@@ -1731,7 +1730,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     "metric_id": self.session_user_metric,
                     "timestamp": user_ts,
                     "tags": {
-                        self.session_status_tag: indexer.record(self.organization.id, "init"),
                         self.release_tag: indexer.record(org_id, "foobar@2.0"),
                     },
                     "type": "s",
@@ -1773,7 +1771,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     "metric_id": self.session_user_metric,
                     "timestamp": user_ts,
                     "tags": {
-                        self.session_status_tag: indexer.record(org_id, "init"),
                         self.release_tag: indexer.record(org_id, "foobar@1.0"),
                     },
                     "type": "s",
@@ -1799,7 +1796,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     "metric_id": self.session_user_metric,
                     "timestamp": user_ts,
                     "tags": {
-                        self.session_status_tag: indexer.record(self.organization.id, "init"),
                         self.release_tag: indexer.record(org_id, "foobar@2.0"),
                     },
                     "type": "s",
@@ -2002,7 +1998,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             statsPeriod="6m",
             interval="6m",
         )
-        print(response.data["groups"])
         group = response.data["groups"][0]
         assert group["totals"]["session.healthy"] == 6
         assert group["series"]["session.healthy"] == [6]
@@ -2132,9 +2127,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                     "project_id": self.project.id,
                     "metric_id": self.session_user_metric,
                     "timestamp": user_ts,
-                    "tags": {
-                        self.session_status_tag: indexer.record(org_id, "init"),
-                    },
+                    "tags": {},
                     "type": "s",
                     "value": [1, 2, 4, 5, 7],  # 3 and 6 did not recorded at init
                     "retention_days": 90,

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1496,11 +1496,9 @@ class InitWithoutUserTestCase(TestCase, SnubaTestCase):
 
         # Last returned date is generated within function, should be close to now:
         last_date = data[-1].pop("date")
-        print(last_date)
 
         assert timezone.now() - last_date < timedelta(seconds=1)
 
-        print(self.session_started)
         assert data == [
             {
                 "crash_free_sessions": None,

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -297,7 +297,6 @@ def test_filter_env_in_query(default_project):
         f"field=sum(session)&interval=2h&statsPeriod=2h&query=environment%3A{env}",
         params=params,
     )
-    print(query_def)
     assert query_def.query == f"environment:{env}"
     assert query_def.conditions == [[["environment", "=", env]]]
 


### PR DESCRIPTION
As of https://github.com/getsentry/sentry/pull/34858, we don't consider the `init` tag anymore to get the total user count in release health metrics. To simplify tests, don't submit this tag in data fixtures.

Also remove some stray `print` calls in tests.