### PR TITLE
Revert "ref(page-filters): Remove mentions of global header in acceptance tests"

### DIFF
--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -58,7 +58,7 @@ function DatePageFilter({router, resetParamsOnChange, ...props}: Props) {
         hideBottomBorder={false}
         isOpen={isOpen}
         highlighted={desyncedFilters.has('datetime')}
-        data-test-id="page-filter-timerange-selector"
+        data-test-id="global-header-timerange-selector"
         {...getActorProps()}
       >
         <DropdownTitle>

--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -66,7 +66,7 @@ function EnvironmentPageFilter({
         hideBottomBorder={false}
         isOpen={isOpen}
         highlighted={desyncedFilters.has('environments')}
-        data-test-id="page-filter-environment-selector"
+        data-test-id="global-header-environment-selector"
       >
         <DropdownTitle>
           <PageFilterPinIndicator filter="environments">
@@ -87,7 +87,7 @@ function EnvironmentPageFilter({
     <PageFilterDropdownButton
       showChevron={false}
       disabled
-      data-test-id="page-filter-environment-selector"
+      data-test-id="global-header-environment-selector"
     >
       <DropdownTitle>
         <IconWindow />

--- a/static/app/components/organizations/environmentSelector.tsx
+++ b/static/app/components/organizations/environmentSelector.tsx
@@ -199,7 +199,7 @@ function EnvironmentSelector({
   if (forceEnvironment !== undefined) {
     return (
       <StyledHeaderItem
-        data-test-id="page-filter-environment-selector"
+        data-test-id="global-header-environment-selector"
         icon={<IconWindow />}
         isOpen={false}
         locked
@@ -216,7 +216,7 @@ function EnvironmentSelector({
   if (loadingProjects) {
     return (
       <StyledHeaderItem
-        data-test-id="page-filter-environment-selector"
+        data-test-id="global-header-environment-selector"
         icon={<IconWindow />}
         loading={loadingProjects}
         hasChanges={false}
@@ -281,7 +281,7 @@ function EnvironmentSelector({
               customDropdownButton({isOpen, actions, value: validatedValue})
             ) : (
               <StyledHeaderItem
-                data-test-id="page-filter-environment-selector"
+                data-test-id="global-header-environment-selector"
                 icon={<IconWindow />}
                 isOpen={isOpen}
                 hasSelected={value && !!value.length}

--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -248,7 +248,7 @@ function ProjectSelector({
 
     return (
       <StyledHeaderItem
-        data-test-id="page-filter-project-selector"
+        data-test-id="global-header-project-selector"
         icon={
           forceProject && (
             <PlatformList
@@ -275,7 +275,7 @@ function ProjectSelector({
     return (
       <Fragment>{customLoadingIndicator}</Fragment> ?? (
         <StyledHeaderItem
-          data-test-id="page-filter-project-selector-loading"
+          data-test-id="global-header-project-selector-loading"
           icon={<IconProject />}
           loading
         >
@@ -436,7 +436,7 @@ function ProjectSelector({
 
             return (
               <StyledHeaderItem
-                data-test-id="page-filter-project-selector"
+                data-test-id="global-header-project-selector"
                 icon={icon}
                 hasSelected={hasSelected}
                 hasChanges={hasChanges}

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -476,7 +476,7 @@ class TimeRangeSelector extends PureComponent<Props, State> {
                     customDropdownButton({getActorProps, isOpen})
                   ) : (
                     <StyledHeaderItem
-                      data-test-id="page-filter-timerange-selector"
+                      data-test-id="global-header-timerange-selector"
                       icon={label ?? <IconCalendar />}
                       isOpen={isOpen}
                       hasSelected={

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -164,7 +164,7 @@ function ProjectPageFilter({
           hideBottomBorder={false}
           isOpen={isOpen}
           highlighted={desyncedFilters.has('projects')}
-          data-test-id="page-filter-project-selector"
+          data-test-id="global-header-project-selector"
         >
           <DropdownTitle>
             <PageFilterPinIndicator filter="projects">{icon}</PageFilterPinIndicator>
@@ -182,7 +182,7 @@ function ProjectPageFilter({
     <PageFilterDropdownButton
       showChevron={false}
       disabled
-      data-test-id="page-filter-project-selector-loading"
+      data-test-id="global-header-project-selector-loading"
     >
       <DropdownTitle>
         <IconProject />

--- a/tests/acceptance/page_objects/global_selection.py
+++ b/tests/acceptance/page_objects/global_selection.py
@@ -3,19 +3,19 @@ from .base import BasePage
 
 class GlobalSelectionPage(BasePage):
     def get_selected_project_slug(self):
-        return self.browser.element('[data-test-id="page-filter-project-selector"]').text
+        return self.browser.element('[data-test-id="global-header-project-selector"]').text
 
     def get_selected_environment(self):
-        return self.browser.element('[data-test-id="page-filter-environment-selector"]').text
+        return self.browser.element('[data-test-id="global-header-environment-selector"]').text
 
     def get_selected_date(self):
-        return self.browser.element('[data-test-id="page-filter-timerange-selector"]').text
+        return self.browser.element('[data-test-id="global-header-timerange-selector"]').text
 
     def go_back_to_issues(self):
         self.browser.click('[data-test-id="breadcrumb-link"]')
 
     def open_project_selector(self):
-        self.browser.click('[data-test-id="page-filter-project-selector"]')
+        self.browser.click('[data-test-id="global-header-project-selector"]')
 
     def select_project_by_slug(self, slug):
         project_item_selector = f'//*[@data-test-id="badge-display-name" and text()="{slug}"]'
@@ -30,7 +30,7 @@ class GlobalSelectionPage(BasePage):
         self.browser.click('[aria-label="Lock filter"]')
 
     def open_environment_selector(self):
-        self.browser.click('[data-test-id="page-filter-environment-selector"]')
+        self.browser.click('[data-test-id="global-header-environment-selector"]')
 
     def select_environment(self, environment):
         environment_path = f'//*[text()="{environment}"]'
@@ -40,7 +40,7 @@ class GlobalSelectionPage(BasePage):
         self.browser.click(xpath=environment_path)
 
     def open_date_selector(self):
-        self.browser.click('[data-test-id="page-filter-timerange-selector"]')
+        self.browser.click('[data-test-id="global-header-timerange-selector"]')
 
     def select_date(self, date):
         date_path = f'//*[text()="{date}"]'

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -72,13 +72,13 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         )
         self.browser.wait_until_test_id("awaiting-events")
 
-        self.browser.click('[data-test-id="page-filter-project-selector"]')
+        self.browser.click('[data-test-id="global-header-project-selector"]')
         self.browser.snapshot("globalSelectionHeader - project selector")
 
-        self.browser.click('[data-test-id="page-filter-environment-selector"]')
+        self.browser.click('[data-test-id="global-header-environment-selector"]')
         self.browser.snapshot("globalSelectionHeader - environment selector")
 
-        self.browser.click('[data-test-id="page-filter-timerange-selector"]')
+        self.browser.click('[data-test-id="global-header-timerange-selector"]')
         self.browser.snapshot("globalSelectionHeader - timerange selector")
 
     @pytest.mark.skip(reason="Has been flaky lately.")
@@ -167,16 +167,16 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             assert "environment=" not in self.browser.current_url
             assert self.issue_details.global_selection.get_selected_environment() == "All Env"
 
-            self.browser.click('[data-test-id="page-filter-environment-selector"]')
+            self.browser.click('[data-test-id="global-header-environment-selector"]')
             self.browser.click('[data-test-id="environment-prod"]')
             self.issues_list.wait_until_loaded()
             assert "environment=prod" in self.browser.current_url
             assert self.issue_details.global_selection.get_selected_environment() == "prod"
 
             # clear environment prod
-            self.browser.click('[data-test-id="page-filter-environment-selector"]')
+            self.browser.click('[data-test-id="global-header-environment-selector"]')
             self.browser.click('[data-test-id="environment-prod"] [role="checkbox"]')
-            self.browser.click('[data-test-id="page-filter-environment-selector"]')
+            self.browser.click('[data-test-id="global-header-environment-selector"]')
             self.issues_list.wait_until_loaded()
             assert "environment=" not in self.browser.current_url
             assert self.issue_details.global_selection.get_selected_environment() == "All Env"

--- a/tests/acceptance/test_organization_switch.py
+++ b/tests/acceptance/test_organization_switch.py
@@ -37,7 +37,7 @@ class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
         @TimedRetryPolicy.wrap(timeout=20, exceptions=(TimeoutException,))
         def open_project_selector():
             self.browser.click_when_visible(
-                selector='[data-test-id="page-filter-project-selector"]'
+                selector='[data-test-id="global-header-project-selector"]'
             )
             # Check if the automplete-list has shown up, if that fails we
             # want to retry this step.


### PR DESCRIPTION
Reverts getsentry/sentry#35075

have to revert because a change recently went out in `eventsV2/results.spec.jsx` that has a mention I didn't account for.