### PR TITLE
chore(deps): Bump compression-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "cbor-web": "^8.1.0",
     "classnames": "2.3.1",
     "color": "^4.2.1",
-    "compression-webpack-plugin": "9.2.0",
+    "compression-webpack-plugin": "10.0.0",
     "copy-text-to-clipboard": "3.0.1",
     "core-js": "^3.21.1",
     "crypto-browserify": "^3.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6413,10 +6413,10 @@ compressible@~2.0.16:
   dependencies:
     mime-db ">= 1.43.0 < 2"
 
-compression-webpack-plugin@9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-9.2.0.tgz#57fd539d17c5907eebdeb4e83dcfe2d7eceb9ef6"
-  integrity sha512-R/Oi+2+UHotGfu72fJiRoVpuRifZT0tTC6UqFD/DUo+mv8dbOow9rVOuTvDv5nPPm3GZhHL/fKkwxwIHnJ8Nyw==
+compression-webpack-plugin@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-10.0.0.tgz#3496af1b0dc792e13efc474498838dbff915c823"
+  integrity sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==
   dependencies:
     schema-utils "^4.0.0"
     serialize-javascript "^6.0.0"


### PR DESCRIPTION
[Changelog](https://github.com/webpack-contrib/compression-webpack-plugin/blob/master/CHANGELOG.md#-breaking-changes)

We don't use Brotli compression

Required node is now 14 (we're on 16)