### PR TITLE
fix(relay): Increase rate-limit on auth endpoints [INGEST-1310]

### DIFF
--- a/src/sentry/api/endpoints/relay/constants.py
+++ b/src/sentry/api/endpoints/relay/constants.py
@@ -1,0 +1,9 @@
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+RELAY_AUTH_RATE_LIMITS = {
+    "default": {
+        RateLimitCategory.IP: RateLimit(200, 1),
+        RateLimitCategory.USER: RateLimit(200, 1),
+        RateLimitCategory.ORGANIZATION: RateLimit(200, 1),
+    }
+}

--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -9,6 +9,7 @@ from sentry.api.authentication import is_internal_relay, is_static_relay, relay_
 from sentry.api.base import Endpoint
 from sentry.api.serializers import serialize
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import json
 
 from . import RelayIdSerializer
@@ -21,7 +22,15 @@ class RelayRegisterChallengeSerializer(RelayIdSerializer):
 class RelayRegisterChallengeEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
-    enforce_rate_limit = False
+
+    enforce_rate_limit = True
+    rate_limits = {
+        "default": {
+            RateLimitCategory.IP: RateLimit(200, 1),
+            RateLimitCategory.USER: RateLimit(200, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(200, 1),
+        }
+    }
 
     def post(self, request: Request) -> Response:
         """

--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -7,9 +7,9 @@ from sentry_relay import create_register_challenge, is_version_supported
 from sentry import options
 from sentry.api.authentication import is_internal_relay, is_static_relay, relay_from_id
 from sentry.api.base import Endpoint
+from sentry.api.endpoints.relay.constants import RELAY_AUTH_RATE_LIMITS
 from sentry.api.serializers import serialize
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import json
 
 from . import RelayIdSerializer
@@ -24,13 +24,7 @@ class RelayRegisterChallengeEndpoint(Endpoint):
     permission_classes = ()
 
     enforce_rate_limit = True
-    rate_limits = {
-        "default": {
-            RateLimitCategory.IP: RateLimit(200, 1),
-            RateLimitCategory.USER: RateLimit(200, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(200, 1),
-        }
-    }
+    rate_limits = RELAY_AUTH_RATE_LIMITS
 
     def post(self, request: Request) -> Response:
         """

--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -21,6 +21,7 @@ class RelayRegisterChallengeSerializer(RelayIdSerializer):
 class RelayRegisterChallengeEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
+    enforce_rate_limit = False
 
     def post(self, request: Request) -> Response:
         """

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -7,10 +7,10 @@ from sentry_relay import UnpackErrorSignatureExpired, validate_register_response
 from sentry import options
 from sentry.api.authentication import is_internal_relay, relay_from_id
 from sentry.api.base import Endpoint
+from sentry.api.endpoints.relay.constants import RELAY_AUTH_RATE_LIMITS
 from sentry.api.serializers import serialize
 from sentry.models import Relay, RelayUsage
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import json
 
 from . import RelayIdSerializer
@@ -25,13 +25,7 @@ class RelayRegisterResponseEndpoint(Endpoint):
     permission_classes = ()
 
     enforce_rate_limit = True
-    rate_limits = {
-        "default": {
-            RateLimitCategory.IP: RateLimit(200, 1),
-            RateLimitCategory.USER: RateLimit(200, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(200, 1),
-        }
-    }
+    rate_limits = RELAY_AUTH_RATE_LIMITS
 
     def post(self, request: Request) -> Response:
         """

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -22,6 +22,7 @@ class RelayRegisterResponseSerializer(RelayIdSerializer):
 class RelayRegisterResponseEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
+    enforce_rate_limit = False
 
     def post(self, request: Request) -> Response:
         """

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -10,6 +10,7 @@ from sentry.api.base import Endpoint
 from sentry.api.serializers import serialize
 from sentry.models import Relay, RelayUsage
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import json
 
 from . import RelayIdSerializer
@@ -22,7 +23,15 @@ class RelayRegisterResponseSerializer(RelayIdSerializer):
 class RelayRegisterResponseEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
-    enforce_rate_limit = False
+
+    enforce_rate_limit = True
+    rate_limits = {
+        "default": {
+            RateLimitCategory.IP: RateLimit(200, 1),
+            RateLimitCategory.USER: RateLimit(200, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(200, 1),
+        }
+    }
 
     def post(self, request: Request) -> Response:
         """


### PR DESCRIPTION
Internal Relays require the authentication endpoints during deployments.
We need to make sure those endpoints are always available within reason.

At the same time, external Relays operated by customers will also access
the same endpoints repeatedly. To avoid overloading internal systems, we
keep a higher rate limit of 200/s in place.