### PR TITLE
feat(rules): add support for cocoa-platform path munging

### DIFF
--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -233,6 +233,45 @@ def test_matcher_test_platform_java_threads():
     assert not Matcher("path", "*.py").test({})
 
 
+def test_matcher_test_platform_cocoa_threads():
+    data = {
+        "platform": "cocoa",
+        "threads": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "package": "SampleProject",
+                                "abs_path": "/Users/gszeto/code/SwiftySampleProject/SampleProject/Classes/App Delegate/AppDelegate.swift",
+                                # munged_filename: "SampleProject/Classes/App Delegate/AppDelegate.swift"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+
+    assert Matcher("path", "*.swift").test(data)
+    assert Matcher("path", "SampleProject/Classes/App Delegate/AppDelegate.swift").test(data)
+    assert not Matcher(
+        "path", "SwiftySampleProject/SampleProject/Classes/App Delegate/AppDelegate.swift"
+    ).test(data)
+    assert Matcher("path", "**/App Delegate/AppDelegate.swift").test(data)
+    assert Matcher("codeowners", "*.swift").test(data)
+    assert Matcher("codeowners", "SampleProject/Classes/App Delegate/*.swift").test(data)
+    assert Matcher("codeowners", "SampleProject/Classes/App Delegate/AppDelegate.swift").test(data)
+    assert not Matcher(
+        "codeowners", "SwiftySampleProject/SampleProject/Classes/App Delegate/AppDelegate.swift"
+    ).test(data)
+    assert Matcher("codeowners", "**/App Delegate/AppDelegate.swift").test(data)
+    assert not Matcher("path", "*.js").test(data)
+    assert not Matcher("path", "*.jsx").test(data)
+    assert not Matcher("url", "*.py").test(data)
+    assert not Matcher("path", "*.py").test({})
+
+
 def test_matcher_test_platform_none_threads():
     data = {
         "threads": {


### PR DESCRIPTION
To support Swift platform (`cocoa`) for suspect commits and codeowners rule matching we need to 'munge' the frame data to produce a useable source code filepath to be used to matching against commit file changes and/or codeowner paths.

This PR opts to use the `package` and `abs_path` to formulate a reasonable starting point for sourcing that filepath. 

Another alternate approach involving transforming the filepath using `RepositoryProjectPathConfig` to replace the stackframe 'stack_root' with `source_root` a la stacktrace linking was looked into as well as can be added as a fallback if the package-relative strategy falls-through in certain scenarios.

Another strategy considered is to use `source_root` as a path starting point, i.e. `abs_path=/Users/me/a/b/c/d/code/MyStarterApp/Classes/Main/AppDelegate.swift` and `source_root=/MyStarterApp/` would result in a `munged_filepath=MyStarterApp/Classes/Main/AppDelegate.swift`. 

For now, to move forward, I opted to keep it simple and implement the package-relative strategy and make changes if needed once this deploys and we have more information.


Fixes WOR-1803