### PR TITLE
ref(ui-word): Replace data set with dataset

### DIFF
--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -124,7 +124,7 @@ type EventsRequestPartialProps = {
    */
   confirmedQuery?: boolean;
   /**
-   * Name used for display current series data set tooltip
+   * Name used for display current series dataset tooltip
    */
   currentSeriesNames?: string[];
   /**
@@ -333,7 +333,7 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
   };
 
   /**
-   * Retrieves data set for the current period (since data can potentially
+   * Retrieves dataset for the current period (since data can potentially
    * contain previous period's data), as well as the previous period if
    * possible.
    *

--- a/static/app/components/charts/transitionChart.tsx
+++ b/static/app/components/charts/transitionChart.tsx
@@ -32,7 +32,7 @@ class TransitionChart extends Component<Props, State> {
     // - reloading (also called pending in other apps)
     //
     // This component remounts the chart to ensure the stable transition
-    // from one data set to the next.
+    // from one dataset to the next.
 
     const prevReloading = state.prevReloading;
     const nextReloading = props.reloading;

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -877,7 +877,7 @@ class AddDashboardWidgetModal extends Component<Props, State> {
           </DoubleFieldWrapper>
           {(showIssueDatasetSelector || showMetricsDatasetSelector) && (
             <Fragment>
-              <StyledFieldLabel>{t('Data Set')}</StyledFieldLabel>
+              <StyledFieldLabel>{t('Dataset')}</StyledFieldLabel>
               <StyledRadioGroup
                 style={{flex: 1}}
                 choices={datasetChoices}

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -483,7 +483,7 @@ class MetricChart extends PureComponent<Props, State> {
     }
 
     // If the chart duration isn't as long as the rollup duration the events-stats
-    // endpoint will return an invalid timeseriesData data set
+    // endpoint will return an invalid timeseriesData dataset
     const viableStartDate = getUtcDateString(
       moment.min(
         moment.utc(timePeriod.start),

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -33,14 +33,14 @@ export function DataSetStep({
   if (displayType !== DisplayType.TABLE) {
     disabledChoices.push([
       DataSet.ISSUES,
-      t('This data set is restricted to tabular visualization.'),
+      t('This dataset is restricted to tabular visualization.'),
     ]);
 
     if (displayType === DisplayType.WORLD_MAP) {
       disabledChoices.push([
         DataSet.RELEASES,
         t(
-          'This data set is restricted to big number, tabular and time series visualizations.'
+          'This dataset is restricted to big number, tabular and time series visualizations.'
         ),
       ]);
     }
@@ -48,7 +48,7 @@ export function DataSetStep({
 
   return (
     <BuildStep
-      title={t('Choose your data set')}
+      title={t('Choose your dataset')}
       description={tct(
         `This reflects the type of information you want to use. To learn more, [link: read the docs].`,
         {

--- a/static/app/views/performance/landing/samplingModal.tsx
+++ b/static/app/views/performance/landing/samplingModal.tsx
@@ -40,7 +40,7 @@ const SamplingModal = (props: Props) => {
       <Body>
         <Instruction>
           {tct(
-            "The visualizations shown are based on your data without any filters or sampling. This does not contribute to your quota usage but transaction details are limited. If you'd like to improve accuracy, we recommend adding more transactions to your quota. or modifying your data set through [projectSettings: Filters & Sampling in settings].",
+            "The visualizations shown are based on your data without any filters or sampling. This does not contribute to your quota usage but transaction details are limited. If you'd like to improve accuracy, we recommend adding more transactions to your quota. or modifying your dataset through [projectSettings: Filters & Sampling in settings].",
             {
               projectSettings: (
                 <Link

--- a/tests/js/spec/components/helpSearch.spec.jsx
+++ b/tests/js/spec/components/helpSearch.spec.jsx
@@ -40,7 +40,7 @@ const mockResults = [
         url: 'https://develop.sentry.dev/services/digests/',
         context: {context1: 'Services > Digests'},
         title: 'Notification Digests',
-        text: '… operation, especially on large data sets. Backends <mark>Dumm</mark>y Backend The <mark>dumm</mark>y backend disables digest scheduling …',
+        text: '… operation, especially on large datasets. Backends <mark>Dumm</mark>y Backend The <mark>dumm</mark>y backend disables digest scheduling …',
       },
     ],
   },

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -1239,7 +1239,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       await tick();
       userEvent.click(screen.getByText('Table'));
       userEvent.click(screen.getByText('Line Chart'));
-      expect(screen.queryByText('Data Set')).not.toBeInTheDocument();
+      expect(screen.queryByText('Dataset')).not.toBeInTheDocument();
       wrapper.unmount();
     });
 
@@ -1254,7 +1254,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
 
       expect(metricsDataMock).not.toHaveBeenCalled();
 
-      expect(screen.getByText('Data Set')).toBeInTheDocument();
+      expect(screen.getByText('Dataset')).toBeInTheDocument();
       expect(
         screen.getByText('All Events (Errors and Transactions)')
       ).toBeInTheDocument();
@@ -1313,7 +1313,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
         source: types.DashboardWidgetSource.DASHBOARDS,
       });
 
-      expect(await screen.findByText('Data Set')).toBeInTheDocument();
+      expect(await screen.findByText('Dataset')).toBeInTheDocument();
 
       expect(
         screen.getByText('All Events (Errors and Transactions)')
@@ -1547,7 +1547,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
         await screen.findByRole('heading', {name: 'Add Widget'})
       ).toBeInTheDocument();
 
-      // change data set to metrics
+      // change dataset to metrics
       userEvent.click(screen.getByLabelText(/release/i));
 
       // open visualization select

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -324,7 +324,7 @@ describe('WidgetBuilder', function () {
 
     // Content - Step 1
     expect(
-      screen.getByRole('heading', {name: 'Choose your data set'})
+      screen.getByRole('heading', {name: 'Choose your dataset'})
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Select Errors and Transactions')).toBeChecked();
 
@@ -394,7 +394,7 @@ describe('WidgetBuilder', function () {
 
     // Content - Step 1
     expect(
-      screen.getByRole('heading', {name: 'Choose your data set'})
+      screen.getByRole('heading', {name: 'Choose your dataset'})
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Select Errors and Transactions')).toBeChecked();
 
@@ -2240,7 +2240,7 @@ describe('WidgetBuilder', function () {
       expect(handleSave).toHaveBeenCalledTimes(1);
     });
 
-    it('render issues data set disabled when the display type is not set to table', async function () {
+    it('render issues dataset disabled when the display type is not set to table', async function () {
       renderTestComponent({
         query: {
           source: DashboardWidgetSource.DISCOVERV2,
@@ -2345,7 +2345,7 @@ describe('WidgetBuilder', function () {
       'dashboards-releases',
     ];
 
-    it('does not show the Release Health data set if there is no dashboards-releases flag', async function () {
+    it('does not show the Release Health dataset if there is no dashboards-releases flag', async function () {
       renderTestComponent({
         orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
       });
@@ -2356,7 +2356,7 @@ describe('WidgetBuilder', function () {
       ).not.toBeInTheDocument();
     });
 
-    it('shows the Release Health data set if there is the dashboards-releases flag', async function () {
+    it('shows the Release Health dataset if there is the dashboards-releases flag', async function () {
       renderTestComponent({
         orgFeatures: releaseHealthFeatureFlags,
       });
@@ -2561,7 +2561,7 @@ describe('WidgetBuilder', function () {
         await screen.findByText('Releases (sessions, crash rates)')
       ).toBeInTheDocument();
 
-      // change data set to releases
+      // change dataset to releases
       userEvent.click(screen.getByLabelText(/releases/i));
 
       userEvent.click(screen.getByText('Table'));
@@ -2632,7 +2632,7 @@ describe('WidgetBuilder', function () {
       );
     });
 
-    it('render release data set disabled when the display type is world map', async function () {
+    it('render release dataset disabled when the display type is world map', async function () {
       renderTestComponent({
         query: {
           source: DashboardWidgetSource.DISCOVERV2,


### PR DESCRIPTION
Dataset and Data set are both valid words, but since dataset (the together version) is way more used (please see the screenshot below) than data set, after an internal discussion we decided to replace the word with the most common version.

<img width="1590" alt="image" src="https://user-images.githubusercontent.com/29228205/170274834-4c70c7dc-5c93-4853-b388-46d2949c070a.png">

cc @imatwawana