### PR TITLE
feat(rules): suspect commits and issue owner support for flutter stack frames

### DIFF
--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -14,7 +14,7 @@ from rest_framework.serializers import ValidationError
 
 from sentry.eventstore.models import EventSubjectTemplateData
 from sentry.models import ActorTuple, RepositoryProjectPathConfig
-from sentry.utils.event_frames import find_stack_frames, munged_filename_and_frames
+from sentry.utils.event_frames import find_stack_frames, get_sdk_name, munged_filename_and_frames
 from sentry.utils.glob import glob_match
 from sentry.utils.safe import PathSearchable, get_path
 
@@ -107,9 +107,10 @@ class Matcher(namedtuple("Matcher", "type pattern")):
     def munge_if_needed(data: PathSearchable) -> Tuple[Sequence[Mapping[str, Any]], Sequence[str]]:
         keys = ["filename", "abs_path"]
         platform = data.get("platform")
+        sdk_name = get_sdk_name(data)
         frames = find_stack_frames(data)
         if platform:
-            munged = munged_filename_and_frames(platform, frames, "munged_filename")
+            munged = munged_filename_and_frames(platform, frames, "munged_filename", sdk_name)
             if munged:
                 keys.append(munged[0])
                 frames = munged[1]

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -50,7 +50,7 @@ def _process_suspect_commits(
                 "sentry.tasks.process_suspect_commits.get_serialized_event_file_committers"
             ):
                 committers = get_event_file_committers(
-                    project, group_id, event_frames, event_platform, sdk_name
+                    project, group_id, event_frames, event_platform, sdk_name=sdk_name
                 )
             owner_scores = {}
             for committer in committers:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -10,6 +10,7 @@ from sentry.signals import event_processed, issue_unignored, transaction_process
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.cache import cache
+from sentry.utils.event_frames import get_sdk_name
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.safe import safe_execute
 from sentry.utils.sdk import bind_organization_context, set_current_event_project
@@ -386,12 +387,14 @@ def post_process_group(
 
                             cache.set(group_cache_key, True, 604800)  # 1 week in seconds
                             event_frames = get_frame_paths(event)
+                            sdk_name = get_sdk_name(event.data)
                             process_suspect_commits.delay(
                                 event_id=event.event_id,
                                 event_platform=event.platform,
                                 event_frames=event_frames,
                                 group_id=event.group_id,
                                 project_id=event.project_id,
+                                sdk_name=sdk_name,
                             )
             except UnableToAcquireLock:
                 pass

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -294,11 +294,16 @@ def get_event_file_committers(
 
 
 def get_serialized_event_file_committers(
-    project: Project, event: Event, frame_limit: int = 25
+    project: Project, event: Event, frame_limit: int = 25, sdk_name: str | None = None
 ) -> Sequence[AuthorCommitsSerialized]:
     event_frames = get_frame_paths(event)
     committers = get_event_file_committers(
-        project, event.group_id, event_frames, event.platform, frame_limit=frame_limit
+        project,
+        event.group_id,
+        event_frames,
+        event.platform,
+        frame_limit=frame_limit,
+        sdk_name=sdk_name,
     )
     commits = [commit for committer in committers for commit in committer["commits"]]
     serialized_commits: Sequence[MutableMapping[str, Any]] = serialize(

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -231,6 +231,7 @@ def get_event_file_committers(
     event_frames: Sequence[Mapping[str, Any]],
     event_platform: str,
     frame_limit: int = 25,
+    sdk_name: str | None = None,
 ) -> Sequence[AuthorCommits]:
     group = Group.objects.get_from_cache(id=group_id)
 
@@ -247,7 +248,7 @@ def get_event_file_committers(
         raise Commit.DoesNotExist
 
     frames = event_frames or []
-    munged = munged_filename_and_frames(event_platform, frames, "munged_filename")
+    munged = munged_filename_and_frames(event_platform, frames, "munged_filename", sdk_name)
     if munged:
         frames = munged[1]
     app_frames = [frame for frame in frames if frame.get("in_app")][-frame_limit:]

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -26,7 +26,7 @@ from sentry.eventstore.models import Event
 from sentry.models import Commit, CommitFileChange, Group, Project, Release, ReleaseCommit
 from sentry.utils import metrics
 from sentry.utils.compat import zip
-from sentry.utils.event_frames import find_stack_frames, munged_filename_and_frames
+from sentry.utils.event_frames import find_stack_frames, get_sdk_name, munged_filename_and_frames
 from sentry.utils.hashlib import hash_values
 
 PATH_SEPARATORS = frozenset(["/", "\\"])
@@ -294,9 +294,10 @@ def get_event_file_committers(
 
 
 def get_serialized_event_file_committers(
-    project: Project, event: Event, frame_limit: int = 25, sdk_name: str | None = None
+    project: Project, event: Event, frame_limit: int = 25
 ) -> Sequence[AuthorCommitsSerialized]:
     event_frames = get_frame_paths(event)
+    sdk_name = get_sdk_name(event.data)
     committers = get_event_file_committers(
         project,
         event.group_id,

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -272,6 +272,63 @@ def test_matcher_test_platform_cocoa_threads():
     assert not Matcher("path", "*.py").test({})
 
 
+def test_matcher_test_platform_react_native():
+    data = {
+        "platform": "javascript",
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "callFunctionReturnFlushedQueue",
+                                "module": "react-native/Libraries/BatchedBridge/MessageQueue",
+                                "filename": "node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js",
+                                "abs_path": "app:///node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js",
+                                "lineno": 115,
+                                "colno": 5,
+                                "in_app": False,
+                                "data": {"sourcemap": "app:///main.jsbundle.map"},
+                            },
+                            {
+                                "function": "apply",
+                                "filename": "native",
+                                "abs_path": "native",
+                                "in_app": True,
+                            },
+                            {
+                                "function": "onPress",
+                                "module": "src/screens/EndToEndTestsScreen",
+                                "filename": "src/screens/EndToEndTestsScreen.tsx",
+                                "abs_path": "app:///src/screens/EndToEndTestsScreen.tsx",
+                                "lineno": 57,
+                                "colno": 11,
+                                "in_app": True,
+                                "data": {"sourcemap": "app:///main.jsbundle.map"},
+                            },
+                        ]
+                    }
+                }
+            ],
+        },
+    }
+
+    assert Matcher("path", "src/screens/EndToEndTestsScreen.tsx").test(data)
+    assert Matcher("path", "src/*/EndToEndTestsScreen.tsx").test(data)
+    assert Matcher("path", "*/EndToEndTestsScreen.tsx").test(data)
+    assert Matcher("path", "**/EndToEndTestsScreen.tsx").test(data)
+    assert Matcher("path", "*.tsx").test(data)
+    assert Matcher("codeowners", "src/screens/EndToEndTestsScreen.tsx").test(data)
+    assert Matcher("codeowners", "*.tsx").test(data)
+    assert not Matcher("url", "*.tsx").test(data)
+
+    # external lib matching still works
+    assert Matcher("path", "**/Libraries/BatchedBridge/MessageQueue.js").test(data)
+
+    # we search on filename and abs_path, if a user explicitly tests on the abs_path, we let them
+    assert Matcher("path", "app:///src/screens/EndToEndTestsScreen.tsx").test(data)
+
+
 def test_matcher_test_platform_none_threads():
     data = {
         "threads": {

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -329,6 +329,75 @@ def test_matcher_test_platform_react_native():
     assert Matcher("path", "app:///src/screens/EndToEndTestsScreen.tsx").test(data)
 
 
+def test_matcher_test_platform_other_flutter():
+    data = {
+        "platform": "other",
+        "sdk": {"name": "sentry.dart.flutter"},
+        "exception": {
+            "values": [
+                {
+                    "type": "StateError",
+                    "value": "Bad state: try catch",
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "_dispatchPointerDataPacket",
+                                "filename": "hooks.dart",
+                                "abs_path": "dart:ui/hooks.dart",
+                                "lineno": 94,
+                                "colno": 31,
+                                "in_app": False,
+                            },
+                            {
+                                "function": "_InkResponseState._handleTap",
+                                "package": "flutter",
+                                "filename": "ink_well.dart",
+                                "abs_path": "package:flutter/src/material/ink_well.dart",
+                                "lineno": 1005,
+                                "colno": 21,
+                                "in_app": False,
+                            },
+                            {
+                                "function": "MainScaffold.build.<fn>",
+                                "package": "sentry_flutter_example",
+                                "filename": "main.dart",
+                                "abs_path": "package:sentry_flutter_example/main.dart",
+                                "lineno": 117,
+                                "colno": 32,
+                                "in_app": True,
+                            },
+                            {
+                                "function": "tryCatchModule",
+                                "package": "sentry_flutter_example",
+                                "filename": "test.dart",
+                                "abs_path": "package:sentry_flutter_example/a/b/test.dart",
+                                "lineno": 8,
+                                "colno": 5,
+                                "in_app": True,
+                            },
+                        ]
+                    },
+                }
+            ]
+        },
+    }
+
+    assert Matcher("path", "a/b/test.dart").test(data)
+    assert Matcher("path", "a/*/test.dart").test(data)
+    assert Matcher("path", "*/test.dart").test(data)
+    assert Matcher("path", "**/test.dart").test(data)
+    assert Matcher("path", "*.dart").test(data)
+    assert Matcher("codeowners", "a/b/test.dart").test(data)
+    assert Matcher("codeowners", "*.dart").test(data)
+    assert not Matcher("url", "*.dart").test(data)
+
+    # non in-app/user code still works here,
+    assert Matcher("path", "src/material/ink_well.dart").test(data)
+
+    # we search on filename and abs_path, if a user explicitly tests on the abs_path, we let them
+    assert Matcher("path", "package:sentry_flutter_example/a/b/test.dart").test(data)
+
+
 def test_matcher_test_platform_none_threads():
     data = {
         "threads": {

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -621,32 +621,6 @@ class GetEventFileCommitters(CommitTestCase):
                             "stacktrace": {
                                 "frames": [
                                     {
-                                        "function": "_dispatchPointerDataPacket",
-                                        "filename": "hooks.dart",
-                                        "abs_path": "dart:ui/hooks.dart",
-                                        "lineno": 94,
-                                        "colno": 31,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "_InkResponseState._handleTap",
-                                        "package": "flutter",
-                                        "filename": "ink_well.dart",
-                                        "abs_path": "package:flutter/src/material/ink_well.dart",
-                                        "lineno": 1005,
-                                        "colno": 21,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "MainScaffold.build.<fn>",
-                                        "package": "sentry_flutter_example",
-                                        "filename": "main.dart",
-                                        "abs_path": "package:sentry_flutter_example/main.dart",
-                                        "lineno": 117,
-                                        "colno": 32,
-                                        "in_app": True,
-                                    },
-                                    {
                                         "function": "tryCatchModule",
                                         "package": "sentry_flutter_example",
                                         "filename": "test.dart",

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -301,6 +301,66 @@ class CocoaFilenameMungingTestCase(unittest.TestCase):
         )
 
 
+class ReactNativeFilenameMungingTestCase(TestCase):
+    def test_simple(self):
+        frames = [
+            {
+                "function": "callFunctionReturnFlushedQueue",
+                "module": "react-native/Libraries/BatchedBridge/MessageQueue",
+                "filename": "node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js",
+                "abs_path": "app:///node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js",
+                "lineno": 115,
+                "colno": 5,
+                "pre_context": [
+                    "  callFunctionReturnFlushedQueue(",
+                    "    module: string,",
+                    "    method: string,",
+                    "    args: mixed[],",
+                    "  ): null | [Array<number>, Array<number>, Array<mixed>, number] {",
+                ],
+                "context_line": "    this.__guard(() => {",
+                "post_context": [
+                    "      this.__callFunction(module, method, args);",
+                    "    });",
+                    "",
+                    "    return this.flushedQueue();",
+                    "  }",
+                ],
+                "in_app": False,
+                "data": {"sourcemap": "app:///main.jsbundle.map"},
+            },
+            {"function": "apply", "filename": "native", "abs_path": "native", "in_app": True},
+            {
+                "function": "onPress",
+                "module": "src/screens/EndToEndTestsScreen",
+                "filename": "src/screens/EndToEndTestsScreen.tsx",
+                "abs_path": "app:///src/screens/EndToEndTestsScreen.tsx",
+                "lineno": 57,
+                "colno": 11,
+                "pre_context": [
+                    "        }}>",
+                    "        throw new Error",
+                    "      </Text>",
+                    "      <Text",
+                    "        onPress={() => {",
+                ],
+                "context_line": "          new Promise(() => {",
+                "post_context": [
+                    "            throw new Error('Unhandled Promise Rejection');",
+                    "          });",
+                    "        }}",
+                    "        {...getTestProps('unhandledPromiseRejection')}>",
+                    "        Unhandled Promise Rejection",
+                ],
+                "in_app": True,
+                "data": {"sourcemap": "app:///main.jsbundle.map"},
+            },
+        ]
+
+        munged_frames = munged_filename_and_frames("javascript", frames)
+        assert not munged_frames
+
+
 class CocoaWaterFallTestCase(TestCase):
     def test_crashing_event_with_exception_interface_but_no_frame_should_waterfall_to_thread_frames(
         self,


### PR DESCRIPTION
This PR adds stack frame 'munging' support for flutter-based events.

The bulk of the logic looks at the frame data, particularly `abs_path`. The pathing looks to take two forms: `dart:ui/file.dart` or `package:<name-of-package>/path/to/file.dart`.

In the case of `abs_path` with `dart:` prefixed, we simply ignore it since these are likely sys libs and not user code.

In the case of `package:` prefixed abs_path, we match the `package:<name-of-package>` part and strip it out before writing this munged path to the frame. 

Approach is documented in: https://www.notion.so/sentry/Tech-Spec-for-Mobile-Language-Stack-Transformation-5580956cfa404a90860c3e0cbf76e2c1#f2c40cd51b454e33a47868384774010d

Fixes WOR-1805