### PR TITLE
fix(profiling): lift tooltip zindex

### DIFF
--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -7,8 +7,9 @@ import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegrap
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
+import theme from 'sentry/utils/theme';
 
-function tooltipPlacement(cursor: vec2, container: Rect) {
+function computeBestTooltipPlacement(cursor: vec2, container: Rect) {
   // This is because the cursor's origin is in the top left corner of the arrow, so we want
   // to offset it just enough so that the tooltip does not overlap with the arrow's tail.
   // When the tooltip placed to the left of the cursor, we do not have that issue and hence
@@ -26,6 +27,7 @@ function tooltipPlacement(cursor: vec2, container: Rect) {
     style.left = undefined;
     style.right = container.width - cursor[0]; // No offset is applied here as tooltip is placed to the left
   }
+
   return style;
 }
 
@@ -59,7 +61,7 @@ function BoundTooltip({
     flamegraphCanvas.physicalToLogicalSpace
   );
 
-  const placement = tooltipPlacement(logicalSpaceCursor, bounds);
+  const placement = computeBestTooltipPlacement(logicalSpaceCursor, bounds);
 
   return (
     <Tooltip
@@ -68,6 +70,7 @@ function BoundTooltip({
         ...placement,
         fontSize: flamegraphTheme.SIZES.TOOLTIP_FONT_SIZE,
         fontFamily: flamegraphTheme.FONTS.FONT,
+        zIndex: theme.zIndex.tooltip,
         maxWidth: bounds.width,
       }}
     >


### PR DESCRIPTION
Add zIndex to the tooltip so that the framestack bar doesnt cover it in case user hovers a frame that overlaps

<img width="747" alt="CleanShot 2022-05-25 at 14 21 11@2x" src="https://user-images.githubusercontent.com/9317857/170339003-de9226a4-1de4-4bb3-89d6-358141c8839d.png">
