### PR TITLE
feat(workflow): Add name of team and member to notifications sent to in Alert Details

### DIFF
--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -21,7 +21,7 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {DateString, Organization, Project} from 'sentry/types';
+import {DateString, Member, Organization, Project} from 'sentry/types';
 import {IssueAlertRule} from 'sentry/types/alerts';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {ALERT_DEFAULT_CHART_PERIOD} from 'sentry/views/alerts/rules/metric/details/constants';
@@ -36,6 +36,7 @@ type Props = AsyncComponent['props'] & {
 } & RouteComponentProps<{orgId: string; projectId: string; ruleId: string}, {}>;
 
 type State = AsyncComponent['state'] & {
+  memberList: Member[];
   rule: IssueAlertRule | null;
 };
 
@@ -75,6 +76,7 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
     return {
       ...super.getDefaultState(),
       rule: null,
+      memberList: [],
     };
   }
 
@@ -85,6 +87,11 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
         'rule',
         `/projects/${orgId}/${projectId}/rules/${ruleId}/`,
         {query: {expand: 'lastTriggered'}},
+      ],
+      [
+        'memberList',
+        `/organizations/${orgId}/users/`,
+        {query: {project: this.props.project.id}},
       ],
     ];
   }
@@ -186,7 +193,7 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
     const {orgId, ruleId, projectId} = params;
     const {cursor} = location.query;
     const {period, start, end, utc} = this.getDataDatetime();
-    const {rule} = this.state;
+    const {rule, memberList} = this.state;
 
     if (!rule) {
       return <LoadingError message={t('There was an error loading the alert rule.')} />;
@@ -291,7 +298,7 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
             />
           </Layout.Main>
           <Layout.Side>
-            <Sidebar rule={rule} />
+            <Sidebar rule={rule} memberList={memberList} teams={project.teams} />
           </Layout.Side>
         </Layout.Body>
       </PageFiltersContainer>

--- a/static/app/views/alerts/rules/issue/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/issue/details/sidebar.tsx
@@ -42,11 +42,11 @@ class Sidebar extends PureComponent<Props> {
           const user = memberList.find(
             member => member.user.id === `${action.targetIdentifier}`
           );
-          name = t(`Send a notification to ${user?.email}`);
+          name = t('Send a notification to %s', user?.email);
         }
         if (action.targetType === 'Team') {
           const team = teams.find(tm => tm.id === `${action.targetIdentifier}`);
-          name = t(`Send a notification to #${team?.name}`);
+          name = t('Send a notification to #%s', team?.name);
         }
         if (
           action.id === 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction'

--- a/static/app/views/alerts/rules/issue/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/issue/details/sidebar.tsx
@@ -10,16 +10,19 @@ import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
-import {Actor} from 'sentry/types';
+import {Actor, Member, Team} from 'sentry/types';
 import {IssueAlertRule} from 'sentry/types/alerts';
 
 type Props = {
+  memberList: Member[];
   rule: IssueAlertRule;
+  teams: Team[];
 };
 
 class Sidebar extends PureComponent<Props> {
   renderConditions() {
-    const {rule} = this.props;
+    const {rule, memberList, teams} = this.props;
+
     const conditions = rule.conditions.length
       ? rule.conditions.map(condition => (
           <ConditionsBadge key={condition.id}>{condition.name}</ConditionsBadge>
@@ -35,6 +38,16 @@ class Sidebar extends PureComponent<Props> {
     const actions = rule.actions.length ? (
       rule.actions.map(action => {
         let name = action.name;
+        if (action.targetType === 'Member') {
+          const user = memberList.find(
+            member => member.user.id === `${action.targetIdentifier}`
+          );
+          name = t(`Send a notification to ${user?.email}`);
+        }
+        if (action.targetType === 'Team') {
+          const team = teams.find(tm => tm.id === `${action.targetIdentifier}`);
+          name = t(`Send a notification to #${team?.name}`);
+        }
         if (
           action.id === 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction'
         ) {

--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -66,9 +66,15 @@ describe('AlertRuleDetails', () => {
           '<https://sentry.io/api/0/projects/org-slug/project-slug/rules/1/group-history/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"',
       },
     });
+
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/projects/`,
       body: [project],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
     });
 
     ProjectsStore.init();


### PR DESCRIPTION
Add the name of the team and member email to the Alert Details page under 'perform these actions' conditions. Previously, this only displayed 'Team' or 'Member'.

[FIXES WOR-1872
](https://getsentry.atlassian.net/browse/WOR-1872)

# Before
<img width="273" alt="Screen Shot 2022-05-25 at 1 17 04 AM" src="https://user-images.githubusercontent.com/20312973/170225250-861242cb-96b7-4ac0-a7e2-1a402303801d.png">

# After
<img width="268" alt="Screen Shot 2022-05-25 at 1 54 51 AM" src="https://user-images.githubusercontent.com/20312973/170225276-b0b91e60-8c5a-48d6-880d-e71e4f8fa394.png">

