### PR TITLE
fix(integrations): Ignore 30x errors in response type

### DIFF
--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -61,9 +61,9 @@ class BaseApiResponse:
         elif response.text.startswith("<"):
             if not allow_text:
                 raise ValueError(f"Not a valid response type: {response.text[:128]}")
-            elif ignore_webhook_errors and response.status_code >= 300:
+            elif ignore_webhook_errors and response.status_code >= 400:
                 return BaseApiResponse()
-            elif response.status_code < 200 or response.status_code >= 300:
+            elif response.status_code < 200 or response.status_code >= 400:
                 raise ValueError(
                     f"Received unexpected plaintext response for code {response.status_code}"
                 )


### PR DESCRIPTION


<!-- Describe your PR here. -->

Fixes SENTRY-T3E

We don't really care about redirects since that's handled by the client (whether we follow them or not). It was mentionned in https://github.com/getsentry/sentry/pull/31327/ but might have been missed.

Also added tests for default redirect behaviour of the client.

