### PR TITLE
ref: trim the methods that S001 mock plugin checks

### DIFF
--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -473,7 +473,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         assert results[0]["sessionStats"]["currentCrashFreeRate"] == 75.63453
         assert results[0]["sessionStats"]["hasHealthData"]
 
-        check_has_health_data.assert_not_called()  # NOQA
+        check_has_health_data.assert_not_called()
 
     @mock.patch("sentry.api.serializers.models.project.release_health.check_has_health_data")
     @mock.patch(
@@ -502,7 +502,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         assert results[0]["sessionStats"]["currentCrashFreeRate"] is None
         assert results[0]["sessionStats"]["hasHealthData"]
 
-        check_has_health_data.assert_called()  # NOQA
+        check_has_health_data.assert_called()
 
 
 class ProjectWithOrganizationSerializerTest(TestCase):

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -318,7 +318,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
         self.metrics.incr.reset_mock()
         self.send_update(self.rule, self.trigger.alert_threshold, timedelta(hours=1))
-        self.metrics.incr.assert_not_called()  # NOQA
+        self.metrics.incr.assert_not_called()
 
     def test_no_alert(self):
         rule = self.rule

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -51,7 +51,7 @@ class TestSendSubscriberNotifications(BaseIncidentActivityTest, TestCase):
         )
         send_subscriber_notifications(activity.id)
         # User shouldn't receive an email for their own activity
-        self.send_async.assert_not_called()  # NOQA
+        self.send_async.assert_not_called()
 
         self.send_async.reset_mock()
         non_member_user = self.create_user(email="non_member@test.com")
@@ -73,7 +73,7 @@ class TestSendSubscriberNotifications(BaseIncidentActivityTest, TestCase):
         activity_type = IncidentActivityType.CREATED
         activity = create_incident_activity(self.incident, activity_type)
         send_subscriber_notifications(activity.id)
-        self.send_async.assert_not_called()  # NOQA
+        self.send_async.assert_not_called()
         self.send_async.reset_mock()
 
 

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -78,9 +78,9 @@ class PostProcessGroupTest(TestCase):
             cache_key=cache_key,
         )
 
-        mock_processor.assert_not_called()  # NOQA
-        mock_process_service_hook.assert_not_called()  # NOQA
-        mock_process_resource_change_bound.assert_not_called()  # NOQA
+        mock_processor.assert_not_called()
+        mock_process_service_hook.assert_not_called()
+        mock_process_resource_change_bound.assert_not_called()
 
         mock_signal.assert_called_once_with(
             sender=ANY, project=self.project, event=EventMatcher(event), primary_hash=None

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -206,7 +206,7 @@ def test_project_get_option_does_not_reload(default_project, task_runner, monkey
                     "sentry:relay_pii_config", '{"applications": {"$string": ["@creditcard:mask"]}}'
                 )
 
-    update_config_cache.assert_not_called()  # noqa
+    update_config_cache.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/tests/tools/flake8_plugin_test.py
+++ b/tests/tools/flake8_plugin_test.py
@@ -15,15 +15,15 @@ def _errors(*errors):
 def test_S001():
     S001_py = """\
 class A:
-    def assert_called_once():
+    def called_once():
         pass
 
 
-A().assert_called_once()
+A().called_once()
 """
 
     errors = _run(S001_py)
-    assert errors == _errors(S001(6, 0, vars=("assert_called_once",)))
+    assert errors == _errors(S001(6, 0, vars=("called_once",)))
 
 
 def test_S002():

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -82,10 +82,6 @@ S001 = Error(
     "behavior."
 )
 S001.methods = {
-    "assert_calls",
-    "assert_not_called",
-    "assert_called",
-    "assert_called_once",
     "not_called",
     "called_once",
     "called_once_with",


### PR DESCRIPTION
there's no need to check for methods starting with assert as modern unittest.mock raises an error for invalid methods there

we should at some point maybe consider replacing this with [`python-check-mock-methods`](https://github.com/pre-commit/pygrep-hooks#provided-hooks)

```pycon
>>> from unittest import mock
>>> mck = mock.Mock()
>>> mck.assert_wat()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/asottile/.pyenv/versions/3.8.13/lib/python3.8/unittest/mock.py", line 642, in __getattr__
    raise AttributeError("Attributes cannot start with 'assert' "
AttributeError: Attributes cannot start with 'assert' or 'assret'
>>> mck.assret_wat()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/asottile/.pyenv/versions/3.8.13/lib/python3.8/unittest/mock.py", line 642, in __getattr__
    raise AttributeError("Attributes cannot start with 'assert' "
AttributeError: Attributes cannot start with 'assert' or 'assret'
```