### PR TITLE
fix(release-health): Restrict project release count to metric ID

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1430,8 +1430,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         if scope.endswith("_24h"):
             stats_period = "24h"
 
-        metric_id = resolve(organization_id, SessionMRI.USER.value)
-
         granularity, stats_start, _ = get_rollup_starts_and_buckets(stats_period, now=now)
         where = [
             Condition(Column("timestamp"), Op.GTE, stats_start),
@@ -1465,7 +1463,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             match = Entity(EntityKey.MetricsCounters.value)
             mri = SessionMRI.SESSION
 
-        metric_id = resolve(organization_id, mri.value)  # Should not fail because shared string
+        metric_id = resolve(organization_id, mri.value)
         where.append(Condition(Column("metric_id"), Op.EQ, metric_id))
 
         query_columns = [

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -9,6 +9,7 @@ from sentry.release_health.base import OverviewStat
 from sentry.release_health.duplex import DuplexReleaseHealthBackend
 from sentry.release_health.metrics import MetricsReleaseHealthBackend
 from sentry.release_health.sessions import SessionsReleaseHealthBackend
+from sentry.snuba.dataset import EntityKey
 from sentry.snuba.sessions import _make_stats
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.cases import SessionMetricsTestCase
@@ -1021,6 +1022,38 @@ class GetProjectReleasesCountTest(TestCase, SnubaTestCase):
         # Test no errors when no session data
         org = self.create_organization()
         proj = self.create_project(organization=org)
+        assert (
+            self.backend.get_project_releases_count(
+                org.id, [proj.id], "crash_free_users", stats_period="14d"
+            )
+            == 0
+        )
+
+    def test_with_other_metrics(self):
+        if not self.backend.is_metrics_based():
+            return
+
+        # Test no errors when no session data
+        org = self.create_organization()
+        proj = self.create_project(organization=org)
+
+        # Insert a different set metric:
+        self._send_buckets(
+            [
+                {
+                    "org_id": org.id,
+                    "project_id": proj.id,
+                    "metric_id": 666,  # any other metric ID
+                    "timestamp": time.time(),
+                    "tags": {},
+                    "type": "s",
+                    "value": [1, 2, 3],
+                    "retention_days": 90,
+                }
+            ],
+            entity=EntityKey.MetricsSets.value,
+        )
+
         assert (
             self.backend.get_project_releases_count(
                 org.id, [proj.id], "crash_free_users", stats_period="14d"


### PR DESCRIPTION
The snuba query for `get_project_releases_count` was not restricted to any metric ID, so it also counted `(project, release)` combinations of other metrics (see added test case).