### PR TITLE
feat(workflow): Add custom chart size to incident email chart

### DIFF
--- a/src/sentry/charts/base.py
+++ b/src/sentry/charts/base.py
@@ -1,10 +1,10 @@
 import logging
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from sentry import options
 from sentry.utils.services import Service
 
-from .types import ChartType
+from .types import ChartSize, ChartType
 
 logger = logging.getLogger("sentry.charts")
 
@@ -29,7 +29,9 @@ class ChartRenderer(Service):
         """
         return bool(options.get("chart-rendering.enabled", False))
 
-    def generate_chart(self, style: ChartType, data: Any, upload: bool = True) -> Union[str, bytes]:
+    def generate_chart(
+        self, style: ChartType, data: Any, upload: bool = True, size: Optional[ChartSize] = None
+    ) -> Union[str, bytes]:
         """
         Produces a chart. You may specify the upload kwarg to have the chart
         uploaded to storage and receive a public URL for the chart

--- a/src/sentry/charts/chartcuterie.py
+++ b/src/sentry/charts/chartcuterie.py
@@ -57,7 +57,7 @@ class Chartcuterie(ChartRenderer):
     ) -> Union[str, bytes]:
         request_id = uuid4().hex
 
-        data = {
+        payload = {
             "requestId": request_id,
             "style": style.value,
             "data": data,
@@ -65,7 +65,7 @@ class Chartcuterie(ChartRenderer):
 
         # Override the default size defined by the chart style
         if size:
-            data.update(size)
+            payload.update(size)
 
         with sentry_sdk.start_span(
             op="charts.chartcuterie.generate_chart",
@@ -75,7 +75,7 @@ class Chartcuterie(ChartRenderer):
             # Using sentry json formatter to handle datetime objects
             resp = requests.post(
                 url=urljoin(self.service_url, "render"),
-                data=json.dumps(data, cls=json._default_encoder),
+                data=json.dumps(payload, cls=json._default_encoder),
                 headers={"Content-Type": "application/json"},
             )
 

--- a/src/sentry/charts/chartcuterie.py
+++ b/src/sentry/charts/chartcuterie.py
@@ -14,7 +14,7 @@ from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
 from .base import ChartRenderer, logger
-from .types import ChartType
+from .types import ChartSize, ChartType
 
 
 class Chartcuterie(ChartRenderer):
@@ -52,7 +52,9 @@ class Chartcuterie(ChartRenderer):
         if not self.service_url:
             raise InvalidConfiguration("`chart-rendering.chartcuterie.url` is not configured")
 
-    def generate_chart(self, style: ChartType, data: Any, upload: bool = True) -> Union[str, bytes]:
+    def generate_chart(
+        self, style: ChartType, data: Any, upload: bool = True, size: Optional[ChartSize] = None
+    ) -> Union[str, bytes]:
         request_id = uuid4().hex
 
         data = {
@@ -60,6 +62,10 @@ class Chartcuterie(ChartRenderer):
             "style": style.value,
             "data": data,
         }
+
+        # Override the default size defined by the chart style
+        if size:
+            data.update(size)
 
         with sentry_sdk.start_span(
             op="charts.chartcuterie.generate_chart",

--- a/src/sentry/charts/types.py
+++ b/src/sentry/charts/types.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import TypedDict
 
 
 class ChartType(Enum):
@@ -20,3 +21,8 @@ class ChartType(Enum):
     SLACK_DISCOVER_WORLDMAP = "slack:discover.worldmap"
     SLACK_METRIC_ALERT_EVENTS = "slack:metricAlert.events"
     SLACK_METRIC_ALERT_SESSIONS = "slack:metricAlert.sessions"
+
+
+class ChartSize(TypedDict):
+    width: int
+    height: int

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -8,6 +8,7 @@ from django.template.defaultfilters import pluralize
 from django.urls import reverse
 
 from sentry import features
+from sentry.charts.types import ChartSize
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.charts import build_metric_alert_chart
 from sentry.incidents.models import (
@@ -219,6 +220,7 @@ def generate_incident_trigger_email_context(
                 organization=incident.organization,
                 alert_rule=incident.alert_rule,
                 selected_incident=incident,
+                size=ChartSize({"width": 600, "height": 200}),
             )
         except Exception as e:
             sentry_sdk.capture_exception(e)

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -11,7 +11,7 @@ from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
 from sentry.api.serializers.models.incident import DetailedIncidentSerializer
 from sentry.api.utils import get_datetime_from_stats_period
 from sentry.charts import generate_chart
-from sentry.charts.types import ChartType
+from sentry.charts.types import ChartSize, ChartType
 from sentry.incidents.logic import translate_aggregate_field
 from sentry.incidents.models import AlertRule, Incident, User
 from sentry.models import ApiKey, Organization
@@ -153,6 +153,7 @@ def build_metric_alert_chart(
     start: Optional[str] = None,
     end: Optional[str] = None,
     user: Optional["User"] = None,
+    size: Optional[ChartSize] = None,
 ) -> Optional[str]:
     """Builds the dataset required for metric alert chart the same way the frontend would"""
     snuba_query: SnubaQuery = alert_rule.snuba_query
@@ -225,7 +226,7 @@ def build_metric_alert_chart(
         )
 
     try:
-        url = generate_chart(style, chart_data)
+        url = generate_chart(style, chart_data, size=size)
         return cast(str, url)
     except RuntimeError as exc:
         logger.error(

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -335,3 +335,4 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
         assert chart_data["selectedIncident"]["identifier"] == str(incident.identifier)
         series_data = chart_data["timeseriesData"][0]["data"]
         assert len(series_data) > 0
+        assert mock_generate_chart.call_args[1]["size"] == {"width": 600, "height": 200}


### PR DESCRIPTION
Add width/height when requesting chartcuterie charts for email. We want them to be slightly larger for the email template, but not for slack.

Chartcuterie added width/height in https://github.com/getsentry/chartcuterie/pull/85
We reverted the size change to slack in https://github.com/getsentry/sentry/pull/34837

