### PR TITLE
fix(activity): Add a line break between commit link and release status

### DIFF
--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -3,7 +3,6 @@ import functools
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.commit import CommitWithReleaseSerializer
 from sentry.models import Activity, Commit, Group, PullRequest
-from sentry.utils.compat import zip
 from sentry.utils.functional import apply_values
 
 
@@ -25,9 +24,6 @@ class ActivitySerializer(Serializer):
                 c.id: d
                 for c, d in zip(
                     commit_list,
-                    # serialize with just commits and no associated releases
-                    # serialize(commit_list, user, serializer=CommitSerializer()),
-                    # serialize with commit with any associated releases
                     serialize(commit_list, user, serializer=CommitWithReleaseSerializer()),
                 )
             }

--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -146,7 +146,6 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
           if (release.dateReleased !== null) {
             deployed_releases.push(release);
           }
-          return deployed_releases;
         }
         if (deployed_releases.length !== 0) {
           return tct(

--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -141,13 +141,13 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
               author,
             });
       case GroupActivityType.SET_RESOLVED_IN_COMMIT:
-        const deployed_releases: Array<BaseRelease> = [];
-        for (const release of activity.data.commit.releases) {
+        const deployedReleases: Array<BaseRelease> = [];
+        for (const release of activity.data.commit?.releases) {
           if (release.dateReleased !== null) {
-            deployed_releases.push(release);
+            deployedReleases.push(release);
           }
         }
-        if (deployed_releases.length !== 0) {
+        if (deployedReleases.length !== 0) {
           return tct(
             '[author] marked this issue as resolved in [version]\n' +
               'This commit was released in [release]',
@@ -162,7 +162,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
               ),
               release: (
                 <Version
-                  version={deployed_releases[0].version}
+                  version={deployedReleases[0].version}
                   projectId={projectId}
                   tooltipRawVersion
                 />

--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -10,7 +10,6 @@ import Version from 'sentry/components/version';
 import {t, tct, tn} from 'sentry/locale';
 import TeamStore from 'sentry/stores/teamStore';
 import {
-  BaseRelease,
   GroupActivity,
   GroupActivityAssigned,
   GroupActivitySetIgnored,
@@ -142,18 +141,14 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
               author,
             });
       case GroupActivityType.SET_RESOLVED_IN_COMMIT:
-        const deployedReleases: Array<BaseRelease> = [];
-        for (const release of activity.data.commit?.releases) {
-          if (release.dateReleased !== null) {
-            deployedReleases.push(release);
-          }
-        }
-        deployedReleases.sort(
-          (a, b) => moment(a.dateReleased).valueOf() - moment(b.dateReleased).valueOf()
-        );
+        const deployedReleases = (activity.data.commit?.releases || [])
+          .filter(r => r.dateReleased !== null)
+          .sort(
+            (a, b) => moment(a.dateReleased).valueOf() - moment(b.dateReleased).valueOf()
+          );
         if (deployedReleases.length === 1) {
           return tct(
-            '[author] marked this issue as resolved in [version]\n' +
+            '[author] marked this issue as resolved in [version] [break]' +
               'This commit was released in [release]',
             {
               author,
@@ -164,6 +159,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
                   repository={activity.data.commit.repository}
                 />
               ),
+              break: <br />,
               release: (
                 <Version
                   version={deployedReleases[0].version}
@@ -176,7 +172,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
         }
         if (deployedReleases.length > 1) {
           return tct(
-            '[author] marked this issue as resolved in [version]\n' +
+            '[author] marked this issue as resolved in [version] [break]' +
               'This commit was released in [release] and ' +
               (deployedReleases.length - 1) +
               ' others',
@@ -189,6 +185,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
                   repository={activity.data.commit.repository}
                 />
               ),
+              break: <br />,
               release: (
                 <Version
                   version={deployedReleases[0].version}

--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import moment from 'moment';
 
 import CommitLink from 'sentry/components/commitLink';
 import Duration from 'sentry/components/duration';
@@ -147,10 +148,38 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
             deployedReleases.push(release);
           }
         }
-        if (deployedReleases.length !== 0) {
+        deployedReleases.sort(
+          (a, b) => moment(a.dateReleased).valueOf() - moment(b.dateReleased).valueOf()
+        );
+        if (deployedReleases.length === 1) {
           return tct(
             '[author] marked this issue as resolved in [version]\n' +
               'This commit was released in [release]',
+            {
+              author,
+              version: (
+                <CommitLink
+                  inline
+                  commitId={activity.data.commit.id}
+                  repository={activity.data.commit.repository}
+                />
+              ),
+              release: (
+                <Version
+                  version={deployedReleases[0].version}
+                  projectId={projectId}
+                  tooltipRawVersion
+                />
+              ),
+            }
+          );
+        }
+        if (deployedReleases.length > 1) {
+          return tct(
+            '[author] marked this issue as resolved in [version]\n' +
+              'This commit was released in [release] and ' +
+              (deployedReleases.length - 1) +
+              ' others',
             {
               author,
               version: (

--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -9,6 +9,7 @@ import Version from 'sentry/components/version';
 import {t, tct, tn} from 'sentry/locale';
 import TeamStore from 'sentry/stores/teamStore';
 import {
+  BaseRelease,
   GroupActivity,
   GroupActivityAssigned,
   GroupActivitySetIgnored,
@@ -140,6 +141,36 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
               author,
             });
       case GroupActivityType.SET_RESOLVED_IN_COMMIT:
+        const deployed_releases: Array<BaseRelease> = [];
+        for (const release of activity.data.commit.releases) {
+          if (release.dateReleased !== null) {
+            deployed_releases.push(release);
+          }
+          return deployed_releases;
+        }
+        if (deployed_releases.length !== 0) {
+          return tct(
+            '[author] marked this issue as resolved in [version]\n' +
+              'This commit was released in [release]',
+            {
+              author,
+              version: (
+                <CommitLink
+                  inline
+                  commitId={activity.data.commit.id}
+                  repository={activity.data.commit.repository}
+                />
+              ),
+              release: (
+                <Version
+                  version={deployed_releases[0].version}
+                  projectId={projectId}
+                  tooltipRawVersion
+                />
+              ),
+            }
+          );
+        }
         return tct('[author] marked this issue as resolved in [version]', {
           author,
           version: (

--- a/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
@@ -88,6 +88,7 @@ describe('GroupActivity', function () {
       'assigned this issue to themselves'
     );
   });
+
   it('resolved in commit with no releases', function () {
     const wrapper = createWrapper({
       activity: [
@@ -97,6 +98,8 @@ describe('GroupActivity', function () {
           data: {
             author: 'hello',
             commit: {
+              id: 'komal-commit',
+              repository: {},
               releases: [],
             },
           },
@@ -105,11 +108,11 @@ describe('GroupActivity', function () {
       ],
     });
     expect(wrapper.find('GroupActivityItem').text()).toContain(
-      'marked this issue as resolved in'
+      'Foo Bar marked this issue as resolved in komal-commit'
     );
   });
 
-  it('resolved in commit with releases', function () {
+  it('resolved in commit with one release', function () {
     const wrapper = createWrapper({
       activity: [
         {
@@ -118,16 +121,14 @@ describe('GroupActivity', function () {
           data: {
             author: 'hello',
             commit: {
+              id: 'komal-commit',
+              repository: {},
               releases: [
                 {
                   dateCreated: '2022-05-01',
                   dateReleased: '2022-05-02',
-                  ref: 'random',
-                  shortVersion: 'random',
-                  url: 'random',
                   version: 'random',
                 },
-                {},
               ],
             },
           },
@@ -136,7 +137,52 @@ describe('GroupActivity', function () {
       ],
     });
     expect(wrapper.find('GroupActivityItem').text()).toContain(
-      'This commit was released in'
+      'Foo Bar marked this issue as resolved in komal-commit\n' +
+        'This commit was released in random'
+    );
+  });
+
+  it('resolved in commit with multiple releases', function () {
+    const wrapper = createWrapper({
+      activity: [
+        {
+          type: 'set_resolved_in_commit',
+          id: '123',
+          data: {
+            commit: {
+              id: 'komal-commit',
+              repository: {},
+              releases: [
+                {
+                  dateCreated: '2022-05-01',
+                  dateReleased: '2022-05-02',
+                  version: 'random',
+                },
+                {
+                  dateCreated: '2022-06-01',
+                  dateReleased: '2022-06-02',
+                  version: 'newest',
+                },
+                {
+                  dateCreated: '2021-08-03',
+                  dateReleased: '2021-08-03',
+                  version: 'oldest-release',
+                },
+                {
+                  dateCreated: '2022-04-21',
+                  dateReleased: '2022-04-21',
+                  version: 'randomTwo',
+                },
+              ],
+            },
+          },
+          user: TestStubs.User(),
+        },
+      ],
+    });
+    expect(wrapper.find('GroupActivityItem').text()).toContain(
+      'Foo Bar marked this issue as resolved in komal-commit\n' +
+        'This commit was released in oldest-release and 3 others'
     );
   });
 

--- a/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
@@ -120,13 +120,12 @@ describe('GroupActivity', function () {
             commit: {
               releases: [
                 {
-                  dateCreated: 'string',
-                  dateReleased: 'string',
-                  ref: 'string',
-                  shortVersion: 'string',
-                  status: ReleaseStatus.Active,
-                  url: 'string',
-                  version: 'string',
+                  dateCreated: '2022-05-01',
+                  dateReleased: '2022-05-02',
+                  ref: 'random',
+                  shortVersion: 'random',
+                  url: 'random',
+                  version: 'random',
                 },
                 {},
               ],

--- a/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
@@ -136,7 +136,7 @@ describe('GroupActivity', function () {
       ],
     });
     expect(wrapper.find('GroupActivityItem').text()).toContain(
-      'marked this issue as resolved in'
+      'This commit was released in'
     );
   });
 

--- a/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
@@ -137,8 +137,7 @@ describe('GroupActivity', function () {
       ],
     });
     expect(wrapper.find('GroupActivityItem').text()).toContain(
-      'Foo Bar marked this issue as resolved in komal-commit\n' +
-        'This commit was released in random'
+      'Foo Bar marked this issue as resolved in komal-commit This commit was released in random'
     );
   });
 
@@ -181,8 +180,7 @@ describe('GroupActivity', function () {
       ],
     });
     expect(wrapper.find('GroupActivityItem').text()).toContain(
-      'Foo Bar marked this issue as resolved in komal-commit\n' +
-        'This commit was released in oldest-release and 3 others'
+      'Foo Bar marked this issue as resolved in komal-commit This commit was released in oldest-release and 3 others'
     );
   });
 

--- a/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
@@ -88,6 +88,58 @@ describe('GroupActivity', function () {
       'assigned this issue to themselves'
     );
   });
+  it('resolved in commit with no releases', function () {
+    const wrapper = createWrapper({
+      activity: [
+        {
+          type: 'set_resolved_in_commit',
+          id: '123',
+          data: {
+            author: 'hello',
+            commit: {
+              releases: [],
+            },
+          },
+          user: TestStubs.User(),
+        },
+      ],
+    });
+    expect(wrapper.find('GroupActivityItem').text()).toContain(
+      'marked this issue as resolved in'
+    );
+  });
+
+  it('resolved in commit with releases', function () {
+    const wrapper = createWrapper({
+      activity: [
+        {
+          type: 'set_resolved_in_commit',
+          id: '123',
+          data: {
+            author: 'hello',
+            commit: {
+              releases: [
+                {
+                  dateCreated: 'string',
+                  dateReleased: 'string',
+                  ref: 'string',
+                  shortVersion: 'string',
+                  status: ReleaseStatus.Active,
+                  url: 'string',
+                  version: 'string',
+                },
+                {},
+              ],
+            },
+          },
+          user: TestStubs.User(),
+        },
+      ],
+    });
+    expect(wrapper.find('GroupActivityItem').text()).toContain(
+      'marked this issue as resolved in'
+    );
+  });
 
   it('requests assignees that are not in the team store', async function () {
     const team = TestStubs.Team({id: '123', name: 'workflow'});

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -54,3 +54,71 @@ class GroupActivityTestCase(TestCase):
         commit = result["commit"]
         assert commit["repository"]["name"] == "organization-bar"
         assert commit["message"] == "gemuse"
+
+    def test_serialize_set_resolve_in_commit_activity_with_release(self):
+        project = self.create_project(name="test_throwaway")
+        group = self.create_group(project)
+        user = self.create_user()
+        release = self.create_release(project=project, user=user)
+        commit = Commit.objects.filter(releasecommit__id=release.id).get()
+
+        Activity.objects.create(
+            project_id=project.id,
+            group=group,
+            type=Activity.SET_RESOLVED_IN_COMMIT,
+            ident=commit.id,
+            user=user,
+            data={"commit": commit.id},
+        )
+
+        act = Activity.objects.get(type=Activity.SET_RESOLVED_IN_COMMIT)
+        serialized = serialize(act)
+
+        assert len(serialized["data"]["commit"]["releases"]) == 1
+
+    def test_serialize_set_resolve_in_commit_activity_with_no_releases(self):
+        self.org = self.create_organization(name="komal-test")
+        project = self.create_project(name="random-proj")
+        user = self.create_user()
+        repo = self.create_repo(self.project, name="idk-org")
+        group = self.create_group(project)
+
+        commit = Commit.objects.create(organization_id=self.org.id, repository_id=repo.id)
+
+        Activity.objects.create(
+            project_id=project.id,
+            group=group,
+            type=Activity.SET_RESOLVED_IN_COMMIT,
+            ident=commit.id,
+            user=user,
+            data={"commit": commit.id},
+        )
+
+        act = Activity.objects.get(type=Activity.SET_RESOLVED_IN_COMMIT)
+        serialized = serialize(act)
+
+        assert len(serialized["data"]["commit"]["releases"]) == 0
+        assert not Commit.objects.filter(releasecommit__id=commit.id).exists()
+
+    def test_serialize_set_resolve_in_commit_activity_with_release_not_deployed(self):
+        project = self.create_project(name="random-test")
+        group = self.create_group(project)
+        user = self.create_user()
+        release = self.create_release(project=project, user=user)
+        release.date_released = None
+        release.save()
+        commit = Commit.objects.filter(releasecommit__id=release.id).get()
+
+        Activity.objects.create(
+            project_id=project.id,
+            group=group,
+            type=Activity.SET_RESOLVED_IN_COMMIT,
+            ident=commit.id,
+            user=user,
+            data={"commit": commit.id},
+        )
+
+        act = Activity.objects.get(type=Activity.SET_RESOLVED_IN_COMMIT)
+        serialized = serialize(act)
+
+        assert len(serialized["data"]["commit"]["releases"]) == 1

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -60,7 +60,8 @@ class GroupActivityTestCase(TestCase):
         group = self.create_group(project)
         user = self.create_user()
         release = self.create_release(project=project, user=user)
-        commit = Commit.objects.filter(releasecommit__id=release.id).get()
+        release.save()
+        commit = Commit.objects.filter(releasecommit__release_id=release.id).get()
 
         Activity.objects.create(
             project_id=project.id,
@@ -80,7 +81,7 @@ class GroupActivityTestCase(TestCase):
         self.org = self.create_organization(name="komal-test")
         project = self.create_project(name="random-proj")
         user = self.create_user()
-        repo = self.create_repo(self.project, name="idk-org")
+        repo = self.create_repo(self.project, name="idk-repo")
         group = self.create_group(project)
 
         commit = Commit.objects.create(organization_id=self.org.id, repository_id=repo.id)
@@ -107,7 +108,7 @@ class GroupActivityTestCase(TestCase):
         release = self.create_release(project=project, user=user)
         release.date_released = None
         release.save()
-        commit = Commit.objects.filter(releasecommit__id=release.id).get()
+        commit = Commit.objects.filter(releasecommit__release_id=release.id).get()
 
         Activity.objects.create(
             project_id=project.id,


### PR DESCRIPTION
A new line was not being added after the commit link.

Before:
<img width="1655" alt="Screen Shot 2022-06-03 at 10 39 10 AM" src="https://user-images.githubusercontent.com/52506101/171917412-51a1fea8-c764-4a71-8997-a667e8f0219f.png">

After:
<img width="1126" alt="Screen Shot 2022-06-03 at 10 37 32 AM" src="https://user-images.githubusercontent.com/52506101/171917434-5213e233-a533-4f2c-bba1-c039c8497ddb.png">

Changes made:

- `groupActivityItem.tsx`: Used `.filter` instead of a for loop to build array of deployed releases, added `break` property to template strings
- `groupActivity.spec.jsx`: Removed `\n` from tests
