### PR TITLE
ref: remove unneeded calls to BytesIO

### DIFF
--- a/tests/sentry/api/endpoints/test_debug_files.py
+++ b/tests/sentry/api/endpoints/test_debug_files.py
@@ -210,7 +210,7 @@ class DebugFilesUploadTest(APITestCase):
         )
         assert response.get("Content-Length") == str(len(PROGUARD_SOURCE))
         assert response.get("Content-Type") == "application/octet-stream"
-        assert PROGUARD_SOURCE == BytesIO(b"".join(response.streaming_content)).getvalue()
+        assert PROGUARD_SOURCE == b"".join(response.streaming_content)
 
         # Download as a superuser
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -61,7 +61,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
         assert response.get("Content-Disposition") == 'attachment; filename="hello.png"'
         assert response.get("Content-Length") == str(self.file.size)
         assert response.get("Content-Type") == "application/octet-stream"
-        assert b"File contents here" == BytesIO(b"".join(response.streaming_content)).getvalue()
+        assert b"File contents here" == b"".join(response.streaming_content)
 
     def test_delete(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_organization_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_file_details.py
@@ -71,7 +71,7 @@ class ReleaseFileDetailsTest(APITestCase):
         assert response.get("Content-Disposition") == 'attachment; filename="appli catios n.js"'
         assert response.get("Content-Length") == str(f.size)
         assert response.get("Content-Type") == "application/octet-stream"
-        assert b"File contents here" == BytesIO(b"".join(response.streaming_content)).getvalue()
+        assert b"File contents here" == b"".join(response.streaming_content)
 
         user_no_permission = self.create_user("baz@localhost", username="baz")
         self.login_as(user=user_no_permission)

--- a/tests/sentry/api/endpoints/test_project_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_file_details.py
@@ -82,7 +82,7 @@ class ReleaseFileDetailsTest(APITestCase):
         assert response.get("Content-Disposition") == 'attachment; filename="appli catios n.js"'
         assert response.get("Content-Length") == str(f.size)
         assert response.get("Content-Type") == "application/octet-stream"
-        assert b"File contents here" == BytesIO(b"".join(response.streaming_content)).getvalue()
+        assert b"File contents here" == b"".join(response.streaming_content)
 
         # Download as a superuser
         self.login_as(user=self.user)


### PR DESCRIPTION
I assume these were cargo cult / copy paste -- encountered these while cleaning up resource warnings