### PR TITLE
feat(rules): suspect commits and issue owner support for flutter stack frames

### DIFF
--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -294,7 +294,7 @@ def get_event_file_committers(
 
 
 def get_serialized_event_file_committers(
-    project: Project, event: Event, frame_limit: int = 25
+    project: Project, event: Event, frame_limit: int = 25, sdk_name: str | None = None
 ) -> Sequence[AuthorCommitsSerialized]:
     event_frames = get_frame_paths(event)
     sdk_name = get_sdk_name(event.data)

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -294,7 +294,7 @@ def get_event_file_committers(
 
 
 def get_serialized_event_file_committers(
-    project: Project, event: Event, frame_limit: int = 25, sdk_name: str | None = None
+    project: Project, event: Event, frame_limit: int = 25
 ) -> Sequence[AuthorCommitsSerialized]:
     event_frames = get_frame_paths(event)
     sdk_name = get_sdk_name(event.data)

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import namedtuple
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import (
@@ -56,6 +57,12 @@ def cocoa_frame_munger(key: str, frame: MutableMapping[str, Any]) -> bool:
     return False
 
 
+def js_react_native_frame_munger(key: str, frame: MutableMapping[str, Any]) -> bool:
+    # intentionally left blank
+    # react-native doesn't need frame munging
+    return False
+
+
 def package_relative_path(abs_path: str, package: str) -> str | None:
     """
     returns the left-biased shortened path relative to the package directory
@@ -73,8 +80,11 @@ def package_relative_path(abs_path: str, package: str) -> str | None:
 
 
 PLATFORM_FRAME_MUNGER: Mapping[str, SdkFrameMunger] = {
-    "java": SdkFrameMunger(java_frame_munger),
-    "cocoa": SdkFrameMunger(cocoa_frame_munger),
+    "java": SdkFrameMunger(java_frame_munger, False, {}),
+    "cocoa": SdkFrameMunger(cocoa_frame_munger, False, {}),
+    "javascript": SdkFrameMunger(
+        js_react_native_frame_munger, True, {"sentry.javascript.react-native"}
+    ),
 }
 
 

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import namedtuple
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import (
@@ -57,12 +56,6 @@ def cocoa_frame_munger(key: str, frame: MutableMapping[str, Any]) -> bool:
     return False
 
 
-def js_react_native_frame_munger(key: str, frame: MutableMapping[str, Any]) -> bool:
-    # intentionally left blank
-    # react-native doesn't need frame munging
-    return False
-
-
 def package_relative_path(abs_path: str, package: str) -> str | None:
     """
     returns the left-biased shortened path relative to the package directory
@@ -80,11 +73,8 @@ def package_relative_path(abs_path: str, package: str) -> str | None:
 
 
 PLATFORM_FRAME_MUNGER: Mapping[str, SdkFrameMunger] = {
-    "java": SdkFrameMunger(java_frame_munger, False, {}),
-    "cocoa": SdkFrameMunger(cocoa_frame_munger, False, {}),
-    "javascript": SdkFrameMunger(
-        js_react_native_frame_munger, True, {"sentry.javascript.react-native"}
-    ),
+    "java": SdkFrameMunger(java_frame_munger),
+    "cocoa": SdkFrameMunger(cocoa_frame_munger),
 }
 
 

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -329,6 +329,75 @@ def test_matcher_test_platform_react_native():
     assert Matcher("path", "app:///src/screens/EndToEndTestsScreen.tsx").test(data)
 
 
+def test_matcher_test_platform_other_flutter():
+    data = {
+        "platform": "other",
+        "sdk": {"name": "sentry.dart.flutter"},
+        "exception": {
+            "values": [
+                {
+                    "type": "StateError",
+                    "value": "Bad state: try catch",
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "_dispatchPointerDataPacket",
+                                "filename": "hooks.dart",
+                                "abs_path": "dart:ui/hooks.dart",
+                                "lineno": 94,
+                                "colno": 31,
+                                "in_app": False,
+                            },
+                            {
+                                "function": "_InkResponseState._handleTap",
+                                "package": "flutter",
+                                "filename": "ink_well.dart",
+                                "abs_path": "package:flutter/src/material/ink_well.dart",
+                                "lineno": 1005,
+                                "colno": 21,
+                                "in_app": False,
+                            },
+                            {
+                                "function": "MainScaffold.build.<fn>",
+                                "package": "sentry_flutter_example",
+                                "filename": "main.dart",
+                                "abs_path": "package:sentry_flutter_example/main.dart",
+                                "lineno": 117,
+                                "colno": 32,
+                                "in_app": True,
+                            },
+                            {
+                                "function": "tryCatchModule",
+                                "package": "sentry_flutter_example",
+                                "filename": "test.dart",
+                                "abs_path": "package:sentry_flutter_example/a/b/test.dart",
+                                "lineno": 8,
+                                "colno": 5,
+                                "in_app": True,
+                            },
+                        ]
+                    },
+                }
+            ]
+        },
+    }
+
+    assert Matcher("path", "a/b/test.dart").test(data)
+    assert Matcher("path", "a/*/test.dart").test(data)
+    assert Matcher("path", "*/test.dart").test(data)
+    assert Matcher("path", "**/test.dart").test(data)
+    assert Matcher("path", "*.dart").test(data)
+    assert Matcher("codeowners", "a/b/test.dart").test(data)
+    assert Matcher("codeowners", "*.dart").test(data)
+    assert not Matcher("url", "*.dart").test(data)
+
+    # non in-app/user code still works here,
+    assert Matcher("path", "src/material/ink_well.dart").test(data)
+
+    # we search on filename and abs_path, if a user explicitly tests on the abs_path, we let them
+    assert Matcher("path", "package:sentry_flutter_example/a/b/test.dart").test(data)
+
+
 def test_matcher_test_platform_none_threads():
     data = {
         "threads": {

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -621,32 +621,6 @@ class GetEventFileCommitters(CommitTestCase):
                             "stacktrace": {
                                 "frames": [
                                     {
-                                        "function": "_dispatchPointerDataPacket",
-                                        "filename": "hooks.dart",
-                                        "abs_path": "dart:ui/hooks.dart",
-                                        "lineno": 94,
-                                        "colno": 31,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "_InkResponseState._handleTap",
-                                        "package": "flutter",
-                                        "filename": "ink_well.dart",
-                                        "abs_path": "package:flutter/src/material/ink_well.dart",
-                                        "lineno": 1005,
-                                        "colno": 21,
-                                        "in_app": False,
-                                    },
-                                    {
-                                        "function": "MainScaffold.build.<fn>",
-                                        "package": "sentry_flutter_example",
-                                        "filename": "main.dart",
-                                        "abs_path": "package:sentry_flutter_example/main.dart",
-                                        "lineno": 117,
-                                        "colno": 32,
-                                        "in_app": True,
-                                    },
-                                    {
                                         "function": "tryCatchModule",
                                         "package": "sentry_flutter_example",
                                         "filename": "test.dart",


### PR DESCRIPTION
This PR adds stack frame 'munging' support for flutter-based events.

The bulk of the logic looks at the frame data, particularly abs_path. The pathing looks to take two forms: `dart:ui/file.dart` or `package:<name-of-package>/path/to/file.dart`.

In the case of abs_path with `dart:` prefixed, we simply ignore it since these are likely sys libs and not user code.

In the case of `package:` prefixed abs_path, we match the `package:<name-of-package>` part and strip it out before writing this munged path to the frame.

Approach is documented in: https://www.notion.so/sentry/Tech-Spec-for-Mobile-Language-Stack-Transformation-5580956cfa404a90860c3e0cbf76e2c1#f2c40cd51b454e33a47868384774010d

Fixes WOR-1805
