### PR TITLE
feat(instrumentation): Tag the per_page parameter

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -28,6 +28,7 @@ from sentry.utils.audit import create_audit_entry
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
 from sentry.utils.http import absolute_uri, is_valid_origin, origin_from_request
+from sentry.utils.numbers import format_grouped_length
 from sentry.utils.sdk import capture_exception
 
 from .authentication import ApiKeyAuthentication, TokenAuthentication
@@ -343,6 +344,10 @@ class Endpoint(APIView):
                 description=type(self).__name__,
             ) as span:
                 span.set_data("Limit", per_page)
+                sentry_sdk.set_tag("query.per_page", per_page)
+                sentry_sdk.set_tag(
+                    "query.per_page.grouped", format_grouped_length(per_page, [1, 10, 50, 100])
+                )
                 cursor_result = paginator.get_result(limit=per_page, cursor=input_cursor)
         except BadPaginationError as e:
             raise ParseError(detail=str(e))


### PR DESCRIPTION
- This is cause I want to look into the releases endpoint and confirm
  that a higher per_page causes a longer query. But because this is on
  span data and not a transaction tag I cannot make that correlation
