### PR TITLE
feat(profiling): zoom to frame from call tree table

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -105,7 +105,12 @@ function FrameStack(props: FrameStackProps) {
         </li>
         <li style={{flex: '1 1 100%', cursor: 'ns-resize'}} onMouseDown={onMouseDown} />
       </FrameTabs>
-      <FrameStackTable {...props} roots={roots ?? []} referenceNode={selectedNode} />
+      <FrameStackTable
+        {...props}
+        roots={roots ?? []}
+        referenceNode={selectedNode}
+        canvasPoolManager={props.canvasPoolManager}
+      />
     </FrameDrawer>
   ) : null;
 }

--- a/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
@@ -33,7 +33,7 @@ export function FrameStackContextMenu(props: FrameStackContextMenuProps) {
             {...props.contextMenu.getMenuItemProps()}
             onClick={props.onZoomIntoNodeClick}
           >
-            Scope view to this node
+            {t('Scope view to this node')}
           </ProfilingContextMenuItem>
         </ProfilingContextMenuGroup>
       </ProfilingContextMenu>

--- a/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
@@ -28,7 +28,7 @@ export function FrameStackContextMenu(props: FrameStackContextMenuProps) {
         }}
       >
         <ProfilingContextMenuGroup>
-          <ProfilingContextMenuHeading>Flamegraph</ProfilingContextMenuHeading>
+          <ProfilingContextMenuHeading>{t('Flamegraph')}</ProfilingContextMenuHeading>
           <ProfilingContextMenuItem
             {...props.contextMenu.getMenuItemProps()}
             onClick={props.onZoomIntoNodeClick}

--- a/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
@@ -1,3 +1,42 @@
-export function FrameStackContextMenu() {
-  return null;
+import {Fragment} from 'react';
+
+import {
+  ProfilingContextMenu,
+  ProfilingContextMenuGroup,
+  ProfilingContextMenuHeading,
+  ProfilingContextMenuItem,
+  ProfilingContextMenuLayer,
+} from 'sentry/components/profiling/ProfilingContextMenu/profilingContextMenu';
+import {useContextMenu} from 'sentry/utils/profiling/hooks/useContextMenu';
+
+interface FrameStackContextMenuProps {
+  contextMenu: ReturnType<typeof useContextMenu>;
+  onZoomIntoNodeClick: (evt: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+export function FrameStackContextMenu(props: FrameStackContextMenuProps) {
+  return props.contextMenu.open ? (
+    <Fragment>
+      <ProfilingContextMenuLayer onClick={() => props.contextMenu.setOpen(false)} />
+      <ProfilingContextMenu
+        {...props.contextMenu.getMenuProps()}
+        style={{
+          position: 'absolute',
+          left: props.contextMenu.position?.left ?? -9999,
+          top: props.contextMenu.position?.top ?? -9999,
+          maxHeight: props.contextMenu.containerCoordinates?.height ?? 'auto',
+        }}
+      >
+        <ProfilingContextMenuGroup>
+          <ProfilingContextMenuHeading>Flamegraph</ProfilingContextMenuHeading>
+          <ProfilingContextMenuItem
+            {...props.contextMenu.getMenuItemProps()}
+            onClick={props.onZoomIntoNodeClick}
+          >
+            Scope view to this node
+          </ProfilingContextMenuItem>
+        </ProfilingContextMenuGroup>
+      </ProfilingContextMenu>
+    </Fragment>
+  ) : null;
 }

--- a/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
@@ -7,6 +7,7 @@ import {
   ProfilingContextMenuItem,
   ProfilingContextMenuLayer,
 } from 'sentry/components/profiling/ProfilingContextMenu/profilingContextMenu';
+import {t} from 'sentry/locale';
 import {useContextMenu} from 'sentry/utils/profiling/hooks/useContextMenu';
 
 interface FrameStackContextMenuProps {

--- a/static/app/components/profiling/FrameStack/frameStackTable.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackTable.tsx
@@ -4,12 +4,15 @@ import styled from '@emotion/styled';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
+import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {useContextMenu} from 'sentry/utils/profiling/hooks/useContextMenu';
 import {useVirtualizedTree} from 'sentry/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree';
 import {VirtualizedTreeNode} from 'sentry/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 
 import {FrameCallersTableCell} from './frameStack';
+import {FrameStackContextMenu} from './frameStackContextMenu';
 import {FrameStackTableRow} from './frameStackTableRow';
 
 function makeSortFunction(
@@ -68,6 +71,7 @@ function makeSortFunction(
 }
 
 interface FrameStackTableProps {
+  canvasPoolManager: CanvasPoolManager;
   flamegraphRenderer: FlamegraphRenderer;
   referenceNode: FlamegraphFrame;
   roots: FlamegraphFrame[];
@@ -76,6 +80,7 @@ interface FrameStackTableProps {
 export function FrameStackTable({
   roots,
   flamegraphRenderer,
+  canvasPoolManager,
   referenceNode,
 }: FrameStackTableProps) {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
@@ -116,6 +121,19 @@ export function FrameStackTable({
     [sort, direction, handleSortingChange]
   );
 
+  const [clickedContextMenuNode, setClickedContextMenuClose] =
+    useState<VirtualizedTreeNode<FlamegraphFrame> | null>(null);
+
+  const contextMenu = useContextMenu({container: scrollContainerRef.current});
+
+  const handleZoomIntoNodeClick = useCallback(() => {
+    if (!clickedContextMenuNode) {
+      return;
+    }
+
+    canvasPoolManager.dispatch('zoomIntoFrame', [clickedContextMenuNode.node]);
+  }, [canvasPoolManager, clickedContextMenuNode]);
+
   return (
     <FrameBar>
       <FrameCallersTable>
@@ -145,10 +163,15 @@ export function FrameStackTable({
             </TableHeaderButton>
           </FrameNameCell>
         </FrameCallersTableHeader>
+        <FrameStackContextMenu
+          onZoomIntoNodeClick={handleZoomIntoNodeClick}
+          contextMenu={contextMenu}
+        />
         <div
           ref={scrollContainerRef}
           style={scrollContainerStyles}
           onScroll={handleScroll}
+          onContextMenu={contextMenu.handleContextMenu}
         >
           <div style={containerStyles}>
             {items.map(r => {
@@ -159,7 +182,11 @@ export function FrameStackTable({
                   style={r.styles}
                   referenceNode={referenceNode}
                   flamegraphRenderer={flamegraphRenderer}
-                  handleExpandedClick={handleExpandTreeNode}
+                  onExpandClick={handleExpandTreeNode}
+                  onContextMenu={evt => {
+                    setClickedContextMenuClose(r.item);
+                    contextMenu.handleContextMenu(evt);
+                  }}
                 />
               );
             })}

--- a/static/app/components/profiling/FrameStack/frameStackTable.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackTable.tsx
@@ -95,8 +95,11 @@ export function FrameStackTable({
 
   const {
     items,
+    tabIndexKey,
     scrollContainerStyles,
     containerStyles,
+    handleRowClick,
+    handleRowKeyDown,
     handleExpandTreeNode,
     handleSortingChange,
     handleScroll,
@@ -178,11 +181,15 @@ export function FrameStackTable({
               return (
                 <FrameStackTableRow
                   key={r.key}
+                  ref={n => (r.ref = n)}
                   node={r.item}
                   style={r.styles}
                   referenceNode={referenceNode}
+                  tabIndex={tabIndexKey === r.key ? 0 : 1}
                   flamegraphRenderer={flamegraphRenderer}
+                  onClick={() => handleRowClick(r.key)}
                   onExpandClick={handleExpandTreeNode}
+                  onKeyDown={evt => handleRowKeyDown(r.key, evt)}
                   onContextMenu={evt => {
                     setClickedContextMenuClose(r.item);
                     contextMenu.handleContextMenu(evt);

--- a/static/app/components/profiling/FrameStack/frameStackTableRow.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackTableRow.tsx
@@ -20,11 +20,12 @@ function computeRelativeWeight(base: number, value: number) {
 
 interface FrameStackTableRowProps {
   flamegraphRenderer: FlamegraphRenderer;
-  handleExpandedClick: (
+  node: VirtualizedTreeNode<FlamegraphFrame>;
+  onContextMenu: React.MouseEventHandler<HTMLDivElement>;
+  onExpandClick: (
     node: VirtualizedTreeNode<FlamegraphFrame>,
     opts?: {expandChildren: boolean}
   ) => void;
-  node: VirtualizedTreeNode<FlamegraphFrame>;
   referenceNode: FlamegraphFrame;
   style: React.CSSProperties;
 }
@@ -33,7 +34,8 @@ export function FrameStackTableRow({
   node,
   flamegraphRenderer,
   referenceNode,
-  handleExpandedClick,
+  onExpandClick,
+  onContextMenu,
   style,
 }: FrameStackTableRowProps) {
   const colorString = useMemo(() => {
@@ -42,13 +44,13 @@ export function FrameStackTableRow({
 
   const handleExpanding = useCallback(
     (evt: React.MouseEvent) => {
-      handleExpandedClick(node, {expandChildren: evt.metaKey});
+      onExpandClick(node, {expandChildren: evt.metaKey});
     },
-    [node, handleExpandedClick]
+    [node, onExpandClick]
   );
 
   return (
-    <FrameCallersRow style={style}>
+    <FrameCallersRow style={style} onContextMenu={onContextMenu}>
       <FrameCallersTableCell textAlign="right">
         {flamegraphRenderer.flamegraph.formatter(node.node.node.selfWeight)}
         <Weight
@@ -112,6 +114,7 @@ const FrameWeightTypeContainer = styled('div')`
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  position: relative;
 `;
 
 const FrameTypeIndicator = styled('div')`

--- a/static/app/components/profiling/ProfilingContextMenu/profilingContextMenu.tsx
+++ b/static/app/components/profiling/ProfilingContextMenu/profilingContextMenu.tsx
@@ -22,40 +22,14 @@ const Menu = styled(
   border-radius: ${p => p.theme.borderRadius};
   box-shadow: ${p => p.theme.dropShadowHeavy};
   width: auto;
+  min-width: 164px;
   overflow: auto;
-
-  &:focus {
-    outline: none;
-  }
+  padding-bottom: ${space(0.5)};
 `;
 
 export {Menu as ProfilingContextMenu};
 
-interface MenuItemCheckboxProps
-  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
-  checked?: boolean;
-}
-
-const MenuItemCheckbox = styled(
-  forwardRef(
-    (props: MenuItemCheckboxProps, ref: React.Ref<HTMLDivElement> | undefined) => {
-      const {children, checked, className, style, ...rest} = props;
-
-      return (
-        // @ts-ignore this ref is forwarded
-        <MenuItem ref={ref} {...rest}>
-          <label className={className} style={style}>
-            <MenuLeadingItem>
-              <Input type="checkbox" checked={checked} onChange={() => void 0} />
-              <IconCheckmark />
-            </MenuLeadingItem>
-            <MenuContent>{children}</MenuContent>
-          </label>
-        </MenuItem>
-      );
-    }
-  )
-)`
+const MenuContentContainer = styled('div')`
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -68,8 +42,43 @@ const MenuItemCheckbox = styled(
   &:focus {
     color: ${p => p.theme.textColor};
     background: ${p => p.theme.hover};
+    outline: none;
   }
 `;
+
+const MenuItemCheckboxLabel = styled('label')`
+  display: flex;
+  align-items: center;
+  font-weight: normal;
+  margin: 0;
+  cursor: pointer;
+  flex: 1 1 100%;
+`;
+
+interface MenuItemCheckboxProps
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  checked?: boolean;
+}
+
+const MenuItemCheckbox = forwardRef(
+  (props: MenuItemCheckboxProps, ref: React.Ref<HTMLDivElement> | undefined) => {
+    const {children, checked, ...rest} = props;
+
+    return (
+      <MenuContentOuterContainer>
+        <MenuContentContainer ref={ref} role="menuitem" {...rest}>
+          <MenuItemCheckboxLabel>
+            <MenuLeadingItem>
+              <Input type="checkbox" checked={checked} onChange={() => void 0} />
+              <IconCheckmark />
+            </MenuLeadingItem>
+            <MenuContent>{children}</MenuContent>
+          </MenuItemCheckboxLabel>
+        </MenuContentContainer>
+      </MenuContentOuterContainer>
+    );
+  }
+);
 
 export {MenuItemCheckbox as ProfilingContextMenuItemCheckbox};
 
@@ -131,9 +140,11 @@ const MenuItem = styled(
   forwardRef((props: MenuItemProps, ref: React.Ref<HTMLDivElement> | undefined) => {
     const {children, ...rest} = props;
     return (
-      <div ref={ref} role="menuitem" {...rest}>
-        {children}
-      </div>
+      <MenuContentOuterContainer>
+        <MenuContentContainer ref={ref} role="menuitem" {...rest}>
+          <MenuContent>{children}</MenuContent>
+        </MenuContentContainer>
+      </MenuContentOuterContainer>
     );
   })
 )`
@@ -152,6 +163,10 @@ const MenuItem = styled(
 `;
 
 export {MenuItem as ProfilingContextMenuItem};
+
+const MenuContentOuterContainer = styled('div')`
+  padding: 0 ${space(0.5)};
+`;
 
 const MenuGroup = styled('div')`
   padding-top: 0;

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -14,7 +14,6 @@ import {
 } from 'sentry/utils/profiling/flamegraph/useFlamegraphState';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {formatColorForFrame, Rect} from 'sentry/utils/profiling/gl/utils';
 import {useContextMenu} from 'sentry/utils/profiling/hooks/useContextMenu';
@@ -326,9 +325,8 @@ function FlamegraphZoomView({
       setConfigSpaceCursor(null);
     };
 
-    const onZoomIntoFrame = (frame: FlamegraphFrame) => {
+    const onZoomIntoFrame = () => {
       setConfigSpaceCursor(null);
-      dispatchFlamegraphState({type: 'set selected node', payload: frame});
     };
 
     scheduler.on('resetZoom', onResetZoom);

--- a/static/app/utils/profiling/hooks/useContextMenu.tsx
+++ b/static/app/utils/profiling/hooks/useContextMenu.tsx
@@ -50,7 +50,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
   );
 
   const getMenuProps = useCallback(() => {
-    const menuProps = itemProps.getMenuKeyboardEventHandlers();
+    const menuProps = itemProps.getMenuProps();
 
     return {
       ...menuProps,
@@ -64,7 +64,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
   }, [itemProps, wrapSetOpen]);
 
   const getMenuItemProps = useCallback(() => {
-    const menuItemProps = itemProps.getMenuItemKeyboardEventHandlers();
+    const menuItemProps = itemProps.getItemProps();
 
     return {
       ...menuItemProps,

--- a/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
+++ b/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
@@ -1,10 +1,53 @@
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
+
+export function useRovingTabIndex(items: any[]) {
+  const [tabIndex, setTabIndex] = useState<number | null>(null);
+
+  const onKeyDown = useCallback(
+    (evt: React.KeyboardEvent) => {
+      if (items.length === 0) {
+        return;
+      }
+
+      if (evt.key === 'Escape') {
+        setTabIndex(null);
+      }
+
+      if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
+        evt.preventDefault();
+
+        if (tabIndex === items.length - 1 || tabIndex === null) {
+          setTabIndex(0);
+        } else {
+          setTabIndex((tabIndex ?? 0) + 1);
+        }
+      }
+
+      if (evt.key === 'ArrowUp' || (evt.key === 'Tab' && evt.shiftKey)) {
+        evt.preventDefault();
+
+        if (tabIndex === 0 || tabIndex === null) {
+          setTabIndex(items.length - 1);
+        } else {
+          setTabIndex((tabIndex ?? 0) - 1);
+        }
+      }
+    },
+    [tabIndex, items]
+  );
+
+  return {
+    tabIndex,
+    setTabIndex,
+    onKeyDown,
+  };
+}
 
 export function useKeyboardNavigation() {
   const [menuRef, setMenuRef] = useState<HTMLDivElement | null>(null);
-  const [tabIndex, setTabIndex] = useState<number | null>(null);
-
   const items: {id: number; node: HTMLElement | null}[] = [];
+
+  const {tabIndex, setTabIndex, onKeyDown} = useRovingTabIndex(items);
 
   useEffect(() => {
     if (menuRef) {
@@ -14,43 +57,15 @@ export function useKeyboardNavigation() {
     }
   }, [menuRef, tabIndex]);
 
-  function getMenuKeyboardEventHandlers() {
+  function getMenuProps() {
     return {
       tabIndex: -1,
       ref: setMenuRef,
-      onKeyDown: (evt: React.KeyboardEvent) => {
-        if (items.length === 0) {
-          return;
-        }
-
-        if (evt.key === 'Escape') {
-          setTabIndex(null);
-        }
-
-        if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
-          evt.preventDefault();
-
-          if (tabIndex === items.length - 1 || tabIndex === null) {
-            setTabIndex(0);
-          } else {
-            setTabIndex((tabIndex ?? 0) + 1);
-          }
-        }
-
-        if (evt.key === 'ArrowUp' || (evt.key === 'Tab' && evt.shiftKey)) {
-          evt.preventDefault();
-
-          if (tabIndex === 0 || tabIndex === null) {
-            setTabIndex(items.length - 1);
-          } else {
-            setTabIndex((tabIndex ?? 0) - 1);
-          }
-        }
-      },
+      onKeyDown,
     };
   }
 
-  function getMenuItemKeyboardEventHandlers() {
+  function getItemProps() {
     const idx = items.length;
     items.push({id: idx, node: null});
 
@@ -67,46 +82,14 @@ export function useKeyboardNavigation() {
       onMouseEnter: () => {
         setTabIndex(idx);
       },
-      onKeyDown: (evt: React.KeyboardEvent) => {
-        if (items.length === 0) {
-          return;
-        }
-
-        if (evt.key === 'Escape') {
-          setTabIndex(null);
-        }
-
-        if (evt.key === 'Enter' || evt.key === ' ') {
-          items?.[idx]?.node?.click?.();
-        }
-
-        if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
-          evt.preventDefault();
-
-          if (tabIndex === items.length || tabIndex === null) {
-            setTabIndex(0);
-          } else {
-            setTabIndex((tabIndex ?? 0) + 1);
-          }
-        }
-
-        if (evt.key === 'ArrowUp' || (evt.key === 'Tab' && evt.shiftKey)) {
-          evt.preventDefault();
-
-          if (tabIndex === 0 || tabIndex === null) {
-            setTabIndex(items.length);
-          } else {
-            setTabIndex((tabIndex ?? 0) - 1);
-          }
-        }
-      },
+      onKeyDown,
     };
   }
 
   return {
     menuRef,
-    getMenuItemKeyboardEventHandlers,
-    getMenuKeyboardEventHandlers,
+    getItemProps,
+    getMenuProps,
     tabIndex,
     setTabIndex,
   };


### PR DESCRIPTION
Adds the ability to zoom to frames from the call tree table. This is kind of rough but is a good first feature. We ideally need to provide a visual anchor once users click the scope to view - kind of what we do with hoveredNode and selectedNode, but because the table currently reads from the selectedNode, zooming via zoomIntoFrame has the unwanted behavior of also scoping the tree down to that node (which we want to preserve so that users dont lose state due to some implicit behavior)

https://user-images.githubusercontent.com/9317857/170559584-f4e48bf4-efc3-4130-a1e3-b514aade8c1b.mp4

