### PR TITLE
ref(audit-logs): Modify text for issue linking/creating

### DIFF
--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -187,7 +187,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
       }
       case GroupActivityType.CREATE_ISSUE: {
         const {data} = activity;
-        return tct('[author] created an issue on [provider] titled [title]', {
+        return tct('[author] linked to an issue on [provider] titled [title]', {
           author,
           provider: data.provider,
           title: <ExternalLink href={data.location}>{data.title}</ExternalLink>,


### PR DESCRIPTION


<!-- Describe your PR here. -->

This PR changes the audit log text to say 'linked to an issue' instead of 'created'. 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
