### PR TITLE
fix(tsdb) Fix outcome conditions in tsdb queries

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -27,6 +27,15 @@ OUTCOMES_CATEGORY_CONDITION = [
     DataCategory.error_categories(),
 ]
 
+# We include a subset of outcome results as to not show client-discards
+# and invalid results as those are not shown in org-stats and we want
+# data to line up.
+TOTAL_RECEIVED_OUTCOMES = [
+    outcomes.Outcome.ACCEPTED,
+    outcomes.Outcome.FILTERED,
+    outcomes.Outcome.RATE_LIMITED,
+]
+
 
 class SnubaTSDB(BaseTSDB):
     """
@@ -80,7 +89,11 @@ class SnubaTSDB(BaseTSDB):
             snuba.Dataset.Outcomes,
             "project_id",
             "quantity",
-            [["reason", "=", reason], OUTCOMES_CATEGORY_CONDITION],
+            [
+                ["reason", "=", reason],
+                ["outcome", "IN", TOTAL_RECEIVED_OUTCOMES],
+                OUTCOMES_CATEGORY_CONDITION,
+            ],
         )
         for reason, model in FILTER_STAT_KEYS_TO_VALUES.items()
     }
@@ -90,7 +103,10 @@ class SnubaTSDB(BaseTSDB):
             snuba.Dataset.Outcomes,
             "org_id",
             "quantity",
-            [["outcome", "!=", outcomes.Outcome.INVALID], OUTCOMES_CATEGORY_CONDITION],
+            [
+                ["outcome", "IN", TOTAL_RECEIVED_OUTCOMES],
+                OUTCOMES_CATEGORY_CONDITION,
+            ],
         ),
         TSDBModel.organization_total_rejected: SnubaModelQuerySettings(
             snuba.Dataset.Outcomes,
@@ -108,7 +124,7 @@ class SnubaTSDB(BaseTSDB):
             snuba.Dataset.Outcomes,
             "project_id",
             "quantity",
-            [["outcome", "!=", outcomes.Outcome.INVALID], OUTCOMES_CATEGORY_CONDITION],
+            [["outcome", "IN", TOTAL_RECEIVED_OUTCOMES], OUTCOMES_CATEGORY_CONDITION],
         ),
         TSDBModel.project_total_rejected: SnubaModelQuerySettings(
             snuba.Dataset.Outcomes,
@@ -126,7 +142,7 @@ class SnubaTSDB(BaseTSDB):
             snuba.Dataset.Outcomes,
             "key_id",
             "quantity",
-            [["outcome", "!=", outcomes.Outcome.INVALID], OUTCOMES_CATEGORY_CONDITION],
+            [["outcome", "IN", TOTAL_RECEIVED_OUTCOMES], OUTCOMES_CATEGORY_CONDITION],
         ),
         TSDBModel.key_total_rejected: SnubaModelQuerySettings(
             snuba.Dataset.Outcomes,

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -142,6 +142,19 @@ class SnubaTSDBTest(OutcomesSnubaTest):
                 1,
             )
 
+        # Add client-discards (which we shouldn't show in total queries)
+        self.store_outcomes(
+            {
+                "org_id": other_organization.id,
+                "project_id": self.project.id,
+                "outcome": Outcome.CLIENT_DISCARD.value,
+                "category": DataCategory.ERROR,
+                "timestamp": self.start_time,
+                "quantity": 1,
+            },
+            5,
+        )
+
         for tsdb_model, granularity, floor_func, start_time_count, day_later_count in [
             (TSDBModel.organization_total_received, 3600, floor_to_hour_epoch, 4 * 3, 5 * 3),
             (TSDBModel.organization_total_rejected, 3600, floor_to_hour_epoch, 4, 5),


### PR DESCRIPTION
Since the addition of CLIENT_DISCARD outcomes all 'total' TSDB queries have been incorrectly including discard outcomes. By updating these queries results will once again be aligned with organization stats.
