### PR TITLE
fix(ui): Fix semi-broken <LazyLoad>

### DIFF
--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -1,4 +1,4 @@
-import {Component, ErrorInfo, lazy, Suspense} from 'react';
+import {Component, ErrorInfo, lazy, Suspense, useMemo} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
@@ -41,13 +41,17 @@ type Props<C extends ComponentType> = Omit<React.ComponentProps<C>, 'route'> & {
 function LazyLoad<C extends ComponentType>(props: Props<C>) {
   const importComponent = props.component ?? props.route?.componentPromise;
 
-  const LazyComponent = lazy(() => {
-    if (!importComponent) {
-      throw new Error('No component to load');
-    }
+  const LazyComponent = useMemo(
+    () =>
+      lazy(() => {
+        if (!importComponent) {
+          throw new Error('No component to load');
+        }
 
-    return retryableImport(importComponent);
-  });
+        return retryableImport(importComponent);
+      }),
+    [importComponent]
+  );
 
   return (
     <ErrorBoundary>
@@ -58,9 +62,7 @@ function LazyLoad<C extends ComponentType>(props: Props<C>) {
           </LoadingContainer>
         }
       >
-        <div>
-          <LazyComponent {...(props as React.ComponentProps<C>)} />;
-        </div>
+        <LazyComponent {...(props as React.ComponentProps<C>)} />;
       </Suspense>
     </ErrorBoundary>
   );

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -62,7 +62,7 @@ function LazyLoad<C extends ComponentType>(props: Props<C>) {
           </LoadingContainer>
         }
       >
-        <LazyComponent {...(props as React.ComponentProps<C>)} />;
+        <LazyComponent {...(props as React.ComponentProps<C>)} />
       </Suspense>
     </ErrorBoundary>
   );

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -68,8 +68,13 @@ function LazyLoad<C extends ComponentType>(props: Props<C>) {
   );
 }
 
+interface ErrorBoundaryState {
+  error: Error | null;
+  hasError: boolean;
+}
+
 // Error boundaries currently have to be classes.
-class ErrorBoundary extends Component {
+class ErrorBoundary extends Component<{}, ErrorBoundaryState> {
   static getDerivedStateFromError(error: Error) {
     return {
       hasError: true,
@@ -92,14 +97,15 @@ class ErrorBoundary extends Component {
     console.error(error);
   }
 
-  fetchRetry = () => this.setState({hasError: false});
+  // Reset `hasError` so that we attempt to render `this.props.children` again
+  handleRetry = () => this.setState({hasError: false});
 
   render() {
     if (this.state.hasError) {
       return (
         <LoadingErrorContainer>
           <LoadingError
-            onRetry={this.fetchRetry}
+            onRetry={this.handleRetry}
             message={t('There was an error loading a component.')}
           />
         </LoadingErrorContainer>

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import {Component, ErrorInfo, lazy, Suspense} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
@@ -39,84 +39,72 @@ type Props<C extends ComponentType> = Omit<React.ComponentProps<C>, 'route'> & {
  *   <LazyLoad component={() => import('./myComponent')} someComponentProps={...} />
  */
 function LazyLoad<C extends ComponentType>(props: Props<C>) {
-  const [LazyComponent, setLazyComponent] = useState<C | null>(null);
-  const [error, setError] = useState<any>(null);
-
-  const handleFetchError = useCallback(
-    (fetchError: any) => {
-      Sentry.withScope(scope => {
-        if (isWebpackChunkLoadingError(fetchError)) {
-          scope.setFingerprint(['webpack', 'error loading chunk']);
-        }
-        Sentry.captureException(fetchError);
-      });
-
-      // eslint-disable-next-line no-console
-      console.error(fetchError);
-      setError(fetchError);
-    },
-    [setError]
-  );
-
   const importComponent = props.component ?? props.route?.componentPromise;
 
-  const fetchComponent = useCallback(async () => {
-    if (importComponent === undefined) {
-      return;
+  const LazyComponent = lazy(() => {
+    if (!importComponent) {
+      throw new Error('No component to load');
     }
 
-    // If we're refetching due to a change to importComponent we want to make
-    // sure the current LazyComponent is cleared out.
-    setLazyComponent(null);
+    return retryableImport(importComponent);
+  });
 
-    try {
-      const resolvedComponent = await retryableImport(importComponent);
+  return (
+    <ErrorBoundary>
+      <Suspense
+        fallback={
+          <LoadingContainer>
+            <LoadingIndicator />
+          </LoadingContainer>
+        }
+      >
+        <div>
+          <LazyComponent {...(props as React.ComponentProps<C>)} />;
+        </div>
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
 
-      // XXX: Because the resolvedComponent may be a functional component (a
-      // function) trying to pass it into the setLazyComponent will cause the
-      // useState to try and execute the function (because useState provides a
-      // "functional updates" invocation, see [0]) which is NOT what we want.
-      // So we use a functional update invocation to set the component.
-      //
-      // [0]: https://reactjs.org/docs/hooks-reference.html#functional-updates
-      setLazyComponent(() => resolvedComponent);
-    } catch (err) {
-      handleFetchError(err);
+// Error boundaries currently have to be classes.
+class ErrorBoundary extends Component {
+  static getDerivedStateFromError(error: Error) {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  state = {hasError: false, error: null};
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    Sentry.withScope(scope => {
+      if (isWebpackChunkLoadingError(error)) {
+        scope.setFingerprint(['webpack', 'error loading chunk']);
+      }
+      scope.setExtra('errorInfo', errorInfo);
+      Sentry.captureException(error);
+    });
+
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+
+  fetchRetry = () => this.setState({hasError: false});
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <LoadingErrorContainer>
+          <LoadingError
+            onRetry={this.fetchRetry}
+            message={t('There was an error loading a component.')}
+          />
+        </LoadingErrorContainer>
+      );
     }
-  }, [importComponent, handleFetchError]);
-
-  // Fetch the component on mount and if the importComponent is updated
-  useEffect(() => void fetchComponent(), [fetchComponent]);
-
-  const fetchRetry = useCallback(() => {
-    setError(null);
-    fetchComponent();
-  }, [setError, fetchComponent]);
-
-  if (error) {
-    return (
-      <LoadingErrorContainer>
-        <LoadingError
-          onRetry={fetchRetry}
-          message={t('There was an error loading a component.')}
-        />
-      </LoadingErrorContainer>
-    );
+    return this.props.children;
   }
-
-  if (!LazyComponent) {
-    return (
-      <LoadingContainer>
-        <LoadingIndicator />
-      </LoadingContainer>
-    );
-  }
-
-  if (LazyComponent === null) {
-    return null;
-  }
-
-  return <LazyComponent {...(props as React.ComponentProps<C>)} />;
 }
 
 const LoadingContainer = styled('div')`

--- a/static/app/utils/retryableImport.tsx
+++ b/static/app/utils/retryableImport.tsx
@@ -8,7 +8,7 @@ export default async function retryableImport<T>(
   let retries = 0;
   const tryLoad = async () => {
     try {
-      return fn();
+      return await fn();
     } catch (err) {
       if (isWebpackChunkLoadingError(err) && retries < MAX_RETRIES) {
         retries++;

--- a/static/app/utils/retryableImport.tsx
+++ b/static/app/utils/retryableImport.tsx
@@ -4,12 +4,11 @@ const MAX_RETRIES = 2;
 
 export default async function retryableImport<T>(
   fn: () => Promise<{default: T}>
-): Promise<T> {
+): Promise<{default: T}> {
   let retries = 0;
   const tryLoad = async () => {
     try {
-      const module = await fn();
-      return module.default ?? module;
+      return fn();
     } catch (err) {
       if (isWebpackChunkLoadingError(err) && retries < MAX_RETRIES) {
         retries++;

--- a/tests/js/spec/utils/retryableImport.spec.jsx
+++ b/tests/js/spec/utils/retryableImport.spec.jsx
@@ -17,7 +17,9 @@ describe('retryableImport', function () {
     const result = await retryableImport(() => importMock());
 
     expect(result).toEqual({
-      foo: 'bar',
+      default: {
+        foo: 'bar',
+      },
     });
     expect(importMock).toHaveBeenCalledTimes(1);
   });
@@ -60,7 +62,9 @@ describe('retryableImport', function () {
     const result = await retryableImport(() => importMock());
 
     expect(result).toEqual({
-      foo: 'bar',
+      default: {
+        foo: 'bar',
+      },
     });
     expect(importMock).toHaveBeenCalledTimes(3);
   });


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/34857 caused a regression where switching routes (for views that use `useRouteContext`) causes the old route component to re-render instead of unmounting. This breaks because assumptions of route parameters existing in that component no longer exist. (e.g. a details page that expects a route parameter of ID will crash when navigating to a list page because the details page gets re-rendered with the route for the list page).

Instead of using state to attempt to manage the unmounting/mounting of code split components, we can use `<Suspense>` from Reacts core API.