### PR TITLE
ref: close unclosed socket in test_statsd test

### DIFF
--- a/tests/sentry/metrics/test_statsd.py
+++ b/tests/sentry/metrics/test_statsd.py
@@ -1,24 +1,33 @@
 from unittest.mock import patch
 
+import pytest
+
 from sentry.metrics.statsd import StatsdMetricsBackend
-from sentry.testutils import TestCase
 
 
-class StatsdMetricsBackendTest(TestCase):
-    def setUp(self):
-        self.backend = StatsdMetricsBackend(prefix="sentrytest.")
+@pytest.fixture(scope="module")
+def statsd_backend():
+    backend = StatsdMetricsBackend(prefix="sentrytest.")
+    try:
+        yield backend
+    finally:
+        # XXX: this socket is never closed so we close it to prevent ResourceWarning
+        backend.client._sock.close()
 
-    @patch("statsd.StatsClient.incr")
-    def test_incr(self, mock_incr):
-        self.backend.incr("foo")
-        mock_incr.assert_called_once_with("sentrytest.foo", 1, 1)
 
-    @patch("statsd.StatsClient.timing")
-    def test_timing(self, mock_timing):
-        self.backend.timing("foo", 30)
-        mock_timing.assert_called_once_with("sentrytest.foo", 30, 1)
+@patch("statsd.StatsClient.incr")
+def test_incr(mock_incr, statsd_backend):
+    statsd_backend.incr("foo")
+    mock_incr.assert_called_once_with("sentrytest.foo", 1, 1)
 
-    @patch("statsd.StatsClient.gauge")
-    def test_gauge(self, mock_gauge):
-        self.backend.gauge("foo", 5)
-        mock_gauge.assert_called_once_with("sentrytest.foo", 5, 1)
+
+@patch("statsd.StatsClient.timing")
+def test_timing(mock_timing, statsd_backend):
+    statsd_backend.timing("foo", 30)
+    mock_timing.assert_called_once_with("sentrytest.foo", 30, 1)
+
+
+@patch("statsd.StatsClient.gauge")
+def test_gauge(mock_gauge, statsd_backend):
+    statsd_backend.gauge("foo", 5)
+    mock_gauge.assert_called_once_with("sentrytest.foo", 5, 1)


### PR DESCRIPTION
fixes these warnings (via `pytest -Wonce`):

```
tests/sentry/metrics/test_statsd.py::StatsdMetricsBackendTest::test_incr
tests/sentry/metrics/test_statsd.py::StatsdMetricsBackendTest::test_timing
  /Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/_pytest/unittest.py:161: ResourceWarning: unclosed <socket.socket fd=19, family=AddressFamily.AF_INET, type=SocketKind.SOCK_DGRAM, proto=0, laddr=('0.0.0.0', 0)>
    self._obj = None

tests/sentry/metrics/test_statsd.py::StatsdMetricsBackendTest::test_timing
  /Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/_pytest/runner.py:394: ResourceWarning: unclosed <socket.socket fd=18, family=AddressFamily.AF_INET, type=SocketKind.SOCK_DGRAM, proto=0, laddr=('0.0.0.0', 0)>
    fin()
```