### PR TITLE
chore(analytics): Add analytics events for sidebar items

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -38,7 +38,6 @@ import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
-import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import theme from 'sentry/utils/theme';
 import useMedia from 'sentry/utils/useMedia';
@@ -163,19 +162,12 @@ function Sidebar({location, organization}: Props) {
     orientation,
     collapsed,
     hasPanel,
-  };
-
-  const recordAnalytics = (item: string) => {
-    trackAdvancedAnalyticsEvent('growth.clicked_sidebar', {
-      item,
-      organization: organization || null,
-    });
+    organization,
   };
 
   const projects = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
-      onClick={() => recordAnalytics('projects')}
       index
       icon={<IconProject size="md" />}
       label={<GuideAnchor target="projects">{t('Projects')}</GuideAnchor>}
@@ -188,7 +180,6 @@ function Sidebar({location, organization}: Props) {
     <SidebarItem
       {...sidebarItemProps}
       onClick={(_id, evt) => {
-        recordAnalytics('issues');
         navigateWithPageFilters(`/organizations/${organization.slug}/issues/`, evt);
       }}
       icon={<IconIssues size="md" />}
@@ -207,7 +198,6 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         onClick={(_id, evt) => {
-          recordAnalytics('discover2');
           navigateWithPageFilters(getDiscoverLandingUrl(organization), evt);
         }}
         icon={<IconTelescope size="md" />}
@@ -229,7 +219,6 @@ function Sidebar({location, organization}: Props) {
           <SidebarItem
             {...sidebarItemProps}
             onClick={(_id, evt) => {
-              recordAnalytics('performance');
               navigateWithPageFilters(
                 `/organizations/${organization.slug}/performance/`,
                 evt
@@ -250,7 +239,6 @@ function Sidebar({location, organization}: Props) {
     <SidebarItem
       {...sidebarItemProps}
       onClick={(_id, evt) => {
-        recordAnalytics('releases');
         navigateWithPageFilters(`/organizations/${organization.slug}/releases/`, evt);
       }}
       icon={<IconReleases size="md" />}
@@ -264,7 +252,6 @@ function Sidebar({location, organization}: Props) {
     <SidebarItem
       {...sidebarItemProps}
       onClick={(_id, evt) => {
-        recordAnalytics('userFeedback');
         navigateWithPageFilters(
           `/organizations/${organization.slug}/user-feedback/`,
           evt
@@ -281,7 +268,6 @@ function Sidebar({location, organization}: Props) {
     <SidebarItem
       {...sidebarItemProps}
       onClick={(_id, evt) => {
-        recordAnalytics('alerts');
         navigateWithPageFilters(`/organizations/${organization.slug}/alerts/rules/`, evt);
       }}
       icon={<IconSiren size="md" />}
@@ -296,7 +282,6 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         onClick={(_id, evt) => {
-          recordAnalytics('monitors');
           navigateWithPageFilters(`/organizations/${organization.slug}/monitors/`, evt);
         }}
         icon={<IconLab size="md" />}
@@ -312,7 +297,6 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         onClick={(_id, evt) => {
-          recordAnalytics('replays');
           navigateWithPageFilters(`/organizations/${organization.slug}/replays/`, evt);
         }}
         icon={<IconPlay size="md" />}
@@ -334,7 +318,6 @@ function Sidebar({location, organization}: Props) {
         {...sidebarItemProps}
         index
         onClick={(_id, evt) => {
-          recordAnalytics('dashboards');
           navigateWithPageFilters(`/organizations/${organization.slug}/dashboards/`, evt);
         }}
         icon={<IconDashboard size="md" />}
@@ -356,7 +339,6 @@ function Sidebar({location, organization}: Props) {
         {...sidebarItemProps}
         index
         onClick={(_id, evt) => {
-          recordAnalytics('profiling');
           navigateWithPageFilters(`/organizations/${organization.slug}/profiling/`, evt);
         }}
         icon={<IconSpan size="md" />}
@@ -372,7 +354,6 @@ function Sidebar({location, organization}: Props) {
       {...sidebarItemProps}
       icon={<IconList size="md" />}
       label={t('Activity')}
-      onClick={() => recordAnalytics('activity')}
       to={`/organizations/${organization.slug}/activity/`}
       id="activity"
     />
@@ -383,7 +364,6 @@ function Sidebar({location, organization}: Props) {
       {...sidebarItemProps}
       icon={<IconStats size="md" />}
       label={t('Stats')}
-      onClick={() => recordAnalytics('stats')}
       to={`/organizations/${organization.slug}/stats/`}
       id="stats"
     />
@@ -394,7 +374,6 @@ function Sidebar({location, organization}: Props) {
       {...sidebarItemProps}
       icon={<IconSettings size="md" />}
       label={t('Settings')}
-      onClick={() => recordAnalytics('settings')}
       to={`/settings/${organization.slug}/`}
       id="settings"
     />
@@ -459,8 +438,10 @@ function Sidebar({location, organization}: Props) {
           <SidebarSection>
             {HookStore.get('sidebar:bottom-items').length > 0 &&
               HookStore.get('sidebar:bottom-items')[0]({
+                orientation,
+                collapsed,
+                hasPanel,
                 organization,
-                ...sidebarItemProps,
               })}
             <SidebarHelp
               orientation={orientation}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -179,9 +179,9 @@ function Sidebar({location, organization}: Props) {
   const issues = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
-      onClick={(_id, evt) => {
-        navigateWithPageFilters(`/organizations/${organization.slug}/issues/`, evt);
-      }}
+      onClick={(_id, evt) =>
+        navigateWithPageFilters(`/organizations/${organization.slug}/issues/`, evt)
+      }
       icon={<IconIssues size="md" />}
       label={<GuideAnchor target="issues">{t('Issues')}</GuideAnchor>}
       to={`/organizations/${organization.slug}/issues/`}
@@ -197,9 +197,9 @@ function Sidebar({location, organization}: Props) {
     >
       <SidebarItem
         {...sidebarItemProps}
-        onClick={(_id, evt) => {
-          navigateWithPageFilters(getDiscoverLandingUrl(organization), evt);
-        }}
+        onClick={(_id, evt) =>
+          navigateWithPageFilters(getDiscoverLandingUrl(organization), evt)
+        }
         icon={<IconTelescope size="md" />}
         label={<GuideAnchor target="discover">{t('Discover')}</GuideAnchor>}
         to={getDiscoverLandingUrl(organization)}
@@ -218,12 +218,12 @@ function Sidebar({location, organization}: Props) {
         {(overideProps: Partial<React.ComponentProps<typeof SidebarItem>>) => (
           <SidebarItem
             {...sidebarItemProps}
-            onClick={(_id, evt) => {
+            onClick={(_id, evt) =>
               navigateWithPageFilters(
                 `/organizations/${organization.slug}/performance/`,
                 evt
-              );
-            }}
+              )
+            }
             icon={<IconLightning size="md" />}
             label={<GuideAnchor target="performance">{t('Performance')}</GuideAnchor>}
             to={`/organizations/${organization.slug}/performance/`}
@@ -238,9 +238,9 @@ function Sidebar({location, organization}: Props) {
   const releases = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
-      onClick={(_id, evt) => {
-        navigateWithPageFilters(`/organizations/${organization.slug}/releases/`, evt);
-      }}
+      onClick={(_id, evt) =>
+        navigateWithPageFilters(`/organizations/${organization.slug}/releases/`, evt)
+      }
       icon={<IconReleases size="md" />}
       label={<GuideAnchor target="releases">{t('Releases')}</GuideAnchor>}
       to={`/organizations/${organization.slug}/releases/`}
@@ -267,9 +267,9 @@ function Sidebar({location, organization}: Props) {
   const alerts = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
-      onClick={(_id, evt) => {
-        navigateWithPageFilters(`/organizations/${organization.slug}/alerts/rules/`, evt);
-      }}
+      onClick={(_id, evt) =>
+        navigateWithPageFilters(`/organizations/${organization.slug}/alerts/rules/`, evt)
+      }
       icon={<IconSiren size="md" />}
       label={t('Alerts')}
       to={`/organizations/${organization.slug}/alerts/rules/`}
@@ -281,9 +281,9 @@ function Sidebar({location, organization}: Props) {
     <Feature features={['monitors']} organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
-        onClick={(_id, evt) => {
-          navigateWithPageFilters(`/organizations/${organization.slug}/monitors/`, evt);
-        }}
+        onClick={(_id, evt) =>
+          navigateWithPageFilters(`/organizations/${organization.slug}/monitors/`, evt)
+        }
         icon={<IconLab size="md" />}
         label={t('Monitors')}
         to={`/organizations/${organization.slug}/monitors/`}
@@ -296,9 +296,9 @@ function Sidebar({location, organization}: Props) {
     <Feature features={['session-replay']} organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
-        onClick={(_id, evt) => {
-          navigateWithPageFilters(`/organizations/${organization.slug}/replays/`, evt);
-        }}
+        onClick={(_id, evt) =>
+          navigateWithPageFilters(`/organizations/${organization.slug}/replays/`, evt)
+        }
         icon={<IconPlay size="md" />}
         label={t('Replays')}
         to={`/organizations/${organization.slug}/replays/`}
@@ -317,9 +317,9 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         index
-        onClick={(_id, evt) => {
-          navigateWithPageFilters(`/organizations/${organization.slug}/dashboards/`, evt);
-        }}
+        onClick={(_id, evt) =>
+          navigateWithPageFilters(`/organizations/${organization.slug}/dashboards/`, evt)
+        }
         icon={<IconDashboard size="md" />}
         label={t('Dashboards')}
         to={`/organizations/${organization.slug}/dashboards/`}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -251,12 +251,9 @@ function Sidebar({location, organization}: Props) {
   const userFeedback = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
-      onClick={(_id, evt) => {
-        navigateWithPageFilters(
-          `/organizations/${organization.slug}/user-feedback/`,
-          evt
-        );
-      }}
+      onClick={(_id, evt) =>
+        navigateWithPageFilters(`/organizations/${organization.slug}/user-feedback/`, evt)
+      }
       icon={<IconSupport size="md" />}
       label={t('User Feedback')}
       to={`/organizations/${organization.slug}/user-feedback/`}
@@ -338,9 +335,9 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         index
-        onClick={(_id, evt) => {
-          navigateWithPageFilters(`/organizations/${organization.slug}/profiling/`, evt);
-        }}
+        onClick={(_id, evt) =>
+          navigateWithPageFilters(`/organizations/${organization.slug}/profiling/`, evt)
+        }
         icon={<IconSpan size="md" />}
         label={t('Profiling')}
         to={`/organizations/${organization.slug}/profiling/`}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -38,6 +38,7 @@ import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import theme from 'sentry/utils/theme';
 import useMedia from 'sentry/utils/useMedia';
@@ -164,9 +165,17 @@ function Sidebar({location, organization}: Props) {
     hasPanel,
   };
 
+  const recordAnalytics = (item: string) => {
+    trackAdvancedAnalyticsEvent('growth.clicked_sidebar', {
+      item,
+      organization: organization || null,
+    });
+  };
+
   const projects = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
+      onClick={() => recordAnalytics('projects')}
       index
       icon={<IconProject size="md" />}
       label={<GuideAnchor target="projects">{t('Projects')}</GuideAnchor>}
@@ -178,9 +187,10 @@ function Sidebar({location, organization}: Props) {
   const issues = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
-      onClick={(_id, evt) =>
-        navigateWithPageFilters(`/organizations/${organization.slug}/issues/`, evt)
-      }
+      onClick={(_id, evt) => {
+        recordAnalytics('issues');
+        navigateWithPageFilters(`/organizations/${organization.slug}/issues/`, evt);
+      }}
       icon={<IconIssues size="md" />}
       label={<GuideAnchor target="issues">{t('Issues')}</GuideAnchor>}
       to={`/organizations/${organization.slug}/issues/`}
@@ -196,9 +206,10 @@ function Sidebar({location, organization}: Props) {
     >
       <SidebarItem
         {...sidebarItemProps}
-        onClick={(_id, evt) =>
-          navigateWithPageFilters(getDiscoverLandingUrl(organization), evt)
-        }
+        onClick={(_id, evt) => {
+          recordAnalytics('discover2');
+          navigateWithPageFilters(getDiscoverLandingUrl(organization), evt);
+        }}
         icon={<IconTelescope size="md" />}
         label={<GuideAnchor target="discover">{t('Discover')}</GuideAnchor>}
         to={getDiscoverLandingUrl(organization)}
@@ -217,12 +228,13 @@ function Sidebar({location, organization}: Props) {
         {(overideProps: Partial<React.ComponentProps<typeof SidebarItem>>) => (
           <SidebarItem
             {...sidebarItemProps}
-            onClick={(_id, evt) =>
+            onClick={(_id, evt) => {
+              recordAnalytics('performance');
               navigateWithPageFilters(
                 `/organizations/${organization.slug}/performance/`,
                 evt
-              )
-            }
+              );
+            }}
             icon={<IconLightning size="md" />}
             label={<GuideAnchor target="performance">{t('Performance')}</GuideAnchor>}
             to={`/organizations/${organization.slug}/performance/`}
@@ -237,9 +249,10 @@ function Sidebar({location, organization}: Props) {
   const releases = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
-      onClick={(_id, evt) =>
-        navigateWithPageFilters(`/organizations/${organization.slug}/releases/`, evt)
-      }
+      onClick={(_id, evt) => {
+        recordAnalytics('releases');
+        navigateWithPageFilters(`/organizations/${organization.slug}/releases/`, evt);
+      }}
       icon={<IconReleases size="md" />}
       label={<GuideAnchor target="releases">{t('Releases')}</GuideAnchor>}
       to={`/organizations/${organization.slug}/releases/`}
@@ -250,9 +263,13 @@ function Sidebar({location, organization}: Props) {
   const userFeedback = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
-      onClick={(_id, evt) =>
-        navigateWithPageFilters(`/organizations/${organization.slug}/user-feedback/`, evt)
-      }
+      onClick={(_id, evt) => {
+        recordAnalytics('userFeedback');
+        navigateWithPageFilters(
+          `/organizations/${organization.slug}/user-feedback/`,
+          evt
+        );
+      }}
       icon={<IconSupport size="md" />}
       label={t('User Feedback')}
       to={`/organizations/${organization.slug}/user-feedback/`}
@@ -263,9 +280,10 @@ function Sidebar({location, organization}: Props) {
   const alerts = hasOrganization && (
     <SidebarItem
       {...sidebarItemProps}
-      onClick={(_id, evt) =>
-        navigateWithPageFilters(`/organizations/${organization.slug}/alerts/rules/`, evt)
-      }
+      onClick={(_id, evt) => {
+        recordAnalytics('alerts');
+        navigateWithPageFilters(`/organizations/${organization.slug}/alerts/rules/`, evt);
+      }}
       icon={<IconSiren size="md" />}
       label={t('Alerts')}
       to={`/organizations/${organization.slug}/alerts/rules/`}
@@ -277,9 +295,10 @@ function Sidebar({location, organization}: Props) {
     <Feature features={['monitors']} organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
-        onClick={(_id, evt) =>
-          navigateWithPageFilters(`/organizations/${organization.slug}/monitors/`, evt)
-        }
+        onClick={(_id, evt) => {
+          recordAnalytics('monitors');
+          navigateWithPageFilters(`/organizations/${organization.slug}/monitors/`, evt);
+        }}
         icon={<IconLab size="md" />}
         label={t('Monitors')}
         to={`/organizations/${organization.slug}/monitors/`}
@@ -292,9 +311,10 @@ function Sidebar({location, organization}: Props) {
     <Feature features={['session-replay']} organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
-        onClick={(_id, evt) =>
-          navigateWithPageFilters(`/organizations/${organization.slug}/replays/`, evt)
-        }
+        onClick={(_id, evt) => {
+          recordAnalytics('replays');
+          navigateWithPageFilters(`/organizations/${organization.slug}/replays/`, evt);
+        }}
         icon={<IconPlay size="md" />}
         label={t('Replays')}
         to={`/organizations/${organization.slug}/replays/`}
@@ -313,9 +333,10 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         index
-        onClick={(_id, evt) =>
-          navigateWithPageFilters(`/organizations/${organization.slug}/dashboards/`, evt)
-        }
+        onClick={(_id, evt) => {
+          recordAnalytics('dashboards');
+          navigateWithPageFilters(`/organizations/${organization.slug}/dashboards/`, evt);
+        }}
         icon={<IconDashboard size="md" />}
         label={t('Dashboards')}
         to={`/organizations/${organization.slug}/dashboards/`}
@@ -334,9 +355,10 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         index
-        onClick={(_id, evt) =>
-          navigateWithPageFilters(`/organizations/${organization.slug}/profiling/`, evt)
-        }
+        onClick={(_id, evt) => {
+          recordAnalytics('profiling');
+          navigateWithPageFilters(`/organizations/${organization.slug}/profiling/`, evt);
+        }}
         icon={<IconSpan size="md" />}
         label={t('Profiling')}
         to={`/organizations/${organization.slug}/profiling/`}
@@ -350,6 +372,7 @@ function Sidebar({location, organization}: Props) {
       {...sidebarItemProps}
       icon={<IconList size="md" />}
       label={t('Activity')}
+      onClick={() => recordAnalytics('activity')}
       to={`/organizations/${organization.slug}/activity/`}
       id="activity"
     />
@@ -360,6 +383,7 @@ function Sidebar({location, organization}: Props) {
       {...sidebarItemProps}
       icon={<IconStats size="md" />}
       label={t('Stats')}
+      onClick={() => recordAnalytics('stats')}
       to={`/organizations/${organization.slug}/stats/`}
       id="stats"
     />
@@ -370,6 +394,7 @@ function Sidebar({location, organization}: Props) {
       {...sidebarItemProps}
       icon={<IconSettings size="md" />}
       label={t('Settings')}
+      onClick={() => recordAnalytics('settings')}
       to={`/settings/${organization.slug}/`}
       id="settings"
     />

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -70,6 +70,9 @@ type Props = WithRouterProps & {
    */
   isNewSeenKeySuffix?: string;
   onClick?: (id: string, e: React.MouseEvent<HTMLAnchorElement>) => void;
+  /**
+   * The current organization. Useful for analytics.
+   */
   organization?: Organization;
 
   to?: string;

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -8,6 +8,8 @@ import HookOrDefault from 'sentry/components/hookOrDefault';
 import Link from 'sentry/components/links/link';
 import TextOverflow from 'sentry/components/textOverflow';
 import Tooltip from 'sentry/components/tooltip';
+import {Organization} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import localStorage from 'sentry/utils/localStorage';
 import {Theme} from 'sentry/utils/theme';
 
@@ -68,6 +70,8 @@ type Props = WithRouterProps & {
    */
   isNewSeenKeySuffix?: string;
   onClick?: (id: string, e: React.MouseEvent<HTMLAnchorElement>) => void;
+  organization?: Organization;
+
   to?: string;
 };
 
@@ -87,6 +91,7 @@ const SidebarItem = ({
   className,
   orientation,
   isNewSeenKeySuffix,
+  organization,
   onClick,
   ...props
 }: Props) => {
@@ -117,6 +122,12 @@ const SidebarItem = ({
   const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}`;
   const showIsNew = isNew && !localStorage.getItem(isNewSeenKey);
 
+  const recordAnalytics = () => {
+    trackAdvancedAnalyticsEvent('growth.clicked_sidebar', {
+      item: id,
+      organization: organization || null,
+    });
+  };
   return (
     <Tooltip disabled={!collapsed} title={label} position={placement}>
       <StyledSidebarItem
@@ -127,6 +138,7 @@ const SidebarItem = ({
         className={className}
         onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
           !(to || href) && event.preventDefault();
+          recordAnalytics();
           onClick?.(id, event);
           showIsNew && localStorage.setItem(isNewSeenKey, 'true');
         }}

--- a/static/app/utils/analytics/growthAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/growthAnalyticsEvents.tsx
@@ -59,6 +59,9 @@ export type GrowthEventParameters = {
   };
   'growth.clicked_mobile_prompt_ask_teammate': MobilePromptBannerParams;
   'growth.clicked_mobile_prompt_setup_project': MobilePromptBannerParams;
+  'growth.clicked_sidebar': {
+    item: string;
+  };
   'growth.demo_click_docs': {};
   'growth.demo_click_get_started': {cta?: string};
   'growth.demo_click_request_demo': {};
@@ -145,6 +148,7 @@ export const growthEventMap: Record<GrowthAnalyticsKey, string | null> = {
   'growth.demo_click_get_started': 'Growth: Demo Click Get Started',
   'growth.demo_click_docs': 'Growth: Demo Click Docs',
   'growth.demo_click_request_demo': 'Growth: Demo Click Request Demo',
+  'growth.clicked_sidebar': 'Growth: Clicked Sidebar',
   'growth.onboarding_load_choose_platform':
     'Growth: Onboarding Load Choose Platform Page',
   'growth.onboarding_set_up_your_project': 'Growth: Onboarding Click Set Up Your Project',


### PR DESCRIPTION
This helps us to better understand usage levels for some of the left nav items including “User Feedback” , “Activity” and “Monitors”.
