### PR TITLE
feat(profiling): add virtualized tree and node

### DIFF
--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
@@ -9,7 +9,7 @@ export class VirtualizedTree<T extends TreeLike> {
 
   constructor(roots: VirtualizedTreeNode<T>[], flattenedList?: VirtualizedTreeNode<T>[]) {
     this.roots = roots;
-    this.flattened = flattenedList || this.toExpandedList();
+    this.flattened = flattenedList || VirtualizedTree.toExpandedList(this.roots);
   }
 
   // Rebuilds the tree
@@ -38,6 +38,31 @@ export class VirtualizedTree<T extends TreeLike> {
     }
 
     return new VirtualizedTree<T>(roots);
+  }
+
+  // Returns a list of nodes that are visible in the tree.
+  static toExpandedList<T extends TreeLike>(
+    nodes: VirtualizedTreeNode<T>[]
+  ): VirtualizedTreeNode<T>[] {
+    const list: VirtualizedTreeNode<T>[] = [];
+
+    function visit(node: VirtualizedTreeNode<T>): void {
+      list.push(node);
+
+      if (!node.expanded) {
+        return;
+      }
+
+      for (let i = 0; i < node.children.length; i++) {
+        visit(node.children[i]);
+      }
+    }
+
+    for (let i = 0; i < nodes.length; i++) {
+      visit(nodes[i]);
+    }
+
+    return list;
   }
 
   expandNode(
@@ -83,29 +108,6 @@ export class VirtualizedTree<T extends TreeLike> {
       visit(sortedRoots[i]);
     }
 
-    this.flattened = this.toExpandedList();
-  }
-
-  // Returns a list of nodes that are visible in the tree.
-  toExpandedList(): VirtualizedTreeNode<T>[] {
-    const list: VirtualizedTreeNode<T>[] = [];
-
-    function visit(node: VirtualizedTreeNode<T>): void {
-      list.push(node);
-
-      if (!node.expanded) {
-        return;
-      }
-
-      for (let i = 0; i < node.children.length; i++) {
-        visit(node.children[i]);
-      }
-    }
-
-    for (let i = 0; i < this.roots.length; i++) {
-      visit(this.roots[i]);
-    }
-
-    return list;
+    this.flattened = VirtualizedTree.toExpandedList(this.roots);
   }
 }

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
@@ -1,0 +1,111 @@
+import {VirtualizedTreeNode} from './VirtualizedTreeNode';
+
+interface TreeLike {
+  children: TreeLike[];
+}
+export class VirtualizedTree<T extends TreeLike> {
+  roots: VirtualizedTreeNode<T>[] = [];
+  flattened: VirtualizedTreeNode<T>[] = [];
+
+  constructor(roots: VirtualizedTreeNode<T>[], flattenedList?: VirtualizedTreeNode<T>[]) {
+    this.roots = roots;
+    this.flattened = flattenedList || this.toExpandedList();
+  }
+
+  // Rebuilds the tree
+  static fromRoots<T extends TreeLike>(items: T[]): VirtualizedTree<T> {
+    const roots: VirtualizedTreeNode<T>[] = [];
+
+    function toTreeNode(
+      node: T,
+      parent: VirtualizedTreeNode<T> | null,
+      collection: VirtualizedTreeNode<T>[] | null,
+      depth: number
+    ) {
+      const treeNode = new VirtualizedTreeNode<T>(node, parent, depth);
+
+      if (collection) {
+        collection.push(treeNode);
+      }
+
+      for (let i = 0; i < node.children.length; i++) {
+        toTreeNode(node.children[i] as T, treeNode, treeNode.children, depth + 1);
+      }
+    }
+
+    for (let i = 0; i < items.length; i++) {
+      toTreeNode(items[i], null, roots, 0);
+    }
+
+    return new VirtualizedTree<T>(roots);
+  }
+
+  expandNode(
+    node: VirtualizedTreeNode<T>,
+    value: boolean,
+    opts?: {expandChildren: boolean}
+  ) {
+    // Because node.setExpanded handles toggling the node and all it's children, we still need to update the
+    // flattened list. To do that w/o having to rebuild the entire tree, we can just remove the node and add them
+    const removedOrAddedNodes = node.setExpanded(value, opts);
+
+    // If toggling the node resulted in no changes to the actual tree, do nothing
+    if (!removedOrAddedNodes.length) {
+      return removedOrAddedNodes;
+    }
+
+    // If a node was expanded, we need to add all of its children to the flattened list.
+    if (node.expanded) {
+      this.flattened.splice(this.flattened.indexOf(node) + 1, 0, ...removedOrAddedNodes);
+    } else {
+      // If a node was collapsed, we need to remove all of its children from the flattened list.
+      this.flattened.splice(this.flattened.indexOf(node) + 1, removedOrAddedNodes.length);
+    }
+
+    return removedOrAddedNodes;
+  }
+
+  // Sorts the entire tree and rebuilds the flattened list.
+  sort(sortFn: (a: VirtualizedTreeNode<T>, b: VirtualizedTreeNode<T>) => number) {
+    if (!this.roots.length) {
+      return;
+    }
+
+    function visit(node: VirtualizedTreeNode<T>) {
+      const sortedChildren = node.children.sort(sortFn);
+      for (let i = 0; i < sortedChildren.length; i++) {
+        visit(sortedChildren[i]);
+      }
+    }
+
+    const sortedRoots = this.roots.sort(sortFn);
+    for (let i = 0; i < sortedRoots.length; i++) {
+      visit(sortedRoots[i]);
+    }
+
+    this.flattened = this.toExpandedList();
+  }
+
+  // Returns a list of nodes that are visible in the tree.
+  toExpandedList(): VirtualizedTreeNode<T>[] {
+    const list: VirtualizedTreeNode<T>[] = [];
+
+    function visit(node: VirtualizedTreeNode<T>): void {
+      list.push(node);
+
+      if (!node.expanded) {
+        return;
+      }
+
+      for (let i = 0; i < node.children.length; i++) {
+        visit(node.children[i]);
+      }
+    }
+
+    for (let i = 0; i < this.roots.length; i++) {
+      visit(this.roots[i]);
+    }
+
+    return list;
+  }
+}

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
@@ -43,29 +43,6 @@ export class VirtualizedTreeNode<T> {
     return count;
   }
 
-  // Returns a list of nodes that are visible in the tree.
-  toExpandedList(): VirtualizedTreeNode<T>[] {
-    const list: VirtualizedTreeNode<T>[] = [];
-
-    function visit(node: VirtualizedTreeNode<T>): void {
-      list.push(node);
-
-      if (!node.expanded) {
-        return;
-      }
-
-      for (let i = 0; i < node.children.length; i++) {
-        visit(node.children[i]);
-      }
-    }
-
-    for (let i = 0; i < this.children.length; i++) {
-      visit(this.children[i]);
-    }
-
-    return list;
-  }
-
   setExpanded(value: boolean, opts?: {expandChildren: boolean}) {
     if (value === this.expanded) {
       return [];

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
@@ -1,0 +1,109 @@
+export class VirtualizedTreeNode<T> {
+  node: T;
+  parent: VirtualizedTreeNode<T> | null;
+  children: VirtualizedTreeNode<T>[];
+  expanded: boolean;
+  depth: number;
+
+  constructor(
+    node: T,
+    parent: VirtualizedTreeNode<T> | null,
+    depth: number,
+    expanded?: boolean
+  ) {
+    this.node = node;
+    this.parent = parent;
+    this.expanded = expanded ?? false;
+    this.children = [];
+    this.depth = depth;
+  }
+
+  getVisibleChildrenCount(): number {
+    if (!this.expanded || !this.children.length) {
+      return 0;
+    }
+
+    let count = 0;
+    const queue = [...this.children];
+
+    while (queue.length > 0) {
+      const next = queue.pop();
+      if (next === undefined) {
+        throw new Error('Undefined queue node, this should never happen');
+      }
+
+      if (next.expanded) {
+        for (let i = 0; i < next.children.length; i++) {
+          queue.push(next.children[i]);
+        }
+      }
+      count++;
+    }
+
+    return count;
+  }
+
+  // Returns a list of nodes that are visible in the tree.
+  toExpandedList(): VirtualizedTreeNode<T>[] {
+    const list: VirtualizedTreeNode<T>[] = [];
+
+    function visit(node: VirtualizedTreeNode<T>): void {
+      list.push(node);
+
+      if (!node.expanded) {
+        return;
+      }
+
+      for (let i = 0; i < node.children.length; i++) {
+        visit(node.children[i]);
+      }
+    }
+
+    for (let i = 0; i < this.children.length; i++) {
+      visit(this.children[i]);
+    }
+
+    return list;
+  }
+
+  setExpanded(value: boolean, opts?: {expandChildren: boolean}) {
+    if (value === this.expanded) {
+      return [];
+    }
+
+    // We are closing a node, so we need to remove all of its children. To do that, we just get the
+    // count of visible children and return it.
+    if (!value) {
+      const removedCount = this.getVisibleChildrenCount();
+      this.expanded = value;
+      return new Array(removedCount);
+    }
+
+    // If we are opening a node, we need to add all of its children to the list and insert it
+    this.expanded = value;
+
+    // Collect the newly visible children.
+    const list: VirtualizedTreeNode<T>[] = [];
+    function visit(node: VirtualizedTreeNode<T>): void {
+      if (opts?.expandChildren) {
+        node.expanded = true;
+      }
+
+      list.push(node);
+
+      if (!node.expanded) {
+        return;
+      }
+
+      for (let i = 0; i < node.children.length; i++) {
+        visit(node.children[i]);
+      }
+    }
+
+    for (let i = 0; i < this.children.length; i++) {
+      visit(this.children[i]);
+    }
+
+    return list;
+  }
+}

--- a/tests/js/spec/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.spec.tsx
+++ b/tests/js/spec/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.spec.tsx
@@ -67,7 +67,9 @@ describe('VirtualizedTree', () => {
       const tree = VirtualizedTree.fromRoots([root]);
 
       tree.roots[0].setExpanded(false);
-      expect(tree.toExpandedList().map(i => i.node.id)).toEqual(['root']);
+      expect(VirtualizedTree.toExpandedList(tree.roots).map(i => i.node.id)).toEqual([
+        'root',
+      ]);
     });
   });
 

--- a/tests/js/spec/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.spec.tsx
+++ b/tests/js/spec/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.spec.tsx
@@ -1,0 +1,94 @@
+import {VirtualizedTree} from 'sentry/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree';
+import {VirtualizedTreeNode} from 'sentry/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode';
+
+const n = d => {
+  return {...d, children: []};
+};
+
+function toFlattenedList(tree: VirtualizedTree<any>): VirtualizedTreeNode<any>[] {
+  const list: VirtualizedTreeNode<any>[] = [];
+
+  function visit(node: VirtualizedTreeNode<any>): void {
+    list.push(node);
+
+    for (let i = 0; i < node.children.length; i++) {
+      visit(node.children[i]);
+    }
+  }
+
+  for (let i = 0; i < tree.roots.length; i++) {
+    visit(tree.roots[i]);
+  }
+
+  return list;
+}
+
+describe('VirtualizedTree', () => {
+  describe('expandNode', () => {
+    it('expands a closed node', () => {
+      const root = n({id: 'root'});
+      const child1 = n({id: 'child1'});
+      root.children = [child1];
+
+      const tree = VirtualizedTree.fromRoots([root]);
+      const addedNodes = tree.expandNode(tree.roots[0], true);
+
+      expect(addedNodes.length).toBe(1);
+
+      expect(tree.flattened[1]).toBe(tree.roots[0].children[0]);
+      expect(tree.flattened).toHaveLength(2);
+    });
+
+    it('closes a expanded node', () => {
+      const root = n({id: 'root'});
+      const child1 = n({id: 'child1'});
+      root.children = [child1];
+
+      const tree = VirtualizedTree.fromRoots([root]);
+
+      // Expand all
+      tree.expandNode(tree.roots[0], true, {expandChildren: true});
+
+      // Close root
+      const removedNodes = tree.expandNode(tree.roots[0], false);
+      expect(removedNodes.length).toBe(1);
+
+      expect(tree.flattened[0]).toBe(tree.roots[0]);
+      expect(tree.flattened).toHaveLength(1);
+    });
+  });
+
+  describe('toExpandedList', () => {
+    it('skips non-expanded nodes', () => {
+      const root = n({id: 'root'});
+      const child1 = n({id: 'child1'});
+
+      root.children = [child1];
+      const tree = VirtualizedTree.fromRoots([root]);
+
+      tree.roots[0].setExpanded(false);
+      expect(tree.toExpandedList().map(i => i.node.id)).toEqual(['root']);
+    });
+  });
+
+  describe('sort', () => {
+    it('sorts the tree at each level', () => {
+      const root = n({id: 'root', weight: 3});
+      const child1 = n({id: 'child1', weight: 1});
+      const child2 = n({id: 'child2', weight: 2});
+
+      root.children = [child1, child2];
+
+      const tree = VirtualizedTree.fromRoots([root]);
+      tree.sort((a, b) => {
+        return b.node.weight - a.node.weight;
+      });
+
+      expect(toFlattenedList(tree).map(i => i.node.id)).toEqual([
+        'root',
+        'child2',
+        'child1',
+      ]);
+    });
+  });
+});

--- a/tests/js/spec/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.spec.tsx
+++ b/tests/js/spec/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.spec.tsx
@@ -1,0 +1,54 @@
+import {VirtualizedTreeNode} from 'sentry/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode';
+
+describe('VirtualizedTreeNode', () => {
+  describe('getVisibleChildrenCount', () => {
+    it('should return 0 if the node is not expanded', () => {
+      const root = new VirtualizedTreeNode({id: 0}, null, 0);
+      const child_1 = new VirtualizedTreeNode({id: 1}, root, 1);
+      const child_2 = new VirtualizedTreeNode({id: 2}, root, 1);
+
+      root.children = [child_1, child_2];
+      expect(root.getVisibleChildrenCount()).toBe(0);
+    });
+
+    it('should return children count if the root is expanded', () => {
+      const root = new VirtualizedTreeNode({id: 0}, null, 0);
+      const child_1 = new VirtualizedTreeNode({id: 1}, root, 1);
+      const child_2 = new VirtualizedTreeNode({id: 2}, root, 1);
+
+      root.children = [child_1];
+      child_1.children = [child_2];
+
+      root.setExpanded(true);
+      expect(root.getVisibleChildrenCount()).toBe(1);
+      child_1.setExpanded(true);
+      expect(root.getVisibleChildrenCount()).toBe(2);
+    });
+  });
+
+  describe('setExpanded', () => {
+    it('expands node', () => {
+      const root = new VirtualizedTreeNode({id: 0}, null, 0);
+      const child_1 = new VirtualizedTreeNode({id: 1}, root, 1);
+
+      root.children = [child_1];
+
+      root.setExpanded(true, {expandChildren: false});
+      expect(root.expanded).toBe(true);
+      expect(child_1.expanded).toBe(false);
+    });
+    it('expands all children', () => {
+      const root = new VirtualizedTreeNode({id: 0}, null, 0);
+      const child_1 = new VirtualizedTreeNode({id: 1}, root, 1);
+      const child_2 = new VirtualizedTreeNode({id: 2}, root, 1);
+
+      root.children = [child_1];
+      child_1.children = [child_2];
+
+      root.setExpanded(true, {expandChildren: true});
+      expect(root.expanded).toBe(true);
+      expect(child_1.expanded).toBe(true);
+      expect(child_2.expanded).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Adds VirtualizedTree and VirtualizedTreeNode implementations. VirtualizedTree handles the tree operations and its flattened representation for virtualization while the VirtualizedTreeNode handles storing the node data + expanded state. The idea behind VirtualizedTree is to have efficient expand/collapse operation without having to rebuild the entire tree, to do that we splice the flattened representation by either inserting new nodes or removing the non visible ones.