### PR TITLE
fix(issues): undefined checks tagKey before creating an eventView with it

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -79,13 +79,13 @@ export type TagCollection = Record<string, Tag>;
 export type TagValue = {
   count: number;
   firstSeen: string;
-  key: string;
   lastSeen: string;
   name: string;
   value: string;
   email?: string;
   identifier?: string;
   ipAddress?: string;
+  key?: string;
   query?: string;
   username?: string;
 } & AvatarUser;

--- a/static/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/static/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -28,7 +28,7 @@ import EventView from 'sentry/utils/discover/eventView';
 type RouteParams = {
   groupId: string;
   orgId: string;
-  tagKey: string;
+  tagKey?: string;
 };
 
 type Props = {
@@ -95,7 +95,7 @@ class GroupTagValues extends AsyncComponent<
       const issuesQuery = tagValue.query || `${key}:"${tagValue.value}"`;
       const discoverView = EventView.fromSavedQuery({
         id: undefined,
-        name: key,
+        name: key ?? '',
         fields: [
           ...(key !== undefined ? [key] : []),
           ...discoverFields.filter(field => field !== key),

--- a/static/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/static/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -96,7 +96,10 @@ class GroupTagValues extends AsyncComponent<
       const discoverView = EventView.fromSavedQuery({
         id: undefined,
         name: key,
-        fields: [key, ...discoverFields.filter(field => field !== key)],
+        fields: [
+          ...(key !== undefined ? [key] : []),
+          ...discoverFields.filter(field => field !== key),
+        ],
         orderby: '-timestamp',
         query: `issue.id:${groupId} ${issuesQuery}`,
         projects: [Number(project?.id)],


### PR DESCRIPTION
Checks to make sure `key` is defined before passing it as a field in eventView (otherwise it breaks).