### PR TITLE
fix(pageFilterRow): Prevent content from wrapping

### DIFF
--- a/static/app/components/organizations/pageFilterRow.tsx
+++ b/static/app/components/organizations/pageFilterRow.tsx
@@ -95,6 +95,7 @@ const Label = styled('div')<{multi: boolean}>`
   height: 100%;
   flex-grow: 1;
   user-select: none;
+  white-space: nowrap;
 
   &:hover {
     text-decoration: ${p => (p.multi ? 'underline' : null)};


### PR DESCRIPTION
When the text inside `PageFilterRow` is too long and there are dashes present (which is very much the case for the project and environment filters), the text will wrap. To fix this, we just need to add `white-space: nowrap` to the container.

**Before:**
<img width="269" alt="Screen Shot 2022-06-02 at 3 42 48 PM" src="https://user-images.githubusercontent.com/44172267/171750255-989f4ed9-53ef-438d-aed0-cf7b368d36ea.png">


**After:**
<img width="269" alt="Screen Shot 2022-06-02 at 3 42 28 PM" src="https://user-images.githubusercontent.com/44172267/171750274-94c9a96b-aacb-486e-b57a-bff5256ab13e.png">
