### PR TITLE
feat(discover): Bumping the sampling rate a bit

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -50,8 +50,8 @@ SAMPLED_URL_NAMES = {
     "sentry-api-0-user-notification-settings": settings.SAMPLED_DEFAULT_RATE,
     "sentry-api-0-team-notification-settings": settings.SAMPLED_DEFAULT_RATE,
     # events
-    "sentry-api-0-organization-eventsv2": 0.01,
-    "sentry-api-0-organization-events": 0.01,
+    "sentry-api-0-organization-eventsv2": 0.1,
+    "sentry-api-0-organization-events": 1,
     # releases
     "sentry-api-0-organization-releases": settings.SAMPLED_DEFAULT_RATE,
     "sentry-api-0-organization-release-details": settings.SAMPLED_DEFAULT_RATE,


### PR DESCRIPTION
- for eventsv2 eps is less than 0.05, bumping this up 10x should be fine
  and give a better idea of usage
- events is not in use yet, and should be gradual in growth so should be
  easy to drop back down
