### PR TITLE
ref(dropdownButton): Bolden prefix, not value

### DIFF
--- a/static/app/components/dropdownButton.tsx
+++ b/static/app/components/dropdownButton.tsx
@@ -1,7 +1,7 @@
 import {forwardRef} from 'react';
 import styled from '@emotion/styled';
 
-import Button, {ButtonProps} from 'sentry/components/button';
+import Button, {ButtonLabel, ButtonProps} from 'sentry/components/button';
 import {IconChevron} from 'sentry/icons';
 import space from 'sentry/styles/space';
 
@@ -59,6 +59,7 @@ const DropdownButton = ({
       type="button"
       aria-haspopup="listbox"
       aria-expanded={detached ? isOpen : undefined}
+      hasPrefix={!!prefix}
       disabled={disabled}
       priority={priority}
       isOpen={isOpen}
@@ -102,7 +103,9 @@ const StyledButton = styled(Button)<
       DropdownButtonProps,
       'isOpen' | 'disabled' | 'hideBottomBorder' | 'detached' | 'priority'
     >
-  >
+  > & {
+    hasPrefix: boolean;
+  }
 >`
   border-bottom-right-radius: ${p =>
     p.isOpen && !p.detached ? 0 : p.theme.borderRadius};
@@ -111,6 +114,7 @@ const StyledButton = styled(Button)<
   z-index: 2;
 
   ${p => (p.isOpen || p.disabled) && 'box-shadow: none'};
+  ${p => p.hasPrefix && `${ButtonLabel} {font-weight: 400;}`}
 
   &,
   &:active,
@@ -125,7 +129,7 @@ const StyledButton = styled(Button)<
 `;
 
 const LabelText = styled('span')`
-  font-weight: 400;
+  font-weight: 600;
   padding-right: ${space(0.75)};
   &:after {
     content: ':';

--- a/static/app/components/dropdownButtonV2.tsx
+++ b/static/app/components/dropdownButtonV2.tsx
@@ -1,7 +1,7 @@
 import {forwardRef} from 'react';
 import styled from '@emotion/styled';
 
-import Button, {ButtonProps} from 'sentry/components/button';
+import Button, {ButtonLabel, ButtonProps} from 'sentry/components/button';
 import {IconChevron} from 'sentry/icons';
 import space from 'sentry/styles/space';
 
@@ -39,6 +39,7 @@ const DropdownButton = forwardRef<
     <StyledButton
       {...props}
       type="button"
+      hasPrefix={!!prefix}
       disabled={disabled}
       priority={priority}
       isOpen={isOpen}
@@ -59,13 +60,16 @@ const StyledChevron = styled(IconChevron)`
 `;
 
 const StyledButton = styled(Button)<
-  Required<Pick<DropdownButtonProps, 'isOpen' | 'disabled' | 'priority'>>
+  Required<Pick<DropdownButtonProps, 'isOpen' | 'disabled' | 'priority'>> & {
+    hasPrefix: boolean;
+  }
 >`
   position: relative;
   max-width: 100%;
   z-index: 2;
 
   ${p => (p.isOpen || p.disabled) && 'box-shadow: none;'}
+  ${p => p.hasPrefix && `${ButtonLabel} {font-weight: 400;}`}
 `;
 
 const LabelText = styled('span')`
@@ -73,7 +77,7 @@ const LabelText = styled('span')`
     content: ':';
   }
 
-  font-weight: 400;
+  font-weight: 600;
   padding-right: ${space(0.75)};
 `;
 


### PR DESCRIPTION
The design specs have been updated - we should now bolden button prefixes, not the main value label.

**Before:**
<img width="244" alt="image" src="https://user-images.githubusercontent.com/44172267/170561600-eb96c4d2-d20d-4aee-9e1d-afff47e43437.png">
<img width="197" alt="image" src="https://user-images.githubusercontent.com/44172267/170561711-4774ea93-c3b8-404e-9c76-6098761b6dae.png">


**After:**
<img width="241" alt="image" src="https://user-images.githubusercontent.com/44172267/170561652-93f48d31-eebf-46c7-979c-fd3ddad4e448.png">
<img width="195" alt="image" src="https://user-images.githubusercontent.com/44172267/170561742-d2630b0f-3531-4f94-bef2-4cdb3b5e1e49.png">
