### PR TITLE
ref: remove unused `@python_2_unicode_compatible`

### DIFF
--- a/src/sentry/auth/provider.py
+++ b/src/sentry/auth/provider.py
@@ -3,14 +3,13 @@ import logging
 from collections import namedtuple
 from typing import Any
 
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import force_text
 
 from sentry.pipeline import PipelineProvider
 
 from .view import ConfigureView
 
 
-@python_2_unicode_compatible
 class MigratingIdentityId(namedtuple("MigratingIdentityId", ["id", "legacy_id"])):
     """
     MigratingIdentityId may be used in the ``id`` field of an identity

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from django.db import models, transaction
 from django.utils import timezone
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import force_text
 
 from sentry.db.models import BaseManager, FlexibleForeignKey, Model, sane_repr
 from sentry.models.apiscopes import HasApiScopes
@@ -19,7 +19,6 @@ def generate_token():
     return uuid4().hex + uuid4().hex
 
 
-@python_2_unicode_compatible
 class ApiToken(Model, HasApiScopes):
     __include_in_export__ = True
 

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -1,10 +1,9 @@
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import force_text
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import warnings
 
 
-@python_2_unicode_compatible
 class Version(tuple):
     def __str__(self):
         return ".".join(map(force_text, self))


### PR DESCRIPTION
this is a noop in python3+