### PR TITLE
feat(releases): updates releases performance card table to use events

### DIFF
--- a/static/app/components/discover/performanceCardTable.tsx
+++ b/static/app/components/discover/performanceCardTable.tsx
@@ -49,7 +49,7 @@ function PerformanceCardTable({
 }: PerformanceCardTableProps) {
   const miseryRenderer =
     allReleasesTableData?.meta &&
-    getFieldRenderer('user_misery', allReleasesTableData.meta);
+    getFieldRenderer('user_misery()', allReleasesTableData.meta, false);
 
   function renderChange(
     allReleasesScore: number,
@@ -85,8 +85,8 @@ function PerformanceCardTable({
   }
 
   function userMiseryTrend() {
-    const allReleasesUserMisery = allReleasesTableData?.data?.[0]?.user_misery;
-    const thisReleaseUserMisery = thisReleaseTableData?.data?.[0]?.user_misery;
+    const allReleasesUserMisery = allReleasesTableData?.data?.[0]?.['user_misery()'];
+    const thisReleaseUserMisery = thisReleaseTableData?.data?.[0]?.['user_misery()'];
     return (
       <StyledPanelItem>
         {renderChange(
@@ -100,16 +100,16 @@ function PerformanceCardTable({
 
   function renderFrontendPerformance() {
     const webVitals = [
-      {title: WebVital.FCP, field: 'p75_measurements_fcp'},
-      {title: WebVital.FID, field: 'p75_measurements_fid'},
-      {title: WebVital.LCP, field: 'p75_measurements_lcp'},
-      {title: WebVital.CLS, field: 'p75_measurements_cls'},
+      {title: WebVital.FCP, field: 'p75(measurements.fcp)'},
+      {title: WebVital.FID, field: 'p75(measurements.fid)'},
+      {title: WebVital.LCP, field: 'p75(measurements.lcp)'},
+      {title: WebVital.CLS, field: 'p75(measurements.cls)'},
     ];
 
     const spans = [
-      {title: 'HTTP', column: 'p75(spans.http)', field: 'p75_spans_http'},
-      {title: 'Browser', column: 'p75(spans.browser)', field: 'p75_spans_browser'},
-      {title: 'Resource', column: 'p75(spans.resource)', field: 'p75_spans_resource'},
+      {title: 'HTTP', column: 'p75(spans.http)', field: 'p75(spans.http)'},
+      {title: 'Browser', column: 'p75(spans.browser)', field: 'p75(spans.browser)'},
+      {title: 'Resource', column: 'p75(spans.resource)', field: 'p75(spans.resource)'},
     ];
 
     const webVitalTitles = webVitals.map((vital, idx) => {
@@ -142,13 +142,13 @@ function PerformanceCardTable({
     const webVitalsRenderer = webVitals.map(
       vital =>
         allReleasesTableData?.meta &&
-        getFieldRenderer(vital.field, allReleasesTableData?.meta)
+        getFieldRenderer(vital.field, allReleasesTableData?.meta, false)
     );
 
     const spansRenderer = spans.map(
       span =>
         allReleasesTableData?.meta &&
-        getFieldRenderer(span.field, allReleasesTableData?.meta)
+        getFieldRenderer(span.field, allReleasesTableData?.meta, false)
     );
 
     const webReleaseTrend = webVitals.map(vital => {
@@ -318,12 +318,13 @@ function PerformanceCardTable({
     });
 
     const apdexRenderer =
-      allReleasesTableData?.meta && getFieldRenderer('apdex', allReleasesTableData.meta);
+      allReleasesTableData?.meta &&
+      getFieldRenderer('apdex', allReleasesTableData.meta, false);
 
     const spansRenderer = spans.map(
       span =>
         allReleasesTableData?.meta &&
-        getFieldRenderer(span.field, allReleasesTableData?.meta)
+        getFieldRenderer(span.field, allReleasesTableData?.meta, false)
     );
 
     const spansReleaseTrend = spans.map(span => {
@@ -464,14 +465,15 @@ function PerformanceCardTable({
     });
 
     const mobileVitalFields = [
-      'p75_measurements_app_start_cold',
-      'p75_measurements_app_start_warm',
-      'p75_measurements_frames_slow',
-      'p75_measurements_frames_frozen',
+      'p75(measurements.app_start_cold)',
+      'p75(measurements.app_start_warm)',
+      'p75(measurements.frames_slow)',
+      'p75(measurements.frames_frozen)',
     ];
     const mobileVitalsRenderer = mobileVitalFields.map(
       field =>
-        allReleasesTableData?.meta && getFieldRenderer(field, allReleasesTableData?.meta)
+        allReleasesTableData?.meta &&
+        getFieldRenderer(field, allReleasesTableData?.meta, false)
     );
 
     const mobileReleaseTrend = mobileVitalFields.map(field => {
@@ -699,12 +701,14 @@ function PerformanceCardTableWrapper({
       eventView={allReleasesEventView}
       orgSlug={organization.slug}
       location={location}
+      useEvents
     >
       {({isLoading, tableData: allReleasesTableData}) => (
         <DiscoverQuery
           eventView={releaseEventView}
           orgSlug={organization.slug}
           location={location}
+          useEvents
         >
           {({isLoading: isReleaseLoading, tableData: thisReleaseTableData}) => (
             <PerformanceCardTable


### PR DESCRIPTION
updates releases performance card table to use the new `events` endpoint instead of `eventsv2`
