### PR TITLE
ref(useTeams): Memoize filteredTeams

### DIFF
--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import uniqBy from 'lodash/uniqBy';
 
 import {fetchUserTeams} from 'sentry/actionCreators/teams';
@@ -332,13 +332,15 @@ function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
 
   const isSuperuser = isActiveSuperuser();
 
-  const filteredTeams = slugs
-    ? store.teams.filter(t => slugs.includes(t.slug))
-    : ids
-    ? store.teams.filter(t => ids.includes(t.id))
-    : provideUserTeams && !isSuperuser
-    ? store.teams.filter(t => t.isMember)
-    : store.teams;
+  const filteredTeams = useMemo(() => {
+    return slugs
+      ? store.teams.filter(t => slugs.includes(t.slug))
+      : ids
+      ? store.teams.filter(t => ids.includes(t.id))
+      : provideUserTeams && !isSuperuser
+      ? store.teams.filter(t => t.isMember)
+      : store.teams;
+  }, [store, ids, slugs, provideUserTeams, isSuperuser]);
 
   const result: Result = {
     teams: filteredTeams,

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -340,7 +340,7 @@ function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
       : provideUserTeams && !isSuperuser
       ? store.teams.filter(t => t.isMember)
       : store.teams;
-  }, [store, ids, slugs, provideUserTeams, isSuperuser]);
+  }, [store.teams, ids, slugs, provideUserTeams, isSuperuser]);
 
   const result: Result = {
     teams: filteredTeams,


### PR DESCRIPTION
If the `provideUserTeams` prop is true, then `useTeams` will return a different `teams` array on each re-render. This causes whatever that consumes `teams` to also re-render, as seen here by `CompactSelect`'s flickery behavior:
https://user-images.githubusercontent.com/44172267/169878204-21de031c-4432-4d90-84de-ac5d50881c3e.mov

Memoizing the value of the `teams` array  (declared internally as `filteredTeams`) fixes this issue:
https://user-images.githubusercontent.com/44172267/169878287-fd2fafc2-a9ec-48ca-b016-4903d27e69f7.mov


