### PR TITLE
fix(discover): filters out invalid teams from location

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -239,7 +239,9 @@ const decodeTeams = (location: Location): ('myteams' | number)[] => {
     return [];
   }
   const value = location.query.team;
-  return Array.isArray(value) ? value.map(decodeTeam) : [decodeTeam(value)];
+  return (Array.isArray(value) ? value.map(decodeTeam) : [decodeTeam(value)]).filter(
+    team => team === 'myteams' || !isNaN(team)
+  );
 };
 
 const decodeProjects = (location: Location): number[] => {

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -998,6 +998,19 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       display: 'previous',
     });
   });
+
+  it('filters out invalid teams', function () {
+    const eventView = EventView.fromSavedQueryOrLocation(undefined, {
+      query: {
+        statsPeriod: '14d',
+        project: ['123'],
+        team: ['myteams', '1', 'unassigned'],
+        environment: ['staging'],
+      },
+    });
+
+    expect(eventView.team).toEqual(['myteams', 1]);
+  });
 });
 
 describe('EventView.generateQueryStringObject()', function () {


### PR DESCRIPTION
Filters out invalid team values (`NaN`) when constructing an EventView.

This fixes an issue with users passing invalid team url params to the discover results page and breaking queries.