### PR TITLE
ref(js): Use real Button for pullRequestLink

### DIFF
--- a/static/app/components/pullRequestLink.tsx
+++ b/static/app/components/pullRequestLink.tsx
@@ -1,5 +1,9 @@
+import styled from '@emotion/styled';
+
+import Button from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {IconBitbucket, IconGithub, IconGitlab} from 'sentry/icons';
+import space from 'sentry/styles/space';
 import {PullRequest, Repository} from 'sentry/types';
 
 function renderIcon(repo: Repository) {
@@ -28,21 +32,34 @@ type Props = {
   inline?: boolean;
 };
 
-const PullRequestLink = ({pullRequest, repository, inline}: Props) => {
+function PullRequestLink({pullRequest, repository, inline}: Props) {
   const displayId = `${repository.name} #${pullRequest.id}: ${pullRequest.title}`;
 
-  return pullRequest.externalUrl ? (
-    <ExternalLink
-      className={inline ? 'inline-commit' : 'btn btn-default btn-sm'}
+  if (!pullRequest.externalUrl) {
+    return <span>{displayId}</span>;
+  }
+
+  return !inline ? (
+    <Button
+      external
       href={pullRequest.externalUrl}
+      size="small"
+      icon={renderIcon(repository)}
     >
-      {renderIcon(repository)}
-      {inline ? '' : ' '}
       {displayId}
-    </ExternalLink>
+    </Button>
   ) : (
-    <span>{displayId}</span>
+    <ExternalPullLink href={pullRequest.externalUrl}>
+      {renderIcon(repository)}
+      {displayId}
+    </ExternalPullLink>
   );
-};
+}
+
+const ExternalPullLink = styled(ExternalLink)`
+  display: inline-flex;
+  align-items: center;
+  gap: ${space(0.5)};
+`;
 
 export default PullRequestLink;


### PR DESCRIPTION
Currently both usages are just of the `inline` variant

![image](https://user-images.githubusercontent.com/1421724/170430017-2b2b3c1d-4cc3-4aa0-8fbd-0e748a09a1e0.png)
