### PR TITLE
feat(discover): Handle invalid team ids on the events endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import InvalidParams
 from sentry.search.events.fields import is_function
 from sentry.snuba import discover, metrics_enhanced_performance
 
@@ -54,6 +55,8 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
             params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response([])
+        except InvalidParams as err:
+            raise ParseError(err)
 
         referrer = request.GET.get("referrer")
         use_metrics = features.has(
@@ -135,6 +138,8 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response([])
+        except InvalidParams as err:
+            raise ParseError(err)
 
         referrer = request.GET.get("referrer")
         use_metrics = features.has(

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1,3 +1,4 @@
+import math
 from base64 import b64encode
 from unittest import mock
 
@@ -523,6 +524,13 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 403, response.content
 
         assert response.data["detail"] == "You do not have permission to perform this action."
+
+    def test_team_is_nan(self):
+        query = {"field": ["id"], "project": [self.project.id], "team": [math.nan]}
+        response = self.do_request(query)
+        assert response.status_code == 400, response.content
+
+        assert response.data["detail"] == "Invalid Team ID: nan"
 
     def test_comparison_operators_on_numeric_field(self):
         project = self.create_project()
@@ -6453,6 +6461,13 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 403, response.content
 
         assert response.data["detail"] == "You do not have permission to perform this action."
+
+    def test_team_is_nan(self):
+        query = {"field": ["id"], "project": [self.project.id], "team": [math.nan]}
+        response = self.do_request(query)
+        assert response.status_code == 400, response.content
+
+        assert response.data["detail"] == "Invalid Team ID: nan"
 
     def test_comparison_operators_on_numeric_field(self):
         project = self.create_project()


### PR DESCRIPTION
- This handles invalid team ids like NaN on the events endpoint so we
  send a bad request back instead of 500ing