### PR TITLE
ref(datePageFilter): Show absolute time when selected

### DIFF
--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -12,9 +12,9 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {
-  getFormattedDate,
   DEFAULT_DAY_END_TIME,
   DEFAULT_DAY_START_TIME,
+  getFormattedDate,
 } from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 

--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -11,6 +11,11 @@ import {IconCalendar} from 'sentry/icons';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
+import {
+  getFormattedDate,
+  DEFAULT_DAY_END_TIME,
+  DEFAULT_DAY_START_TIME,
+} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = Omit<
@@ -42,11 +47,17 @@ function DatePageFilter({router, resetParamsOnChange, ...props}: Props) {
   const customDropdownButton = ({getActorProps, isOpen}) => {
     let label;
     if (start && end) {
-      const startString = start.toLocaleString('default', {
-        month: 'short',
-        day: 'numeric',
-      });
-      const endString = end.toLocaleString('default', {month: 'short', day: 'numeric'});
+      const startTimeFormatted = getFormattedDate(start, 'HH:mm:ss', {local: true});
+      const endTimeFormatted = getFormattedDate(end, 'HH:mm:ss', {local: true});
+
+      const shouldShowTimes =
+        startTimeFormatted !== DEFAULT_DAY_START_TIME ||
+        endTimeFormatted !== DEFAULT_DAY_END_TIME;
+      const format = shouldShowTimes ? 'MMM D, h:mma' : 'MMM D';
+
+      const startString = getFormattedDate(start, format, {local: true});
+      const endString = getFormattedDate(end, format, {local: true});
+
       label = `${startString} - ${endString}`;
     } else {
       label = period?.toUpperCase();
@@ -100,6 +111,7 @@ const DropdownTitle = styled('div')`
   display: flex;
   align-items: center;
   flex: 1;
+  width: 100%;
 `;
 
 export default withRouter(DatePageFilter);


### PR DESCRIPTION
**Before:** no time is shown even when the user has selected a custom time
<img width="614" alt="Screen Shot 2022-06-03 at 11 45 41 AM" src="https://user-images.githubusercontent.com/44172267/171927533-0482c864-8ae2-40e4-b1bb-22ca8d5e07ea.png">

**After:** time is shown _but only when_ the user has selected a custom time (second screenshot)
<img width="614" alt="Screen Shot 2022-06-03 at 11 44 30 AM" src="https://user-images.githubusercontent.com/44172267/171927139-c65db3b1-5e7f-4fc9-8a49-00cb9c777d53.png">
<img width="614" alt="Screen Shot 2022-06-03 at 11 44 47 AM" src="https://user-images.githubusercontent.com/44172267/171927218-fe4058c5-4cd0-4005-b578-f7eb23dc2136.png">

