### PR TITLE
ref(ui): Simplify ListItem component

### DIFF
--- a/static/app/components/events/interfaces/searchBarAction/searchBarActionFilter.tsx
+++ b/static/app/components/events/interfaces/searchBarAction/searchBarActionFilter.tsx
@@ -131,7 +131,10 @@ const StyledList = styled(List)`
   gap: 0;
 `;
 
-const StyledListItem = styled(ListItem)<{hasDescription: boolean; isChecked: boolean}>`
+const StyledListItem = styled(ListItem, {
+  shouldForwardProp: prop =>
+    typeof prop === 'string' && !['hasDescription', 'isChecked'].includes(prop),
+})<{hasDescription: boolean; isChecked: boolean}>`
   display: grid;
   grid-template-columns: ${p =>
     p.hasDescription ? 'max-content 1fr max-content' : '1fr max-content'};

--- a/static/app/components/list/listItem.tsx
+++ b/static/app/components/list/listItem.tsx
@@ -1,39 +1,25 @@
+import {forwardRef} from 'react';
 import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';
 
-type Props = {
-  'aria-label'?: string;
-  children?: React.ReactNode;
-  className?: string;
-  'data-test-id'?: string;
-  onClick?: (event: React.MouseEvent) => void;
+interface ListeItemProps extends React.HTMLAttributes<HTMLLIElement> {
+  padding?: string;
   symbol?: React.ReactElement;
-};
+}
 
 const ListItem = styled(
-  ({
-    children,
-    className,
-    symbol,
-    onClick,
-    'aria-label': ariaLabel,
-    'data-test-id': dataTestId,
-  }: Props) => (
-    <li
-      className={className}
-      onClick={onClick}
-      role={onClick ? 'button' : undefined}
-      aria-label={onClick ? ariaLabel : undefined}
-      data-test-id={dataTestId}
-    >
-      {symbol && <Symbol>{symbol}</Symbol>}
-      {children}
-    </li>
+  forwardRef<HTMLLIElement, ListeItemProps>(
+    ({symbol, children, padding: _padding, ...props}, ref) => (
+      <li ref={ref} role={props.onClick ? 'button' : undefined} {...props}>
+        {symbol && <Symbol>{symbol}</Symbol>}
+        {children}
+      </li>
+    )
   )
 )`
   position: relative;
-  ${p => p.symbol && `padding-left: ${space(4)};`}
+  ${p => p.symbol && `padding-left: ${p.padding ?? space(4)};`}
 `;
 
 const Symbol = styled('div')`


### PR DESCRIPTION
Generalizes it a bit and forwards the ref so we can wrap tooltips