### PR TITLE
fix(ui): Prevent double padding in settings

### DIFF
--- a/static/app/views/settings/components/settingsLayout.tsx
+++ b/static/app/views/settings/components/settingsLayout.tsx
@@ -6,6 +6,7 @@ import Button from 'sentry/components/button';
 import {IconClose, IconMenu} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {fadeIn, slideInLeft} from 'sentry/styles/animations';
+import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 
 import SettingsBreadcrumb from './settingsBreadcrumb';
@@ -165,6 +166,14 @@ const Content = styled('div')`
   flex: 1;
   padding: ${space(4)};
   min-width: 0; /* keep children from stretching container */
+
+  /**
+   * PageContent is not normally used in settings but <PermissionDenied /> uses it under the hood.
+   * This prevents double padding.
+   */
+  ${PageContent} {
+    padding: 0;
+  }
 `;
 
 export default SettingsLayout;


### PR DESCRIPTION
### Before
![Screen Shot 2022-06-01 at 12 28 17](https://user-images.githubusercontent.com/9060071/171403263-96203569-ac33-4897-b402-8f25a2fde93b.png)

### After
![Screen Shot 2022-06-01 at 12 29 31](https://user-images.githubusercontent.com/9060071/171403246-4eba69d2-3120-420e-9850-6401261ed642.png)

Relates to https://github.com/getsentry/sentry/pull/18692