### PR TITLE
feat(core-ui): Consolidate menu item design pattern into a reusable component

### DIFF
--- a/static/app/components/dropdownMenuItemV2.tsx
+++ b/static/app/components/dropdownMenuItemV2.tsx
@@ -9,16 +9,11 @@ import {LocationDescriptor} from 'history';
 import Link from 'sentry/components/links/link';
 import MenuListItem, {
   InnerWrap as MenuListItemInnerWrap,
+  MenuListItemProps,
 } from 'sentry/components/menuListItem';
 import {IconChevron} from 'sentry/icons';
 
-/**
- * Menu item priority. Currently there's only one option other than default,
- * but we may choose to add more in the future.
- */
-type Priority = 'danger' | 'default';
-
-export type MenuItemProps = {
+export type MenuItemProps = MenuListItemProps & {
   /**
    * Item key. Must be unique across the entire menu, including sub-menus.
    */
@@ -30,11 +25,6 @@ export type MenuItemProps = {
    */
   children?: MenuItemProps[];
   /**
-   * Optional descriptive text. Like 'label', should preferably be a string or
-   * have appropriate aria-labels.
-   */
-  details?: React.ReactNode;
-  /**
    * Hide item from the dropdown menu. Note: this will also remove the item
    * from the selection manager.
    */
@@ -45,29 +35,10 @@ export type MenuItemProps = {
    */
   isSubmenu?: boolean;
   /**
-   * Item label. Should prefereably be a string. If not, make sure that
-   * there are appropriate aria-labels.
-   */
-  label?: React.ReactNode;
-  /*
-   * Items to be added to the left of the label
-   */
-  leadingItems?: React.ReactNode;
-  /*
-   * Whether leading items should be centered with respect to the entire
-   * height of the menu item. If false (default), they will be centered with
-   * respect to the first line of the label element.
-   */
-  leadingItemsSpanFullHeight?: boolean;
-  /**
    * Function to call when user selects/clicks/taps on the menu item. The
    * item's key is passed as an argument.
    */
   onAction?: (key: MenuItemProps['key']) => void;
-  /**
-   * Accented text and background (on hover) colors.
-   */
-  priority?: Priority;
   /**
    * Whether to show a line divider below this menu item
    */
@@ -81,16 +52,6 @@ export type MenuItemProps = {
    * Destination if this menu item is a link. See also: `isExternalLink`.
    */
   to?: LocationDescriptor;
-  /*
-   * Items to be added to the right of the label.
-   */
-  trailingItems?: React.ReactNode;
-  /*
-   * Whether trailing items should be centered wrt/ the entire height of the
-   * menu item. If false (default), they will be centered wrt/ the first line of the
-   * label element.
-   */
-  trailingItemsSpanFullHeight?: boolean;
 };
 
 type Props = {

--- a/static/app/components/forms/selectControl.tsx
+++ b/static/app/components/forms/selectControl.tsx
@@ -102,12 +102,6 @@ export type ControlProps<OptionType = GeneralSelectValue> = Omit<
    * can't have a good type here.
    */
   value?: any;
-  /**
-   * If false (default), checkmarks/checkboxes will be vertically centered
-   * wrt the first line of the label text. If true, they will be centered
-   * wrt the entire height of the option wrap.
-   */
-  verticallyCenterCheckWrap?: boolean;
 };
 
 /**
@@ -243,7 +237,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
       cursor: 'pointer',
       color: theme.textColor,
       background: 'transparent',
-      padding: `0 ${space(0.5)}`,
+      padding: 0,
       ':active': {
         background: 'transparent',
       },

--- a/static/app/components/forms/selectOption.tsx
+++ b/static/app/components/forms/selectOption.tsx
@@ -1,27 +1,23 @@
+import {Fragment} from 'react';
 import {components as selectComponents} from 'react-select';
 import styled from '@emotion/styled';
 
+import MenuListItem from 'sentry/components/menuListItem';
 import Tooltip from 'sentry/components/tooltip';
 import {IconCheckmark} from 'sentry/icons';
-import overflowEllipsis from 'sentry/styles/overflowEllipsis';
-import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 
 type Props = React.ComponentProps<typeof selectComponents.Option>;
 
 function SelectOption(props: Props) {
   const {label, data, selectProps, isMulti, isSelected, isFocused, isDisabled} = props;
-  const {showDividers, verticallyCenterCheckWrap} = selectProps;
+  const {showDividers} = selectProps;
   const {
     value,
-    details,
     tooltip,
     tooltipOptions = {delay: 500},
-    leadingItems,
-    trailingItems,
-    leadingItemsSpanFullHeight,
-    trailingItemsSpanFullHeight,
     selectionMode,
+    ...itemProps
   } = data;
 
   const isMultiple = defined(selectionMode) ? selectionMode === 'multiple' : isMulti;
@@ -29,70 +25,35 @@ function SelectOption(props: Props) {
   return (
     <selectComponents.Option className="select-option" {...props}>
       <Tooltip skipWrapper title={tooltip} {...tooltipOptions}>
-        <InnerWrap isFocused={isFocused} isDisabled={isDisabled} data-test-id={value}>
-          <Indent isMultiple={isMultiple} centerCheckWrap={verticallyCenterCheckWrap}>
-            <CheckWrap isMultiple={isMultiple} isSelected={isSelected}>
-              {isSelected && (
-                <IconCheckmark
-                  size={isMultiple ? 'xs' : 'sm'}
-                  color={isMultiple ? 'white' : undefined}
-                />
-              )}
-            </CheckWrap>
-          </Indent>
-          <ContentWrap
-            isFocused={isFocused}
-            showDividers={showDividers}
-            addRightMargin={defined(trailingItems)}
-          >
-            {leadingItems && (
-              <LeadingItems spanFullHeight={leadingItemsSpanFullHeight}>
-                {leadingItems}
-              </LeadingItems>
-            )}
-            <LabelWrap>
-              <Label as={typeof label === 'string' ? 'p' : 'div'}>{label}</Label>
-              {details && <Details>{details}</Details>}
-            </LabelWrap>
-            {trailingItems && (
-              <TrailingItems spanFullHeight={trailingItemsSpanFullHeight}>
-                {trailingItems}
-              </TrailingItems>
-            )}
-          </ContentWrap>
-        </InnerWrap>
+        <MenuListItem
+          {...itemProps}
+          as="div"
+          label={label}
+          isDisabled={isDisabled}
+          isFocused={isFocused}
+          showDivider={showDividers}
+          innerWrapProps={{'data-test-id': value}}
+          labelProps={{as: typeof label === 'string' ? 'p' : 'div'}}
+          leadingItems={
+            <Fragment>
+              <CheckWrap isMultiple={isMultiple} isSelected={isSelected}>
+                {isSelected && (
+                  <IconCheckmark
+                    size={isMultiple ? 'xs' : 'sm'}
+                    color={isMultiple ? 'white' : undefined}
+                  />
+                )}
+              </CheckWrap>
+              {data.leadingItems}
+            </Fragment>
+          }
+        />
       </Tooltip>
     </selectComponents.Option>
   );
 }
 
 export default SelectOption;
-
-const InnerWrap = styled('div')<{isDisabled: boolean; isFocused: boolean}>`
-  display: flex;
-  padding: 0 ${space(1)};
-  border-radius: ${p => p.theme.borderRadius};
-  box-sizing: border-box;
-
-  ${p => p.isFocused && `background: ${p.theme.hover};`}
-  ${p =>
-    p.isDisabled &&
-    `
-    color: ${p.theme.subText};
-    cursor: not-allowed;
-  `}
-`;
-
-const Indent = styled('div')<{centerCheckWrap?: boolean; isMultiple?: boolean}>`
-  display: flex;
-  justify-content: center;
-  gap: ${space(1)};
-  padding: ${space(1)};
-  padding-left: ${space(0.5)};
-
-  ${p => p.isMultiple && !p.centerCheckWrap && `margin-top: 0.2em;`}
-  ${p => p.centerCheckWrap && 'align-items: center;'}
-`;
 
 const CheckWrap = styled('div')<{isMultiple: boolean; isSelected: boolean}>`
   display: flex;
@@ -122,72 +83,4 @@ const CheckWrap = styled('div')<{isMultiple: boolean; isSelected: boolean}>`
       height: 1.4em;
       padding-bottom: 1px;
     `}
-`;
-
-const ContentWrap = styled('div')<{
-  addRightMargin: boolean;
-  isFocused: boolean;
-  showDividers?: boolean;
-}>`
-  position: relative;
-  width: 100%;
-  display: flex;
-  gap: ${space(1)};
-  justify-content: space-between;
-  padding: ${space(1)} 0;
-  min-width: 0;
-
-  ${p =>
-    p.addRightMargin &&
-    `
-    margin-right: ${space(1)};
-    width: calc(100% - ${space(2)});
-  `}
-
-  ${p =>
-    p.showDividers &&
-    !p.isFocused &&
-    `
-      z-index: -1;
-      box-shadow: 0 1px 0 0 ${p.theme.innerBorder};
-
-      .select-option:last-of-type & {
-        box-shadow: none;
-      }
-    `}
-`;
-
-const LeadingItems = styled('div')<{spanFullHeight?: boolean}>`
-  display: flex;
-  align-items: center;
-  height: ${p => (p.spanFullHeight ? '100%' : '1.4em')};
-  gap: ${space(1)};
-`;
-
-const LabelWrap = styled('div')`
-  padding-right: ${space(1)};
-  width: 100%;
-  min-width: 0;
-`;
-
-const Label = styled('p')`
-  margin-bottom: 0;
-  line-height: 1.4;
-  white-space: nowrap;
-  ${overflowEllipsis}
-`;
-
-const Details = styled('p')`
-  font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.subText};
-  line-height: 1.2;
-  margin-bottom: 0;
-`;
-
-const TrailingItems = styled('div')<{spanFullHeight?: boolean}>`
-  display: flex;
-  align-items: center;
-  height: ${p => (p.spanFullHeight ? '100%' : '1.4em')};
-  gap: ${space(1)};
-  margin-right: ${space(0.5)};
 `;

--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -257,7 +257,6 @@ function TeamSelector(props: Props) {
         ...(multiple ? {} : placeholderSelectStyles),
         ...(styles ?? {}),
       }}
-      verticallyCenterCheckWrap
       isLoading={fetching}
       {...extraProps}
     />

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -1,0 +1,255 @@
+import {forwardRef as reactForwardRef} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
+import styled from '@emotion/styled';
+
+import overflowEllipsis from 'sentry/styles/overflowEllipsis';
+import space from 'sentry/styles/space';
+
+/**
+ * Menu item priority. Currently there's only one option other than default,
+ * but we may choose to add more in the future.
+ */
+type Priority = 'danger' | 'default';
+
+export type MenuListItemProps = {
+  /**
+   * Optional descriptive text. Like 'label', should preferably be a string or
+   * have appropriate aria-labels.
+   */
+  details?: React.ReactNode;
+  /**
+   * Item label. Should prefereably be a string. If not, make sure that
+   * there are appropriate aria-labels.
+   */
+  label?: React.ReactNode;
+  /*
+   * Items to be added to the left of the label
+   */
+  leadingItems?: React.ReactNode;
+  /*
+   * Whether leading items should be centered with respect to the entire
+   * height of the item. If false (default), they will be centered with
+   * respect to the first line of the label element.
+   */
+  leadingItemsSpanFullHeight?: boolean;
+  /**
+   * Accented text and background (on hover) colors.
+   */
+  priority?: Priority;
+  /**
+   * Whether to show a line divider below this item
+   */
+  showDivider?: boolean;
+  /*
+   * Items to be added to the right of the label.
+   */
+  trailingItems?: React.ReactNode;
+  /*
+   * Whether trailing items should be centered wrt/ the entire height of the
+   * item. If false (default), they will be centered wrt/ the first line of
+   * the label element.
+   */
+  trailingItemsSpanFullHeight?: boolean;
+};
+
+type OtherProps = {
+  as?: React.ElementType;
+  detailsProps?: object;
+  innerWrapProps?: object;
+  isDisabled?: boolean;
+  isFocused?: boolean;
+  labelProps?: object;
+};
+
+type Props = MenuListItemProps &
+  OtherProps & {
+    forwardRef: React.ForwardedRef<HTMLLIElement>;
+  };
+
+function BaseMenuListItem({
+  label,
+  details,
+  as = 'li',
+  priority = 'default',
+  showDivider = false,
+  leadingItems = false,
+  leadingItemsSpanFullHeight = false,
+  trailingItems = false,
+  trailingItemsSpanFullHeight = false,
+  isFocused = false,
+  isDisabled = false,
+  innerWrapProps = {},
+  labelProps = {},
+  detailsProps = {},
+  forwardRef,
+  ...props
+}: Props) {
+  return (
+    <MenuItemWrap as={as} ref={forwardRef} {...props}>
+      <InnerWrap
+        isDisabled={isDisabled}
+        isFocused={isFocused}
+        priority={priority}
+        {...innerWrapProps}
+      >
+        <ContentWrap isFocused={isFocused} showDivider={showDivider}>
+          {leadingItems && (
+            <LeadingItems
+              isDisabled={isDisabled}
+              spanFullHeight={leadingItemsSpanFullHeight}
+            >
+              {leadingItems}
+            </LeadingItems>
+          )}
+          <LabelWrap>
+            <Label aria-hidden="true" {...labelProps}>
+              {label}
+            </Label>
+            {details && (
+              <Details isDisabled={isDisabled} priority={priority} {...detailsProps}>
+                {details}
+              </Details>
+            )}
+          </LabelWrap>
+          {trailingItems && (
+            <TrailingItems
+              isDisabled={isDisabled}
+              spanFullHeight={trailingItemsSpanFullHeight}
+            >
+              {trailingItems}
+            </TrailingItems>
+          )}
+        </ContentWrap>
+      </InnerWrap>
+    </MenuItemWrap>
+  );
+}
+
+const MenuListItem = reactForwardRef<HTMLLIElement, MenuListItemProps & OtherProps>(
+  (props, ref) => <BaseMenuListItem {...props} forwardRef={ref} />
+);
+
+export default MenuListItem;
+
+const MenuItemWrap = styled('li')`
+  position: static;
+  list-style-type: none;
+  margin: 0;
+  padding: 0 ${space(0.5)};
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+  }
+  &:focus-visible {
+    outline: none;
+  }
+`;
+
+export const InnerWrap = styled('div', {
+  shouldForwardProp: prop =>
+    typeof prop === 'string' &&
+    isPropValid(prop) &&
+    !['isDisabled', 'isFocused', 'priority'].includes(prop),
+})<{
+  isDisabled: boolean;
+  isFocused: boolean;
+  priority: Priority;
+}>`
+  display: flex;
+  position: relative;
+  padding: 0 ${space(1)};
+  border-radius: ${p => p.theme.borderRadius};
+  box-sizing: border-box;
+
+  &,
+  &:hover {
+    color: ${p => p.theme.textColor};
+  }
+  ${p => p.priority === 'danger' && `&,&:hover {color: ${p.theme.errorText}}`}
+  ${p =>
+    p.isDisabled &&
+    `
+    &, &:hover {
+      color: ${p.theme.subText};
+      cursor: initial;
+    }
+  `}
+
+  ${p =>
+    p.isFocused &&
+    `
+      background: ${p.priority === 'danger' ? p.theme.red100 : p.theme.hover};
+      z-index: 1;
+    `}
+`;
+
+const ContentWrap = styled('div')<{isFocused: boolean; showDivider: boolean}>`
+  position: relative;
+  width: 100%;
+  display: flex;
+  gap: ${space(1)};
+  justify-content: space-between;
+  padding: ${space(1)} 0;
+  margin-left: ${space(0.5)};
+
+  ${p =>
+    p.showDivider &&
+    !p.isFocused &&
+    `
+      &::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+        height: 1px;
+        box-shadow:  0 1px 0 0 ${p.theme.innerBorder};
+      }
+    `}
+`;
+
+const LeadingItems = styled('div')<{isDisabled: boolean; spanFullHeight: boolean}>`
+  display: flex;
+  align-items: center;
+  height: 1.4em;
+  gap: ${space(1)};
+  padding: ${space(1)} 0;
+
+  ${p => p.isDisabled && `opacity: 0.5;`}
+  ${p => p.spanFullHeight && `height: 100%;`}
+`;
+
+const LabelWrap = styled('div')`
+  padding-right: ${space(1)};
+  width: 100%;
+`;
+
+const Label = styled('p')`
+  margin-bottom: 0;
+  line-height: 1.4;
+  white-space: nowrap;
+  ${overflowEllipsis}
+`;
+
+const Details = styled('p')<{isDisabled: boolean; priority: Priority}>`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+  line-height: 1.2;
+  margin-bottom: 0;
+  ${overflowEllipsis}
+
+  ${p => p.priority === 'danger' && `color: ${p.theme.errorText};`}
+  ${p => p.isDisabled && `color: ${p.theme.subText};`}
+`;
+
+const TrailingItems = styled('div')<{isDisabled: boolean; spanFullHeight: boolean}>`
+  display: flex;
+  align-items: center;
+  height: 1.4em;
+  gap: ${space(1)};
+  margin-right: ${space(0.5)};
+
+  ${p => p.isDisabled && `opacity: 0.5;`}
+  ${p => p.spanFullHeight && `height: 100%;`}
+`;


### PR DESCRIPTION
Both `SelectOption` and `DropdownMenuItemV2` use a design pattern with a main label, smaller details text, and leading/trailing items:
<img width="159" alt="image" src="https://user-images.githubusercontent.com/44172267/170589900-3902ba21-682d-4e7c-b8e9-9af7e93b6443.png">

We can turn this into a new low-level component that can be used by both `SelectOption` and `DropdownMenuItemV2`, along with any future menu component that we might create.

