### PR TITLE
fix(saml2): Don't break if flow from redis is None

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -81,6 +81,12 @@ class AuthHelperSessionStore(PipelineSessionStore):
         super().mark_session()
         self.request.session.modified = True
 
+    def is_valid(self):
+        return super().is_valid() and self.flow in (
+            AuthHelper.FLOW_LOGIN,
+            AuthHelper.FLOW_SETUP_PROVIDER,
+        )
+
 
 @dataclass
 class AuthIdentityHandler:

--- a/src/sentry/utils/session_store.py
+++ b/src/sentry/utils/session_store.py
@@ -92,7 +92,7 @@ class RedisSessionStore:
         self.mark_session()
 
     def is_valid(self):
-        return self.redis_key and self._client.get(self.redis_key)
+        return bool(self.redis_key and self._client.get(self.redis_key))
 
     def get_state(self):
         if not self.redis_key:

--- a/tests/sentry/utils/test_session_store.py
+++ b/tests/sentry/utils/test_session_store.py
@@ -42,7 +42,7 @@ class RedisSessionStoreTestCase(TestCase):
         self.store.clear()
 
     def test_uninitialized_store(self):
-        assert not self.store.is_valid()
+        assert self.store.is_valid() is False
         assert self.store.get_state() is None
         assert self.store.some_value is None
 

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -122,8 +122,6 @@ class AuthSAML2Test(AuthProviderTestCase):
         assert auth.context["existing_user"] == self.user
 
     def test_auth_idp_initiated_invalid_flow_from_session(self):
-        self.client.post(self.login_path, {"init": True})
-
         original_is_valid = AuthHelperSessionStore.is_valid
 
         def side_effect(self):

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -10,6 +10,7 @@ from exam import fixture
 
 from sentry import audit_log
 from sentry.auth.authenticators import TotpInterface
+from sentry.auth.helper import AuthHelperSessionStore
 from sentry.auth.providers.saml2.provider import HAS_SAML2, Attributes, SAML2Provider
 from sentry.models import AuditLogEntry, AuthProvider, Organization
 from sentry.testutils import AuthProviderTestCase
@@ -116,6 +117,26 @@ class AuthSAML2Test(AuthProviderTestCase):
 
     def test_auth_idp_initiated(self):
         auth = self.accept_auth()
+
+        assert auth.status_code == 200
+        assert auth.context["existing_user"] == self.user
+
+    def test_auth_idp_initiated_invalid_flow_from_session(self):
+        self.client.post(self.login_path, {"init": True})
+
+        original_is_valid = AuthHelperSessionStore.is_valid
+
+        def side_effect(self):
+            self.flow = None
+            assert original_is_valid(self) is False
+            return False
+
+        with mock.patch(
+            "sentry.auth.helper.AuthHelperSessionStore.is_valid",
+            side_effect=side_effect,
+            autospec=True,
+        ):
+            auth = self.accept_auth()
 
         assert auth.status_code == 200
         assert auth.context["existing_user"] == self.user


### PR DESCRIPTION
I'm not entirely sure how [SENTRY-T04](https://sentry.io/organizations/sentry/issues/2872341568/) was generated, but this should help avoid raising `NotImplementedError`.

-----

Reference: https://sentry.io/organizations/sentry/issues/2872341568/

Fixes SENTRY-T04