### PR TITLE
ref: use py36+ dict instead of OrderedDict for sort_rule_groups

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import itertools
 import logging
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 from typing import Any, Mapping, MutableMapping, MutableSequence, Sequence
 
 from sentry.app import tsdb
@@ -141,7 +141,7 @@ def sort_group_contents(
     rules: MutableMapping[str, Mapping[Group, Sequence[Record]]]
 ) -> Mapping[str, Mapping[Group, Sequence[Record]]]:
     for key, groups in rules.items():
-        rules[key] = OrderedDict(
+        rules[key] = dict(
             sorted(
                 groups.items(),
                 # x = (group, records)
@@ -153,7 +153,7 @@ def sort_group_contents(
 
 
 def sort_rule_groups(rules: Mapping[str, Rule]) -> Mapping[str, Rule]:
-    return OrderedDict(
+    return dict(
         sorted(
             rules.items(),
             # x = (rule, groups)

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from functools import reduce
 
 from exam import fixture
@@ -108,12 +108,17 @@ class SortRecordsTestCase(TestCase):
 
         grouped = {rules[0]: {groups[0]: []}, rules[1]: {groups[1]: [], groups[2]: []}}
 
-        assert sort_rule_groups(sort_group_contents(grouped)) == OrderedDict(
-            (
-                (rules[1], OrderedDict(((groups[1], []), (groups[2], [])))),
-                (rules[0], OrderedDict(((groups[0], []),))),
-            )
-        )
+        ret = sort_rule_groups(sort_group_contents(grouped))
+
+        # ensure top-level keys are sorted
+        assert tuple(ret) == (rules[1], rules[0])
+        # ensure second-level keys are sorted
+        assert tuple(ret[rules[1]]) == (groups[1], groups[2])
+
+        assert ret == {
+            rules[1]: {groups[1]: [], groups[2]: []},
+            rules[0]: {groups[0]: []},
+        }
 
 
 class SplitKeyTestCase(TestCase):


### PR DESCRIPTION
- in python3.6+ dictionaries retain insertion order
- updated the test to ensure order is preserved