### PR TITLE
chore(cookies): Clean up test cookie once user is verified to have working cookies

### DIFF
--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -140,8 +140,11 @@ class AuthenticationForm(forms.Form):
         return self.cleaned_data
 
     def check_for_test_cookie(self):
-        if self.request and not self.request.session.test_cookie_worked():
-            raise forms.ValidationError(self.error_messages["no_cookies"])
+        if self.request:
+            if not self.request.session.test_cookie_worked():
+                raise forms.ValidationError(self.error_messages["no_cookies"])
+            else:
+                self.request.session.delete_test_cookie()
 
     def get_user_id(self):
         if self.user_cache:

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -236,15 +236,12 @@ class AuthLoginTest(TestCase):
         resp = self.client.post(
             self.path,
             {"username": self.user.username, "password": "admin", "op": "login"},
-            follow=False,
-        )
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
-        resp = self.client.post(
-            self.path,
-            {"username": self.user.username, "password": "admin", "op": "login"},
             follow=True,
         )
-        self.assertRedirects(resp, "/organizations/new/")
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/new/", 302),
+        ]
 
     def test_redirects_already_authed_non_superuser(self):
         self.user.update(is_superuser=False)


### PR DESCRIPTION
Making use of `delete_test_cookie()` to clean up after ourselves as suggested in https://docs.djangoproject.com/en/2.2/topics/http/sessions/#setting-test-cookies