### PR TITLE
fix(reload): Fix type for onboarding_v2.first_event_recieved and onboarding_v2.first_transaction_recieved

### DIFF
--- a/static/app/utils/eventWaiter.tsx
+++ b/static/app/utils/eventWaiter.tsx
@@ -19,7 +19,7 @@ const recordAnalyticsFirstEvent = ({
 }) =>
   analytics(`onboarding_v2.${key}`, {
     org_id: parseInt(organization.id, 10),
-    project: project.id,
+    project: String(project.id),
   });
 
 /**

--- a/static/app/utils/eventWaiter.tsx
+++ b/static/app/utils/eventWaiter.tsx
@@ -8,10 +8,18 @@ import withApi from 'sentry/utils/withApi';
 
 const DEFAULT_POLL_INTERVAL = 5000;
 
-const recordAnalyticsFirstEvent = ({key, organization, project}) =>
+const recordAnalyticsFirstEvent = ({
+  key,
+  organization,
+  project,
+}: {
+  key: 'first_event_recieved' | 'first_transaction_recieved';
+  organization: Organization;
+  project: Project;
+}) =>
   analytics(`onboarding_v2.${key}`, {
     org_id: parseInt(organization.id, 10),
-    project: parseInt(project.id, 10),
+    project: project.id,
   });
 
 /**


### PR DESCRIPTION
`project` field in associated reload event schema are of type `str` as defined here https://github.com/getsentry/reload/blob/55d44767167d2c52eda697c15b2104f641c8e8ec/reload_app/events.py#L998-L1005



-----

Fixes [RELOAD-27](https://sentry.io/organizations/sentry/issues/1851101396/) and [RELOAD-28](https://sentry.io/organizations/sentry/issues/1858657498/)