### PR TITLE
feat(replays): Adjust player with to prevent black-bars above/below

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -28,6 +28,7 @@ function BasePlayerRoot({className, height = Infinity}: Props) {
     width: 0,
     height: 0,
   });
+  const [actualHeight, setActualHeight] = useState(height);
 
   // Create the `rrweb` instance which creates an iframe inside `viewEl`
   useEffect(() => initRoot(viewEl.current), [initRoot]);
@@ -57,12 +58,15 @@ function BasePlayerRoot({className, height = Infinity}: Props) {
     if (viewEl.current) {
       const windowHeight = height === Infinity ? windowDimensions.height : height;
 
-      const scale = Math.min(
-        windowDimensions.width / videoDimensions.width,
-        windowHeight / videoDimensions.height,
-        1
-      );
+      const scaleWidth = windowDimensions.width / videoDimensions.width;
+      const scaleHeight = windowHeight / videoDimensions.height;
+      const scale = Math.min(scaleWidth, scaleHeight, 1);
       if (scale) {
+        const isConstrainedByWidth = scale === scaleWidth;
+        if (isConstrainedByWidth) {
+          // Adjust the height so we don't get 'black bars' above/below the video
+          setActualHeight(videoDimensions.height * scale);
+        }
         viewEl.current.style['transform-origin'] = 'top left';
         viewEl.current.style.transform = `scale(${scale})`;
         viewEl.current.style.width = `${videoDimensions.width * scale}px`;
@@ -72,7 +76,7 @@ function BasePlayerRoot({className, height = Infinity}: Props) {
   }, [windowDimensions, videoDimensions, height]);
 
   return (
-    <SizingWindow ref={windowEl} className="sr-block" minHeight={height}>
+    <SizingWindow ref={windowEl} className="sr-block" minHeight={actualHeight || height}>
       <div ref={viewEl} className={className} />
       {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
       {isBuffering ? <PositionedBuffering /> : null}


### PR DESCRIPTION
Update the player sizing to remove black-bars from the top/bottom of the video when the video is landscape

When loading the page, the video area is always set to the same height, just enough so that 1/2 the timeline is visible:
<img width="1393" alt="Screen Shot 2022-05-25 at 9 07 27 PM" src="https://user-images.githubusercontent.com/187460/170275768-32246d73-64fd-4911-bceb-4b4592cfa874.png">

After the page is loaded, there are two things that can happen:
1. If the video is portrait orientation (more tall, not as wide) then the player area will stay the same size (1/2 the timeline visible) and you get bars on the size:
<img width="1604" alt="Screen Shot 2022-05-25 at 9 38 44 PM" src="https://user-images.githubusercontent.com/187460/170276097-dbf7f4a1-4ee0-4f7e-ad3b-786ad7de4384.png">

2. BUT if the video is landscape orientation (more wide, not as tall) then the player area will get shorter, removing black bars:
<img width="1393" alt="Screen Shot 2022-05-25 at 9 07 23 PM" src="https://user-images.githubusercontent.com/187460/170276240-6150cf75-fea5-482c-a67c-e2e40760620f.png">


I noticed there are still issues with resizing the page afterwards 