### PR TITLE
ref: use importlib.metadata over pkg_resources for plugin loading

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import logging
 import os
 import sys
@@ -13,8 +14,6 @@ logger = logging.getLogger("sentry.runner.initializer")
 
 
 def register_plugins(settings, raise_on_plugin_load_failure=False):
-    from pkg_resources import iter_entry_points
-
     from sentry.plugins.base import plugins
 
     # entry_points={
@@ -22,7 +21,14 @@ def register_plugins(settings, raise_on_plugin_load_failure=False):
     #         'phabricator = sentry_phabricator.plugins:PhabricatorPlugin'
     #     ],
     # },
-    for ep in iter_entry_points("sentry.plugins"):
+    entry_points = {
+        ep
+        for dist in importlib.metadata.distributions()
+        for ep in dist.entry_points
+        if ep.group == "sentry.plugins"
+    }
+
+    for ep in entry_points:
         try:
             plugin = ep.load()
         except Exception:


### PR DESCRIPTION
- importlib.metadata is standard library
- pkg_resources comes from setuptools
- pkg_resources is significantly slow to import
- importlib.metadata does not error when trying other packages:

```console
$ pip install jsonschema==4.5.1
...
$ pytest tests/sentry_plugins/pushover/test_plugin.py
Failed to load plugin 'amazon_sqs':
Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/src/sentry/runner/initializer.py", line 27, in register_plugins
    plugin = ep.load()
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2449, in load
    self.require(*args, **kwargs)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2472, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 777, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (jsonschema 4.5.1 (/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages), Requirement.parse('jsonschema==3.2.0'))

(repeated manmy times)
```


