### PR TITLE
ref: fix sentry.plugins.base test

### DIFF
--- a/tests/sentry/plugins/base/project_api_urls_test.py
+++ b/tests/sentry/plugins/base/project_api_urls_test.py
@@ -1,18 +1,7 @@
 from django.conf.urls import url
 
-from sentry.plugins.base.response import JSONResponse
+from sentry.plugins.base.project_api_urls import load_plugin_urls
 from sentry.plugins.base.v2 import Plugin2
-from sentry.testutils import TestCase
-
-
-def test_json_response():
-    resp = JSONResponse({}).respond(None)
-    assert resp.status_code == 200
-
-
-def test_json_response_with_status_kwarg():
-    resp = JSONResponse({}, status=400).respond(None)
-    assert resp.status_code == 400
 
 
 def test_load_plugin_project_urls():
@@ -38,8 +27,6 @@ def test_load_plugin_project_urls():
             from django.views.generic.list import BaseListView
 
             return [url("", BaseListView.as_view())]
-
-    from sentry.plugins.base.project_api_urls import load_plugin_urls
 
     patterns = load_plugin_urls((BadPluginA(), BadPluginB(), BadPluginC(), GoodPluginA()))
 
@@ -67,18 +54,3 @@ def test_load_plugin_group_urls():
     )
 
     assert len(patterns) == 6
-
-
-class Plugin2TestCase(TestCase):
-    def test_reset_config(self):
-        class APlugin(Plugin2):
-            def get_conf_key(self):
-                return "a-plugin"
-
-        project = self.create_project()
-
-        a_plugin = APlugin()
-        a_plugin.set_option("key", "value", project=project)
-        assert a_plugin.get_option("key", project=project) == "value"
-        a_plugin.reset_options(project=project)
-        assert a_plugin.get_option("key", project=project) is None

--- a/tests/sentry/plugins/base/response_test.py
+++ b/tests/sentry/plugins/base/response_test.py
@@ -1,0 +1,11 @@
+from sentry.plugins.base.response import JSONResponse
+
+
+def test_json_response():
+    resp = JSONResponse({}).respond(None)
+    assert resp.status_code == 200
+
+
+def test_json_response_with_status_kwarg():
+    resp = JSONResponse({}, status=400).respond(None)
+    assert resp.status_code == 400

--- a/tests/sentry/plugins/base/test.py
+++ b/tests/sentry/plugins/base/test.py
@@ -66,7 +66,7 @@ def test_load_plugin_group_urls():
         )
     )
 
-    assert len(patterns) == 7
+    assert len(patterns) == 6
 
 
 class Plugin2TestCase(TestCase):

--- a/tests/sentry/plugins/base/v2_test.py
+++ b/tests/sentry/plugins/base/v2_test.py
@@ -1,0 +1,17 @@
+from sentry.plugins.base.v2 import Plugin2
+from sentry.testutils import TestCase
+
+
+class Plugin2TestCase(TestCase):
+    def test_reset_config(self):
+        class APlugin(Plugin2):
+            def get_conf_key(self):
+                return "a-plugin"
+
+        project = self.create_project()
+
+        a_plugin = APlugin()
+        a_plugin.set_option("key", "value", project=project)
+        assert a_plugin.get_option("key", project=project) == "value"
+        a_plugin.reset_options(project=project)
+        assert a_plugin.get_option("key", project=project) is None


### PR DESCRIPTION
this regressed in f50e4601b2987de730243da79cb26ef3727ed2c4

these tests were failing but were not being run because they are named incorrectly.

this test required manual changes to fix the failures -- here's how it was failing before:

```console
$ pytest tests/sentry/plugins/base/test.py 
============================= test session starts ==============================
platform darwin -- Python 3.8.13, pytest-6.1.0, py-1.11.0, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: rerunfailures-9.1.1, cov-2.11.1, django-3.10.0, sentry-0.1.9
collected 5 items                                                              

tests/sentry/plugins/base/test.py ....F                                  [100%]

=================================== FAILURES ===================================
_________________________ test_load_plugin_group_urls __________________________
tests/sentry/plugins/base/test.py:69: in test_load_plugin_group_urls
    assert len(patterns) == 7
E   AssertionError: assert 6 == 7
E    +  where 6 = len([<URLResolver <URLPattern list> (None:None) '^jira/'>, <URLResolver <URLPattern list> (None:None) '^github/'>, <URLRes...'>, <URLResolver <URLPattern list> (None:None) '^asana/'>, <URLResolver <URLPattern list> (None:None) '^phabricator/'>])
=========================== short test summary info ============================
FAILED tests/sentry/plugins/base/test.py::test_load_plugin_group_urls - Asser...
========================= 1 failed, 4 passed in 4.30s ==========================
```
see also https://getsentry.atlassian.net/browse/DEVINFRA-43