### PR TITLE
fix(release-health): Do not treat InvalidParams as crash [TET-124]

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -67,17 +67,7 @@ def make_session(project, **kwargs):
     )
 
 
-class SessionsTestCase(APITestCase):
-    def do_request(self, query, user=None, org=None):
-        self.login_as(user=user or self.user)
-        url = reverse(
-            "sentry-api-0-organization-sessions",
-            kwargs={"organization_slug": (org or self.organization).slug},
-        )
-        return self.client.get(url, query, format="json")
-
-
-class OrganizationSessionsEndpointTest(SessionsTestCase, SnubaTestCase):
+class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()
         self.setup_fixture()
@@ -1445,6 +1435,14 @@ class OrganizationSessionsEndpointMetricsTest(
 
 @patch("sentry.api.endpoints.organization_sessions.release_health", MetricsReleaseHealthBackend())
 class SessionsMetricsSortReleaseTimestampTest(SessionMetricsTestCase, APITestCase):
+    def do_request(self, query, user=None, org=None):
+        self.login_as(user=user or self.user)
+        url = reverse(
+            "sentry-api-0-organization-sessions",
+            kwargs={"organization_slug": (org or self.organization).slug},
+        )
+        return self.client.get(url, query, format="json")
+
     @freeze_time(MOCK_DATETIME)
     def test_order_by_with_no_releases(self):
         """


### PR DESCRIPTION
The duplex release health backend currently attempts to return results from the metrics backend, unless it raises an exception. But when the exception is `InvalidParams`, we actually want to treat it as a valid result and not a crash. The easiest way to achieve this is to let the exception bubble up instead of capturing it and falling back to sessions.

Note that this bypasses some of the logic in the duplex backend. For example, the `releasehealth.metrics.should_return` metric will not be emitted.

Fixes SENTRY-TW9 SENTRY-V8K SENTRY-TX2