### PR TITLE
feat(perf): Track page views on Vital Detail & Trace View

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -52,6 +52,8 @@ export type PerformanceEventParameters = {
   'performance_views.tour.advance': PerformanceTourParams;
   'performance_views.tour.close': PerformanceTourParams;
   'performance_views.tour.start': {};
+  'performance_views.trace_view.view': {};
+  'performance_views.vital_detail.view': {};
 };
 
 export type PerformanceEventKey = keyof PerformanceEventParameters;
@@ -79,4 +81,6 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.spans.change_sort': 'Performance Views: Change span sort column',
   'performance_views.overview.view': 'Performance Views: Transaction overview view',
   'performance_views.overview.search': 'Performance Views: Transaction overview search',
+  'performance_views.vital_detail.view': 'Performance Views: Vital Detail viewed',
+  'performance_views.trace_view.view': 'Performance Views: Trace View viewed',
 };

--- a/static/app/views/performance/traceDetails/traceView.tsx
+++ b/static/app/views/performance/traceDetails/traceView.tsx
@@ -1,4 +1,4 @@
-import React, {createRef} from 'react';
+import React, {createRef, useEffect} from 'react';
 import {RouteComponentProps} from 'react-router';
 import * as Sentry from '@sentry/react';
 
@@ -15,6 +15,7 @@ import {
 import {pickBarColor, toPercent} from 'sentry/components/performance/waterfall/utils';
 import {tct} from 'sentry/locale';
 import {Organization} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
 import {TraceFullDetailed, TraceMeta} from 'sentry/utils/performance/quickTrace/types';
 import {
@@ -97,6 +98,11 @@ export default function TraceView({
     op: 'trace.render',
     description: 'trace-view-content',
   });
+  useEffect(() => {
+    trackAdvancedAnalyticsEvent('performance_views.trace_view.view', {
+      organization,
+    });
+  }, [organization]);
 
   function renderTransaction(
     transaction: TraceFullDetailed,

--- a/static/app/views/performance/vitalDetail/index.tsx
+++ b/static/app/views/performance/vitalDetail/index.tsx
@@ -11,6 +11,7 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import {Organization, PageFilters, Project} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
 import {WebVital} from 'sentry/utils/discover/fields';
 import {PerformanceEventViewProvider} from 'sentry/utils/performance/contexts/performanceEventViewContext';
@@ -53,6 +54,10 @@ class VitalDetail extends Component<Props, State> {
     const {api, organization, selection} = this.props;
     loadOrganizationTags(api, organization.slug, selection);
     addRoutePerformanceContext(selection);
+
+    trackAdvancedAnalyticsEvent('performance_views.vital_detail.view', {
+      organization,
+    });
   }
 
   componentDidUpdate(prevProps: Props) {


### PR DESCRIPTION
Adds some analytics events to track page views on the Vital Detail and Trace View pages.

Dependent on: https://github.com/getsentry/reload/pull/267
