### PR TITLE
fix(alerts): If user isn't a member but has project access use first project in alert wizard

### DIFF
--- a/static/app/views/alerts/builder/projectProvider.tsx
+++ b/static/app/views/alerts/builder/projectProvider.tsx
@@ -2,6 +2,7 @@ import {cloneElement, Fragment, isValidElement, useEffect} from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
+import {navigateTo} from 'sentry/actionCreators/navigation';
 import Alert from 'sentry/components/alert';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -52,6 +53,16 @@ function AlertBuilderProjectProvider(props: Props) {
 
   if (!initiallyLoaded || fetching) {
     return <LoadingIndicator />;
+  }
+
+  // If there's no project show the project selector modal
+  if (!project && !fetchError) {
+    navigateTo(
+      hasAlertWizardV3
+        ? `/organizations/${organization.slug}/alerts/wizard/?referrer=${props.location.query.referrer}&project=:projectId`
+        : `/organizations/${organization.slug}/alerts/:projectId/wizard/?referrer=${props.location.query.referrer}`,
+      props.router
+    );
   }
 
   // if loaded, but project fetching states incomplete or project can't be found, project doesn't exist

--- a/static/app/views/alerts/builder/projectProvider.tsx
+++ b/static/app/views/alerts/builder/projectProvider.tsx
@@ -38,7 +38,7 @@ function AlertBuilderProjectProvider(props: Props) {
         }
   );
   const project = useFirstProject
-    ? projects.find(p => p.isMember)
+    ? projects.find(p => p.isMember) ?? (projects.length && projects[0])
     : projects.find(({slug}) => slug === projectId);
 
   useEffect(() => {


### PR DESCRIPTION
This fixes a small bug for alert wizard. When a user isn't a member of any projects but has access to projects, they still see `The project you were looking for was not found` error. Select the first available project if the org has alert wizard v3. If the org doesn't have alert wizard v3 or a project that isn't available is in the url parameters, show the project selector modal.

Jira: [WOR-1904](https://getsentry.atlassian.net/browse/WOR-1904)