### PR TITLE
fix: Fix KeyCollection test

### DIFF
--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -253,8 +253,8 @@ class KeyCollectionTest(TestCase):
 
         assert collection.mapping == org_strings
         assert collection.size == 5
-        assert list(collection.as_tuples()).sort() == collection_tuples.sort()
-        assert list(collection.as_strings()).sort() == collection_strings.sort()
+        assert sorted(list(collection.as_tuples())) == sorted(collection_tuples)
+        assert sorted(list(collection.as_strings())) == sorted(collection_strings)
 
 
 class KeyResultsTest(TestCase):


### PR DESCRIPTION
This was introduced in https://github.com/getsentry/sentry/pull/32780

`.sort()` function returns `None` and doesn't return the sorted list. So the asserts were tautologies. 