### PR TITLE
feat(search): Move term operator descriptions for clarity

### DIFF
--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -181,37 +181,44 @@ export function generateOperatorEntryMap(tag: string) {
     [TermOperator.Default]: {
       type: ItemType.TAG_OPERATOR,
       value: ':',
-      desc: `${tag}:${t('[value] is equal to')}`,
+      desc: `${tag}:${t('[value]')}`,
+      documentation: 'is equal to',
     },
     [TermOperator.GreaterThanEqual]: {
       type: ItemType.TAG_OPERATOR,
       value: ':>=',
-      desc: `${tag}:${t('>=[value] is greater than or equal to')}`,
+      desc: `${tag}:${t('>=[value]')}`,
+      documentation: 'is greater than or equal to',
     },
     [TermOperator.LessThanEqual]: {
       type: ItemType.TAG_OPERATOR,
       value: ':<=',
-      desc: `${tag}:${t('<=[value] is less than or equal to')}`,
+      desc: `${tag}:${t('<=[value]')}`,
+      documentation: 'is less than or equal to',
     },
     [TermOperator.GreaterThan]: {
       type: ItemType.TAG_OPERATOR,
       value: ':>',
-      desc: `${tag}:${t('>[value] is greater than')}`,
+      desc: `${tag}:${t('>[value]')}`,
+      documentation: 'is greater than',
     },
     [TermOperator.LessThan]: {
       type: ItemType.TAG_OPERATOR,
       value: ':<',
-      desc: `${tag}:${t('<[value] is less than')}`,
+      desc: `${tag}:${t('<[value]')}`,
+      documentation: 'is less than',
     },
     [TermOperator.Equal]: {
       type: ItemType.TAG_OPERATOR,
       value: ':=',
-      desc: `${tag}:${t('=[value] is equal to')}`,
+      desc: `${tag}:${t('=[value]')}`,
+      documentation: 'is equal to',
     },
     [TermOperator.NotEqual]: {
       type: ItemType.TAG_OPERATOR,
       value: '!:',
-      desc: `!${tag}:${t('[value] is not equal to')}`,
+      desc: `!${tag}:${t('[value]')}`,
+      documentation: 'is not equal to',
     },
   };
 }


### PR DESCRIPTION


<!-- Describe your PR here. -->
Could be confusing to initial users that the helper text is not part of the syntax due to being the same color with no distinction. This PR just moves the helper text to become `documentation` so it's displayed in grey on the right side.

Old:
![Screen Shot 2022-05-25 at 4 50 58 PM](https://user-images.githubusercontent.com/30991498/170387657-319b2980-eafa-4682-9738-7b23c3d0a8a5.png)


New:
![Screen Shot 2022-05-25 at 3 53 48 PM](https://user-images.githubusercontent.com/30991498/170387614-68b49d44-722d-4eda-bfb3-4b22466724ae.png)


