### PR TITLE
fix: close unclosed file in sentry.data_export.tasks

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -343,9 +343,10 @@ def merge_export_blobs(data_export_id, **kwargs):
                     size += blob.size
                     blob_checksum = sha1(b"")
 
-                    for chunk in blob.getfile().chunks():
-                        blob_checksum.update(chunk)
-                        file_checksum.update(chunk)
+                    with blob.getfile() as f:
+                        for chunk in f.chunks():
+                            blob_checksum.update(chunk)
+                            file_checksum.update(chunk)
 
                     if blob.checksum != blob_checksum.hexdigest():
                         raise AssembleChecksumMismatch("Checksum mismatch")


### PR DESCRIPTION
fixes:

```
tests/sentry/data_export/test_tasks.py::AssembleDownloadTest::test_no_error_on_retry
  /Users/asottile/workspace/sentry/src/sentry/data_export/tasks.py:346: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/sentry-files/a7/cbfd/ad635b4a5c92103985489ccbc3'>
    for chunk in blob.getfile().chunks():
```

(shown when running `pytest -Wonce tests/sentry/data_export/test_tasks.py`)