### PR TITLE
ref: replace compat.zip with list(zip(...)) for `ChoiceField`s

### DIFF
--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -11,7 +11,6 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint
 from sentry.assistant import manager
 from sentry.models import AssistantActivity
-from sentry.utils.compat import zip
 
 VALID_STATUSES = frozenset(("viewed", "dismissed"))
 
@@ -19,7 +18,7 @@ VALID_STATUSES = frozenset(("viewed", "dismissed"))
 class AssistantSerializer(serializers.Serializer):
     guide = serializers.CharField(required=False)
     guide_id = serializers.IntegerField(required=False)
-    status = serializers.ChoiceField(choices=zip(VALID_STATUSES, VALID_STATUSES))
+    status = serializers.ChoiceField(choices=list(zip(VALID_STATUSES, VALID_STATUSES)))
     useful = serializers.BooleanField(required=False)
 
     def validate_guide_id(self, value):

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -11,7 +11,6 @@ from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
 from sentry.models import Organization, Project, PromptsActivity
-from sentry.utils.compat import zip
 from sentry.utils.prompts import prompt_config
 
 VALID_STATUSES = frozenset(("snoozed", "dismissed"))
@@ -20,7 +19,9 @@ VALID_STATUSES = frozenset(("snoozed", "dismissed"))
 # Endpoint to retrieve multiple PromptsActivity at once
 class PromptsActivitySerializer(serializers.Serializer):
     feature = serializers.CharField(required=True)
-    status = serializers.ChoiceField(choices=zip(VALID_STATUSES, VALID_STATUSES), required=True)
+    status = serializers.ChoiceField(
+        choices=list(zip(VALID_STATUSES, VALID_STATUSES)), required=True
+    )
 
     def validate_feature(self, value):
         if value is None:

--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -5,7 +5,6 @@ from rest_framework import serializers
 from sentry.api.fields import ActorField
 from sentry.models import Actor, Team, User
 from sentry.models.group import STATUS_UPDATE_CHOICES
-from sentry.utils.compat import zip
 
 from . import InboxDetailsValidator, StatusDetailsValidator
 
@@ -14,7 +13,7 @@ class GroupValidator(serializers.Serializer):  # type: ignore
     inbox = serializers.BooleanField()
     inboxDetails = InboxDetailsValidator()
     status = serializers.ChoiceField(
-        choices=zip(STATUS_UPDATE_CHOICES.keys(), STATUS_UPDATE_CHOICES.keys())
+        choices=list(zip(STATUS_UPDATE_CHOICES.keys(), STATUS_UPDATE_CHOICES.keys()))
     )
     statusDetails = StatusDetailsValidator()
     hasSeen = serializers.BooleanField()

--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -7,7 +7,6 @@ from rest_framework import serializers
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.models import MonitorStatus, MonitorType, ScheduleType
-from sentry.utils.compat import zip
 
 SCHEDULE_TYPES = OrderedDict(
     [("crontab", ScheduleType.CRONTAB), ("interval", ScheduleType.INTERVAL)]
@@ -39,7 +38,7 @@ class ObjectField(serializers.Field):
 
 class CronJobValidator(serializers.Serializer):
     schedule_type = serializers.ChoiceField(
-        choices=zip(SCHEDULE_TYPES.keys(), SCHEDULE_TYPES.keys())
+        choices=list(zip(SCHEDULE_TYPES.keys(), SCHEDULE_TYPES.keys()))
     )
     schedule = ObjectField()
     checkin_margin = EmptyIntegerField(required=False, default=None)
@@ -86,9 +85,9 @@ class MonitorValidator(serializers.Serializer):
     project = ProjectField()
     name = serializers.CharField()
     status = serializers.ChoiceField(
-        choices=zip(MONITOR_STATUSES.keys(), MONITOR_STATUSES.keys()), default="active"
+        choices=list(zip(MONITOR_STATUSES.keys(), MONITOR_STATUSES.keys())), default="active"
     )
-    type = serializers.ChoiceField(choices=zip(MONITOR_TYPES.keys(), MONITOR_TYPES.keys()))
+    type = serializers.ChoiceField(choices=list(zip(MONITOR_TYPES.keys(), MONITOR_TYPES.keys())))
     config = ObjectField()
 
     def validate(self, attrs):


### PR DESCRIPTION
~technically ChoiceFiled can take an iterator and function correctly, though the repr(...) is broken:

```pycon
>>> from rest_framework.fields import ChoiceField
>>> t1, t2 = [1, 2, 3], ['a', 'b', 'c']
>>> field = ChoiceField(choices=zip(t1, t2))
>>> field
ChoiceField(choices=<zip object>)
>>> field.choices
OrderedDict([(1, 'a'), (2, 'b'), (3, 'c')])
```

so I opted to stick with the pattern that preserves the repr


