### PR TITLE
chore: Improve hasSimilarItems condition

### DIFF
--- a/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -178,7 +178,7 @@ class SimilarStackTrace extends Component<Props, State> {
     const isLoadedSuccessfully = !isError && !isLoading;
     const hasSimilarItems =
       this.hasSimilarityFeature() &&
-      (similarItems.length >= 0 || filteredSimilarItems.length >= 0) &&
+      (similarItems.length > 0 || filteredSimilarItems.length > 0) &&
       isLoadedSuccessfully;
 
     return (


### PR DESCRIPTION
`similarItems` and `filteredSimilarItems` always have a non-negative number of items. 