### PR TITLE
fix: Fix API key stats missing key_id condition

### DIFF
--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -50,7 +50,7 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
         )
         query_data["groupBy"] = "outcome"
         query_data["category"] = "error"
-        query_data["key"] = key.id
+        query_data["key_id"] = key.id
 
         try:
             stats_params = self._parse_args(request)

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -50,6 +50,7 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
         )
         query_data["groupBy"] = "outcome"
         query_data["category"] = "error"
+        query_data["key"] = key.id
 
         try:
             stats_params = self._parse_args(request)

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -48,6 +48,7 @@ by these fields
 - `outcome`
 - `reason`
 - `category`
+- `key_id`
 """
 
 ResultSet = List[Dict[str, Any]]
@@ -167,8 +168,8 @@ class KeyDimension(Dimension):
         def _parse_value(key_id: str) -> Outcome:
             try:
                 return int(key_id)
-            except KeyError:
-                raise InvalidField(f'Invalid key: "{key_id}"')
+            except ValueError:
+                raise InvalidQuery(f'Invalid key: "{key_id}"')
 
         return [_parse_value(o) for o in raw_filter]
 
@@ -199,7 +200,7 @@ DIMENSION_MAP: Mapping[str, Dimension] = {
     "outcome": OutcomeDimension("outcome"),
     "category": CategoryDimension("category"),
     "reason": ReasonDimension("reason"),
-    "key": KeyDimension("key"),
+    "key_id": KeyDimension("key_id"),
 }
 
 GROUPBY_MAP = {

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -165,7 +165,7 @@ class OutcomeDimension(Dimension):
 
 class KeyDimension(Dimension):
     def resolve_filter(self, raw_filter: Sequence[str]) -> List[int]:
-        def _parse_value(key_id: str) -> Outcome:
+        def _parse_value(key_id: str) -> int:
             try:
                 return int(key_id)
             except ValueError:

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -207,6 +207,8 @@ GROUPBY_MAP = {
     **DIMENSION_MAP,
     "project": SimpleGroupBy("project_id", "project"),
 }
+# We don't have any scenarios where we need to group by key right now.
+GROUPBY_MAP.pop("key_id")
 
 TS_COL = "time"
 

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -164,7 +164,7 @@ class OutcomeDimension(Dimension):
 
 
 class KeyDimension(Dimension):
-    def resolve_filter(self, raw_filter: Sequence[str]) -> List[Outcome]:
+    def resolve_filter(self, raw_filter: Sequence[str]) -> List[int]:
         def _parse_value(key_id: str) -> Outcome:
             try:
                 return int(key_id)

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -162,6 +162,21 @@ class OutcomeDimension(Dimension):
             row["outcome"] = Outcome(row["outcome"]).api_name()
 
 
+class KeyDimension(Dimension):
+    def resolve_filter(self, raw_filter: Sequence[str]) -> List[Outcome]:
+        def _parse_value(key_id: str) -> Outcome:
+            try:
+                return int(key_id)
+            except KeyError:
+                raise InvalidField(f'Invalid key: "{key_id}"')
+
+        return [_parse_value(o) for o in raw_filter]
+
+    def map_row(self, row: MutableMapping[str, Any]) -> None:
+        # No changes are required to map key_id values.
+        pass
+
+
 class ReasonDimension(Dimension):
     def resolve_filter(self, raw_filter: Sequence[str]) -> List[str]:
         return [
@@ -184,6 +199,7 @@ DIMENSION_MAP: Mapping[str, Dimension] = {
     "outcome": OutcomeDimension("outcome"),
     "category": CategoryDimension("category"),
     "reason": ReasonDimension("reason"),
+    "key": KeyDimension("key"),
 }
 
 GROUPBY_MAP = {

--- a/tests/sentry/api/endpoints/test_project_key_stats.py
+++ b/tests/sentry/api/endpoints/test_project_key_stats.py
@@ -15,11 +15,28 @@ class ProjectKeyStatsTest(OutcomesSnubaTest, SnubaTestCase, APITestCase):
         self.path = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/keys/{self.key.public_key}/stats/"
 
     def test_simple(self):
+        # This outcome should not be included.
+        other_key = ProjectKey.objects.create(project=self.project)
         self.store_outcomes(
             {
                 "org_id": self.organization.id,
                 "timestamp": before_now(hours=1),
                 "project_id": self.project.id,
+                "key_id": other_key.id,
+                "outcome": Outcome.ACCEPTED,
+                "reason": "none",
+                "category": DataCategory.ERROR,
+                "quantity": 100,
+            },
+            1,
+        )
+        # These outcomes should be included.
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "timestamp": before_now(hours=1),
+                "project_id": self.project.id,
+                "key_id": self.key.id,
                 "outcome": Outcome.ACCEPTED,
                 "reason": "none",
                 "category": DataCategory.ERROR,
@@ -32,6 +49,7 @@ class ProjectKeyStatsTest(OutcomesSnubaTest, SnubaTestCase, APITestCase):
                 "org_id": self.organization.id,
                 "timestamp": before_now(hours=1),
                 "project_id": self.project.id,
+                "key_id": self.key.id,
                 "outcome": Outcome.FILTERED,
                 "reason": "none",
                 "category": DataCategory.ERROR,
@@ -43,6 +61,7 @@ class ProjectKeyStatsTest(OutcomesSnubaTest, SnubaTestCase, APITestCase):
             {
                 "org_id": self.organization.id,
                 "timestamp": before_now(hours=1),
+                "key_id": self.key.id,
                 "project_id": self.project.id,
                 "outcome": Outcome.RATE_LIMITED,
                 "reason": "none",
@@ -69,6 +88,7 @@ class ProjectKeyStatsTest(OutcomesSnubaTest, SnubaTestCase, APITestCase):
                 "org_id": self.organization.id,
                 "timestamp": before_now(hours=1),
                 "project_id": self.project.id,
+                "key_id": self.key.id,
                 "outcome": Outcome.ACCEPTED,
                 "reason": "none",
                 "category": DataCategory.ERROR,
@@ -81,6 +101,7 @@ class ProjectKeyStatsTest(OutcomesSnubaTest, SnubaTestCase, APITestCase):
                 "org_id": self.organization.id,
                 "timestamp": before_now(hours=1),
                 "project_id": self.project.id,
+                "key_id": self.key.id,
                 "outcome": Outcome.CLIENT_DISCARD,
                 "reason": "none",
                 "category": DataCategory.ERROR,
@@ -106,6 +127,7 @@ class ProjectKeyStatsTest(OutcomesSnubaTest, SnubaTestCase, APITestCase):
                 "org_id": self.organization.id,
                 "timestamp": before_now(hours=1),
                 "project_id": self.project.id,
+                "key_id": self.key.id,
                 "outcome": Outcome.ACCEPTED,
                 "reason": "none",
                 "category": DataCategory.ERROR,
@@ -118,6 +140,7 @@ class ProjectKeyStatsTest(OutcomesSnubaTest, SnubaTestCase, APITestCase):
                 "org_id": self.organization.id,
                 "timestamp": before_now(days=10),
                 "project_id": self.project.id,
+                "key_id": self.key.id,
                 "outcome": Outcome.ACCEPTED,
                 "reason": "none",
                 "category": DataCategory.ERROR,

--- a/tests/sentry/snuba/test_outcomes.py
+++ b/tests/sentry/snuba/test_outcomes.py
@@ -117,3 +117,18 @@ class OutcomesQueryDefinitionTests(TestCase):
         )
         assert Condition(Column("org_id"), Op.EQ, 1) in query.conditions
         assert Condition(Column("project_id"), Op.IN, [1, 2, 3, 4, 5]) in query.conditions
+
+    def test_key_id_filter(self):
+        query = _make_query(
+            "statsPeriod=4d&interval=1d&groupBy=category&key_id=12345&field=sum(quantity)",
+            {"organization_id": 1},
+        )
+
+        assert Condition(Column("key_id"), Op.IN, [12345]) in query.conditions
+
+    def test_key_id_filter_invalid(self):
+        with pytest.raises(InvalidQuery):
+            _make_query(
+                "statsPeriod=4d&interval=1d&groupBy=category&key_id=INVALID&field=sum(quantity)",
+                {"organization_id": 1},
+            )


### PR DESCRIPTION
Add the missing keyid condition to make key stats accurate. I missed this when converting this endpoint away from `tsdb`.
