### PR TITLE
chore(deps): upgrade urllib3 to 1.26.9

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ toronado==0.1.0
 typing-extensions==3.10.0.2
 ua-parser==0.10.0
 unidiff==0.7.1
-urllib3[brotli]==1.25.11
+urllib3[brotli]==1.26.9
 brotlipy==0.7.0
 # See if we can remove LDFLAGS from lib.sh
 # https://github.com/getsentry/sentry/pull/30094

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.7.1
-boto3==1.13.16
-botocore==1.16.16
+boto3==1.22.12
+botocore==1.25.12
 celery==4.4.7
 click==8.0.4
 # See if we can remove CPATH from lib.sh


### PR DESCRIPTION
See first: #34524.

Looking at the diff of urllib3 1.25.11 and 1.26.9, our [SafeConnectionMixin](https://github.com/getsentry/sentry/blob/44a5b454214527b42922ff9bd83d1096a9fbdbf9/src/sentry/net/http.py#L18) should be fine.
