### PR TITLE
feat(performance): feature flag for performance using new events endpoint

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -943,8 +943,10 @@ SENTRY_FEATURES = {
     "organizations:create": True,
     # Enable the 'discover' interface.
     "organizations:discover": False,
-    # Enables events endpoint usage on frontend
+    # Enables events endpoint usage on discover and dashboards frontend
     "organizations:discover-frontend-use-events-endpoint": False,
+    # Enables events endpoint usage on performance frontend
+    "organizations:performance-frontend-use-events-endpoint": False,
     # Enable duplicating alert rules.
     "organizations:duplicate-alert-rule": False,
     # Enable attaching arbitrary files to events.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -67,6 +67,9 @@ default_manager.add("organizations:discover", OrganizationFeature)
 default_manager.add(
     "organizations:discover-frontend-use-events-endpoint", OrganizationFeature, True
 )
+default_manager.add(
+    "organizations:performance-frontend-use-events-endpoint", OrganizationFeature, True
+)
 default_manager.add("organizations:duplicate-alert-rule", OrganizationFeature, True)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature)
 default_manager.add("organizations:filters-and-sampling", OrganizationFeature, True)


### PR DESCRIPTION
Creates a feature flag to be used on Performance to toggle frontend using the new `events` endpoint over `eventsv2`.