### PR TITLE
feat(replays): add 'Share' button in header to deeplink timestamp

### DIFF
--- a/static/app/utils/replays/createUrlToShare.tsx
+++ b/static/app/utils/replays/createUrlToShare.tsx
@@ -1,8 +1,8 @@
 function createUrlToShare(currentTimeMs: number) {
   const url = new URL(window.location.href);
-  const curentTimeSec = Math.floor(msToSec(currentTimeMs) || 0);
-  if (curentTimeSec > 0) {
-    url.searchParams.set('t', curentTimeSec.toString());
+  const currentTimeSec = Math.floor(msToSec(currentTimeMs) || 0);
+  if (currentTimeSec > 0) {
+    url.searchParams.set('t', currentTimeSec.toString());
   }
   return url.toString();
 }

--- a/static/app/utils/replays/createUrlToShare.tsx
+++ b/static/app/utils/replays/createUrlToShare.tsx
@@ -1,0 +1,14 @@
+function createUrlToShare(currentTimeMs: number) {
+  const url = new URL(window.location.href);
+  const curentTimeSec = Math.floor(msToSec(currentTimeMs) || 0);
+  if (curentTimeSec > 0) {
+    url.searchParams.set('t', curentTimeSec.toString());
+  }
+  return url.toString();
+}
+
+function msToSec(ms: number) {
+  return ms / 1000;
+}
+
+export default createUrlToShare;

--- a/static/app/views/replays/detail/detailLayout.tsx
+++ b/static/app/views/replays/detail/detailLayout.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import Breadcrumbs from 'sentry/components/breadcrumbs';
+import Button from 'sentry/components/button';
+import Clipboard from 'sentry/components/clipboard';
 import Duration from 'sentry/components/duration';
 import FeatureBadge from 'sentry/components/featureBadge';
 import {FeatureFeedback} from 'sentry/components/featureFeedback';
@@ -12,10 +14,13 @@ import {KeyMetricData, KeyMetrics} from 'sentry/components/replays/keyMetrics';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import TimeSince from 'sentry/components/timeSince';
+import {IconLink} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
 import {Crumb} from 'sentry/types/breadcrumbs';
 import {Event} from 'sentry/types/event';
 import getUrlPathname from 'sentry/utils/getUrlPathname';
+import createUrlToShare from 'sentry/utils/replays/createUrlToShare';
 
 type Props = {
   children: React.ReactNode;
@@ -25,7 +30,12 @@ type Props = {
 };
 
 function DetailLayout({children, event, orgId, crumbs}: Props) {
+  const {currentTime} = useReplayContext();
   const title = event ? `${event.id} - Replays - ${orgId}` : `Replays - ${orgId}`;
+
+  const urlToShare = useMemo(() => {
+    return createUrlToShare(currentTime);
+  }, [currentTime]);
 
   return (
     <SentryDocumentTitle title={title}>
@@ -49,7 +59,10 @@ function DetailLayout({children, event, orgId, crumbs}: Props) {
               ]}
             />
           </Layout.HeaderContent>
-          <FeedbackButtonWrapper>
+          <ButtonActionsWrapper>
+            <Clipboard hideUnsupported value={urlToShare}>
+              <Button icon={<IconLink />}>{t('Share')}</Button>
+            </Clipboard>
             <FeatureFeedback
               featureName="replay"
               feedbackTypes={[
@@ -59,7 +72,7 @@ function DetailLayout({children, event, orgId, crumbs}: Props) {
                 'Other reason',
               ]}
             />
-          </FeedbackButtonWrapper>
+          </ButtonActionsWrapper>
           <React.Fragment>
             <Layout.HeaderContent>
               <EventHeader event={event} />
@@ -154,8 +167,11 @@ const BigNameUserBadge = styled(UserBadge)`
 `;
 
 // TODO(replay); This could make a lot of sense to put inside HeaderActions by default
-const FeedbackButtonWrapper = styled(Layout.HeaderActions)`
-  align-items: end;
+const ButtonActionsWrapper = styled(Layout.HeaderActions)`
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  justify-content: flex-end;
+  gap: ${space(1)};
 `;
 
 export default DetailLayout;


### PR DESCRIPTION
### Description

```
If you land on a replay details page with ?t=30 the video will start at the 30 second mark.
We should have a button on the details page so people can generate these deeplinks, copy+paste them and share them around.
For example: this "Share" button should include the correct t= query param.
```

Closes: #34178 

### Screenshots

#### Disclaimer: The icon probably gonna change to the right one.

<img width="759" alt="image" src="https://user-images.githubusercontent.com/14813235/170790499-5cf8a652-a6c1-4c85-bf67-89c5721f4a86.png">



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
