### PR TITLE
chore(js): Remove unnecessary 'async' in tests

### DIFF
--- a/tests/js/spec/actionCreators/committers.spec.jsx
+++ b/tests/js/spec/actionCreators/committers.spec.jsx
@@ -82,7 +82,7 @@ describe('CommitterActionCreator', function () {
     });
   });
 
-  it('short-circuits the JS event loop', async () => {
+  it('short-circuits the JS event loop', () => {
     expect(CommitterStore.state.committersLoading).toEqual(undefined);
 
     getCommitters(api, {

--- a/tests/js/spec/actionCreators/events.spec.jsx
+++ b/tests/js/spec/actionCreators/events.spec.jsx
@@ -68,7 +68,7 @@ describe('Events ActionCreator', function () {
     );
   });
 
-  it('requests events stats with absolute period', async function () {
+  it('requests events stats with absolute period', function () {
     const start = new Date('2017-10-12T12:00:00.000Z');
     const end = new Date('2017-10-17T00:00:00.000Z');
     doEventsRequest(api, {

--- a/tests/js/spec/actionCreators/release.spec.jsx
+++ b/tests/js/spec/actionCreators/release.spec.jsx
@@ -58,7 +58,7 @@ describe('ReleaseActionCreator', function () {
       expect(ReleaseStore.state.releaseError[releaseKey]).toEqual(undefined);
     });
 
-    it('short-circuits the JS event loop when fetching Release', async () => {
+    it('short-circuits the JS event loop when fetching Release', () => {
       expect(ReleaseStore.state.releaseLoading[releaseKey]).toEqual(undefined);
 
       getProjectRelease(api, {orgSlug, projectSlug, releaseVersion});
@@ -111,7 +111,7 @@ describe('ReleaseActionCreator', function () {
       expect(ReleaseStore.state.deploysError[releaseKey]).toEqual(undefined);
     });
 
-    it('short-circuits the JS event loop when fetching Deploys', async () => {
+    it('short-circuits the JS event loop when fetching Deploys', () => {
       expect(ReleaseStore.state.deploysLoading[releaseKey]).toEqual(undefined);
 
       getReleaseDeploys(api, {orgSlug, projectSlug, releaseVersion});

--- a/tests/js/spec/actionCreators/repositories.spec.jsx
+++ b/tests/js/spec/actionCreators/repositories.spec.jsx
@@ -54,7 +54,7 @@ describe('RepositoryActionCreator', function () {
     expect(RepositoryStore.state.repositoriesLoading).toEqual(false);
   });
 
-  it('short-circuits the JS event loop', async () => {
+  it('short-circuits the JS event loop', () => {
     expect(RepositoryStore.state.repositoriesLoading).toEqual(undefined);
 
     getRepositories(api, {orgSlug}); // Fire Action.loadRepositories

--- a/tests/js/spec/components/assigneeSelector.spec.jsx
+++ b/tests/js/spec/components/assigneeSelector.spec.jsx
@@ -112,7 +112,7 @@ describe('AssigneeSelector', function () {
   });
 
   describe('render with props', function () {
-    it('renders members from the prop when present', async function () {
+    it('renders members from the prop when present', function () {
       assigneeSelector = mountWithTheme(
         <AssigneeSelectorComponent id={GROUP_1.id} memberList={[USER_2, USER_3]} />
       );
@@ -159,7 +159,7 @@ describe('AssigneeSelector', function () {
     expect(assigneeSelector.find('LoadingIndicator')).toHaveLength(1);
   });
 
-  it('does not have loading state and shows member list after calling MemberListStore.loadInitialData', async function () {
+  it('does not have loading state and shows member list after calling MemberListStore.loadInitialData', function () {
     openMenu();
     MemberListStore.loadInitialData([USER_1, USER_2]);
     assigneeSelector.update();
@@ -274,7 +274,7 @@ describe('AssigneeSelector', function () {
     );
   });
 
-  it('shows invite member button', async function () {
+  it('shows invite member button', function () {
     jest.spyOn(ConfigStore, 'get').mockImplementation(() => true);
 
     openMenu();
@@ -360,7 +360,7 @@ describe('AssigneeSelector', function () {
     );
   });
 
-  it('renders unassigned', async function () {
+  it('renders unassigned', function () {
     jest.spyOn(GroupStore, 'get').mockImplementation(() => GROUP_2);
     assigneeSelector = mountWithTheme(<AssigneeSelectorComponent id={GROUP_2.id} />);
     const avatarTooltip = mountWithTheme(assigneeSelector.find('Tooltip').prop('title'));

--- a/tests/js/spec/components/assistant/guideAnchor.spec.jsx
+++ b/tests/js/spec/components/assistant/guideAnchor.spec.jsx
@@ -113,7 +113,7 @@ describe('GuideAnchor', function () {
     expect(screen.getByTestId('child-div')).toBeInTheDocument();
   });
 
-  it('renders children when disabled', async function () {
+  it('renders children when disabled', function () {
     render(
       <GuideAnchor disabled target="exception">
         <div data-test-id="child-div" />

--- a/tests/js/spec/components/charts/eventsRequest.spec.jsx
+++ b/tests/js/spec/components/charts/eventsRequest.spec.jsx
@@ -38,7 +38,7 @@ describe('EventsRequest', function () {
       wrapper = mountWithTheme(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
     });
 
-    it('makes requests', async function () {
+    it('makes requests', function () {
       expect(mock).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
@@ -574,7 +574,7 @@ describe('EventsRequest', function () {
       doEventsRequest.mockClear();
     });
 
-    it('does not make request', async function () {
+    it('does not make request', function () {
       wrapper = mountWithTheme(
         <EventsRequest {...DEFAULTS} expired>
           {mock}
@@ -583,7 +583,7 @@ describe('EventsRequest', function () {
       expect(doEventsRequest).not.toHaveBeenCalled();
     });
 
-    it('errors', async function () {
+    it('errors', function () {
       wrapper = mountWithTheme(
         <EventsRequest {...DEFAULTS} expired>
           {mock}

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -180,7 +180,7 @@ describe('CreateAlertFromViewButton', () => {
     expect(onCloseMock).toHaveBeenCalledTimes(1);
   });
 
-  it('disables the create alert button for members', async () => {
+  it('disables the create alert button for members', () => {
     const eventView = EventView.fromSavedQuery({
       ...DEFAULT_EVENT_VIEW,
     });
@@ -195,7 +195,7 @@ describe('CreateAlertFromViewButton', () => {
     expect(button.props()['aria-disabled']).toBe(true);
   });
 
-  it('shows a guide for members', async () => {
+  it('shows a guide for members', () => {
     const noAccessOrg = {
       ...organization,
       access: [],
@@ -209,7 +209,7 @@ describe('CreateAlertFromViewButton', () => {
     expect(guide.props().target).toBe('alerts_write_member');
   });
 
-  it('shows a guide for owners/admins', async () => {
+  it('shows a guide for owners/admins', () => {
     const adminAccessOrg = {
       ...organization,
       access: ['org:write'],
@@ -224,7 +224,7 @@ describe('CreateAlertFromViewButton', () => {
     expect(guide.props().onFinish).toBeDefined();
   });
 
-  it('redirects to alert wizard with no project', async () => {
+  it('redirects to alert wizard with no project', () => {
     jest.spyOn(navigation, 'navigateTo');
 
     const wrapper = generateWrappedComponentButton(organization);
@@ -235,7 +235,7 @@ describe('CreateAlertFromViewButton', () => {
     );
   });
 
-  it('redirects to alert wizard with a project', async () => {
+  it('redirects to alert wizard with a project', () => {
     const wrapper = generateWrappedComponentButton(organization, {
       projectSlug: 'proj-slug',
     });
@@ -245,7 +245,7 @@ describe('CreateAlertFromViewButton', () => {
     );
   });
 
-  it('removes a duplicate project filter', async () => {
+  it('removes a duplicate project filter', () => {
     const eventView = EventView.fromSavedQuery({
       ...DEFAULT_EVENT_VIEW,
       query: 'event.type:error project:project-slug',

--- a/tests/js/spec/components/events/eventVitals.spec.jsx
+++ b/tests/js/spec/components/events/eventVitals.spec.jsx
@@ -46,7 +46,7 @@ describe('EventVitals', function () {
     expect(wrapper.find('EventVital')).toHaveLength(7);
   });
 
-  it('should render some web vitals with a heading and a sdk warning', async function () {
+  it('should render some web vitals with a heading and a sdk warning', function () {
     const event = makeEvent({fp: 1}, {version: '5.26.0'});
     const wrapper = mountWithTheme(<EventVitals event={event} />);
     expect(wrapper.find('SectionHeading').text()).toEqual('Web Vitals');

--- a/tests/js/spec/components/events/interfaces/frame/stacktraceLink.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frame/stacktraceLink.spec.jsx
@@ -73,7 +73,7 @@ describe('StacktraceLink', function () {
     );
   });
 
-  it('renders source url link', async function () {
+  it('renders source url link', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       query: {file: frame.filename, commitId: 'master', platform},
@@ -92,7 +92,7 @@ describe('StacktraceLink', function () {
     expect(wrapper.find('OpenInName').text()).toEqual('GitHub');
   });
 
-  it('renders file_not_found message', async function () {
+  it('renders file_not_found message', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       query: {file: frame.filename, commitId: 'master', platform},
@@ -120,7 +120,7 @@ describe('StacktraceLink', function () {
     expect(wrapper.state('match').attemptedUrl).toEqual('https://something.io/blah');
   });
 
-  it('renders stack_root_mismatch message', async function () {
+  it('renders stack_root_mismatch message', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       query: {file: frame.filename, commitId: 'master', platform},
@@ -146,7 +146,7 @@ describe('StacktraceLink', function () {
     );
   });
 
-  it('renders default error message', async function () {
+  it('renders default error message', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       query: {file: frame.filename, commitId: 'master', platform},

--- a/tests/js/spec/components/events/interfaces/frame/stacktraceLinkModal.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frame/stacktraceLinkModal.spec.jsx
@@ -70,7 +70,7 @@ describe('StacktraceLinkModal', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('renders manual setup option', async function () {
+  it('renders manual setup option', function () {
     const wrapper = createWrapper();
     expect(wrapper.find('IntegrationName').text()).toEqual('Test Integration');
   });

--- a/tests/js/spec/components/events/interfaces/spans/traceView.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/traceView.spec.tsx
@@ -752,7 +752,7 @@ describe('TraceView', () => {
     expect(within(labelContainer!).getByText(/lcp/i)).toBeInTheDocument();
   });
 
-  it('should not merge web vitals labels if they are spaced away from each other', async () => {
+  it('should not merge web vitals labels if they are spaced away from each other', () => {
     const data = initializeData({});
 
     const event = generateSampleEvent();

--- a/tests/js/spec/components/forms/teamSelector.spec.jsx
+++ b/tests/js/spec/components/forms/teamSelector.spec.jsx
@@ -69,7 +69,7 @@ describe('Team Selector', function () {
     );
   });
 
-  it('respects the team filter', async function () {
+  it('respects the team filter', function () {
     const teamFilter = team => team.slug === 'team1';
     createWrapper({teamFilter});
 
@@ -82,7 +82,7 @@ describe('Team Selector', function () {
     expect(screen.queryByText('#team3')).not.toBeInTheDocument();
   });
 
-  it('respects the project filter', async function () {
+  it('respects the project filter', function () {
     createWrapper({project});
     userEvent.type(screen.getByText('Select...'), '{keyDown}');
 
@@ -92,7 +92,7 @@ describe('Team Selector', function () {
     expect(screen.getAllByRole('button').length).toBe(2);
   });
 
-  it('respects the team and project filter', async function () {
+  it('respects the team and project filter', function () {
     const teamFilter = team => team.slug === 'team1' || team.slug === 'team2';
     createWrapper({teamFilter, project});
     userEvent.type(screen.getByText('Select...'), '{keyDown}');
@@ -106,7 +106,7 @@ describe('Team Selector', function () {
     expect(screen.getAllByRole('button').length).toBe(1);
   });
 
-  it('allows you to add teams outside of project', async function () {
+  it('allows you to add teams outside of project', function () {
     createWrapper({project});
     userEvent.type(screen.getByText('Select...'), '{keyDown}');
 

--- a/tests/js/spec/components/integrationExternalMappingForm.spec.jsx
+++ b/tests/js/spec/components/integrationExternalMappingForm.spec.jsx
@@ -51,7 +51,7 @@ describe('IntegrationExternalMappingForm', function () {
   });
 
   // No mapping provided (e.g. Create a new mapping)
-  it('renders with no mapping provided as a form', async function () {
+  it('renders with no mapping provided as a form', function () {
     render(<IntegrationExternalMappingForm type="user" {...baseProps} />);
     expect(screen.getByPlaceholderText('@username')).toBeInTheDocument();
     expect(screen.getByText('Select Sentry User')).toBeInTheDocument();
@@ -97,7 +97,7 @@ describe('IntegrationExternalMappingForm', function () {
   });
 
   // Suggested mapping provided (e.g. Create new mapping from suggested external name)
-  it('renders with a suggested mapping provided as a form', async function () {
+  it('renders with a suggested mapping provided as a form', function () {
     render(
       <IntegrationExternalMappingForm
         type="team"
@@ -109,7 +109,7 @@ describe('IntegrationExternalMappingForm', function () {
     expect(screen.getByText('Select Sentry Team')).toBeInTheDocument();
     expect(screen.getByTestId('form-submit')).toBeInTheDocument();
   });
-  it('renders with a suggested mapping provided as an inline field', async function () {
+  it('renders with a suggested mapping provided as an inline field', function () {
     render(
       <IntegrationExternalMappingForm
         isInline

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -77,7 +77,7 @@ function mountModalWithRtl({initialData, onAddWidget, onUpdateWidget, widget, so
   );
 }
 
-async function clickSubmit(wrapper) {
+function clickSubmit(wrapper) {
   // Click on submit.
   const button = wrapper.find('Button[data-test-id="add-widget"] button');
   button.simulate('click');
@@ -1136,7 +1136,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     wrapper.unmount();
   });
 
-  it('renders the tab button bar from widget library', async function () {
+  it('renders the tab button bar from widget library', function () {
     const onAddLibraryWidgetMock = jest.fn();
     const wrapper = mountModal({
       initialData,

--- a/tests/js/spec/components/modals/dashboardWidgetLibraryModal.spec.jsx
+++ b/tests/js/spec/components/modals/dashboardWidgetLibraryModal.spec.jsx
@@ -48,7 +48,7 @@ describe('Modals -> DashboardWidgetLibraryModal', function () {
     }
   });
 
-  it('opens modal and renders correctly', async function () {
+  it('opens modal and renders correctly', function () {
     // Checking initial modal states
     container = mountModal({initialData});
 

--- a/tests/js/spec/components/modals/emailVerificationModal.spec.js
+++ b/tests/js/spec/components/modals/emailVerificationModal.spec.js
@@ -10,7 +10,7 @@ describe('Email Verification Modal', function () {
     );
   });
 
-  it('renders', async function () {
+  it('renders', function () {
     expect(wrapper.find('TextBlock').text()).toEqual(
       'Please verify your email before taking this action, or go to your email settings.'
     );
@@ -20,7 +20,7 @@ describe('Email Verification Modal', function () {
     expect(wrapper.find('EmailAddresses')).toHaveLength(1);
   });
 
-  it('renders with action param', async function () {
+  it('renders with action param', function () {
     wrapper = mountWithTheme(
       <EmailVerificationModal
         Body={p => p.children}

--- a/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
+++ b/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
@@ -39,7 +39,7 @@ describe('InviteMembersModal', function () {
     body: {roles},
   });
 
-  it('renders', async function () {
+  it('renders', function () {
     const wrapper = mountWithTheme(
       <InviteMembersModal {...modalProps} organization={org} />
     );
@@ -53,7 +53,7 @@ describe('InviteMembersModal', function () {
     expect(wrapper.find('RoleSelectControl SingleValue').text()).toBe('Member');
   });
 
-  it('renders without organization.access', async function () {
+  it('renders without organization.access', function () {
     const organization = TestStubs.Organization({access: undefined});
     const wrapper = mountWithTheme(
       <InviteMembersModal {...modalProps} organization={organization} />
@@ -62,7 +62,7 @@ describe('InviteMembersModal', function () {
     expect(wrapper.find('StyledInviteRow').exists()).toBe(true);
   });
 
-  it('can add a second row', async function () {
+  it('can add a second row', function () {
     const wrapper = mountWithTheme(
       <InviteMembersModal {...modalProps} organization={org} />
     );
@@ -72,7 +72,7 @@ describe('InviteMembersModal', function () {
     expect(wrapper.find('StyledInviteRow')).toHaveLength(2);
   });
 
-  it('errors on duplicate emails', async function () {
+  it('errors on duplicate emails', function () {
     const wrapper = mountWithTheme(
       <InviteMembersModal {...modalProps} organization={org} />
     );

--- a/tests/js/spec/components/modals/recoveryOptionsModal.spec.jsx
+++ b/tests/js/spec/components/modals/recoveryOptionsModal.spec.jsx
@@ -28,7 +28,7 @@ describe('RecoveryOptionsModal', function () {
 
   afterEach(function () {});
 
-  it('can redirect to recovery codes if user skips backup phone setup', async function () {
+  it('can redirect to recovery codes if user skips backup phone setup', function () {
     const getRecoveryCodes = 'RecoveryOptionsModal Button[name="getCodes"]';
     expect(wrapper.find(getRecoveryCodes)).toHaveLength(0);
 
@@ -45,7 +45,7 @@ describe('RecoveryOptionsModal', function () {
     expect(closeModal).toHaveBeenCalled();
   });
 
-  it('can redirect to backup phone setup', async function () {
+  it('can redirect to backup phone setup', function () {
     const backupPhone = 'RecoveryOptionsModal Button[name="addPhone"]';
 
     expect(wrapper.find(backupPhone)).toHaveLength(1);
@@ -57,7 +57,7 @@ describe('RecoveryOptionsModal', function () {
     expect(closeModal).toHaveBeenCalled();
   });
 
-  it('skips backup phone setup if text message authenticator unavailable', async function () {
+  it('skips backup phone setup if text message authenticator unavailable', function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/users/me/authenticators/',

--- a/tests/js/spec/components/multiPlatformPicker.spec.jsx
+++ b/tests/js/spec/components/multiPlatformPicker.spec.jsx
@@ -13,7 +13,7 @@ describe('MultiPlatformPicker', function () {
     expect(screen.getByText('Android')).toBeInTheDocument();
     expect(screen.queryByText('Electron')).not.toBeInTheDocument();
   });
-  it('should render renderPlatformList with Python when filtered with py', async function () {
+  it('should render renderPlatformList with Python when filtered with py', function () {
     const props = {
       ...baseProps,
     };

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -989,7 +989,7 @@ describe('GlobalSelectionHeader', function () {
         initialData.router.replace.mockClear();
       });
 
-      it('appends projectId to URL when mounted with `forceProject`', async function () {
+      it('appends projectId to URL when mounted with `forceProject`', function () {
         // forceProject generally starts undefined
         createWrapper({
           shouldForceProject: true,
@@ -1052,7 +1052,7 @@ describe('GlobalSelectionHeader', function () {
         expect(initialData.router.replace).not.toHaveBeenCalled();
       });
 
-      it('does not append projectId to URL when `loadingProjects` changes and finishes loading', async function () {
+      it('does not append projectId to URL when `loadingProjects` changes and finishes loading', function () {
         ProjectsStore.reset();
 
         createWrapper();
@@ -1067,7 +1067,7 @@ describe('GlobalSelectionHeader', function () {
         expect(initialData.router.replace).not.toHaveBeenCalled();
       });
 
-      it('appends projectId to URL when `forceProject` becomes available (async)', async function () {
+      it('appends projectId to URL when `forceProject` becomes available (async)', function () {
         ProjectsStore.reset();
 
         // forceProject generally starts undefined

--- a/tests/js/spec/components/organizations/projectSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/projectSelector.spec.jsx
@@ -99,7 +99,7 @@ describe('ProjectSelector', function () {
     expect(screen.getByText(anotherProject.slug)).toBeInTheDocument();
   });
 
-  it('can filter projects by project name', async function () {
+  it('can filter projects by project name', function () {
     render(<ProjectSelector {...props} />, {context: routerContext});
     openMenu();
 
@@ -122,7 +122,7 @@ describe('ProjectSelector', function () {
     expect(screen.getByText('No projects found')).toBeInTheDocument();
   });
 
-  it('does not close dropdown when input is clicked', async function () {
+  it('does not close dropdown when input is clicked', function () {
     render(<ProjectSelector {...props} />, {context: routerContext});
     openMenu();
 

--- a/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
@@ -238,7 +238,7 @@ describe('TimeRangeSelector', function () {
     });
   });
 
-  it('maintains time when switching UTC to local time', async function () {
+  it('maintains time when switching UTC to local time', function () {
     // Times should never change when changing UTC option
     // Instead, the utc flagged is used when querying to create proper date
 

--- a/tests/js/spec/components/projects/bookmarkStar.spec.tsx
+++ b/tests/js/spec/components/projects/bookmarkStar.spec.tsx
@@ -28,7 +28,7 @@ describe('BookmarkStar', function () {
     expect(container).toSnapshot();
   });
 
-  it('can star', async function () {
+  it('can star', function () {
     render(
       <BookmarkStar
         organization={TestStubs.Organization()}
@@ -45,7 +45,7 @@ describe('BookmarkStar', function () {
     );
   });
 
-  it('can unstar', async function () {
+  it('can unstar', function () {
     render(
       <BookmarkStar
         organization={TestStubs.Organization()}

--- a/tests/js/spec/components/repositoryRow.spec.jsx
+++ b/tests/js/spec/components/repositoryRow.spec.jsx
@@ -154,7 +154,7 @@ describe('RepositoryRow', function () {
     });
     const routerContext = TestStubs.routerContext([{organization}]);
 
-    it('sends api request to cancel', async function () {
+    it('sends api request to cancel', function () {
       const cancel = Client.addMockResponse({
         url: `/organizations/${organization.slug}/repos/${pendingRepo.id}/`,
         method: 'PUT',

--- a/tests/js/spec/components/sidebar/sidebarDrodown/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/sidebarDrodown/index.spec.jsx
@@ -34,13 +34,13 @@ describe('SidebarDropdown', function () {
     const {container} = renderDropdown({hideOrgLinks: true});
     expect(container).toSnapshot();
   });
-  it('renders open sidebar', async function () {
+  it('renders open sidebar', function () {
     const config = {...ConfigStore.get('config'), singleOrganization: false};
     renderDropdown({collapsed: false, config});
     userEvent.click(screen.getByTestId('sidebar-dropdown'));
     expect(screen.getByText('Switch organization')).toBeInTheDocument();
   });
-  it('sandbox/demo mode render open sidebar', async function () {
+  it('sandbox/demo mode render open sidebar', function () {
     ConfigStore.set('demoMode', true);
     const config = {...ConfigStore.get('config'), singleOrganization: false};
     renderDropdown({collapsed: false, config});

--- a/tests/js/spec/components/sidebar/switchOrganization.spec.tsx
+++ b/tests/js/spec/components/sidebar/switchOrganization.spec.tsx
@@ -3,7 +3,7 @@ import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {SwitchOrganization} from 'sentry/components/sidebar/sidebarDropdown/switchOrganization';
 
 describe('SwitchOrganization', function () {
-  it('can list organizations', async function () {
+  it('can list organizations', function () {
     jest.useFakeTimers();
     render(
       <SwitchOrganization

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -687,7 +687,7 @@ describe('SmartSearchBar', function () {
       expect(searchBar.state.activeSearchItem).toEqual(-1);
     });
 
-    it('shows errors on incorrect tokens', async function () {
+    it('shows errors on incorrect tokens', function () {
       const props = {
         query: 'tag: is: has: ',
         organization,

--- a/tests/js/spec/components/tooltip.spec.tsx
+++ b/tests/js/spec/components/tooltip.spec.tsx
@@ -87,7 +87,7 @@ describe('Tooltip', function () {
     userEvent.unhover(screen.getByText('My Button'));
   });
 
-  it('displays a tooltip if the content overflows with showOnlyOnOverflow', async function () {
+  it('displays a tooltip if the content overflows with showOnlyOnOverflow', function () {
     // Mock this to return true because scrollWidth and clientWidth are 0 in JSDOM
     mockOverflow(100, 50);
 

--- a/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
+++ b/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
@@ -35,7 +35,7 @@ describe('OrganizationEnvironmentsStore', function () {
     ]);
   });
 
-  it('has the correct loading state', async function () {
+  it('has the correct loading state', function () {
     OrganizationEnvironmentsStore.onFetchEnvironments();
 
     const {environments, error} = OrganizationEnvironmentsStore.getState();
@@ -44,7 +44,7 @@ describe('OrganizationEnvironmentsStore', function () {
     expect(error).toBeNull();
   });
 
-  it('has the correct error state', async function () {
+  it('has the correct error state', function () {
     OrganizationEnvironmentsStore.onFetchEnvironmentsError(Error('bad'));
 
     const {environments, error} = OrganizationEnvironmentsStore.getState();

--- a/tests/js/spec/stores/persistedStore.spec.tsx
+++ b/tests/js/spec/stores/persistedStore.spec.tsx
@@ -116,7 +116,7 @@ describe('PersistedStore', function () {
     expect(state2).toBe(DefaultLoadedPersistedStore.onboarding);
   });
 
-  it('returns default when state fails to load', async function () {
+  it('returns default when state fails to load', function () {
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/client-state/`,
       statusCode: 500,

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -254,7 +254,7 @@ describe('getFieldRenderer', function () {
     expect(value.text()).toEqual(project.slug);
   });
 
-  it('can render team key transaction as a star with the dropdown', async function () {
+  it('can render team key transaction as a star with the dropdown', function () {
     const renderer = getFieldRenderer('team_key_transaction', {
       team_key_transaction: 'boolean',
     });
@@ -271,7 +271,7 @@ describe('getFieldRenderer', function () {
     expect(wrapper.find('TeamKeyTransaction')).toHaveLength(1);
   });
 
-  it('can render team key transaction as a star without the dropdown', async function () {
+  it('can render team key transaction as a star without the dropdown', function () {
     const renderer = getFieldRenderer('team_key_transaction', {
       team_key_transaction: 'boolean',
     });
@@ -294,7 +294,7 @@ describe('getFieldRenderer', function () {
     const getWidth = (wrapper, index) =>
       wrapper.children().children().at(index).getDOMNode().style.width;
 
-    it('can render operation breakdowns', async function () {
+    it('can render operation breakdowns', function () {
       const renderer = getFieldRenderer(SPAN_OP_RELATIVE_BREAKDOWN_FIELD, {
         [SPAN_OP_RELATIVE_BREAKDOWN_FIELD]: 'string',
       });
@@ -312,7 +312,7 @@ describe('getFieldRenderer', function () {
       expect(getWidth(value, 3)).toEqual('26.667%');
     });
 
-    it('renders operation breakdowns in sorted order when a sort field is provided', async function () {
+    it('renders operation breakdowns in sorted order when a sort field is provided', function () {
       const renderer = getFieldRenderer(SPAN_OP_RELATIVE_BREAKDOWN_FIELD, {
         [SPAN_OP_RELATIVE_BREAKDOWN_FIELD]: 'string',
       });

--- a/tests/js/spec/utils/locale.spec.jsx
+++ b/tests/js/spec/utils/locale.spec.jsx
@@ -3,7 +3,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {tct} from 'sentry/locale';
 
 describe('locale.gettextComponentTemplate', () => {
-  it('should render two component templates inside the same parent', async () => {
+  it('should render two component templates inside the same parent', () => {
     render(
       <div data-test-id="subject">
         {tct('1st: [one]', {

--- a/tests/js/spec/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.spec.tsx
+++ b/tests/js/spec/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.spec.tsx
@@ -147,7 +147,7 @@ describe('useVirtualizedTree', () => {
     expect(result.current.items.length).toBe(10);
   });
 
-  it('shows overscroll items', async () => {
+  it('shows overscroll items', () => {
     const mockScrollContainer = {
       getBoundingClientRect: () => {
         return {height: 100};
@@ -179,7 +179,7 @@ describe('useVirtualizedTree', () => {
     expect(result.current.items.length).toBe(14);
   });
 
-  it('items have a stable key', async () => {
+  it('items have a stable key', () => {
     const mockScrollContainer = {
       getBoundingClientRect: () => {
         return {height: 100};

--- a/tests/js/spec/utils/projects.spec.jsx
+++ b/tests/js/spec/utils/projects.spec.jsx
@@ -27,7 +27,7 @@ describe('utils.projects', function () {
   });
 
   describe('with predefined list of slugs', function () {
-    it('gets projects that are in the ProjectsStore', async function () {
+    it('gets projects that are in the ProjectsStore', function () {
       createWrapper({slugs: ['foo', 'bar']});
 
       // This is initial state
@@ -236,7 +236,7 @@ describe('utils.projects', function () {
   });
 
   describe('with predefined list of project ids', function () {
-    it('gets project ids that are in the ProjectsStore', async function () {
+    it('gets project ids that are in the ProjectsStore', function () {
       createWrapper({projectIds: [1, 2]});
 
       // This is initial state
@@ -560,7 +560,7 @@ describe('utils.projects', function () {
     let mockProjects;
     let request;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       mockProjects = [
         TestStubs.Project({
           id: '100',

--- a/tests/js/spec/utils/teams.spec.jsx
+++ b/tests/js/spec/utils/teams.spec.jsx
@@ -16,7 +16,7 @@ describe('utils.teams', function () {
     renderer.mockClear();
   });
 
-  afterEach(async function () {
+  afterEach(function () {
     act(() => void TeamStore.loadInitialData([]));
   });
 

--- a/tests/js/spec/utils/withTags.spec.jsx
+++ b/tests/js/spec/utils/withTags.spec.jsx
@@ -8,7 +8,7 @@ describe('withTags HoC', function () {
     TagStore.reset();
   });
 
-  it('works', async function () {
+  it('works', function () {
     const MyComponent = ({other, tags}) => {
       return (
         <div>

--- a/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
+++ b/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
@@ -180,7 +180,7 @@ describe('AcceptOrganizationInvite', function () {
     window.location.replace = replace;
   });
 
-  it('shows right options for logged in user and optional SSO', async function () {
+  it('shows right options for logged in user and optional SSO', function () {
     addMock({
       orgSlug: 'test-org',
       needsAuthentication: false,

--- a/tests/js/spec/views/alerts/issueRules/ticketRuleModal.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRules/ticketRuleModal.spec.jsx
@@ -124,7 +124,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
   };
 
   describe('Create Rule', function () {
-    it('should render the Ticket Rule modal', async function () {
+    it('should render the Ticket Rule modal', function () {
       const wrapper = createWrapper();
       expect(wrapper.find('Button[data-test-id="form-submit"]').text()).toEqual(
         'Apply Changes'
@@ -135,19 +135,19 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       expect(formFields.at(1).text()).toEqual('Description');
     });
 
-    it('should save the modal data when "Apply Changes" is clicked with valid data', async function () {
+    it('should save the modal data when "Apply Changes" is clicked with valid data', function () {
       const wrapper = createWrapper();
       selectByValue(wrapper, 'a', {name: 'reporter'});
       submitSuccess(wrapper);
     });
 
-    it('should raise validation errors when "Apply Changes" is clicked with invalid data', async function () {
+    it('should raise validation errors when "Apply Changes" is clicked with invalid data', function () {
       // This doesn't test anything TicketRules specific but I'm leaving it here as an example.
       const wrapper = createWrapper();
       submitErrors(wrapper, 1);
     });
 
-    it('should reload fields when an "updatesForm" field changes', async function () {
+    it('should reload fields when an "updatesForm" field changes', function () {
       const wrapper = createWrapper();
       selectByValue(wrapper, 'a', {name: 'reporter'});
 
@@ -165,7 +165,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       submitSuccess(wrapper);
     });
 
-    it('should persist values when the modal is reopened', async function () {
+    it('should persist values when the modal is reopened', function () {
       const wrapper = createWrapper({data: {reporter: 'a'}});
       submitSuccess(wrapper);
     });

--- a/tests/js/spec/views/alerts/metricRules/details.spec.jsx
+++ b/tests/js/spec/views/alerts/metricRules/details.spec.jsx
@@ -53,7 +53,7 @@ describe('Incident Rules Details', function () {
     });
   });
 
-  it('renders and edits trigger', async function () {
+  it('renders and edits trigger', function () {
     const {organization, project} = initializeOrg();
     const rule = TestStubs.MetricRule();
     const onChangeTitleMock = jest.fn();

--- a/tests/js/spec/views/alerts/metricRules/duplicate.spec.tsx
+++ b/tests/js/spec/views/alerts/metricRules/duplicate.spec.tsx
@@ -46,7 +46,7 @@ describe('Incident Rules Duplicate', function () {
     });
   });
 
-  it('renders new alert form with values copied over', async function () {
+  it('renders new alert form with values copied over', function () {
     const rule = TestStubs.MetricRule();
     rule.triggers.push({
       label: AlertRuleTriggerType.WARNING,

--- a/tests/js/spec/views/alerts/metricRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/alerts/metricRules/ruleForm.spec.jsx
@@ -258,7 +258,7 @@ describe('Incident Rules Form', () => {
       );
     });
 
-    it('pending status keeps loading true', async () => {
+    it('pending status keeps loading true', () => {
       const alertRule = TestStubs.MetricRule({name: 'Slack Alert Rule'});
       MockApiClient.addMockResponse({
         url: `/projects/org-slug/project-slug/alert-rules/${alertRule.id}/`,

--- a/tests/js/spec/views/app.spec.jsx
+++ b/tests/js/spec/views/app.spec.jsx
@@ -28,7 +28,7 @@ describe('App', function () {
     });
   });
 
-  it('renders', async function () {
+  it('renders', function () {
     render(
       <App params={{orgId: 'org-slug'}}>
         <div>placeholder content</div>

--- a/tests/js/spec/views/dashboardsV2/releaseWidgetQueries.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/releaseWidgetQueries.spec.tsx
@@ -176,7 +176,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     );
   });
 
-  it('calls session api when session.status is a group by', async function () {
+  it('calls session api when session.status is a group by', function () {
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sessions/',
       body: TestStubs.MetricsField({

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -276,7 +276,7 @@ describe('WidgetBuilder', function () {
       ).toBeInTheDocument();
     });
 
-    it('renders a widget not found message if the widget index url is not an integer', async function () {
+    it('renders a widget not found message if the widget index url is not an integer', function () {
       const widget: Widget = {
         displayType: DisplayType.AREA,
         interval: '1d',

--- a/tests/js/spec/views/eventsV2/chartFooter.spec.tsx
+++ b/tests/js/spec/views/eventsV2/chartFooter.spec.tsx
@@ -92,7 +92,7 @@ describe('EventsV2 > ChartFooter', function () {
     expect(optionSelector.props().selected).toEqual('5');
   });
 
-  it('renders single value y-axis dropdown selector on a Top display', async function () {
+  it('renders single value y-axis dropdown selector on a Top display', function () {
     const organization = TestStubs.Organization({
       features,
     });
@@ -118,7 +118,7 @@ describe('EventsV2 > ChartFooter', function () {
     expect(yAxis).toEqual(['failure_count()']);
   });
 
-  it('renders multi value y-axis dropdown selector on a non-Top display', async function () {
+  it('renders multi value y-axis dropdown selector on a non-Top display', function () {
     const organization = TestStubs.Organization({
       features,
     });

--- a/tests/js/spec/views/eventsV2/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/index.spec.jsx
@@ -96,7 +96,7 @@ describe('EventsV2 > Landing', function () {
     expect(content.text()).toContain("You don't have access to this feature");
   });
 
-  it('has the right sorts', async function () {
+  it('has the right sorts', function () {
     const org = TestStubs.Organization({features});
 
     const wrapper = mountWithTheme(

--- a/tests/js/spec/views/eventsV2/queryList.spec.jsx
+++ b/tests/js/spec/views/eventsV2/queryList.spec.jsx
@@ -139,7 +139,7 @@ describe('EventsV2 > QueryList', function () {
     expect(queryChangeMock).toHaveBeenCalled();
   });
 
-  it('returns short url location for saved query', async function () {
+  it('returns short url location for saved query', function () {
     const wrapper = mountWithTheme(
       <QueryList
         organization={organization}

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.tsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.tsx
@@ -627,7 +627,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
       MockApiClient.clearMockResponses();
     });
 
-    it('opens widget modal when add to dashboard is clicked', async () => {
+    it('opens widget modal when add to dashboard is clicked', () => {
       mount(
         initialData.router.location,
         initialData.organization,
@@ -654,7 +654,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
       );
     });
 
-    it('populates dashboard widget modal with saved query data if created from discover', async () => {
+    it('populates dashboard widget modal with saved query data if created from discover', () => {
       mount(
         initialData.router.location,
         initialData.organization,
@@ -681,7 +681,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
       );
     });
 
-    it('adds equation to query fields if yAxis includes comprising functions', async () => {
+    it('adds equation to query fields if yAxis includes comprising functions', () => {
       mount(
         initialData.router.location,
         initialData.organization,

--- a/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
@@ -114,7 +114,7 @@ describe('TableView > CellActions', function () {
     ProjectsStore.reset();
   });
 
-  it('updates sort order on equation fields', async function () {
+  it('updates sort order on equation fields', function () {
     const view = eventView.clone();
     const wrapper = makeWrapper(initialData, rows, view);
     const equationSort = wrapper.find('SortLink').last();
@@ -125,7 +125,7 @@ describe('TableView > CellActions', function () {
     );
   });
 
-  it('updates sort order on non-equation fields', async function () {
+  it('updates sort order on non-equation fields', function () {
     const view = eventView.clone();
     const wrapper = makeWrapper(initialData, rows, view);
     const equationSort = wrapper.find('SortLink').at(1);

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -54,7 +54,7 @@ describe('IssueListActions', function () {
         wrapper.unmount();
       });
 
-      it('after checking "Select all" checkbox, displays bulk select message', async function () {
+      it('after checking "Select all" checkbox, displays bulk select message', function () {
         wrapper.find('ActionsCheckbox Checkbox').simulate('change');
         expect(wrapper.find('SelectAllNotice')).toSnapshot();
       });
@@ -122,7 +122,7 @@ describe('IssueListActions', function () {
         wrapper.unmount();
       });
 
-      it('after checking "Select all" checkbox, displays bulk select message', async function () {
+      it('after checking "Select all" checkbox, displays bulk select message', function () {
         wrapper.find('ActionsCheckbox Checkbox').simulate('change');
         expect(wrapper.find('SelectAllNotice')).toSnapshot();
       });
@@ -374,7 +374,7 @@ describe('IssueListActions', function () {
 
   describe('mark reviewed', function () {
     let issuesApiMock;
-    beforeEach(async () => {
+    beforeEach(() => {
       SelectedGroupStore.records = {};
       const organization = TestStubs.Organization();
 

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -1291,7 +1291,7 @@ describe('IssueList', function () {
       }
     });
 
-    it('uses correct statsPeriod when fetching issues list and no datetime given', async function () {
+    it('uses correct statsPeriod when fetching issues list and no datetime given', function () {
       const selection = {projects: [99], environments: [], datetime: {}};
       wrapper.setProps({selection, foo: 'bar'});
 
@@ -1352,7 +1352,7 @@ describe('IssueList', function () {
       wrapper = mountWithThemeAndOrg(<IssueListOverview {...props} />);
     });
 
-    it('fetches and displays processing issues', async function () {
+    it('fetches and displays processing issues', function () {
       const instance = wrapper.instance();
       instance.componentDidMount();
       wrapper.update();

--- a/tests/js/spec/views/onboarding/components/firstEventIndicator.spec.jsx
+++ b/tests/js/spec/views/onboarding/components/firstEventIndicator.spec.jsx
@@ -3,7 +3,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {Indicator} from 'sentry/views/onboarding/components/firstEventIndicator';
 
 describe('FirstEventIndicator', function () {
-  it('renders waiting status', async function () {
+  it('renders waiting status', function () {
     const org = TestStubs.Organization();
 
     const wrapper = mountWithTheme(<Indicator organization={org} firstIssue={null} />);
@@ -22,7 +22,7 @@ describe('FirstEventIndicator', function () {
       expect(wrapper.find('ReceivedIndicator').exists()).toBe(true);
     });
 
-    it('renders without a known issue ID', async function () {
+    it('renders without a known issue ID', function () {
       const org = TestStubs.Organization();
       const project = TestStubs.ProjectDetails({});
 

--- a/tests/js/spec/views/organizationContextContainer.spec.jsx
+++ b/tests/js/spec/views/organizationContextContainer.spec.jsx
@@ -61,7 +61,7 @@ describe('OrganizationContextContainer', function () {
     jest.spyOn(OrganizationActionCreator, 'fetchOrganizationDetails');
   });
 
-  afterEach(async function () {
+  afterEach(function () {
     wrapper.unmount();
     OrganizationStore.reset();
 

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -36,7 +36,7 @@ describe('OrganizationDetails', function () {
     });
   });
 
-  it('can fetch projects and teams', async function () {
+  it('can fetch projects and teams', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/',
       body: TestStubs.Organization({

--- a/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.tsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.tsx
@@ -39,7 +39,7 @@ describe('groupEventDetailsContainer', () => {
     OrganizationEnvironmentsStore.teardown();
   });
 
-  it('fetches environments', async function () {
+  it('fetches environments', function () {
     const environmentsCall = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/environments/`,
       body: TestStubs.Environments(),

--- a/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -88,7 +88,7 @@ describe('IntegrationCodeMappings', function () {
     ModalStore.teardown();
   });
 
-  it('shows the paths', async () => {
+  it('shows the paths', () => {
     expect(wrapper.find('RepoName').length).toEqual(2);
     expect(wrapper.find('RepoName').at(0).text()).toEqual(repos[0].name);
     expect(wrapper.find('RepoName').at(1).text()).toEqual(repos[1].name);

--- a/tests/js/spec/views/organizationIntegrations/integrationDetailedView.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationDetailedView.spec.jsx
@@ -93,7 +93,7 @@ describe('IntegrationDetailedView', function () {
     expect(screen.getByRole('button', {name: 'Add integration'})).toBeEnabled();
   });
 
-  it('view configurations', async function () {
+  it('view configurations', function () {
     render(
       <IntegrationDetailedView
         params={{integrationSlug: 'bitbucket', orgId: org.slug}}

--- a/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -46,7 +46,7 @@ describe('IntegrationListDirectory', function () {
       );
     });
 
-    it('shows installed integrations at the top in order of weight', async function () {
+    it('shows installed integrations at the top in order of weight', function () {
       expect(wrapper.find('SearchBar').exists()).toBeTruthy();
       expect(wrapper.find('PanelBody').exists()).toBeTruthy();
       expect(wrapper.find('IntegrationRow')).toHaveLength(7);
@@ -64,13 +64,13 @@ describe('IntegrationListDirectory', function () {
       );
     });
 
-    it('does not show legacy plugin that has a First Party Integration if not installed', async function () {
+    it('does not show legacy plugin that has a First Party Integration if not installed', function () {
       wrapper.find('IntegrationRow').forEach(node => {
         expect(node.props().displayName).not.toEqual('Github (Legacy)');
       });
     });
 
-    it('shows legacy plugin that has a First Party Integration if installed', async function () {
+    it('shows legacy plugin that has a First Party Integration if installed', function () {
       const legacyPluginRow = wrapper
         .find('IntegrationRow')
         .filterWhere(node => node.props().displayName === 'PagerDuty (Legacy)');

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -80,7 +80,7 @@ describe('IntegrationRepos', function () {
       expect(RepositoryActions.resetRepositories).toHaveBeenCalled();
     });
 
-    it('handles failure during save', async function () {
+    it('handles failure during save', function () {
       const addRepo = Client.addMockResponse({
         url: `/organizations/${org.slug}/repos/`,
         method: 'POST',

--- a/tests/js/spec/views/organizationIntegrations/integrationRow.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRow.spec.jsx
@@ -11,7 +11,7 @@ describe('IntegrationRow', function () {
   const org = TestStubs.Organization();
 
   describe('SentryApp', function () {
-    it('is an internal SentryApp', async function () {
+    it('is an internal SentryApp', function () {
       const wrapper = mountWithTheme(
         <IntegrationRow
           organization={org}
@@ -37,7 +37,7 @@ describe('IntegrationRow', function () {
       expect(wrapper.find('PublishStatus').props().status).toEqual('internal');
     });
 
-    it('is a published SentryApp', async function () {
+    it('is a published SentryApp', function () {
       const wrapper = mountWithTheme(
         <IntegrationRow
           organization={org}
@@ -60,7 +60,7 @@ describe('IntegrationRow', function () {
     });
   });
   describe('First Party Integration', function () {
-    it('has been installed (1 configuration)', async function () {
+    it('has been installed (1 configuration)', function () {
       const wrapper = mountWithTheme(
         <IntegrationRow
           organization={org}
@@ -83,7 +83,7 @@ describe('IntegrationRow', function () {
       expect(wrapper.find('StyledLink').props().children).toEqual('1 Configuration');
     });
 
-    it('has been installed (3 configurations)', async function () {
+    it('has been installed (3 configurations)', function () {
       const wrapper = mountWithTheme(
         <IntegrationRow
           organization={org}
@@ -106,7 +106,7 @@ describe('IntegrationRow', function () {
       expect(wrapper.find('StyledLink').props().children).toEqual('3 Configurations');
     });
 
-    it('has not been installed', async function () {
+    it('has not been installed', function () {
       const wrapper = mountWithTheme(
         <IntegrationRow
           organization={org}
@@ -130,7 +130,7 @@ describe('IntegrationRow', function () {
     });
   });
   describe('Plugin', function () {
-    it('has been installed (1 project)', async function () {
+    it('has been installed (1 project)', function () {
       const wrapper = mountWithTheme(
         <IntegrationRow
           organization={org}
@@ -153,7 +153,7 @@ describe('IntegrationRow', function () {
       expect(wrapper.find('StyledLink').props().children).toEqual('1 Configuration');
     });
 
-    it('has been installed (3 projects)', async function () {
+    it('has been installed (3 projects)', function () {
       const wrapper = mountWithTheme(
         <IntegrationRow
           organization={org}
@@ -176,7 +176,7 @@ describe('IntegrationRow', function () {
       expect(wrapper.find('StyledLink').props().children).toEqual('3 Configurations');
     });
 
-    it('has not been installed', async function () {
+    it('has not been installed', function () {
       const wrapper = mountWithTheme(
         <IntegrationRow
           organization={org}

--- a/tests/js/spec/views/organizationIntegrations/pluginDetailedView.spec.js
+++ b/tests/js/spec/views/organizationIntegrations/pluginDetailedView.spec.js
@@ -74,22 +74,22 @@ describe('PluginDetailedView', function () {
       />
     );
   });
-  it('shows the Integration name and install status', async function () {
+  it('shows the Integration name and install status', function () {
     expect(wrapper.find('Name').props().children).toEqual('PagerDuty (Legacy)');
     expect(wrapper.find('IntegrationStatus').props().status).toEqual('Installed');
   });
-  it('shows the Add to Project button', async function () {
+  it('shows the Add to Project button', function () {
     expect(wrapper.find('AddButton').props().disabled).toEqual(false);
     expect(wrapper.find('AddButton').props().children).toEqual('Add to Project');
   });
 
-  it('onClick', async function () {
+  it('onClick', function () {
     modal.openModal = jest.fn();
     wrapper.find('AddButton').simulate('click');
     expect(modal.openModal).toHaveBeenCalled();
   });
 
-  it('view configurations', async function () {
+  it('view configurations', function () {
     wrapper = mountWithTheme(
       <PluginDetailedView
         params={{integrationSlug: 'pagerduty', orgId: org.slug}}

--- a/tests/js/spec/views/organizationIntegrations/sentryAppDetailedView.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/sentryAppDetailedView.spec.jsx
@@ -124,11 +124,11 @@ describe('SentryAppDetailedView', function () {
       );
     });
 
-    it('shows the Integration name and install status', async function () {
+    it('shows the Integration name and install status', function () {
       expect(wrapper.find('Name').props().children).toEqual('ClickUp');
       expect(wrapper.find('IntegrationStatus').props().status).toEqual('Not Installed');
     });
-    it('shows the Accept & Install button', async function () {
+    it('shows the Accept & Install button', function () {
       expect(wrapper.find('InstallButton').props().disabled).toEqual(false);
       expect(wrapper.find('InstallButton').props().children).toEqual('Accept & Install');
     });
@@ -309,11 +309,11 @@ describe('SentryAppDetailedView', function () {
         />
       );
     });
-    it('shows the Integration name and install status', async function () {
+    it('shows the Integration name and install status', function () {
       expect(wrapper.find('Name').props().children).toEqual('La Croix Monitor');
       expect(wrapper.find('IntegrationStatus').props().status).toEqual('Not Installed');
     });
-    it('shows the Accept & Install button', async function () {
+    it('shows the Accept & Install button', function () {
       expect(wrapper.find('InstallButton').props().disabled).toEqual(false);
       expect(wrapper.find('InstallButton').props().children).toEqual('Accept & Install');
     });
@@ -398,11 +398,11 @@ describe('SentryAppDetailedView', function () {
       );
       mockRouterPush(wrapper, router);
     });
-    it('shows the Integration name and install status', async function () {
+    it('shows the Integration name and install status', function () {
       expect(wrapper.find('Name').props().children).toEqual('Go to Google');
       expect(wrapper.find('IntegrationStatus').props().status).toEqual('Not Installed');
     });
-    it('shows the Accept & Install button', async function () {
+    it('shows the Accept & Install button', function () {
       expect(wrapper.find('InstallButton').props().disabled).toEqual(false);
       expect(wrapper.find('InstallButton').props().children).toEqual('Accept & Install');
     });

--- a/tests/js/spec/views/organizationStats/teamInsights/teamAlertsTriggered.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamAlertsTriggered.spec.jsx
@@ -3,7 +3,7 @@ import {render} from 'sentry-test/reactTestingLibrary';
 import TeamAlertsTriggered from 'sentry/views/organizationStats/teamInsights/teamAlertsTriggered';
 
 describe('TeamAlertsTriggered', () => {
-  it('should render graph of alerts triggered', async () => {
+  it('should render graph of alerts triggered', () => {
     const team = TestStubs.Team();
     const organization = TestStubs.Organization();
     const alertsTriggeredApi = MockApiClient.addMockResponse({

--- a/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
@@ -101,7 +101,7 @@ describe('TeamMisery', () => {
     expect(screen.getAllByText('0% change')).toHaveLength(noChangeItems);
   });
 
-  it('should render empty state', async () => {
+  it('should render empty state', () => {
     render(
       <TeamMisery
         organization={TestStubs.Organization()}

--- a/tests/js/spec/views/organizationStats/teamInsights/teamResolutionTime.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamResolutionTime.spec.jsx
@@ -3,7 +3,7 @@ import {render} from 'sentry-test/reactTestingLibrary';
 import TeamResolutionTime from 'sentry/views/organizationStats/teamInsights/teamResolutionTime';
 
 describe('TeamResolutionTime', () => {
-  it('should render graph of issue time to resolution', async () => {
+  it('should render graph of issue time to resolution', () => {
     const team = TestStubs.Team();
     const organization = TestStubs.Organization();
     const timeToResolutionApi = MockApiClient.addMockResponse({

--- a/tests/js/spec/views/organizationStats/teamInsights/teamStability.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamStability.spec.jsx
@@ -3,7 +3,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import TeamStability from 'sentry/views/organizationStats/teamInsights/teamStability';
 
 describe('TeamStability', () => {
-  it('should comparse selected past crash rate with current week', async () => {
+  it('should comparse selected past crash rate with current week', () => {
     const sessionsApi = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/sessions/`,
       body: TestStubs.SessionStatusCountByProjectInPeriod(),
@@ -23,7 +23,7 @@ describe('TeamStability', () => {
     expect(sessionsApi).toHaveBeenCalledTimes(3);
   });
 
-  it('should render no sessions', async () => {
+  it('should render no sessions', () => {
     const noSessionProject = TestStubs.Project({hasSessions: false, id: 123});
     render(
       <TeamStability
@@ -36,7 +36,7 @@ describe('TeamStability', () => {
     expect(screen.getAllByText('\u2014')).toHaveLength(3);
   });
 
-  it('should render no projects', async () => {
+  it('should render no projects', () => {
     render(
       <TeamStability projects={[]} organization={TestStubs.Organization()} period="7d" />
     );

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.tsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.tsx
@@ -107,7 +107,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     }
   });
 
-  it('Check requests when changing widget props', async function () {
+  it('Check requests when changing widget props', function () {
     const data = initializeData();
 
     wrapper = render(
@@ -160,7 +160,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
   });
 
-  it('Check requests when changing widget props for GenericDiscoverQuery based widget', async function () {
+  it('Check requests when changing widget props for GenericDiscoverQuery based widget', function () {
     const data = initializeData();
 
     wrapper = render(

--- a/tests/js/spec/views/performance/transactionDetails/index.spec.jsx
+++ b/tests/js/spec/views/performance/transactionDetails/index.spec.jsx
@@ -10,7 +10,7 @@ const alertText =
 describe('EventDetails', () => {
   afterEach(cleanup);
 
-  it('renders alert for sample transaction', async () => {
+  it('renders alert for sample transaction', () => {
     const project = TestStubs.Project();
     ProjectsStore.loadInitialData([project]);
     const organization = TestStubs.Organization({

--- a/tests/js/spec/views/performance/transactionSummary/transactionThresholdModal.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionThresholdModal.spec.jsx
@@ -8,14 +8,14 @@ import TransactionThresholdModal from 'sentry/views/performance/transactionSumma
 
 const stubEl = props => <div>{props.children}</div>;
 
-async function clickSubmit(wrapper) {
+function clickSubmit(wrapper) {
   // Click on submit.
   const button = wrapper.find('Button[data-test-id="apply-threshold"] button');
   button.simulate('click');
   return tick();
 }
 
-async function clickReset(wrapper) {
+function clickReset(wrapper) {
   // Click on submit.
   const button = wrapper.find('Button[data-test-id="reset-all"] button');
   button.simulate('click');

--- a/tests/js/spec/views/performance/trends/index.spec.tsx
+++ b/tests/js/spec/views/performance/trends/index.spec.tsx
@@ -92,13 +92,13 @@ async function waitForMockCall(mock: any) {
   });
 }
 
-async function enterSearch(el, text) {
+function enterSearch(el, text) {
   fireEvent.change(el, {target: {value: text}});
   fireEvent.submit(el);
 }
 
 // Might swap on/off the skiphover to check perf later.
-async function clickEl(el) {
+function clickEl(el) {
   userEvent.click(el, undefined, {skipHover: true, skipPointerEventsCheck: true});
 }
 
@@ -678,7 +678,7 @@ describe('Performance > Trends', function () {
     }
   });
 
-  it('Visiting trends with trends feature will update filters if none are set', async function () {
+  it('Visiting trends with trends feature will update filters if none are set', function () {
     const data = initializeTrendsData(undefined, {}, false);
 
     render(

--- a/tests/js/spec/views/projectDetail/projectLatestReleases.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectLatestReleases.spec.jsx
@@ -10,7 +10,7 @@ describe('ProjectDetail > ProjectLatestReleases', function () {
   let endpointMock, endpointOlderReleasesMock;
   const {organization, project, router} = initializeOrg();
 
-  beforeEach(async function () {
+  beforeEach(function () {
     endpointMock = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/releases/`,
       body: [

--- a/tests/js/spec/views/projectOwnership.spec.jsx
+++ b/tests/js/spec/views/projectOwnership.spec.jsx
@@ -74,7 +74,7 @@ describe('Project Ownership', function () {
       expect(wrapper.find('CodeOwnerButton').exists()).toBe(true);
     });
 
-    it('clicking button opens modal', async function () {
+    it('clicking button opens modal', function () {
       org = TestStubs.Organization({
         features: ['integrations-codeowners'],
         access: ['org:integrations'],

--- a/tests/js/spec/views/projectTeams.spec.jsx
+++ b/tests/js/spec/views/projectTeams.spec.jsx
@@ -50,7 +50,7 @@ describe('ProjectTeams', function () {
     modals.openCreateTeamModal.mockRestore();
   });
 
-  it('renders', async function () {
+  it('renders', function () {
     const wrapper = mountWithTheme(
       <ProjectTeams
         params={{orgId: org.slug, projectId: project.slug}}
@@ -195,7 +195,7 @@ describe('ProjectTeams', function () {
     );
   });
 
-  it('can associate a team with project', async function () {
+  it('can associate a team with project', function () {
     const endpoint = `/projects/${org.slug}/${project.slug}/teams/${team2.slug}/`;
     const mock = MockApiClient.addMockResponse({
       url: endpoint,

--- a/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
@@ -11,7 +11,7 @@ describe('NoProjectMessage', function () {
 
   const org = TestStubs.Organization();
 
-  it('renders', async function () {
+  it('renders', function () {
     const organization = TestStubs.Organization({slug: 'org-slug'});
     const childrenMock = jest.fn().mockReturnValue(null);
     delete organization.projects;

--- a/tests/js/spec/views/releases/detail/overview/releaseIssues.spec.jsx
+++ b/tests/js/spec/views/releases/detail/overview/releaseIssues.spec.jsx
@@ -99,7 +99,7 @@ describe('ReleaseIssues', function () {
     );
   });
 
-  it('filters the issues', async function () {
+  it('filters the issues', function () {
     const wrapper = mountWithTheme(<ReleaseIssues {...props} />);
 
     const filterOptions = wrapper.find('ButtonBar Button');

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -41,7 +41,7 @@ describe('ReleasesList', () => {
   };
   let endpointMock, sessionApiMock;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     ProjectsStore.loadInitialData(organization.projects);
     endpointMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/releases/',

--- a/tests/js/spec/views/settings/account/apiApplications.spec.jsx
+++ b/tests/js/spec/views/settings/account/apiApplications.spec.jsx
@@ -30,7 +30,7 @@ describe('ApiApplications', function () {
     }
   });
 
-  it('renders empty', async function () {
+  it('renders empty', function () {
     requestMock = MockApiClient.addMockResponse({
       url: '/api-applications/',
       body: [],
@@ -39,7 +39,7 @@ describe('ApiApplications', function () {
     expect(wrapper.find('EmptyMessage')).toHaveLength(1);
   });
 
-  it('renders', async function () {
+  it('renders', function () {
     createWrapper();
 
     expect(requestMock).toHaveBeenCalled();

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -64,7 +64,7 @@ describe('SettingsSearch', function () {
     });
   });
 
-  it('renders', async function () {
+  it('renders', function () {
     render(<SettingsSearch params={{orgId: 'org-slug'}} />);
 
     // renders input

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -229,7 +229,7 @@ describe('Organization Developer Settings', function () {
       expect(deleteButton).toHaveAttribute('aria-disabled', 'false');
     });
 
-    it('publish button does not exist', async () => {
+    it('publish button does not exist', () => {
       render(
         <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />
       );

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -321,7 +321,7 @@ describe('Sentry Application Details', function () {
       expect(wrapper.find('EmptyMessage').exists()).toBe(true);
     });
 
-    it('removing webhookURL unsets isAlertable and changes webhookDisabled to true', async () => {
+    it('removing webhookURL unsets isAlertable and changes webhookDisabled to true', () => {
       expect(wrapper.find(PermissionsObserver).prop('webhookDisabled')).toBe(false);
       expect(wrapper.find('Switch[name="isAlertable"]').prop('isActive')).toBe(true);
       wrapper.find('Input[name="webhookUrl"]').simulate('change', {target: {value: ''}});

--- a/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
@@ -131,7 +131,7 @@ describe('InviteRequestRow', function () {
     expect(mockApprove).not.toHaveBeenCalled();
   });
 
-  it('non-admin can not approve or deny invite request', async function () {
+  it('non-admin can not approve or deny invite request', function () {
     const wrapper = mountWithTheme(
       <InviteRequestRow
         orgId={orgId}

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -126,7 +126,7 @@ describe('OrganizationMemberDetail', function () {
       );
     });
 
-    it('joins a team', async function () {
+    it('joins a team', function () {
       wrapper = mountWithTheme(
         <OrganizationMemberDetail params={{memberId: member.id}} />,
         routerContext
@@ -164,7 +164,7 @@ describe('OrganizationMemberDetail', function () {
       routerContext = TestStubs.routerContext([{organization}]);
     });
 
-    it('can not change roles, teams, or save', async function () {
+    it('can not change roles, teams, or save', function () {
       wrapper = mountWithTheme(
         <OrganizationMemberDetail params={{memberId: member.id}} />,
         routerContext

--- a/tests/js/spec/views/settings/organizationMembers/organizationMembersList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMembersList.spec.jsx
@@ -298,7 +298,7 @@ describe('OrganizationMembersList', function () {
     expect(inviteMock).toHaveBeenCalled();
   });
 
-  it('can search organization members', async function () {
+  it('can search organization members', function () {
     const searchMock = MockApiClient.addMockResponse({
       url: '/organizations/org-id/members/',
       body: [],
@@ -328,7 +328,7 @@ describe('OrganizationMembersList', function () {
     expect(routerContext.context.router.push).toHaveBeenCalledTimes(1);
   });
 
-  it('can filter members', async function () {
+  it('can filter members', function () {
     const searchMock = MockApiClient.addMockResponse({
       url: '/organizations/org-id/members/',
       body: [],
@@ -405,7 +405,7 @@ describe('OrganizationMembersList', function () {
       role: 'member',
       teams: [],
     });
-    it('disable buttons for no access', async function () {
+    it('disable buttons for no access', function () {
       const org = TestStubs.Organization({
         status: {
           id: 'active',

--- a/tests/js/spec/views/settings/organizationProjects.spec.jsx
+++ b/tests/js/spec/views/settings/organizationProjects.spec.jsx
@@ -54,7 +54,7 @@ describe('OrganizationProjects', function () {
     expect(projectsPutMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should search organization projects', async function () {
+  it('should search organization projects', function () {
     const searchMock = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/projects/`,
       body: [],

--- a/tests/js/spec/views/settings/organizationTeams.spec.jsx
+++ b/tests/js/spec/views/settings/organizationTeams.spec.jsx
@@ -41,7 +41,7 @@ describe('OrganizationTeams', function () {
         routerContext
       );
 
-    it('opens "create team modal" when creating a new team from header', async function () {
+    it('opens "create team modal" when creating a new team from header', function () {
       const wrapper = createWrapper();
 
       // Click "Create Team" in Panel Header

--- a/tests/js/spec/views/settings/projectEnvironments.spec.jsx
+++ b/tests/js/spec/views/settings/projectEnvironments.spec.jsx
@@ -54,7 +54,7 @@ describe('ProjectEnvironments', function () {
       expect(wrapper.find('ProjectEnvironments')).toSnapshot();
     });
 
-    it('renders environment list', async function () {
+    it('renders environment list', function () {
       MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/environments/',
         body: TestStubs.Environments(false),

--- a/tests/js/spec/views/team/organizationTeamProjects.spec.jsx
+++ b/tests/js/spec/views/team/organizationTeamProjects.spec.jsx
@@ -56,7 +56,7 @@ describe('OrganizationTeamProjects', function () {
     Client.clearMockResponses();
   });
 
-  it('fetches linked and unlinked projects', async function () {
+  it('fetches linked and unlinked projects', function () {
     mountWithTheme(
       <OrganizationTeamProjects
         api={new MockApiClient()}


### PR DESCRIPTION
Uses https://eslint.org/docs/rules/require-await.

Unfortunately this is not autofixable, so I scripted this

These functions were not `await`ing anything.