### PR TITLE
fix(sessions): Sort by sum(session) if available

### DIFF
--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -299,7 +299,7 @@ class QueryDefinition:
         for i, field in enumerate(self.fields.values()):
             columns = field.get_snuba_columns(raw_groupby)
             if i == 0 or field == "sum(session)":  # Prefer first, but sum(session) always wins
-                self.primary_column = columns[0]  # Will be used in order by
+                self.primary_column = columns[i]  # Will be used in order by
             query_columns.update(columns)
         for groupby in self.groupby:
             query_columns.update(groupby.get_snuba_columns())

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -296,11 +296,12 @@ class QueryDefinition:
         self.params = params
 
         query_columns = set()
-        for i, field in enumerate(self.fields.values()):
+        for i, (field_name, field) in enumerate(self.fields.items()):
             columns = field.get_snuba_columns(raw_groupby)
-            if i == 0 or field == "sum(session)":  # Prefer first, but sum(session) always wins
-                self.primary_column = columns[i]  # Will be used in order by
+            if i == 0 or field_name == "sum(session)":  # Prefer first, but sum(session) always wins
+                self.primary_column = columns[0]  # Will be used in order by
             query_columns.update(columns)
+
         for groupby in self.groupby:
             query_columns.update(groupby.get_snuba_columns())
         self.query_columns = list(query_columns)

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -936,7 +936,7 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert result_sorted(response.data)["groups"] == [
+        assert response.data["groups"] == [
             {
                 "by": {"release": "foo@1.0.0"},
                 "series": {"count_unique(user)": [0], "sum(session)": [3]},

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -773,7 +773,8 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
                     "project": [-1],
                     "statsPeriod": "3d",
                     "interval": "1d",
-                    "field": ["sum(session)", "count_unique(user)"],
+                    # "user" is the first field, but "session" always wins:
+                    "field": ["count_unique(user)", "sum(session)"],
                     "groupBy": ["project", "release", "environment"],
                 }
             )
@@ -936,7 +937,7 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert response.data["groups"] == [
+        assert result_sorted(response.data)["groups"] == [
             {
                 "by": {"release": "foo@1.0.0"},
                 "series": {"count_unique(user)": [0], "sum(session)": [3]},


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/33827, we changed the default order-by for the sessions endpoint (see [this comment](https://github.com/getsentry/sentry/pull/33827/files#r856084666) for reasoning).

However this did not actually change the column used for order-by because ~~I forgot to use the appropriate index~~ we compared a `Field` object to a string, which always evaluates to `False`.