### PR TITLE
feat(sampling): Implement denylist query param in project tags API [TET-113]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ tests/fixtures/integrations/*/data/**
 /test_cli/
 Gemfile.lock
 .idea/
+.vim/
 *.iml
 .pytest_cache/
 .vscode/tags

--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -21,9 +21,7 @@ class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
                 # existing api consumers.
                 include_values_seen=True,
             )
-            only_sampling_tags = request.GET.get("onlySamplingTags") == "1"
-
-            if only_sampling_tags:
+            if request.GET.get("onlySamplingTags") == "1":
                 kwargs.update(denylist=DS_DENYLIST)
 
             tag_keys = sorted(

--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from sentry import tagstore
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.constants import PROTECTED_TAG_KEYS
+from sentry.constants import DS_DENYLIST, PROTECTED_TAG_KEYS
 from sentry.models import Environment
 
 
@@ -15,15 +15,19 @@ class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
         except Environment.DoesNotExist:
             tag_keys = []
         else:
+            kwargs = dict(
+                # We might be able to stop including these values, but this
+                # is a pretty old endpoint, so concerned about breaking
+                # existing api consumers.
+                include_values_seen=True,
+            )
+            only_sampling_tags = request.GET.get("onlySamplingTags") == "1"
+
+            if only_sampling_tags:
+                kwargs.update(denylist=DS_DENYLIST)
+
             tag_keys = sorted(
-                tagstore.get_tag_keys(
-                    project.id,
-                    environment_id,
-                    # We might be able to stop including these values, but this
-                    # is a pretty old endpoint, so concerned about breaking
-                    # existing api consumers.
-                    include_values_seen=True,
-                ),
+                tagstore.get_tag_keys(project.id, environment_id, **kwargs),
                 key=lambda x: x.key,
             )
 

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -581,8 +581,8 @@ DataCategory = sentry_relay.DataCategory
 CRASH_RATE_ALERT_SESSION_COUNT_ALIAS = "_total_count"
 CRASH_RATE_ALERT_AGGREGATE_ALIAS = "_crash_rate_alert_aggregate"
 
-# TODO: @andriisoldatenko update with correct values
-# Dynamic sampling denylist
+# Dynamic sampling denylist composed manually from:
+# - iter_tags
 DS_DENYLIST = frozenset(
     [
         "browser",
@@ -594,7 +594,8 @@ DS_DENYLIST = frozenset(
         "gpu.vendor",
         "level",
         "logger",
-        "monitor.id" "os",
+        "monitor.id",
+        "os",
         "os.name",
         "os.rooted",
         "runtime",

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -588,12 +588,16 @@ CRASH_RATE_ALERT_AGGREGATE_ALIAS = "_crash_rate_alert_aggregate"
 # 2. `src/sentry/event_manager.py:_pull_out_data` we have `set_tag`.
 # 3. `src/sentry/event_manager.py:_get_event_user_many` we have `set_tag`.
 # 4. `src/sentry/event_manager.py:_get_or_create_release_many` we have `set_tag`.
-#
+# 5. `src/sentry/interfaces/exception.py:Mechanism` we have `iter_tags`.
+# 6. `src/sentry/plugins/sentry_urls/models.py:UrlsPlugin`.
+# 7. `sentry/src/sentry/plugins/sentry_interface_types/models.py`.
+# 8. `src/sentry/plugins/sentry_useragents/models.py:UserAgentPlugin`.
 # Note:
 # should be sorted alphabetically so that it is easy to maintain in future
 # if you update this list please add explanation or source of it
 DS_DENYLIST = frozenset(
     [
+        "app.device",
         "browser",
         "browser.name",
         "device",
@@ -602,8 +606,11 @@ DS_DENYLIST = frozenset(
         "environment",
         "gpu.name",
         "gpu.vendor",
+        "handled",
+        "interface_type",
         "level",
         "logger",
+        "mechanism",
         "monitor.id",
         "os",
         "os.name",
@@ -612,6 +619,7 @@ DS_DENYLIST = frozenset(
         "runtime",
         "runtime.name",
         "transaction",
+        "url",
         "user",
     ]
 )

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -582,10 +582,10 @@ CRASH_RATE_ALERT_SESSION_COUNT_ALIAS = "_total_count"
 CRASH_RATE_ALERT_AGGREGATE_ALIAS = "_crash_rate_alert_aggregate"
 
 # Dynamic sampling denylist composed manually from
-# `src/sentry/event_manager.py:save`. We have function
+# 1. `src/sentry/event_manager.py:save`. We have function
 # `_derive_interface_tags_many(jobs)` which iterates across all interfaces
-# and execute `iter_tags`, so i've searched usage of `iter_tags` and build
-# current denylist:
+# and execute `iter_tags`, so i've searched usage of `iter_tags`.
+# 2. `src/sentry/event_manager.py:_pull_out_data` we have `set_tag`
 DS_DENYLIST = frozenset(
     [
         "browser",

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -580,3 +580,25 @@ DataCategory = sentry_relay.DataCategory
 
 CRASH_RATE_ALERT_SESSION_COUNT_ALIAS = "_total_count"
 CRASH_RATE_ALERT_AGGREGATE_ALIAS = "_crash_rate_alert_aggregate"
+
+# TODO: @andriisoldatenko update with correct values
+# Dynamic sampling denylist
+DS_DENYLIST = frozenset(
+    [
+        "browser",
+        "browser.name",
+        "device",
+        "device.family",
+        "environment",
+        "gpu.name",
+        "gpu.vendor",
+        "level",
+        "logger",
+        "monitor.id" "os",
+        "os.name",
+        "os.rooted",
+        "runtime",
+        "runtime.name",
+        "transaction",
+    ]
+)

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -602,7 +602,6 @@ DS_DENYLIST = frozenset(
         "browser.name",
         "device",
         "device.family",
-        "dist",
         "environment",
         "gpu.name",
         "gpu.vendor",
@@ -615,11 +614,12 @@ DS_DENYLIST = frozenset(
         "os",
         "os.name",
         "os.rooted",
-        "release",
         "runtime",
         "runtime.name",
+        "sentry:dist",
+        "sentry:release",
+        "sentry:user",
         "transaction",
         "url",
-        "user",
     ]
 )

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -581,8 +581,11 @@ DataCategory = sentry_relay.DataCategory
 CRASH_RATE_ALERT_SESSION_COUNT_ALIAS = "_total_count"
 CRASH_RATE_ALERT_AGGREGATE_ALIAS = "_crash_rate_alert_aggregate"
 
-# Dynamic sampling denylist composed manually from:
-# - iter_tags
+# Dynamic sampling denylist composed manually from
+# `src/sentry/event_manager.py:save`. We have function
+# `_derive_interface_tags_many(jobs)` which iterates across all interfaces
+# and execute `iter_tags`, so i've searched usage of `iter_tags` and build
+# current denylist:
 DS_DENYLIST = frozenset(
     [
         "browser",

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -590,7 +590,7 @@ CRASH_RATE_ALERT_AGGREGATE_ALIAS = "_crash_rate_alert_aggregate"
 # 4. `src/sentry/event_manager.py:_get_or_create_release_many` we have `set_tag`.
 #
 # Note:
-# should be sorted alphabetically for easy to maintanin in future
+# should be sorted alphabetically so that it is easy to maintain in future
 # if you update this list please add explanation or source of it
 DS_DENYLIST = frozenset(
     [

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -585,13 +585,20 @@ CRASH_RATE_ALERT_AGGREGATE_ALIAS = "_crash_rate_alert_aggregate"
 # 1. `src/sentry/event_manager.py:save`. We have function
 # `_derive_interface_tags_many(jobs)` which iterates across all interfaces
 # and execute `iter_tags`, so i've searched usage of `iter_tags`.
-# 2. `src/sentry/event_manager.py:_pull_out_data` we have `set_tag`
+# 2. `src/sentry/event_manager.py:_pull_out_data` we have `set_tag`.
+# 3. `src/sentry/event_manager.py:_get_event_user_many` we have `set_tag`.
+# 4. `src/sentry/event_manager.py:_get_or_create_release_many` we have `set_tag`.
+#
+# Note:
+# should be sorted alphabetically for easy to maintanin in future
+# if you update this list please add explanation or source of it
 DS_DENYLIST = frozenset(
     [
         "browser",
         "browser.name",
         "device",
         "device.family",
+        "dist",
         "environment",
         "gpu.name",
         "gpu.vendor",
@@ -601,8 +608,10 @@ DS_DENYLIST = frozenset(
         "os",
         "os.name",
         "os.rooted",
+        "release",
         "runtime",
         "runtime.name",
         "transaction",
+        "user",
     ]
 )

--- a/tests/snuba/api/endpoints/test_project_tags.py
+++ b/tests/snuba/api/endpoints/test_project_tags.py
@@ -32,7 +32,7 @@ class ProjectTagsTest(APITestCase, SnubaTestCase):
         assert data["bar"]["canDelete"]
         assert data["bar"]["uniqueValues"] == 2
 
-    def test_simple_with_deny(self):
+    def test_simple_remove_tags_in_denylist(self):
         self.store_event(
             data={
                 # "browser" is in denylist sentry.constants.DS_DENYLIST

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -212,7 +212,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
         }
         assert set(keys) == expected_keys
 
-    def test_get_tag_keys_with_denylist(self):
+    def test_get_tag_keys_removed_from_denylist(self):
         denylist_keys = frozenset(["browser"])
         expected_keys = {
             "baz",
@@ -232,9 +232,10 @@ class TagStorageTest(TestCase, SnubaTestCase):
         keys = {
             k.key: k
             for k in self.ts.get_tag_keys(
-                project_id=self.proj1.id, environment_id=self.proj1env1.id, denylist=denylist_keys
+                project_id=self.proj1.id, environment_id=self.proj1env1.id
             )
         }
+        expected_keys |= {"browser"}
         assert set(keys) == expected_keys
 
     def test_get_group_tag_key(self):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -213,12 +213,11 @@ class TagStorageTest(TestCase, SnubaTestCase):
         assert set(keys) == expected_keys
 
     def test_get_tag_keys_removed_from_denylist(self):
-        denylist_keys = frozenset(["browser"])
+        denylist_keys = frozenset(["browser", "sentry:release"])
         expected_keys = {
             "baz",
             "environment",
             "foo",
-            "sentry:release",
             "sentry:user",
             "level",
         }
@@ -235,7 +234,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 project_id=self.proj1.id, environment_id=self.proj1env1.id
             )
         }
-        expected_keys |= {"browser"}
+        expected_keys |= {"browser", "sentry:release"}
         assert set(keys) == expected_keys
 
     def test_get_group_tag_key(self):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -212,6 +212,31 @@ class TagStorageTest(TestCase, SnubaTestCase):
         }
         assert set(keys) == expected_keys
 
+    def test_get_tag_keys_with_denylist(self):
+        denylist_keys = frozenset(["browser"])
+        expected_keys = {
+            "baz",
+            "environment",
+            "foo",
+            "sentry:release",
+            "sentry:user",
+            "level",
+        }
+        keys = {
+            k.key: k
+            for k in self.ts.get_tag_keys(
+                project_id=self.proj1.id, environment_id=self.proj1env1.id, denylist=denylist_keys
+            )
+        }
+        assert set(keys) == expected_keys
+        keys = {
+            k.key: k
+            for k in self.ts.get_tag_keys(
+                project_id=self.proj1.id, environment_id=self.proj1env1.id, denylist=denylist_keys
+            )
+        }
+        assert set(keys) == expected_keys
+
     def test_get_group_tag_key(self):
         with pytest.raises(GroupTagKeyNotFound):
             self.ts.get_group_tag_key(


### PR DESCRIPTION
Add new optional query param `onlySamplingTags` to
`/api/0/projects/<organization>/<project>/tags/`.
So we can filter out tags using sentry.constants.DS_DENYLIST.

Fixes TET-113




<!-- Describe your PR here. -->

