### PR TITLE
fix(timeRangeSelector): Fix overflowing divider

### DIFF
--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -448,7 +448,7 @@ class TimeRangeSelector extends PureComponent<Props, State> {
                 onSelect={this.handleSelect}
                 subPanel={
                   isAbsoluteSelected && (
-                    <div>
+                    <AbsoluteRangeWrap>
                       <DateRangeHook
                         start={start ?? null}
                         end={end ?? null}
@@ -467,7 +467,7 @@ class TimeRangeSelector extends PureComponent<Props, State> {
                           }
                         />
                       </SubmitRow>
-                    </div>
+                    </AbsoluteRangeWrap>
                   )
                 }
               >
@@ -525,6 +525,11 @@ const StyledDropdownAutoComplete = styled(DropdownAutoComplete)`
 
 const StyledHeaderItem = styled(HeaderItem)`
   height: 100%;
+`;
+
+const AbsoluteRangeWrap = styled('div')`
+  display: flex;
+  flex-direction: column;
 `;
 
 const SubmitRow = styled('div')`


### PR DESCRIPTION
**Before:**
<img width="611" alt="Screen Shot 2022-05-26 at 10 46 13 AM" src="https://user-images.githubusercontent.com/44172267/170545948-b92db0d4-d2f4-4b79-a059-feff30bf992a.png">

**After:**
<img width="612" alt="Screen Shot 2022-05-26 at 10 46 43 AM" src="https://user-images.githubusercontent.com/44172267/170545960-6d436d1b-d639-4ed6-8ed6-7ba2b334b0f0.png">
