### PR TITLE
fix(alerts): Fix metric selector and group reduce crash for crash free alerts

### DIFF
--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -98,13 +98,13 @@ export function getCrashFreeRateSeries(
   return compact(
     intervals.map((interval, i) => {
       const intervalTotalSessions = groups.reduce(
-        (acc, group) => acc + group.series[field][i],
+        (acc, group) => acc + (group.series[field]?.[i] ?? 0),
         0
       );
 
       const intervalCrashedSessions =
         groups.find(group => group.by['session.status'] === SessionStatus.CRASHED)
-          ?.series[field][i] ?? 0;
+          ?.series[field]?.[i] ?? 0;
 
       const crashedSessionsPercent = percent(
         intervalCrashedSessions,

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -125,12 +125,11 @@ export default function WizardField({
             AlertWizardRuleTemplates,
             template =>
               template.aggregate === aggregate &&
-              (template.dataset === dataset || (
-                organization.features.includes('alert-crash-free-metrics')
-                && (template.aggregate === SessionsAggregate.CRASH_FREE_SESSIONS
-                  || template.aggregate === SessionsAggregate.CRASH_FREE_USERS)
-                && (dataset === Dataset.METRICS)
-              )) &&
+              (template.dataset === dataset ||
+                (organization.features.includes('alert-crash-free-metrics') &&
+                  (template.aggregate === SessionsAggregate.CRASH_FREE_SESSIONS ||
+                    template.aggregate === SessionsAggregate.CRASH_FREE_USERS) &&
+                  dataset === Dataset.METRICS)) &&
               eventTypes.includes(template.eventTypes)
           ) || 'num_errors';
 

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -8,7 +8,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {explodeFieldString, generateFieldAsString} from 'sentry/utils/discover/fields';
-import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {Dataset, SessionsAggregate} from 'sentry/views/alerts/rules/metric/types';
 import {
   AlertType,
   AlertWizardAlertNames,
@@ -125,7 +125,12 @@ export default function WizardField({
             AlertWizardRuleTemplates,
             template =>
               template.aggregate === aggregate &&
-              template.dataset === dataset &&
+              (template.dataset === dataset || (
+                organization.features.includes('alert-crash-free-metrics')
+                && (template.aggregate === SessionsAggregate.CRASH_FREE_SESSIONS
+                  || template.aggregate === SessionsAggregate.CRASH_FREE_USERS)
+                && (dataset === Dataset.METRICS)
+              )) &&
               eventTypes.includes(template.eventTypes)
           ) || 'num_errors';
 


### PR DESCRIPTION
This fixes 2 small issues with crash free rate alerts:
- changing between crash free users and crash free sessions in the metric alert wizard v3 no longer crashes the form
- crash free alerts with `alert-crash-free-metrics` flag picks the right metric in metric alert wizard v3