### PR TITLE
feat(ui): Fix rrweb integration for core SDK v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@sentry/node": "7.0.0",
     "@sentry/react": "7.0.0",
     "@sentry/release-parser": "^1.3.0",
-    "@sentry/rrweb": "^0.3.1",
+    "@sentry/rrweb": "^0.3.3",
     "@sentry/tracing": "7.0.0",
     "@sentry/utils": "7.0.0",
     "@testing-library/jest-dom": "^5.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,10 +2943,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-1.3.0.tgz#8175b835bede83346728e329bf226d80c1063653"
   integrity sha512-m6yuQTI8XiT+L7ELbCzqPRhBvSQ5Go3YTPzj2socm9Aekp3Jcze0ZlNJIqvuPPmuysmF+SOM849WYN47kM9ERg==
 
-"@sentry/rrweb@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@sentry/rrweb/-/rrweb-0.3.1.tgz#a0f7496e086a30679d7af227d62ab76cfd5ed934"
-  integrity sha512-AJIy2yqjtgpcow3L1gyxxr6x+rqLN9HXMlsNNmLeUKlPBxaSMP47lM6aexI3V+XkKnRmOW05H21cLimyuM+59Q==
+"@sentry/rrweb@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@sentry/rrweb/-/rrweb-0.3.3.tgz#cbc55e6a99f88e98616a7141210b3f4544427b2a"
+  integrity sha512-GaPHoCpzUMW+SCyK/ZMxzZJb4snWE2VSj8vYddHcPnboIG2xH+V4XEGxpKbEXc5s0WGDuhPTQv1j1Q44/gt/kA==
 
 "@sentry/tracing@7.0.0":
   version "7.0.0"


### PR DESCRIPTION
This fixes the rrweb integration that regressed when upgrading to v7 of our core SDK. Thanks @lobsterkatie for making the rrweb plugin compatible with v7!
