### PR TITLE
feat(dashboards): Introduce a config interface for datasets

### DIFF
--- a/static/app/views/dashboardsV2/datasetConfig/base.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/base.tsx
@@ -1,0 +1,15 @@
+import {Series} from 'sentry/types/echarts';
+import {TableData} from 'sentry/utils/discover/discoverQuery';
+
+export interface DatasetConfig<SeriesResponse, TableResponse> {
+  /**
+   * Transforms timeseries API results into series data that is
+   * ingestable by echarts for timeseries visualizations.
+   */
+  transformSeries?: (data: SeriesResponse) => Series[];
+  /**
+   * Transforms table API results into format that is used by
+   * table and big number components
+   */
+  transformTable?: (data: TableResponse) => TableData;
+}

--- a/static/app/views/dashboardsV2/datasetConfig/context.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/context.tsx
@@ -1,0 +1,127 @@
+import {ReactNode, useState} from 'react';
+
+import {
+  EventsStats,
+  Group,
+  MetricsApiResponse,
+  MultiSeriesEventsStats,
+  SessionApiResponse,
+} from 'sentry/types';
+import {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
+
+import {WidgetType} from '../types';
+
+import {DatasetConfig} from './base';
+
+interface DatasetConfigContextInterface<SeriesResponse, TableResponse> {
+  setDatasetConfig: (value?: DatasetConfig<SeriesResponse, TableResponse>) => void;
+  datasetConfig?: DatasetConfig<SeriesResponse, TableResponse>;
+}
+
+function createDatasetConfigContext<SeriesResponse, TableResponse>() {
+  const [_DatasetConfigProvider, useDatasetConfigContext, DatasetConfigContext] =
+    createDefinedContext<DatasetConfigContextInterface<SeriesResponse, TableResponse>>({
+      name: 'DatasetConfigContext',
+    });
+
+  function DatasetConfigProvider({children}: {children: ReactNode}) {
+    const [datasetConfig, setDatasetConfig] = useState<
+      DatasetConfig<SeriesResponse, TableResponse> | undefined
+    >(undefined); // undefined means not initialized
+
+    return (
+      <_DatasetConfigProvider
+        value={{
+          datasetConfig,
+          setDatasetConfig,
+        }}
+      >
+        {children}
+      </_DatasetConfigProvider>
+    );
+  }
+  const DatasetConfigConsumer = DatasetConfigContext.Consumer;
+
+  return {
+    DatasetConfigProvider,
+    useDatasetConfigContext,
+    DatasetConfigContext,
+    DatasetConfigConsumer,
+  };
+}
+
+export const {
+  DatasetConfigProvider: ReleasesDatasetConfigProvider,
+  useDatasetConfigContext: useReleasesDatasetConfigContext,
+  DatasetConfigContext: ReleasesDatasetConfigContext,
+  DatasetConfigConsumer: ReleasesDatasetConfigConsumer,
+} = createDatasetConfigContext<
+  SessionApiResponse | MetricsApiResponse,
+  SessionApiResponse | MetricsApiResponse
+>();
+
+export const {
+  DatasetConfigProvider: IssuesDatasetConfigProvider,
+  useDatasetConfigContext: useIssuesDatasetConfigContext,
+  DatasetConfigContext: IssuesDatasetConfigContext,
+  DatasetConfigConsumer: IssuesDatasetConfigConsumer,
+} = createDatasetConfigContext<never, Group[]>();
+
+export const {
+  DatasetConfigProvider: ErrorsAndTransactionsDatasetConfigProvider,
+  useDatasetConfigContext: useErrorsAndTransactionsDatasetConfigContext,
+  DatasetConfigContext: ErrorsAndTransactionsDatasetConfigContext,
+  DatasetConfigConsumer: ErrorsAndTransactionsDatasetConfigConsumer,
+} = createDatasetConfigContext<
+  EventsStats | MultiSeriesEventsStats,
+  TableData | EventsTableData
+>();
+
+export function getDatasetConfigProvider(widgetType: WidgetType | undefined) {
+  switch (widgetType) {
+    case WidgetType.RELEASE:
+      return ReleasesDatasetConfigProvider;
+    case WidgetType.ISSUE:
+      return IssuesDatasetConfigProvider;
+    case WidgetType.DISCOVER:
+    default:
+      return ErrorsAndTransactionsDatasetConfigProvider;
+  }
+}
+
+export function getDatasetConfigContext(widgetType: WidgetType | undefined) {
+  switch (widgetType) {
+    case WidgetType.RELEASE:
+      return ReleasesDatasetConfigContext;
+    case WidgetType.ISSUE:
+      return IssuesDatasetConfigContext;
+    case WidgetType.DISCOVER:
+    default:
+      return ErrorsAndTransactionsDatasetConfigContext;
+  }
+}
+
+export function getDatasetConfigConsumer(widgetType: WidgetType | undefined) {
+  switch (widgetType) {
+    case WidgetType.RELEASE:
+      return ReleasesDatasetConfigConsumer;
+    case WidgetType.ISSUE:
+      return IssuesDatasetConfigConsumer;
+    case WidgetType.DISCOVER:
+    default:
+      return ErrorsAndTransactionsDatasetConfigConsumer;
+  }
+}
+
+export function getDefinedContext(widgetType: WidgetType | undefined) {
+  switch (widgetType) {
+    case WidgetType.RELEASE:
+      return useReleasesDatasetConfigContext;
+    case WidgetType.ISSUE:
+      return useIssuesDatasetConfigContext;
+    case WidgetType.DISCOVER:
+    default:
+      return useErrorsAndTransactionsDatasetConfigContext;
+  }
+}

--- a/static/app/views/dashboardsV2/datasetConfig/context.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/context.tsx
@@ -8,7 +8,7 @@ import {ErrorsAndTransactionsConfig} from './errorsAndTransactions';
 import {IssuesConfig} from './issues';
 import {ReleasesConfig} from './releases';
 
-function createDatasetConfigContext(widgetType: WidgetType) {
+function createDatasetConfigContext(widgetType: WidgetType | undefined) {
   const config = getDatasetConfig(widgetType);
   const [_DatasetConfigProvider, useDatasetConfigContext, DatasetConfigContext] =
     createDefinedContext<{datasetConfig: typeof config}>({
@@ -107,7 +107,7 @@ export function getDatasetConfigContextHook(widgetType: WidgetType | undefined) 
   }
 }
 
-export function getDatasetConfig(widgetType: WidgetType) {
+export function getDatasetConfig(widgetType: WidgetType | undefined) {
   switch (widgetType) {
     case WidgetType.RELEASE:
       return ReleasesConfig;

--- a/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
@@ -1,0 +1,17 @@
+import {EventsStats, MultiSeriesEventsStats} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
+import {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+
+import DatasetConfig from './base';
+
+export const ErrorsAndTransactionsConfig: DatasetConfig<
+  EventsStats | MultiSeriesEventsStats,
+  TableData | EventsTableData
+> = {
+  transformSeries: (_data: EventsStats | MultiSeriesEventsStats) => {
+    return [] as Series[];
+  },
+  transformTable: (_data: TableData | EventsTableData) => {
+    return {data: []} as TableData;
+  },
+};

--- a/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
@@ -2,7 +2,7 @@ import {EventsStats, MultiSeriesEventsStats} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 
-import DatasetConfig from './base';
+import {DatasetConfig} from './base';
 
 export const ErrorsAndTransactionsConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats,

--- a/static/app/views/dashboardsV2/datasetConfig/issues.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/issues.tsx
@@ -1,7 +1,7 @@
 import {Group} from 'sentry/types';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 
-import DatasetConfig from './base';
+import {DatasetConfig} from './base';
 
 export const IssuesConfig: DatasetConfig<never, Group[]> = {
   transformTable: (_data: Group[]) => {

--- a/static/app/views/dashboardsV2/datasetConfig/issues.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/issues.tsx
@@ -1,0 +1,10 @@
+import {Group} from 'sentry/types';
+import {TableData} from 'sentry/utils/discover/discoverQuery';
+
+import DatasetConfig from './base';
+
+export const IssuesConfig: DatasetConfig<never, Group[]> = {
+  transformTable: (_data: Group[]) => {
+    return {data: []} as TableData;
+  },
+};

--- a/static/app/views/dashboardsV2/datasetConfig/releases.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/releases.tsx
@@ -2,7 +2,7 @@ import {MetricsApiResponse, SessionApiResponse} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 
-import DatasetConfig from './base';
+import {DatasetConfig} from './base';
 
 export const ReleasesConfig: DatasetConfig<
   SessionApiResponse | MetricsApiResponse,

--- a/static/app/views/dashboardsV2/datasetConfig/releases.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/releases.tsx
@@ -1,0 +1,17 @@
+import {MetricsApiResponse, SessionApiResponse} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
+import {TableData} from 'sentry/utils/discover/discoverQuery';
+
+import DatasetConfig from './base';
+
+export const ReleasesConfig: DatasetConfig<
+  SessionApiResponse | MetricsApiResponse,
+  SessionApiResponse | MetricsApiResponse
+> = {
+  transformSeries: (_data: SessionApiResponse | MetricsApiResponse) => {
+    return [] as Series[];
+  },
+  transformTable: (_data: SessionApiResponse | MetricsApiResponse) => {
+    return {data: []} as TableData;
+  },
+};


### PR DESCRIPTION
We want to introduce a common interface for different
widget types to plug into dashboards. This PR just
introduces a skeleton, it's not being used anywhere.