### PR TITLE
feat(replays): show lists of replays on Issues details page

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1232,6 +1232,16 @@ function buildRoutes() {
         }}
       />
       <Route
+        path="replays/"
+        component={make(
+          () => import('sentry/views/organizationGroupDetails/groupReplays')
+        )}
+        props={{
+          currentTab: Tab.REPLAYS,
+          isEventRoute: false,
+        }}
+      />
+      <Route
         path="activity/"
         component={make(
           () => import('sentry/views/organizationGroupDetails/groupActivity')

--- a/static/app/utils/replays/getQueryParamAsString.tsx
+++ b/static/app/utils/replays/getQueryParamAsString.tsx
@@ -1,0 +1,6 @@
+export function getQueryParamAsString(query: string | string[] | null | undefined) {
+  if (!query) {
+    return '';
+  }
+  return Array.isArray(query) ? query.join(' ') : query;
+}

--- a/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
@@ -1,0 +1,162 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import FeatureBadge from 'sentry/components/featureBadge';
+import Link from 'sentry/components/links/link';
+import PageHeading from 'sentry/components/pageHeading';
+import Pagination from 'sentry/components/pagination';
+import {PanelTable} from 'sentry/components/panels';
+import {IconArrow} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {PageContent, PageHeader} from 'sentry/styles/organization';
+import space from 'sentry/styles/space';
+import {NewQuery} from 'sentry/types';
+import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
+import EventView from 'sentry/utils/discover/eventView';
+import {getQueryParamAsString} from 'sentry/utils/replays/getQueryParamAsString';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import ReplayTable from 'sentry/views/replays/replayTable';
+import {Replay} from 'sentry/views/replays/types';
+
+const DEFAULT_DISCOVER_LIMIT = 50;
+
+const GroupReplays = () => {
+  const location = useLocation();
+  const organization = useOrganization();
+  const params = useParams();
+
+  const getEventView = () => {
+    const {groupId} = params;
+    const eventQueryParams: NewQuery = {
+      id: '',
+      name: '',
+      version: 2,
+      fields: [
+        'eventID',
+        'project',
+        'timestamp',
+        'url',
+        'user.display',
+        'user.email',
+        'user.id',
+        'user.ip_address',
+        'user.name',
+        'user.username',
+      ],
+      projects: [],
+      orderby: getQueryParamAsString(query.sort) || '-timestamp',
+      query: `issue.id:${groupId}`,
+    };
+
+    return EventView.fromNewQueryWithLocation(eventQueryParams, location);
+  };
+
+  const {query} = location;
+  const {cursor: _cursor, page: _page, ...currentQuery} = query;
+
+  const sort: {
+    field: string;
+  } = {
+    field: getQueryParamAsString(query.sort) || '-timestamp',
+  };
+
+  const arrowDirection = sort.field.startsWith('-') ? 'down' : 'up';
+  const sortArrow = <IconArrow color="gray300" size="xs" direction={arrowDirection} />;
+
+  return (
+    <Fragment>
+      <StyledPageHeader>
+        <HeaderTitle>
+          {t('Replays')} <FeatureBadge type="alpha" />
+        </HeaderTitle>
+      </StyledPageHeader>
+      <StyledPageContent>
+        <DiscoverQuery
+          eventView={getEventView()}
+          location={location}
+          orgSlug={organization.slug}
+          limit={DEFAULT_DISCOVER_LIMIT}
+        >
+          {data => {
+            return (
+              <Fragment>
+                <StyledPanelTable
+                  isLoading={data.isLoading}
+                  isEmpty={data.tableData?.data.length === 0}
+                  headers={[
+                    t('Session'),
+                    <SortLink
+                      key="timestamp"
+                      role="columnheader"
+                      aria-sort={
+                        !sort.field.endsWith('timestamp')
+                          ? 'none'
+                          : sort.field === '-timestamp'
+                          ? 'descending'
+                          : 'ascending'
+                      }
+                      to={{
+                        pathname: location.pathname,
+                        query: {
+                          ...currentQuery,
+                          sort: sort.field === '-timestamp' ? 'timestamp' : '-timestamp',
+                        },
+                      }}
+                    >
+                      {t('Timestamp')} {sort.field.endsWith('timestamp') && sortArrow}
+                    </SortLink>,
+                    t('Duration'),
+                    t('Errors'),
+                  ]}
+                >
+                  {data.tableData ? (
+                    <ReplayTable replayList={data.tableData.data as Replay[]} />
+                  ) : null}
+                </StyledPanelTable>
+                <Pagination pageLinks={data.pageLinks} />
+              </Fragment>
+            );
+          }}
+        </DiscoverQuery>
+      </StyledPageContent>
+    </Fragment>
+  );
+};
+
+const StyledPageHeader = styled(PageHeader)`
+  background-color: ${p => p.theme.background};
+  min-width: max-content;
+  padding: ${space(3)} ${space(0)} ${space(4)} ${space(4)};
+  margin-bottom: ${space(0)};
+`;
+
+const StyledPanelTable = styled(PanelTable)`
+  grid-template-columns: minmax(0, 1fr) max-content max-content max-content;
+`;
+
+const HeaderTitle = styled(PageHeading)`
+  display: flex;
+  align-items: center;
+  flex: 1;
+`;
+
+const StyledPageContent = styled(PageContent)`
+  box-shadow: 0px 0px 1px ${p => p.theme.gray200};
+  background-color: ${p => p.theme.background};
+`;
+
+const SortLink = styled(Link)`
+  color: inherit;
+
+  :hover {
+    color: inherit;
+  }
+
+  svg {
+    vertical-align: top;
+  }
+`;
+
+export default GroupReplays;

--- a/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
@@ -1,16 +1,13 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import FeatureBadge from 'sentry/components/featureBadge';
 import Link from 'sentry/components/links/link';
-import PageHeading from 'sentry/components/pageHeading';
 import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {PageContent, PageHeader} from 'sentry/styles/organization';
-import space from 'sentry/styles/space';
-import {NewQuery} from 'sentry/types';
+import {PageContent} from 'sentry/styles/organization';
+import {Group, NewQuery} from 'sentry/types';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {getQueryParamAsString} from 'sentry/utils/replays/getQueryParamAsString';
@@ -22,10 +19,15 @@ import {Replay} from 'sentry/views/replays/types';
 
 const DEFAULT_DISCOVER_LIMIT = 50;
 
-const GroupReplays = () => {
+type Props = {
+  group: Group;
+};
+
+const GroupReplays = ({group}: Props) => {
   const location = useLocation();
   const organization = useOrganization();
   const params = useParams();
+  const {project} = group;
 
   const getEventView = () => {
     const {groupId} = params;
@@ -34,6 +36,7 @@ const GroupReplays = () => {
       name: '',
       version: 2,
       fields: [
+        'replayId',
         'eventID',
         'project',
         'timestamp',
@@ -45,7 +48,7 @@ const GroupReplays = () => {
         'user.name',
         'user.username',
       ],
-      projects: [],
+      projects: [+project.id],
       orderby: getQueryParamAsString(query.sort) || '-timestamp',
       query: `issue.id:${groupId}`,
     };
@@ -67,11 +70,6 @@ const GroupReplays = () => {
 
   return (
     <Fragment>
-      <StyledPageHeader>
-        <HeaderTitle>
-          {t('Replays')} <FeatureBadge type="alpha" />
-        </HeaderTitle>
-      </StyledPageHeader>
       <StyledPageContent>
         <DiscoverQuery
           eventView={getEventView()}
@@ -112,7 +110,10 @@ const GroupReplays = () => {
                   ]}
                 >
                   {data.tableData ? (
-                    <ReplayTable replayList={data.tableData.data as Replay[]} />
+                    <ReplayTable
+                      idKey="replayId"
+                      replayList={data.tableData.data as Replay[]}
+                    />
                   ) : null}
                 </StyledPanelTable>
                 <Pagination pageLinks={data.pageLinks} />
@@ -125,21 +126,8 @@ const GroupReplays = () => {
   );
 };
 
-const StyledPageHeader = styled(PageHeader)`
-  background-color: ${p => p.theme.background};
-  min-width: max-content;
-  padding: ${space(3)} ${space(0)} ${space(4)} ${space(4)};
-  margin-bottom: ${space(0)};
-`;
-
 const StyledPanelTable = styled(PanelTable)`
   grid-template-columns: minmax(0, 1fr) max-content max-content max-content;
-`;
-
-const HeaderTitle = styled(PageHeading)`
-  display: flex;
-  align-items: center;
-  flex: 1;
 `;
 
 const StyledPageContent = styled(PageContent)`

--- a/static/app/views/organizationGroupDetails/groupReplays/index.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/index.tsx
@@ -2,11 +2,16 @@ import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
+import {Group} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import GroupReplays from './groupReplays';
 
-const GroupReplaysContainer = () => {
+type Props = {
+  group: Group;
+};
+
+const GroupReplaysContainer = ({group}: Props) => {
   const organization = useOrganization();
   function renderNoAccess() {
     return (
@@ -22,7 +27,7 @@ const GroupReplaysContainer = () => {
       organization={organization}
       renderDisabled={renderNoAccess}
     >
-      <GroupReplays />
+      <GroupReplays group={group} />
     </Feature>
   );
 };

--- a/static/app/views/organizationGroupDetails/groupReplays/index.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/index.tsx
@@ -1,0 +1,30 @@
+import Feature from 'sentry/components/acl/feature';
+import Alert from 'sentry/components/alert';
+import {t} from 'sentry/locale';
+import {PageContent} from 'sentry/styles/organization';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import GroupReplays from './groupReplays';
+
+const GroupReplaysContainer = () => {
+  const organization = useOrganization();
+  function renderNoAccess() {
+    return (
+      <PageContent>
+        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+      </PageContent>
+    );
+  }
+
+  return (
+    <Feature
+      features={['session-replay']}
+      organization={organization}
+      renderDisabled={renderNoAccess}
+    >
+      <GroupReplays />
+    </Feature>
+  );
+};
+
+export default GroupReplaysContainer;

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -5,6 +5,7 @@ import omit from 'lodash/omit';
 
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
 import {Client} from 'sentry/api';
+import Feature from 'sentry/components/acl/feature';
 import AssigneeSelector from 'sentry/components/assigneeSelector';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Badge from 'sentry/components/badge';
@@ -420,6 +421,14 @@ class GroupHeader extends Component<Props, State> {
                 {t('Similar Issues')}
               </ListLink>
             )}
+            <Feature features={['session-replay']} organization={organization}>
+              <ListLink
+                to={`${baseUrl}replays/${location.search}`}
+                isActive={() => currentTab === Tab.REPLAYS}
+              >
+                {t('Replays')}
+              </ListLink>
+            </Feature>
           </NavTabs>
         </div>
       </Layout.Header>

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -49,6 +49,7 @@ type Props = WithRouterProps & {
   groupReprocessingStatus: ReprocessingStatus;
   organization: Organization;
   project: Project;
+  replaysCount: number | null;
   event?: Event;
 };
 
@@ -114,8 +115,16 @@ class GroupHeader extends Component<Props, State> {
   }
 
   render() {
-    const {project, group, currentTab, baseUrl, event, organization, location} =
-      this.props;
+    const {
+      project,
+      group,
+      currentTab,
+      baseUrl,
+      event,
+      organization,
+      location,
+      replaysCount,
+    } = this.props;
     const projectFeatures = new Set(project ? project.features : []);
     const organizationFeatures = new Set(organization ? organization.features : []);
     const userCount = group.userCount;
@@ -426,7 +435,7 @@ class GroupHeader extends Component<Props, State> {
                 to={`${baseUrl}replays/${location.search}`}
                 isActive={() => currentTab === Tab.REPLAYS}
               >
-                {t('Replays')}
+                {t('Replays')} <Badge text={replaysCount ?? ''} />
               </ListLink>
             </Feature>
           </NavTabs>

--- a/static/app/views/organizationGroupDetails/types.tsx
+++ b/static/app/views/organizationGroupDetails/types.tsx
@@ -8,4 +8,5 @@ export enum Tab {
   MERGED = 'merged',
   GROUPING = 'grouping',
   SIMILAR_ISSUES = 'similar-issues',
+  REPLAYS = 'Replays',
 }

--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -25,6 +25,7 @@ import {Replay} from './types';
 
 type Props = {
   replayList: Replay[];
+  showProjectColumn?: boolean;
 };
 
 type ReplayDurationAndErrors = {
@@ -36,7 +37,7 @@ type ReplayDurationAndErrors = {
   replayId: string;
 };
 
-function ReplayTable({replayList}: Props) {
+function ReplayTable({replayList, showProjectColumn}: Props) {
   const location = useLocation();
   const organization = useOrganization();
   const {projects} = useProjects();
@@ -108,7 +109,7 @@ function ReplayTable({replayList}: Props) {
                 // this is the subheading for the avatar, so displayEmail in this case is a misnomer
                 displayEmail={getUrlPathname(replay.url) ?? ''}
               />
-              {isScreenLarge && (
+              {isScreenLarge && showProjectColumn && (
                 <Item>
                   <ProjectBadge
                     project={

--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -24,6 +24,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {Replay} from './types';
 
 type Props = {
+  idKey: string;
   replayList: Replay[];
   showProjectColumn?: boolean;
 };
@@ -37,7 +38,7 @@ type ReplayDurationAndErrors = {
   replayId: string;
 };
 
-function ReplayTable({replayList, showProjectColumn}: Props) {
+function ReplayTable({replayList, idKey, showProjectColumn}: Props) {
   const location = useLocation();
   const organization = useOrganization();
   const {projects} = useProjects();
@@ -93,7 +94,7 @@ function ReplayTable({replayList, showProjectColumn}: Props) {
                   <Link
                     to={`/organizations/${organization.slug}/replays/${generateEventSlug({
                       project: replay.project,
-                      id: replay.id,
+                      id: replay[idKey],
                     })}/`}
                   >
                     {replay['user.display']}

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -156,6 +156,7 @@ function Replays() {
                   >
                     {data.tableData ? (
                       <ReplayTable
+                        idKey="id"
                         showProjectColumn
                         replayList={data.tableData.data as Replay[]}
                       />

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -15,6 +15,7 @@ import space from 'sentry/styles/space';
 import {NewQuery} from 'sentry/types';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
+import {getQueryParamAsString} from 'sentry/utils/replays/getQueryParamAsString';
 import theme from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
@@ -24,15 +25,6 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import ReplaysFilters from './filters';
 import ReplayTable from './replayTable';
 import {Replay} from './types';
-
-// certain query params can be either a string or an array of strings
-// so if we have an array we reduce it down to a string
-const getQueryParamAsString = query => {
-  if (!query) {
-    return '';
-  }
-  return Array.isArray(query) ? query.join(' ') : query;
-};
 
 const columns = [t('Session'), t('Project')];
 
@@ -163,7 +155,10 @@ function Replays() {
                     ]}
                   >
                     {data.tableData ? (
-                      <ReplayTable replayList={data.tableData.data as Replay[]} />
+                      <ReplayTable
+                        showProjectColumn
+                        replayList={data.tableData.data as Replay[]}
+                      />
                     ) : null}
                   </StyledPanelTable>
                   <Pagination pageLinks={data.pageLinks} />

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -108,6 +108,17 @@ describe('groupDetails', () => {
       url: `/issues/${group.id}/first-last-release/`,
       body: {firstRelease: group.firstRelease, lastRelease: group.lastRelease},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      statusCode: 200,
+      body: {
+        data: [
+          {
+            'count()': 1,
+          },
+        ],
+      },
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
### Description

- We should show a list of replays on an Issue Details page so that users can navigate from an error to the replay.

Closes: #35090 
Closes #35253 

### Screenshots

Header 

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/14813235/171194877-2fd8b9d5-126e-401f-b1bf-63a089494062.png">

Header with active state

<img width="902" alt="image" src="https://user-images.githubusercontent.com/14813235/171195217-f0f798d1-a077-4077-acf6-f0363381a898.png">


Replays table

<img width="816" alt="image" src="https://user-images.githubusercontent.com/14813235/171267572-67ddca09-dca1-4b72-b644-f6f4914bb09b.png">

Badge count for replays

![image](https://user-images.githubusercontent.com/14813235/171943084-d270a0dc-e973-4a74-840b-e5a835781c14.png)



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
