### PR TITLE
fix: Pass metadata for BaseEvent.get_title

### DIFF
--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -81,7 +81,7 @@ class BaseEvent:
 
     def to_string(self, metadata):
         warn(DeprecationWarning("This method was replaced by get_title", stacklevel=2))
-        return self.get_title()
+        return self.get_title(metadata)
 
 
 class DefaultEvent(BaseEvent):


### PR DESCRIPTION
As reported in https://github.com/getsentry/sentry/issues/34904.

Refactored from https://github.com/getsentry/sentry/pull/12089