### PR TITLE
feat(meta) Add meta tags for unauthenticated requests

### DIFF
--- a/src/sentry/analytics/events/metalink.py
+++ b/src/sentry/analytics/events/metalink.py
@@ -1,0 +1,17 @@
+from sentry import analytics
+
+
+class MetaLinkScrapedEvent(analytics.Event):
+    type = "metalink.scraped"
+
+    attributes = (analytics.Attribute("provider"),)
+
+
+class SharedMetaLinkScrapedEvent(analytics.Event):
+    type = "metalink.shared.scraped"
+
+    attributes = (analytics.Attribute("provider"),)
+
+
+analytics.register(MetaLinkScrapedEvent)
+analytics.register(SharedMetaLinkScrapedEvent)

--- a/src/sentry/utils/metatags.py
+++ b/src/sentry/utils/metatags.py
@@ -1,0 +1,40 @@
+def get_provider_by_user_agent(user_agent):
+    user_agent = user_agent.lower()
+    for keyword, provider in [
+        (
+            "telegram",
+            "telegram",
+        ),  # User-agent is "TelegramBot (like TwitterBot)" so it must go before Twitter
+        ("twitter", "twitter"),
+        ("notion", "notion"),
+        ("atlassian", "atlassian"),  # Could be trello or jira
+        ("discord", "discord"),
+        ("slack", "slack"),
+        ("skype", "msteams"),
+        ("reddit", "reddit"),
+        ("facebook", "facebook"),
+        ("quora", "quora"),
+        ("linkedin", "linkedin"),
+        ("iframely", "iframely"),  # Generic embedding framework
+        ("embedly", "embedly"),  # Generic embedding framework
+    ]:
+        if keyword in user_agent:
+            return provider
+    return None
+
+
+# Providers that we have an integration
+META_PROVIDER_TO_INTEGRATIONS = {
+    "atlassian": "Jira/Trello",
+    "slack": "Slack",
+    "msteams": "Microsoft Teams",
+}
+
+# Providers that are considered public facing
+META_PUBLIC_PROVIDERS = [
+    "twitter",
+    "reddit",
+    "linkedin",
+    "facebook",
+    "quora",
+]

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -17,6 +17,7 @@ from sentry.http import get_server_hostname
 from sentry.models import AuthProvider, Organization, OrganizationMember, OrganizationStatus
 from sentry.signals import join_request_link_viewed, user_signup
 from sentry.utils import auth, json, metrics
+from sentry.utils.assets import get_asset_url
 from sentry.utils.auth import (
     get_login_redirect,
     has_user_registration,
@@ -74,6 +75,7 @@ class AuthLoginView(BaseView):
             provider = get_provider_by_user_agent(user_agent)
         if provider:
             analytics.record("metalink.scraped", provider=provider)
+        image_url = get_asset_url("sentry", "images/logos/sentry-avatar.png")
         opengraph_meta = {}
         if provider in META_PROVIDER_TO_INTEGRATIONS:
             opengraph_meta = {
@@ -81,6 +83,7 @@ class AuthLoginView(BaseView):
                 "og:title": f"Install {META_PROVIDER_TO_INTEGRATIONS[provider]} integration to preview",
                 "og:description": f"The content requires authentication. Install our {META_PROVIDER_TO_INTEGRATIONS[provider]} integration to preview details.",
                 "og:site_name": "Sentry",
+                "og:image": image_url,
             }
         elif provider in META_PUBLIC_PROVIDERS:
             if provider == "twitter":
@@ -89,6 +92,7 @@ class AuthLoginView(BaseView):
                     "twitter:site": "@getsentry",
                     "twitter:title": "Enable public share link to preview",
                     "twitter:description": "This content requires authentication. Enable public share link so that people can see it.",
+                    "twitter:image": image_url,
                 }
             else:
                 opengraph_meta = {
@@ -96,6 +100,7 @@ class AuthLoginView(BaseView):
                     "og:title": "Enable public share link to preview",
                     "og:description": "This content requires authentication. Enable public share link so that people can see it.",
                     "og:site_name": "Sentry",
+                    "og:image": image_url,
                 }
         return opengraph_meta
 

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -14,6 +14,7 @@ from sentry.web.frontend.auth_login import AuthLoginView
 
 class AuthOrganizationLoginView(AuthLoginView):
     def respond_login(self, request: Request, context, *args, **kwargs) -> Response:
+        self.context_add_meta_tags(request, context, **kwargs)
         return self.respond("sentry/organization-login.html", context)
 
     def handle_sso(self, request: Request, organization, auth_provider):

--- a/src/sentry/web/frontend/shared_group_details.py
+++ b/src/sentry/web/frontend/shared_group_details.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 
 from sentry import analytics
 from sentry.models import Group
+from sentry.utils.assets import get_asset_url
 from sentry.utils.metatags import get_provider_by_user_agent
 from sentry.web.frontend.react_page import GenericReactPageView
 
@@ -23,14 +24,17 @@ class SharedGroupDetailsView(GenericReactPageView):
         if provider:
             analytics.record("metalink.shared.scraped", provider=provider)
 
+        image_url = get_asset_url("sentry", "images/logos/sentry-avatar.png")
         return {
             **obj,
             "og:type": "website",
             "og:title": group.title,
             "og:description": group.message,
+            "og:image": image_url,
             "og:site_name": "Sentry",
             "twitter:card": "summary",
             "twitter:site": "@getsentry",
             "twitter:title": group.title,
             "twitter:description": group.message,
+            "twitter:image": image_url,
         }

--- a/src/sentry/web/frontend/shared_group_details.py
+++ b/src/sentry/web/frontend/shared_group_details.py
@@ -1,18 +1,30 @@
 from rest_framework.request import Request
 
+from sentry import analytics
 from sentry.models import Group
+from sentry.utils.metatags import get_provider_by_user_agent
 from sentry.web.frontend.react_page import GenericReactPageView
 
 
 class SharedGroupDetailsView(GenericReactPageView):
     def meta_tags(self, request: Request, share_id):
+        obj = super().meta_tags(request)
         try:
             group = Group.objects.from_share_id(share_id)
         except Group.DoesNotExist:
             return {}
         if group.organization.flags.disable_shared_issues:
             return {}
+
+        user_agent = request.META.get("HTTP_USER_AGENT")
+        provider = None
+        if user_agent:
+            provider = get_provider_by_user_agent(user_agent)
+        if provider:
+            analytics.record("metalink.shared.scraped", provider=provider)
+
         return {
+            **obj,
             "og:type": "website",
             "og:title": group.title,
             "og:description": group.message,


### PR DESCRIPTION
This shows a mete tag asking the user to either share a public link or install integration based on where the user pasted the private link.
<img width="692" alt="image" src="https://user-images.githubusercontent.com/8980455/171965644-3e0c9ec1-fa6f-4986-a472-33dd090f6a07.png">
<img width="812" alt="image" src="https://user-images.githubusercontent.com/8980455/171965791-d91bd2ee-d784-4249-b19c-aced761c686a.png">
