### PR TITLE
feat(mep): Allow some leeway on query period to use larger granularities

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -2019,9 +2019,9 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
             functions_acl=functions_acl,
             dry_run=dry_run,
         )
-        if self.granularity.granularity > interval:
+        if self.granularity.granularity >= interval:
             for granularity in METRICS_GRANULARITIES:
-                if granularity <= interval:
+                if granularity < interval:
                     self.granularity = Granularity(granularity)
                     break
 

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1606,10 +1606,10 @@ class MetricsQueryBuilder(QueryBuilder):
         """
         duration = (self.end - self.start).total_seconds()
 
-        near_midnight = lambda time: (time.minute <= 30 and time.hour == 0) or (
-            time.minute >= 30 and time.hour == 23
-        )
-        near_hour = lambda time: time.minute <= 15 or time.minute >= 15
+        near_midnight: Callable[[datetime], bool] = lambda time: (
+            time.minute <= 30 and time.hour == 0
+        ) or (time.minute >= 30 and time.hour == 23)
+        near_hour: Callable[[datetime], bool] = lambda time: time.minute <= 15 or time.minute >= 15
 
         if (
             # precisely going hour to hour

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1893,15 +1893,15 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         end = datetime.datetime(2015, 5, 19, 0, 0, 0, tzinfo=timezone.utc)
         assert get_granularity(start, end, 30) == 10, "A day at midnight, 30s interval"
         assert get_granularity(start, end, 900) == 60, "A day at midnight, 15min interval"
-        assert get_granularity(start, end, 3600) == 3600, "A day at midnight, 1hr interval"
-        assert get_granularity(start, end, 86400) == 86400, "A day at midnight, 1d interval"
+        assert get_granularity(start, end, 3600) == 60, "A day at midnight, 1hr interval"
+        assert get_granularity(start, end, 86400) == 3600, "A day at midnight, 1d interval"
 
         # If we're on the start of the hour we should use the hour granularity
         start = datetime.datetime(2015, 5, 18, 23, 0, 0, tzinfo=timezone.utc)
         end = datetime.datetime(2015, 5, 20, 1, 0, 0, tzinfo=timezone.utc)
         assert get_granularity(start, end, 30) == 10, "On the hour, 30s interval"
         assert get_granularity(start, end, 900) == 60, "On the hour, 15min interval"
-        assert get_granularity(start, end, 3600) == 3600, "On the hour, 1hr interval"
+        assert get_granularity(start, end, 3600) == 60, "On the hour, 1hr interval"
         assert get_granularity(start, end, 86400) == 3600, "On the hour, 1d interval"
 
         # Even though this is >24h of data, because its a random hour in the middle of the day to the next we use minute
@@ -1916,7 +1916,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             get_granularity(start, end, 3600) == 60
         ), "A few hours, but random minute, 1hr interval"
         assert (
-            get_granularity(start, end, 86400) == 60
+            get_granularity(start, end, 86400) == 3600
         ), "A few hours, but random minute, 1d interval"
 
         # Less than a minute, no reason to work hard for such a small window, just use a minute
@@ -1925,7 +1925,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         assert get_granularity(start, end, 30) == 10, "less than a minute, 30s interval"
         assert get_granularity(start, end, 900) == 60, "less than a minute, 15min interval"
         assert get_granularity(start, end, 3600) == 60, "less than a minute, 1hr interval"
-        assert get_granularity(start, end, 86400) == 60, "less than a minute, 1d interval"
+        assert get_granularity(start, end, 86400) == 3600, "less than a minute, 1d interval"
 
     def test_transaction_in_filter(self):
         query = TimeseriesMetricQueryBuilder(

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1030,6 +1030,11 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         end = datetime.datetime(2015, 5, 28, 23, 59, 0, tzinfo=timezone.utc)
         assert get_granularity(start, end) == 86400, "Several days"
 
+        # We're doing a long period, use the biggest granularity
+        start = datetime.datetime(2015, 5, 18, 12, 33, 0, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 7, 28, 17, 22, 0, tzinfo=timezone.utc)
+        assert get_granularity(start, end) == 86400, "Big range"
+
         # If we're on the start of the hour we should use the hour granularity
         start = datetime.datetime(2015, 5, 18, 23, 0, 0, tzinfo=timezone.utc)
         end = datetime.datetime(2015, 5, 20, 1, 0, 0, tzinfo=timezone.utc)
@@ -1039,6 +1044,11 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         start = datetime.datetime(2015, 5, 18, 23, 3, 0, tzinfo=timezone.utc)
         end = datetime.datetime(2015, 5, 21, 1, 57, 0, tzinfo=timezone.utc)
         assert get_granularity(start, end) == 3600, "On the hour, close"
+
+        # A decently long period but not close to hour ends, still use hour bucket
+        start = datetime.datetime(2015, 5, 18, 23, 3, 0, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 28, 1, 57, 0, tzinfo=timezone.utc)
+        assert get_granularity(start, end) == 3600, "On the hour, long period"
 
         # Even though this is >24h of data, because its a random hour in the middle of the day to the next we use minute
         # granularity

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1053,12 +1053,12 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         # Even though this is >24h of data, because its a random hour in the middle of the day to the next we use minute
         # granularity
         start = datetime.datetime(2015, 5, 18, 10, 15, 1, tzinfo=timezone.utc)
-        end = datetime.datetime(2015, 5, 19, 15, 15, 1, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 18, 18, 15, 1, tzinfo=timezone.utc)
         assert get_granularity(start, end) == 60, "A few hours, but random minute"
 
         # Less than a minute, no reason to work hard for such a small window, just use a minute
         start = datetime.datetime(2015, 5, 18, 10, 15, 1, tzinfo=timezone.utc)
-        end = datetime.datetime(2015, 5, 19, 10, 15, 34, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 18, 10, 15, 34, tzinfo=timezone.utc)
         assert get_granularity(start, end) == 60, "less than a minute"
 
     def test_run_query(self):

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1025,10 +1025,20 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         end = datetime.datetime(2015, 5, 19, 0, 0, 0, tzinfo=timezone.utc)
         assert get_granularity(start, end) == 86400, "A day at midnight"
 
+        # If we're doing several days, allow more range
+        start = datetime.datetime(2015, 5, 18, 0, 10, 0, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 28, 23, 59, 0, tzinfo=timezone.utc)
+        assert get_granularity(start, end) == 86400, "Several days"
+
         # If we're on the start of the hour we should use the hour granularity
         start = datetime.datetime(2015, 5, 18, 23, 0, 0, tzinfo=timezone.utc)
         end = datetime.datetime(2015, 5, 20, 1, 0, 0, tzinfo=timezone.utc)
         assert get_granularity(start, end) == 3600, "On the hour"
+
+        # If we're close to the start of the hour we should use the hour granularity
+        start = datetime.datetime(2015, 5, 18, 23, 3, 0, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 21, 1, 57, 0, tzinfo=timezone.utc)
+        assert get_granularity(start, end) == 3600, "On the hour, close"
 
         # Even though this is >24h of data, because its a random hour in the middle of the day to the next we use minute
         # granularity


### PR DESCRIPTION
- This fixes a bug where duration was actually just the number of
  seconds in the time-delta instead of the total number of seconds
- If duration is between 12 hours to 3d we allow 15 minutes on the hour boundaries for hourly granularity
- if duration is between 3d to 30d we allow 30 minutes on the day boundaries for daily granularities and will fallback to hourly granularity
- If the duration is over 30d we always use the daily granularities
