### PR TITLE
fix(workflow): Handle assignment messages on activity tab

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -308,6 +308,7 @@ export type GroupActivityAssigned = GroupActivityBase & {
     assignee: string;
     assigneeType: string;
     user: Team | User;
+    assigneeEmail?: string;
   };
   type: GroupActivityType.ASSIGNED;
 };

--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -7,7 +7,6 @@ import Link from 'sentry/components/links/link';
 import PullRequestLink from 'sentry/components/pullRequestLink';
 import Version from 'sentry/components/version';
 import {t, tct, tn} from 'sentry/locale';
-import MemberListStore from 'sentry/stores/memberListStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {
   GroupActivity,
@@ -93,12 +92,10 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
       return tct('[author] assigned this issue to themselves', {author});
     }
 
-    assignee = MemberListStore.getById(data.assignee);
-
-    if (typeof assignee === 'object' && assignee?.email) {
+    if (data.assigneeType === 'user' && data.assigneeEmail) {
       return tct('[author] assigned this issue to [assignee]', {
         author,
-        assignee: assignee.email,
+        assignee: data.assigneeEmail,
       });
     }
 


### PR DESCRIPTION
Fix race condition for user assignment message. This doesn't fail consistently, but assignment message to user will sometimes display 'unknown user' until refresh or clicking the tab again to display the correct user.

[FIXES WOR-1842
](https://getsentry.atlassian.net/browse/WOR-1842)
<img width="832" alt="Screen Shot 2022-05-24 at 1 40 16 AM" src="https://user-images.githubusercontent.com/20312973/170007060-86edcef9-f085-4d3b-af46-ffcfde1286c2.png">
<img width="837" alt="Screen Shot 2022-05-24 at 3 07 14 AM" src="https://user-images.githubusercontent.com/20312973/170007196-3385e5d7-8604-4248-9d11-9b2047ad3b7b.png">


