### PR TITLE
ref: test the whole apidocs namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ test-relay-integration:
 
 test-api-docs: build-api-docs
 	yarn run validate-api-examples
-	pytest tests/apidocs/endpoints
+	pytest tests/apidocs
 	@echo ""
 
 review-python-snapshots:


### PR DESCRIPTION
there was one other test in there (but named incorrectly so it wasn't running for **two** reasons) -- this just makes sure we don't accidentally miss more in this directory in the future!