### PR TITLE
feat(dashboards): Show an alert on release widgets without backfill

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -214,10 +214,11 @@ class WidgetCard extends Component<Props, State> {
       windowWidth,
       noLazyLoad,
       showStoredAlert,
+      isEditing,
     } = this.props;
     const {start, period} = selection.datetime;
     let showIncompleteDataAlert: boolean = false;
-    if (widget.widgetType === WidgetType.RELEASE) {
+    if (widget.widgetType === WidgetType.RELEASE && isEditing) {
       if (start) {
         let startDate: Date | undefined = undefined;
         if (typeof start === 'string') {

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -22,6 +22,7 @@ import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
+import {statsPeriodToDays} from 'sentry/utils/dates';
 import {TableDataRow, TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -226,9 +227,10 @@ class WidgetCard extends Component<Props, State> {
           startDate = start;
         }
         showIncompleteDataAlert = startDate < METRICS_BACKED_SESSIONS_START_DATE;
-      } else if (period && period === '90d') {
+      } else if (period) {
+        const periodInDays = statsPeriodToDays(period);
         const current = new Date();
-        const prior = new Date(new Date().setDate(current.getDate() - 90));
+        const prior = new Date(new Date().setDate(current.getDate() - periodInDays));
         showIncompleteDataAlert = prior < METRICS_BACKED_SESSIONS_START_DATE;
       }
     }
@@ -299,11 +301,9 @@ class WidgetCard extends Component<Props, State> {
             {showIncompleteDataAlert && (
               <StoredDataAlert showIcon>
                 {tct(
-                  'Your selection may have incomplete data. Release data available only after [date].',
+                  'Releases data is only available from [date]. Data may be incomplete as a result.',
                   {
-                    date: (
-                      <DateTime date={METRICS_BACKED_SESSIONS_START_DATE} shortDate />
-                    ),
+                    date: <DateTime date={METRICS_BACKED_SESSIONS_START_DATE} dateOnly />,
                   }
                 )}
               </StoredDataAlert>

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -214,11 +214,10 @@ class WidgetCard extends Component<Props, State> {
       windowWidth,
       noLazyLoad,
       showStoredAlert,
-      isEditing,
     } = this.props;
     const {start, period} = selection.datetime;
     let showIncompleteDataAlert: boolean = false;
-    if (widget.widgetType === WidgetType.RELEASE && isEditing) {
+    if (widget.widgetType === WidgetType.RELEASE && showStoredAlert) {
       if (start) {
         let startDate: Date | undefined = undefined;
         if (typeof start === 'string') {


### PR DESCRIPTION
Since we're EAin without the 90 day backfill, we want to
show an alert if users try to query for data before that
date.

Open to better error messages cc: @jas-kas 

![Screen Shot 2022-06-06 at 4 48 09 PM](https://user-images.githubusercontent.com/63818634/172246885-da770431-44cd-4d81-88d5-b224542513ef.png)

