### PR TITLE
ref(metrics): Rename `APIQueryDefinition` to `QueryDefinition` [TET-106]

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -8,7 +8,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import InvalidParams
 from sentry.snuba.metrics import (
-    APIQueryDefinition,
+    QueryDefinition,
     get_metrics,
     get_series,
     get_single_metric_info,
@@ -117,7 +117,7 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
 
         def data_fn(offset: int, limit: int):
             try:
-                query = APIQueryDefinition(
+                query = QueryDefinition(
                     projects, request.GET, paginator_kwargs={"limit": limit, "offset": offset}
                 )
                 data = get_series(projects, query.to_metrics_query())

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -1,5 +1,5 @@
 __all__ = (
-    "APIQueryDefinition",
+    "QueryDefinition",
     "SnubaQueryBuilder",
     "SnubaResultConverter",
     "get_date_range",
@@ -220,15 +220,17 @@ def parse_query(query_string: str, projects: Sequence[Project]) -> Sequence[Cond
     return where
 
 
-class APIQueryDefinition:
+class QueryDefinition:
     """
-    This is the definition of the query the user wants to execute.
-    This is constructed out of the request params, and also contains a list of
-    `fields` and `groupby` definitions as [`ColumnDefinition`] objects.
+    Class meant to serve as a thin layer that converts API request params to the fields necessary to
+    instantiate an instance of `MetricsQuery`
 
-    Adapted from [`sentry.snuba.sessions_v2`].
+    Adapted from [`sentry.snuba.sessions_v2`] and meant to keep consistency in naming between
+    sessions v2 and metrics APIs.
 
     """
+
+    # ToDo(ahmed): Move validation down to `MetricsQuery`
 
     def __init__(self, projects, query_params, paginator_kwargs: Optional[Dict] = None):
         self._projects = projects

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -51,7 +51,7 @@ from sentry.snuba.metrics.fields.snql import (
 from sentry.snuba.metrics.naming_layer.mapping import get_mri
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.metrics.query import MetricField
-from sentry.snuba.metrics.query_builder import APIQueryDefinition
+from sentry.snuba.metrics.query_builder import QueryDefinition
 
 
 @dataclass
@@ -407,7 +407,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2, monkeypatch):
             "statsPeriod": ["2d"],
         }
     )
-    query_definition = APIQueryDefinition([PseudoProject(1, 1)], query_params)
+    query_definition = QueryDefinition([PseudoProject(1, 1)], query_params)
     query_builder = SnubaQueryBuilder([PseudoProject(1, 1)], query_definition.to_metrics_query())
     snuba_queries, fields_in_entities = query_builder.get_snuba_queries()
     assert fields_in_entities == {
@@ -537,7 +537,7 @@ def test_build_snuba_query_orderby(mock_now, mock_now2, monkeypatch):
             "per_page": [2],
         }
     )
-    query_definition = APIQueryDefinition(
+    query_definition = QueryDefinition(
         [PseudoProject(1, 1)], query_params, paginator_kwargs={"limit": 3}
     )
     snuba_queries, _ = SnubaQueryBuilder(
@@ -623,7 +623,7 @@ def test_build_snuba_query_with_derived_alias(mock_now, mock_now2, monkeypatch):
             "per_page": [2],
         }
     )
-    query_definition = APIQueryDefinition(
+    query_definition = QueryDefinition(
         [PseudoProject(1, 1)], query_params, paginator_kwargs={"limit": 3}
     )
     snuba_queries, _ = SnubaQueryBuilder(
@@ -726,7 +726,7 @@ def test_translate_results(_1, _2, monkeypatch):
             "statsPeriod": ["2d"],
         }
     )
-    query_definition = APIQueryDefinition([PseudoProject(1, 1)], query_params)
+    query_definition = QueryDefinition([PseudoProject(1, 1)], query_params)
     fields_in_entities = {
         "metrics_counters": [("sum", SessionMRI.SESSION.value)],
         "metrics_distributions": [
@@ -904,7 +904,7 @@ def test_translate_results_derived_metrics(_1, _2, monkeypatch):
             "statsPeriod": ["2d"],
         }
     )
-    query_definition = APIQueryDefinition([PseudoProject(1, 1)], query_params)
+    query_definition = QueryDefinition([PseudoProject(1, 1)], query_params)
     fields_in_entities = {
         "metrics_counters": [
             (None, SessionMRI.ERRORED_PREAGGREGATED.value),
@@ -1003,7 +1003,7 @@ def test_translate_results_missing_slots(_1, _2, monkeypatch):
             "statsPeriod": ["3d"],
         }
     )
-    query_definition = APIQueryDefinition([PseudoProject(1, 1)], query_params)
+    query_definition = QueryDefinition([PseudoProject(1, 1)], query_params)
     fields_in_entities = {
         "metrics_counters": [
             ("sum", SessionMRI.SESSION.value),


### PR DESCRIPTION
Renames class `APIQueryDefinition` to `QueryDefinition`
to maintain naming consistency between sessions v2
and metrics API

