### PR TITLE
fix(workflow): Add back slack incident message color

### DIFF
--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -50,7 +50,7 @@ def send_incident_alert_notification(
         incident, new_status, metric_value, chart_url
     ).build()
     text = attachment["text"]
-    blocks = {"blocks": attachment["blocks"]}
+    blocks = {"blocks": attachment["blocks"], "color": attachment["color"]}
 
     payload = {
         "token": integration.metadata["access_token"],

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -60,7 +60,9 @@ class SlackActionHandlerTest(FireTest, TestCase):
         slack_body = SlackIncidentsMessageBuilder(
             incident, IncidentStatus(incident.status), metric_value, chart_url
         ).build()
-        assert json.loads(data["attachments"][0])[0]["blocks"] == slack_body["blocks"]
+        attachments = json.loads(data["attachments"][0])
+        assert attachments[0]["color"] == slack_body["color"]
+        assert attachments[0]["blocks"] == slack_body["blocks"]
         assert data["text"][0] == slack_body["text"]
 
     def test_fire_metric_alert(self):
@@ -121,7 +123,9 @@ class SlackWorkspaceActionHandlerTest(FireTest, TestCase):
         slack_body = SlackIncidentsMessageBuilder(
             incident, IncidentStatus(incident.status), metric_value
         ).build()
-        assert json.loads(data["attachments"][0])[0]["blocks"] == slack_body["blocks"]
+        attachments = json.loads(data["attachments"][0])
+        assert attachments[0]["color"] == slack_body["color"]
+        assert attachments[0]["blocks"] == slack_body["blocks"]
         assert data["text"][0] == slack_body["text"]
 
     def test_fire_metric_alert(self):


### PR DESCRIPTION
forgot to pass the color property

no color on attachments
<img width="540" alt="image" src="https://user-images.githubusercontent.com/1400464/171496277-68bb6bd6-9a22-4387-9e33-8faea870ab87.png">
