### PR TITLE
feat(replays): filtered out null values from traceIds so the fetch call doesn't fail.

### DIFF
--- a/static/app/views/replays/detail/trace.tsx
+++ b/static/app/views/replays/detail/trace.tsx
@@ -19,7 +19,6 @@ import {
 import useApi from 'sentry/utils/useApi';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 import TraceView from 'sentry/views/performance/traceDetails/traceView';
-import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
 
 type State = {
   /**
@@ -93,7 +92,7 @@ export default function Trace({event, organization}: Props) {
           eventView.getEventsAPIPayload(location)
         );
 
-        const traceIds = data.data.map(({trace}) => trace);
+        const traceIds = data.data.map(({trace}) => trace).filter(trace => trace);
 
         // TODO(replays): Potential performance concerns here if number of traceIds is large
         const traceDetails = await Promise.all(
@@ -134,10 +133,6 @@ export default function Trace({event, organization}: Props) {
 
   if (state.isLoading) {
     return <LoadingIndicator />;
-  }
-
-  if (state.error.status === 404) {
-    return <EmptyMessage title={`${t('No traces available for this replay.')}`} />;
   }
 
   if (state.error || !state.traceEventView) {

--- a/static/app/views/replays/detail/trace.tsx
+++ b/static/app/views/replays/detail/trace.tsx
@@ -19,6 +19,7 @@ import {
 import useApi from 'sentry/utils/useApi';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 import TraceView from 'sentry/views/performance/traceDetails/traceView';
+import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
 
 type State = {
   /**
@@ -133,6 +134,10 @@ export default function Trace({event, organization}: Props) {
 
   if (state.isLoading) {
     return <LoadingIndicator />;
+  }
+
+  if (state.error.status === 404) {
+    return <EmptyMessage title={`${t('No traces available for this replay.')}`} />;
   }
 
   if (state.error || !state.traceEventView) {


### PR DESCRIPTION
Closes #35367 

Screenshots: 
<img width="794" alt="image" src="https://user-images.githubusercontent.com/7014871/172204827-5330a8b4-aec4-482f-8a73-3adb8d2a863d.png">



<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
