### PR TITLE
chore(chartcuterie): Revert default font hacks

### DIFF
--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -13,12 +13,7 @@ import {t} from 'sentry/locale';
 import {EventsGeoData, EventsStats} from 'sentry/types';
 import {lightTheme as theme} from 'sentry/utils/theme';
 
-import {
-  DEFAULT_FONT_FAMILY,
-  slackChartDefaults,
-  slackChartSize,
-  slackGeoChartSize,
-} from './slack';
+import {slackChartDefaults, slackChartSize, slackGeoChartSize} from './slack';
 import {ChartType, RenderDescriptor} from './types';
 
 const discoverxAxis = XAxis({
@@ -27,7 +22,7 @@ const discoverxAxis = XAxis({
   boundaryGap: true,
   splitNumber: 3,
   isGroupedByDate: true,
-  axisLabel: {fontSize: 11, fontFamily: DEFAULT_FONT_FAMILY},
+  axisLabel: {fontSize: 11},
 });
 
 export const discoverCharts: RenderDescriptor<ChartType>[] = [];

--- a/static/app/chartcuterie/metricAlert.tsx
+++ b/static/app/chartcuterie/metricAlert.tsx
@@ -11,14 +11,14 @@ import {
   transformSessionResponseToSeries,
 } from 'sentry/views/alerts/rules/metric/details/metricChartOption';
 
-import {DEFAULT_FONT_FAMILY, slackChartDefaults, slackChartSize} from './slack';
+import {slackChartDefaults, slackChartSize} from './slack';
 import {ChartType, RenderDescriptor} from './types';
 
 const metricAlertXaxis = XAxis({
   theme,
   splitNumber: 3,
   isGroupedByDate: true,
-  axisLabel: {fontSize: 11, fontFamily: DEFAULT_FONT_FAMILY},
+  axisLabel: {fontSize: 11},
 });
 
 function transformAreaSeries(series: AreaChartSeries[]): LineSeriesOption[] {
@@ -38,11 +38,6 @@ function transformAreaSeries(series: AreaChartSeries[]): LineSeriesOption[] {
       animationDuration: 0,
       ...otherSeriesProps,
     });
-
-    // Fix incident label font family, cannot use Rubik
-    if (areaSeries.markLine?.label?.fontFamily) {
-      areaSeries.markLine.label.fontFamily = DEFAULT_FONT_FAMILY;
-    }
 
     return areaSeries;
   });

--- a/static/app/chartcuterie/slack.tsx
+++ b/static/app/chartcuterie/slack.tsx
@@ -4,8 +4,6 @@ import XAxis from 'sentry/components/charts/components/xAxis';
 import YAxis from 'sentry/components/charts/components/yAxis';
 import {lightTheme as theme} from 'sentry/utils/theme';
 
-export const DEFAULT_FONT_FAMILY = 'sans-serif';
-
 /**
  * Size configuration for SLACK_* type charts
  */
@@ -31,17 +29,16 @@ export const slackChartDefaults = {
     itemHeight: 6,
     top: 2,
     right: 10,
-    textStyle: {fontFamily: DEFAULT_FONT_FAMILY},
   }),
   yAxis: YAxis({
     theme,
     splitNumber: 3,
-    axisLabel: {fontSize: 11, fontFamily: DEFAULT_FONT_FAMILY},
+    axisLabel: {fontSize: 11},
   }),
   xAxis: XAxis({
     theme,
     nameGap: 5,
     isGroupedByDate: true,
-    axisLabel: {fontSize: 11, fontFamily: DEFAULT_FONT_FAMILY},
+    axisLabel: {fontSize: 11},
   }),
 };


### PR DESCRIPTION
With the new deployment of chartcuterie, custom fonts
should now be available in the service so removing the
use of the built in sans-serif fonts.