### PR TITLE
ref(metrics): Rename `QueryDefinition` to `MetricsQuery` [TET-105]

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -120,7 +120,7 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
                 query = APIQueryDefinition(
                     projects, request.GET, paginator_kwargs={"limit": limit, "offset": offset}
                 )
-                data = get_series(projects, query.to_query_definition())
+                data = get_series(projects, query.to_metrics_query())
                 data["query"] = query.query
             except (
                 InvalidField,

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -56,8 +56,7 @@ from sentry.release_health.base import (
 from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics.datasource import get_series
 from sentry.snuba.metrics.naming_layer.public import SessionMetricKey
-from sentry.snuba.metrics.query import MetricField, OrderBy
-from sentry.snuba.metrics.query import QueryDefinition as MetricsQuery
+from sentry.snuba.metrics.query import MetricField, MetricsQuery, OrderBy
 from sentry.snuba.metrics.utils import OrderByNotSupportedOverCompositeEntityException
 from sentry.snuba.sessions_v2 import (
     InvalidParams,

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -25,7 +25,7 @@ from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.fields import run_metrics_query
 from sentry.snuba.metrics.fields.base import get_derived_metrics, org_id_from_projects
 from sentry.snuba.metrics.naming_layer.mapping import get_mri, get_public_name_from_mri
-from sentry.snuba.metrics.query import Groupable, QueryDefinition
+from sentry.snuba.metrics.query import Groupable, MetricsQuery
 from sentry.snuba.metrics.query_builder import (
     ALLOWED_GROUPBY_COLUMNS,
     SnubaQueryBuilder,
@@ -449,17 +449,19 @@ class GroupLimitFilters:
 
 
 def _get_group_limit_filters(
-    query: QueryDefinition, results: List[Mapping[str, int]]
+    metrics_query: MetricsQuery, results: List[Mapping[str, int]]
 ) -> Optional[GroupLimitFilters]:
-    if not query.groupby or not results:
+    if not metrics_query.groupby or not results:
         return None
 
     # Translate the groupby fields of the query into their tag keys because these fields
     # will be used to filter down and order the results of the 2nd query.
     # For example, (project_id, transaction) is translated to (project_id, tags[3])
     keys = tuple(
-        resolve_tag_key(query.org_id, field) if field not in ALLOWED_GROUPBY_COLUMNS else field
-        for field in query.groupby
+        resolve_tag_key(metrics_query.org_id, field)
+        if field not in ALLOWED_GROUPBY_COLUMNS
+        else field
+        for field in metrics_query.groupby
     )
 
     # Get an ordered list of tuples containing the values of the group keys.
@@ -556,19 +558,21 @@ def _prune_extra_groups(results: dict, filters: GroupLimitFilters) -> None:
             queries[key]["data"] = filtered
 
 
-def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
+def get_series(projects: Sequence[Project], metrics_query: MetricsQuery) -> dict:
     """Get time series for the given query"""
-    intervals = list(get_intervals(query.start, query.end, query.granularity.granularity))
+    intervals = list(
+        get_intervals(metrics_query.start, metrics_query.end, metrics_query.granularity.granularity)
+    )
     results = {}
     fields_in_entities = {}
 
-    if not query.groupby:
+    if not metrics_query.groupby:
         # When there is no groupBy columns specified, we don't want to go through running an
         # initial query first to get the groups because there are no groups, and it becomes just
         # one group which is basically identical to eliminating the orderBy altogether
-        query = replace(query, orderby=None)
+        metrics_query = replace(metrics_query, orderby=None)
 
-    if query.orderby is not None:
+    if metrics_query.orderby is not None:
         # ToDo(ahmed): Now that we have conditional aggregates as select statements, we might be
         #  able to shave off a query here. we only need the other queries for fields spanning other
         #  entities otherwise if all the fields belong to one entity then there is no need
@@ -581,14 +585,16 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
 
         # Multi-field select with order by functionality. Currently only supports the
         # performance table.
-        original_select = copy(query.select)
+        original_select = copy(metrics_query.select)
 
         # The initial query has to contain only one field which is the same as the order by
         # field
-        orderby_field = [field for field in query.select if field == query.orderby.field][0]
-        query = replace(query, select=[orderby_field])
+        orderby_field = [
+            field for field in metrics_query.select if field == metrics_query.orderby.field
+        ][0]
+        metrics_query = replace(metrics_query, select=[orderby_field])
 
-        snuba_queries, _ = SnubaQueryBuilder(projects, query).get_snuba_queries()
+        snuba_queries, _ = SnubaQueryBuilder(projects, metrics_query).get_snuba_queries()
         if len(snuba_queries) > 1:
             # Currently accepting an order by field that spans multiple entities is not
             # supported, but it might change in the future. Even then, it might be better
@@ -622,12 +628,12 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
             # the group by tags from the first query so we basically remove the order by columns,
             # and reset the query fields to the original fields because in the second query,
             # we want to query for all the metrics in the request api call
-            query = replace(query, select=original_select, orderby=None)
+            metrics_query = replace(metrics_query, select=original_select, orderby=None)
 
-            query_builder = SnubaQueryBuilder(projects, query)
+            query_builder = SnubaQueryBuilder(projects, metrics_query)
             snuba_queries, fields_in_entities = query_builder.get_snuba_queries()
 
-            group_limit_filters = _get_group_limit_filters(query, initial_query_results)
+            group_limit_filters = _get_group_limit_filters(metrics_query, initial_query_results)
 
             # This loop has constant time complexity as it will always have a maximum of
             # three queries corresponding to the three available entities:
@@ -657,7 +663,9 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
                     results[entity][key] = {"data": snuba_result}
 
     else:
-        snuba_queries, fields_in_entities = SnubaQueryBuilder(projects, query).get_snuba_queries()
+        snuba_queries, fields_in_entities = SnubaQueryBuilder(
+            projects, metrics_query
+        ).get_snuba_queries()
         group_limit_filters = None
 
         for entity, queries in snuba_queries.items():
@@ -677,7 +685,7 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
 
                 snuba_limit = snuba_query.limit.limit if snuba_query.limit else None
                 if not group_limit_filters and snuba_limit and len(snuba_result) == snuba_limit:
-                    group_limit_filters = _get_group_limit_filters(query, snuba_result)
+                    group_limit_filters = _get_group_limit_filters(metrics_query, snuba_result)
 
                     # We're now applying a filter that past queries may not have
                     # had. To avoid partial results, remove extra groups that
@@ -689,7 +697,7 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
 
     assert projects
     converter = SnubaResultConverter(
-        projects[0].organization_id, query, fields_in_entities, intervals, results
+        projects[0].organization_id, metrics_query, fields_in_entities, intervals, results
     )
 
     result_groups = converter.translate_results()
@@ -697,12 +705,12 @@ def get_series(projects: Sequence[Project], query: QueryDefinition) -> dict:
     # groups that doesn't meet the limit of the query for each of the entities, and hence they
     # don't go through the pruning logic resulting in a total number of groups that is greater
     # than the limit, and hence we need to prune those excess groups
-    if len(result_groups) > query.limit.limit:
-        result_groups = result_groups[0 : query.limit.limit]
+    if len(result_groups) > metrics_query.limit.limit:
+        result_groups = result_groups[0 : metrics_query.limit.limit]
 
     return {
-        "start": query.start,
-        "end": query.end,
+        "start": metrics_query.start,
+        "end": metrics_query.end,
         "intervals": intervals,
         "groups": result_groups,
     }

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -31,7 +31,7 @@ class OrderBy:
 
 
 @dataclass(frozen=True)
-class QueryDefinition:
+class MetricsQuery:
     """Definition of a metrics query, inspired by snuba_sdk.Query"""
 
     org_id: int

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -36,9 +36,9 @@ from sentry.snuba.metrics.fields.base import (
     org_id_from_projects,
 )
 from sentry.snuba.metrics.naming_layer.mapping import get_mri, get_public_name_from_mri
-from sentry.snuba.metrics.query import MetricField
+from sentry.snuba.metrics.query import MetricField, MetricsQuery
 from sentry.snuba.metrics.query import OrderBy as MetricsOrderBy
-from sentry.snuba.metrics.query import QueryDefinition, Tag
+from sentry.snuba.metrics.query import Tag
 from sentry.snuba.metrics.utils import (
     ALLOWED_GROUPBY_COLUMNS,
     FIELD_REGEX,
@@ -270,8 +270,8 @@ class APIQueryDefinition:
         if not (self.include_series or self.include_totals):
             raise InvalidParams("Cannot omit both series and totals")
 
-    def to_query_definition(self) -> QueryDefinition:
-        return QueryDefinition(
+    def to_metrics_query(self) -> MetricsQuery:
+        return MetricsQuery(
             org_id=org_id_from_projects(self._projects),
             project_ids=[project.id for project in self._projects],
             include_totals=self.include_totals,
@@ -380,19 +380,19 @@ class SnubaQueryBuilder:
         "metrics_sets",
     }
 
-    def __init__(self, projects: Sequence[Project], query_definition: QueryDefinition):
+    def __init__(self, projects: Sequence[Project], metrics_query: MetricsQuery):
         self._projects = projects
-        self._query_definition = query_definition
-        self._org_id = query_definition.org_id
+        self._metrics_query = metrics_query
+        self._org_id = metrics_query.org_id
 
     def _build_where(self) -> List[Union[BooleanCondition, Condition]]:
         where: List[Union[BooleanCondition, Condition]] = [
             Condition(Column("org_id"), Op.EQ, self._org_id),
-            Condition(Column("project_id"), Op.IN, self._query_definition.project_ids),
-            Condition(Column(TS_COL_QUERY), Op.GTE, self._query_definition.start),
-            Condition(Column(TS_COL_QUERY), Op.LT, self._query_definition.end),
+            Condition(Column("project_id"), Op.IN, self._metrics_query.project_ids),
+            Condition(Column(TS_COL_QUERY), Op.GTE, self._metrics_query.start),
+            Condition(Column(TS_COL_QUERY), Op.LT, self._metrics_query.end),
         ]
-        filter_ = resolve_tags(self._org_id, self._query_definition.where)
+        filter_ = resolve_tags(self._org_id, self._metrics_query.where)
         if filter_:
             where.extend(filter_)
 
@@ -400,7 +400,7 @@ class SnubaQueryBuilder:
 
     def _build_groupby(self) -> List[Column]:
         groupby_cols = []
-        for field in self._query_definition.groupby or []:
+        for field in self._metrics_query.groupby or []:
             if field in UNALLOWED_TAGS:
                 raise InvalidParams(f"Tag name {field} cannot be used to groupBy query")
             if field in ALLOWED_GROUPBY_COLUMNS:
@@ -411,9 +411,9 @@ class SnubaQueryBuilder:
         return groupby_cols
 
     def _build_orderby(self) -> Optional[List[OrderBy]]:
-        if self._query_definition.orderby is None:
+        if self._metrics_query.orderby is None:
             return None
-        orderby = self._query_definition.orderby
+        orderby = self._metrics_query.orderby
         op = orderby.field.op
         metric_mri = get_mri(orderby.field.metric_name)
         metric_field_obj = metric_object_factory(op, metric_mri)
@@ -421,7 +421,7 @@ class SnubaQueryBuilder:
         return metric_field_obj.generate_orderby_clause(
             projects=self._projects,
             direction=orderby.direction,
-            query_definition=self._query_definition,
+            metrics_query=self._metrics_query,
         )
 
     def __build_totals_and_series_queries(
@@ -439,10 +439,10 @@ class SnubaQueryBuilder:
             orderby=orderby,
         )
 
-        if self._query_definition.include_totals:
+        if self._metrics_query.include_totals:
             rv["totals"] = totals_query
 
-        if self._query_definition.include_series:
+        if self._metrics_query.include_series:
             series_limit = limit.limit * intervals_len
             rv["series"] = totals_query.set_limit(series_limit).set_groupby(
                 list(totals_query.groupby or []) + [Column(TS_COL_GROUP)]
@@ -470,7 +470,7 @@ class SnubaQueryBuilder:
         metric_mri_to_obj_dict = {}
         fields_in_entities = {}
 
-        for field in self._query_definition.select:
+        for field in self._metrics_query.select:
             metric_mri = get_mri(field.metric_name)
             metric_field_obj = metric_object_factory(field.op, metric_mri)
             # `get_entity` is called the first, to fetch the entities of constituent metrics,
@@ -523,7 +523,7 @@ class SnubaQueryBuilder:
             for field in fields:
                 metric_field_obj = metric_mri_to_obj_dict[field]
                 select += metric_field_obj.generate_select_statements(
-                    projects=self._projects, query_definition=self._query_definition
+                    projects=self._projects, metrics_query=self._metrics_query
                 )
                 metric_ids_set |= metric_field_obj.generate_metric_ids(self._projects)
 
@@ -542,15 +542,15 @@ class SnubaQueryBuilder:
                 where=where + where_for_entity,
                 groupby=groupby,
                 orderby=orderby,
-                limit=self._query_definition.limit,
-                offset=self._query_definition.offset,
-                rollup=self._query_definition.granularity,
+                limit=self._metrics_query.limit,
+                offset=self._metrics_query.offset,
+                rollup=self._metrics_query.granularity,
                 intervals_len=len(
                     list(
                         get_intervals(
-                            self._query_definition.start,
-                            self._query_definition.end,
-                            self._query_definition.granularity.granularity,
+                            self._metrics_query.start,
+                            self._metrics_query.end,
+                            self._metrics_query.granularity.granularity,
                         )
                     )
                 ),
@@ -565,7 +565,7 @@ class SnubaResultConverter:
     def __init__(
         self,
         organization_id: int,
-        query_definition: QueryDefinition,
+        metrics_query: MetricsQuery,
         fields_in_entities: dict,
         intervals: List[datetime],
         results,
@@ -573,11 +573,11 @@ class SnubaResultConverter:
         self._organization_id = organization_id
         self._intervals = intervals
         self._results = results
-        self._query_definition = query_definition
+        self._metrics_query = metrics_query
 
-        # This is a set of all the `(op, metric_mri)` combinations passed in the query_definition
-        self._query_definition_fields_set = {
-            (field.op, get_mri(field.metric_name)) for field in query_definition.select
+        # This is a set of all the `(op, metric_mri)` combinations passed in the metrics_query
+        self._metrics_query_fields_set = {
+            (field.op, get_mri(field.metric_name)) for field in metrics_query.select
         }
         # This is a set of all queryable `(op, metric_mri)` combinations. Queryable can mean it
         # includes one of the following: AggregatedRawMetric (op, metric_mri), instance of
@@ -588,14 +588,14 @@ class SnubaResultConverter:
             elem for fields_in_entity in fields_in_entities.values() for elem in fields_in_entity
         }
         self._set_of_constituent_queries = self._fields_in_entities_set.union(
-            self._query_definition_fields_set
+            self._metrics_query_fields_set
         )
 
         # This basically generate a dependency tree for all instances of `MetricFieldBase` so
         # that in the case of a CompositeEntityDerivedMetric, we are able to calculate it but
         # only after calculating its dependencies
         self._bottom_up_dependency_tree = generate_bottom_up_dependency_tree_for_metrics(
-            self._query_definition_fields_set
+            self._metrics_query_fields_set
         )
 
         self._timestamp_index = {timestamp: index for index, timestamp in enumerate(intervals)}
@@ -612,16 +612,16 @@ class SnubaResultConverter:
         )
 
         tag_data = groups.setdefault(tags, {})
-        if self._query_definition.include_series:
+        if self._metrics_query.include_series:
             tag_data.setdefault("series", {})
-        if self._query_definition.include_totals:
+        if self._metrics_query.include_totals:
             tag_data.setdefault("totals", {})
 
         bucketed_time = data.pop(TS_COL_GROUP, None)
         if bucketed_time is not None:
             bucketed_time = parse_snuba_datetime(bucketed_time)
 
-        # We query the union of the query_definition fields, and the fields_in_entities from the
+        # We query the union of the metrics_query fields, and the fields_in_entities from the
         # QueryBuilder necessary as it contains the constituent instances of
         # SingularEntityDerivedMetric for instances of CompositeEntityDerivedMetric
         for op, metric_mri in self._set_of_constituent_queries:
@@ -647,7 +647,7 @@ class SnubaResultConverter:
                 if key not in tag_data["totals"] or tag_data["totals"][key] == default_null_value:
                     tag_data["totals"][key] = cleaned_value
 
-            if self._query_definition.include_series:
+            if self._metrics_query.include_series:
                 if bucketed_time is not None or tag_data["totals"][key] == default_null_value:
                     empty_values = len(self._intervals) * [default_null_value]
                     series = tag_data["series"].setdefault(key, empty_values)
@@ -689,7 +689,7 @@ class SnubaResultConverter:
 
                 if totals is not None:
                     totals[grp_key] = metric_obj.run_post_query_function(
-                        totals, query_definition=self._query_definition
+                        totals, metrics_query=self._metrics_query
                     )
 
                 if series is not None:
@@ -700,7 +700,7 @@ class SnubaResultConverter:
                             [metric_obj.generate_default_null_values()] * len(self._intervals),
                         )
                         series[grp_key][idx] = metric_obj.run_post_query_function(
-                            series, query_definition=self._query_definition, idx=idx
+                            series, metrics_query=self._metrics_query, idx=idx
                         )
 
         # Remove the extra fields added due to the constituent metrics that were added
@@ -720,7 +720,7 @@ class SnubaResultConverter:
                     operation = None
                     metric_mri = key
 
-                if (operation, metric_mri) not in self._query_definition_fields_set:
+                if (operation, metric_mri) not in self._metrics_query_fields_set:
                     if totals is not None:
                         del totals[key]
                     if series is not None:

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -30,7 +30,7 @@ from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics import (
     MAX_POINTS,
     OP_TO_SNUBA_FUNCTION,
-    QueryDefinition,
+    MetricsQuery,
     SnubaQueryBuilder,
     SnubaResultConverter,
     get_date_range,
@@ -282,7 +282,7 @@ def test_timestamps():
 def test_build_snuba_query(mock_now, mock_now2, monkeypatch):
     monkeypatch.setattr("sentry.sentry_metrics.indexer.resolve", MockIndexer().resolve)
     # Your typical release health query querying everything
-    query_definition = QueryDefinition(
+    query_definition = MetricsQuery(
         org_id=1,
         project_ids=[1],
         select=[
@@ -408,7 +408,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2, monkeypatch):
         }
     )
     query_definition = APIQueryDefinition([PseudoProject(1, 1)], query_params)
-    query_builder = SnubaQueryBuilder([PseudoProject(1, 1)], query_definition.to_query_definition())
+    query_builder = SnubaQueryBuilder([PseudoProject(1, 1)], query_definition.to_metrics_query())
     snuba_queries, fields_in_entities = query_builder.get_snuba_queries()
     assert fields_in_entities == {
         "metrics_counters": [
@@ -541,7 +541,7 @@ def test_build_snuba_query_orderby(mock_now, mock_now2, monkeypatch):
         [PseudoProject(1, 1)], query_params, paginator_kwargs={"limit": 3}
     )
     snuba_queries, _ = SnubaQueryBuilder(
-        [PseudoProject(1, 1)], query_definition.to_query_definition()
+        [PseudoProject(1, 1)], query_definition.to_metrics_query()
     ).get_snuba_queries()
 
     org_id = 1
@@ -627,7 +627,7 @@ def test_build_snuba_query_with_derived_alias(mock_now, mock_now2, monkeypatch):
         [PseudoProject(1, 1)], query_params, paginator_kwargs={"limit": 3}
     )
     snuba_queries, _ = SnubaQueryBuilder(
-        [PseudoProject(1, 1)], query_definition.to_query_definition()
+        [PseudoProject(1, 1)], query_definition.to_metrics_query()
     ).get_snuba_queries()
 
     org_id = 1
@@ -850,7 +850,7 @@ def test_translate_results(_1, _2, monkeypatch):
     }
 
     assert SnubaResultConverter(
-        org_id, query_definition.to_query_definition(), fields_in_entities, intervals, results
+        org_id, query_definition.to_metrics_query(), fields_in_entities, intervals, results
     ).translate_results() == [
         {
             "by": {"session.status": "healthy"},
@@ -969,7 +969,7 @@ def test_translate_results_derived_metrics(_1, _2, monkeypatch):
     }
 
     assert SnubaResultConverter(
-        1, query_definition.to_query_definition(), fields_in_entities, intervals, results
+        1, query_definition.to_metrics_query(), fields_in_entities, intervals, results
     ).translate_results() == [
         {
             "by": {},
@@ -1042,7 +1042,7 @@ def test_translate_results_missing_slots(_1, _2, monkeypatch):
         get_intervals(query_definition.start, query_definition.end, query_definition.rollup)
     )
     assert SnubaResultConverter(
-        org_id, query_definition.to_query_definition(), fields_in_entities, intervals, results
+        org_id, query_definition.to_metrics_query(), fields_in_entities, intervals, results
     ).translate_results() == [
         {
             "by": {},


### PR DESCRIPTION
Refactors the metrics service layer by renaming
`QueryDefinition` to `MetricsQuery` similar to
`snuba_sdk.Query` to act as a code representation
of a SNQL Query to the metrics dataset

