### PR TITLE
ref(js): retryableImport does not need to be `async`

### DIFF
--- a/static/app/utils/retryableImport.tsx
+++ b/static/app/utils/retryableImport.tsx
@@ -2,7 +2,7 @@ import {isWebpackChunkLoadingError} from 'sentry/utils';
 
 const MAX_RETRIES = 2;
 
-export default async function retryableImport<T>(
+export default function retryableImport<T>(
   fn: () => Promise<{default: T}>
 ): Promise<{default: T}> {
   let retries = 0;


### PR DESCRIPTION
It already returns a promise which may be awaited.