### PR TITLE
fix(metrics): Restrict public name regex [TET-111]

### DIFF
--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -18,7 +18,10 @@ metric that is queryable by the API.
 """
 __all__ = ("SessionMRI", "TransactionMRI")
 
+import re
 from enum import Enum
+
+MRI_NAME_REGEX = re.compile(r"^(\w+)\(([\w.:/@]+)\)$")
 
 
 class SessionMRI(Enum):

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -16,12 +16,21 @@ and so it is a private metric, whereas `SessionMRI.CRASH_FREE_RATE` has a corres
 `SessionMetricKey` with the same name i.e. `SessionMetricKey.CRASH_FREE_RATE` and hence is a public
 metric that is queryable by the API.
 """
-__all__ = ("SessionMRI", "TransactionMRI")
+__all__ = ("SessionMRI", "TransactionMRI", "MRI_SCHEMA_REGEX", "MRI_EXPRESSION_REGEX")
 
 import re
 from enum import Enum
 
-MRI_NAME_REGEX = re.compile(r"^(\w+)\(([\w.:/@]+)\)$")
+from sentry.snuba.metrics.utils import OP_REGEX
+
+NAMESPACE_REGEX = r"(transactions|errors|issues|sessions|alerts|custom)"
+ENTITY_TYPE_REGEX = r"(c|s|d|g|e)"
+# This regex allows for a string of words composed of small letters alphabet characters with
+# allowed the underscore character, optionally separated by a single dot
+MRI_NAME_REGEX = r"([a-z_]+(?:\.[a-z_]+)*)"
+# ToDo(ahmed): Add a better regex for unit portion for MRI
+MRI_SCHEMA_REGEX = rf"{ENTITY_TYPE_REGEX}:{NAMESPACE_REGEX}/{MRI_NAME_REGEX}@([\w.]*)"
+MRI_EXPRESSION_REGEX = re.compile(rf"^{OP_REGEX}\(({MRI_SCHEMA_REGEX})\)$")
 
 
 class SessionMRI(Enum):

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -15,12 +15,17 @@ __all__ = (
     "TransactionTagsKey",
     "TransactionStatusTagValue",
     "TransactionSatisfactionTagValue",
+    "PUBLIC_EXPRESSION_REGEX",
+    "PUBLIC_NAME_REGEX",
 )
 
 import re
 from enum import Enum
 
-PUBLIC_NAME_REGEX = re.compile(r"^(\w+)\(([\w.]+)\)$")
+from sentry.snuba.metrics.utils import OP_REGEX
+
+PUBLIC_NAME_REGEX = r"([a-z_]+(?:\.[a-z_]+)*)"
+PUBLIC_EXPRESSION_REGEX = re.compile(rf"^{OP_REGEX}\({PUBLIC_NAME_REGEX}\)$")
 
 
 class SessionMetricKey(Enum):

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -17,7 +17,10 @@ __all__ = (
     "TransactionSatisfactionTagValue",
 )
 
+import re
 from enum import Enum
+
+PUBLIC_NAME_REGEX = re.compile(r"^(\w+)\(([\w.]+)\)$")
 
 
 class SessionMetricKey(Enum):

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -33,8 +33,8 @@ from sentry.snuba.metrics.fields.base import (
     org_id_from_projects,
 )
 from sentry.snuba.metrics.naming_layer.mapping import get_mri, get_public_name_from_mri
-from sentry.snuba.metrics.naming_layer.mri import MRI_NAME_REGEX
-from sentry.snuba.metrics.naming_layer.public import PUBLIC_NAME_REGEX
+from sentry.snuba.metrics.naming_layer.mri import MRI_EXPRESSION_REGEX
+from sentry.snuba.metrics.naming_layer.public import PUBLIC_EXPRESSION_REGEX
 from sentry.snuba.metrics.query import MetricField, MetricsQuery
 from sentry.snuba.metrics.query import OrderBy as MetricsOrderBy
 from sentry.snuba.metrics.query import Tag
@@ -53,7 +53,7 @@ from sentry.utils.snuba import parse_snuba_datetime
 
 
 def parse_field(field: str) -> MetricField:
-    matches = PUBLIC_NAME_REGEX.match(field)
+    matches = PUBLIC_EXPRESSION_REGEX.match(field)
     try:
         if matches is None:
             raise TypeError
@@ -642,7 +642,7 @@ class SnubaResultConverter:
             series = group.get("series")
 
             for key in set(totals or ()) | set(series or ()):
-                matches = MRI_NAME_REGEX.match(key)
+                matches = MRI_EXPRESSION_REGEX.match(key)
                 if matches:
                     operation = matches[1]
                     metric_mri = matches[2]

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -33,12 +33,13 @@ from sentry.snuba.metrics.fields.base import (
     org_id_from_projects,
 )
 from sentry.snuba.metrics.naming_layer.mapping import get_mri, get_public_name_from_mri
+from sentry.snuba.metrics.naming_layer.mri import MRI_NAME_REGEX
+from sentry.snuba.metrics.naming_layer.public import PUBLIC_NAME_REGEX
 from sentry.snuba.metrics.query import MetricField, MetricsQuery
 from sentry.snuba.metrics.query import OrderBy as MetricsOrderBy
 from sentry.snuba.metrics.query import Tag
 from sentry.snuba.metrics.utils import (
     FIELD_ALIAS_MAPPINGS,
-    FIELD_REGEX,
     OPERATIONS_PERCENTILES,
     TS_COL_GROUP,
     TS_COL_QUERY,
@@ -52,7 +53,7 @@ from sentry.utils.snuba import parse_snuba_datetime
 
 
 def parse_field(field: str) -> MetricField:
-    matches = FIELD_REGEX.match(field)
+    matches = PUBLIC_NAME_REGEX.match(field)
     try:
         if matches is None:
             raise TypeError
@@ -641,7 +642,7 @@ class SnubaResultConverter:
             series = group.get("series")
 
             for key in set(totals or ()) | set(series or ()):
-                matches = FIELD_REGEX.match(key)
+                matches = MRI_NAME_REGEX.match(key)
                 if matches:
                     operation = matches[1]
                     metric_mri = matches[2]

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -30,6 +30,7 @@ __all__ = (
     "UNALLOWED_TAGS",
     "combine_dictionary_of_list_values",
     "get_intervals",
+    "OP_REGEX",
 )
 
 
@@ -80,7 +81,7 @@ MetricType = Literal["counter", "set", "distribution", "numeric"]
 
 MetricEntity = Literal["metrics_counters", "metrics_sets", "metrics_distributions"]
 
-OP_TO_SNUBA_FUNCTION: Mapping[str, Mapping[MetricOperationType, str]] = {
+OP_TO_SNUBA_FUNCTION = {
     "metrics_counters": {"sum": "sumIf"},
     "metrics_distributions": {
         "avg": "avgIf",
@@ -96,6 +97,24 @@ OP_TO_SNUBA_FUNCTION: Mapping[str, Mapping[MetricOperationType, str]] = {
     },
     "metrics_sets": {"count_unique": "uniqIf"},
 }
+
+
+def generate_operation_regex():
+    """
+    Generates a regex of all supported operations defined in OP_TO_SNUBA_FUNCTION
+    """
+    op_lst = []
+    for item in OP_TO_SNUBA_FUNCTION.values():
+        op_lst += list(item.keys())
+
+    op_regex = r"("
+    for op in op_lst:
+        op_regex += f"{op}|"
+    op_regex = op_regex[0:-1] + ")"
+    return op_regex
+
+
+OP_REGEX = generate_operation_regex()
 
 
 AVAILABLE_OPERATIONS = {

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -3,7 +3,6 @@ __all__ = (
     "GRANULARITY",
     "TS_COL_QUERY",
     "TS_COL_GROUP",
-    "FIELD_REGEX",
     "TAG_REGEX",
     "MetricOperationType",
     "MetricUnit",
@@ -52,14 +51,12 @@ from typing import (
 
 from sentry.snuba.dataset import EntityKey
 
+#: Max number of data points per time series:
 MAX_POINTS = 10000
 GRANULARITY = 24 * 60 * 60
 TS_COL_QUERY = "timestamp"
 TS_COL_GROUP = "bucketed_time"
 
-#: Max number of data points per time series:
-# ToDo modify this regex to only support the operations provided
-FIELD_REGEX = re.compile(r"^(\w+)\(([\w.:/@]+)\)$")
 TAG_REGEX = re.compile(r"^([\w.]+)$")
 
 #: A function that can be applied to a metric

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -103,15 +103,10 @@ def generate_operation_regex():
     """
     Generates a regex of all supported operations defined in OP_TO_SNUBA_FUNCTION
     """
-    op_lst = []
+    operations = []
     for item in OP_TO_SNUBA_FUNCTION.values():
-        op_lst += list(item.keys())
-
-    op_regex = r"("
-    for op in op_lst:
-        op_regex += f"{op}|"
-    op_regex = op_regex[0:-1] + ")"
-    return op_regex
+        operations += list(item.keys())
+    return rf"({'|'.join(map(str, operations))})"
 
 
 OP_REGEX = generate_operation_regex()

--- a/tests/sentry/snuba/metrics/test_naming_layer.py
+++ b/tests/sentry/snuba/metrics/test_naming_layer.py
@@ -51,6 +51,14 @@ def test_invalid_public_name_regex(name):
         "e:sessions/healthy.crashed.crashed@",
         "e:sessions/healthy_crashed.crashed@",
         "e:sessions/healthy.crashed_crashed_sessions@",
+        "d:transactions/measurements.frames_slow_rate@ratio",
+        "c:sessions/session@none",
+        "s:sessions/error@none",
+        "g:sessions/error@none",
+        "g:alerts/error@none",
+        "g:custom/error@none",
+        "g:issues/error@none",
+        "c:errors/error@none",
     ],
 )
 def test_valid_mri_schema_regex(name):

--- a/tests/sentry/snuba/metrics/test_naming_layer.py
+++ b/tests/sentry/snuba/metrics/test_naming_layer.py
@@ -1,0 +1,77 @@
+import re
+
+import pytest
+
+from sentry.snuba.metrics.naming_layer.mri import MRI_SCHEMA_REGEX
+from sentry.snuba.metrics.naming_layer.public import PUBLIC_NAME_REGEX
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "session.duration",
+        "session.all",
+        "session.abnormal",
+        "session.crashed",
+        "session.crash_free_user_rate" "foo.bar.bar",
+        "foo_bar.bar",
+    ],
+)
+def test_valid_public_name_regex(name):
+    matches = re.compile(rf"^{PUBLIC_NAME_REGEX}$").match(name)
+    assert matches
+    assert matches[0] == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "session.",
+        ".session",
+        "session..crashed",
+        "..crashed",
+        "e:sessions/error.preaggr@none",
+        "e:sessions/crashed_abnormal@none",
+        "e:sessions/user.crashed_abnormal@none",
+        "session.09_crashed",
+    ],
+)
+def test_invalid_public_name_regex(name):
+    assert re.compile(rf"^{PUBLIC_NAME_REGEX}$").match(name) is None
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "e:sessions/error.preaggr@none",
+        "e:sessions/crashed_abnormal@none",
+        "e:sessions/user.crashed_abnormal@none",
+        "e:sessions/healthy@",
+        "e:sessions/healthy.crashed@",
+        "e:sessions/healthy.crashed.crashed@",
+        "e:sessions/healthy_crashed.crashed@",
+        "e:sessions/healthy.crashed_crashed_sessions@",
+    ],
+)
+def test_valid_mri_schema_regex(name):
+    matches = re.compile(rf"^{MRI_SCHEMA_REGEX}$").match(name)
+    assert matches
+    assert matches[0] == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "e:sessions/healthy.@",
+        "e:sessions/healthy..@",
+        "e:sessions/healthy..crashed@",
+        "e:sessions/.healthy@",
+        "e:sessions/..healthy@",
+        "e:sessions/healthy..crashed.crashed@",
+        "t:sessions/error.preaggr@none",
+        "e:foo/error.preaggr@none" "foo.bar",
+        "e:sessions/error.098preaggr@none",
+    ],
+)
+def test_invalid_mri_schema_regex(name):
+    assert re.compile(rf"^{MRI_SCHEMA_REGEX}$").match(name) is None


### PR DESCRIPTION
Restricts the public name regex for metrics
by separating out the public name regex
and the mri name regex from the shared field
regex and removing characters that are not
expected to be in public facing names
