### PR TITLE
ref(projectconfig): Late acknowledge of project config computation

### DIFF
--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -7,7 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import Hub, set_tag, start_span, start_transaction
 
-import sentry.options
+from sentry import options
 from sentry.api.authentication import RelayAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.permissions import RelayPermission
@@ -52,7 +52,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         no_cache = request.relay_request_data.get("no_cache") or False
         set_tag("relay_no_cache", no_cache)
 
-        enable_v3 = random.random() < sentry.options.get("relay.project-config-v3-enable")
+        enable_v3 = random.random() < options.get("relay.project-config-v3-enable")
 
         if enable_v3 and version == "3" and not no_cache:
             # Always compute the full config. It's invalid to send partial

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -48,7 +48,7 @@ def update_config_cache(
     sentry_sdk.set_tag("update_reason", update_reason)
     sentry_sdk.set_tag("generate", generate)
 
-    # Weird way to experiment with this easily.
+    # TODO: Weird way to experiment with this easily.
     late_debounce_free = 0 < sentry.options.get("relay.project-config-v3-enable")
 
     if not late_debounce_free and not should_update_cache(

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -3,7 +3,7 @@ import logging
 import sentry_sdk
 from django.conf import settings
 
-import sentry.options
+from sentry import options
 from sentry.relay import projectconfig_debounce_cache
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
@@ -49,7 +49,7 @@ def update_config_cache(
     sentry_sdk.set_tag("generate", generate)
 
     # TODO: Weird way to experiment with this easily.
-    late_debounce_free = 0 < sentry.options.get("relay.project-config-v3-enable")
+    late_debounce_free = 0 < options.get("relay.project-config-v3-enable")
 
     if not late_debounce_free and not should_update_cache(
         organization_id=organization_id, project_id=project_id, public_key=public_key

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -27,6 +27,7 @@ def update_config_cache(
     :param project_id: The project for which to invalidate configs.
     :param generate: If `True`, caches will be eagerly regenerated, not only
         invalidated.
+    :param update_reason: A string to set as tag in sentry.
     """
 
     from sentry.models import Project, ProjectKey, ProjectKeyStatus

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -66,9 +66,9 @@ def call_endpoint(client, relay, private_key, default_projectkey):
 
 @pytest.fixture(autouse=True)
 def max_sample_rate():
-    import sentry.options
+    from sentry import options
 
-    sentry.options.set("relay.project-config-v3-enable", 1)
+    options.set("relay.project-config-v3-enable", 1)
 
 
 @pytest.fixture

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -181,6 +181,11 @@ def test_debounce_task_if_proj_config_not_cached_already_enqueued(
     assert task_mock.call_count == 0
 
 
+# This checks that if a race occurred during scheduling of the task and two were scheduled,
+# only one is actually executed since only one can delete the debouncing key.  This race is
+# allowed to happen for the experiment where we delete the debouncing key at the end of the
+# computation.
+@pytest.mark.xfail
 @patch("sentry.relay.projectconfig_cache.set_many")
 @pytest.mark.django_db
 def test_task_doesnt_run_if_not_debounced(


### PR DESCRIPTION
This is an experiment to only delete the debounce key after the
project config is computed.  This results in cache invalidations
getting lost but is a cheap way to experiment how the system would
behave if we would debounce better.