### PR TITLE
ref(celery): refactor celery configuration to prep for upgrade

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -869,7 +869,7 @@ def create_mock_transactions(project_map, load_trends=False, slow=False):
 
 
 if __name__ == "__main__":
-    settings.CELERY_ALWAYS_EAGER = True
+    settings.CELERY_TASK_ALWAYS_EAGER = True
 
     from optparse import OptionParser
 

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -69,7 +69,7 @@ LEVELS = itertools.cycle(["error", "error", "error", "fatal", "warning"])
 
 ENVIRONMENTS = itertools.cycle(["production", "production", "staging", "alpha", "beta", ""])
 
-MONITOR_NAMES = itertools.cycle(settings.CELERYBEAT_SCHEDULE.keys())
+MONITOR_NAMES = itertools.cycle(settings.CELERY_BEAT_SCHEDULE.keys())
 
 MONITOR_SCHEDULES = itertools.cycle(["* * * * *", "0 * * * *", "0 0 * * *"])
 

--- a/bin/mock-traces
+++ b/bin/mock-traces
@@ -278,7 +278,7 @@ def main(slow=False):
 
 
 if __name__ == "__main__":
-    settings.CELERY_ALWAYS_EAGER = True
+    settings.CELERY_TASK_ALWAYS_EAGER = True
 
     from optparse import OptionParser
 

--- a/docker/sentry.conf.py
+++ b/docker/sentry.conf.py
@@ -135,7 +135,7 @@ SENTRY_CACHE = "sentry.cache.redis.RedisCache"
 rabbitmq = env("SENTRY_RABBITMQ_HOST") or (env("RABBITMQ_PORT_5672_TCP_ADDR") and "rabbitmq")
 
 if rabbitmq:
-    BROKER_URL = (
+    CELERY_BROKER_URL = (
         "amqp://"
         + (env("SENTRY_RABBITMQ_USERNAME") or env("RABBITMQ_ENV_RABBITMQ_DEFAULT_USER") or "guest")
         + ":"
@@ -146,7 +146,9 @@ if rabbitmq:
         + (env("SENTRY_RABBITMQ_VHOST") or env("RABBITMQ_ENV_RABBITMQ_DEFAULT_VHOST") or "/")
     )
 else:
-    BROKER_URL = "redis://:" + redis_password + "@" + redis + ":" + redis_port + "/" + redis_db
+    CELERY_BROKER_URL = (
+        "redis://:" + redis_password + "@" + redis + ":" + redis_port + "/" + redis_db
+    )
 
 
 ###############

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -76,7 +76,7 @@ zstandard==0.14.1
 msgpack==1.0.0
 cryptography==3.4.8
 # celery
-billiard==3.6.3
+billiard==3.6.4
 kombu==4.6.11
 
 # Note, grpcio>1.30.0 requires setting GRPC_POLL_STRATEGY=epoll1

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -510,32 +510,32 @@ SOCIAL_AUTH_FORCE_POST_DISCONNECT = True
 # Queue configuration
 from kombu import Exchange, Queue
 
-BROKER_URL = "redis://127.0.0.1:6379"
-BROKER_TRANSPORT_OPTIONS = {}
+CELERY_BROKER_URL = "redis://127.0.0.1:6379"
+CELERY_BROKER_TRANSPORT_OPTIONS = {}
 
 # Ensure workers run async by default
 # in Development you might want them to run in-process
 # though it would cause timeouts/recursions in some cases
-CELERY_ALWAYS_EAGER = False
+CELERY_TASK_ALWAYS_EAGER = False
 
 # We use the old task protocol because during benchmarking we noticed that it's faster
 # than the new protocol. If we ever need to bump this it should be fine, there were no
 # compatibility issues, just need to run benchmarks and do some tests to make sure
 # things run ok.
 CELERY_TASK_PROTOCOL = 1
-CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
-CELERY_IGNORE_RESULT = True
-CELERY_SEND_EVENTS = False
+CELERY_TASK_EAGER_PROPAGATES = True
+CELERY_TASK_IGNORE_RESULT = True
+CELERY_WORKER_SEND_TASK_EVENTS = False
 CELERY_RESULT_BACKEND = None
-CELERY_TASK_RESULT_EXPIRES = 1
-CELERY_DISABLE_RATE_LIMITS = True
-CELERY_DEFAULT_QUEUE = "default"
-CELERY_DEFAULT_EXCHANGE = "default"
-CELERY_DEFAULT_EXCHANGE_TYPE = "direct"
-CELERY_DEFAULT_ROUTING_KEY = "default"
-CELERY_CREATE_MISSING_QUEUES = True
-CELERY_REDIRECT_STDOUTS = False
-CELERYD_HIJACK_ROOT_LOGGER = False
+CELERY_RESULT_EXPIRES = 1
+CELERY_WORKER_DISABLE_RATE_LIMITS = True
+CELERY_TASK_DEFAULT_QUEUE = "default"
+CELERY_TASK_DEFAULT_EXCHANGE = "default"
+CELERY_TASK_DEFAULT_EXCHANGE_TYPE = "direct"
+CELERY_TASK_DEFAULT_ROUTING_KEY = "default"
+CELERY_TASK_CREATE_MISSING_QUEUES = True
+CELERY_WORKER_REDIRECT_STDOUTS = False
+CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 CELERY_TASK_SERIALIZER = "pickle"
 CELERY_RESULT_SERIALIZER = "pickle"
 CELERY_ACCEPT_CONTENT = {"pickle"}
@@ -587,7 +587,7 @@ CELERY_IMPORTS = (
     "sentry.release_health.duplex",
     "sentry.release_health.tasks",
 )
-CELERY_QUEUES = [
+CELERY_TASK_QUEUES = [
     Queue("activity.notify", routing_key="activity.notify"),
     Queue("alerts", routing_key="alerts"),
     Queue("app_platform", routing_key="app_platform"),
@@ -656,16 +656,16 @@ CELERY_QUEUES = [
     Queue("release_health.duplex", routing_key="release_health.duplex"),
 ]
 
-for queue in CELERY_QUEUES:
+for queue in CELERY_TASK_QUEUES:
     queue.durable = False
 
-CELERY_ROUTES = ("sentry.queue.routers.SplitQueueRouter",)
+CELERY_TASK_ROUTES = ("sentry.queue.routers.SplitQueueRouter",)
 
 
 def create_partitioned_queues(name):
     exchange = Exchange(name, type="direct")
     for num in range(1):
-        CELERY_QUEUES.append(Queue(f"{name}-{num}", exchange=exchange))
+        CELERY_TASK_QUEUES.append(Queue(f"{name}-{num}", exchange=exchange))
 
 
 create_partitioned_queues("counters")
@@ -674,8 +674,8 @@ create_partitioned_queues("triggers")
 from celery.schedules import crontab
 
 # XXX: Make sure to register the monitor_id for each job in `SENTRY_CELERYBEAT_MONITORS`!
-CELERYBEAT_SCHEDULE_FILENAME = os.path.join(tempfile.gettempdir(), "sentry-celerybeat")
-CELERYBEAT_SCHEDULE = {
+CELERY_BEAT_SCHEDULE_FILENAME = os.path.join(tempfile.gettempdir(), "sentry-celerybeat")
+CELERY_BEAT_SCHEDULE = {
     "check-auth": {
         "task": "sentry.tasks.check_auth",
         "schedule": timedelta(minutes=1),

--- a/src/sentry/data/config/sentry.conf.py.default
+++ b/src/sentry/data/config/sentry.conf.py.default
@@ -65,7 +65,7 @@ SENTRY_CACHE = 'sentry.cache.redis.RedisCache'
 # configuring your queue broker and workers. Sentry relies on a Python
 # framework called Celery to manage queues.
 
-BROKER_URL = 'redis://localhost:6379'
+CELERY_BROKER_URL = 'redis://localhost:6379'
 
 ###############
 # Rate Limits #

--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -91,6 +91,6 @@ def get_queue_by_name(name):
 backends = {"redis": RedisBackend, "amqp": AmqpBackend}
 
 try:
-    backend = get_backend_for_broker(settings.BROKER_URL)
+    backend = get_backend_for_broker(settings.CELERY_BROKER_URL)
 except KeyError:
     backend = None

--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -83,7 +83,7 @@ def get_backend_for_broker(broker_url):
 
 def get_queue_by_name(name):
     "Lookup a celery Queue object by it's name"
-    for queue in settings.CELERY_QUEUES:
+    for queue in settings.CELERY_TASK_QUEUES:
         if queue.name == name:
             return queue
 

--- a/src/sentry/queue/routers.py
+++ b/src/sentry/queue/routers.py
@@ -12,7 +12,7 @@ TRIGGER_TASKS = {
 
 class SplitQueueRouter:
     def __init__(self):
-        queues = current_app.conf["CELERY_QUEUES"]
+        queues = current_app.conf["CELERY_TASK_QUEUES"]
         self.counter_queues = itertools.cycle(
             [q.name for q in queues if q.name.startswith("counters-")]
         )

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -217,9 +217,9 @@ def devserver(
     os.environ["SENTRY_USE_RELAY"] = "1" if settings.SENTRY_USE_RELAY else ""
 
     if workers:
-        if settings.CELERY_ALWAYS_EAGER:
+        if settings.CELERY_TASK_ALWAYS_EAGER:
             raise click.ClickException(
-                "Disable CELERY_ALWAYS_EAGER in your settings file to spawn workers."
+                "Disable CELERY_TASK_ALWAYS_EAGER in your settings file to spawn workers."
             )
 
         daemons += [_get_daemon("worker"), _get_daemon("cron")]

--- a/src/sentry/runner/commands/queues.py
+++ b/src/sentry/runner/commands/queues.py
@@ -22,7 +22,7 @@ def list(sort_size, reverse):
     if backend is None:
         raise click.ClickException("unknown broker type")
 
-    queues = backend.bulk_get_sizes([q.name for q in settings.CELERY_QUEUES])
+    queues = backend.bulk_get_sizes([q.name for q in settings.CELERY_TASK_QUEUES])
 
     if sort_size:
         queues = sorted(queues, key=lambda q: (-q[1], q[0]), reverse=reverse)

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -151,9 +151,9 @@ def run_worker(**options):
     """
     from django.conf import settings
 
-    if settings.CELERY_ALWAYS_EAGER:
+    if settings.CELERY_TASK_ALWAYS_EAGER:
         raise click.ClickException(
-            "Disable CELERY_ALWAYS_EAGER in your settings file to spawn workers."
+            "Disable CELERY_TASK_ALWAYS_EAGER in your settings file to spawn workers."
         )
 
     # These options are no longer used, but keeping around
@@ -231,7 +231,7 @@ def worker(ignore_unknown_queues, **options):
 
     from sentry.celery import app
 
-    known_queues = frozenset(c_queue.name for c_queue in app.conf.CELERY_QUEUES)
+    known_queues = frozenset(c_queue.name for c_queue in app.conf.CELERY_TASK_QUEUES)
 
     if options["queues"] is not None:
         if not options["queues"].issubset(known_queues):
@@ -287,9 +287,9 @@ def cron(**options):
     "Run periodic task dispatcher."
     from django.conf import settings
 
-    if settings.CELERY_ALWAYS_EAGER:
+    if settings.CELERY_TASK_ALWAYS_EAGER:
         raise click.ClickException(
-            "Disable CELERY_ALWAYS_EAGER in your settings file to spawn workers."
+            "Disable CELERY_TASK_ALWAYS_EAGER in your settings file to spawn workers."
         )
 
     from sentry.celery import app

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -81,7 +81,7 @@ def init_plugin(plugin):
     if hasattr(plugin, "get_cron_schedule") and plugin.is_enabled():
         schedules = plugin.get_cron_schedule()
         if schedules:
-            settings.CELERYBEAT_SCHEDULE.update(schedules)
+            settings.CELERY_BEAT_SCHEDULE.update(schedules)
 
     if hasattr(plugin, "get_worker_imports") and plugin.is_enabled():
         imports = plugin.get_worker_imports()
@@ -98,7 +98,7 @@ def init_plugin(plugin):
                 name = routing_key = queue
             q = Queue(name, routing_key=routing_key)
             q.durable = False
-            settings.CELERY_QUEUES.append(q)
+            settings.CELERY_TASK_QUEUES.append(q)
 
 
 def initialize_receivers():
@@ -315,7 +315,7 @@ def initialize_app(config, skip_service_validation=False):
 
     # Commonly setups don't correctly configure themselves for production envs
     # so lets try to provide a bit more guidance
-    if settings.CELERY_ALWAYS_EAGER and not settings.DEBUG:
+    if settings.CELERY_TASK_ALWAYS_EAGER and not settings.DEBUG:
         warnings.warn(
             "Sentry is configured to run asynchronous tasks in-process. "
             "This is not recommended within production environments. "
@@ -533,11 +533,11 @@ def apply_legacy_settings(settings):
         warnings.warn(
             DeprecatedSettingWarning(
                 "SENTRY_USE_QUEUE",
-                "CELERY_ALWAYS_EAGER",
+                "CELERY_TASK_ALWAYS_EAGER",
                 "https://develop.sentry.dev/services/queue/",
             )
         )
-        settings.CELERY_ALWAYS_EAGER = not settings.SENTRY_USE_QUEUE
+        settings.CELERY_TASK_ALWAYS_EAGER = not settings.SENTRY_USE_QUEUE
 
     for old, new in (
         ("SENTRY_ADMIN_EMAIL", "system.admin-email"),

--- a/src/sentry/status_checks/celery_alive.py
+++ b/src/sentry/status_checks/celery_alive.py
@@ -11,7 +11,7 @@ from .base import Problem, StatusCheck
 class CeleryAliveCheck(StatusCheck):
     def check(self):
         # There is no queue, and celery is not running, so never show error
-        if settings.CELERY_ALWAYS_EAGER:
+        if settings.CELERY_TASK_ALWAYS_EAGER:
             return []
         last_ping = options.get("sentry:last_worker_ping") or 0
         if last_ping >= time() - 300:

--- a/src/sentry/status_checks/celery_app_version.py
+++ b/src/sentry/status_checks/celery_app_version.py
@@ -9,7 +9,7 @@ from .base import Problem, StatusCheck
 class CeleryAppVersionCheck(StatusCheck):
     def check(self):
         # There is no queue, and celery is not running, so never show error
-        if settings.CELERY_ALWAYS_EAGER:
+        if settings.CELERY_TASK_ALWAYS_EAGER:
             return []
         version = options.get("sentry:last_worker_version")
         if not version:

--- a/src/sentry/testutils/helpers/task_runner.py
+++ b/src/sentry/testutils/helpers/task_runner.py
@@ -9,11 +9,11 @@ from django.conf import settings
 
 @contextmanager
 def TaskRunner():
-    settings.CELERY_ALWAYS_EAGER = True
-    current_app.conf.CELERY_ALWAYS_EAGER = True
+    settings.CELERY_TASK_ALWAYS_EAGER = True
+    current_app.conf.CELERY_TASK_ALWAYS_EAGER = True
     yield
-    current_app.conf.CELERY_ALWAYS_EAGER = False
-    settings.CELERY_ALWAYS_EAGER = False
+    current_app.conf.CELERY_TASK_ALWAYS_EAGER = False
+    settings.CELERY_TASK_ALWAYS_EAGER = False
 
 
 @contextmanager

--- a/src/sentry/utils/monitors.py
+++ b/src/sentry/utils/monitors.py
@@ -32,7 +32,7 @@ def connect(app):
     schedule = (
         app.conf.beat_schedule
         if hasattr(app.conf, "beat_schedule")
-        else app.conf["CELERYBEAT_SCHEDULE"]
+        else app.conf["CELERY_BEAT_SCHEDULE"]
     )
     for schedule_name, monitor_id in settings.SENTRY_CELERYBEAT_MONITORS.items():
         schedule[schedule_name].setdefault("options", {}).setdefault("headers", {}).setdefault(

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -99,9 +99,9 @@ def pytest_configure(config):
     settings.SENTRY_NEWSLETTER_OPTIONS = {}
 
     settings.BROKER_BACKEND = "memory"
-    settings.BROKER_URL = "memory://"
-    settings.CELERY_ALWAYS_EAGER = False
-    settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+    settings.CELERY_BROKER_URL = "memory://"
+    settings.CELERY_TASK_ALWAYS_EAGER = False
+    settings.CELERY_TASK_EAGER_PROPAGATES = True
 
     settings.DEBUG_VIEWS = True
     settings.SERVE_UPLOADED_FILES = True

--- a/tests/sentry/celery/test_app.py
+++ b/tests/sentry/celery/test_app.py
@@ -9,7 +9,7 @@ app.loader.import_default_modules()
 
 # XXX(dcramer): this doesn't actually work as we'd expect, as if the task is imported
 # anywhere else before this code is run it will still show up as registered
-@pytest.mark.parametrize("name,entry", list(settings.CELERYBEAT_SCHEDULE.items()))
+@pytest.mark.parametrize("name,entry", list(settings.CELERY_BEAT_SCHEDULE.items()))
 def test_validate_celerybeat_schedule(name, entry):
     entry = ScheduleEntry(name=name, app=app, **entry)
     assert entry.task in app.tasks

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -203,7 +203,7 @@ def test_apply_legacy_settings(settings):
     settings.SENTRY_FILESTORE_OPTIONS = {"filestore-foo": "filestore-bar"}
     with pytest.warns(DeprecatedSettingWarning) as warninfo:
         apply_legacy_settings(settings)
-    assert settings.CELERY_ALWAYS_EAGER is False
+    assert settings.CELERY_TASK_ALWAYS_EAGER is False
     assert settings.SENTRY_FEATURES["auth:register"] is True
     assert settings.SENTRY_OPTIONS == {
         "system.admin-email": "admin-email",
@@ -234,7 +234,7 @@ def test_apply_legacy_settings(settings):
             ("SENTRY_SMTP_HOSTNAME", "SENTRY_OPTIONS['mail.reply-hostname']"),
             ("SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE", "SENTRY_OPTIONS['system.rate-limit']"),
             ("SENTRY_URL_PREFIX", "SENTRY_OPTIONS['system.url-prefix']"),
-            ("SENTRY_USE_QUEUE", "CELERY_ALWAYS_EAGER"),
+            ("SENTRY_USE_QUEUE", "CELERY_TASK_ALWAYS_EAGER"),
         },
     )
 

--- a/tests/sentry/tasks/test_queues_registered.py
+++ b/tests/sentry/tasks/test_queues_registered.py
@@ -6,7 +6,7 @@ from sentry.testutils import TestCase
 
 class CeleryQueueRegisteredTest(TestCase):
     def test(self):
-        queue_names = {q.name for q in settings.CELERY_QUEUES}
+        queue_names = {q.name for q in settings.CELERY_TASK_QUEUES}
         missing_queue_tasks = []
         for task in current_app.tasks.values():
             # Filter out any tasks that aren't sentry specific, or don't specify `queue`.
@@ -17,5 +17,5 @@ class CeleryQueueRegisteredTest(TestCase):
 
         assert not missing_queue_tasks, (
             "Found tasks with queues that are undefined. These must be defined in "
-            "settings.CELERY_QUEUES.\nTask Info:\n{}.".format("\n".join(missing_queue_tasks))
+            "settings.CELERY_TASK_QUEUES.\nTask Info:\n{}.".format("\n".join(missing_queue_tasks))
         )


### PR DESCRIPTION
- Updates `celery` settings to new upcoming naming expectations.
  - current names will not be supported in celery 6.0
  - see https://docs.celeryq.dev/en/stable/userguide/configuration.html#conf-old-settings-map
  - and https://docs.celeryq.dev/en/stable/history/whatsnew-4.0.html#latentcall-django-admonition
- bumps `billiard` dependency to 3.6.4 (see #34955)
- should help ease our path into celery 5.2.6