### PR TITLE
meta(deps): Change CODEOWNERS for JS dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,9 +64,9 @@ requirements*.txt   @getsentry/owners-python-build
 pyproject.toml      @getsentry/owners-python-build
 tsconfig.*          @getsentry/owners-js-build
 webpack.config.*    @getsentry/owners-js-build
-package.json        @getsentry/owners-js-build
 babel.config.*      @getsentry/owners-js-build
 build-utils/        @getsentry/owners-js-build
+package.json        @getsentry/owners-js-deps
 
 # Design
 /static/app/icons/    @getsentry/design

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,7 +67,7 @@ webpack.config.*    @getsentry/owners-js-build
 babel.config.*      @getsentry/owners-js-build
 build-utils/        @getsentry/owners-js-build
 package.json        @getsentry/owners-js-deps
-yarn.lock        @getsentry/owners-js-deps
+yarn.lock           @getsentry/owners-js-deps
 
 # Design
 /static/app/icons/    @getsentry/design

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,7 @@ webpack.config.*    @getsentry/owners-js-build
 babel.config.*      @getsentry/owners-js-build
 build-utils/        @getsentry/owners-js-build
 package.json        @getsentry/owners-js-deps
+yarn.lock        @getsentry/owners-js-deps
 
 # Design
 /static/app/icons/    @getsentry/design

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       timezone: America/Los_Angeles
       time: '15:30'
     reviewers:
-      - '@getsentry/owners-js-build'
+      - '@getsentry/owners-js-deps'
     ignore:
       # Babel updates all really should happen in unison, so let's keep these
       # ignored for now and manually handle it


### PR DESCRIPTION
dependabot causes a lot of noise for `owners-js-build`, so lets separate it from `package.json`.
