### PR TITLE
fix(ui): Don't show chart labels when loading in releaseAdoption

### DIFF
--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -260,22 +260,24 @@ function ReleaseAdoption({
         </SidebarSection>
       )}
       <RelativeBox>
-        <ChartLabel top="0px">
-          <ChartTitle
-            title={t('Sessions Adopted')}
-            icon={
-              <QuestionTooltip
-                position="top"
-                title={t(
-                  'Adoption compares the sessions of a release with the total sessions for this project.'
-                )}
-                size="sm"
-              />
-            }
-          />
-        </ChartLabel>
+        {!loading && (
+          <ChartLabel top="0px">
+            <ChartTitle
+              title={t('Sessions Adopted')}
+              icon={
+                <QuestionTooltip
+                  position="top"
+                  title={t(
+                    'Adoption compares the sessions of a release with the total sessions for this project.'
+                  )}
+                  size="sm"
+                />
+              }
+            />
+          </ChartLabel>
+        )}
 
-        {hasUsers && (
+        {!loading && hasUsers && (
           <ChartLabel top="140px">
             <ChartTitle
               title={t('Users Adopted')}


### PR DESCRIPTION
Looks like this:
![image](https://user-images.githubusercontent.com/1421724/170369725-9064e94a-4b0f-4e3f-804e-47628328b089.png)

Used to look like this:
![image](https://user-images.githubusercontent.com/1421724/170369739-9f9024a7-1711-41e4-a269-2abeb093de7b.png)
