### PR TITLE
fix: Remove return from constructor in CamelSnakeSerializer

### DIFF
--- a/src/sentry/api/serializers/rest_framework/base.py
+++ b/src/sentry/api/serializers/rest_framework/base.py
@@ -47,7 +47,7 @@ class CamelSnakeSerializer(Serializer):
     def __init__(self, instance=None, data=empty, **kwargs):
         if data is not empty:
             data = convert_dict_key_case(data, camel_to_snake_case)
-        return super().__init__(instance=instance, data=data, **kwargs)
+        super().__init__(instance=instance, data=data, **kwargs)
 
     @property
     def errors(self):


### PR DESCRIPTION
Apply similar fix as in https://github.com/getsentry/sentry/pull/34905 for `CamelSnakeSerializer`