### PR TITLE
feat(metrics): Allow grouping by project [TET-16]

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -26,13 +26,10 @@ from sentry.snuba.metrics.fields import run_metrics_query
 from sentry.snuba.metrics.fields.base import get_derived_metrics, org_id_from_projects
 from sentry.snuba.metrics.naming_layer.mapping import get_mri, get_public_name_from_mri
 from sentry.snuba.metrics.query import Groupable, MetricsQuery
-from sentry.snuba.metrics.query_builder import (
-    ALLOWED_GROUPBY_COLUMNS,
-    SnubaQueryBuilder,
-    SnubaResultConverter,
-)
+from sentry.snuba.metrics.query_builder import SnubaQueryBuilder, SnubaResultConverter
 from sentry.snuba.metrics.utils import (
     AVAILABLE_OPERATIONS,
+    FIELD_ALIAS_MAPPINGS,
     METRIC_TYPE_TO_ENTITY,
     UNALLOWED_TAGS,
     DerivedMetricParseException,
@@ -459,7 +456,7 @@ def _get_group_limit_filters(
     # For example, (project_id, transaction) is translated to (project_id, tags[3])
     keys = tuple(
         resolve_tag_key(metrics_query.org_id, field)
-        if field not in ALLOWED_GROUPBY_COLUMNS
+        if field not in FIELD_ALIAS_MAPPINGS.values()
         else field
         for field in metrics_query.groupby
     )

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -155,8 +155,8 @@ def resolve_tags(org_id: int, input_: Any) -> Any:
             and input_.lhs.parameters[0].name == "tags[project]"
         ):
             # Special condition as when we send a `project:<slug>` query, discover converter
-            # converts it into it a tags[project]:[<slug>] query, so we want to further process
-            # the lhs to get to its translation of `project_id` but we don't to further resolve
+            # converts it into a tags[project]:[<slug>] query, so we want to further process
+            # the lhs to get to its translation of `project_id` but we don't go further resolve
             # rhs and we just want to extract the project ids from the slugs
             rhs = [p.id for p in Project.objects.filter(slug__in=input_.rhs)]
             return Condition(lhs=resolve_tags(org_id, input_.lhs), op=input_.op, rhs=rhs)

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -20,7 +20,6 @@ from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Project
 from sentry.search.events.builder import UnresolvedQuery
-from sentry.search.events.filter import get_filter
 from sentry.sentry_metrics.utils import (
     STRING_NOT_FOUND,
     resolve_tag_key,
@@ -40,7 +39,7 @@ from sentry.snuba.metrics.query import MetricField, MetricsQuery
 from sentry.snuba.metrics.query import OrderBy as MetricsOrderBy
 from sentry.snuba.metrics.query import Tag
 from sentry.snuba.metrics.utils import (
-    ALLOWED_GROUPBY_COLUMNS,
+    FIELD_ALIAS_MAPPINGS,
     FIELD_REGEX,
     MAX_POINTS,
     OPERATIONS,
@@ -149,7 +148,18 @@ def resolve_tags(org_id: int, input_: Any) -> Any:
             return Condition(
                 lhs=resolve_tags(org_id, input_.lhs), op=Op.EQ, rhs=resolve_tags(org_id, "")
             )
-
+        if (
+            isinstance(input_.lhs, Function)
+            and input_.lhs.function == "ifNull"
+            and isinstance(input_.lhs.parameters[0], Column)
+            and input_.lhs.parameters[0].name == "tags[project]"
+        ):
+            # Special condition as when we send a `project:<slug>` query, discover converter
+            # converts it into it a tags[project]:[<slug>] query, so we want to further process
+            # the lhs to get to its translation of `project_id` but we don't to further resolve
+            # rhs and we just want to extract the project ids from the slugs
+            rhs = [p.id for p in Project.objects.filter(slug__in=input_.rhs)]
+            return Condition(lhs=resolve_tags(org_id, input_.lhs), op=input_.op, rhs=rhs)
         return Condition(
             lhs=resolve_tags(org_id, input_.lhs), op=input_.op, rhs=resolve_tags(org_id, input_.rhs)
         )
@@ -163,6 +173,10 @@ def resolve_tags(org_id: int, input_: Any) -> Any:
             return input_
         # HACK: Some tags already take the form "tags[...]" in discover, take that into account:
         if input_.subscriptable == "tags":
+            # Handles translating field aliases to their "metrics" equivalent, for example
+            # "project" -> "project_id"
+            if input_.key in FIELD_ALIAS_MAPPINGS:
+                return Column(FIELD_ALIAS_MAPPINGS[input_.key])
             name = input_.key
         else:
             name = input_.name
@@ -186,34 +200,10 @@ def parse_query(query_string: str, projects: Sequence[Project]) -> Sequence[Cond
         query_builder = UnresolvedQuery(
             Dataset.Sessions,
             params={
-                "project_id": 0,
+                "project_id": [project.id for project in projects],
             },
         )
         where, _ = query_builder.resolve_conditions(query_string, use_aggregate_conditions=True)
-
-        # XXX(ahmed): Hack to accept project:slug filter as we are no longer maintaining the
-        # metrics API.
-        # Essentially prior to this change `project` slug query filters were treated as `tags[
-        # project]` filters, so I loop over the where list and when its found it popped out of
-        # the list and replaced with the appropriate `project_id` filter.
-        for idx, condition in enumerate(list(where)):
-            if isinstance(condition, Condition) and condition.lhs == Function(
-                "ifNull", parameters=[Column("tags[project]"), ""]
-            ):
-                del where[idx]
-
-                snuba_filter_conditions = get_filter(
-                    query_string, {"project_id": [p.id for p in projects]}
-                ).conditions
-                for snuba_condition in snuba_filter_conditions:
-                    if snuba_condition[0] == "project_id":
-                        where.append(
-                            Condition(
-                                Column(snuba_condition[0]),
-                                Op(snuba_condition[1]),
-                                snuba_condition[2],
-                            )
-                        )
 
     except InvalidSearchQuery as e:
         raise InvalidParams(f"Failed to parse query: {e}")
@@ -405,7 +395,11 @@ class SnubaQueryBuilder:
         for field in self._metrics_query.groupby or []:
             if field in UNALLOWED_TAGS:
                 raise InvalidParams(f"Tag name {field} cannot be used to groupBy query")
-            if field in ALLOWED_GROUPBY_COLUMNS:
+            # Handles the case when we are trying to group by `project` for example, but we want
+            # to translate it to `project_id` as that is what the metrics dataset understands
+            if field in FIELD_ALIAS_MAPPINGS:
+                groupby_cols.append(Column(FIELD_ALIAS_MAPPINGS[field]))
+            elif field in FIELD_ALIAS_MAPPINGS.values():
                 groupby_cols.append(Column(field))
             else:
                 assert isinstance(field, Tag)
@@ -610,7 +604,7 @@ class SnubaResultConverter:
         tags = tuple(
             (key, data[key])
             for key in sorted(data.keys())
-            if (key.startswith("tags[") or key in ALLOWED_GROUPBY_COLUMNS)
+            if (key.startswith("tags[") or key in FIELD_ALIAS_MAPPINGS.values())
         )
 
         tag_data = groups.setdefault(tags, {})
@@ -671,7 +665,7 @@ class SnubaResultConverter:
             dict(
                 by=dict(
                     (self._parse_tag(key), reverse_resolve_weak(value))
-                    if key not in ALLOWED_GROUPBY_COLUMNS
+                    if key not in FIELD_ALIAS_MAPPINGS.values()
                     else (key, value)
                     for key, value in tags
                 ),

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -12,7 +12,7 @@ __all__ = (
     "AVAILABLE_OPERATIONS",
     "OPERATIONS_TO_ENTITY",
     "METRIC_TYPE_TO_ENTITY",
-    "ALLOWED_GROUPBY_COLUMNS",
+    "FIELD_ALIAS_MAPPINGS",
     "Tag",
     "TagValue",
     "MetricMeta",
@@ -115,7 +115,7 @@ METRIC_TYPE_TO_ENTITY: Mapping[MetricType, EntityKey] = {
     "distribution": EntityKey.MetricsDistributions,
 }
 
-ALLOWED_GROUPBY_COLUMNS = ("project_id",)
+FIELD_ALIAS_MAPPINGS = {"project": "project_id"}
 
 
 class Tag(TypedDict):

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -185,8 +185,8 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         ]
 
     def test_group_by_project(self):
-        p = self.create_project(name="foo")
-        p2 = self.create_project(name="boo")
+        prj_foo = self.create_project(name="foo")
+        prj_boo = self.create_project(name="boo")
 
         for minute in range(2):
             self.store_session(
@@ -199,7 +199,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         for minute in range(3):
             self.store_session(
                 self.build_session(
-                    project_id=p.id,
+                    project_id=prj_foo.id,
                     started=(time.time() // 60 - minute) * 60,
                     status="ok",
                 )
@@ -207,7 +207,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         for minute in range(5):
             self.store_session(
                 self.build_session(
-                    project_id=p2.id,
+                    project_id=prj_boo.id,
                     started=(time.time() // 60 - minute) * 60,
                     status="ok",
                 )
@@ -216,15 +216,15 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         response = self.get_response(
             self.project.organization.slug,
             field=["sum(sentry.sessions.session)"],
-            project=[p.id, p2.id, self.project.id],
+            project=[prj_foo.id, prj_boo.id, self.project.id],
             interval="24h",
             statsPeriod="24h",
             groupBy="project",
         )
         assert response.status_code == 200
         expected_output = {
-            p.id: {
-                "by": {"project_id": p.id},
+            prj_foo.id: {
+                "by": {"project_id": prj_foo.id},
                 "series": {"sum(sentry.sessions.session)": [3.0]},
                 "totals": {"sum(sentry.sessions.session)": 3.0},
             },
@@ -233,8 +233,8 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
                 "series": {"sum(sentry.sessions.session)": [2.0]},
                 "totals": {"sum(sentry.sessions.session)": 2.0},
             },
-            p2.id: {
-                "by": {"project_id": p2.id},
+            prj_boo.id: {
+                "by": {"project_id": prj_boo.id},
                 "series": {"sum(sentry.sessions.session)": [5.0]},
                 "totals": {"sum(sentry.sessions.session)": 5.0},
             },


### PR DESCRIPTION
Allows grouping by project in metrics API.
Also contains a refactor of parsing queries
with project:<slug> filters
