### PR TITLE
fix(workflow): Set yAxis to 100% for percent based alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -18,6 +18,7 @@ import {
   AlertRuleTriggerType,
   Dataset,
   MetricRule,
+  SessionsAggregate,
 } from 'sentry/views/alerts/rules/metric/types';
 import {Incident, IncidentActivityType, IncidentStatus} from 'sentry/views/alerts/types';
 import {
@@ -346,12 +347,20 @@ export function getMetricAlertChartOption({
     maxThresholdValue = Math.max(maxThresholdValue, rule.resolveThreshold);
   }
 
+  const crashFreeMax =
+    rule.aggregate === SessionsAggregate.CRASH_FREE_SESSIONS ||
+    rule.aggregate === SessionsAggregate.CRASH_FREE_USERS;
+
   const yAxis: YAXisComponentOption = {
     axisLabel: {
       formatter: (value: number) =>
         alertAxisFormatter(value, timeseriesData[0].seriesName, rule.aggregate),
     },
-    max: maxThresholdValue > maxSeriesValue ? maxThresholdValue : undefined,
+    max: crashFreeMax
+      ? 100
+      : maxThresholdValue > maxSeriesValue
+      ? maxThresholdValue
+      : undefined,
     min: minChartValue || undefined,
   };
 

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -18,7 +18,6 @@ import {
   AlertRuleTriggerType,
   Dataset,
   MetricRule,
-  SessionsAggregate,
 } from 'sentry/views/alerts/rules/metric/types';
 import {Incident, IncidentActivityType, IncidentStatus} from 'sentry/views/alerts/types';
 import {
@@ -30,6 +29,8 @@ import {
 } from 'sentry/views/alerts/utils';
 import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
+
+import {isCrashFreeAlert} from '../utils/isCrashFreeAlert';
 
 function formatTooltipDate(date: moment.MomentInput, format: string): string {
   const {
@@ -347,16 +348,12 @@ export function getMetricAlertChartOption({
     maxThresholdValue = Math.max(maxThresholdValue, rule.resolveThreshold);
   }
 
-  const crashFreeMax =
-    rule.aggregate === SessionsAggregate.CRASH_FREE_SESSIONS ||
-    rule.aggregate === SessionsAggregate.CRASH_FREE_USERS;
-
   const yAxis: YAXisComponentOption = {
     axisLabel: {
       formatter: (value: number) =>
         alertAxisFormatter(value, timeseriesData[0].seriesName, rule.aggregate),
     },
-    max: crashFreeMax
+    max: isCrashFreeAlert(rule.dataset)
       ? 100
       : maxThresholdValue > maxSeriesValue
       ? maxThresholdValue


### PR DESCRIPTION
Set yAxis to static 100% for percent based alerts.

[FIXES WOR-1889
](https://getsentry.atlassian.net/browse/WOR-1889)

# Before
<img width="947" alt="Screen Shot 2022-05-26 at 4 20 49 AM" src="https://user-images.githubusercontent.com/20312973/170482661-aeb83382-ccc1-40e5-83b2-1c0140473484.png">

# After
<img width="944" alt="Screen Shot 2022-05-26 at 4 22 00 AM" src="https://user-images.githubusercontent.com/20312973/170482677-87822be9-8d8f-443d-a377-8667675dd32d.png">


