### PR TITLE
fix(dropdownButtonV2): Fix forwardRef typing

### DIFF
--- a/static/app/components/dropdownButtonV2.tsx
+++ b/static/app/components/dropdownButtonV2.tsx
@@ -20,10 +20,7 @@ export type DropdownButtonProps = {
   showChevron?: boolean;
 } & Omit<ButtonProps, 'type' | 'prefix'>;
 
-const DropdownButton = forwardRef<
-  React.RefObject<HTMLElement> | null,
-  DropdownButtonProps
->(
+const DropdownButton = forwardRef<HTMLElement, DropdownButtonProps>(
   (
     {
       children,


### PR DESCRIPTION
`forwardRef`'s generic type accepts an `Element` type as an argument (e.g. `HTMLElement`), without the need to wrap it inside `RefObject`.