### PR TITLE
fix(replays): Remove position:sticky to performance span waterfall

### DIFF
--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -731,7 +731,6 @@ const DurationGuideBox = styled('div')<{alignLeft: boolean}>`
 
 const HeaderContainer = styled('div')`
   width: 100%;
-  position: sticky;
   left: 0;
   top: ${p => (ConfigStore.get('demoMode') ? p.theme.demo.headerSize : 0)};
   z-index: ${p => p.theme.zIndex.traceView.minimapContainer};


### PR DESCRIPTION
### Description

```
The Network tab (no longer Performance) includes an existing waterfall component that shows span data.
The header of this component is position: sticky because it made sense for the original use-case of that component.
On our details page we have our own sticky content. So that header should not be sticky on our page.
```

Fixes: #35044 

### Screenshots

![image](https://user-images.githubusercontent.com/14813235/170509573-66cf7afe-eb4b-4b73-8a8a-7fed29cd8244.png)


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
