### PR TITLE
ref(perf): Rename View Transaction button to View Event

### DIFF
--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -92,7 +92,7 @@ class TransactionDetail extends Component<Props> {
 
     return (
       <StyledButton size="xsmall" to={target}>
-        {t('View Transaction')}
+        {t('View Event')}
       </StyledButton>
     );
   }
@@ -176,7 +176,7 @@ class TransactionDetail extends Component<Props> {
                 <TransactionIdTitle
                   onClick={this.scrollBarIntoView(transaction.event_id)}
                 >
-                  Transaction ID
+                  {t('Event ID')}
                   <StyledIconAnchor />
                 </TransactionIdTitle>
               }


### PR DESCRIPTION
In the trace view, clicking on a transaction opens the transaction details. Within the details, we refer to Events as Transactions, which is a bit misleading.

### Before
![image](https://user-images.githubusercontent.com/16740047/171470614-ed8fed35-e48b-40bd-8ee3-85dad51a3d8d.png)

### After
![image](https://user-images.githubusercontent.com/16740047/171470757-e5a66b35-8f05-4812-95de-fadb81fe5d46.png)
