### PR TITLE
fix(ui): URL for documentation on connecting services has changed

### DIFF
--- a/static/app/components/quickTrace/index.tsx
+++ b/static/app/components/quickTrace/index.tsx
@@ -588,7 +588,7 @@ class MissingServiceNode extends Component<MissingServiceProps, MissingServiceSt
     const docsHref =
       docPlatform === null || docPlatform === 'javascript'
         ? 'https://docs.sentry.io/platforms/javascript/performance/connect-services/'
-        : `https://docs.sentry.io/platforms/${docPlatform}/performance#connecting-services`;
+        : `https://docs.sentry.io/platforms/${docPlatform}/performance/connecting-services`;
     return (
       <Fragment>
         {connectorSide === 'left' && <TraceConnector />}


### PR DESCRIPTION
The correct URL I should have taken to is:
https://docs.sentry.io/platforms/python/performance/connect-services/