### PR TITLE
fix: Fix unreachable code for DjangoCache.get

### DIFF
--- a/src/sentry/cache/django.py
+++ b/src/sentry/cache/django.py
@@ -13,5 +13,6 @@ class DjangoCache(BaseCache):
         self._mark_transaction("delete")
 
     def get(self, key, version=None, raw=False):
-        return cache.get(key, version=version or self.version)
+        result = cache.get(key, version=version or self.version)
         self._mark_transaction("get")
+        return result


### PR DESCRIPTION
The marker was introduced in https://github.com/getsentry/sentry/pull/25989. 

@untitaker unsure if you're still tracking this.