### PR TITLE
feat(span-tree): Don't move tree when collapsing/expanding groups

### DIFF
--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -188,6 +188,9 @@ export class Provider extends Component<Props, State> {
     if (spanBarDOM) {
       this.syncVirtualScrollbar(spanBarDOM);
     }
+
+    const left = this.spansInView.getScrollVal();
+    this.performScroll(left);
   };
 
   syncVirtualScrollbar = (spanBar: HTMLDivElement) => {


### PR DESCRIPTION
Previously, if you click to expand/collapse a span's children, or expand/collapse an autogroup, the entire span tree's left positioning would get reset. In my opinion this behaviour was quite annoying, so this PR adds a quick fix that recalculate's the left positioning of the spans and applies them on re-initialization of the tree. This way, the tree will stay at its current position instead of resetting.


