### PR TITLE
fix: Missing organization parameter in from_auth

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -403,7 +403,6 @@ def from_request(
             permissions=get_permissions_for_user(request.user.id),
         )
 
-    # TODO: from_auth does not take scopes as a parameter so this fails for anon user
     if hasattr(request, "auth") and not request.user.is_authenticated:
         return from_auth(request.auth, organization)
 

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -405,7 +405,7 @@ def from_request(
 
     # TODO: from_auth does not take scopes as a parameter so this fails for anon user
     if hasattr(request, "auth") and not request.user.is_authenticated:
-        return from_auth(request.auth, scopes=scopes)
+        return from_auth(request.auth, organization)
 
     return from_user(request.user, organization, scopes=scopes)
 


### PR DESCRIPTION
There is a bug whereby `organization` was not propagated properly to `from_auth()` in cases when an API key or an access token is used.

I've added some tests to demonstrate this. 