### PR TITLE
ref(sampling): Add tab navigation - [TET-118]

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -14,6 +14,7 @@ import {EXPERIMENTAL_SPA} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import HookStore from 'sentry/stores/hookStore';
 import {HookName} from 'sentry/types/hooks';
+import {SamplingRuleType} from 'sentry/types/sampling';
 import errorHandler from 'sentry/utils/errorHandler';
 import App from 'sentry/views/app';
 import AuthLayout from 'sentry/views/auth/layout';
@@ -464,7 +465,10 @@ function buildRoutes() {
         path="sampling/"
         name={t('Sampling')}
         component={make(() => import('sentry/views/settings/project/sampling'))}
-      />
+      >
+        <IndexRedirect to={`${SamplingRuleType.TRACE}/`} />
+        <Route path=":ruleType/" />
+      </Route>
       <Route
         path="issue-grouping/"
         name={t('Issue Grouping')}

--- a/static/app/views/settings/project/sampling/index.tsx
+++ b/static/app/views/settings/project/sampling/index.tsx
@@ -1,14 +1,17 @@
+import {RouteComponentProps} from 'react-router';
+
 import Access from 'sentry/components/acl/access';
 import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {PanelAlert} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
 import {Project} from 'sentry/types';
+import {SamplingRuleType} from 'sentry/types/sampling';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {Sampling} from './sampling';
 
-type Props = {
+type Props = RouteComponentProps<{ruleType: SamplingRuleType}, {}> & {
   project: Project;
 };
 

--- a/static/app/views/settings/project/sampling/rules/index.tsx
+++ b/static/app/views/settings/project/sampling/rules/index.tsx
@@ -167,6 +167,7 @@ export class Rules extends PureComponent<Props, State> {
                     ? SamplingRuleOperator.ELSE
                     : SamplingRuleOperator.ELSE_IF
                 }
+                hideGrabButton={items.length === 1}
                 rule={{...currentRule, disabled: itemsRule.disabled}}
                 onEditRule={onEditRule(currentRule)}
                 onDeleteRule={onDeleteRule(currentRule)}

--- a/static/app/views/settings/project/sampling/rules/rule/index.tsx
+++ b/static/app/views/settings/project/sampling/rules/rule/index.tsx
@@ -16,6 +16,11 @@ import {Conditions} from './conditions';
 
 type Props = {
   dragging: boolean;
+  /**
+   * Hide the grab button if true.
+   * This is used when the list has a single item, making sorting not possible.
+   */
+  hideGrabButton: boolean;
   listeners: DraggableSyntheticListeners;
   noPermission: boolean;
   onDeleteRule: () => void;
@@ -40,6 +45,7 @@ export function Rule({
   listeners,
   operator,
   grabAttributes,
+  hideGrabButton,
 }: Props) {
   const [state, setState] = useState<State>({isMenuActionsOpen: false});
 
@@ -50,22 +56,27 @@ export function Rule({
   }, [dragging, sorting, state.isMenuActionsOpen]);
 
   return (
-    <Columns disabled={rule.disabled ?? noPermission}>
-      <GrabColumn>
-        <Tooltip
-          title={
-            noPermission
-              ? t('You do not have permission to reorder rules.')
-              : operator === SamplingRuleOperator.ELSE
-              ? t('Rules without conditions cannot be reordered.')
-              : undefined
-          }
-        >
-          <IconGrabbableWrapper {...listeners} {...grabAttributes}>
-            <IconGrabbable />
-          </IconGrabbableWrapper>
-        </Tooltip>
-      </GrabColumn>
+    <Columns disabled={rule.disabled || noPermission}>
+      {hideGrabButton ? (
+        <Column />
+      ) : (
+        <GrabColumn>
+          <Tooltip
+            title={
+              noPermission
+                ? t('You do not have permission to reorder rules.')
+                : operator === SamplingRuleOperator.ELSE
+                ? t('Rules without conditions cannot be reordered.')
+                : undefined
+            }
+          >
+            <IconGrabbableWrapper {...listeners} {...grabAttributes}>
+              <IconGrabbable />
+            </IconGrabbableWrapper>
+          </Tooltip>
+        </GrabColumn>
+      )}
+
       <Column>
         <Operator>
           {operator === SamplingRuleOperator.IF
@@ -134,9 +145,6 @@ const Columns = styled('div')<{disabled: boolean}>`
   ${p =>
     p.disabled &&
     css`
-      ${Operator} {
-        color: ${p.theme.disabled};
-      }
       ${GrabColumn} {
         color: ${p.theme.disabled};
         [role='button'] {

--- a/static/app/views/settings/project/sampling/rulesPanel.tsx
+++ b/static/app/views/settings/project/sampling/rulesPanel.tsx
@@ -3,15 +3,17 @@ import styled from '@emotion/styled';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {Panel, PanelFooter} from 'sentry/components/panels';
+import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 
 import {Rules} from './rules';
 import {SAMPLING_DOC_LINK} from './utils';
 
-type Props = Omit<React.ComponentProps<typeof Rules>, 'emptyMessage'> & {
+export interface RulesPanelProps
+  extends Omit<React.ComponentProps<typeof Rules>, 'emptyMessage'> {
   onAddRule: () => void;
-};
+}
 
 export function RulesPanel({
   rules,
@@ -20,7 +22,7 @@ export function RulesPanel({
   onDeleteRule,
   onUpdateRules,
   disabled,
-}: Props) {
+}: RulesPanelProps) {
   return (
     <Panel>
       <Rules
@@ -34,10 +36,14 @@ export function RulesPanel({
       <StyledPanelFooter>
         <StyledButtonBar gap={1}>
           <Button href={SAMPLING_DOC_LINK} external>
-            {t('Read the docs')}
+            {t('Read Docs')}
           </Button>
-          <AddRuleButton priority="primary" onClick={onAddRule}>
-            {t('Add transaction rule')}
+          <AddRuleButton
+            priority="primary"
+            onClick={onAddRule}
+            icon={<IconAdd isCircled />}
+          >
+            {t('Add Rule')}
           </AddRuleButton>
         </StyledButtonBar>
       </StyledPanelFooter>

--- a/static/app/views/settings/project/sampling/sampling.tsx
+++ b/static/app/views/settings/project/sampling/sampling.tsx
@@ -1,35 +1,36 @@
 import {Fragment} from 'react';
+import {RouteComponentProps} from 'react-router';
 import partition from 'lodash/partition';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
-import Alert from 'sentry/components/alert';
+import Badge from 'sentry/components/badge';
 import ExternalLink from 'sentry/components/links/externalLink';
+import ListLink from 'sentry/components/links/listLink';
+import NavTabs from 'sentry/components/navTabs';
 import {t, tct} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
-import {
-  SamplingConditionOperator,
-  SamplingRule,
-  SamplingRules,
-  SamplingRuleType,
-} from 'sentry/types/sampling';
+import {SamplingRule, SamplingRules, SamplingRuleType} from 'sentry/types/sampling';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
-import withProject from 'sentry/utils/withProject';
+import recreateRoute from 'sentry/utils/recreateRoute';
 import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
-import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import PermissionAlert from 'sentry/views/settings/organization/permissionAlert';
+
+import TextBlock from '../../components/text/textBlock';
 
 import {modalCss} from './modal/utils';
 import Modal from './modal';
-import {RulesPanel} from './rulesPanel';
+import {TraceRules} from './traceRules';
+import {TransactionRules} from './transactionRules';
 import {SAMPLING_DOC_LINK} from './utils';
 
-type Props = AsyncView['props'] & {
-  hasAccess: boolean;
-  organization: Organization;
-  project: Project;
-};
+type Props = AsyncView['props'] &
+  RouteComponentProps<{ruleType: SamplingRuleType}, {}> & {
+    hasAccess: boolean;
+    organization: Organization;
+    project: Project;
+  };
 
 type State = AsyncView['state'] & {
   projectDetails: Project | null;
@@ -180,49 +181,94 @@ class Sampling extends AsyncView<Props, State> {
 
   renderBody() {
     const {rules} = this.state;
-    const {hasAccess} = this.props;
+    const {hasAccess, location, params, routes} = this.props;
     const disabled = !hasAccess;
 
-    const hasNotSupportedConditionOperator = rules.some(
-      rule => rule.condition.op !== SamplingConditionOperator.AND
-    );
+    const commonRuleProps = {
+      disabled,
+      onAddRule: this.handleOpenRule(),
+      onEditRule: this.handleOpenRule,
+      onDeleteRule: this.handleDeleteRule,
+    };
 
-    if (hasNotSupportedConditionOperator) {
-      return (
-        <Alert type="error">
-          {t('A condition operator has been found that is not yet supported.')}
-        </Alert>
-      );
-    }
+    const [traceRules, transactionRules] = partition(
+      rules,
+      rule => rule.type === SamplingRuleType.TRACE
+    );
 
     return (
       <Fragment>
-        <SettingsPageHeader title={this.getTitle()} />
-        <PermissionAlert />
-        <TextBlock>
-          {tct(
-            'Manage the inbound data you want to store. To change the sampling rate or rate limits, [link:update your SDK configuration]. The rules added below will apply on top of your SDK configuration. Any new rule may take a few minutes to propagate.',
-            {
-              link: <ExternalLink href={SAMPLING_DOC_LINK} />,
-            }
-          )}
-        </TextBlock>
-        <TextBlock>
-          {t('Rules for traces should precede rules for individual transactions.')}
-        </TextBlock>
-        <RulesPanel
-          rules={rules}
-          disabled={disabled}
-          onAddRule={this.handleOpenRule()}
-          onEditRule={this.handleOpenRule}
-          onDeleteRule={this.handleDeleteRule}
-          onUpdateRules={this.handleUpdateRules}
+        <SettingsPageHeader
+          title={this.getTitle()}
+          subtitle={
+            <Fragment>
+              <TextBlock>
+                {tct(
+                  'Here you can define what transactions count towards your quota without updating your SDK. Any rules specified here are applied after your [link:SDK sampling configuration]. New rules will propagate within a few minutes.',
+                  {
+                    link: <ExternalLink href={SAMPLING_DOC_LINK} />,
+                  }
+                )}
+              </TextBlock>
+              <PermissionAlert />
+            </Fragment>
+          }
+          tabs={
+            <NavTabs role="tablist" aria-label={t('Rules tabs')} underlined>
+              <ListLink
+                to={recreateRoute(`${SamplingRuleType.TRACE}/`, {
+                  routes,
+                  location,
+                  params,
+                  stepBack: -1,
+                })}
+                role="tab"
+                aria-selected={params.ruleType === SamplingRuleType.TRACE}
+                tabIndex={params.ruleType === SamplingRuleType.TRACE ? 0 : -1}
+                isActive={() => params.ruleType === SamplingRuleType.TRACE}
+                index
+              >
+                {t('Distributed Traces')}
+                <Badge>{traceRules.length}</Badge>
+              </ListLink>
+              <ListLink
+                to={recreateRoute(`${SamplingRuleType.TRANSACTION}/`, {
+                  routes,
+                  location,
+                  params,
+                  stepBack: -1,
+                })}
+                role="tab"
+                aria-selected={params.ruleType === SamplingRuleType.TRANSACTION}
+                tabIndex={params.ruleType === SamplingRuleType.TRANSACTION ? 0 : -1}
+                isActive={() => params.ruleType === SamplingRuleType.TRANSACTION}
+              >
+                {t('Individual Transactions')}
+                <Badge>{transactionRules.length}</Badge>
+              </ListLink>
+            </NavTabs>
+          }
         />
+        {params.ruleType === SamplingRuleType.TRANSACTION ? (
+          <TransactionRules
+            rules={transactionRules}
+            onUpdateRules={newRules =>
+              this.handleUpdateRules([...traceRules, ...newRules])
+            }
+            {...commonRuleProps}
+          />
+        ) : (
+          <TraceRules
+            rules={traceRules}
+            onUpdateRules={newRules =>
+              this.handleUpdateRules([...transactionRules, ...newRules])
+            }
+            {...commonRuleProps}
+          />
+        )}
       </Fragment>
     );
   }
 }
 
-const SamplingWithProject = withProject(Sampling);
-
-export {SamplingWithProject as Sampling};
+export {Sampling};

--- a/static/app/views/settings/project/sampling/traceRules.tsx
+++ b/static/app/views/settings/project/sampling/traceRules.tsx
@@ -1,0 +1,33 @@
+import {Fragment} from 'react';
+
+import Alert from 'sentry/components/alert';
+import {t} from 'sentry/locale';
+import {SamplingConditionOperator} from 'sentry/types/sampling';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
+
+import {RulesPanel, RulesPanelProps} from './rulesPanel';
+
+interface Props extends RulesPanelProps {}
+
+export function TraceRules(props: Props) {
+  const notSupportedConditionOperator = props.rules.some(
+    rule => rule.condition.op !== SamplingConditionOperator.AND
+  );
+
+  return (
+    <Fragment>
+      <TextBlock>
+        {t(
+          'Using a Trace ID, select all Transactions distributed across multiple projects/services which match your conditions.'
+        )}
+      </TextBlock>
+      {notSupportedConditionOperator ? (
+        <Alert type="error">
+          {t('A condition operator has been found that is not yet supported.')}
+        </Alert>
+      ) : (
+        <RulesPanel {...props} />
+      )}
+    </Fragment>
+  );
+}

--- a/static/app/views/settings/project/sampling/transactionRules.tsx
+++ b/static/app/views/settings/project/sampling/transactionRules.tsx
@@ -1,0 +1,31 @@
+import {Fragment} from 'react';
+
+import Alert from 'sentry/components/alert';
+import {t} from 'sentry/locale';
+import {SamplingConditionOperator} from 'sentry/types/sampling';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
+
+import {RulesPanel, RulesPanelProps} from './rulesPanel';
+
+interface Props extends RulesPanelProps {}
+
+export function TransactionRules(props: Props) {
+  const notSupportedConditionOperator = props.rules.some(
+    rule => rule.condition.op !== SamplingConditionOperator.AND
+  );
+
+  return (
+    <Fragment>
+      <TextBlock>
+        {t('Select Transactions only within this project which match your conditions.')}
+      </TextBlock>
+      {notSupportedConditionOperator ? (
+        <Alert type="error">
+          {t('A condition operator has been found that is not yet supported.')}
+        </Alert>
+      ) : (
+        <RulesPanel {...props} />
+      )}
+    </Fragment>
+  );
+}

--- a/tests/js/spec/views/settings/projectSampling/rules.spec.tsx
+++ b/tests/js/spec/views/settings/projectSampling/rules.spec.tsx
@@ -6,6 +6,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
+import {SamplingRuleType} from 'sentry/types/sampling';
 import {
   LEGACY_BROWSER_LIST,
   SAMPLING_DOC_LINK,
@@ -13,7 +14,7 @@ import {
 
 import {commonConditionCategories, renderComponent, renderModal} from './utils';
 
-describe('Filters and Sampling - Transaction rule', function () {
+describe('Sampling - rules', function () {
   beforeEach(() => {
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/tags/',
@@ -22,7 +23,7 @@ describe('Filters and Sampling - Transaction rule', function () {
     });
   });
 
-  describe('transaction rule', function () {
+  describe('Distributed trace rule', function () {
     it('renders', async function () {
       MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/',
@@ -152,6 +153,7 @@ describe('Filters and Sampling - Transaction rule', function () {
       );
 
       expect(screen.getByText('If')).toBeInTheDocument();
+
       expect(screen.getByText('Release')).toBeInTheDocument();
 
       // Old values
@@ -182,7 +184,7 @@ describe('Filters and Sampling - Transaction rule', function () {
         renderComponent();
 
         // Open Modal
-        await renderModal(screen.getByText('Add transaction rule'), true);
+        await renderModal(screen.getByText('Add Rule'), true);
 
         // Modal content
         expect(screen.getByText('Add Transaction Sampling Rule')).toBeInTheDocument();
@@ -220,7 +222,7 @@ describe('Filters and Sampling - Transaction rule', function () {
         renderComponent();
 
         // Open Modal
-        await renderModal(screen.getByText('Add transaction rule'));
+        await renderModal(screen.getByText('Add Rule'));
 
         // Click on 'Add condition'
         userEvent.click(screen.getByText('Add Condition'));
@@ -293,7 +295,7 @@ describe('Filters and Sampling - Transaction rule', function () {
           renderComponent();
 
           // Open Modal
-          await renderModal(screen.getByText('Add transaction rule'));
+          await renderModal(screen.getByText('Add Rule'));
 
           // Checked tracing checkbox
           expect(screen.getByRole('checkbox')).toBeChecked();
@@ -345,6 +347,7 @@ describe('Filters and Sampling - Transaction rule', function () {
           ).not.toBeInTheDocument();
 
           expect(screen.getByText('If')).toBeInTheDocument();
+
           expect(screen.getByText('Release')).toBeInTheDocument();
           expect(screen.getByText('1.2.3')).toBeInTheDocument();
           expect(screen.getByText('20%')).toBeInTheDocument();
@@ -385,10 +388,10 @@ describe('Filters and Sampling - Transaction rule', function () {
               body: [{value: '1.2.3'}],
             });
 
-            renderComponent();
+            renderComponent({ruleType: SamplingRuleType.TRANSACTION});
 
             // Open Modal
-            await renderModal(screen.getByText('Add transaction rule'));
+            await renderModal(screen.getByText('Add Rule'));
 
             // Unchecked tracing checkbox
             userEvent.click(screen.getByRole('checkbox'));
@@ -480,10 +483,10 @@ describe('Filters and Sampling - Transaction rule', function () {
               }),
             });
 
-            renderComponent();
+            renderComponent({ruleType: SamplingRuleType.TRANSACTION});
 
             // Open Modal
-            await renderModal(screen.getByText('Add transaction rule'));
+            await renderModal(screen.getByText('Add Rule'));
 
             // Checked tracing checkbox
             expect(screen.getByRole('checkbox')).toBeChecked();
@@ -567,7 +570,7 @@ describe('Filters and Sampling - Transaction rule', function () {
     });
   });
 
-  describe('individual transaction rule', function () {
+  describe('Individual transaction rule', function () {
     it('renders', async function () {
       MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/',
@@ -629,13 +632,12 @@ describe('Filters and Sampling - Transaction rule', function () {
         body: [{value: '[0-9]'}],
       });
 
-      renderComponent();
+      renderComponent({ruleType: SamplingRuleType.TRANSACTION});
 
       // Transaction traces and individual transactions rules container
       expect(
         screen.queryByText('There are no transaction rules to display')
       ).not.toBeInTheDocument();
-
       expect(screen.getByText('If')).toBeInTheDocument();
 
       // Open rule modal - edit transaction rule

--- a/tests/js/spec/views/settings/projectSampling/utils.tsx
+++ b/tests/js/spec/views/settings/projectSampling/utils.tsx
@@ -4,8 +4,9 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import GlobalModal from 'sentry/components/globalModal';
+import {SamplingRuleType} from 'sentry/types/sampling';
 import {OrganizationContext} from 'sentry/views/organizationContext';
-import FiltersAndSampling from 'sentry/views/settings/project/sampling';
+import Sampling from 'sentry/views/settings/project/sampling';
 
 export const commonConditionCategories = [
   'Release',
@@ -22,21 +23,40 @@ export const commonConditionCategories = [
   'Transaction',
 ];
 
-export function renderComponent(withModal = true) {
-  const {organization, project} = initializeOrg({
+export function renderComponent({
+  ruleType = SamplingRuleType.TRACE,
+  withModal = true,
+}: {
+  ruleType?: SamplingRuleType;
+  withModal?: boolean;
+} = {}) {
+  const {organization, project, router, routerContext} = initializeOrg({
     organization: {
       features: ['filters-and-sampling'],
     },
   } as Parameters<typeof initializeOrg>[0]);
 
-  return render(
+  const {container} = render(
     <Fragment>
       {withModal && <GlobalModal />}
       <OrganizationContext.Provider value={organization}>
-        <FiltersAndSampling project={project} />
+        <Sampling
+          project={project}
+          routes={router.routes}
+          router={router}
+          route={{}}
+          location={router.location}
+          routeParams={router.params}
+          params={{ruleType}}
+        />
       </OrganizationContext.Provider>
-    </Fragment>
+    </Fragment>,
+    {
+      context: routerContext,
+    }
   );
+
+  return {container, router};
 }
 
 export async function renderModal(actionElement: HTMLElement, takeScreenshot = false) {


### PR DESCRIPTION
**What this PR does:**

- Update the sampling route to support a rule type param (trace/ transaction)
- Add tab navigations distributed traces and individual transactions
- Update copy of the page header
- Update/ Add tests


**Before:**

![image](https://user-images.githubusercontent.com/29228205/171228180-6f20e6dc-4742-4e80-b1a2-f3424a84e492.png)


**After:**

https://user-images.githubusercontent.com/29228205/171228112-f879d6c1-b752-4c54-a886-76daedd49cf6.mov

