### PR TITLE
feat(ui): Remove All Environments title from sidebar

### DIFF
--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -50,7 +50,7 @@ const GroupReleaseStats = ({
   const releaseTrackingUrl = `/settings/${organization.slug}/projects/${project.slug}/release-tracking/`;
 
   return (
-    <SidebarSection title={<span data-test-id="env-label">{environmentLabel}</span>}>
+    <div>
       {!group || !allEnvironments ? (
         <Placeholder height="288px" />
       ) : (
@@ -157,7 +157,7 @@ const GroupReleaseStats = ({
           ) : null}
         </Fragment>
       )}
-    </SidebarSection>
+    </div>
   );
 };
 

--- a/tests/js/spec/components/group/releaseStats.spec.jsx
+++ b/tests/js/spec/components/group/releaseStats.spec.jsx
@@ -20,7 +20,6 @@ describe('GroupReleaseStats', function () {
 
   it('renders all environments', function () {
     createWrapper();
-    expect(screen.getByTestId('env-label')).toHaveTextContent('All Environments');
     expect(screen.getByText('Last 24 Hours')).toBeInTheDocument();
     expect(screen.getByText('Last 30 Days')).toBeInTheDocument();
     expect(screen.getByText('Last seen')).toBeInTheDocument();
@@ -32,9 +31,6 @@ describe('GroupReleaseStats', function () {
 
   it('renders specific environments', function () {
     createWrapper({environments: TestStubs.Environments()});
-    expect(screen.getByTestId('env-label')).toHaveTextContent(
-      'Production, Staging, STAGING'
-    );
     expect(screen.getByText('Last 24 Hours')).toBeInTheDocument();
     expect(screen.getByText('Last 30 Days')).toBeInTheDocument();
     expect(screen.getByText('Last seen')).toBeInTheDocument();


### PR DESCRIPTION
Remove All Environments title from the sidebar in Issue Details.

[FIXES WOR-1850
](https://getsentry.atlassian.net/browse/WOR-1850)

# Before
<img width="328" alt="Screen Shot 2022-05-26 at 3 39 49 PM" src="https://user-images.githubusercontent.com/20312973/170591996-a6ce393f-c66b-44ee-ad9c-1debbd12dc48.png">

# After
<img width="329" alt="Screen Shot 2022-05-26 at 3 45 35 PM" src="https://user-images.githubusercontent.com/20312973/170592017-509eabea-5989-41cb-a038-4682b14a2f65.png">

