### PR TITLE
fix(digests): Slack notification title rendering incorrectly

### DIFF
--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -68,11 +68,12 @@ class DigestNotification(ProjectNotification):
         if not context:
             return "Digest Report"
 
-        return "<!date^{:.0f}^{count} {noun} detected in {project} {date} | Digest Report".format(
+        return "<!date^{:.0f}^{count} {noun} detected {date} in| Digest Report for> <{project_link}|{project_name}>".format(
             to_timestamp(context["start"]),
             count=len(context["counts"]),
             noun="issue" if len(context["counts"]) == 1 else "issues",
-            project=context["group"].project.name,
+            project_link=f'https://sentry.io/organizations/{context["group"].project.organization.slug}/projects/{context["group"].project.slug}/',
+            project_name=context["group"].project.name,
             date="{date_pretty}",
         )
 

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -30,6 +30,7 @@ from sentry.notifications.utils.digest import (
 )
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.dates import to_timestamp
+from sentry.utils.http import absolute_uri
 
 if TYPE_CHECKING:
     from sentry.models import Organization, Project, Team, User
@@ -72,7 +73,9 @@ class DigestNotification(ProjectNotification):
             to_timestamp(context["start"]),
             count=len(context["counts"]),
             noun="issue" if len(context["counts"]) == 1 else "issues",
-            project_link=f'https://sentry.io/organizations/{context["group"].project.organization.slug}/projects/{context["group"].project.slug}/',
+            project_link=absolute_uri(
+                f'/organizations/{context["group"].project.organization.slug}/projects/{context["group"].project.slug}/'
+            ),
             project_name=context["group"].project.name,
             date="{date_pretty}",
         )

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -113,6 +113,6 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         attachments = json.loads(data["attachments"][0])
         assert (
             data["text"][0]
-            == f"<!date^1652977338^2 issues detected {{date_pretty}} in| Digest Report for> <https://sentry.io/organizations/{self.organization.slug}/projects/{self.project.slug}/|{self.project.name}>"
+            == f"<!date^1652977338^2 issues detected {{date_pretty}} in| Digest Report for> <http://testserver/organizations/{self.organization.slug}/projects/{self.project.slug}/|{self.project.name}>"
         )
         assert len(attachments) == 2

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -113,6 +113,6 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         attachments = json.loads(data["attachments"][0])
         assert (
             data["text"][0]
-            == "<!date^1652977338^2 issues detected in Bar {date_pretty} | Digest Report"
+            == f"<!date^1652977338^2 issues detected {{date_pretty}} in| Digest Report for> <https://sentry.io/organizations/{self.organization.slug}/projects/{self.project.slug}/|{self.project.name}>"
         )
         assert len(attachments) == 2


### PR DESCRIPTION
## Objective:
Current:
<img width="911" alt="slack digest notification title incorrect render" src="https://user-images.githubusercontent.com/10491193/171967044-a0fd3a09-d26e-4e2a-b243-42317189d938.png">

After:
![slack digest notification title correct render](https://user-images.githubusercontent.com/10491193/171967062-51a81687-8136-4253-98e6-d1399bf4c3a9.png)
