### PR TITLE
feat(api): Add initial skeleton for deprecation decorator

### DIFF
--- a/src/sentry/api/helpers/deprecation.py
+++ b/src/sentry/api/helpers/deprecation.py
@@ -68,7 +68,7 @@ def deprecated(deprecation_date: datetime, suggested_api: str | None = None):
         @functools.wraps(func)
         def endpoint_method(self, request: Request, *args, **kwargs):
 
-            # Don't do anything for deprecated endpoitns on self hosted
+            # Don't do anything for deprecated endpoints on self hosted
             if is_self_hosted():
                 return func(self, request, *args, **kwargs)
 

--- a/src/sentry/api/helpers/deprecation.py
+++ b/src/sentry/api/helpers/deprecation.py
@@ -1,0 +1,62 @@
+import functools
+from datetime import datetime, timedelta
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.status import HTTP_410_GONE as GONE
+
+BROWNOUT_LENGTH = timedelta(days=30)
+GONE_MESSAGE = {"message": "This API no longer exists."}
+DEPRECATION_HEADER = "X-Sentry-Deprecation-Date"
+
+
+def _track_deprecated_metrics(request: Request, deprecation_date: datetime, now: datetime):
+    # indicate the request is on a deprecated endpoint
+    request.is_deprecated = deprecation_date >= now
+    request.deprecation_date = deprecation_date
+
+
+def _should_be_blocked(deprecation_date: datetime, now: datetime):
+    # Placeholder logic
+    # Will need to check redis if the hour fits into the brownout period
+    return now >= deprecation_date
+
+
+def _add_deprecation_headers(response: Response, deprecation_date: datetime):
+    response[DEPRECATION_HEADER] = deprecation_date.isoformat()
+
+
+def deprecated(deprecation_date: datetime):
+    """
+    Deprecation decorator that handles all the overhead related to deprecated endpoints
+
+    Usage example:
+    @deprecated(datetime.fromisoformat("2022-01-02T00:00:00Z")
+    def get(self, request):
+
+    This decorator does 3 things:
+    1) Add additional metrics to be tracked for deprecated endpoints
+    2) Add headers indicating deprecation date to requests on deprecated endpoints
+    3) Reject requests if they fall within a brownout window
+    """
+
+    now = datetime.utcnow()
+
+    def decorator(func):
+        @functools.wraps(func)
+        def endpoint_method(self, request: Request, *args, **kwargs):
+
+            _track_deprecated_metrics(request, deprecation_date, now)
+
+            if now > deprecation_date and _should_be_blocked(deprecation_date, now):
+                response = Response(GONE_MESSAGE, status=GONE)
+            else:
+                response = func(self, request, *args, **kwargs)
+
+            _add_deprecation_headers(response, deprecation_date)
+
+            return response
+
+        return endpoint_method
+
+    return decorator

--- a/tests/sentry/helpers/test_deprecation.py
+++ b/tests/sentry/helpers/test_deprecation.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+
+from django.conf.urls import url
+from django.test import override_settings
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+from sentry.api.helpers.deprecation import deprecated
+from sentry.testutils import APITestCase
+
+replacement_api = "replacement-api"
+
+
+class TestEndpoint(Endpoint):
+    permision_classes = (AllowAny,)
+
+    @deprecated(datetime.fromisoformat("2020-01-01T00:00:00Z"), suggested_api=replacement_api)
+    def get(self):
+        return Response({"ok": True})
+
+    def head(self):
+        return Response({"ok": True})
+
+
+urlpatterns = [url(r"^/testapi$", TestEndpoint.as_view(), name="deprecation-test-api")]
+
+
+@override_settings(ROOT_URLCONF="tests.sentry.helpers.test_deprecation", SENTRY_SELF_HOSTED=False)
+class TestDeprecationDecorator(APITestCase):
+
+    endpoint = "deprecation-test-api"
+
+    def has_ratelimit_meta(self):
+        pass
+
+    def assert_allowed_request(self):
+        pass
+
+    def assert_denied_request(self):
+        pass
+
+    def test_before_deprecation_date(self):
+        pass
+
+    def test_after_deprecation_date(self):
+        pass
+
+    def test_self_hosted(self):
+        pass
+
+    def test_no_header(self):
+        pass

--- a/tests/sentry/helpers/test_deprecation.py
+++ b/tests/sentry/helpers/test_deprecation.py
@@ -16,8 +16,7 @@ test_date = datetime.fromisoformat("2020-01-01T00:00:00+00:00:00")
 timeiter = croniter("* 12 * * *", test_date)
 
 
-class TestEndpoint(Endpoint):
-    __test__ = False
+class DummyEndpoint(Endpoint):
     permision_classes = ()
 
     @deprecated(test_date, suggested_api=replacement_api)
@@ -28,7 +27,7 @@ class TestEndpoint(Endpoint):
         return Response({"ok": True})
 
 
-test_endpoint = TestEndpoint.as_view()
+dummy_endpoint = DummyEndpoint.as_view()
 
 
 class TestDeprecationDecorator(APITestCase):
@@ -44,7 +43,7 @@ class TestDeprecationDecorator(APITestCase):
 
     def assert_not_deprecated(self, method):
         request = self.make_request(method=method)
-        resp = test_endpoint(request)
+        resp = dummy_endpoint(request)
         assert resp.status_code == HTTP_200_OK
         assert not hasattr(request, "is_deprecated")
         assert not hasattr(request, "deprecation_date")
@@ -54,14 +53,14 @@ class TestDeprecationDecorator(APITestCase):
     def assert_allowed_request(self, method):
         request = self.make_request(method=method)
         request.META["HTTP_ORIGIN"] = "http://example.com"
-        resp = test_endpoint(request)
+        resp = dummy_endpoint(request)
         resp.render()
         assert resp.status_code == HTTP_200_OK
         self.assert_deprecation_metadata(request, resp)
 
     def assert_denied_request(self, method):
         request = self.make_request(method=method)
-        resp = test_endpoint(request)
+        resp = dummy_endpoint(request)
         assert resp.status_code == HTTP_410_GONE
         assert resp.data == {"message": "This API no longer exists."}
         self.assert_deprecation_metadata(request, resp)


### PR DESCRIPTION
The decorator will eventually handle all the overhead for a deprecated endpoint including
* Metric tracking
* Brownout
* Deprecation Headers

Later PRs will introduce crontab logic for brownout periods and unit tests
