### PR TITLE
ref(utils): use more robust approach to handling paths

### DIFF
--- a/src/sentry/api/endpoints/project_create_sample.py
+++ b/src/sentry/api/endpoints/project_create_sample.py
@@ -1,7 +1,9 @@
+from django.core.exceptions import SuspiciousFileOperation
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
+from sentry.api.exceptions import SuspiciousClientOperation
 from sentry.api.serializers import serialize
 from sentry.models.groupinbox import GroupInboxReason, add_group_to_inbox
 from sentry.utils.samples import create_sample_event
@@ -13,11 +15,14 @@ class ProjectCreateSampleEndpoint(ProjectEndpoint):
     permission_classes = (ProjectEventPermission,)
 
     def post(self, request: Request, project) -> Response:
-        event = create_sample_event(
-            project, platform=project.platform, default="javascript", tagged=True
-        )
-        add_group_to_inbox(event.group, GroupInboxReason.NEW)
+        try:
+            event = create_sample_event(
+                project, platform=project.platform, default="javascript", tagged=True
+            )
+            add_group_to_inbox(event.group, GroupInboxReason.NEW)
 
-        data = serialize(event, request.user)
+            data = serialize(event, request.user)
 
-        return Response(data)
+            return Response(data)
+        except (SuspiciousFileOperation, IsADirectoryError):
+            raise SuspiciousClientOperation

--- a/src/sentry/api/endpoints/project_create_sample.py
+++ b/src/sentry/api/endpoints/project_create_sample.py
@@ -1,9 +1,9 @@
 from django.core.exceptions import SuspiciousFileOperation
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
-from sentry.api.exceptions import SuspiciousClientOperation
 from sentry.api.serializers import serialize
 from sentry.models.groupinbox import GroupInboxReason, add_group_to_inbox
 from sentry.utils.samples import create_sample_event
@@ -25,4 +25,4 @@ class ProjectCreateSampleEndpoint(ProjectEndpoint):
 
             return Response(data)
         except (SuspiciousFileOperation, IsADirectoryError):
-            raise SuspiciousClientOperation
+            return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/project_create_sample_transaction.py
+++ b/src/sentry/api/endpoints/project_create_sample_transaction.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from uuid import uuid4
 
 import pytz
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -70,7 +71,15 @@ class ProjectCreateSampleTransactionEndpoint(ProjectEndpoint):
 
     def post(self, request: Request, project) -> Response:
         samples_root = os.path.join(DATA_ROOT, "samples")
-        with open(os.path.join(samples_root, get_json_name(project))) as fp:
+
+        expected_commonpath = os.path.realpath(samples_root)
+        json_path = os.path.join(samples_root, get_json_name(project))
+        json_real_path = os.path.realpath(json_path)
+
+        if expected_commonpath != os.path.commonpath([expected_commonpath, json_real_path]):
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        with open(json_path) as fp:
             data = json.load(fp)
 
         data = fix_event_data(data)

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -126,11 +126,5 @@ class ConflictError(APIException):
     status_code = status.HTTP_409_CONFLICT
 
 
-class SuspiciousClientOperation(SentryAPIException):
-    status_code = status.HTTP_400_BAD_REQUEST
-    code = "suspicious-client-operation"
-    message = "A suspicious client request was denied"
-
-
 class InvalidRepository(Exception):
     pass

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -126,5 +126,11 @@ class ConflictError(APIException):
     status_code = status.HTTP_409_CONFLICT
 
 
+class SuspiciousClientOperation(SentryAPIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    code = "suspicious-client-operation"
+    message = "A suspicious client request was denied"
+
+
 class InvalidRepository(Exception):
     pass

--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -46,23 +46,34 @@ def echo(what):
 
 
 def dump_doc(path, data):
-    fn = os.path.join(DOC_FOLDER, path + ".json")
-    directory = os.path.dirname(fn)
+    expected_commonpath = os.path.realpath(DOC_FOLDER)
+    doc_path = os.path.join(DOC_FOLDER, f"{path}.json")
+    doc_real_path = os.path.realpath(doc_path)
+
+    if expected_commonpath != os.path.commonpath([expected_commonpath, doc_real_path]):
+        raise Exception("illegal path access")
+
+    directory = os.path.dirname(doc_path)
     try:
         os.makedirs(directory)
     except OSError:
         pass
-    with open(fn, "wt", encoding="utf-8") as f:
+    with open(doc_path, "wt", encoding="utf-8") as f:
         f.write(json.dumps(data, indent=2))
         f.write("\n")
 
 
 def load_doc(path):
-    if "/" in path:
-        return None
-    fn = os.path.join(DOC_FOLDER, path + ".json")
+
+    expected_commonpath = os.path.realpath(DOC_FOLDER)
+    doc_path = os.path.join(DOC_FOLDER, f"{path}.json")
+    doc_real_path = os.path.realpath(doc_path)
+
+    if expected_commonpath != os.path.commonpath([expected_commonpath, doc_real_path]):
+        raise Exception("illegal path access")
+
     try:
-        with open(fn, encoding="utf-8") as f:
+        with open(doc_path, encoding="utf-8") as f:
             return json.load(f)
     except OSError:
         return None

--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -21,6 +21,11 @@ DOC_FOLDER = os.environ.get("INTEGRATION_DOC_FOLDER") or os.path.abspath(
     os.path.join(os.path.dirname(sentry.__file__), "integration-docs")
 )
 
+
+class SuspiciousDocPathOperation(Exception):
+    """A suspicious operation was attempted while accessing the doc path"""
+
+
 """
 Looking to add a new framework/language to /settings/install?
 
@@ -51,7 +56,7 @@ def dump_doc(path, data):
     doc_real_path = os.path.realpath(doc_path)
 
     if expected_commonpath != os.path.commonpath([expected_commonpath, doc_real_path]):
-        raise Exception("illegal path access")
+        raise SuspiciousDocPathOperation("illegal path access")
 
     directory = os.path.dirname(doc_path)
     try:
@@ -70,7 +75,7 @@ def load_doc(path):
     doc_real_path = os.path.realpath(doc_path)
 
     if expected_commonpath != os.path.commonpath([expected_commonpath, doc_real_path]):
-        raise Exception("illegal path access")
+        raise SuspiciousDocPathOperation("illegal path access")
 
     try:
         with open(doc_path, encoding="utf-8") as f:

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -146,7 +146,7 @@ def load_data(
             raise SuspiciousFileOperation("potential path traversal attack detected")
 
         if not os.path.exists(json_path):
-            raise FileNotFoundError(f"platform sample not found {json_path}")
+            raise FileNotFoundError("platform sample not found")
 
         if not os.path.isfile(json_path):
             raise IsADirectoryError("expected file but found a directory instead")

--- a/tests/sentry/api/endpoints/test_project_create_sample.py
+++ b/tests/sentry/api/endpoints/test_project_create_sample.py
@@ -118,3 +118,17 @@ class ProjectCreateSampleTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert "groupID" in json.loads(response.content)
+
+    def test_attempted_path_traversal_returns_400(self):
+        project = self.create_project(teams=[self.team], name="foo", platform="../../../etc/passwd")
+
+        url = reverse(
+            "sentry-api-0-project-create-sample",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+
+        response = self.client.post(url, format="json")
+        assert response.status_code == 400, response.content
+
+        response_json = json.loads(response.content)
+        assert response_json["detail"]["code"] == "suspicious-client-operation", response_json

--- a/tests/sentry/api/endpoints/test_project_create_sample.py
+++ b/tests/sentry/api/endpoints/test_project_create_sample.py
@@ -128,7 +128,4 @@ class ProjectCreateSampleTest(APITestCase):
         )
 
         response = self.client.post(url, format="json")
-        assert response.status_code == 400, response.content
-
-        response_json = json.loads(response.content)
-        assert response_json["detail"]["code"] == "suspicious-client-operation", response_json
+        assert response.status_code == 400

--- a/tests/sentry/api/endpoints/test_project_create_sample_transaction.py
+++ b/tests/sentry/api/endpoints/test_project_create_sample_transaction.py
@@ -70,3 +70,18 @@ class ProjectCreateSampleTransactionTest(APITestCase):
 
         assert response.status_code == 200
         assert response.data["title"] == "/productstore"
+
+    def test_path_traversal_attempt(self):
+
+        project = self.create_project(teams=[self.team], name="foo", platform="../../../etc/passwd")
+
+        url = reverse(
+            "sentry-api-0-project-create-sample-transaction",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.post(url, format="json")
+
+        # Why a 200 and not something like a 400? The current implementation will default to a
+        # `react-transaction` if no matching platform is found.
+        assert response.status_code == 200
+        assert response.data["title"] == "/productstore"

--- a/tests/sentry/utils/test_integrationdocs.py
+++ b/tests/sentry/utils/test_integrationdocs.py
@@ -1,0 +1,39 @@
+import pytest
+
+from sentry.utils.integrationdocs import dump_doc, load_doc
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ("/"),
+        ("/.."),
+        ("//...."),
+        ("/%5c.."),
+        ("../"),
+        ("../../"),
+        ("../../../etc/passwd"),
+    ],
+)
+def test_path_traversal_attempt_on_load_doc_raises_exception(path):
+    with pytest.raises(Exception):
+        load_doc(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ("/"),
+        ("/.."),
+        ("//...."),
+        ("/%5c.."),
+        ("../"),
+        ("../../"),
+        ("../../../etc/passwd"),
+    ],
+)
+def test_path_traversal_attempt_on_dump_doc_raises_exception(path):
+    data = {"foo": "bar", "baz": 1234}
+
+    with pytest.raises(Exception):
+        dump_doc(path, data)

--- a/tests/sentry/utils/test_integrationdocs.py
+++ b/tests/sentry/utils/test_integrationdocs.py
@@ -1,39 +1,45 @@
 import pytest
 
-from sentry.utils.integrationdocs import dump_doc, load_doc
+from sentry.utils.integrationdocs import SuspiciousDocPathOperation, dump_doc, load_doc
 
 
 @pytest.mark.parametrize(
     "path",
     [
-        ("/"),
-        ("/.."),
-        ("//...."),
-        ("/%5c.."),
-        ("../"),
-        ("../../"),
-        ("../../../etc/passwd"),
+        "/",
+        "/..",
+        "//....",
+        "/%5c..",
+        "../",
+        "../../",
+        "../../../etc/passwd",
     ],
 )
 def test_path_traversal_attempt_on_load_doc_raises_exception(path):
-    with pytest.raises(Exception):
+    with pytest.raises(SuspiciousDocPathOperation) as excinfo:
         load_doc(path)
+
+    (msg,) = excinfo.value.args
+    assert msg == "illegal path access"
 
 
 @pytest.mark.parametrize(
     "path",
     [
-        ("/"),
-        ("/.."),
-        ("//...."),
-        ("/%5c.."),
-        ("../"),
-        ("../../"),
-        ("../../../etc/passwd"),
+        "/",
+        "/..",
+        "//....",
+        "/%5c..",
+        "../",
+        "../../",
+        "../../../etc/passwd",
     ],
 )
 def test_path_traversal_attempt_on_dump_doc_raises_exception(path):
     data = {"foo": "bar", "baz": 1234}
 
-    with pytest.raises(Exception):
+    with pytest.raises(SuspiciousDocPathOperation) as excinfo:
         dump_doc(path, data)
+
+    (msg,) = excinfo.value.args
+    assert msg == "illegal path access"

--- a/tests/sentry/utils/test_samples.py
+++ b/tests/sentry/utils/test_samples.py
@@ -24,14 +24,11 @@ def test_path_traversal_attempt_raises_exception(platform):
     assert msg == "potential path traversal attack detected"
 
 
-def test_missing_sample_raises_exception():
+def test_missing_sample_returns_none():
     platform = "random-platform-that-does-not-exist"
+    data = load_data(platform)
 
-    with pytest.raises(FileNotFoundError) as excinfo:
-        load_data(platform)
-
-    (msg,) = excinfo.value.args
-    assert msg == "platform sample not found"
+    assert data is None
 
 
 def test_sample_as_directory_raises_exception(monkeypatch, tmp_path):

--- a/tests/sentry/utils/test_samples.py
+++ b/tests/sentry/utils/test_samples.py
@@ -1,0 +1,41 @@
+import pytest
+from django.core.exceptions import SuspiciousFileOperation
+
+from sentry.utils.samples import load_data
+
+
+@pytest.mark.parametrize(
+    "platform",
+    [
+        ("/"),
+        ("/.."),
+        ("//...."),
+        ("/%5c.."),
+        ("../"),
+        ("../../"),
+        ("../../../etc/passwd"),
+    ],
+)
+def test_path_traversal_attempt_raises_exception(platform):
+    with pytest.raises(SuspiciousFileOperation):
+        load_data(platform)
+
+
+def test_missing_sample_raises_exception():
+    platform = "random-platform-that-does-not-exist"
+
+    with pytest.raises(FileNotFoundError):
+        load_data(platform)
+
+
+def test_sample_as_directory_raises_exception(monkeypatch, tmp_path):
+    # override DATA_ROOT to a tmp directory
+    monkeypatch.setattr("sentry.utils.samples.DATA_ROOT", tmp_path)
+
+    # create a directory ending with `.json`
+    samples_root = tmp_path / "samples" / "a_directory.json"
+    samples_root.mkdir(parents=True)
+
+    platform = "a_directory"
+    with pytest.raises(IsADirectoryError):
+        load_data(platform)


### PR DESCRIPTION
Refactors handling of paths in our `samples` and `integrationdocs` code to provide a more robust approach to defend against path traversal attacks.