### PR TITLE
fix(activity): Add a line break between commit link and release status

### DIFF
--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -10,7 +10,6 @@ import Version from 'sentry/components/version';
 import {t, tct, tn} from 'sentry/locale';
 import TeamStore from 'sentry/stores/teamStore';
 import {
-  BaseRelease,
   GroupActivity,
   GroupActivityAssigned,
   GroupActivitySetIgnored,
@@ -142,18 +141,14 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
               author,
             });
       case GroupActivityType.SET_RESOLVED_IN_COMMIT:
-        const deployedReleases: Array<BaseRelease> = [];
-        for (const release of activity.data.commit?.releases) {
-          if (release.dateReleased !== null) {
-            deployedReleases.push(release);
-          }
-        }
-        deployedReleases.sort(
-          (a, b) => moment(a.dateReleased).valueOf() - moment(b.dateReleased).valueOf()
-        );
+        const deployedReleases = (activity.data.commit?.releases || [])
+          .filter(r => r.dateReleased !== null)
+          .sort(
+            (a, b) => moment(a.dateReleased).valueOf() - moment(b.dateReleased).valueOf()
+          );
         if (deployedReleases.length === 1) {
           return tct(
-            '[author] marked this issue as resolved in [version]\n' +
+            '[author] marked this issue as resolved in [version] [break]' +
               'This commit was released in [release]',
             {
               author,
@@ -164,6 +159,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
                   repository={activity.data.commit.repository}
                 />
               ),
+              break: <br />,
               release: (
                 <Version
                   version={deployedReleases[0].version}
@@ -176,7 +172,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
         }
         if (deployedReleases.length > 1) {
           return tct(
-            '[author] marked this issue as resolved in [version]\n' +
+            '[author] marked this issue as resolved in [version] [break]' +
               'This commit was released in [release] and ' +
               (deployedReleases.length - 1) +
               ' others',
@@ -189,6 +185,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
                   repository={activity.data.commit.repository}
                 />
               ),
+              break: <br />,
               release: (
                 <Version
                   version={deployedReleases[0].version}

--- a/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
@@ -137,8 +137,7 @@ describe('GroupActivity', function () {
       ],
     });
     expect(wrapper.find('GroupActivityItem').text()).toContain(
-      'Foo Bar marked this issue as resolved in komal-commit\n' +
-        'This commit was released in random'
+      'Foo Bar marked this issue as resolved in komal-commit This commit was released in random'
     );
   });
 
@@ -181,8 +180,7 @@ describe('GroupActivity', function () {
       ],
     });
     expect(wrapper.find('GroupActivityItem').text()).toContain(
-      'Foo Bar marked this issue as resolved in komal-commit\n' +
-        'This commit was released in oldest-release and 3 others'
+      'Foo Bar marked this issue as resolved in komal-commit This commit was released in oldest-release and 3 others'
     );
   });
 


### PR DESCRIPTION
A new line was not being added after the commit link.

Before:
<img width="1655" alt="Screen Shot 2022-06-03 at 10 39 10 AM" src="https://user-images.githubusercontent.com/52506101/171917412-51a1fea8-c764-4a71-8997-a667e8f0219f.png">

After:
<img width="1126" alt="Screen Shot 2022-06-03 at 10 37 32 AM" src="https://user-images.githubusercontent.com/52506101/171917434-5213e233-a533-4f2c-bba1-c039c8497ddb.png">

Changes made:

- `groupActivityItem.tsx`: Used `.filter` instead of a for loop to build array of deployed releases, added `break` property to template strings
- `groupActivity.spec.jsx`: Removed `\n` from tests
