### PR TITLE
ref(js): Remove componentPromise from Route props

### DIFF
--- a/static/app/bootstrap/initializeApp.tsx
+++ b/static/app/bootstrap/initializeApp.tsx
@@ -1,7 +1,7 @@
 import './legacyTwitterBootstrap';
 import './exportGlobals';
 
-import routes from 'sentry/routes';
+import {routes} from 'sentry/routes';
 import {Config} from 'sentry/types';
 import {metric} from 'sentry/utils/analytics';
 

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -16,40 +16,20 @@ type Props<C extends ComponentType> = Omit<React.ComponentProps<C>, 'route'> & {
   /**
    * Accepts a function to trigger the import resolution of the component.
    */
-  component?: () => PromisedImport<C>;
-  /**
-   * Accepts a route object from react-router that has a `componentPromise` property
-   */
-  route?: {componentPromise: () => PromisedImport<C>};
+  component: () => PromisedImport<C>;
 };
 
 /**
  * LazyLoad is used to dynamically load codesplit components via a `import`
- * call. Typically this component is used as part of the routing tree, though
- * it does have a standalone mode.
+ * call. This is primarily used in our routing tree.
  *
- * Route tree usage:
- *   <Route
- *     path="somePath"
- *     component={LazyLoad}
- *     componentPromise={() => import('./somePathView')}
- *   />
- *
- * Standalone usage:
- *   <LazyLoad component={() => import('./myComponent')} someComponentProps={...} />
+ * <LazyLoad component={() => import('./myComponent')} someComponentProps={...} />
  */
 function LazyLoad<C extends ComponentType>(props: Props<C>) {
-  const importComponent = props.component ?? props.route?.componentPromise;
+  const importComponent = props.component;
 
   const LazyComponent = useMemo(
-    () =>
-      lazy(() => {
-        if (!importComponent) {
-          throw new Error('No component to load');
-        }
-
-        return retryableImport(importComponent);
-      }),
+    () => lazy(() => retryableImport(importComponent)),
     [importComponent]
   );
 

--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -2,7 +2,7 @@ import {browserHistory, Router, RouterContext} from 'react-router';
 
 import DemoHeader from 'sentry/components/demo/demoHeader';
 import ThemeAndStyleProvider from 'sentry/components/themeAndStyleProvider';
-import routes from 'sentry/routes';
+import {routes} from 'sentry/routes';
 import ConfigStore from 'sentry/stores/configStore';
 import {RouteContext} from 'sentry/views/routeContext';
 


### PR DESCRIPTION
Take two of #34983, which failed getsentry CI since acceptance tests were not happy.

This time there is an associated getsentry PR https://github.com/getsentry/getsentry/pull/7556