### PR TITLE
config(last_seen updater): do proper sampling

### DIFF
--- a/src/sentry/sentry_metrics/last_seen_updater.py
+++ b/src/sentry/sentry_metrics/last_seen_updater.py
@@ -39,9 +39,13 @@ class LastSeenUpdaterMessageFilter(StreamMessageFilter[Message[KafkaPayload]]): 
     def should_drop(self, message: Message[KafkaPayload]) -> bool:
         feature_enabled: float = options.get("sentry-metrics.last-seen-updater.accept-rate")
         bypass_for_user = random.random() > feature_enabled
-        self.__metrics.incr(
-            "last_seen_updater.accept_rate", sample_rate=0.001, tags={"bypass": bypass_for_user}
-        )
+        sample_rate = 0.001
+        if random.random() < sample_rate:
+            self.__metrics.incr(
+                "last_seen_updater.accept_rate",
+                tags={"bypass": bypass_for_user},
+                amount=1.0 / sample_rate,
+            )
 
         if bypass_for_user:
             return True


### PR DESCRIPTION
We don't actually seem to be sampling on this metric (https://app.datadoghq.com/s/FH6-Y3/pir-cgc-33e), and our CPU is really high even though we're not processing much (right now we drop 75% of messages based on the "accept rate")