### PR TITLE
feat(proj-config): acks_late proj config tasks [INGEST-1364 INGEST-1324]

### DIFF
--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -11,7 +11,9 @@ from sentry.utils.sdk import set_current_event_project
 logger = logging.getLogger(__name__)
 
 
-@instrumented_task(name="sentry.tasks.relay.update_config_cache", queue="relay_config")
+@instrumented_task(
+    name="sentry.tasks.relay.update_config_cache", queue="relay_config", acks_late=True
+)
 def update_config_cache(
     generate, organization_id=None, project_id=None, public_key=None, update_reason=None
 ):


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/35238.

We want to ensure the task fully executes, since we rely on the task
removing the debounce key in the `finally` block of the task.

Not removing the debounce key produces a situation where the endpoint
will debounce new requests to update the cache, while the cache either
doesn't have the project config or has a stale one.