### PR TITLE
fix(github-enterprise): Fix github enterprise integration app url 

### DIFF
--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -388,7 +388,7 @@ class GitHubEnterpriseInstallationRedirect(PipelineView):
     def get_app_url(self, installation_data):
         url = installation_data.get("url")
         name = installation_data.get("name")
-        return f"https://{url}/github-apps/{name}"
+        return f"https://{url}/apps/{name}"
 
     def dispatch(self, request: Request, pipeline) -> Response:
         installation_data = pipeline.fetch_state(key="installation_data")

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -41,7 +41,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         redirect = urlparse(resp["Location"])
         assert redirect.scheme == "https"
         assert redirect.netloc == "github.example.org"
-        assert redirect.path == "/github-apps/test-app"
+        assert redirect.path == "/apps/test-app"
 
         # App installation ID is provided, mveo thr
         resp = self.client.get(


### PR DESCRIPTION
When you try to add configuration for github enterprise app, it redirects you to https://{github-url}/github-apps/ which is not a correct url and returns 404 not found. The correct url is https://{github-url}/apps. 

