### PR TITLE
fix(replays): add description for Error tooltip

### DIFF
--- a/static/app/components/replays/actionCategory.tsx
+++ b/static/app/components/replays/actionCategory.tsx
@@ -32,7 +32,7 @@ function getActionCategoryInfo(crumb: Crumb): ActionCategoryInfo {
     case BreadcrumbType.ERROR:
       return {
         title: t('Error'),
-        description: `${crumb.category}: ${crumb.message}`,
+        description: `${crumb.data?.type}: ${crumb.data?.value}`,
       };
     case BreadcrumbType.INIT:
       return {


### PR DESCRIPTION
### Description

- Add description for Error tooltip, right now is showing `undefined`

Fixes: #34766 

### Screenshots

<img width="408" alt="image" src="https://user-images.githubusercontent.com/14813235/170111759-e67b1c45-1036-40f2-a2ba-174f428ddfb6.png">


---
