### PR TITLE
feat(performance): Performance landing page updated to use events endpoint

### DIFF
--- a/static/app/utils/discover/discoverQuery.tsx
+++ b/static/app/utils/discover/discoverQuery.tsx
@@ -33,6 +33,7 @@ type DiscoverQueryPropsWithThresholds = DiscoverQueryProps & {
 
 type DiscoverQueryComponentProps = DiscoverQueryPropsWithThresholds & {
   children: (props: GenericChildrenProps<TableData>) => React.ReactNode;
+  useEvents?: boolean;
 };
 
 function shouldRefetchData(
@@ -47,10 +48,21 @@ function shouldRefetchData(
 }
 
 function DiscoverQuery(props: DiscoverQueryComponentProps) {
+  const endpoint = props.useEvents ? 'events' : 'eventsv2';
+  const afterFetch = props.useEvents
+    ? (data, _) => {
+        const {fields, ...otherMeta} = data.meta ?? {};
+        return {
+          ...data,
+          meta: {...fields, ...otherMeta},
+        };
+      }
+    : undefined;
   return (
     <GenericDiscoverQuery<TableData, DiscoverQueryPropsWithThresholds>
-      route="eventsv2"
+      route={endpoint}
       shouldRefetchData={shouldRefetchData}
+      afterFetch={afterFetch}
       {...props}
     />
   );

--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -136,11 +136,12 @@ class Table extends PureComponent<TableProps, TableState> {
           return;
         }
 
+        const {fields, ...nonFieldsMeta} = data.meta ?? {};
         // events api uses a different response format so we need to construct tableData differently
         const tableData = shouldUseEvents
           ? {
               ...data,
-              meta: {...data.meta?.fields, isMetricsData: data.meta?.isMetricsData},
+              meta: {...fields, nonFieldsMeta},
             }
           : data;
 

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -56,7 +56,10 @@ const framesList = [
 export function LineChartListWidget(props: PerformanceWidgetProps) {
   const mepSetting = useMEPSettingContext();
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
-  const {ContainerActions} = props;
+  const {ContainerActions, organization} = props;
+  const useEvents = organization.features.includes(
+    'discover-frontend-use-events-endpoint'
+  );
   const pageError = usePageError();
 
   const field = props.fields[0];
@@ -115,83 +118,89 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
             cursor="0:0:1"
             noPagination
             queryExtras={getMEPParamsIfApplicable(mepSetting, props.chartSetting)}
+            useEvents={useEvents}
           />
         );
       },
       transform: transformDiscoverToList,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [props.chartSetting, mepSetting.memoizationKey]
   );
 
-  const chartQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(() => {
-    return {
-      enabled: widgetData => {
-        return !!widgetData?.list?.data?.length;
-      },
-      fields: field,
-      component: provided => {
-        const eventView = props.eventView.clone();
-        if (!provided.widgetData.list.data[selectedListIndex]?.transaction) {
-          return null;
-        }
-        eventView.additionalConditions.setFilterValues('transaction', [
-          provided.widgetData.list.data[selectedListIndex].transaction as string,
-        ]);
-        if (props.chartSetting === PerformanceWidgetSetting.MOST_RELATED_ISSUES) {
-          if (!provided.widgetData.list.data[selectedListIndex]?.issue) {
+  const chartQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
+    () => {
+      return {
+        enabled: widgetData => {
+          return !!widgetData?.list?.data?.length;
+        },
+        fields: field,
+        component: provided => {
+          const eventView = props.eventView.clone();
+          if (!provided.widgetData.list.data[selectedListIndex]?.transaction) {
             return null;
           }
-          eventView.fields = [
-            {field: 'issue'},
-            {field: 'issue.id'},
-            {field: 'transaction'},
-            {field},
-          ];
-          eventView.additionalConditions.setFilterValues('issue', [
-            provided.widgetData.list.data[selectedListIndex].issue as string,
+          eventView.additionalConditions.setFilterValues('transaction', [
+            provided.widgetData.list.data[selectedListIndex].transaction as string,
           ]);
-          eventView.additionalConditions.setFilterValues('event.type', ['error']);
-          eventView.additionalConditions.setFilterValues('!tags[transaction]', ['']);
-          eventView.additionalConditions.removeFilter('transaction.op'); // Remove transaction op incase it's applied from the performance view.
-          eventView.additionalConditions.removeFilter('!transaction.op'); // Remove transaction op incase it's applied from the performance view.
-          const mutableSearch = new MutableSearch(eventView.query);
-          mutableSearch.removeFilter('transaction.duration');
-          eventView.query = mutableSearch.formatString();
-        } else {
-          eventView.fields = [{field: 'transaction'}, {field}];
-        }
-        return (
-          <EventsRequest
-            {...pick(provided, eventsRequestQueryProps)}
-            limit={1}
-            includePrevious
-            includeTransformedData
-            partial
-            currentSeriesNames={[field]}
-            query={eventView.getQueryWithAdditionalConditions()}
-            interval={getInterval(
-              {
-                start: provided.start,
-                end: provided.end,
-                period: provided.period,
-              },
-              'medium'
-            )}
-            hideError
-            onError={pageError.setPageError}
-            queryExtras={getMEPParamsIfApplicable(mepSetting, props.chartSetting)}
-            userModified={decodeScalar(props.location.query.userModified)}
-          />
-        );
-      },
-      transform: transformEventsRequestToArea,
-    };
-  }, [
-    props.chartSetting,
-    selectedListIndex,
-    mepSetting.memoizationKey,
-    props.location.query.userModified,
-  ]);
+          if (props.chartSetting === PerformanceWidgetSetting.MOST_RELATED_ISSUES) {
+            if (!provided.widgetData.list.data[selectedListIndex]?.issue) {
+              return null;
+            }
+            eventView.fields = [
+              {field: 'issue'},
+              {field: 'issue.id'},
+              {field: 'transaction'},
+              {field},
+            ];
+            eventView.additionalConditions.setFilterValues('issue', [
+              provided.widgetData.list.data[selectedListIndex].issue as string,
+            ]);
+            eventView.additionalConditions.setFilterValues('event.type', ['error']);
+            eventView.additionalConditions.setFilterValues('!tags[transaction]', ['']);
+            eventView.additionalConditions.removeFilter('transaction.op'); // Remove transaction op incase it's applied from the performance view.
+            eventView.additionalConditions.removeFilter('!transaction.op'); // Remove transaction op incase it's applied from the performance view.
+            const mutableSearch = new MutableSearch(eventView.query);
+            mutableSearch.removeFilter('transaction.duration');
+            eventView.query = mutableSearch.formatString();
+          } else {
+            eventView.fields = [{field: 'transaction'}, {field}];
+          }
+          return (
+            <EventsRequest
+              {...pick(provided, eventsRequestQueryProps)}
+              limit={1}
+              includePrevious
+              includeTransformedData
+              partial
+              currentSeriesNames={[field]}
+              query={eventView.getQueryWithAdditionalConditions()}
+              interval={getInterval(
+                {
+                  start: provided.start,
+                  end: provided.end,
+                  period: provided.period,
+                },
+                'medium'
+              )}
+              hideError
+              onError={pageError.setPageError}
+              queryExtras={getMEPParamsIfApplicable(mepSetting, props.chartSetting)}
+              userModified={decodeScalar(props.location.query.userModified)}
+            />
+          );
+        },
+        transform: transformEventsRequestToArea,
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      props.chartSetting,
+      selectedListIndex,
+      mepSetting.memoizationKey,
+      props.location.query.userModified,
+    ]
+  );
 
   const Queries = {
     list: listQuery,

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -266,7 +266,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                   additionalQuery,
                 });
 
-                const fieldString = getAggregateAlias(field);
+                const fieldString = useEvents ? field : getAggregateAlias(field);
 
                 const valueMap = {
                   [PerformanceWidgetSetting.MOST_RELATED_ERRORS]: listItem.failure_count,

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -88,6 +88,9 @@ export function transformFieldsWithStops(props: {
 export function VitalWidget(props: PerformanceWidgetProps) {
   const mepSetting = useMEPSettingContext();
   const {ContainerActions, eventView, organization, location} = props;
+  const useEvents = organization.features.includes(
+    'discover-frontend-use-events-endpoint'
+  );
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
   const field = props.fields[0];
   const pageError = usePageError();
@@ -128,11 +131,13 @@ export function VitalWidget(props: PerformanceWidgetProps) {
               cursor="0:0:1"
               noPagination
               queryExtras={getMEPQueryParams(mepSetting)}
+              useEvents={useEvents}
             />
           );
         },
         transform: transformDiscoverToList,
       }),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [props.eventView, fieldsList, props.organization.slug, mepSetting.memoizationKey]
     ),
     chart: useMemo<QueryDefinition<DataType, WidgetDataResult>>(
@@ -174,6 +179,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
         },
         transform: transformEventsRequestToVitals,
       }),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [
         props.chartSetting,
         selectedListIndex,
@@ -207,7 +213,11 @@ export function VitalWidget(props: PerformanceWidgetProps) {
         const vital = settingToVital[props.chartSetting];
 
         const data = {
-          [settingToVital[props.chartSetting]]: getVitalDataForListItem(listItem, vital),
+          [settingToVital[props.chartSetting]]: getVitalDataForListItem(
+            listItem,
+            vital,
+            !useEvents
+          ),
         };
 
         return (
@@ -289,7 +299,8 @@ export function VitalWidget(props: PerformanceWidgetProps) {
                 const data = {
                   [settingToVital[props.chartSetting]]: getVitalDataForListItem(
                     listItem,
-                    vital
+                    vital,
+                    !useEvents
                   ),
                 };
 
@@ -327,15 +338,20 @@ export function VitalWidget(props: PerformanceWidgetProps) {
   );
 }
 
-function getVitalDataForListItem(listItem: TableDataRow, vital: WebVital) {
+function getVitalDataForListItem(
+  listItem: TableDataRow,
+  vital: WebVital,
+  useAggregateAlias: boolean = true
+) {
   const vitalFields = getVitalFields(vital);
-
+  const transformFieldName = (fieldName: string) =>
+    useAggregateAlias ? getAggregateAlias(fieldName) : fieldName;
   const poorData: number =
-    (listItem[getAggregateAlias(vitalFields.poorCountField)] as number) || 0;
+    (listItem[transformFieldName(vitalFields.poorCountField)] as number) || 0;
   const mehData: number =
-    (listItem[getAggregateAlias(vitalFields.mehCountField)] as number) || 0;
+    (listItem[transformFieldName(vitalFields.mehCountField)] as number) || 0;
   const goodData: number =
-    (listItem[getAggregateAlias(vitalFields.goodCountField)] as number) || 0;
+    (listItem[transformFieldName(vitalFields.goodCountField)] as number) || 0;
   const _vitalData = {
     poor: poorData,
     meh: mehData,

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -154,6 +154,9 @@ class _Table extends Component<Props, State> {
     dataRow: TableDataRow
   ): React.ReactNode {
     const {eventView, organization, projects, location} = this.props;
+    const isAlias = !organization.features.includes(
+      'discover-frontend-use-events-endpoint'
+    );
 
     if (!tableData || !tableData.meta) {
       return dataRow[column.key];
@@ -161,7 +164,7 @@ class _Table extends Component<Props, State> {
     const tableMeta = tableData.meta;
 
     const field = String(column.key);
-    const fieldRenderer = getFieldRenderer(field, tableMeta);
+    const fieldRenderer = getFieldRenderer(field, tableMeta, isAlias);
     const rendered = fieldRenderer(dataRow, {organization, location});
 
     const allowActions = [
@@ -369,10 +372,12 @@ class _Table extends Component<Props, State> {
 
   render() {
     const {eventView, organization, location, setError} = this.props;
-
+    const useEvents = organization.features.includes(
+      'discover-frontend-use-events-endpoint'
+    );
     const {widths, transaction, transactionThreshold} = this.state;
     const columnOrder = eventView
-      .getColumns()
+      .getColumns(useEvents)
       // remove team_key_transactions from the column order as we'll be rendering it
       // via a prepended column
       .filter(
@@ -406,6 +411,7 @@ class _Table extends Component<Props, State> {
               transactionName={transaction}
               transactionThreshold={transactionThreshold}
               queryExtras={getMEPQueryParams(value)}
+              useEvents={useEvents}
             >
               {({pageLinks, isLoading, tableData}) => (
                 <Fragment>

--- a/tests/js/spec/utils/discover/discoverQuery.spec.jsx
+++ b/tests/js/spec/utils/discover/discoverQuery.spec.jsx
@@ -22,139 +22,283 @@ describe('DiscoverQuery', function () {
     });
   });
 
-  it('fetches data on mount', async function () {
-    const getMock = MockApiClient.addMockResponse({
-      url: '/organizations/test-org/eventsv2/',
-      body: {
-        meta: {transaction: 'string', count: 'number'},
-        data: [{transaction: '/health', count: 1000}],
-      },
-    });
-    render(
-      <DiscoverQuery
-        orgSlug="test-org"
-        api={api}
-        location={location}
-        eventView={eventView}
-      >
-        {({tableData, isLoading}) => {
-          if (isLoading) {
-            return 'loading';
-          }
-          return <p>{tableData.data[0].transaction}</p>;
-        }}
-      </DiscoverQuery>
-    );
-    await tick();
-
-    // Children should be rendered, and API should be called.
-    expect(getMock).toHaveBeenCalledTimes(1);
-    expect(await screen.findByText('/health')).toBeInTheDocument();
-  });
-
-  it('applies limit and cursor props', async function () {
-    const getMock = MockApiClient.addMockResponse({
-      url: '/organizations/test-org/eventsv2/',
-      body: {
-        meta: {transaction: 'string', count: 'number'},
-        data: [{transaction: '/health', count: 1000}],
-      },
-    });
-    render(
-      <DiscoverQuery
-        orgSlug="test-org"
-        api={api}
-        location={location}
-        eventView={eventView}
-        limit={3}
-        cursor="1:0:1"
-      >
-        {({tableData, isLoading}) => {
-          if (isLoading) {
-            return 'loading';
-          }
-          return <p>{tableData.data[0].transaction}</p>;
-        }}
-      </DiscoverQuery>
-    );
-    await tick();
-
-    expect(getMock).toHaveBeenCalledTimes(1);
-    expect(getMock).toHaveBeenCalledWith(
-      '/organizations/test-org/eventsv2/',
-      expect.objectContaining({
-        method: 'GET',
-        query: expect.objectContaining({
-          per_page: 3,
-          cursor: '1:0:1',
-        }),
-      })
-    );
-  });
-
-  it('parses string errors correctly', async function () {
-    MockApiClient.addMockResponse({
-      url: '/organizations/test-org/eventsv2/',
-      body: {
-        detail: 'Error Message',
-      },
-      statusCode: 400,
-    });
-
-    let errorValue;
-    render(
-      <DiscoverQuery
-        orgSlug="test-org"
-        api={api}
-        location={location}
-        eventView={eventView}
-        setError={e => (errorValue = e)}
-      >
-        {({isLoading}) => {
-          if (isLoading) {
-            return 'loading';
-          }
-          return null;
-        }}
-      </DiscoverQuery>
-    );
-    await tick();
-
-    expect(errorValue.message).toEqual('Error Message');
-  });
-
-  it('parses object errors correctly', async function () {
-    MockApiClient.addMockResponse({
-      url: '/organizations/test-org/eventsv2/',
-      body: {
-        detail: {
-          code: '?',
-          message: 'Object Error',
-          extra: {},
+  describe('with eventsv2', function () {
+    it('fetches data on mount', async function () {
+      const getMock = MockApiClient.addMockResponse({
+        url: '/organizations/test-org/eventsv2/',
+        body: {
+          meta: {transaction: 'string', count: 'number'},
+          data: [{transaction: '/health', count: 1000}],
         },
-      },
-      statusCode: 400,
+      });
+      render(
+        <DiscoverQuery
+          orgSlug="test-org"
+          api={api}
+          location={location}
+          eventView={eventView}
+        >
+          {({tableData, isLoading}) => {
+            if (isLoading) {
+              return 'loading';
+            }
+            return <p>{tableData.data[0].transaction}</p>;
+          }}
+        </DiscoverQuery>
+      );
+      await tick();
+
+      // Children should be rendered, and API should be called.
+      expect(getMock).toHaveBeenCalledTimes(1);
+      expect(await screen.findByText('/health')).toBeInTheDocument();
     });
 
-    let errorValue;
-    render(
-      <DiscoverQuery
-        orgSlug="test-org"
-        api={api}
-        location={location}
-        eventView={eventView}
-        setError={e => (errorValue = e)}
-      >
-        {({isLoading}) => {
-          if (isLoading) {
-            return 'loading';
-          }
-          return null;
-        }}
-      </DiscoverQuery>
-    );
-    await tick();
+    it('applies limit and cursor props', async function () {
+      const getMock = MockApiClient.addMockResponse({
+        url: '/organizations/test-org/eventsv2/',
+        body: {
+          meta: {transaction: 'string', count: 'number'},
+          data: [{transaction: '/health', count: 1000}],
+        },
+      });
+      render(
+        <DiscoverQuery
+          orgSlug="test-org"
+          api={api}
+          location={location}
+          eventView={eventView}
+          limit={3}
+          cursor="1:0:1"
+        >
+          {({tableData, isLoading}) => {
+            if (isLoading) {
+              return 'loading';
+            }
+            return <p>{tableData.data[0].transaction}</p>;
+          }}
+        </DiscoverQuery>
+      );
+      await tick();
 
-    expect(errorValue.message).toEqual('Object Error');
+      expect(getMock).toHaveBeenCalledTimes(1);
+      expect(getMock).toHaveBeenCalledWith(
+        '/organizations/test-org/eventsv2/',
+        expect.objectContaining({
+          method: 'GET',
+          query: expect.objectContaining({
+            per_page: 3,
+            cursor: '1:0:1',
+          }),
+        })
+      );
+    });
+
+    it('parses string errors correctly', async function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/test-org/eventsv2/',
+        body: {
+          detail: 'Error Message',
+        },
+        statusCode: 400,
+      });
+
+      let errorValue;
+      render(
+        <DiscoverQuery
+          orgSlug="test-org"
+          api={api}
+          location={location}
+          eventView={eventView}
+          setError={e => (errorValue = e)}
+        >
+          {({isLoading}) => {
+            if (isLoading) {
+              return 'loading';
+            }
+            return null;
+          }}
+        </DiscoverQuery>
+      );
+      await tick();
+
+      expect(errorValue.message).toEqual('Error Message');
+    });
+
+    it('parses object errors correctly', async function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/test-org/eventsv2/',
+        body: {
+          detail: {
+            code: '?',
+            message: 'Object Error',
+            extra: {},
+          },
+        },
+        statusCode: 400,
+      });
+
+      let errorValue;
+      render(
+        <DiscoverQuery
+          orgSlug="test-org"
+          api={api}
+          location={location}
+          eventView={eventView}
+          setError={e => (errorValue = e)}
+        >
+          {({isLoading}) => {
+            if (isLoading) {
+              return 'loading';
+            }
+            return null;
+          }}
+        </DiscoverQuery>
+      );
+      await tick();
+
+      expect(errorValue.message).toEqual('Object Error');
+    });
+  });
+
+  describe('with events', function () {
+    it('fetches data on mount', async function () {
+      const getMock = MockApiClient.addMockResponse({
+        url: '/organizations/test-org/events/',
+        body: {
+          meta: {fields: {transaction: 'string', count: 'number'}},
+          data: [{transaction: '/health', count: 1000}],
+        },
+      });
+      render(
+        <DiscoverQuery
+          orgSlug="test-org"
+          api={api}
+          location={location}
+          eventView={eventView}
+          useEvents
+        >
+          {({tableData, isLoading}) => {
+            if (isLoading) {
+              return 'loading';
+            }
+            return <p>{tableData.data[0].transaction}</p>;
+          }}
+        </DiscoverQuery>
+      );
+      await tick();
+
+      // Children should be rendered, and API should be called.
+      expect(getMock).toHaveBeenCalledTimes(1);
+      expect(await screen.findByText('/health')).toBeInTheDocument();
+    });
+
+    it('applies limit and cursor props', async function () {
+      const getMock = MockApiClient.addMockResponse({
+        url: '/organizations/test-org/events/',
+        body: {
+          meta: {fields: {transaction: 'string', count: 'number'}},
+          data: [{transaction: '/health', count: 1000}],
+        },
+      });
+      render(
+        <DiscoverQuery
+          orgSlug="test-org"
+          api={api}
+          location={location}
+          eventView={eventView}
+          limit={3}
+          cursor="1:0:1"
+          useEvents
+        >
+          {({tableData, isLoading}) => {
+            if (isLoading) {
+              return 'loading';
+            }
+            return <p>{tableData.data[0].transaction}</p>;
+          }}
+        </DiscoverQuery>
+      );
+      await tick();
+
+      expect(getMock).toHaveBeenCalledTimes(1);
+      expect(getMock).toHaveBeenCalledWith(
+        '/organizations/test-org/events/',
+        expect.objectContaining({
+          method: 'GET',
+          query: expect.objectContaining({
+            per_page: 3,
+            cursor: '1:0:1',
+          }),
+        })
+      );
+    });
+
+    it('parses string errors correctly', async function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/test-org/events/',
+        body: {
+          detail: 'Error Message',
+        },
+        statusCode: 400,
+      });
+
+      let errorValue;
+      render(
+        <DiscoverQuery
+          orgSlug="test-org"
+          api={api}
+          location={location}
+          eventView={eventView}
+          setError={e => (errorValue = e)}
+          useEvents
+        >
+          {({isLoading}) => {
+            if (isLoading) {
+              return 'loading';
+            }
+            return null;
+          }}
+        </DiscoverQuery>
+      );
+      await tick();
+
+      expect(errorValue.message).toEqual('Error Message');
+    });
+
+    it('parses object errors correctly', async function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/test-org/events/',
+        body: {
+          detail: {
+            code: '?',
+            message: 'Object Error',
+            extra: {},
+          },
+        },
+        statusCode: 400,
+      });
+
+      let errorValue;
+      render(
+        <DiscoverQuery
+          orgSlug="test-org"
+          api={api}
+          location={location}
+          eventView={eventView}
+          setError={e => (errorValue = e)}
+          useEvents
+        >
+          {({isLoading}) => {
+            if (isLoading) {
+              return 'loading';
+            }
+            return null;
+          }}
+        </DiscoverQuery>
+      );
+      await tick();
+
+      expect(errorValue.message).toEqual('Object Error');
+    });
   });
 });


### PR DESCRIPTION
Updates the performance landing pages to use the `events` endpoint over the `eventsv2` endpoints when the user is feature flagged with `discover-frontend-use-events-endpoint`