### PR TITLE
fix(tests): unpin snuba, remove tests reliant on old subscriptions infrastructure

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1941,7 +1941,7 @@ SENTRY_DEVSERVICES = {
     ),
     "snuba": lambda settings, options: (
         {
-            "image": "getsentry/snuba:f063336085e7be0ccbdb52791aaf97882ba7a26f" if not APPLE_ARM64
+            "image": "getsentry/snuba:nightly" if not APPLE_ARM64
             # We cross-build arm64 images on GH's Apple Intel runners
             else "ghcr.io/getsentry/snuba-arm64-dev:latest",
             "pull": True,


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/34906 I pinned snuba to unblock CI, but we shouldn't pin snuba for much longer. This unpins snuba and removes the failing tests (please see https://github.com/getsentry/sentry/pull/34906, https://github.com/getsentry/sentry/runs/6538111731?check_suite_focus=true) that fail with snuba@ 3cacc16753696de0953e80af5dcdabefc65d370e.

I don't know this part of Sentry very much, so going to be triaging this to people who can determine the best thing to do (fix these tests, adapt to new snuba stuff?). This is purely just to unblock CI and keep snuba on nightly.

```
Traceback (most recent call last):
  File "/home/runner/work/sentry/sentry/src/sentry/api/base.py", line 139, in handle_exception
    response = super().handle_exception(exc)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/rest_framework/views.py", line 465, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/rest_framework/views.py", line 476, in raise_uncaught_exception
    raise exc
  File "/home/runner/work/sentry/sentry/src/sentry/api/base.py", line 254, in dispatch
    response = handler(request, *args, **kwargs)
  File "/home/runner/work/sentry/sentry/src/sentry/incidents/endpoints/project_alert_rule_index.py", line 110, in post
    alert_rule = serializer.save()
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/rest_framework/serializers.py", line 212, in save
    self.instance = self.create(validated_data)
  File "/home/runner/work/sentry/sentry/src/sentry/incidents/serializers/alert_rule.py", line 377, in create
    self._handle_triggers(alert_rule, triggers)
  File "/home/runner/work/sentry/sentry/src/sentry/incidents/serializers/alert_rule.py", line 426, in _handle_triggers
    trigger_serializer.save()
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/rest_framework/serializers.py", line 212, in save
    self.instance = self.create(validated_data)
  File "/home/runner/work/sentry/sentry/src/sentry/incidents/serializers/alert_rule_trigger.py", line 45, in create
    self._handle_actions(alert_rule_trigger, actions)
  File "/home/runner/work/sentry/sentry/src/sentry/incidents/serializers/alert_rule_trigger.py", line 96, in _handle_actions
    if action_serializer.is_valid():
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/rest_framework/serializers.py", line 234, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/rest_framework/serializers.py", line 436, in run_validation
    value = self.validate(value)
  File "/home/runner/work/sentry/sentry/src/sentry/incidents/serializers/alert_rule_trigger_action.py", line 85, in validate
    type_info = AlertRuleTriggerAction.get_registered_type(type)
  File "/home/runner/work/sentry/sentry/src/sentry/incidents/models.py", line 621, in get_registered_type
    return cls._type_registrations[type]
KeyError: <Type.SLACK: 2>
```