### PR TITLE
fix(span-tree): Horizontal autoscroll improvements

### DIFF
--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -109,7 +109,7 @@ export class Provider extends Component<Props, State> {
           clearInterval(this.anchorCheckInterval!);
           this.anchorCheckInterval = null;
         }
-      }, 100);
+      }, 50);
 
       // If the anchored span is never found in the view (malformed ID), cancel the interval
       setTimeout(() => {

--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -117,7 +117,7 @@ export class Provider extends Component<Props, State> {
           clearInterval(this.anchorCheckInterval);
           this.anchorCheckInterval = null;
         }
-      }, 5000);
+      }, 1000);
 
       return;
     }

--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -10,6 +10,7 @@ import getDisplayName from 'sentry/utils/getDisplayName';
 import {setBodyUserSelect, UserSelectValues} from 'sentry/utils/userselect';
 
 import {DragManagerChildrenProps} from './dragManager';
+import SpanBar from './spanBar';
 import {SpansInViewMap} from './utils';
 
 export type ScrollbarManagerChildrenProps = {
@@ -20,6 +21,7 @@ export type ScrollbarManagerChildrenProps = {
   onScroll: () => void;
   onWheel: (deltaX: number) => void;
   scrollBarAreaRef: React.RefObject<HTMLDivElement>;
+  storeSpanBar: (spanBar: SpanBar) => void;
   updateScrollState: () => void;
   virtualScrollbarRef: React.RefObject<HTMLDivElement>;
 };
@@ -34,6 +36,7 @@ const ScrollbarManagerContext = createContext<ScrollbarManagerChildrenProps>({
   updateScrollState: () => {},
   markSpanOutOfView: () => {},
   markSpanInView: () => {},
+  storeSpanBar: () => {},
 });
 
 const selectRefs = (
@@ -84,6 +87,32 @@ export class Provider extends Component<Props, State> {
     // but only for DOM elements that actually got rendered
 
     this.initializeScrollState();
+
+    const anchoredSpanHash = window.location.hash.split('#')[1];
+
+    // If the user is opening the span tree with an anchor link provided, we need to reconnect the observers after a short delay.
+    // This is because we need to wait for the window to scroll to the anchored span first, or there will be inconsistencies in
+    // the spans that are actually considered in the view. This is because the IntersectionObserver API cannot keep up with the speed
+    // at which the window scrolls to the anchored span, and will be unable to recognize the spans that went out of the view
+
+    if (anchoredSpanHash) {
+      // We cannot assume the root is in view to start off, if there is an anchored span
+      this.spansInView.isRootSpanInView = false;
+      setTimeout(() => {
+        this.spanBars.forEach(spanBar => {
+          if (spanBar.spanRowDOMRef.current) {
+            spanBar.connectObservers();
+          }
+        });
+      }, 1000);
+      return;
+    }
+
+    this.spanBars.forEach(spanBar => {
+      if (spanBar.spanRowDOMRef.current) {
+        spanBar.connectObservers();
+      }
+    });
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -118,6 +147,7 @@ export class Provider extends Component<Props, State> {
   animationTimeout: NodeJS.Timeout | null = null;
   previousUserSelect: UserSelectValues | null = null;
   spansInView: SpansInViewMap = new SpansInViewMap();
+  spanBars: SpanBar[] = [];
 
   getReferenceSpanBar() {
     for (const currentSpanBar of this.contentSpanBar) {
@@ -514,6 +544,10 @@ export class Provider extends Component<Props, State> {
     });
   }
 
+  storeSpanBar = (spanBar: SpanBar) => {
+    this.spanBars.push(spanBar);
+  };
+
   render() {
     const childrenProps: ScrollbarManagerChildrenProps = {
       generateContentSpanBarRef: this.generateContentSpanBarRef,
@@ -525,6 +559,7 @@ export class Provider extends Component<Props, State> {
       updateScrollState: this.initializeScrollState,
       markSpanOutOfView: this.markSpanOutOfView,
       markSpanInView: this.markSpanInView,
+      storeSpanBar: this.storeSpanBar,
     };
 
     return (

--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -93,11 +93,18 @@ export class Provider extends Component<Props, State> {
     // If the user is opening the span tree with an anchor link provided, we need to reconnect the observers after a short delay.
     // This is because we need to wait for the window to scroll to the anchored span first, or there will be inconsistencies in
     // the spans that are actually considered in the view. This is because the IntersectionObserver API cannot keep up with the speed
-    // at which the window scrolls to the anchored span, and will be unable to recognize the spans that went out of the view
+    // at which the window scrolls to the anchored span, and will be unable to register the spans that went out of the view
 
     if (anchoredSpanHash) {
       // We cannot assume the root is in view to start off, if there is an anchored span
       this.spansInView.isRootSpanInView = false;
+
+      this.spanBars.forEach(spanBar => {
+        if (spanBar.spanRowDOMRef.current) {
+          spanBar.disconnectObservers();
+        }
+      });
+
       setTimeout(() => {
         this.spanBars.forEach(spanBar => {
           if (spanBar.spanRowDOMRef.current) {

--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -98,28 +98,15 @@ export class Provider extends Component<Props, State> {
     if (anchoredSpanHash) {
       // We cannot assume the root is in view to start off, if there is an anchored span
       this.spansInView.isRootSpanInView = false;
-
-      this.spanBars.forEach(spanBar => {
-        if (spanBar.spanRowDOMRef.current) {
-          spanBar.disconnectObservers();
-        }
-      });
+      this.spanBars.forEach(spanBar => spanBar.disconnectObservers());
 
       setTimeout(() => {
-        this.spanBars.forEach(spanBar => {
-          if (spanBar.spanRowDOMRef.current) {
-            spanBar.connectObservers();
-          }
-        });
-      }, 1000);
+        this.spanBars.forEach(spanBar => spanBar.connectObservers());
+      }, 500);
       return;
     }
 
-    this.spanBars.forEach(spanBar => {
-      if (spanBar.spanRowDOMRef.current) {
-        spanBar.connectObservers();
-      }
-    });
+    this.spanBars.forEach(spanBar => spanBar.connectObservers());
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -92,7 +92,7 @@ export class Provider extends Component<Props, State> {
 
     // If the user is opening the span tree with an anchor link provided, we need to reconnect the observers after a short delay.
     // This is because we need to wait for the window to scroll to the anchored span first, or there will be inconsistencies in
-    // the spans that are actually considered in the view. This is because the IntersectionObserver API cannot keep up with the speed
+    // the spans that are actually considered in the view. The IntersectionObserver API cannot keep up with the speed
     // at which the window scrolls to the anchored span, and will be unable to register the spans that went out of the view
 
     if (anchoredSpanHash) {

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -147,8 +147,10 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
 
   componentDidMount() {
     this._mounted = true;
-    this.props.storeSpanBar(this);
-    this.connectObservers();
+    if (this.spanRowDOMRef.current) {
+      this.props.storeSpanBar(this);
+      this.connectObservers();
+    }
 
     if (this.spanTitleRef.current) {
       this.spanTitleRef.current.addEventListener('wheel', this.handleWheel, {

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -661,15 +661,13 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
               return;
             }
 
-            if (this.props.numOfSpanChildren !== 0) {
-              // TODO: Remove this check when this feature is GA'd
-              if (organization.features.includes('performance-span-tree-autoscroll')) {
-                // If isIntersecting is false, this means the span is out of view below the viewport
-                if (!entry.isIntersecting) {
-                  this.props.markSpanOutOfView(span.span_id);
-                } else {
-                  this.props.markSpanInView(span.span_id, treeDepth);
-                }
+            // TODO: Remove this check when this feature is GA'd
+            if (organization.features.includes('performance-span-tree-autoscroll')) {
+              // If isIntersecting is false, this means the span is out of view below the viewport
+              if (!entry.isIntersecting) {
+                this.props.markSpanOutOfView(span.span_id);
+              } else {
+                this.props.markSpanInView(span.span_id, treeDepth);
               }
             }
 
@@ -690,11 +688,9 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
               return;
             }
 
-            if (this.props.numOfSpanChildren !== 0) {
-              // TODO: Remove this check when this feature is GA'd
-              if (organization.features.includes('performance-span-tree-autoscroll')) {
-                this.props.markSpanOutOfView(span.span_id);
-              }
+            // TODO: Remove this check when this feature is GA'd
+            if (organization.features.includes('performance-span-tree-autoscroll')) {
+              this.props.markSpanOutOfView(span.span_id);
             }
 
             return;

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -211,7 +211,8 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
       return;
     }
     const boundingRect = element.getBoundingClientRect();
-    const offset = boundingRect.top + window.scrollY - MINIMAP_CONTAINER_HEIGHT;
+    // The extra 1 pixel is necessary so that the span is recognized as in view by the IntersectionObserver
+    const offset = boundingRect.top + window.scrollY - MINIMAP_CONTAINER_HEIGHT - 1;
     this.setState({showDetail: true}, () => window.scrollTo(0, offset));
   };
 

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -210,7 +210,9 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
     }
     const boundingRect = element.getBoundingClientRect();
     const offset = boundingRect.top + window.scrollY - MINIMAP_CONTAINER_HEIGHT;
-    this.setState({showDetail: true}, () => window.scrollTo(0, offset));
+    this.setState({showDetail: true}, () =>
+      window.scrollTo({top: offset, behavior: 'smooth'})
+    );
   };
 
   renderDetail({

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -119,6 +119,7 @@ type SpanBarProps = {
   showSpanTree: boolean;
   span: Readonly<ProcessedSpanType>;
   spanNumber: number;
+  storeSpanBar: (spanBar: SpanBar) => void;
   toggleEmbeddedChildren:
     | ((props: {eventSlug: string; orgSlug: string}) => void)
     | undefined;
@@ -146,9 +147,8 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
 
   componentDidMount() {
     this._mounted = true;
-    if (this.spanRowDOMRef.current) {
-      this.connectObservers();
-    }
+    this.props.storeSpanBar(this);
+    this.connectObservers();
 
     if (this.spanTitleRef.current) {
       this.spanTitleRef.current.addEventListener('wheel', this.handleWheel, {
@@ -210,9 +210,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
     }
     const boundingRect = element.getBoundingClientRect();
     const offset = boundingRect.top + window.scrollY - MINIMAP_CONTAINER_HEIGHT;
-    this.setState({showDetail: true}, () =>
-      window.scrollTo({top: offset, behavior: 'smooth'})
-    );
+    this.setState({showDetail: true}, () => window.scrollTo({top: offset}));
   };
 
   renderDetail({
@@ -580,7 +578,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
      */
 
     this.intersectionObserver = new IntersectionObserver(
-      entries => {
+      entries =>
         entries.forEach(entry => {
           if (!this._mounted) {
             return;
@@ -720,8 +718,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
           }
 
           minimapSlider.style.top = `-${panYPixels}px`;
-        });
-      },
+        }),
       {
         threshold: INTERSECTION_THRESHOLDS,
         rootMargin: `-${MINIMAP_CONTAINER_HEIGHT * this.zoomLevel}px 0px 0px 0px`,

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -212,7 +212,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
     }
     const boundingRect = element.getBoundingClientRect();
     const offset = boundingRect.top + window.scrollY - MINIMAP_CONTAINER_HEIGHT;
-    this.setState({showDetail: true}, () => window.scrollTo({top: offset}));
+    this.setState({showDetail: true}, () => window.scrollTo(0, offset));
   };
 
   renderDetail({

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -159,6 +159,7 @@ class SpanTree extends Component<PropType> {
       generateContentSpanBarRef,
       markSpanOutOfView,
       markSpanInView,
+      storeSpanBar,
     } = this.props;
     const generateBounds = waterfallModel.generateBounds({
       viewStart: dragProps.viewWindowStart,
@@ -321,6 +322,7 @@ class SpanTree extends Component<PropType> {
             generateContentSpanBarRef={generateContentSpanBarRef}
             markSpanOutOfView={markSpanOutOfView}
             markSpanInView={markSpanInView}
+            storeSpanBar={storeSpanBar}
           />
         );
 

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -823,6 +823,10 @@ export class SpansInViewMap {
     return true;
   }
 
+  has(spanId: string) {
+    return this.spanDepthsInView.has(spanId);
+  }
+
   getScrollVal() {
     if (this.isRootSpanInView) {
       return 0;

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -5,14 +5,16 @@ import isString from 'lodash/isString';
 import set from 'lodash/set';
 import moment from 'moment';
 
-import {TOGGLE_BORDER_BOX} from 'sentry/components/performance/waterfall/treeConnector';
+import {
+  TOGGLE_BORDER_BOX,
+  TOGGLE_BUTTON_MAX_WIDTH,
+} from 'sentry/components/performance/waterfall/treeConnector';
 import {EntryType, EventTransaction} from 'sentry/types/event';
 import {assert} from 'sentry/types/utils';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {getPerformanceTransaction} from 'sentry/utils/performanceForSentry';
 
 import {MERGE_LABELS_THRESHOLD_PERCENT} from './constants';
-import {MARGIN_LEFT} from './spanBar';
 import {
   EnhancedSpan,
   GapSpanType,
@@ -827,6 +829,6 @@ export class SpansInViewMap {
     }
 
     const avgDepth = Math.round(this.treeDepthSum / this.length);
-    return avgDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
+    return avgDepth * (TOGGLE_BORDER_BOX / 2) - TOGGLE_BUTTON_MAX_WIDTH / 2;
   }
 }

--- a/static/app/components/performance/waterfall/treeConnector.tsx
+++ b/static/app/components/performance/waterfall/treeConnector.tsx
@@ -6,7 +6,7 @@ import {IconChevron} from 'sentry/icons';
 import space from 'sentry/styles/space';
 
 const TOGGLE_BUTTON_MARGIN_RIGHT = 16;
-const TOGGLE_BUTTON_MAX_WIDTH = 30;
+export const TOGGLE_BUTTON_MAX_WIDTH = 30;
 export const TOGGLE_BORDER_BOX = TOGGLE_BUTTON_MAX_WIDTH + TOGGLE_BUTTON_MARGIN_RIGHT;
 const TREE_TOGGLE_CONTAINER_WIDTH = 40;
 


### PR DESCRIPTION
This PR adds the following:

- Fixes a bug where spans without any descendants were not getting considered when determining horizontal positioning
- Horizontal positioning has been changed so that the entire child span toggle button remains in view, instead of half
- Fixes a bug where horizontal positioning was inconsistent when visiting the event view from an anchor link