### PR TITLE
feat(alerts): Create correct template query when creating alerts from vitals

### DIFF
--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -297,6 +297,11 @@ function CreateAlertFromViewButton({
     );
   }
   const hasErrors = Object.values(errors).some(x => x);
+
+  const alertTemplate = alertType
+    ? AlertWizardRuleTemplates[alertType]
+    : DEFAULT_WIZARD_TEMPLATE;
+
   const to = hasErrors
     ? undefined
     : {
@@ -309,10 +314,9 @@ function CreateAlertFromViewButton({
           referrer,
           ...(useAlertWizardV3
             ? {
+                ...alertTemplate,
                 project: project?.slug,
-                ...(alertType
-                  ? AlertWizardRuleTemplates[alertType]
-                  : DEFAULT_WIZARD_TEMPLATE),
+                aggregate: queryParams.yAxis ?? alertTemplate.aggregate,
               }
             : {}),
         },

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -132,7 +132,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   getDefaultState(): State {
     const {rule, location} = this.props;
     const triggersClone = [...rule.triggers];
-    const {aggregate, eventTypes: _eventTypes, dataset} = location?.query ?? {};
+    const {aggregate, eventTypes: _eventTypes, dataset, name} = location?.query ?? {};
     const eventTypes = typeof _eventTypes === 'string' ? [_eventTypes] : _eventTypes;
 
     // Warning trigger is removed if it is blank when saving
@@ -143,10 +143,11 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     return {
       ...super.getDefaultState(),
 
+      name: name ?? rule.name ?? '',
       aggregate: aggregate ?? rule.aggregate,
       dataset: dataset ?? rule.dataset,
       eventTypes: eventTypes ?? rule.eventTypes,
-      query: rule.query || '',
+      query: rule.query ?? '',
       timeWindow: rule.timeWindow,
       environment: rule.environment || null,
       triggerErrors: new Map(),
@@ -683,6 +684,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const {organization, ruleId, rule, onSubmitSuccess, router, disableProjectSelector} =
       this.props;
     const {
+      name,
       query,
       project,
       timeWindow,
@@ -794,11 +796,11 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
               }`}
               submitDisabled={disabled}
               initialData={{
-                name: rule.name || '',
+                name,
                 dataset,
                 eventTypes,
                 aggregate,
-                query: rule.query || '',
+                query,
                 timeWindow: rule.timeWindow,
                 environment: rule.environment || null,
                 owner: rule.owner,

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -7,18 +7,30 @@ import SelectControl from 'sentry/components/forms/selectControl';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
-import {explodeFieldString, generateFieldAsString} from 'sentry/utils/discover/fields';
+import {
+  AggregationKey,
+  AggregationRefinement,
+  explodeFieldString,
+  generateFieldAsString,
+} from 'sentry/utils/discover/fields';
 import {Dataset, SessionsAggregate} from 'sentry/views/alerts/rules/metric/types';
 import {
   AlertType,
   AlertWizardAlertNames,
   AlertWizardRuleTemplates,
+  WizardRuleTemplate,
 } from 'sentry/views/alerts/wizard/options';
 import {QueryField} from 'sentry/views/eventsV2/table/queryField';
 import {FieldValueKind} from 'sentry/views/eventsV2/table/types';
 import {generateFieldOptions} from 'sentry/views/eventsV2/utils';
 
 import {getFieldOptionConfig} from './metricField';
+
+type WizardAggregateFieldValue = {
+  function: [AggregationKey, string, AggregationRefinement, AggregationRefinement];
+  kind: 'function';
+  alias?: string;
+};
 
 type MenuOption = {label: string; value: AlertType};
 
@@ -113,25 +125,51 @@ export default function WizardField({
   alertType,
   ...fieldProps
 }: Props) {
+  const matchTemplateAggregate = (
+    template: WizardRuleTemplate,
+    aggregate: string
+  ): boolean => {
+    const templateFieldValue = explodeFieldString(
+      template.aggregate
+    ) as WizardAggregateFieldValue;
+    const aggregateFieldValue = explodeFieldString(
+      aggregate
+    ) as WizardAggregateFieldValue;
+
+    return (
+      template.aggregate === aggregate ||
+      (templateFieldValue.function?.[1] && aggregateFieldValue.function?.[1]
+        ? templateFieldValue.function?.[1] === aggregateFieldValue.function?.[1]
+        : templateFieldValue.function?.[0] === aggregateFieldValue.function?.[0])
+    );
+  };
+
+  const matchTemplateDataset = (
+    template: WizardRuleTemplate,
+    dataset: Dataset
+  ): boolean =>
+    template.dataset === dataset ||
+    (organization.features.includes('alert-crash-free-metrics') &&
+      (template.aggregate === SessionsAggregate.CRASH_FREE_SESSIONS ||
+        template.aggregate === SessionsAggregate.CRASH_FREE_USERS) &&
+      dataset === Dataset.METRICS);
+
   return (
     <FormField {...fieldProps}>
-      {({onChange, value, model, disabled}) => {
-        const aggregate = model.getValue('aggregate');
-        const dataset = model.getValue('dataset');
+      {({onChange, value: aggregate, model, disabled}) => {
+        const dataset: Dataset = model.getValue('dataset');
         const eventTypes = [...(model.getValue('eventTypes') ?? [])];
 
         const selectedTemplate =
-          findKey(
-            AlertWizardRuleTemplates,
-            template =>
-              template.aggregate === aggregate &&
-              (template.dataset === dataset ||
-                (organization.features.includes('alert-crash-free-metrics') &&
-                  (template.aggregate === SessionsAggregate.CRASH_FREE_SESSIONS ||
-                    template.aggregate === SessionsAggregate.CRASH_FREE_USERS) &&
-                  dataset === Dataset.METRICS)) &&
-              eventTypes.includes(template.eventTypes)
-          ) || 'num_errors';
+          alertType === 'custom'
+            ? alertType
+            : findKey(
+                AlertWizardRuleTemplates,
+                template =>
+                  matchTemplateAggregate(template, aggregate) &&
+                  matchTemplateDataset(template, dataset) &&
+                  eventTypes.includes(template.eventTypes)
+              ) || 'num_errors';
 
         const {fieldOptionsConfig, hidePrimarySelector, hideParameterSelector} =
           getFieldOptionConfig({
@@ -139,7 +177,7 @@ export default function WizardField({
             alertType,
           });
         const fieldOptions = generateFieldOptions({organization, ...fieldOptionsConfig});
-        const fieldValue = explodeFieldString(value ?? '');
+        const fieldValue = explodeFieldString(aggregate ?? '');
 
         const fieldKey =
           fieldValue?.kind === FieldValueKind.FUNCTION

--- a/static/app/views/performance/vitalDetail/utils.tsx
+++ b/static/app/views/performance/vitalDetail/utils.tsx
@@ -11,6 +11,7 @@ import {getAggregateAlias, WebVital} from 'sentry/utils/discover/fields';
 import {Browser} from 'sentry/utils/performance/vitals/constants';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {Color, Theme} from 'sentry/utils/theme';
+import {AlertType} from 'sentry/views/alerts/wizard/options';
 
 export function generateVitalDetailRoute({orgSlug}: {orgSlug: string}): string {
   return `/organizations/${orgSlug}/performance/vitaldetail/`;
@@ -138,6 +139,13 @@ export const vitalAbbreviations: Partial<Record<WebVital, string>> = {
   [WebVital.CLS]: 'CLS',
   [WebVital.FID]: 'FID',
   [WebVital.LCP]: 'LCP',
+};
+
+export const vitalAlertTypes: Partial<Record<WebVital, AlertType>> = {
+  [WebVital.FCP]: 'custom',
+  [WebVital.CLS]: 'cls',
+  [WebVital.FID]: 'fid',
+  [WebVital.LCP]: 'lcp',
 };
 
 export function getMaxOfSeries(series: Series[]) {

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -41,6 +41,7 @@ import {getTransactionSearchQuery} from '../utils';
 import Table from './table';
 import {
   vitalAbbreviations,
+  vitalAlertTypes,
   vitalDescription,
   vitalMap,
   vitalSupportedBrowsers,
@@ -118,7 +119,7 @@ class VitalDetailContent extends Component<Props, State> {
   };
 
   renderCreateAlertButton() {
-    const {eventView, organization, projects} = this.props;
+    const {eventView, organization, projects, vitalName} = this.props;
 
     return (
       <CreateAlertFromViewButton
@@ -127,7 +128,9 @@ class VitalDetailContent extends Component<Props, State> {
         projects={projects}
         onIncompatibleQuery={this.handleIncompatibleQuery}
         onSuccess={() => {}}
+        useAlertWizardV3={organization.features.includes('alert-wizard-v3')}
         aria-label={t('Create Alert')}
+        alertType={vitalAlertTypes[vitalName]}
         referrer="performance"
       />
     );


### PR DESCRIPTION
This adds:
- `alertType` to Vital Details' Create Alert button
- added name initialization from query
- added initialization for aggregates other than the ones defined in `AlertWizardRuleTemplates` such as `p75(measurements.fid)`
These only work in alert-wizard-v3, which is going to be released next week.