### PR TITLE
fix(alerts): Remove eventTypes matching to determine alert type

### DIFF
--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -158,7 +158,6 @@ export default function WizardField({
     <FormField {...fieldProps}>
       {({onChange, value: aggregate, model, disabled}) => {
         const dataset: Dataset = model.getValue('dataset');
-        const eventTypes = [...(model.getValue('eventTypes') ?? [])];
 
         const selectedTemplate =
           alertType === 'custom'
@@ -167,8 +166,7 @@ export default function WizardField({
                 AlertWizardRuleTemplates,
                 template =>
                   matchTemplateAggregate(template, aggregate) &&
-                  matchTemplateDataset(template, dataset) &&
-                  eventTypes.includes(template.eventTypes)
+                  matchTemplateDataset(template, dataset)
               ) || 'num_errors';
 
         const {fieldOptionsConfig, hidePrimarySelector, hideParameterSelector} =


### PR DESCRIPTION
This removes the `eventTypes` check to find the alert type in alert wizard v3 for metric alerts. It's not necessary to match alert type and causing issues for Crash Free Rate alerts where eventTypes aren't used.

Jira: [WOR-1905](https://getsentry.atlassian.net/browse/WOR-1905)