### PR TITLE
feat(customer-domains): Add `sentryUrl` and `organizationUrl` to config

### DIFF
--- a/fixtures/js-stubs/config.js
+++ b/fixtures/js-stubs/config.js
@@ -43,6 +43,8 @@ export function Config(params = {}) {
     apmSampling: 1,
     dsn_requests: '',
     demoMode: false,
+    apiUrl: 'sentry.io',
+    organizationUrl: 'foobar.sentry.io',
     ...params,
   };
 }

--- a/fixtures/js-stubs/config.js
+++ b/fixtures/js-stubs/config.js
@@ -43,8 +43,8 @@ export function Config(params = {}) {
     apmSampling: 1,
     dsn_requests: '',
     demoMode: false,
-    apiUrl: 'sentry.io',
-    organizationUrl: 'foobar.sentry.io',
+    sentryUrl: 'https://sentry.io',
+    organizationUrl: 'https://foobar.sentry.io',
     ...params,
   };
 }

--- a/fixtures/js-stubs/config.js
+++ b/fixtures/js-stubs/config.js
@@ -44,7 +44,7 @@ export function Config(params = {}) {
     dsn_requests: '',
     demoMode: false,
     sentryUrl: 'https://sentry.io',
-    organizationUrl: 'https://foobar.sentry.io',
+    organizationUrl: 'https://foobar.us.sentry.io',
     ...params,
   };
 }

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -179,8 +179,8 @@ def get_client_config(request=None):
         "enableAnalytics": settings.ENABLE_ANALYTICS,
         "validateSUForm": getattr(settings, "VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON", False),
         # TODO: to be implemented in the future when customer domain work evolves
-        "apiUrl": None,
-        "organizationUrl": None,
+        "sentryUrl": options.get("system.url-prefix"),
+        "organizationUrl": options.get("system.url-prefix"),
     }
     if user and user.is_authenticated:
         context.update(

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -178,6 +178,9 @@ def get_client_config(request=None):
         "demoMode": settings.DEMO_MODE,
         "enableAnalytics": settings.ENABLE_ANALYTICS,
         "validateSUForm": getattr(settings, "VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON", False),
+        # TODO: to be implemented in the future when customer domain work evolves
+        "apiUrl": None,
+        "organizationUrl": None,
     }
     if user and user.is_authenticated:
         context.update(

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -119,8 +119,9 @@ export interface Config {
   features: Set<string>;
   gravatarBaseUrl: string;
   invitesEnabled: boolean;
-
   isAuthenticated: boolean;
+
+  sentryUrl: string | undefined;
   // Maintain isOnPremise key for backcompat (plugins?).
   isOnPremise: boolean;
   isSelfHosted: boolean;
@@ -130,8 +131,9 @@ export interface Config {
    * This comes from django (django.contrib.messages)
    */
   messages: {level: keyof Theme['alert']; message: string}[];
-  needsUpgrade: boolean;
 
+  needsUpgrade: boolean;
+  organizationUrl: string | undefined;
   privacyUrl: string | null;
   sentryConfig: {
     dsn: string;

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -139,7 +139,7 @@ export interface Config {
     release: string;
     whitelistUrls: string[];
   };
-  sentryUrl: string | undefined;
+  sentryUrl: string;
   singleOrganization: boolean;
   supportEmail: string;
   termsUrl: string | null;

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -121,7 +121,6 @@ export interface Config {
   invitesEnabled: boolean;
   isAuthenticated: boolean;
 
-  sentryUrl: string | undefined;
   // Maintain isOnPremise key for backcompat (plugins?).
   isOnPremise: boolean;
   isSelfHosted: boolean;
@@ -131,8 +130,8 @@ export interface Config {
    * This comes from django (django.contrib.messages)
    */
   messages: {level: keyof Theme['alert']; message: string}[];
-
   needsUpgrade: boolean;
+
   organizationUrl: string | undefined;
   privacyUrl: string | null;
   sentryConfig: {
@@ -140,6 +139,7 @@ export interface Config {
     release: string;
     whitelistUrls: string[];
   };
+  sentryUrl: string | undefined;
   singleOrganization: boolean;
   supportEmail: string;
   termsUrl: string | null;

--- a/tests/js/spec/stores/configStore.spec.tsx
+++ b/tests/js/spec/stores/configStore.spec.tsx
@@ -3,6 +3,6 @@ import ConfigStore from 'sentry/stores/configStore';
 describe('ConfigStore', () => {
   it('should have apiUrl and organizationUrl', () => {
     expect(ConfigStore.get('sentryUrl')).toEqual('https://sentry.io');
-    expect(ConfigStore.get('organizationUrl')).toEqual('https://foobar.sentry.io');
+    expect(ConfigStore.get('organizationUrl')).toEqual('https://foobar.us.sentry.io');
   });
 });

--- a/tests/js/spec/stores/configStore.spec.tsx
+++ b/tests/js/spec/stores/configStore.spec.tsx
@@ -1,0 +1,8 @@
+import ConfigStore from 'sentry/stores/configStore';
+
+describe('ConfigStore', () => {
+  it('should have apiUrl and organizationUrl', () => {
+    expect(ConfigStore.get('sentryUrl')).toEqual('https://sentry.io');
+    expect(ConfigStore.get('organizationUrl')).toEqual('https://foobar.sentry.io');
+  });
+});

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -106,7 +106,18 @@ class ClientConfigViewTest(TestCase):
         assert data["user"]["email"] == user.email
         assert data["user"]["isSuperuser"]
 
-    def test_url_prefix(self):
+    def test_url_prefix_unauthenticated(self):
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+        assert not data["isAuthenticated"]
+        assert data["user"] is None
+        assert data["apiUrl"] is None
+        assert data["organizationUrl"] is None
+
+    def test_url_prefix_authenticated(self):
         user = self.create_user("foo@example.com")
         self.login_as(user)
 
@@ -115,5 +126,6 @@ class ClientConfigViewTest(TestCase):
         assert resp["Content-Type"] == "application/json"
 
         data = json.loads(resp.content)
+        assert data["isAuthenticated"] is True
         assert data["apiUrl"] is None
         assert data["organizationUrl"] is None

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -105,3 +105,15 @@ class ClientConfigViewTest(TestCase):
         assert data["user"]
         assert data["user"]["email"] == user.email
         assert data["user"]["isSuperuser"]
+
+    def test_url_prefix(self):
+        user = self.create_user("foo@example.com")
+        self.login_as(user)
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+        assert data["apiUrl"] is None
+        assert data["organizationUrl"] is None

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -114,8 +114,8 @@ class ClientConfigViewTest(TestCase):
         data = json.loads(resp.content)
         assert not data["isAuthenticated"]
         assert data["user"] is None
-        assert data["apiUrl"] is None
-        assert data["organizationUrl"] is None
+        assert data["sentryUrl"] == "http://testserver"
+        assert data["organizationUrl"] == "http://testserver"
 
     def test_url_prefix_authenticated(self):
         user = self.create_user("foo@example.com")
@@ -127,5 +127,5 @@ class ClientConfigViewTest(TestCase):
 
         data = json.loads(resp.content)
         assert data["isAuthenticated"] is True
-        assert data["apiUrl"] is None
-        assert data["organizationUrl"] is None
+        assert data["sentryUrl"] == "http://testserver"
+        assert data["organizationUrl"] == "http://testserver"


### PR DESCRIPTION
- Add `sentryUrl` and `organizationUrl` to `Config` typescript type.
- Add `sentryUrl` and `organizationUrl` to the config initial data. This is populated to the initial django template served to the user (via `window.__initialData`), and when the bootstrap URL is used for fetching the latest client config.