### PR TITLE
chore(deps): bump billiard to 3.6.4

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -76,7 +76,7 @@ zstandard==0.14.1
 msgpack==1.0.0
 cryptography==3.4.8
 # celery
-billiard==3.6.3
+billiard==3.6.4
 kombu==4.6.11
 
 # Note, grpcio>1.30.0 requires setting GRPC_POLL_STRATEGY=epoll1


### PR DESCRIPTION
Bumps `billiard` to 3.6.4.