### PR TITLE
chore: Update docs links in-app for release setup

### DIFF
--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -335,7 +335,7 @@ function RuleNode({
               "This project doesn't support sessions. [link:View supported platforms]",
               {
                 link: (
-                  <ExternalLink href="https://docs.sentry.io/product/releases/health/setup/" />
+                  <ExternalLink href="https://docs.sentry.io/product/releases/setup/#release-health" />
                 ),
               }
             )}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -407,7 +407,7 @@ class ReleasesList extends AsyncView<Props, State> {
                   )}
                 </div>
                 <ExternalLink
-                  href="https://docs.sentry.io/product/releases/health/setup/"
+                  href="https://docs.sentry.io/product/releases/setup/#release-health"
                   onClick={this.trackAddReleaseHealth}
                 >
                   {t('Add Release Health')}


### PR DESCRIPTION
Update links to https://docs.sentry.io/product/releases/setup/#release-health
(requested by Isabel) since there is a restructure of release health docs
in this PR https://github.com/getsentry/sentry-docs/pull/5108