### PR TITLE
fix(buffers): Fix broken buffer test

### DIFF
--- a/tests/sentry/buffer/base/tests.py
+++ b/tests/sentry/buffer/base/tests.py
@@ -28,16 +28,6 @@ class BufferTest(TestCase):
         self.buf.process(Group, columns, filters)
         assert Group.objects.get(id=group.id).times_seen == group.times_seen + 1
 
-    def test_process_saves_data_without_existing_row(self):
-        columns = {"times_seen": 1}
-        filters = {"message": "foo bar", "project_id": 1}
-        self.buf.process(Group, columns, filters)
-        group = Group.objects.get(message="foo bar")
-        # the default value for times_seen is 1, so we actually end up
-        # incrementing it to 2 here
-        assert group.times_seen == 2
-        assert group.project_id == 1
-
     def test_process_saves_extra(self):
         group = Group.objects.create(project=Project(id=1))
         columns = {"times_seen": 1}

--- a/tests/sentry/buffer/base/tests.py
+++ b/tests/sentry/buffer/base/tests.py
@@ -28,6 +28,14 @@ class BufferTest(TestCase):
         self.buf.process(Group, columns, filters)
         assert Group.objects.get(id=group.id).times_seen == group.times_seen + 1
 
+    def test_process_saves_data_without_existing_row(self):
+        columns = {"new_groups": 1}
+        filters = {"project_id": self.project.id, "release_id": self.release.id}
+        self.buf.process(ReleaseProject, columns, filters)
+        assert ReleaseProject.objects.filter(
+            project_id=self.project.id, release_id=self.release.id, new_groups=1
+        ).exists()
+
     def test_process_saves_extra(self):
         group = Group.objects.create(project=Project(id=1))
         columns = {"times_seen": 1}

--- a/tests/sentry/buffer/base/tests.py
+++ b/tests/sentry/buffer/base/tests.py
@@ -32,9 +32,7 @@ class BufferTest(TestCase):
         columns = {"new_groups": 1}
         filters = {"project_id": self.project.id, "release_id": self.release.id}
         self.buf.process(ReleaseProject, columns, filters)
-        assert ReleaseProject.objects.filter(
-            project_id=self.project.id, release_id=self.release.id, new_groups=1
-        ).exists()
+        assert ReleaseProject.objects.filter(new_groups=1, **filters).exists()
 
     def test_process_saves_extra(self):
         group = Group.objects.create(project=Project(id=1))


### PR DESCRIPTION
This test was trying to ensure that we create a group in buffers if it doesn't exist. The only case
this would happen is if the group had already been deleted in between the buffer call and when we
actually run it. In that case, we don't really want to recreate the group.

However we do want to create new rows for things like `ReleaseProject`, so modify the test to 
work with that model instead.