### PR TITLE
ref(models): `ActivityType`

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -3,6 +3,7 @@
 import time
 
 from sentry.runner import configure
+from sentry.types.activity import ActivityType
 
 configure()
 
@@ -510,7 +511,7 @@ def main(num_events=1, extra_events=False, load_trends=False, slow=False):
             )[0]
 
             Activity.objects.create(
-                type=Activity.RELEASE,
+                type=ActivityType.RELEASE.value,
                 project=project,
                 ident=release.version,
                 user=user,
@@ -541,7 +542,7 @@ def main(num_events=1, extra_events=False, load_trends=False, slow=False):
             )
 
             Activity.objects.create(
-                type=Activity.DEPLOY,
+                type=ActivityType.DEPLOY.value,
                 project=project,
                 ident=release.version,
                 data={
@@ -710,7 +711,7 @@ def main(num_events=1, extra_events=False, load_trends=False, slow=False):
     create_mock_transactions(project_map, load_trends, slow)
 
     Activity.objects.create(
-        type=Activity.RELEASE,
+        type=ActivityType.RELEASE.value,
         project=project,
         ident="4f38b65c62c4565aa94bba391ff8946922a8eed4",
         user=user,

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -10,6 +10,7 @@ from sentry.integrations import IntegrationFeatures
 from sentry.models import Activity, ExternalIssue, GroupLink, Integration
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationFormError
 from sentry.signals import integration_issue_created, integration_issue_linked
+from sentry.types.activity import ActivityType
 
 MISSING_FEATURE_MESSAGE = "Your organization does not have access to this feature."
 
@@ -36,7 +37,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         Activity.objects.create(
             project=group.project,
             group=group,
-            type=Activity.CREATE_ISSUE,
+            type=ActivityType.CREATE_ISSUE.value,
             user=request.user,
             data=issue_information,
         )

--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -18,7 +18,9 @@ from sentry.utils.functional import extract_lazy_object
 
 class GroupNotesEndpoint(GroupEndpoint):
     def get(self, request: Request, group) -> Response:
-        notes = Activity.objects.filter(group=group, type=Activity.NOTE).select_related("user")
+        notes = Activity.objects.filter(group=group, type=ActivityType.NOTE.value).select_related(
+            "user"
+        )
 
         return self.paginate(
             request=request,
@@ -47,7 +49,7 @@ class GroupNotesEndpoint(GroupEndpoint):
 
         if Activity.objects.filter(
             group=group,
-            type=Activity.NOTE,
+            type=ActivityType.NOTE.value,
             user=request.user,
             data=data,
             datetime__gte=timezone.now() - timedelta(hours=1),

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -9,6 +9,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
 from sentry.models import Activity
 from sentry.signals import comment_deleted, comment_updated
+from sentry.types.activity import ActivityType
 
 
 class GroupNotesDetailsEndpoint(GroupEndpoint):
@@ -22,7 +23,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         try:
             note = Activity.objects.get(
-                group=group, type=Activity.NOTE, user=request.user, id=note_id
+                group=group, type=ActivityType.NOTE.value, user=request.user, id=note_id
             )
         except Activity.DoesNotExist:
             raise ResourceDoesNotExist
@@ -52,7 +53,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         try:
             note = Activity.objects.get(
-                group=group, type=Activity.NOTE, user=request.user, id=note_id
+                group=group, type=ActivityType.NOTE.value, user=request.user, id=note_id
             )
         except Activity.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/api/endpoints/organization_activity.py
+++ b/src/sentry/api/endpoints/organization_activity.py
@@ -8,6 +8,7 @@ from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import OrganizationActivitySerializer, serialize
 from sentry.models import Activity, OrganizationMemberTeam, Project
+from sentry.types.activity import ActivityType
 
 
 class OrganizationActivityEndpoint(OrganizationMemberEndpoint, EnvironmentMixin):
@@ -15,7 +16,7 @@ class OrganizationActivityEndpoint(OrganizationMemberEndpoint, EnvironmentMixin)
         # There is an activity record created for both sides of the unmerge
         # operation, so we only need to include one of them here to avoid
         # showing the same entry twice.
-        base_qs = Activity.objects.exclude(type=Activity.UNMERGE_SOURCE).values_list(
+        base_qs = Activity.objects.exclude(type=ActivityType.UNMERGE_SOURCE.value).values_list(
             "id", flat=True
         )
 

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -22,6 +22,7 @@ from sentry.api.serializers.rest_framework import (
 from sentry.models import Activity, Project, Release, ReleaseCommitError, ReleaseStatus
 from sentry.models.release import UnsafeReleaseDeletion
 from sentry.snuba.sessions import STATS_PERIODS
+from sentry.types.activity import ActivityType
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
 
@@ -483,7 +484,7 @@ class OrganizationReleaseDetailsEndpoint(
             if not was_released and release.date_released:
                 for project in projects:
                     Activity.objects.create(
-                        type=Activity.RELEASE,
+                        type=ActivityType.RELEASE.value,
                         project=project,
                         ident=Activity.get_version_ident(release.version),
                         data={"version": release.version},

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -42,6 +42,7 @@ from sentry.search.events.constants import (
 from sentry.search.events.filter import handle_operator_negation, parse_semver
 from sentry.signals import release_created
 from sentry.snuba.sessions import STATS_PERIODS
+from sentry.types.activity import ActivityType
 from sentry.utils.cache import cache
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
@@ -483,7 +484,7 @@ class OrganizationReleasesEndpoint(
                 if release.date_released:
                     for project in new_projects:
                         Activity.objects.create(
-                            type=Activity.RELEASE,
+                            type=ActivityType.RELEASE.value,
                             project=project,
                             ident=Activity.get_version_ident(result["version"]),
                             data={"version": result["version"]},

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -12,6 +12,7 @@ from sentry.models import Activity, Release
 from sentry.models.release import UnsafeReleaseDeletion
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.snuba.sessions import STATS_PERIODS
+from sentry.types.activity import ActivityType
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
 
@@ -129,7 +130,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
 
             if not was_released and release.date_released:
                 Activity.objects.create(
-                    type=Activity.RELEASE,
+                    type=ActivityType.RELEASE.value,
                     project=project,
                     ident=Activity.get_version_ident(release.version),
                     data={"version": release.version},

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -13,6 +13,7 @@ from sentry.models import Activity, Environment, Release, ReleaseStatus
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
 from sentry.signals import release_created
+from sentry.types.activity import ActivityType
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
 
@@ -158,7 +159,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
 
                 if not was_released and release.date_released:
                     Activity.objects.create(
-                        type=Activity.RELEASE,
+                        type=ActivityType.RELEASE.value,
                         project=project,
                         ident=Activity.get_version_ident(result["version"]),
                         data={"version": result["version"]},

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -53,6 +53,7 @@ from sentry.signals import (
 )
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.tasks.merge import merge_groups
+from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.utils.functional import extract_lazy_object
 
@@ -262,7 +263,7 @@ def update_groups(
                 .extra(select={"sort": "COALESCE(date_released, date_added)"})
                 .order_by("-sort")[0]
             )
-            activity_type = Activity.SET_RESOLVED_IN_RELEASE
+            activity_type = ActivityType.SET_RESOLVED_IN_RELEASE.value
             activity_data = {
                 # no version yet
                 "version": ""
@@ -283,7 +284,7 @@ def update_groups(
                     {"detail": "Cannot set resolved in release for multiple projects."}, status=400
                 )
             release = statusDetails["inRelease"]
-            activity_type = Activity.SET_RESOLVED_IN_RELEASE
+            activity_type = ActivityType.SET_RESOLVED_IN_RELEASE.value
             activity_data = {
                 # no version yet
                 "version": release.version
@@ -303,7 +304,7 @@ def update_groups(
                     {"detail": "Cannot set resolved in commit for multiple projects."}, status=400
                 )
             commit = statusDetails["inCommit"]
-            activity_type = Activity.SET_RESOLVED_IN_COMMIT
+            activity_type = ActivityType.SET_RESOLVED_IN_COMMIT.value
             activity_data = {"commit": commit.id}
             status_details = {
                 "inCommit": serialize(commit, user),
@@ -312,7 +313,7 @@ def update_groups(
             res_type_str = "in_commit"
         else:
             res_type_str = "now"
-            activity_type = Activity.SET_RESOLVED
+            activity_type = ActivityType.SET_RESOLVED.value
             activity_data = {}
             status_details = {}
 
@@ -575,7 +576,7 @@ def update_groups(
                 result["statusDetails"] = {}
         if group_list and happened:
             if new_status == GroupStatus.UNRESOLVED:
-                activity_type = Activity.SET_UNRESOLVED
+                activity_type = ActivityType.SET_UNRESOLVED.value
                 activity_data = {}
 
                 for group in group_list:
@@ -596,7 +597,7 @@ def update_groups(
                             sender=update_groups,
                         )
             elif new_status == GroupStatus.IGNORED:
-                activity_type = Activity.SET_IGNORED
+                activity_type = ActivityType.SET_IGNORED.value
                 activity_data = {
                     "ignoreCount": ignore_count,
                     "ignoreDuration": ignore_duration,
@@ -762,7 +763,7 @@ def update_groups(
                 Activity.objects.create(
                     project=project_lookup[group.project_id],
                     group=group,
-                    type=Activity.SET_PRIVATE,
+                    type=ActivityType.SET_PRIVATE.value,
                     user=acting_user,
                 )
 
@@ -776,7 +777,7 @@ def update_groups(
                 Activity.objects.create(
                     project=project_lookup[group.project_id],
                     group=group,
-                    type=Activity.SET_PUBLIC,
+                    type=ActivityType.SET_PUBLIC.value,
                     user=acting_user,
                 )
 
@@ -808,7 +809,7 @@ def update_groups(
         Activity.objects.create(
             project=project_lookup[primary_group.project_id],
             group=primary_group,
-            type=Activity.MERGE,
+            type=ActivityType.MERGE.value,
             user=acting_user,
             data={"issues": [{"id": c.id} for c in groups_to_merge]},
         )

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1349,7 +1349,7 @@ def _handle_regression(group, event, release):
             try:
                 activity = Activity.objects.filter(
                     group=group,
-                    type=Activity.SET_RESOLVED_IN_RELEASE,
+                    type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
                     ident=resolution.id,
                 ).order_by("-datetime")[0]
             except IndexError:

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 
 from django.conf import settings
@@ -21,7 +23,7 @@ if TYPE_CHECKING:
 
 
 class ActivityManager(BaseManager):
-    def get_activities_for_group(self, group: "Group", num: int) -> Sequence["Group"]:
+    def get_activities_for_group(self, group: Group, num: int) -> Sequence[Group]:
         activities = []
         activity_qs = self.filter(group=group).order_by("-datetime").select_related("user")
 
@@ -53,12 +55,12 @@ class ActivityManager(BaseManager):
 
     def create_group_activity(
         self,
-        group: "Group",
+        group: Group,
         type: ActivityType,
-        user: Optional["User"] = None,
+        user: Optional[User] = None,
         data: Optional[Mapping[str, Any]] = None,
         send_notification: bool = True,
-    ) -> "Activity":
+    ) -> Activity:
         activity = self.create(
             project_id=group.project_id,
             group=group,
@@ -74,31 +76,6 @@ class ActivityManager(BaseManager):
 
 class Activity(Model):
     __include_in_export__ = False
-
-    # TODO(mgaeta): Replace all usages with ActivityTypes.
-    ASSIGNED = ActivityType.ASSIGNED.value
-    CREATE_ISSUE = ActivityType.CREATE_ISSUE.value
-    DEPLOY = ActivityType.DEPLOY.value
-    FIRST_SEEN = ActivityType.FIRST_SEEN.value
-    MARK_REVIEWED = ActivityType.MARK_REVIEWED.value
-    MERGE = ActivityType.MERGE.value
-    NEW_PROCESSING_ISSUES = ActivityType.NEW_PROCESSING_ISSUES.value
-    NOTE = ActivityType.NOTE.value
-    RELEASE = ActivityType.RELEASE.value
-    REPROCESS = ActivityType.REPROCESS.value
-    SET_IGNORED = ActivityType.SET_IGNORED.value
-    SET_PRIVATE = ActivityType.SET_PRIVATE.value
-    SET_PUBLIC = ActivityType.SET_PUBLIC.value
-    SET_REGRESSION = ActivityType.SET_REGRESSION.value
-    SET_RESOLVED = ActivityType.SET_RESOLVED.value
-    SET_RESOLVED_BY_AGE = ActivityType.SET_RESOLVED_BY_AGE.value
-    SET_RESOLVED_IN_COMMIT = ActivityType.SET_RESOLVED_IN_COMMIT.value
-    SET_RESOLVED_IN_PULL_REQUEST = ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value
-    SET_RESOLVED_IN_RELEASE = ActivityType.SET_RESOLVED_IN_RELEASE.value
-    SET_UNRESOLVED = ActivityType.SET_UNRESOLVED.value
-    UNASSIGNED = ActivityType.UNASSIGNED.value
-    UNMERGE_DESTINATION = ActivityType.UNMERGE_DESTINATION.value
-    UNMERGE_SOURCE = ActivityType.UNMERGE_SOURCE.value
 
     project = FlexibleForeignKey("sentry.Project")
     group = FlexibleForeignKey("sentry.Group", null=True)
@@ -128,9 +105,11 @@ class Activity(Model):
         from sentry.models import Release
 
         # XXX(dcramer): fix for bad data
-        if self.type in (self.RELEASE, self.DEPLOY) and isinstance(self.data["version"], Release):
+        if self.type in (ActivityType.RELEASE.value, ActivityType.DEPLOY.value) and isinstance(
+            self.data["version"], Release
+        ):
             self.data["version"] = self.data["version"].version
-        if self.type == self.ASSIGNED:
+        if self.type == ActivityType.ASSIGNED.value:
             self.data["assignee"] = str(self.data["assignee"])
 
     def save(self, *args, **kwargs):
@@ -142,14 +121,14 @@ class Activity(Model):
             return
 
         # HACK: support Group.num_comments
-        if self.type == Activity.NOTE:
+        if self.type == ActivityType.NOTE.value:
             self.group.update(num_comments=F("num_comments") + 1)
 
     def delete(self, *args, **kwargs):
         super().delete(*args, **kwargs)
 
         # HACK: support Group.num_comments
-        if self.type == Activity.NOTE:
+        if self.type == ActivityType.NOTE.value:
             self.group.update(num_comments=F("num_comments") - 1)
 
     def send_notification(self):

--- a/src/sentry/models/deploy.py
+++ b/src/sentry/models/deploy.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from sentry.app import locks
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model
+from sentry.types.activity import ActivityType
 from sentry.utils.retries import TimedRetryPolicy
 
 
@@ -69,7 +70,7 @@ class Deploy(Model):
             activity = None
             for project in deploy.release.projects.all():
                 activity = Activity.objects.create(
-                    type=Activity.DEPLOY,
+                    type=ActivityType.DEPLOY.value,
                     project=project,
                     ident=Activity.get_version_ident(release.version),
                     data={

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -12,7 +12,7 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
-from sentry.models import Activity
+from sentry.types.activity import ActivityType
 
 if TYPE_CHECKING:
     from sentry.models import Group, Release, Team, User
@@ -95,11 +95,11 @@ PREVIOUS_STATUSES = {
 }
 
 ACTIVITY_STATUS_TO_GROUP_HISTORY_STATUS = {
-    Activity.SET_IGNORED: GroupHistoryStatus.IGNORED,
-    Activity.SET_RESOLVED: GroupHistoryStatus.RESOLVED,
-    Activity.SET_RESOLVED_IN_COMMIT: GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
-    Activity.SET_RESOLVED_IN_RELEASE: GroupHistoryStatus.SET_RESOLVED_IN_RELEASE,
-    Activity.SET_UNRESOLVED: GroupHistoryStatus.UNRESOLVED,
+    ActivityType.SET_IGNORED.value: GroupHistoryStatus.IGNORED,
+    ActivityType.SET_RESOLVED.value: GroupHistoryStatus.RESOLVED,
+    ActivityType.SET_RESOLVED_IN_COMMIT.value: GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
+    ActivityType.SET_RESOLVED_IN_RELEASE.value: GroupHistoryStatus.SET_RESOLVED_IN_RELEASE,
+    ActivityType.SET_UNRESOLVED.value: GroupHistoryStatus.UNRESOLVED,
 }
 
 

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -9,6 +9,7 @@ from sentry.db.models import FlexibleForeignKey, JSONField, Model
 from sentry.models import Activity
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.signals import inbox_in, inbox_out
+from sentry.types.activity import ActivityType
 
 INBOX_REASON_DETAILS = {
     "type": ["object", "null"],
@@ -100,7 +101,7 @@ def remove_group_from_inbox(group, action=None, user=None, referrer=None):
             Activity.objects.create(
                 project_id=group_inbox.group.project_id,
                 group_id=group_inbox.group_id,
-                type=Activity.MARK_REVIEWED,
+                type=ActivityType.MARK_REVIEWED.value,
                 user=user,
             )
             record_group_history(group, GroupHistoryStatus.REVIEWED, actor=user)

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from sentry.models import Activity, GroupMeta
 from sentry.plugins.base.v1 import Plugin
 from sentry.signals import issue_tracker_used
+from sentry.types.activity import ActivityType
 from sentry.utils.auth import get_auth_providers
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
@@ -234,7 +235,7 @@ class IssueTrackingPlugin(Plugin):
                 Activity.objects.create(
                     project=group.project,
                     group=group,
-                    type=Activity.CREATE_ISSUE,
+                    type=ActivityType.CREATE_ISSUE.value,
                     user=request.user,
                     data=issue_information,
                 )
@@ -266,7 +267,7 @@ class IssueTrackingPlugin(Plugin):
                 Activity.objects.create(
                     project=group.project,
                     group=group,
-                    type=Activity.CREATE_ISSUE,
+                    type=ActivityType.CREATE_ISSUE.value,
                     user=request.user,
                     data=issue_information,
                 )

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -14,6 +14,7 @@ from sentry.plugins.base.configuration import react_plugin_config
 from sentry.plugins.base.v1 import Plugin
 from sentry.plugins.endpoints import PluginGroupEndpoint
 from sentry.signals import issue_tracker_used
+from sentry.types.activity import ActivityType
 from sentry.utils.auth import get_auth_providers
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
@@ -269,7 +270,7 @@ class IssueTrackingPlugin2(Plugin):
         Activity.objects.create(
             project=group.project,
             group=group,
-            type=Activity.CREATE_ISSUE,
+            type=ActivityType.CREATE_ISSUE.value,
             user=request.user,
             data=issue_information,
         )
@@ -336,7 +337,7 @@ class IssueTrackingPlugin2(Plugin):
         Activity.objects.create(
             project=group.project,
             group=group,
-            type=Activity.CREATE_ISSUE,
+            type=ActivityType.CREATE_ISSUE.value,
             user=request.user,
             data=issue_information,
         )

--- a/src/sentry/plugins/interfaces/releasehook.py
+++ b/src/sentry/plugins/interfaces/releasehook.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from sentry.exceptions import HookValidationError
 from sentry.models import Activity, Release
+from sentry.types.activity import ActivityType
 
 
 class ReleaseHook:
@@ -76,7 +77,7 @@ class ReleaseHook:
         release.add_project(self.project)
 
         Activity.objects.create(
-            type=Activity.RELEASE,
+            type=ActivityType.RELEASE.value,
             project=self.project,
             ident=Activity.get_version_ident(version),
             data={"version": version},

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -29,6 +29,7 @@ from sentry.models.grouphistory import (
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import buffer_incr_complete, issue_resolved
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
+from sentry.types.activity import ActivityType
 
 
 def resolve_group_resolutions(instance, created, **kwargs):
@@ -51,11 +52,11 @@ def remove_resolved_link(link):
             Activity.objects.create(
                 project_id=link.project_id,
                 group_id=link.group_id,
-                type=Activity.SET_UNRESOLVED,
+                type=ActivityType.SET_UNRESOLVED.value,
                 ident=link.group_id,
             )
             record_group_history_from_activity_type(
-                Group.objects.get(id=link.group_id), Activity.SET_UNRESOLVED
+                Group.objects.get(id=link.group_id), ActivityType.SET_UNRESOLVED.value
             )
 
 
@@ -120,7 +121,7 @@ def resolved_in_commit(instance, created, **kwargs):
                 Activity.objects.create(
                     project_id=group.project_id,
                     group=group,
-                    type=Activity.SET_RESOLVED_IN_COMMIT,
+                    type=ActivityType.SET_RESOLVED_IN_COMMIT.value,
                     ident=instance.id,
                     user=acting_user,
                     data={"commit": instance.id},
@@ -131,7 +132,7 @@ def resolved_in_commit(instance, created, **kwargs):
                 remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED)
                 record_group_history_from_activity_type(
                     group,
-                    Activity.SET_RESOLVED_IN_COMMIT,
+                    ActivityType.SET_RESOLVED_IN_COMMIT.value,
                     actor=acting_user if acting_user else None,
                 )
 
@@ -202,7 +203,7 @@ def resolved_in_pull_request(instance, created, **kwargs):
                 Activity.objects.create(
                     project_id=group.project_id,
                     group=group,
-                    type=Activity.SET_RESOLVED_IN_PULL_REQUEST,
+                    type=ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
                     ident=instance.id,
                     user=acting_user,
                     data={"pull_request": instance.id},

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -653,7 +653,7 @@ def start_group_reprocessing(
     # Later the activity is migrated to the new group where it is used to serve
     # the success message.
     new_activity = models.Activity.objects.create(
-        type=models.Activity.REPROCESS,
+        type=models.ActivityType.REPROCESS.value,
         project=new_group.project,
         ident=str(group_id),
         group_id=group_id,

--- a/src/sentry/runner/commands/repair.py
+++ b/src/sentry/runner/commands/repair.py
@@ -5,6 +5,7 @@ import click
 from django.db import transaction
 
 from sentry.runner.decorators import configuration
+from sentry.types.activity import ActivityType
 
 
 class RollbackLocally(Exception):
@@ -50,8 +51,6 @@ def create_missing_dsns():
 def fix_group_counters():
     from django.db import connection
 
-    from sentry.models import Activity
-
     click.echo("Correcting Group.num_comments counter")
     cursor = connection.cursor()
     cursor.execute(
@@ -61,7 +60,7 @@ def fix_group_counters():
             WHERE type = %s and group_id = sentry_groupedmessage.id
         )
     """,
-        [Activity.NOTE],
+        [ActivityType.NOTE.value],
     )
 
 

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -16,6 +16,7 @@ from sentry.models import (
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.integrations import kick_off_status_syncs
+from sentry.types.activity import ActivityType
 
 ONE_HOUR = 3600
 
@@ -77,7 +78,10 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
 
         if happened:
             Activity.objects.create(
-                group=group, project=project, type=Activity.SET_RESOLVED_BY_AGE, data={"age": age}
+                group=group,
+                project=project,
+                type=ActivityType.SET_RESOLVED_BY_AGE.value,
+                data={"age": age},
             )
             record_group_history(group, GroupHistoryStatus.AUTO_RESOLVED)
 

--- a/src/sentry/tasks/clear_expired_resolutions.py
+++ b/src/sentry/tasks/clear_expired_resolutions.py
@@ -2,6 +2,7 @@ from django.db.models import Q
 
 from sentry.models import Activity, GroupResolution, Release
 from sentry.tasks.base import instrumented_task
+from sentry.types.activity import ActivityType
 
 
 @instrumented_task(name="sentry.tasks.clear_expired_resolutions", time_limit=15, soft_time_limit=10)
@@ -40,7 +41,7 @@ def clear_expired_resolutions(release_id):
         try:
             activity = Activity.objects.filter(
                 group=resolution.group_id,
-                type=Activity.SET_RESOLVED_IN_RELEASE,
+                type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
                 ident=resolution.id,
             ).order_by("-datetime")[0]
         except IndexError:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -8,6 +8,7 @@ from sentry.exceptions import PluginError
 from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.tasks.base import instrumented_task
+from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.locking import UnableToAcquireLock
@@ -488,7 +489,7 @@ def process_snoozes(group):
         Activity.objects.create(
             project=group.project,
             group=group,
-            type=Activity.SET_UNRESOLVED,
+            type=ActivityType.SET_UNRESOLVED.value,
             user=None,
         )
 

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -42,6 +42,7 @@ from sentry.models import (
 )
 from sentry.snuba.dataset import Dataset
 from sentry.tasks.base import instrumented_task
+from sentry.types.activity import ActivityType
 from sentry.utils import json, redis
 from sentry.utils.compat import filter, map, zip
 from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
@@ -329,7 +330,7 @@ def build_project_issue_summaries(interval, project):
                 last_seen__lt=stop,
                 resolved_at__isnull=False,  # signals this has *ever* been resolved
             ),
-            type__in=(Activity.SET_REGRESSION, Activity.SET_UNRESOLVED),
+            type__in=(ActivityType.SET_REGRESSION.value, ActivityType.SET_UNRESOLVED.value),
             datetime__gte=start,
             datetime__lt=stop,
         )
@@ -779,7 +780,7 @@ def fetch_personal_statistics(start__stop, organization, user):
         Activity.objects.filter(
             project__organization_id=organization.id,
             user_id=user.id,
-            type__in=(Activity.SET_RESOLVED, Activity.SET_RESOLVED_IN_RELEASE),
+            type__in=(ActivityType.SET_RESOLVED.value, ActivityType.SET_RESOLVED_IN_RELEASE.value),
             datetime__gte=start,
             datetime__lt=stop,
             group__status=GroupStatus.RESOLVED,  # only count if the issue is still resolved

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -18,6 +18,7 @@ from sentry.killswitches import killswitch_matches_context
 from sentry.models import Activity, Organization, Project, ProjectOption
 from sentry.stacktraces.processing import process_stacktraces, should_process_for_stacktraces
 from sentry.tasks.base import instrumented_task
+from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.utils.canonical import CANONICAL_TYPES, CanonicalKeyDict
 from sentry.utils.dates import to_datetime
@@ -538,7 +539,7 @@ def create_failed_event(
     if not sent_notification:
         project = Project.objects.get_from_cache(id=project_id)
         Activity.objects.create(
-            type=Activity.NEW_PROCESSING_ISSUES,
+            type=ActivityType.NEW_PROCESSING_ISSUES.value,
             project=project,
             datetime=to_datetime(start_time),
             data={"reprocessing_active": reprocessing_active, "issues": issues},

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -23,6 +23,7 @@ from sentry.models import (
     UserReport,
 )
 from sentry.tasks.base import instrumented_task
+from sentry.types.activity import ActivityType
 from sentry.unmerge import InitialUnmergeArgs, SuccessiveUnmergeArgs, UnmergeArgs, UnmergeArgsBase
 from sentry.utils.query import celery_run_batch_query
 from sentry.utils.safe import get_path
@@ -214,7 +215,7 @@ def migrate_events(
         Activity.objects.create(
             project_id=project.id,
             group_id=destination_id,
-            type=Activity.UNMERGE_DESTINATION,
+            type=ActivityType.UNMERGE_DESTINATION.value,
             user_id=args.actor_id,
             data={"source_id": args.source_id, **args.replacement.get_activity_args()},
         )
@@ -222,7 +223,7 @@ def migrate_events(
         Activity.objects.create(
             project_id=project.id,
             group_id=args.source_id,
-            type=Activity.UNMERGE_SOURCE,
+            type=ActivityType.UNMERGE_SOURCE.value,
             user_id=args.actor_id,
             data={"destination_id": destination_id, **args.replacement.get_activity_args()},
         )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -90,6 +90,7 @@ from sentry.models.integrations.integration_feature import Feature, IntegrationT
 from sentry.models.releasefile import update_artifact_index
 from sentry.signals import project_created
 from sentry.snuba.models import QueryDatasets
+from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json, loremipsum
 
@@ -414,7 +415,7 @@ class Factories:
                 )
 
         Activity.objects.create(
-            type=Activity.RELEASE,
+            type=ActivityType.RELEASE.value,
             project=project,
             ident=Activity.get_version_ident(version),
             user=user,
@@ -1207,5 +1208,9 @@ class Factories:
     def create_comment(issue, project, user, text="hello world"):
         data = {"text": text}
         return Activity.objects.create(
-            project=project, group=issue, type=Activity.NOTE, user=user, data=data
+            project=project,
+            group=issue,
+            type=ActivityType.NOTE.value,
+            user=user,
+            data=data,
         )

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -14,10 +14,12 @@ from sentry.models import (
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, iso_format
 
-
 # XXX(dcramer): this is a compatibility layer to transition to pytest-based fixtures
 # all of the memoized fixtures are copypasta due to our inability to use pytest fixtures
 # on a per-class method basis
+from sentry.types.activity import ActivityType
+
+
 class Fixtures:
     @cached_property
     def session(self):
@@ -79,7 +81,11 @@ class Fixtures:
     @cached_property
     def activity(self):
         return Activity.objects.create(
-            group=self.group, project=self.project, type=Activity.NOTE, user=self.user, data={}
+            group=self.group,
+            project=self.project,
+            type=ActivityType.NOTE.value,
+            user=self.user,
+            data={},
         )
 
     @cached_property

--- a/src/sentry/utils/pytest/fixtures.py
+++ b/src/sentry/utils/pytest/fixtures.py
@@ -20,6 +20,8 @@ import sentry
 
 # These chars cannot be used in Windows paths so replace them:
 # https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#naming-conventions
+from sentry.types.activity import ActivityType
+
 UNSAFE_PATH_CHARS = ("<", ">", ":", '"', " | ", "?", "*")
 
 
@@ -238,7 +240,11 @@ def default_activity(default_group, default_project, default_user):
     from sentry.models import Activity
 
     return Activity.objects.create(
-        group=default_group, project=default_project, type=Activity.NOTE, user=default_user, data={}
+        group=default_group,
+        project=default_project,
+        type=ActivityType.NOTE.value,
+        user=default_user,
+        data={},
     )
 
 

--- a/src/sentry/web/frontend/debug/debug_assigned_email.py
+++ b/src/sentry/web/frontend/debug/debug_assigned_email.py
@@ -1,6 +1,6 @@
 from rest_framework.request import Request
 
-from sentry.models import Activity
+from sentry.types.activity import ActivityType
 
 from .mail import ActivityMailDebugView
 
@@ -8,7 +8,7 @@ from .mail import ActivityMailDebugView
 class DebugAssignedEmailView(ActivityMailDebugView):
     def get_activity(self, request: Request, event):
         return {
-            "type": Activity.ASSIGNED,
+            "type": ActivityType.ASSIGNED.value,
             "user": request.user,
             "data": {
                 "assignee": "10000000",
@@ -21,7 +21,7 @@ class DebugAssignedEmailView(ActivityMailDebugView):
 class DebugSelfAssignedEmailView(ActivityMailDebugView):
     def get_activity(self, request: Request, event):
         return {
-            "type": Activity.ASSIGNED,
+            "type": ActivityType.ASSIGNED.value,
             "user": request.user,
             "data": {
                 "assignee": str(request.user.id),
@@ -34,7 +34,7 @@ class DebugSelfAssignedEmailView(ActivityMailDebugView):
 class DebugSelfAssignedTeamEmailView(ActivityMailDebugView):
     def get_activity(self, request: Request, event):
         return {
-            "type": Activity.ASSIGNED,
+            "type": ActivityType.ASSIGNED.value,
             "user": request.user,
             "data": {"assignee": "1", "assigneeEmail": None, "assigneeType": "team"},
         }

--- a/src/sentry/web/frontend/debug/debug_note_email.py
+++ b/src/sentry/web/frontend/debug/debug_note_email.py
@@ -1,6 +1,6 @@
 from rest_framework.request import Request
 
-from sentry.models import Activity
+from sentry.types.activity import ActivityType
 
 from .mail import ActivityMailDebugView, get_random, make_message
 
@@ -9,7 +9,7 @@ class DebugNoteEmailView(ActivityMailDebugView):
     def get_activity(self, request: Request, event):
         random = get_random(request)
         return {
-            "type": Activity.NOTE,
+            "type": ActivityType.NOTE.value,
             "user": request.user,
             "data": {"text": make_message(random, max(2, int(random.weibullvariate(12, 0.4))))},
         }

--- a/src/sentry/web/frontend/debug/debug_regression_email.py
+++ b/src/sentry/web/frontend/debug/debug_regression_email.py
@@ -1,15 +1,15 @@
 from rest_framework.request import Request
 
-from sentry.models import Activity
+from sentry.types.activity import ActivityType
 
 from .mail import ActivityMailDebugView
 
 
 class DebugRegressionEmailView(ActivityMailDebugView):
     def get_activity(self, request: Request, event):
-        return {"type": Activity.SET_REGRESSION}
+        return {"type": ActivityType.SET_REGRESSION.value}
 
 
 class DebugRegressionReleaseEmailView(ActivityMailDebugView):
     def get_activity(self, request: Request, event):
-        return {"type": Activity.SET_REGRESSION, "data": {"version": "abcdef"}}
+        return {"type": ActivityType.SET_REGRESSION.value, "data": {"version": "abcdef"}}

--- a/src/sentry/web/frontend/debug/debug_resolved_email.py
+++ b/src/sentry/web/frontend/debug/debug_resolved_email.py
@@ -1,10 +1,10 @@
 from rest_framework.request import Request
 
-from sentry.models import Activity
+from sentry.types.activity import ActivityType
 
 from .mail import ActivityMailDebugView
 
 
 class DebugResolvedEmailView(ActivityMailDebugView):
     def get_activity(self, request: Request, event):
-        return {"type": Activity.SET_RESOLVED}
+        return {"type": ActivityType.SET_RESOLVED.value}

--- a/src/sentry/web/frontend/debug/debug_resolved_in_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_resolved_in_release_email.py
@@ -1,15 +1,15 @@
 from rest_framework.request import Request
 
-from sentry.models import Activity
+from sentry.types.activity import ActivityType
 
 from .mail import ActivityMailDebugView
 
 
 class DebugResolvedInReleaseEmailView(ActivityMailDebugView):
     def get_activity(self, request: Request, event):
-        return {"type": Activity.SET_RESOLVED_IN_RELEASE, "data": {"version": "abcdef"}}
+        return {"type": ActivityType.SET_RESOLVED_IN_RELEASE.value, "data": {"version": "abcdef"}}
 
 
 class DebugResolvedInReleaseUpcomingEmailView(ActivityMailDebugView):
     def get_activity(self, request: Request, event):
-        return {"type": Activity.SET_RESOLVED_IN_RELEASE, "data": {"version": ""}}
+        return {"type": ActivityType.SET_RESOLVED_IN_RELEASE.value, "data": {"version": ""}}

--- a/src/sentry/web/frontend/debug/debug_unassigned_email.py
+++ b/src/sentry/web/frontend/debug/debug_unassigned_email.py
@@ -1,10 +1,10 @@
 from rest_framework.request import Request
 
-from sentry.models import Activity
+from sentry.types.activity import ActivityType
 
 from .mail import ActivityMailDebugView
 
 
 class DebugUnassignedEmailView(ActivityMailDebugView):
     def get_activity(self, request: Request, event):
-        return {"type": Activity.UNASSIGNED, "user": request.user}
+        return {"type": ActivityType.UNASSIGNED.value, "user": request.user}

--- a/tests/acceptance/test_organization_activity.py
+++ b/tests/acceptance/test_organization_activity.py
@@ -2,6 +2,7 @@ from django.utils import timezone
 
 from sentry.models import Activity
 from sentry.testutils import AcceptanceTestCase
+from sentry.types.activity import ActivityType
 
 
 class OrganizationActivityTest(AcceptanceTestCase):
@@ -21,7 +22,7 @@ class OrganizationActivityTest(AcceptanceTestCase):
         Activity.objects.create(
             group=self.group,
             project=self.group.project,
-            type=Activity.NOTE,
+            type=ActivityType.NOTE.value,
             user=self.user,
             data={"text": "hello world"},
         )

--- a/tests/sentry/api/endpoints/test_group_activities.py
+++ b/tests/sentry/api/endpoints/test_group_activities.py
@@ -1,5 +1,6 @@
 from sentry.models import Activity, GroupStatus
 from sentry.testutils import APITestCase
+from sentry.types.activity import ActivityType
 
 
 class GroupActivitiesEndpointTest(APITestCase):
@@ -24,7 +25,7 @@ class GroupActivitiesEndpointTest(APITestCase):
             Activity.objects.create(
                 group=group,
                 project=group.project,
-                type=Activity.NOTE,
+                type=ActivityType.NOTE.value,
                 data={"text": "hello world"},
             )
 

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -26,6 +26,7 @@ from sentry.models import (
 )
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.types.activity import ActivityType
 
 
 class GroupDetailsTest(APITestCase, SnubaTestCase):
@@ -323,7 +324,9 @@ class GroupUpdateTest(APITestCase):
         assert GroupAssignee.objects.filter(group=group, user=self.user).exists()
 
         assert (
-            Activity.objects.filter(group=group, user=self.user, type=Activity.ASSIGNED).count()
+            Activity.objects.filter(
+                group=group, user=self.user, type=ActivityType.ASSIGNED.value
+            ).count()
             == 1
         )
 
@@ -357,7 +360,9 @@ class GroupUpdateTest(APITestCase):
         assert GroupAssignee.objects.filter(group=group, user=self.user).exists()
 
         assert (
-            Activity.objects.filter(group=group, user=self.user, type=Activity.ASSIGNED).count()
+            Activity.objects.filter(
+                group=group, user=self.user, type=ActivityType.ASSIGNED.value
+            ).count()
             == 1
         )
 
@@ -410,7 +415,7 @@ class GroupUpdateTest(APITestCase):
 
         assert GroupAssignee.objects.filter(group=group, team=team).exists()
 
-        assert Activity.objects.filter(group=group, type=Activity.ASSIGNED).count() == 1
+        assert Activity.objects.filter(group=group, type=ActivityType.ASSIGNED.value).count() == 1
 
         assert GroupSubscription.objects.filter(
             user=self.user, group=group, is_active=True

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -7,6 +7,7 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.types.activity import ActivityType
 from sentry.utils.http import absolute_uri
 
 
@@ -189,7 +190,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                 linked_id=external_issue.id,
             ).exists()
 
-            activity = Activity.objects.filter(type=Activity.CREATE_ISSUE)[0]
+            activity = Activity.objects.filter(type=ActivityType.CREATE_ISSUE.value)[0]
             assert activity.project_id == group.project_id
             assert activity.group_id == group.id
             assert activity.ident is None
@@ -249,7 +250,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                 linked_id=external_issue.id,
             ).exists()
 
-            activity = Activity.objects.filter(type=Activity.CREATE_ISSUE)[0]
+            activity = Activity.objects.filter(type=ActivityType.CREATE_ISSUE.value)[0]
             assert activity.project_id == group.project_id
             assert activity.group_id == group.id
             assert activity.ident is None
@@ -351,9 +352,8 @@ class GroupIntegrationDetailsTest(APITestCase):
             for field in fields:
                 if field["name"] == "project":
                     project_field = field
+                    assert project_field == expected_project_field
                     break
-
-            assert project_field == expected_project_field
 
         self.login_as(user=self.user)
         org = self.organization

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -8,6 +8,7 @@ from sentry.models import (
 )
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.testutils import APITestCase
+from sentry.types.activity import ActivityType
 
 
 class GroupNoteTest(APITestCase):
@@ -17,7 +18,7 @@ class GroupNoteTest(APITestCase):
         activity = Activity.objects.create(
             group=group,
             project=group.project,
-            type=Activity.NOTE,
+            type=ActivityType.NOTE.value,
             user=self.user,
             data={"text": "hello world"},
         )

--- a/tests/sentry/api/endpoints/test_organization_activity.py
+++ b/tests/sentry/api/endpoints/test_organization_activity.py
@@ -1,6 +1,7 @@
 from sentry.models import Activity
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.types.activity import ActivityType
 
 
 class OrganizationActivityTest(APITestCase):
@@ -21,7 +22,7 @@ class OrganizationActivityTest(APITestCase):
         activity = Activity.objects.create(
             group=group,
             project=group.project,
-            type=Activity.NOTE,
+            type=ActivityType.NOTE.value,
             user=self.user,
             data={"text": "hello world"},
         )
@@ -44,21 +45,21 @@ class OrganizationActivityTest(APITestCase):
         activity = Activity.objects.create(
             group=group,
             project=group.project,
-            type=Activity.NOTE,
+            type=ActivityType.NOTE.value,
             user=self.user,
             data={"text": "hello world"},
         )
         activity_2 = Activity.objects.create(
             group=group_2,
             project=group_2.project,
-            type=Activity.NOTE,
+            type=ActivityType.NOTE.value,
             user=self.user,
             data={"text": "hello world 2"},
         )
         activity_3 = Activity.objects.create(
             group=group,
             project=group.project,
-            type=Activity.NOTE,
+            type=ActivityType.NOTE.value,
             user=self.user,
             data={"text": "hello world 3"},
         )

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -21,6 +21,7 @@ from sentry.models import (
     Repository,
 )
 from sentry.testutils import APITestCase
+from sentry.types.activity import ActivityType
 
 
 class ReleaseDetailsTest(APITestCase):
@@ -914,7 +915,7 @@ class UpdateReleaseDetailsTest(APITestCase):
         assert release.date_released
 
         activity = Activity.objects.filter(
-            type=Activity.RELEASE, project=project, ident=release.version
+            type=ActivityType.RELEASE.value, project=project, ident=release.version
         )
         assert activity.exists()
 
@@ -948,7 +949,7 @@ class UpdateReleaseDetailsTest(APITestCase):
         assert release.date_released
 
         activity = Activity.objects.filter(
-            type=Activity.RELEASE, project=project, ident=release.version[:64]
+            type=ActivityType.RELEASE.value, project=project, ident=release.version[:64]
         )
         assert activity.exists()
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -45,6 +45,7 @@ from sentry.testutils import (
     SnubaTestCase,
     TestCase,
 )
+from sentry.types.activity import ActivityType
 
 
 class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
@@ -1186,10 +1187,10 @@ class OrganizationReleaseCreateTest(APITestCase):
         # should be 201 because 1 project was added
         assert response.status_code == 201, response.content
         assert not Activity.objects.filter(
-            type=Activity.RELEASE, project=project, ident=release.version
+            type=ActivityType.RELEASE.value, project=project, ident=release.version
         ).exists()
         assert Activity.objects.filter(
-            type=Activity.RELEASE, project=project2, ident=release.version
+            type=ActivityType.RELEASE.value, project=project2, ident=release.version
         ).exists()
 
     def test_activity_with_long_release(self):
@@ -1222,10 +1223,10 @@ class OrganizationReleaseCreateTest(APITestCase):
         # should be 201 because 1 project was added
         assert response.status_code == 201, response.content
         assert not Activity.objects.filter(
-            type=Activity.RELEASE, project=project, ident=release.version[:64]
+            type=ActivityType.RELEASE.value, project=project, ident=release.version[:64]
         ).exists()
         assert Activity.objects.filter(
-            type=Activity.RELEASE, project=project2, ident=release.version[:64]
+            type=ActivityType.RELEASE.value, project=project2, ident=release.version[:64]
         ).exists()
 
     def test_version_whitespace(self):

--- a/tests/sentry/api/endpoints/test_project_release_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_details.py
@@ -8,6 +8,7 @@ from sentry.api.endpoints.project_release_details import ReleaseSerializer
 from sentry.constants import MAX_VERSION_LENGTH
 from sentry.models import Activity, File, Release, ReleaseCommit, ReleaseFile, ReleaseProject
 from sentry.testutils import APITestCase
+from sentry.types.activity import ActivityType
 
 
 class ReleaseDetailsTest(APITestCase):
@@ -122,7 +123,7 @@ class UpdateReleaseDetailsTest(APITestCase):
         assert release.date_released
 
         activity = Activity.objects.filter(
-            type=Activity.RELEASE, project=project, ident=release.version
+            type=ActivityType.RELEASE.value, project=project, ident=release.version
         )
         assert activity.exists()
 
@@ -152,7 +153,7 @@ class UpdateReleaseDetailsTest(APITestCase):
         assert release.date_released
 
         activity = Activity.objects.filter(
-            type=Activity.RELEASE, project=project, ident=release.version[:64]
+            type=ActivityType.RELEASE.value, project=project, ident=release.version[:64]
         )
         assert activity.exists()
 

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -1,6 +1,7 @@
 from sentry.api.serializers import serialize
 from sentry.models import Activity, Commit, GroupStatus, PullRequest
 from sentry.testutils import TestCase
+from sentry.types.activity import ActivityType
 
 
 class GroupActivityTestCase(TestCase):
@@ -20,7 +21,7 @@ class GroupActivityTestCase(TestCase):
         activity = Activity.objects.create(
             project_id=group.project_id,
             group=group,
-            type=Activity.SET_RESOLVED_IN_PULL_REQUEST,
+            type=ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
             ident=pr.id,
             user=user,
             data={"pull_request": pr.id},
@@ -44,7 +45,7 @@ class GroupActivityTestCase(TestCase):
         activity = Activity.objects.create(
             project_id=group.project_id,
             group=group,
-            type=Activity.SET_RESOLVED_IN_COMMIT,
+            type=ActivityType.SET_RESOLVED_IN_COMMIT.value,
             ident=commit.id,
             user=user,
             data={"commit": commit.id},

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -67,13 +67,13 @@ class GroupActivityTestCase(TestCase):
         Activity.objects.create(
             project_id=project.id,
             group=group,
-            type=Activity.SET_RESOLVED_IN_COMMIT,
+            type=ActivityType.SET_RESOLVED_IN_COMMIT.value,
             ident=commit.id,
             user=user,
             data={"commit": commit.id},
         )
 
-        act = Activity.objects.get(type=Activity.SET_RESOLVED_IN_COMMIT)
+        act = Activity.objects.get(type=ActivityType.SET_RESOLVED_IN_COMMIT.value)
         serialized = serialize(act)
 
         assert len(serialized["data"]["commit"]["releases"]) == 1
@@ -90,13 +90,13 @@ class GroupActivityTestCase(TestCase):
         Activity.objects.create(
             project_id=project.id,
             group=group,
-            type=Activity.SET_RESOLVED_IN_COMMIT,
+            type=ActivityType.SET_RESOLVED_IN_COMMIT.value,
             ident=commit.id,
             user=user,
             data={"commit": commit.id},
         )
 
-        act = Activity.objects.get(type=Activity.SET_RESOLVED_IN_COMMIT)
+        act = Activity.objects.get(type=ActivityType.SET_RESOLVED_IN_COMMIT.value)
         serialized = serialize(act)
 
         assert len(serialized["data"]["commit"]["releases"]) == 0
@@ -114,13 +114,13 @@ class GroupActivityTestCase(TestCase):
         Activity.objects.create(
             project_id=project.id,
             group=group,
-            type=Activity.SET_RESOLVED_IN_COMMIT,
+            type=ActivityType.SET_RESOLVED_IN_COMMIT.value,
             ident=commit.id,
             user=user,
             data={"commit": commit.id},
         )
 
-        act = Activity.objects.get(type=Activity.SET_RESOLVED_IN_COMMIT)
+        act = Activity.objects.get(type=ActivityType.SET_RESOLVED_IN_COMMIT.value)
         serialized = serialize(act)
 
         assert len(serialized["data"]["commit"]["releases"]) == 1

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -43,6 +43,7 @@ from sentry.models import (
 )
 from sentry.spans.grouping.utils import hash_values
 from sentry.testutils import TestCase, assert_mock_called_once_with_partial
+from sentry.types.activity import ActivityType
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.outcomes import Outcome
 
@@ -406,7 +407,7 @@ class EventManagerTest(TestCase):
         activity = Activity.objects.create(
             group=group,
             project=group.project,
-            type=Activity.SET_RESOLVED_IN_RELEASE,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
             ident=resolution.id,
             data={"version": ""},
         )
@@ -441,7 +442,7 @@ class EventManagerTest(TestCase):
 
         assert not GroupResolution.objects.filter(group=group).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_REGRESSION)
+        activity = Activity.objects.get(group=group, type=ActivityType.SET_REGRESSION.value)
 
         mock_send_activity_notifications_delay.assert_called_once_with(activity.id)
 
@@ -478,7 +479,7 @@ class EventManagerTest(TestCase):
         activity = Activity.objects.create(
             group=group,
             project=group.project,
-            type=Activity.SET_RESOLVED_IN_RELEASE,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
             ident=resolution.id,
             data={"version": "foobar"},
         )
@@ -496,7 +497,9 @@ class EventManagerTest(TestCase):
         activity = Activity.objects.get(id=activity.id)
         assert activity.data["version"] == "foobar"
 
-        regressed_activity = Activity.objects.get(group=group, type=Activity.SET_REGRESSION)
+        regressed_activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_REGRESSION.value
+        )
         assert regressed_activity.data["version"] == "b"
 
         mock_send_activity_notifications_delay.assert_called_once_with(regressed_activity.id)
@@ -534,7 +537,7 @@ class EventManagerTest(TestCase):
         activity = Activity.objects.create(
             group=group,
             project=group.project,
-            type=Activity.SET_RESOLVED_IN_RELEASE,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
             ident=resolution.id,
             data={"version": "", "current_release_version": "pre foobar"},
         )
@@ -553,7 +556,9 @@ class EventManagerTest(TestCase):
         assert activity.data["version"] == "b"
         assert activity.data["current_release_version"] == "pre foobar"
 
-        regressed_activity = Activity.objects.get(group=group, type=Activity.SET_REGRESSION)
+        regressed_activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_REGRESSION.value
+        )
         assert regressed_activity.data["version"] == "b"
 
         mock_send_activity_notifications_delay.assert_called_once_with(regressed_activity.id)
@@ -692,7 +697,7 @@ class EventManagerTest(TestCase):
         activity = Activity.objects.create(
             group=group,
             project=group.project,
-            type=Activity.SET_RESOLVED_IN_RELEASE,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
             ident=resolution.id,
             data={"version": ""},
         )
@@ -733,7 +738,7 @@ class EventManagerTest(TestCase):
 
                 assert not GroupResolution.objects.filter(group=group).exists()
 
-                activity = Activity.objects.get(group=group, type=Activity.SET_REGRESSION)
+                activity = Activity.objects.get(group=group, type=ActivityType.SET_REGRESSION.value)
 
                 mock_send_activity_notifications_delay.assert_called_once_with(activity.id)
 

--- a/tests/sentry/integrations/slack/notifications/test_deploy.py
+++ b/tests/sentry/integrations/slack/notifications/test_deploy.py
@@ -7,6 +7,7 @@ from sentry.models import Activity, Deploy, Release
 from sentry.notifications.notifications.activity import ReleaseActivityNotification
 from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_attachment, send_notification
+from sentry.types.activity import ActivityType
 
 
 class SlackDeployNotificationTest(SlackActivityNotificationTest):
@@ -38,7 +39,7 @@ class SlackDeployNotificationTest(SlackActivityNotificationTest):
             Activity(
                 project=self.project,
                 user=self.user,
-                type=Activity.RELEASE,
+                type=ActivityType.RELEASE.value,
                 data={"version": release.version, "deploy_id": deploy.id},
             )
         )

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -8,6 +8,7 @@ from sentry.notifications.types import (
     NotificationSettingTypes,
 )
 from sentry.testutils.cases import ActivityTestCase
+from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
 
 
@@ -76,7 +77,7 @@ class ReleaseTestCase(ActivityTestCase):
             Activity(
                 project=self.project,
                 user=self.user1,
-                type=Activity.RELEASE,
+                type=ActivityType.RELEASE.value,
                 data={"version": self.release.version, "deploy_id": self.deploy.id},
             )
         )
@@ -125,7 +126,7 @@ class ReleaseTestCase(ActivityTestCase):
             Activity(
                 project=self.project,
                 user=self.user1,
-                type=Activity.RELEASE,
+                type=ActivityType.RELEASE.value,
                 data={"version": "a", "deploy_id": 5},
             )
         )
@@ -139,7 +140,7 @@ class ReleaseTestCase(ActivityTestCase):
             Activity(
                 project=self.project,
                 user=self.user1,
-                type=Activity.RELEASE,
+                type=ActivityType.RELEASE.value,
                 data={"version": release.version, "deploy_id": deploy.id},
             )
         )
@@ -185,7 +186,7 @@ class ReleaseTestCase(ActivityTestCase):
             Activity(
                 project=self.project,
                 user=self.user1,
-                type=Activity.RELEASE,
+                type=ActivityType.RELEASE.value,
                 data={"version": release.version, "deploy_id": deploy.id},
             )
         )

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -45,6 +45,7 @@ from sentry.ownership.grammar import Matcher, Owner, dump_schema
 from sentry.plugins.base import Notification
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
 from sentry.types.rules import RuleFuture
 from sentry.utils.email import MessageBuilder, get_email_addresses
@@ -979,7 +980,7 @@ class MailAdapterNotifyAboutActivityTest(BaseMailAdapterTest):
         activity = Activity.objects.create(
             project=self.project,
             group=self.group,
-            type=Activity.ASSIGNED,
+            type=ActivityType.ASSIGNED.value,
             user=self.create_user("foo@example.com"),
             data={"assignee": str(self.user.id), "assigneeType": "user"},
         )
@@ -1005,7 +1006,7 @@ class MailAdapterNotifyAboutActivityTest(BaseMailAdapterTest):
         activity = Activity.objects.create(
             project=self.project,
             group=self.group,
-            type=Activity.ASSIGNED,
+            type=ActivityType.ASSIGNED.value,
             user=self.create_user("foo@example.com"),
             data={"assignee": str(self.project.teams.first().id), "assigneeType": "team"},
         )
@@ -1032,7 +1033,7 @@ class MailAdapterNotifyAboutActivityTest(BaseMailAdapterTest):
         activity = Activity.objects.create(
             project=self.project,
             group=self.group,
-            type=Activity.NOTE,
+            type=ActivityType.NOTE.value,
             user=user_foo,
             data={"text": "sup guise"},
         )

--- a/tests/sentry/models/test_deploy.py
+++ b/tests/sentry/models/test_deploy.py
@@ -1,5 +1,6 @@
 from sentry.models import Activity, Commit, Deploy, Environment, Release, ReleaseHeadCommit
 from sentry.testutils import TestCase
+from sentry.types.activity import ActivityType
 
 
 class DeployNotifyTest(TestCase):
@@ -15,7 +16,7 @@ class DeployNotifyTest(TestCase):
         Deploy.notify_if_ready(deploy.id)
 
         # make sure activity has been created
-        record = Activity.objects.get(type=Activity.DEPLOY, project=project)
+        record = Activity.objects.get(type=ActivityType.DEPLOY.value, project=project)
         assert release.version.startswith(record.ident)
 
     def test_already_notified(self):
@@ -33,7 +34,7 @@ class DeployNotifyTest(TestCase):
 
         # make sure no activity has been created
         assert not Activity.objects.filter(
-            type=Activity.DEPLOY, project=project, ident=release.version
+            type=ActivityType.DEPLOY.value, project=project, ident=release.version
         ).exists()
 
     def test_no_commits_no_head_commits(self):
@@ -53,12 +54,12 @@ class DeployNotifyTest(TestCase):
 
         # make sure activity has been created
         assert Activity.objects.filter(
-            type=Activity.DEPLOY, project=project, ident=release.version
+            type=ActivityType.DEPLOY.value, project=project, ident=release.version
         ).exists()
         assert (
-            Activity.objects.get(type=Activity.DEPLOY, project=project, ident=release.version).data[
-                "deploy_id"
-            ]
+            Activity.objects.get(
+                type=ActivityType.DEPLOY.value, project=project, ident=release.version
+            ).data["deploy_id"]
             == deploy.id
         )
         assert Deploy.objects.get(id=deploy.id).notified is True
@@ -86,7 +87,7 @@ class DeployNotifyTest(TestCase):
 
         # make sure activity has been created
         assert not Activity.objects.filter(
-            type=Activity.DEPLOY, project=project, ident=release.version
+            type=ActivityType.DEPLOY.value, project=project, ident=release.version
         ).exists()
         assert Deploy.objects.get(id=deploy.id).notified is False
 
@@ -108,12 +109,12 @@ class DeployNotifyTest(TestCase):
 
         # make sure activity has been created
         assert Activity.objects.filter(
-            type=Activity.DEPLOY, project=project, ident=release.version
+            type=ActivityType.DEPLOY.value, project=project, ident=release.version
         ).exists()
         assert (
-            Activity.objects.get(type=Activity.DEPLOY, project=project, ident=release.version).data[
-                "deploy_id"
-            ]
+            Activity.objects.get(
+                type=ActivityType.DEPLOY.value, project=project, ident=release.version
+            ).data["deploy_id"]
             == deploy.id
         )
         assert Deploy.objects.get(id=deploy.id).notified is True

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -13,6 +13,7 @@ from sentry.models import (
     OrganizationIntegration,
 )
 from sentry.testutils import TestCase
+from sentry.types.activity import ActivityType
 
 
 class GroupAssigneeTestCase(TestCase):
@@ -37,7 +38,7 @@ class GroupAssigneeTestCase(TestCase):
         ).exists()
 
         activity = Activity.objects.get(
-            project=self.group.project, group=self.group, type=Activity.ASSIGNED
+            project=self.group.project, group=self.group, type=ActivityType.ASSIGNED.value
         )
 
         assert activity.data["assignee"] == str(self.user.id)
@@ -52,7 +53,7 @@ class GroupAssigneeTestCase(TestCase):
         ).exists()
 
         activity = Activity.objects.get(
-            project=self.group.project, group=self.group, type=Activity.ASSIGNED
+            project=self.group.project, group=self.group, type=ActivityType.ASSIGNED.value
         )
 
         assert activity.data["assignee"] == str(self.team.id)
@@ -67,7 +68,7 @@ class GroupAssigneeTestCase(TestCase):
             project=self.group.project, group=self.group, user=self.user, team__isnull=True
         ).exists()
         activity = Activity.objects.get(
-            project=self.group.project, group=self.group, type=Activity.ASSIGNED
+            project=self.group.project, group=self.group, type=ActivityType.ASSIGNED.value
         )
         assert activity.data["assignee"] == str(self.user.id)
         assert activity.data["assigneeEmail"] == self.user.email
@@ -82,7 +83,7 @@ class GroupAssigneeTestCase(TestCase):
         ).exists()
         # Should be no new activity rows
         activity = Activity.objects.get(
-            project=self.group.project, group=self.group, type=Activity.ASSIGNED
+            project=self.group.project, group=self.group, type=ActivityType.ASSIGNED.value
         )
         assert activity.data["assignee"] == str(self.user.id)
         assert activity.data["assigneeEmail"] == self.user.email
@@ -103,7 +104,7 @@ class GroupAssigneeTestCase(TestCase):
 
         activity = list(
             Activity.objects.filter(
-                project=self.group.project, group=self.group, type=Activity.ASSIGNED
+                project=self.group.project, group=self.group, type=ActivityType.ASSIGNED.value
             ).order_by("id")
         )
 
@@ -158,7 +159,7 @@ class GroupAssigneeTestCase(TestCase):
                 ).exists()
 
                 activity = Activity.objects.get(
-                    project=self.group.project, group=self.group, type=Activity.ASSIGNED
+                    project=self.group.project, group=self.group, type=ActivityType.ASSIGNED.value
                 )
 
                 assert activity.data["assignee"] == str(self.user.id)
@@ -207,7 +208,7 @@ class GroupAssigneeTestCase(TestCase):
                 ).exists()
 
                 assert Activity.objects.filter(
-                    project=self.group.project, group=self.group, type=Activity.UNASSIGNED
+                    project=self.group.project, group=self.group, type=ActivityType.UNASSIGNED.value
                 ).exists()
 
     def test_assignee_sync_inbound_assign(self):

--- a/tests/sentry/models/test_groupinbox.py
+++ b/tests/sentry/models/test_groupinbox.py
@@ -9,6 +9,7 @@ from sentry.models import (
     remove_group_from_inbox,
 )
 from sentry.testutils import TestCase
+from sentry.types.activity import ActivityType
 
 
 class GroupInboxTestCase(TestCase):
@@ -39,7 +40,7 @@ class GroupInboxTestCase(TestCase):
         ).exists()
         activities = Activity.objects.all()
         assert len(activities) == 1
-        assert activities[0].type == Activity.MARK_REVIEWED
+        assert activities[0].type == ActivityType.MARK_REVIEWED.value
         assert inbox_out.called
 
     def test_invalid_reason_details(self):

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -26,6 +26,7 @@ from sentry.models import (
 )
 from sentry.signals import buffer_incr_complete
 from sentry.testutils import TestCase
+from sentry.types.activity import ActivityType
 
 
 class ResolveGroupResolutionsTest(TestCase):
@@ -174,7 +175,7 @@ class ResolvedInCommitTest(TestCase):
         assert GroupAssignee.objects.filter(group=group, user=user).exists()
 
         assert Activity.objects.filter(
-            project=group.project, group=group, type=Activity.ASSIGNED, user=user
+            project=group.project, group=group, type=ActivityType.ASSIGNED.value, user=user
         )[0].data == {
             "assignee": str(user.id),
             "assigneeEmail": user.email,
@@ -207,7 +208,7 @@ class ResolvedInCommitTest(TestCase):
         self.assertResolvedFromCommit(group, commit)
 
         assert not Activity.objects.filter(
-            project=group.project, group=group, type=Activity.ASSIGNED, user=user
+            project=group.project, group=group, type=ActivityType.ASSIGNED.value, user=user
         ).exists()
 
         assert GroupSubscription.objects.filter(group=group, user=user).exists()

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -5,9 +5,11 @@ from sentry.models import Activity, Commit, GroupAssignee, GroupLink, Release, R
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.faux import faux
 
-
 # This testcase needs to be an APITestCase because all of the logic to resolve
 # Issues and kick off side effects are just chillin in the endpoint code -_-
+from sentry.types.activity import ActivityType
+
+
 @patch("sentry.tasks.sentry_apps.workflow_notification.delay")
 class TestIssueWorkflowNotifications(APITestCase):
     def setUp(self):
@@ -217,7 +219,9 @@ class TestComments(APITestCase):
         url = f"/api/0/issues/{self.issue.id}/notes/"
         data = {"text": "hello world"}
         self.client.post(url, data=data, format="json")
-        note = Activity.objects.get(group=self.issue, project=self.project, type=Activity.NOTE)
+        note = Activity.objects.get(
+            group=self.issue, project=self.project, type=ActivityType.NOTE.value
+        )
         data = {
             "comment_id": note.id,
             "timestamp": note.datetime,

--- a/tests/sentry/services/smtp_test.py
+++ b/tests/sentry/services/smtp_test.py
@@ -3,6 +3,7 @@ import os.path
 from sentry.models import Activity
 from sentry.services.smtp import STATUS, SentrySMTPServer
 from sentry.testutils import TestCase
+from sentry.types.activity import ActivityType
 from sentry.utils.email import email_to_group_id, group_id_to_email
 
 with open(os.path.join(os.path.dirname(__file__), "email.txt")) as f:
@@ -25,7 +26,9 @@ class SentrySMTPTest(TestCase):
                 self.server.process_message("", self.user.email, [self.mailto], fixture),
                 STATUS[200],
             )
-        self.assertEqual(Activity.objects.filter(type=Activity.NOTE)[0].data, {"text": "sup"})
+        self.assertEqual(
+            Activity.objects.filter(type=ActivityType.NOTE.value)[0].data, {"text": "sup"}
+        )
 
     def test_process_message_no_recipients(self):
         with self.tasks():

--- a/tests/sentry/tasks/post_process_test.py
+++ b/tests/sentry/tasks/post_process_test.py
@@ -29,6 +29,7 @@ from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
+from sentry.types.activity import ActivityType
 from sentry.utils.cache import cache
 
 
@@ -308,7 +309,7 @@ class PostProcessGroupTest(TestCase):
             group=group, reason=GroupInboxReason.UNIGNORED.value
         ).exists()
         assert Activity.objects.filter(
-            group=group, project=group.project, type=Activity.SET_UNRESOLVED
+            group=group, project=group.project, type=ActivityType.SET_UNRESOLVED.value
         ).exists()
         assert send_robust.called
 

--- a/tests/sentry/tasks/test_clear_expired_resolutions.py
+++ b/tests/sentry/tasks/test_clear_expired_resolutions.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from sentry.models import Activity, Group, GroupResolution, GroupStatus, Release
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
 from sentry.testutils import TestCase
+from sentry.types.activity import ActivityType
 
 
 class ClearExpiredResolutionsTest(TestCase):
@@ -26,7 +27,7 @@ class ClearExpiredResolutionsTest(TestCase):
         activity1 = Activity.objects.create(
             group=group1,
             project=project,
-            type=Activity.SET_RESOLVED_IN_RELEASE,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
             ident=resolution1.id,
             data={"version": ""},
         )
@@ -45,7 +46,7 @@ class ClearExpiredResolutionsTest(TestCase):
         activity2 = Activity.objects.create(
             group=group2,
             project=project,
-            type=Activity.SET_RESOLVED_IN_RELEASE,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
             ident=resolution2.id,
             data={"version": ""},
         )

--- a/tests/sentry/tasks/test_email.py
+++ b/tests/sentry/tasks/test_email.py
@@ -1,6 +1,7 @@
 from sentry.models import Activity
 from sentry.tasks.email import process_inbound_email
 from sentry.testutils import TestCase
+from sentry.types.activity import ActivityType
 
 
 class ProcessInboundEmailTest(TestCase):
@@ -12,7 +13,7 @@ class ProcessInboundEmailTest(TestCase):
 
         process_inbound_email(mailfrom=self.user.email, group_id=group.id, payload="hello world!")
 
-        activity = Activity.objects.get(group=group, type=Activity.NOTE)
+        activity = Activity.objects.get(group=group, type=ActivityType.NOTE.value)
         assert activity.user == self.user
         assert activity.data["text"] == "hello world!"
 
@@ -23,4 +24,4 @@ class ProcessInboundEmailTest(TestCase):
             mailfrom="invalid@example.com", group_id=group.id, payload="hello world!"
         )
 
-        assert not Activity.objects.filter(group=group, type=Activity.NOTE).exists()
+        assert not Activity.objects.filter(group=group, type=ActivityType.NOTE.value).exists()

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -27,6 +27,7 @@ from sentry.tasks.reprocessing2 import reprocess_group
 from sentry.tasks.store import preprocess_event
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.types.activity import ActivityType
 from sentry.utils.cache import cache_key_for_event
 
 
@@ -261,7 +262,7 @@ def test_concurrent_events_go_into_new_group(
 
     assert group.short_id == original_short_id
     assert GroupAssignee.objects.get(group=group) == original_assignee
-    activity = Activity.objects.get(group=group, type=Activity.REPROCESS)
+    activity = Activity.objects.get(group=group, type=ActivityType.REPROCESS.value)
     assert activity.ident == str(original_issue_id)
 
 

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -25,6 +25,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.helpers.faux import DictContaining, faux
+from sentry.types.activity import ActivityType
 from sentry.types.rules import RuleFuture
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
@@ -419,7 +420,7 @@ class TestCommentWebhook(TestCase):
         self.note = Activity.objects.create(
             group=self.issue,
             project=self.project,
-            type=Activity.NOTE,
+            type=ActivityType.NOTE.value,
             user=self.user,
             data={"text": "hello world"},
         )

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -50,6 +50,7 @@ from sentry.search.events.constants import (
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.types.activity import ActivityType
 from sentry.utils import json
 
 
@@ -2047,7 +2048,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == ""
         uo1.delete()
 
@@ -2112,7 +2115,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         # Ensure that Activity has `current_release_version` set on `Resolved in next release`
         activity = Activity.objects.filter(
             group=grp_resolution.group,
-            type=Activity.SET_RESOLVED_IN_RELEASE,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
             ident=grp_resolution.id,
         ).first()
 
@@ -2264,7 +2267,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         activity = Activity.objects.filter(
             group=grp_resolution.group,
-            type=Activity.SET_RESOLVED_IN_RELEASE,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
             ident=grp_resolution.id,
         ).first()
         assert activity.data["version"] == release_2.version
@@ -2333,7 +2336,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == release.version
         assert GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.SET_RESOLVED_IN_RELEASE
@@ -2372,7 +2377,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == release.version
 
     def test_in_semver_projects_set_resolved_in_explicit_release(self):
@@ -2414,7 +2421,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == release_1.version
 
         assert GroupResolution.has_resolution(group=group, release=release_2)
@@ -2449,7 +2458,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == ""
 
     def test_set_resolved_in_next_release_legacy(self):
@@ -2484,7 +2495,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group, status=GroupHistoryStatus.SET_RESOLVED_IN_RELEASE
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == ""
 
     def test_set_resolved_in_explicit_commit_unreleased(self):
@@ -2516,7 +2529,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_COMMIT)
+        activity = Activity.objects.get(group=group, type=ActivityType.SET_RESOLVED_IN_COMMIT.value)
         assert activity.data["commit"] == commit.id
         assert GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.SET_RESOLVED_IN_COMMIT
@@ -2554,7 +2567,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_COMMIT)
+        activity = Activity.objects.get(group=group, type=ActivityType.SET_RESOLVED_IN_COMMIT.value)
         assert activity.data["commit"] == commit.id
 
         resolution = GroupResolution.objects.get(group=group)
@@ -2911,7 +2924,12 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         assert not GroupAssignee.objects.filter(group=group2, user=user).exists()
 
-        assert Activity.objects.filter(group=group1, user=user, type=Activity.ASSIGNED).count() == 1
+        assert (
+            Activity.objects.filter(
+                group=group1, user=user, type=ActivityType.ASSIGNED.value
+            ).count()
+            == 1
+        )
 
         assert GroupSubscription.objects.filter(user=user, group=group1, is_active=True).exists()
 
@@ -2959,7 +2977,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert GroupHistory.objects.filter(group=group, status=GroupHistoryStatus.ASSIGNED).exists()
         assert GroupAssignee.objects.filter(group=group, team=team).exists()
 
-        assert Activity.objects.filter(group=group, type=Activity.ASSIGNED).count() == 1
+        assert Activity.objects.filter(group=group, type=ActivityType.ASSIGNED.value).count() == 1
 
         assert GroupSubscription.objects.filter(group=group, is_active=True).count() == 2
 

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -33,6 +33,7 @@ from sentry.models.groupinbox import GroupInboxReason, add_group_to_inbox
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.types.activity import ActivityType
 from sentry.utils import json
 
 
@@ -589,7 +590,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == ""
         uo1.delete()
 
@@ -661,7 +664,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == release.version
 
     def test_set_resolved_in_explicit_release(self):
@@ -699,7 +704,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == release.version
 
     def test_set_resolved_in_next_release(self):
@@ -735,7 +742,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == ""
 
     def test_set_resolved_in_next_release_legacy(self):
@@ -766,7 +775,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_RELEASE)
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
         assert activity.data["version"] == ""
 
     def test_set_resolved_in_explicit_commit_unreleased(self):
@@ -802,7 +813,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_COMMIT)
+        activity = Activity.objects.get(group=group, type=ActivityType.SET_RESOLVED_IN_COMMIT.value)
         assert activity.data["commit"] == commit.id
 
     def test_set_resolved_in_explicit_commit_released(self):
@@ -841,7 +852,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             user=self.user, group=group, is_active=True
         ).exists()
 
-        activity = Activity.objects.get(group=group, type=Activity.SET_RESOLVED_IN_COMMIT)
+        activity = Activity.objects.get(group=group, type=ActivityType.SET_RESOLVED_IN_COMMIT.value)
         assert activity.data["commit"] == commit.id
 
         resolution = GroupResolution.objects.get(group=group)
@@ -1208,7 +1219,12 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         assert not GroupAssignee.objects.filter(group=group2, user=user).exists()
 
-        assert Activity.objects.filter(group=group1, user=user, type=Activity.ASSIGNED).count() == 1
+        assert (
+            Activity.objects.filter(
+                group=group1, user=user, type=ActivityType.ASSIGNED.value
+            ).count()
+            == 1
+        )
 
         assert GroupSubscription.objects.filter(user=user, group=group1, is_active=True).exists()
 
@@ -1250,7 +1266,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert response.data["assignedTo"]["type"] == "team"
         assert GroupAssignee.objects.filter(group=group, team=team).exists()
 
-        assert Activity.objects.filter(group=group, type=Activity.ASSIGNED).count() == 1
+        assert Activity.objects.filter(group=group, type=ActivityType.ASSIGNED.value).count() == 1
 
         assert GroupSubscription.objects.filter(group=group, is_active=True).count() == 2
 


### PR DESCRIPTION
In this PR I'm trying to separate enum logic from Model logic. This breaks a lot of circular dependencies.
As a next step I'd like to adjust some methods so that we don't need to use `.value` everywhere.