### PR TITLE
feat(performance): update trace not found to use events

### DIFF
--- a/static/app/views/performance/traceDetails/traceNotFound.tsx
+++ b/static/app/views/performance/traceDetails/traceNotFound.tsx
@@ -51,6 +51,7 @@ function TraceNotFound({
         orgSlug={organization.slug}
         location={location}
         referrer="api.trace-view.errors-view"
+        useEvents
       >
         {({isLoading, tableData, error}) => {
           if (isLoading) {

--- a/tests/js/spec/views/performance/traceDetails/content.spec.tsx
+++ b/tests/js/spec/views/performance/traceDetails/content.spec.tsx
@@ -26,7 +26,7 @@ describe('TraceDetailsContent', () => {
   describe('Without Transactions', () => {
     beforeEach(() => {
       MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/eventsv2/',
+        url: '/organizations/org-slug/events/',
         body: SAMPLE_ERROR_DATA,
       });
     });
@@ -74,7 +74,7 @@ describe('TraceDetailsContent', () => {
 
     it('should should display an error if the error events could not be fetched', async () => {
       MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/eventsv2/',
+        url: '/organizations/org-slug/events/',
         statusCode: 404,
         body: {detail: 'This is a test error'},
       });


### PR DESCRIPTION
Updates `TraceNotFound` component to use `events` instead of `eventsv2`