### PR TITLE
fix(metric_alerts): Only default `event_types` to a value for error and transaction alerts

### DIFF
--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -38,16 +38,17 @@ def create_snuba_query(
         environment=environment,
     )
     if not event_types:
-        event_types = [
-            SnubaQueryEventType.EventType.ERROR
-            if dataset == QueryDatasets.EVENTS
-            else SnubaQueryEventType.EventType.TRANSACTION
+        if dataset == QueryDatasets.EVENTS:
+            event_types = [SnubaQueryEventType.EventType.ERROR]
+        elif dataset == QueryDatasets.TRANSACTIONS:
+            event_types = [SnubaQueryEventType.EventType.TRANSACTION]
+
+    if event_types:
+        sq_event_types = [
+            SnubaQueryEventType(snuba_query=snuba_query, type=event_type.value)
+            for event_type in set(event_types)
         ]
-    sq_event_types = [
-        SnubaQueryEventType(snuba_query=snuba_query, type=event_type.value)
-        for event_type in set(event_types)
-    ]
-    SnubaQueryEventType.objects.bulk_create(sq_event_types)
+        SnubaQueryEventType.objects.bulk_create(sq_event_types)
     return snuba_query
 
 

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -68,6 +68,29 @@ class CreateSnubaQueryTest(TestCase):
         assert snuba_query.environment is None
         assert set(snuba_query.event_types) == {SnubaQueryEventType.EventType.DEFAULT}
 
+    def test_event_types_metrics(self):
+        dataset = QueryDatasets.METRICS
+        query = ""
+        aggregate = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
+        time_window = timedelta(minutes=10)
+        resolution = timedelta(minutes=1)
+
+        snuba_query = create_snuba_query(
+            dataset,
+            query,
+            aggregate,
+            time_window,
+            resolution,
+            None,
+        )
+        assert snuba_query.dataset == dataset.value
+        assert snuba_query.query == query
+        assert snuba_query.aggregate == aggregate
+        assert snuba_query.time_window == int(time_window.total_seconds())
+        assert snuba_query.resolution == int(resolution.total_seconds())
+        assert snuba_query.environment is None
+        assert snuba_query.event_types == []
+
 
 class CreateSnubaSubscriptionTest(TestCase):
     def test(self):


### PR DESCRIPTION
Fixes a bug where we set `event_types` to transaction for session and metric alerts. They're unused
for these types of alerts, so this doesn't cause any problems, but just better to set these
correctly.
