### PR TITLE
ref(admin): Dont' show `TOKEN` secrets in InternalEnvironmentEndpoint

### DIFF
--- a/src/sentry/api/endpoints/internal/environment.py
+++ b/src/sentry/api/endpoints/internal/environment.py
@@ -13,7 +13,7 @@ class InternalEnvironmentEndpoint(Endpoint):
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:
-        reserved = ("PASSWORD", "SECRET", "KEY")
+        reserved = ("PASSWORD", "SECRET", "KEY", "TOKEN")
         config = []
         for k in sorted(dir(settings)):
             v_repr = repr(getattr(settings, k))


### PR DESCRIPTION
https://sentry.io/manage/status/environment/

Probably don't want things with the word `TOKEN` either.