### PR TITLE
fix(dahsboards): Restrict aggregate params in big number for RH

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/yAxisStep/yAxisSelector/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/yAxisStep/yAxisSelector/index.tsx
@@ -88,17 +88,17 @@ export function YAxisSelector({
 
   function filterAggregateParameters(fieldValue: QueryFieldValue) {
     return (option: FieldValueOption) => {
-      // Only validate function parameters for timeseries widgets and
-      // world map widgets.
-      if (doNotValidateYAxis(displayType)) {
-        return true;
-      }
-
       if (isReleaseWidget) {
         if (option.value.kind === FieldValueKind.METRICS) {
           return true;
         }
         return false;
+      }
+
+      // Only validate function parameters for timeseries widgets and
+      // world map widgets.
+      if (doNotValidateYAxis(displayType)) {
+        return true;
       }
 
       if (fieldValue.kind !== FieldValueKind.FUNCTION) {


### PR DESCRIPTION
Filter RH params to fields supported by the aggregate
funciton. This logic was being bypassed by the
doNotValidateYAxis check, but it does need to be
validated for release health widgets.

Before:
![Screen Shot 2022-05-30 at 9 13 31 AM](https://user-images.githubusercontent.com/63818634/170999782-469b11fa-b0e0-4c50-abaf-0be82db20b34.png)

After:
![Screen Shot 2022-05-30 at 9 13 38 AM](https://user-images.githubusercontent.com/63818634/170999804-8784b020-39b0-4e50-8ac4-c70b467f912c.png)

