### PR TITLE
ref(menuListItem): Remove label truncation

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -229,7 +229,6 @@ const Label = styled('p')`
   margin-bottom: 0;
   line-height: 1.4;
   white-space: nowrap;
-  ${overflowEllipsis}
 `;
 
 const Details = styled('p')<{isDisabled: boolean; priority: Priority}>`


### PR DESCRIPTION
So far we haven't needed truncation on menu item labels (the "Actually Errors Only" & "Ecosystem!" text below). If at some point we want to limit label width, we can just directly pass a `Truncate` or styled element into the `label` prop.

<img width="338" alt="image" src="https://user-images.githubusercontent.com/44172267/171738678-f5e39862-4f6b-4d67-bc88-2a3831fc2ce0.png">
