### PR TITLE
ref(menuListItem): Move LeadingItems out of ContentWrap

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -92,15 +92,15 @@ function BaseMenuListItem({
         priority={priority}
         {...innerWrapProps}
       >
+        {leadingItems && (
+          <LeadingItems
+            isDisabled={isDisabled}
+            spanFullHeight={leadingItemsSpanFullHeight}
+          >
+            {leadingItems}
+          </LeadingItems>
+        )}
         <ContentWrap isFocused={isFocused} showDivider={showDivider}>
-          {leadingItems && (
-            <LeadingItems
-              isDisabled={isDisabled}
-              spanFullHeight={leadingItemsSpanFullHeight}
-            >
-              {leadingItems}
-            </LeadingItems>
-          )}
           <LabelWrap>
             <Label aria-hidden="true" {...labelProps}>
               {label}
@@ -158,7 +158,7 @@ export const InnerWrap = styled('div', {
 }>`
   display: flex;
   position: relative;
-  padding: 0 ${space(1)};
+  padding: 0 ${space(1)} 0 ${space(1.5)};
   border-radius: ${p => p.theme.borderRadius};
   box-sizing: border-box;
 
@@ -191,7 +191,6 @@ const ContentWrap = styled('div')<{isFocused: boolean; showDivider: boolean}>`
   gap: ${space(1)};
   justify-content: space-between;
   padding: ${space(1)} 0;
-  margin-left: ${space(0.5)};
 
   ${p =>
     p.showDivider &&
@@ -214,7 +213,8 @@ const LeadingItems = styled('div')<{isDisabled: boolean; spanFullHeight: boolean
   align-items: center;
   height: 1.4em;
   gap: ${space(1)};
-  padding: ${space(1)} 0;
+  margin-top: ${space(1)};
+  margin-right: ${space(1)};
 
   ${p => p.isDisabled && `opacity: 0.5;`}
   ${p => p.spanFullHeight && `height: 100%;`}


### PR DESCRIPTION
This has the effect of limiting the width of dividers to just the main text content, and not all the way to the leading items.

**Before:**
<img width="350" alt="Screen Shot 2022-06-03 at 12 18 34 PM" src="https://user-images.githubusercontent.com/44172267/171934157-29930f6e-4921-449d-ae9b-84b6420ff602.png">


**After:**
<img width="350" alt="Screen Shot 2022-06-03 at 12 19 46 PM" src="https://user-images.githubusercontent.com/44172267/171934405-8c71f229-e057-44fc-b99f-3d6a4f06412d.png">

