### PR TITLE
chore: Remove un-used args and kwargs for OrganizationDashboardBase.convert_args

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -20,7 +20,7 @@ READ_FEATURE = "organizations:dashboards-basic"
 class OrganizationDashboardBase(OrganizationEndpoint):
     permission_classes = (OrganizationDashboardsPermission,)
 
-    def convert_args(self, request: Request, organization_slug, dashboard_id, *args, **kwargs):
+    def convert_args(self, request: Request, organization_slug, dashboard_id):
         args, kwargs = super().convert_args(request, organization_slug)
 
         try:


### PR DESCRIPTION
🧹 