### PR TITLE
fix(ui): Fix type check to look at typeof instead

### DIFF
--- a/static/app/components/events/interfaces/frame/contextLine.tsx
+++ b/static/app/components/events/interfaces/frame/contextLine.tsx
@@ -2,23 +2,22 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
-import {defined} from 'sentry/utils';
-
 const Context = styled('div')`
   display: inline;
 `;
 
-type Props = {
+interface Props {
   isActive: boolean;
   line: [number, string];
+  children?: React.ReactNode;
   className?: string;
-} & React.ComponentProps<typeof Fragment>;
+}
 
 const ContextLine = function (props: Props) {
   const {line, isActive, className} = props;
   let lineWs = '';
   let lineCode = '';
-  if (defined(line[1]) && line[1].match) {
+  if (typeof line[1] === 'string') {
     [, lineWs, lineCode] = line[1].match(/^(\s*)(.*?)$/m)!;
   }
   const Component = !props.children ? Fragment : Context;


### PR DESCRIPTION
It was checking the existence of the .match function which exists on strings. Also removes extending Fragment props, that's weird.
