### PR TITLE
feat(performance): Use performance-frontend-use-events-endpoint flag in Performance

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -58,7 +58,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
   const {ContainerActions, organization} = props;
   const useEvents = organization.features.includes(
-    'discover-frontend-use-events-endpoint'
+    'performance-frontend-use-events-endpoint'
   );
   const pageError = usePageError();
 

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -89,7 +89,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
   const mepSetting = useMEPSettingContext();
   const {ContainerActions, eventView, organization, location} = props;
   const useEvents = organization.features.includes(
-    'discover-frontend-use-events-endpoint'
+    'performance-frontend-use-events-endpoint'
   );
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
   const field = props.fields[0];

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -155,7 +155,7 @@ class _Table extends Component<Props, State> {
   ): React.ReactNode {
     const {eventView, organization, projects, location} = this.props;
     const isAlias = !organization.features.includes(
-      'discover-frontend-use-events-endpoint'
+      'performance-frontend-use-events-endpoint'
     );
 
     if (!tableData || !tableData.meta) {
@@ -373,7 +373,7 @@ class _Table extends Component<Props, State> {
   render() {
     const {eventView, organization, location, setError} = this.props;
     const useEvents = organization.features.includes(
-      'discover-frontend-use-events-endpoint'
+      'performance-frontend-use-events-endpoint'
     );
     const {widths, transaction, transactionThreshold} = this.state;
     const columnOrder = eventView

--- a/tests/js/spec/views/performance/table.spec.tsx
+++ b/tests/js/spec/views/performance/table.spec.tsx
@@ -306,7 +306,7 @@ describe('Performance > Table', function () {
         {
           query: 'event.type:transaction transaction:/api*',
         },
-        ['discover-frontend-use-events-endpoint']
+        ['performance-frontend-use-events-endpoint']
       );
 
       const wrapper = mountWithTheme(
@@ -363,7 +363,7 @@ describe('Performance > Table', function () {
         {
           query: 'event.type:transaction transaction:/api*',
         },
-        ['performance-use-metrics', 'discover-frontend-use-events-endpoint']
+        ['performance-use-metrics', 'performance-frontend-use-events-endpoint']
       );
 
       const wrapper = mountWithTheme(


### PR DESCRIPTION
Updates performance to use `performance-frontend-use-events-endpoint` flag instead of `discover-frontend-use-events-endpoint` to determine `events` endpoint usage

