### PR TITLE
fix(widget-builder): Add alert dialog for unsaved changes

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -405,11 +405,8 @@ function WidgetBuilder({
 
   useEffect(() => {
     const onUnload = () => {
-      const UNSAVED_MESSAGE = t(
-        'You have unsaved changes, are you sure you want to leave?'
-      );
       if (!isSubmitting && state.userHasModified) {
-        return UNSAVED_MESSAGE;
+        return t('You have unsaved changes, are you sure you want to leave?');
       }
       return undefined;
     };

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -887,7 +887,6 @@ function WidgetBuilder({
   }
 
   async function handleSave() {
-    setIsSubmitting(true);
     const widgetData: Widget = assignTempId(currentWidget);
 
     if (widgetToBeUpdated) {
@@ -922,6 +921,7 @@ function WidgetBuilder({
       });
     }
 
+    setIsSubmitting(true);
     if (notDashboardsOrigin) {
       submitFromSelectedDashboard(widgetData);
       return;

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1288,6 +1288,35 @@ describe('WidgetBuilder', function () {
       await screen.findByText('Limit to 2 results');
     });
 
+    it('alerts the user if there are unsaved changes', async function () {
+      const {router} = renderTestComponent();
+
+      const alertMock = jest.fn();
+      const setRouteLeaveHookMock = jest.spyOn(router, 'setRouteLeaveHook');
+      setRouteLeaveHookMock.mockImplementationOnce((_route, _callback) => {
+        alertMock();
+      });
+
+      const customWidgetLabels = await screen.findAllByText('Custom Widget');
+      // EditableText and chart title
+      expect(customWidgetLabels).toHaveLength(2);
+
+      // Change title text
+      userEvent.click(customWidgetLabels[0]);
+      userEvent.clear(screen.getByRole('textbox', {name: 'Widget title'}));
+      userEvent.paste(
+        screen.getByRole('textbox', {name: 'Widget title'}),
+        'Unique Users'
+      );
+      userEvent.keyboard('{enter}');
+
+      // Click Cancel
+      userEvent.click(screen.getByText('Cancel'));
+
+      // Assert an alert was triggered
+      expect(alertMock).toHaveBeenCalled();
+    });
+
     describe('Sort by selectors', function () {
       it('renders', async function () {
         renderTestComponent({

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1317,6 +1317,24 @@ describe('WidgetBuilder', function () {
       expect(alertMock).toHaveBeenCalled();
     });
 
+    it('does not trigger alert dialog if no changes', async function () {
+      const {router} = renderTestComponent();
+
+      const alertMock = jest.fn();
+      const setRouteLeaveHookMock = jest.spyOn(router, 'setRouteLeaveHook');
+      setRouteLeaveHookMock.mockImplementationOnce((_route, _callback) => {
+        alertMock();
+      });
+
+      await screen.findAllByText('Custom Widget');
+
+      // Click Cancel
+      userEvent.click(screen.getByText('Cancel'));
+
+      // Assert an alert was triggered
+      expect(alertMock).not.toHaveBeenCalled();
+    });
+
     describe('Sort by selectors', function () {
       it('renders', async function () {
         renderTestComponent({


### PR DESCRIPTION
We weren't triggering an alert for users if they had unsaved changes and were trying to navigate away. This adds a hook that brings up an alert when users leave the current route. I had to add state to track whether we're submitting because submissions (save or delete) also trigger redirects.