### PR TITLE
fix(integrations): Fix deploy notification commits order

### DIFF
--- a/src/sentry/models/commit.py
+++ b/src/sentry/models/commit.py
@@ -24,7 +24,7 @@ class CommitManager(BaseManager):
     def get_for_release(self, release: Release) -> QuerySet[Commit]:
         return (
             self.filter(releasecommit__release=release)
-            .order_by("releasecommit__order")
+            .order_by("-releasecommit__order")
             .select_related("author")
         )
 

--- a/src/sentry/models/commit.py
+++ b/src/sentry/models/commit.py
@@ -1,9 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from django.db import models
 from django.utils import timezone
 
-from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
+from sentry.db.models import (
+    BaseManager,
+    BoundedPositiveIntegerField,
+    FlexibleForeignKey,
+    Model,
+    QuerySet,
+    sane_repr,
+)
 from sentry.utils.cache import memoize
 from sentry.utils.groupreference import find_referenced_groups
+
+if TYPE_CHECKING:
+    from sentry.models import Release
+
+
+class CommitManager(BaseManager):
+    def get_for_release(self, release: Release) -> QuerySet[Commit]:
+        return (
+            self.filter(releasecommit__release=release)
+            .order_by("releasecommit__order")
+            .select_related("author")
+        )
 
 
 class Commit(Model):
@@ -17,6 +40,8 @@ class Commit(Model):
     # when the initial commit object is referenced (and thus created)
     author = FlexibleForeignKey("sentry.CommitAuthor", null=True)
     message = models.TextField(null=True)
+
+    objects = CommitManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -79,29 +79,24 @@ def get_group_counts_by_project(
 
 
 def get_repos(
-    commits: Iterable[Commit], users_by_email: Mapping[str, User], organization: Organization
+    commits: Iterable[Commit],
+    users_by_email: Mapping[str, User],
+    organization: Organization,
 ) -> Iterable[Mapping[str, str | Iterable[tuple[Commit, User | None]]]]:
-    repos = {
-        r_id: {"name": r_name, "commits": []}
-        for r_id, r_name in Repository.objects.filter(
+    repositories_by_id = {
+        repository_id: {"name": repository_name, "commits": []}
+        for repository_id, repository_name in Repository.objects.filter(
             organization_id=organization.id,
             id__in={c.repository_id for c in commits},
         ).values_list("id", "name")
     }
+    # These commits are in order so they should end up in the list of commits still in order.
     for commit in commits:
+        # Get the user object if it exists
         user_option = users_by_email.get(commit.author.email) if commit.author_id else None
-        repos[commit.repository_id]["commits"].append((commit, user_option))
+        repositories_by_id[commit.repository_id]["commits"].append((commit, user_option))
 
-    return list(repos.values())
-
-
-def get_commits_for_release(release: Release) -> set[Commit]:
-    return {
-        rc.commit
-        for rc in ReleaseCommit.objects.filter(release=release).select_related(
-            "commit", "commit__author"
-        )
-    }
+    return list(repositories_by_id.values())
 
 
 def get_environment_for_deploy(deploy: Deploy | None) -> str:

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -100,10 +100,10 @@ class ReleaseTestCase(ActivityTestCase):
         context = email.get_context()
         assert context["environment"] == "production"
         assert context["repos"][0]["commits"] == [
-            (self.commit1, self.user1),
-            (self.commit2, self.user2),
-            (self.commit3, self.user4),
             (self.commit4, self.user5),
+            (self.commit3, self.user4),
+            (self.commit2, self.user2),
+            (self.commit1, self.user1),
         ]
 
         user_context = email.get_recipient_context(self.user1, {})

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -41,10 +41,11 @@ class ReleaseTestCase(ActivityTestCase):
 
         repository = Repository.objects.create(organization_id=self.org.id, name=self.project.name)
 
+        # The commits are intentionally out of order to test commit `order`.
+        self.commit4 = self.another_commit(3, "e", self.user5, repository, user5_alt_email)
         self.commit1 = self.another_commit(0, "a", self.user1, repository)
         self.commit2 = self.another_commit(1, "b", self.user2, repository)
         self.commit3 = self.another_commit(2, "c", self.user4, repository)
-        self.commit4 = self.another_commit(3, "e", self.user5, repository, user5_alt_email)
 
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,


### PR DESCRIPTION
Currently the order in which commits are fetched for a given release are
in the order in which they are stored in a Python set, which is
inherently unordered. This change orders commits explicitly based on the
order field from the releasecommit table.
