### PR TITLE
ref: close streaming responses under test to avoid warnings

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -681,6 +681,7 @@ class PermissionTestCase(TestCase):
         self.login_as(user, superuser=user.is_superuser)
         resp = getattr(self.client, method.lower())(path, **kwargs)
         assert resp.status_code >= 200 and resp.status_code < 300
+        return resp
 
     def assert_cannot_access(self, user, path, method="GET", **kwargs):
         self.login_as(user, superuser=user.is_superuser)
@@ -743,7 +744,7 @@ class PermissionTestCase(TestCase):
         user = self.create_user(is_superuser=False)
         self.create_member(user=user, organization=self.organization, role=role, teams=[self.team])
 
-        self.assert_can_access(user, path, **kwargs)
+        return self.assert_can_access(user, path, **kwargs)
 
     def assert_role_cannot_access(self, path, role, **kwargs):
         user = self.create_user(is_superuser=False)

--- a/src/sentry/testutils/helpers/response.py
+++ b/src/sentry/testutils/helpers/response.py
@@ -1,0 +1,11 @@
+from django.http.response import StreamingHttpResponse
+
+
+def close_streaming_response(response: StreamingHttpResponse) -> None:
+    """Exhausts the streamed file in a response.
+
+    When the file is exahusted, this underlying file descriptor is closed
+    avoiding a `ResourceWarning`.
+    """
+    for _ in response.streaming_content:
+        pass

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -3,6 +3,7 @@ from io import BytesIO
 from sentry.models import EventAttachment, File
 from sentry.testutils import APITestCase, PermissionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.response import close_streaming_response
 
 
 class CreateAttachmentMixin:
@@ -84,14 +85,14 @@ class EventAttachmentDetailsPermissionTest(PermissionTestCase, CreateAttachmentM
 
     def test_member_can_access_by_default(self):
         with self.feature("organizations:event-attachments"):
-            self.assert_member_can_access(self.path)
-            self.assert_can_access(self.owner, self.path)
+            close_streaming_response(self.assert_member_can_access(self.path))
+            close_streaming_response(self.assert_can_access(self.owner, self.path))
 
     def test_member_cannot_access_for_owner_role(self):
         self.organization.update_option("sentry:attachments_role", "owner")
         with self.feature("organizations:event-attachments"):
             self.assert_member_cannot_access(self.path)
-            self.assert_can_access(self.owner, self.path)
+            close_streaming_response(self.assert_can_access(self.owner, self.path))
 
     def test_random_user_cannot_access(self):
         self.organization.update_option("sentry:attachments_role", "owner")
@@ -105,4 +106,4 @@ class EventAttachmentDetailsPermissionTest(PermissionTestCase, CreateAttachmentM
         superuser = self.create_user(is_superuser=True)
 
         with self.feature("organizations:event-attachments"):
-            self.assert_can_access(superuser, self.path)
+            close_streaming_response(self.assert_can_access(superuser, self.path))


### PR DESCRIPTION
fixes these warnings (via `pytest -Wonce`):

```
tests/sentry/web/frontend/generic/test_static_media.py::StaticMediaTest::test_no_cors
  /Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/django/test/client.py:287: ResourceWarning: unclosed file <_io.FileIO name='/Users/asottile/workspace/sentry/src/sentry/static/sentry/js/ads.js.gz' mode='rb' closefd=True>
```