### PR TITLE
feat(profiling): add keyboard nav to table

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStackTable.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackTable.tsx
@@ -95,8 +95,11 @@ export function FrameStackTable({
 
   const {
     items,
+    tabIndexKey,
     scrollContainerStyles,
     containerStyles,
+    handleRowClick,
+    handleRowKeyDown,
     handleExpandTreeNode,
     handleSortingChange,
     handleScroll,
@@ -178,11 +181,15 @@ export function FrameStackTable({
               return (
                 <FrameStackTableRow
                   key={r.key}
+                  ref={n => (r.ref = n)}
                   node={r.item}
                   style={r.styles}
                   referenceNode={referenceNode}
+                  tabIndex={tabIndexKey === r.key ? 0 : 1}
                   flamegraphRenderer={flamegraphRenderer}
+                  onClick={() => handleRowClick(r.key)}
                   onExpandClick={handleExpandTreeNode}
+                  onKeyDown={evt => handleRowKeyDown(r.key, evt)}
                   onContextMenu={evt => {
                     setClickedContextMenuClose(r.item);
                     contextMenu.handleContextMenu(evt);

--- a/static/app/utils/profiling/hooks/useContextMenu.tsx
+++ b/static/app/utils/profiling/hooks/useContextMenu.tsx
@@ -50,7 +50,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
   );
 
   const getMenuProps = useCallback(() => {
-    const menuProps = itemProps.getMenuKeyboardEventHandlers();
+    const menuProps = itemProps.getMenuProps();
 
     return {
       ...menuProps,
@@ -64,7 +64,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
   }, [itemProps, wrapSetOpen]);
 
   const getMenuItemProps = useCallback(() => {
-    const menuItemProps = itemProps.getMenuItemKeyboardEventHandlers();
+    const menuItemProps = itemProps.getItemProps();
 
     return {
       ...menuItemProps,

--- a/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
+++ b/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
@@ -1,10 +1,53 @@
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
+
+export function useRovingTabIndex(items: any[]) {
+  const [tabIndex, setTabIndex] = useState<number | null>(null);
+
+  const onKeyDown = useCallback(
+    (evt: React.KeyboardEvent) => {
+      if (items.length === 0) {
+        return;
+      }
+
+      if (evt.key === 'Escape') {
+        setTabIndex(null);
+      }
+
+      if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
+        evt.preventDefault();
+
+        if (tabIndex === items.length - 1 || tabIndex === null) {
+          setTabIndex(0);
+        } else {
+          setTabIndex((tabIndex ?? 0) + 1);
+        }
+      }
+
+      if (evt.key === 'ArrowUp' || (evt.key === 'Tab' && evt.shiftKey)) {
+        evt.preventDefault();
+
+        if (tabIndex === 0 || tabIndex === null) {
+          setTabIndex(items.length - 1);
+        } else {
+          setTabIndex((tabIndex ?? 0) - 1);
+        }
+      }
+    },
+    [tabIndex, items]
+  );
+
+  return {
+    tabIndex,
+    setTabIndex,
+    onKeyDown,
+  };
+}
 
 export function useKeyboardNavigation() {
   const [menuRef, setMenuRef] = useState<HTMLDivElement | null>(null);
-  const [tabIndex, setTabIndex] = useState<number | null>(null);
-
   const items: {id: number; node: HTMLElement | null}[] = [];
+
+  const {tabIndex, setTabIndex, onKeyDown} = useRovingTabIndex(items);
 
   useEffect(() => {
     if (menuRef) {
@@ -14,43 +57,15 @@ export function useKeyboardNavigation() {
     }
   }, [menuRef, tabIndex]);
 
-  function getMenuKeyboardEventHandlers() {
+  function getMenuProps() {
     return {
       tabIndex: -1,
       ref: setMenuRef,
-      onKeyDown: (evt: React.KeyboardEvent) => {
-        if (items.length === 0) {
-          return;
-        }
-
-        if (evt.key === 'Escape') {
-          setTabIndex(null);
-        }
-
-        if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
-          evt.preventDefault();
-
-          if (tabIndex === items.length - 1 || tabIndex === null) {
-            setTabIndex(0);
-          } else {
-            setTabIndex((tabIndex ?? 0) + 1);
-          }
-        }
-
-        if (evt.key === 'ArrowUp' || (evt.key === 'Tab' && evt.shiftKey)) {
-          evt.preventDefault();
-
-          if (tabIndex === 0 || tabIndex === null) {
-            setTabIndex(items.length - 1);
-          } else {
-            setTabIndex((tabIndex ?? 0) - 1);
-          }
-        }
-      },
+      onKeyDown,
     };
   }
 
-  function getMenuItemKeyboardEventHandlers() {
+  function getItemProps() {
     const idx = items.length;
     items.push({id: idx, node: null});
 
@@ -67,46 +82,14 @@ export function useKeyboardNavigation() {
       onMouseEnter: () => {
         setTabIndex(idx);
       },
-      onKeyDown: (evt: React.KeyboardEvent) => {
-        if (items.length === 0) {
-          return;
-        }
-
-        if (evt.key === 'Escape') {
-          setTabIndex(null);
-        }
-
-        if (evt.key === 'Enter' || evt.key === ' ') {
-          items?.[idx]?.node?.click?.();
-        }
-
-        if (evt.key === 'ArrowDown' || evt.key === 'Tab') {
-          evt.preventDefault();
-
-          if (tabIndex === items.length || tabIndex === null) {
-            setTabIndex(0);
-          } else {
-            setTabIndex((tabIndex ?? 0) + 1);
-          }
-        }
-
-        if (evt.key === 'ArrowUp' || (evt.key === 'Tab' && evt.shiftKey)) {
-          evt.preventDefault();
-
-          if (tabIndex === 0 || tabIndex === null) {
-            setTabIndex(items.length);
-          } else {
-            setTabIndex((tabIndex ?? 0) - 1);
-          }
-        }
-      },
+      onKeyDown,
     };
   }
 
   return {
     menuRef,
-    getMenuItemKeyboardEventHandlers,
-    getMenuKeyboardEventHandlers,
+    getItemProps,
+    getMenuProps,
     tabIndex,
     setTabIndex,
   };


### PR DESCRIPTION
Adds keyboard navigation to the virtualized table. Since we virtualize the list, it's a bit wonky to have a real roving tabIndex, so the tabIndex is the unique key of each node.

https://user-images.githubusercontent.com/9317857/171241816-093d08b1-b937-470d-a8fe-3a15aafbcf0f.mp4

