### PR TITLE
feat(discover): Give a tip when an IN condition could be used

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -231,6 +231,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 meta = {
                     "fields": meta,
                     "isMetricsData": isMetricsData,
+                    "tips": results.get("tips", {}),
                 }
             # TODO(wmak): Check if the performance facets histogram endpoint actually needs meta as a list
             elif isinstance(meta, dict) and "isMetricsData" not in meta:

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -117,6 +117,10 @@ class QueryBuilder:
         self.auto_fields = auto_fields
         self.functions_acl = set() if functions_acl is None else functions_acl
         self.equation_config = {} if equation_config is None else equation_config
+        self.tips: Dict[str, Set[str]] = {
+            "query": set(),
+            "columns": set(),
+        }
 
         # Function is a subclass of CurriedFunction
         self.where: List[WhereType] = []
@@ -349,6 +353,17 @@ class QueryBuilder:
         lhs_where, lhs_having = self.resolve_boolean_conditions(lhs, use_aggregate_conditions)
         rhs_where, rhs_having = self.resolve_boolean_conditions(rhs, use_aggregate_conditions)
 
+        is_where_condition = lambda x: x and len(x) == 1 and isinstance(x[0], Condition)
+
+        if (
+            operator == Or
+            and is_where_condition(lhs_where)
+            and is_where_condition(rhs_where)
+            and lhs_where[0].lhs == rhs_where[0].lhs
+        ):
+            self.tips["query"].add(
+                "Did you know you can replace chained or conditions like `field:a OR field:b OR field:c` with `field:[a,b,c]`"
+            )
         if operator == Or and (lhs_where or rhs_where) and (lhs_having or rhs_having):
             raise InvalidSearchQuery(
                 "Having an OR between aggregate filters and normal filters is invalid."

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -354,7 +354,9 @@ class QueryBuilder:
         lhs_where, lhs_having = self.resolve_boolean_conditions(lhs, use_aggregate_conditions)
         rhs_where, rhs_having = self.resolve_boolean_conditions(rhs, use_aggregate_conditions)
 
-        is_where_condition = lambda x: x and len(x) == 1 and isinstance(x[0], Condition)
+        is_where_condition: Callable[[List[WhereType]], bool] = lambda x: bool(
+            x and len(x) == 1 and isinstance(x[0], Condition)
+        )
 
         if (
             # A direct field:a OR field:b

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -39,6 +39,11 @@ class ThresholdDict(TypedDict):
     meh: float
 
 
+QUERY_TIPS: Dict[str, str] = {
+    "CHAINED_OR": "Did you know you can replace chained or conditions like `field:a OR field:b OR field:c` with `field:[a,b,c]`"
+}
+
+
 VITAL_THRESHOLDS: Dict[str, ThresholdDict] = {
     "lcp": {
         "poor": 4000,

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import random
 from collections import namedtuple
 from copy import deepcopy
 from datetime import timedelta
@@ -188,6 +189,13 @@ def transform_data(result, translated_columns, snuba_filter):
     return result
 
 
+def transform_tips(tips):
+    return {
+        "query": random.choice(list(tips["query"])) if tips["query"] else None,
+        "columns": random.choice(list(tips["columns"])) if tips["columns"] else None,
+    }
+
+
 def query(
     selected_columns,
     query,
@@ -280,6 +288,7 @@ def query(
             translated_columns,
             None,
         )
+        result["tips"] = transform_tips(builder.tips)
     return result
 
 

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -592,9 +592,57 @@ class QueryBuilderTest(TestCase):
                 "field",
             ],
         )
-        assert query.tips["query"] == {
-            "Did you know you can replace chained or conditions like `field:a OR field:b OR field:c` with `field:[a,b,c]`"
-        }
+        assert constants.QUERY_TIPS["CHAINED_OR"] in query.tips["query"]
+
+    def test_chained_or_with_different_terms(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            "field:a or field:b or event.type:transaction or transaction:foo",
+            selected_columns=[
+                "field",
+            ],
+        )
+        # This query becomes something roughly like:
+        # field:a or (field:b or (event.type:transaciton or transaction: foo))
+        assert constants.QUERY_TIPS["CHAINED_OR"] in query.tips["query"]
+
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            "event.type:transaction or transaction:foo or field:a or field:b",
+            selected_columns=[
+                "field",
+            ],
+        )
+        assert constants.QUERY_TIPS["CHAINED_OR"] in query.tips["query"]
+
+    def test_chained_or_with_different_terms_with_and(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            # There's an implicit and between field:b, and event.type:transaction
+            "field:a or field:b event.type:transaction",
+            selected_columns=[
+                "field",
+            ],
+        )
+        # This query becomes something roughly like:
+        # field:a or (field:b and event.type:transaction)
+        assert constants.QUERY_TIPS["CHAINED_OR"] not in query.tips["query"]
+
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            # There's an implicit and between event.type:transaction, and field:a
+            "event.type:transaction field:a or field:b",
+            selected_columns=[
+                "field",
+            ],
+        )
+        # This query becomes something roughly like:
+        # field:a or (field:b and event.type:transaction)
+        assert constants.QUERY_TIPS["CHAINED_OR"] not in query.tips["query"]
 
 
 def _metric_percentile_definition(

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -583,6 +583,19 @@ class QueryBuilderTest(TestCase):
         with self.assertRaises(InvalidSearchQuery):
             query.get_snql_query()
 
+    def test_query_chained_or_tip(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            "field:a OR field:b OR field:c",
+            selected_columns=[
+                "field",
+            ],
+        )
+        assert query.tips["query"] == {
+            "Did you know you can replace chained or conditions like `field:a OR field:b OR field:c` with `field:[a,b,c]`"
+        }
+
 
 def _metric_percentile_definition(
     org_id, quantile, field="transaction.duration", alias=None

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -10962,6 +10962,20 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         assert len(data) == 1
         assert data[0]["p95"] == "<5k"
 
+    def test_chained_or_query_meta_tip(self):
+        query = {
+            "field": ["transaction"],
+            "query": "transaction:a OR transaction:b",
+            "project": [self.project.id],
+        }
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        meta = response.data["meta"]
+        assert meta["tips"] == {
+            "query": "Did you know you can replace chained or conditions like `field:a OR field:b OR field:c` with `field:[a,b,c]`",
+            "columns": None,
+        }
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPerformanceTestCase):
     viewname = "sentry-api-0-organization-events"


### PR DESCRIPTION
- This checks that there's at least one OR condition between two
  identical fields, and returns a tip on the events meta that could help
  users write better queries