### PR TITLE
fix(ui): Align the checkbox with the error level

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -620,6 +620,9 @@ const GroupSummary = styled('div')<{canSelect: boolean}>`
 const GroupCheckBoxWrapper = styled('div')`
   margin-left: ${space(2)};
   align-self: flex-start;
+  height: 15px;
+  display: flex;
+  align-items: center;
 
   & input[type='checkbox'] {
     margin: 0;


### PR DESCRIPTION
Align the checkbox with the error level on the left side. The error level's height is hardcoded to `15px` so we hardcode the height of the checkbox's wrapper to the same height and center it. Currently it also looks aligned to the title, but If we change the size of the title font then it will no longer be aligned with the title but at least it's aligned to the error level on the left.

Before (Chrome)
<img width="387" alt="Screen Shot 2022-06-03 at 10 50 21 AM" src="https://user-images.githubusercontent.com/30991498/171967433-8eb53c80-3059-4437-8126-742afbde4cec.png">


After (Chrome)
<img width="444" alt="Screen Shot 2022-06-03 at 11 04 24 AM" src="https://user-images.githubusercontent.com/30991498/171967431-fef5c140-1a88-42eb-9bd1-96bc22897357.png">

