### PR TITLE
fix(alerts): Update metric alert incident unfurl text

### DIFF
--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -84,7 +84,9 @@ def incident_attachment_info(incident, new_status: IncidentStatus, metric_value=
     if metric_value is None:
         metric_value = get_metric_count_from_incident(incident)
 
-    text = get_incident_status_text(alert_rule, metric_value)
+    text = ""
+    if status != INCIDENT_STATUS[IncidentStatus.CLOSED]:
+        text = get_incident_status_text(alert_rule, metric_value)
     title = f"{status}: {alert_rule.name}"
 
     if unfurl:
@@ -167,7 +169,7 @@ def metric_alert_attachment_info(
             metric_value = get_metric_count_from_incident(incident_info)
 
     text = ""
-    if metric_value is not None:
+    if metric_value is not None and status != INCIDENT_STATUS[IncidentStatus.CLOSED]:
         text = get_incident_status_text(alert_rule, metric_value)
 
     date_started = None

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -72,8 +72,6 @@ def get_incident_status_text(alert_rule: AlertRule, metric_value: str) -> str:
         "time_window": time_window,
         "interval": interval,
     }
-    if alert_rule.snuba_query.query != "":
-        text += f"\nFilter: {alert_rule.snuba_query.query}"
 
     return text
 

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -84,9 +84,7 @@ def incident_attachment_info(incident, new_status: IncidentStatus, metric_value=
     if metric_value is None:
         metric_value = get_metric_count_from_incident(incident)
 
-    text = ""
-    if status != INCIDENT_STATUS[IncidentStatus.CLOSED]:
-        text = get_incident_status_text(alert_rule, metric_value)
+    text = get_incident_status_text(alert_rule, metric_value)
     title = f"{status}: {alert_rule.name}"
 
     if unfurl:

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -63,7 +63,7 @@ class PagerDutyActionHandlerTest(FireTest, TestCase):
         assert data["payload"]["severity"] == "critical"
         assert data["payload"]["source"] == str(incident.identifier)
         assert data["payload"]["custom_details"] == {
-            "details": "1000 events in the last 10 minutes\nFilter: level:error"
+            "details": "1000 events in the last 10 minutes"
         }
         assert data["links"][0]["text"] == f"Critical: {alert_rule.name}"
         assert data["links"][0]["href"] == "http://testserver/organizations/baz/alerts/1/"

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -165,7 +165,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     },
                 )
             ),
-            "text": "",
+            "text": "0 events in the last 10 minutes",
             "fields": [],
             "mrkdwn_in": ["text"],
             "footer_icon": logo_url,

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -165,7 +165,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     },
                 )
             ),
-            "text": "0 events in the last 10 minutes\nFilter: level:error",
+            "text": "0 events in the last 10 minutes",
             "fields": [],
             "mrkdwn_in": ["text"],
             "footer_icon": logo_url,
@@ -206,7 +206,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     },
                 )
             ),
-            "text": f"{metric_value} events in the last 10 minutes\nFilter: level:error",
+            "text": f"{metric_value} events in the last 10 minutes",
             "fields": [],
             "mrkdwn_in": ["text"],
             "footer_icon": logo_url,
@@ -267,9 +267,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
             "blocks": [
                 {
                     "text": {
-                        "text": f"<{link}|*{title}*>  \n"
-                        "0 events in the last 10 minutes\n"
-                        "Filter: level:error",
+                        "text": f"<{link}|*{title}*>  \n0 events in the last 10 minutes",
                         "type": "mrkdwn",
                     },
                     "type": "section",
@@ -299,9 +297,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
             "blocks": [
                 {
                     "text": {
-                        "text": f"<{link}|*{title}*>  \n"
-                        "0 events in the last 10 minutes\n"
-                        "Filter: level:error",
+                        "text": f"<{link}|*{title}*>  \n0 events in the last 10 minutes",
                         "type": "mrkdwn",
                     },
                     "type": "section",
@@ -337,8 +333,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                 {
                     "text": {
                         "text": f"<{link}?alert={incident.identifier}|*{title}*>  \n"
-                        f"{metric_value} events in the last 10 minutes\n"
-                        "Filter: level:error",
+                        f"{metric_value} events in the last 10 minutes",
                         "type": "mrkdwn",
                     },
                     "type": "section",

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -165,7 +165,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     },
                 )
             ),
-            "text": "0 events in the last 10 minutes",
+            "text": "",
             "fields": [],
             "mrkdwn_in": ["text"],
             "footer_icon": logo_url,
@@ -267,7 +267,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
             "blocks": [
                 {
                     "text": {
-                        "text": f"<{link}|*{title}*>  \n0 events in the last 10 minutes",
+                        "text": f"<{link}|*{title}*>  \n",
                         "type": "mrkdwn",
                     },
                     "type": "section",

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -33,7 +33,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
 
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "123 events in the last 10 minutes\nFilter: level:error"
+        assert data["text"] == "123 events in the last 10 minutes"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
         assert (
@@ -77,7 +77,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
             alert_rule.name
         )  # Pulls from trigger, not incident
         assert data["status"] == "Critical"  # Should pull from the action/trigger.
-        assert data["text"] == "4 events in the last 10 minutes\nFilter: level:error"
+        assert data["text"] == "4 events in the last 10 minutes"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
         assert (
@@ -89,7 +89,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         data = incident_attachment_info(incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "4 events in the last 10 minutes\nFilter: level:error"
+        assert data["text"] == "4 events in the last 10 minutes"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
         assert (
@@ -101,7 +101,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         data = incident_attachment_info(incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "4 events in the last 10 minutes\nFilter: level:error"
+        assert data["text"] == "4 events in the last 10 minutes"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
         assert (

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -33,7 +33,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
 
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "123 events in the last 10 minutes"
+        assert data["text"] == ""
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
         assert (
@@ -89,7 +89,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         data = incident_attachment_info(incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "4 events in the last 10 minutes"
+        assert data["text"] == ""
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
         assert (
@@ -101,7 +101,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         data = incident_attachment_info(incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "4 events in the last 10 minutes"
+        assert data["text"] == ""
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
         assert (
@@ -161,7 +161,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, SnubaTestCase):
         data = incident_attachment_info(self.incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {self.alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "100.0% sessions crash free rate in the last 60 minutes"
+        assert data["text"] == ""
         assert data["ts"] == self.date_started
         assert (
             data["logo_url"]
@@ -185,7 +185,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, SnubaTestCase):
         data = incident_attachment_info(self.incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {self.alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == "100.0% users crash free rate in the last 60 minutes"
+        assert data["text"] == ""
         assert data["ts"] == self.date_started
         assert (
             data["logo_url"]

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -33,7 +33,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
 
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == ""
+        assert data["text"] == "123 events in the last 10 minutes"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
         assert (
@@ -89,7 +89,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         data = incident_attachment_info(incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == ""
+        assert data["text"] == "4 events in the last 10 minutes"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
         assert (
@@ -101,7 +101,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         data = incident_attachment_info(incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == ""
+        assert data["text"] == "4 events in the last 10 minutes"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
         assert (
@@ -161,7 +161,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, SnubaTestCase):
         data = incident_attachment_info(self.incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {self.alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == ""
+        assert data["text"] == "100.0% sessions crash free rate in the last 60 minutes"
         assert data["ts"] == self.date_started
         assert (
             data["logo_url"]
@@ -185,7 +185,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, SnubaTestCase):
         data = incident_attachment_info(self.incident, IncidentStatus.CLOSED)
         assert data["title"] == f"Resolved: {self.alert_rule.name}"
         assert data["status"] == "Resolved"
-        assert data["text"] == ""
+        assert data["text"] == "100.0% users crash free rate in the last 60 minutes"
         assert data["ts"] == self.date_started
         assert (
             data["logo_url"]


### PR DESCRIPTION
This updates the incident unfurl text. Removes the alert filter and if the incident status is `Resolved` the status text as well.

Jira: [WOR-1886](https://getsentry.atlassian.net/browse/WOR-1886)