### PR TITLE
feat(profiling): add collapse recursion option

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -7,10 +7,9 @@ import space from 'sentry/styles/space';
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {useFlamegraphProfilesValue} from 'sentry/utils/profiling/flamegraph/useFlamegraphProfiles';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
+import {useVerticallyResizableDrawer} from 'sentry/utils/profiling/hooks/useResizableDrawer';
 import {invertCallTree} from 'sentry/utils/profiling/profile/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
-
-import {useVerticallyResizableDrawer} from '../../../utils/profiling/hooks/useResizableDrawer';
 
 import {FrameStackTable} from './frameStackTable';
 
@@ -45,6 +44,14 @@ function FrameStack(props: FrameStackProps) {
     []
   );
 
+  const onBottomUpClick = useCallback(() => {
+    setTab('bottom up');
+  }, []);
+
+  const onCallOrderClick = useCallback(() => {
+    setTab('call order');
+  }, []);
+
   const {height, onMouseDown} = useVerticallyResizableDrawer({
     initialHeight: (theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET + 2) * theme.SIZES.BAR_HEIGHT,
     minHeight: 30,
@@ -58,19 +65,19 @@ function FrameStack(props: FrameStackProps) {
     >
       <FrameTabs>
         <li className={tab === 'bottom up' ? 'active' : undefined}>
-          <Button priority="link" size="zero" onClick={() => setTab('bottom up')}>
+          <Button priority="link" size="zero" onClick={onBottomUpClick}>
             {t('Bottom Up')}
           </Button>
         </li>
         <li className={tab === 'call order' ? 'active' : undefined}>
-          <Button priority="link" size="zero" onClick={() => setTab('call order')}>
+          <Button priority="link" size="zero" onClick={onCallOrderClick}>
             {t('Call Order')}
           </Button>
         </li>
         <li>
           <FrameDrawerLabel>
             <input type="checkbox" onChange={handleRecursionChange} />
-            Collapse recursion
+            {t('Collapse recursion')}
           </FrameDrawerLabel>
         </li>
         <li style={{flex: '1 1 100%', cursor: 'ns-resize'}} onMouseDown={onMouseDown} />

--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -95,13 +95,16 @@ function FrameStack(props: FrameStackProps) {
             {t('Bottom Up')}
           </Button>
         </li>
-        <li
-          onClick={() => setTab('call order')}
-          className={tab === 'call order' ? 'active' : undefined}
-        >
-          <Button priority="link" size="zero">
+        <li className={tab === 'call order' ? 'active' : undefined}>
+          <Button priority="link" size="zero" onClick={() => setTab('call order')}>
             {t('Call Order')}
           </Button>
+        </li>
+        <li>
+          <FrameDrawerLabel>
+            <input type="checkbox" />
+            Collapse recursion
+          </FrameDrawerLabel>
         </li>
         <li style={{flex: '1 1 100%', cursor: 'ns-resize'}} onMouseDown={onMouseDown} />
       </FrameTabs>
@@ -114,6 +117,18 @@ function FrameStack(props: FrameStackProps) {
     </FrameDrawer>
   ) : null;
 }
+
+const FrameDrawerLabel = styled('label')`
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  margin-bottom: 0;
+  height: 100%;
+
+  > input {
+    margin: 0 ${space(0.5)} 0 0;
+  }
+`;
 
 const FrameDrawer = styled('div')`
   display: flex;

--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
@@ -38,6 +38,13 @@ function FrameStack(props: FrameStackProps) {
     return invertCallTree([selectedNode]);
   }, [selectedNode, tab]);
 
+  const handleRecursionChange = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
+      setRecursion(evt.currentTarget.checked ? 'collapsed' : null);
+    },
+    []
+  );
+
   const {height, onMouseDown} = useVerticallyResizableDrawer({
     initialHeight: (theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET + 2) * theme.SIZES.BAR_HEIGHT,
     minHeight: 30,
@@ -62,7 +69,7 @@ function FrameStack(props: FrameStackProps) {
         </li>
         <li>
           <FrameDrawerLabel>
-            <input type="checkbox" />
+            <input type="checkbox" onChange={handleRecursionChange} />
             Collapse recursion
           </FrameDrawerLabel>
         </li>
@@ -70,6 +77,7 @@ function FrameStack(props: FrameStackProps) {
       </FrameTabs>
       <FrameStackTable
         {...props}
+        recursion={recursion}
         roots={roots ?? []}
         referenceNode={selectedNode}
         canvasPoolManager={props.canvasPoolManager}

--- a/static/app/components/profiling/FrameStack/frameStackTable.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackTable.tsx
@@ -70,9 +70,14 @@ function makeSortFunction(
   throw new Error(`Unknown sort property ${property}`);
 }
 
+function skipRecursiveNodes(n: VirtualizedTreeNode<FlamegraphFrame>): boolean {
+  return n.node.node.isDirectRecursive();
+}
+
 interface FrameStackTableProps {
   canvasPoolManager: CanvasPoolManager;
   flamegraphRenderer: FlamegraphRenderer;
+  recursion: 'collapsed' | null;
   referenceNode: FlamegraphFrame;
   roots: FlamegraphFrame[];
 }
@@ -82,13 +87,13 @@ export function FrameStackTable({
   flamegraphRenderer,
   canvasPoolManager,
   referenceNode,
+  recursion,
 }: FrameStackTableProps) {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const [sort, setSort] = useState<'total weight' | 'self weight' | 'name'>(
     'total weight'
   );
   const [direction, setDirection] = useState<'asc' | 'desc'>('desc');
-
   const sortFunction = useMemo(() => {
     return makeSortFunction(sort, direction);
   }, [sort, direction]);
@@ -104,6 +109,7 @@ export function FrameStackTable({
     handleSortingChange,
     handleScroll,
   } = useVirtualizedTree({
+    skipFunction: recursion === 'collapsed' ? skipRecursiveNodes : undefined,
     sortFunction,
     scrollContainerRef,
     rowHeight: 24,

--- a/static/app/components/profiling/FrameStack/frameStackTableRow.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackTableRow.tsx
@@ -197,8 +197,8 @@ const FrameNameContainer = styled('div')`
 `;
 
 const FrameChildrenIndicator = styled('button')<{open: boolean}>`
-  width: 1ch;
-  height: 1ch;
+  width: 10px;
+  height: 10px;
   display: flex;
   padding: 0;
   border: none;
@@ -222,5 +222,5 @@ const FrameColorIndicator = styled('div')<{
   display: inline-block;
   flex-shrink: 0;
   background-color: ${p => p.backgroundColor};
-  margin-right: ${space(1)};
+  margin-right: ${space(0.5)};
 `;

--- a/static/app/utils/profiling/callTreeNode.tsx
+++ b/static/app/utils/profiling/callTreeNode.tsx
@@ -21,12 +21,19 @@ export class CallTreeNode extends WeightedNode {
     this.parent = parent;
   }
 
-  setRecursive(node: CallTreeNode): void {
+  setRecursiveThroughNode(node: CallTreeNode): void {
     this.recursive = node;
   }
 
   isRecursive(): boolean {
     return !!this.recursive;
+  }
+
+  isDirectRecursive(): boolean {
+    if (!this.parent) {
+      return false;
+    }
+    return this.parent.frame === this.frame;
   }
 
   isLocked(): boolean {

--- a/static/app/utils/profiling/hooks/useResizableDrawer.tsx
+++ b/static/app/utils/profiling/hooks/useResizableDrawer.tsx
@@ -1,5 +1,4 @@
-import {useCallback, useState} from 'react';
-import {vec2} from 'gl-matrix';
+import {useCallback, useEffect, useRef, useState} from 'react';
 
 interface UseVerticallyResizableDrawerOptions {
   initialHeight: number;
@@ -9,52 +8,61 @@ interface UseVerticallyResizableDrawerOptions {
 export function useVerticallyResizableDrawer(
   options: UseVerticallyResizableDrawerOptions
 ) {
+  const rafIdRef = useRef<number | null>(null);
+  const startResizeVectorRef = useRef<[number, number] | null>(null);
   const [drawerHeight, setDrawerHeight] = useState(options.initialHeight);
 
-  const onMouseDown = useCallback(
-    (evt: React.MouseEvent<HTMLElement>) => {
-      let startResizeVector = vec2.fromValues(evt.clientX, evt.clientY);
-      let rafId: number | undefined;
-
-      function handleMouseMove(mvEvent: MouseEvent) {
-        if (rafId !== undefined) {
-          window.cancelAnimationFrame(rafId);
-          rafId = undefined;
-        }
-
-        window.requestAnimationFrame(() => {
-          const currentPositionVector = vec2.fromValues(mvEvent.clientX, mvEvent.clientY);
-
-          const distance = vec2.subtract(
-            vec2.fromValues(0, 0),
-            startResizeVector,
-            currentPositionVector
-          );
-
-          startResizeVector = currentPositionVector;
-
-          setDrawerHeight(h => Math.max(options.minHeight ?? 0, h + distance[1]));
-          rafId = undefined;
-        });
+  const onMouseMove = useCallback(
+    (mvEvent: MouseEvent) => {
+      const rafId = rafIdRef.current;
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+        rafIdRef.current = null;
       }
 
-      function handleMouseUp() {
-        document.removeEventListener('mousemove', handleMouseMove);
-      }
-
-      document.addEventListener('mousemove', handleMouseMove);
-      document.addEventListener('mouseup', handleMouseUp);
-
-      return () => {
-        document.removeEventListener('mousemove', handleMouseMove);
-
-        if (rafId !== undefined) {
-          window.cancelAnimationFrame(rafId);
+      rafIdRef.current = window.requestAnimationFrame(() => {
+        if (!startResizeVectorRef.current) {
+          return;
         }
-      };
+        const currentPositionVector: [number, number] = [
+          mvEvent.clientX,
+          mvEvent.clientY,
+        ];
+
+        const distance = [
+          startResizeVectorRef.current[0] - currentPositionVector[0],
+          startResizeVectorRef.current[1] - currentPositionVector[1],
+        ];
+
+        startResizeVectorRef.current = currentPositionVector;
+        setDrawerHeight(h => Math.max(options.minHeight ?? 0, h + distance[1]));
+      });
     },
     [options.minHeight]
   );
+
+  const onMouseUp = useCallback(() => {
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+  }, [onMouseMove]);
+
+  const onMouseDown = useCallback(
+    (evt: React.MouseEvent<HTMLElement>) => {
+      startResizeVectorRef.current = [evt.clientX, evt.clientY];
+
+      document.addEventListener('mousemove', onMouseMove, {passive: true});
+      document.addEventListener('mouseup', onMouseUp);
+    },
+    [onMouseMove, onMouseUp]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        window.cancelAnimationFrame(rafIdRef.current);
+      }
+    };
+  });
 
   return {height: drawerHeight, onMouseDown};
 }

--- a/static/app/utils/profiling/hooks/useResizableDrawer.tsx
+++ b/static/app/utils/profiling/hooks/useResizableDrawer.tsx
@@ -1,0 +1,60 @@
+import {useCallback, useState} from 'react';
+import {vec2} from 'gl-matrix';
+
+interface UseVerticallyResizableDrawerOptions {
+  initialHeight: number;
+  minHeight?: number;
+}
+
+export function useVerticallyResizableDrawer(
+  options: UseVerticallyResizableDrawerOptions
+) {
+  const [drawerHeight, setDrawerHeight] = useState(options.initialHeight);
+
+  const onMouseDown = useCallback(
+    (evt: React.MouseEvent<HTMLElement>) => {
+      let startResizeVector = vec2.fromValues(evt.clientX, evt.clientY);
+      let rafId: number | undefined;
+
+      function handleMouseMove(mvEvent: MouseEvent) {
+        if (rafId !== undefined) {
+          window.cancelAnimationFrame(rafId);
+          rafId = undefined;
+        }
+
+        window.requestAnimationFrame(() => {
+          const currentPositionVector = vec2.fromValues(mvEvent.clientX, mvEvent.clientY);
+
+          const distance = vec2.subtract(
+            vec2.fromValues(0, 0),
+            startResizeVector,
+            currentPositionVector
+          );
+
+          startResizeVector = currentPositionVector;
+
+          setDrawerHeight(h => Math.max(options.minHeight ?? 0, h + distance[1]));
+          rafId = undefined;
+        });
+      }
+
+      function handleMouseUp() {
+        document.removeEventListener('mousemove', handleMouseMove);
+      }
+
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+
+      return () => {
+        document.removeEventListener('mousemove', handleMouseMove);
+
+        if (rafId !== undefined) {
+          window.cancelAnimationFrame(rafId);
+        }
+      };
+    },
+    [options.minHeight]
+  );
+
+  return {height: drawerHeight, onMouseDown};
+}

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
@@ -12,7 +12,10 @@ export class VirtualizedTree<T extends TreeLike> {
   }
 
   // Rebuilds the tree
-  static fromRoots<T extends TreeLike>(items: T[]): VirtualizedTree<T> {
+  static fromRoots<T extends TreeLike>(
+    items: T[],
+    skipFn: (n: VirtualizedTreeNode<T>) => boolean = () => false
+  ): VirtualizedTree<T> {
     const roots: VirtualizedTreeNode<T>[] = [];
 
     function toTreeNode(
@@ -21,7 +24,17 @@ export class VirtualizedTree<T extends TreeLike> {
       collection: VirtualizedTreeNode<T>[] | null,
       depth: number
     ) {
-      const treeNode = new VirtualizedTreeNode<T>(node, parent, depth);
+      const treeNode = new VirtualizedTreeNode<T>(node, parent, depth, false, false);
+
+      // We cannot skip root nodes, so we check that the parent is not null.
+      // If the node should be skipped, then we don't add it to the tree and descend
+      // into its children without incrementing the depth.
+      if (parent && skipFn(treeNode)) {
+        for (let i = 0; i < node.children.length; i++) {
+          toTreeNode(node.children[i] as T, treeNode, parent.children, depth);
+        }
+        return;
+      }
 
       if (collection) {
         collection.push(treeNode);

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
@@ -14,7 +14,8 @@ export class VirtualizedTree<T extends TreeLike> {
   // Rebuilds the tree
   static fromRoots<T extends TreeLike>(
     items: T[],
-    skipFn: (n: VirtualizedTreeNode<T>) => boolean = () => false
+    skipFn: (n: VirtualizedTreeNode<T>) => boolean = () => false,
+    expandedNodes?: Set<T>
   ): VirtualizedTree<T> {
     const roots: VirtualizedTreeNode<T>[] = [];
 
@@ -24,7 +25,12 @@ export class VirtualizedTree<T extends TreeLike> {
       collection: VirtualizedTreeNode<T>[] | null,
       depth: number
     ) {
-      const treeNode = new VirtualizedTreeNode<T>(node, parent, depth, false, false);
+      const treeNode = new VirtualizedTreeNode<T>(
+        node,
+        parent,
+        depth,
+        expandedNodes ? expandedNodes.has(node) : false
+      );
 
       // We cannot skip root nodes, so we check that the parent is not null.
       // If the node should be skipped, then we don't add it to the tree and descend
@@ -49,7 +55,7 @@ export class VirtualizedTree<T extends TreeLike> {
       toTreeNode(items[i], null, roots, 0);
     }
 
-    return new VirtualizedTree<T>(roots);
+    return new VirtualizedTree<T>(roots, undefined);
   }
 
   // Returns a list of nodes that are visible in the tree.
@@ -121,5 +127,25 @@ export class VirtualizedTree<T extends TreeLike> {
     }
 
     this.flattened = VirtualizedTree.toExpandedList(this.roots);
+  }
+
+  getAllExpandedNodes(previouslyExpandedNodes: Set<T>): Set<T> {
+    const expandedNodes = new Set<T>([...previouslyExpandedNodes]);
+
+    function visit(node: VirtualizedTreeNode<T>) {
+      if (node.expanded) {
+        expandedNodes.add(node.node);
+      }
+
+      for (let i = 0; i < node.children.length; i++) {
+        visit(node.children[i]);
+      }
+    }
+
+    for (let i = 0; i < this.roots.length; i++) {
+      visit(this.roots[i]);
+    }
+
+    return expandedNodes;
   }
 }

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
@@ -3,17 +3,20 @@ export class VirtualizedTreeNode<T> {
   parent: VirtualizedTreeNode<T> | null;
   children: VirtualizedTreeNode<T>[];
   expanded: boolean;
+  skipped: boolean;
   depth: number;
 
   constructor(
     node: T,
     parent: VirtualizedTreeNode<T> | null,
     depth: number,
-    expanded?: boolean
+    expanded: boolean,
+    skipped: boolean
   ) {
     this.node = node;
     this.parent = parent;
     this.expanded = expanded ?? false;
+    this.skipped = skipped ?? false;
     this.children = [];
     this.depth = depth;
   }

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
@@ -9,7 +9,7 @@ export class VirtualizedTreeNode<T> {
     node: T,
     parent: VirtualizedTreeNode<T> | null,
     depth: number,
-    expanded: boolean
+    expanded: boolean = false
   ) {
     this.node = node;
     this.parent = parent;

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
@@ -3,20 +3,17 @@ export class VirtualizedTreeNode<T> {
   parent: VirtualizedTreeNode<T> | null;
   children: VirtualizedTreeNode<T>[];
   expanded: boolean;
-  skipped: boolean;
   depth: number;
 
   constructor(
     node: T,
     parent: VirtualizedTreeNode<T> | null,
     depth: number,
-    expanded: boolean,
-    skipped: boolean
+    expanded: boolean
   ) {
     this.node = node;
     this.parent = parent;
     this.expanded = expanded ?? false;
-    this.skipped = skipped ?? false;
     this.children = [];
     this.depth = depth;
   }

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -50,6 +50,7 @@ interface UseVirtualizedListProps<T extends TreeLike> {
   rowHeight: number;
   scrollContainerRef: React.MutableRefObject<HTMLElement | null>;
   overscroll?: number;
+  skipFunction?: (node: VirtualizedTreeNode<T>) => boolean;
   sortFunction?: (a: VirtualizedTreeNode<T>, b: VirtualizedTreeNode<T>) => number;
 }
 
@@ -59,7 +60,7 @@ export function useVirtualizedTree<T extends TreeLike>(
   props: UseVirtualizedListProps<T>
 ) {
   const [tree, setTree] = useState(() => {
-    const initialTree = VirtualizedTree.fromRoots(props.roots);
+    const initialTree = VirtualizedTree.fromRoots(props.roots, props.skipFunction);
 
     if (props.sortFunction) {
       initialTree.sort(props.sortFunction);
@@ -69,19 +70,19 @@ export function useVirtualizedTree<T extends TreeLike>(
   });
 
   useEffectAfterFirstRender(() => {
-    const newTree = VirtualizedTree.fromRoots(props.roots);
+    const newTree = VirtualizedTree.fromRoots(props.roots, props.skipFunction);
 
     if (props.sortFunction) {
       newTree.sort(props.sortFunction);
     }
 
     setTree(newTree);
-  }, [props.roots]);
+  }, [props.roots, props.skipFunction]);
 
   const [state, dispatch] = useReducer(VirtualizedTreeStateReducer, {
+    scrollTop: 0,
     roots: props.roots,
     overscroll: props.overscroll ?? DEFAULT_OVERSCROLL_ITEMS,
-    scrollTop: 0,
     scrollHeight: props.scrollContainerRef.current?.getBoundingClientRect()?.height ?? 0,
   });
 
@@ -112,6 +113,7 @@ export function useVirtualizedTree<T extends TreeLike>(
     // Points to the currently iterated item
     let indexPointer = 0;
 
+    // Max number of visible items in our list
     const MAX_VISIBLE_ITEMS = Math.ceil(
       (state.scrollHeight + OVERSCROLL_HEIGHT * 2) / props.rowHeight
     );
@@ -145,9 +147,13 @@ export function useVirtualizedTree<T extends TreeLike>(
   const scrollRafId = useRef<number | undefined>(undefined);
   const handleScroll = useCallback(element => {
     // use requestAnimationFrame to avoidoverupdating the UI.
+    if (scrollRafId.current) {
+      window.cancelAnimationFrame(scrollRafId.current);
+      scrollRafId.current = undefined;
+    }
+
     scrollRafId.current = window.requestAnimationFrame(() => {
       dispatch({type: 'set scroll top', payload: Math.max(element.target.scrollTop, 0)});
-      scrollRafId.current = undefined;
     });
   }, []);
 

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -69,8 +69,16 @@ export function useVirtualizedTree<T extends TreeLike>(
     return initialTree;
   });
 
+  const expandedHistory = useRef<Set<T>>(new Set());
   useEffectAfterFirstRender(() => {
-    const newTree = VirtualizedTree.fromRoots(props.roots, props.skipFunction);
+    const expandedNodes = tree.getAllExpandedNodes(expandedHistory.current);
+    const newTree = VirtualizedTree.fromRoots(
+      props.roots,
+      props.skipFunction,
+      expandedNodes
+    );
+
+    expandedHistory.current = expandedNodes;
 
     if (props.sortFunction) {
       newTree.sort(props.sortFunction);
@@ -172,7 +180,10 @@ export function useVirtualizedTree<T extends TreeLike>(
   const handleExpandTreeNode = useCallback(
     (node: VirtualizedTreeNode<T>, opts?: {expandChildren: boolean}) => {
       tree.expandNode(node, !node.expanded, opts);
-      setTree(new VirtualizedTree(tree.roots, tree.flattened));
+      const newTree = new VirtualizedTree(tree.roots, tree.flattened);
+      expandedHistory.current = newTree.getAllExpandedNodes(new Set());
+
+      setTree(newTree);
     },
     [tree]
   );

--- a/static/app/utils/profiling/profile/eventedProfile.tsx
+++ b/static/app/utils/profiling/profile/eventedProfile.tsx
@@ -120,8 +120,8 @@ export class EventedProfile extends Profile {
       while (start >= 0) {
         if (this.appendOrderStack[start].frame === node.frame) {
           // The recursion edge is bidirectional
-          this.appendOrderStack[start].setRecursive(node);
-          node.setRecursive(this.appendOrderStack[start]);
+          this.appendOrderStack[start].setRecursiveThroughNode(node);
+          node.setRecursiveThroughNode(this.appendOrderStack[start]);
           break;
         }
         start--;

--- a/static/app/utils/profiling/profile/jsSelfProfile.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.tsx
@@ -103,8 +103,8 @@ export class JSSelfProfile extends Profile {
       while (stackHeight >= 0) {
         if (framesInStack[stackHeight].frame === node.frame) {
           // The recursion edge is bidirectional
-          framesInStack[stackHeight].setRecursive(node);
-          node.setRecursive(framesInStack[stackHeight]);
+          framesInStack[stackHeight].setRecursiveThroughNode(node);
+          node.setRecursiveThroughNode(framesInStack[stackHeight]);
           break;
         }
         stackHeight--;

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -73,8 +73,8 @@ export class SampledProfile extends Profile {
       while (start >= 0) {
         if (framesInStack[start].frame === node.frame) {
           // The recursion edge is bidirectional
-          framesInStack[start].setRecursive(node);
-          node.setRecursive(framesInStack[start]);
+          framesInStack[start].setRecursiveThroughNode(node);
+          node.setRecursiveThroughNode(framesInStack[start]);
           break;
         }
         start--;

--- a/tests/js/spec/utils/profiling/colors/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/colors/utils.spec.tsx
@@ -139,8 +139,8 @@ describe('makeColorMap', () => {
     // Reverse order to ensure we actually sort
     const frames = [f(0, 'aaa'), f(1, 'aaa'), f(2, 'aaa'), f(3, 'c')];
 
-    frames[1].node.setRecursive(frames[0].node);
-    frames[2].node.setRecursive(frames[1].node);
+    frames[1].node.setRecursiveThroughNode(frames[0].node);
+    frames[2].node.setRecursiveThroughNode(frames[1].node);
 
     const map = makeColorMapByRecursion(frames, makeColorBucketTheme(LCH_LIGHT));
 

--- a/tests/js/spec/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.spec.tsx
+++ b/tests/js/spec/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.spec.tsx
@@ -24,6 +24,37 @@ function toFlattenedList(tree: VirtualizedTree<any>): VirtualizedTreeNode<any>[]
 }
 
 describe('VirtualizedTree', () => {
+  describe('fromRoots', () => {
+    it('build tree from roots', () => {
+      const root = n({id: 'root'});
+      const child1 = n({id: 'child1'});
+      root.children = [child1];
+
+      const tree = VirtualizedTree.fromRoots([root]);
+      tree.expandNode(tree.roots[0], true, {expandChildren: true});
+
+      expect(tree.flattened).toHaveLength(2);
+    });
+
+    it('skips certain nodes roots', () => {
+      const root = n({id: 'root'});
+      const child1 = n({id: 'child1'});
+      const child2 = n({id: 'child2'});
+
+      root.children = [child1];
+      child1.children = [child2];
+
+      const tree = VirtualizedTree.fromRoots([root], node => {
+        return node.node.id === 'child1';
+      });
+
+      tree.expandNode(tree.roots[0], true, {expandChildren: true});
+      expect(tree.flattened).toHaveLength(2);
+
+      expect(tree.flattened[1].depth).toBe(1);
+      expect(tree.flattened[1].node.id).toBe('child2');
+    });
+  });
   describe('expandNode', () => {
     it('expands a closed node', () => {
       const root = n({id: 'root'});


### PR DESCRIPTION
In hindsight, building a "static" tree may not have been the best idea, as it makes mutations difficult. For instance, we are currently assigning things like depth to the nodes as we reconstruct the tree, but as we add dynamic functionality like filtering, those get invalidated and it would have been better to have them assigned as we construct the visible part of the tree. The current approach favors collapsing and expanding the tree more than it does mutations like filtering (hence why I added that expanded history ref in the PR - we do not know if a node was previously expanded because it does not exist in our tree). 

Currently, this feels sub-par and we may be better off refactoring this in the future, but it works for now and I do not imagine we'll need to change this logic again soon, so 🚢.

I added the expanded history because previously, if you expanded a large part of the tree and collapsed recursion, all of the expanded node state would have been lost and I thought that was a very poor UX.

https://user-images.githubusercontent.com/9317857/171693925-b5f2ef41-8ddb-40f2-90d4-1e64e7f79034.mp4

