### PR TITLE
fix(searchbar): Escape predefined values in search bar

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -87,6 +87,13 @@ const generateOpAutocompleteGroup = (
   };
 };
 
+const escapeValue = (value: string): string => {
+  // Wrap in quotes if there is a space
+  return value.includes(' ') || value.includes('"')
+    ? `"${value.replace(/"/g, '\\"')}"`
+    : value;
+};
+
 type ActionProps = {
   api: Client;
   /**
@@ -809,13 +816,12 @@ class SmartSearchBar extends Component<Props, State> {
       this.setState({noValueQuery});
 
       return values.map(value => {
-        // Wrap in quotes if there is a space
-        const escapedValue =
-          value.includes(' ') || value.includes('"')
-            ? `"${value.replace(/"/g, '\\"')}"`
-            : value;
-
-        return {value: escapedValue, desc: escapedValue, type: ItemType.TAG_VALUE};
+        const escapedValue = escapeValue(value);
+        return {
+          value: escapedValue,
+          desc: escapedValue,
+          type: ItemType.TAG_VALUE,
+        };
       });
     },
     DEFAULT_DEBOUNCE_DURATION,
@@ -829,12 +835,17 @@ class SmartSearchBar extends Component<Props, State> {
   getPredefinedTagValues = (tag: Tag, query: string): SearchItem[] =>
     (tag.values ?? [])
       .filter(value => value.indexOf(query) > -1)
-      .map((value, i) => ({
-        value,
-        desc: value,
-        type: ItemType.TAG_VALUE,
-        ignoreMaxSearchItems: tag.maxSuggestedValues ? i < tag.maxSuggestedValues : false,
-      }));
+      .map((value, i) => {
+        const escapedValue = escapeValue(value);
+        return {
+          value: escapedValue,
+          desc: escapedValue,
+          type: ItemType.TAG_VALUE,
+          ignoreMaxSearchItems: tag.maxSuggestedValues
+            ? i < tag.maxSuggestedValues
+            : false,
+        };
+      });
 
   /**
    * Get recent searches

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -796,4 +796,82 @@ describe('SmartSearchBar', function () {
       expect(searchBar.state.query).toEqual('user:"id:1" ');
     });
   });
+
+  it('quotes in predefined values with spaces when autocompleting', async function () {
+    jest.useRealTimers();
+    const onSearch = jest.fn();
+    supportedTags.predefined = {
+      key: 'predefined',
+      name: 'predefined',
+      predefined: true,
+      values: ['predefined tag with spaces'],
+    };
+    const props = {
+      orgId: 'org-slug',
+      projectId: '0',
+      query: '',
+      location,
+      organization,
+      supportedTags,
+      onSearch,
+    };
+    const searchBar = mountWithTheme(
+      <SmartSearchBar {...props} api={new Client()} />,
+
+      options
+    );
+    searchBar.find('textarea').simulate('focus');
+    searchBar
+      .find('textarea')
+      .simulate('change', {target: {value: 'predefined:predefined'}});
+    await tick();
+
+    const preventDefault = jest.fn();
+    searchBar.find('textarea').simulate('keyDown', {key: 'ArrowDown'});
+    searchBar.find('textarea').simulate('keyDown', {key: 'Enter', preventDefault});
+    await tick();
+
+    expect(searchBar.find('textarea').props().value).toEqual(
+      'predefined:"predefined tag with spaces" '
+    );
+  });
+
+  it('escapes quotes in predefined values properly when autocompleting', async function () {
+    jest.useRealTimers();
+    const onSearch = jest.fn();
+    supportedTags.predefined = {
+      key: 'predefined',
+      name: 'predefined',
+      predefined: true,
+      values: ['"predefined" "tag" "with" "quotes"'],
+    };
+    const props = {
+      orgId: 'org-slug',
+      projectId: '0',
+      query: '',
+      location,
+      organization,
+      supportedTags,
+      onSearch,
+    };
+    const searchBar = mountWithTheme(
+      <SmartSearchBar {...props} api={new Client()} />,
+
+      options
+    );
+    searchBar.find('textarea').simulate('focus');
+    searchBar
+      .find('textarea')
+      .simulate('change', {target: {value: 'predefined:predefined'}});
+    await tick();
+
+    const preventDefault = jest.fn();
+    searchBar.find('textarea').simulate('keyDown', {key: 'ArrowDown'});
+    searchBar.find('textarea').simulate('keyDown', {key: 'Enter', preventDefault});
+    await tick();
+
+    expect(searchBar.find('textarea').props().value).toEqual(
+      'predefined:"\\"predefined\\" \\"tag\\" \\"with\\" \\"quotes\\"" '
+    );
+  });
 });


### PR DESCRIPTION
Tag values fetched on demand via the api already gets quoted and escaped
appropriately once they're loaded but the same is not true for the predefined
values. This ensures that the predefined values are appropriately quoted and
escaped during autocompletion so we're not left with a broken query.