### PR TITLE
feat(discover): Update replay trace to use events endpoint

### DIFF
--- a/static/app/views/replays/detail/trace.tsx
+++ b/static/app/views/replays/detail/trace.tsx
@@ -88,7 +88,7 @@ export default function Trace({event, organization}: Props) {
       try {
         const [data, , resp] = await doDiscoverQuery<TableData>(
           api,
-          `/organizations/${orgId}/eventsv2/`,
+          `/organizations/${orgId}/events/`,
           eventView.getEventsAPIPayload(location)
         );
 


### PR DESCRIPTION
Updates the replay trace component to use `events` instead of `eventsv2`.