### PR TITLE
feat: Update loader to support JS SDK v7

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2297,7 +2297,11 @@ GEOIP_PATH_MMDB = None
 JS_SDK_LOADER_CDN_URL = ""
 # Version of the SDK - Used in header Surrogate-Key sdk/JS_SDK_LOADER_SDK_VERSION
 JS_SDK_LOADER_SDK_VERSION = ""
-# This should be the url pointing to the JS SDK
+# This should be the url pointing to the JS SDK. It may contain one or two "%s",
+# the first one will be replaced with the SDK version, the second one is used to
+# inject a bundle modifier in the JS SDK CDN loader. e.g:
+# 'https://browser.sentry-cdn.com/%s/bundle%s.min.js' will become
+# 'https://browser.sentry-cdn.com/7.0.0/bundle.es5.min.js'
 JS_SDK_LOADER_DEFAULT_SDK_URL = ""
 
 # block domains which are generally used by spammers -- keep this configurable

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2297,11 +2297,14 @@ GEOIP_PATH_MMDB = None
 JS_SDK_LOADER_CDN_URL = ""
 # Version of the SDK - Used in header Surrogate-Key sdk/JS_SDK_LOADER_SDK_VERSION
 JS_SDK_LOADER_SDK_VERSION = ""
-# This should be the url pointing to the JS SDK. It may contain one or two "%s".
+# This should be the url pointing to the JS SDK. It may contain up to two "%s".
 # The first "%s" will be replaced with the SDK version, the second one is used
 # to inject a bundle modifier in the JS SDK CDN loader. e.g:
-# 'https://browser.sentry-cdn.com/%s/bundle%s.min.js' will become
+# - 'https://browser.sentry-cdn.com/%s/bundle%s.min.js' will become
 # 'https://browser.sentry-cdn.com/7.0.0/bundle.es5.min.js'
+# - 'https://browser.sentry-cdn.com/%s/bundle.min.js' will become
+# 'https://browser.sentry-cdn.com/7.0.0/bundle.min.js'
+# - 'https://browser.sentry-cdn.com/6.19.7/bundle.min.js' will stay the same.
 JS_SDK_LOADER_DEFAULT_SDK_URL = ""
 
 # block domains which are generally used by spammers -- keep this configurable

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2297,9 +2297,9 @@ GEOIP_PATH_MMDB = None
 JS_SDK_LOADER_CDN_URL = ""
 # Version of the SDK - Used in header Surrogate-Key sdk/JS_SDK_LOADER_SDK_VERSION
 JS_SDK_LOADER_SDK_VERSION = ""
-# This should be the url pointing to the JS SDK. It may contain one or two "%s",
-# the first one will be replaced with the SDK version, the second one is used to
-# inject a bundle modifier in the JS SDK CDN loader. e.g:
+# This should be the url pointing to the JS SDK. It may contain one or two "%s".
+# The first "%s" will be replaced with the SDK version, the second one is used
+# to inject a bundle modifier in the JS SDK CDN loader. e.g:
 # 'https://browser.sentry-cdn.com/%s/bundle%s.min.js' will become
 # 'https://browser.sentry-cdn.com/7.0.0/bundle.es5.min.js'
 JS_SDK_LOADER_DEFAULT_SDK_URL = ""

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -54,11 +54,12 @@ def load_version_from_file():
     return []
 
 
-def get_highest_selected_browser_sdk_version(selected_version):
+def match_selected_version_to_browser_sdk_version(selected_version):
     versions = load_version_from_file()
     if selected_version == "latest":
         return get_highest_browser_sdk_version(versions)
     return get_highest_browser_sdk_version(
+        # Filter for all versions that match the selected versions major
         [x for x in versions if x.startswith(selected_version[0])]
     )
 
@@ -67,7 +68,7 @@ def get_browser_sdk_version(project_key):
     selected_version = get_selected_browser_sdk_version(project_key)
 
     try:
-        return get_highest_selected_browser_sdk_version(selected_version)
+        return match_selected_version_to_browser_sdk_version(selected_version)
     except Exception:
         logger.error("error occurred while trying to read js sdk information from the registry")
         return Version(settings.JS_SDK_LOADER_SDK_VERSION)

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -30,14 +30,14 @@ def load_registry(path):
 def get_highest_browser_sdk_version(versions):
     full_versions = [x for x in versions if _version_regexp.match(x)]
     return (
-        str(max(map(Version, full_versions)))
+        max(map(Version, full_versions))
         if full_versions
-        else settings.JS_SDK_LOADER_SDK_VERSION
+        else Version(settings.JS_SDK_LOADER_SDK_VERSION)
     )
 
 
 def get_browser_sdk_version_versions():
-    return ["latest", "6.x", "5.x", "4.x"]
+    return ["latest", "7.x", "6.x", "5.x", "4.x"]
 
 
 def get_browser_sdk_version_choices():
@@ -70,7 +70,7 @@ def get_browser_sdk_version(project_key):
         return get_highest_selected_browser_sdk_version(selected_version)
     except Exception:
         logger.error("error occurred while trying to read js sdk information from the registry")
-        return settings.JS_SDK_LOADER_SDK_VERSION
+        return Version(settings.JS_SDK_LOADER_SDK_VERSION)
 
 
 def get_selected_browser_sdk_version(project_key):

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -1,7 +1,7 @@
 from sentry.projectoptions import register
 
 # latest epoch
-LATEST_EPOCH = 7
+LATEST_EPOCH = 8
 
 # grouping related configs
 #
@@ -40,7 +40,9 @@ register(key="sentry:secondary_grouping_config", default=None)
 # The JavaScript loader version that is the project default.  This option
 # is expected to be never set but the epoch defaults are used if no
 # version is set on a project's DSN.
-register(key="sentry:default_loader_version", epoch_defaults={1: "4.x", 2: "5.x", 7: "6.x"})
+register(
+    key="sentry:default_loader_version", epoch_defaults={1: "4.x", 2: "5.x", 7: "6.x", 8: "7.x"}
+)
 
 # Default symbol sources.  The ios source does not exist by default and
 # will be skipped later.  The microsoft source exists by default and is

--- a/tests/sentry/loader/test_browsersdkversion.py
+++ b/tests/sentry/loader/test_browsersdkversion.py
@@ -30,20 +30,28 @@ class BrowserSdkVersionTestCase(TestCase):
         "sentry.loader.browsersdkversion.load_version_from_file", return_value=MOCK_VERSIONS
     )
     def test_get_highest_browser_sdk_version_from_versions(self, load_version_from_file):
-        assert get_highest_browser_sdk_version(load_version_from_file()) == "5.10.1"
+        assert str(get_highest_browser_sdk_version(load_version_from_file())) == "5.10.1"
 
     @mock.patch(
         "sentry.loader.browsersdkversion.load_version_from_file", return_value=MOCK_VERSIONS
     )
     def test_get_highest_selected_version(self, load_version_from_file):
-        assert get_highest_selected_browser_sdk_version("4.x") == "4.6.4"
-        assert get_highest_selected_browser_sdk_version("5.x") == "5.10.1"
-        assert get_highest_selected_browser_sdk_version("latest") == "5.10.1"
+        assert str(get_highest_selected_browser_sdk_version("4.x")) == "4.6.4"
+        assert str(get_highest_selected_browser_sdk_version("5.x")) == "5.10.1"
+        assert str(get_highest_selected_browser_sdk_version("latest")) == "5.10.1"
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=[])
     def test_get_highest_selected_version_no_version(self, load_version_from_file):
-        assert get_highest_selected_browser_sdk_version("4.x") == settings.JS_SDK_LOADER_SDK_VERSION
-        assert get_highest_selected_browser_sdk_version("5.x") == settings.JS_SDK_LOADER_SDK_VERSION
+        settings.JS_SDK_LOADER_SDK_VERSION = "0.5.2"
         assert (
-            get_highest_selected_browser_sdk_version("latest") == settings.JS_SDK_LOADER_SDK_VERSION
+            str(get_highest_selected_browser_sdk_version("4.x"))
+            == settings.JS_SDK_LOADER_SDK_VERSION
+        )
+        assert (
+            str(get_highest_selected_browser_sdk_version("5.x"))
+            == settings.JS_SDK_LOADER_SDK_VERSION
+        )
+        assert (
+            str(get_highest_selected_browser_sdk_version("latest"))
+            == settings.JS_SDK_LOADER_SDK_VERSION
         )

--- a/tests/sentry/loader/test_browsersdkversion.py
+++ b/tests/sentry/loader/test_browsersdkversion.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from sentry.loader.browsersdkversion import (
     get_browser_sdk_version_versions,
     get_highest_browser_sdk_version,
-    get_highest_selected_browser_sdk_version,
+    match_selected_version_to_browser_sdk_version,
 )
 from sentry.testutils import TestCase
 
@@ -36,22 +36,22 @@ class BrowserSdkVersionTestCase(TestCase):
         "sentry.loader.browsersdkversion.load_version_from_file", return_value=MOCK_VERSIONS
     )
     def test_get_highest_selected_version(self, load_version_from_file):
-        assert str(get_highest_selected_browser_sdk_version("4.x")) == "4.6.4"
-        assert str(get_highest_selected_browser_sdk_version("5.x")) == "5.10.1"
-        assert str(get_highest_selected_browser_sdk_version("latest")) == "5.10.1"
+        assert str(match_selected_version_to_browser_sdk_version("4.x")) == "4.6.4"
+        assert str(match_selected_version_to_browser_sdk_version("5.x")) == "5.10.1"
+        assert str(match_selected_version_to_browser_sdk_version("latest")) == "5.10.1"
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=[])
     def test_get_highest_selected_version_no_version(self, load_version_from_file):
         settings.JS_SDK_LOADER_SDK_VERSION = "0.5.2"
         assert (
-            str(get_highest_selected_browser_sdk_version("4.x"))
+            str(match_selected_version_to_browser_sdk_version("4.x"))
             == settings.JS_SDK_LOADER_SDK_VERSION
         )
         assert (
-            str(get_highest_selected_browser_sdk_version("5.x"))
+            str(match_selected_version_to_browser_sdk_version("5.x"))
             == settings.JS_SDK_LOADER_SDK_VERSION
         )
         assert (
-            str(get_highest_selected_browser_sdk_version("latest"))
+            str(match_selected_version_to_browser_sdk_version("latest"))
             == settings.JS_SDK_LOADER_SDK_VERSION
         )


### PR DESCRIPTION
For v7 of the JavaScript SDK, we changed the naming of the CDN bundles to be ES6 per default. Meaning `bundle.min.js` is ES6 and `bundle.es5.min.js` is ES5.

Currently, for v7, we serve the ES6 version of the SDK in the loader - which is not what we want. This PR adjusts the behaviour of the loader to provide an es5 bundle when an SDK with version >= 7 is requested.

Changes have been tested locally!

Ref: https://getsentry.atlassian.net/browse/WEB-951