### PR TITLE
fix(workflow): Improve perf of latest incident query for unfurl

### DIFF
--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -117,12 +117,16 @@ def metric_alert_attachment_info(
 ):
     latest_incident = None
     if selected_incident is None:
-        latest_incident = Incident.objects.filter(
-            id__in=Incident.objects.filter(alert_rule=alert_rule)
-            .values("alert_rule_id")
-            .annotate(incident_id=Max("id"))
-            .values("incident_id")
-        ).first()
+        try:
+            # Use .get() instead of .first() to avoid sorting table by id
+            latest_incident = Incident.objects.filter(
+                id__in=Incident.objects.filter(alert_rule=alert_rule)
+                .values("alert_rule_id")
+                .annotate(incident_id=Max("id"))
+                .values("incident_id")
+            ).get()
+        except Incident.DoesNotExist:
+            latest_incident = None
 
     if new_status:
         status = INCIDENT_STATUS[new_status]


### PR DESCRIPTION
using .first sorts the table by id and breaks indexing causing long query time.

example stacktrace - 
https://sentry.io/organizations/sentry/discover/sentry:4c448f93853243589a5fb6285d1c2824/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=transaction.duration&name=All+Events&query=SlackEventEndpoint&sort=-transaction.duration&statsPeriod=24h&yAxis=count()