### PR TITLE
chore: Update getOrganizationReleasesMemoized named parameters

### DIFF
--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -127,8 +127,8 @@ class ReleaseSeries extends Component<Props, State> {
   _isMounted: boolean = false;
 
   getOrganizationReleasesMemoized = memoize(
-    (api, conditions, organization) =>
-      getOrganizationReleases(api, conditions, organization),
+    (api: Client, organization: Organization, conditions: ReleaseConditions) =>
+      getOrganizationReleases(api, organization, conditions),
     (_, __, conditions) =>
       Object.values(conditions)
         .map(val => JSON.stringify(val))


### PR DESCRIPTION
There is no bug. I wanted to get the order of the args right.