### PR TITLE
fix(proj-selector): Fix project settings link in project page filter

### DIFF
--- a/static/app/components/organizations/projectSelector/selectorItem.tsx
+++ b/static/app/components/organizations/projectSelector/selectorItem.tsx
@@ -102,7 +102,7 @@ function ProjectSelectorItem({
         icon={<IconOpen />}
       />
       <ActionButton
-        to={`/settings/${organization.slug}/${project.slug}/`}
+        to={`/settings/${organization.slug}/projects/${project.slug}/`}
         size="zero"
         priority="link"
         aria-label="Project Settings"


### PR DESCRIPTION
Problem: If a project name conflicts with an org settings screen (e.g. "relay", "repos") then clicking this settings link would redirect to that screen rather than the project settings view.
<img width="361" alt="image" src="https://user-images.githubusercontent.com/9372512/171295085-a89f89bd-fc9b-41b2-bdd9-f54973088713.png">

Fixed by correcting project settings link.
