### PR TITLE
fix(page-filters): Reset params on change

### DIFF
--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -49,6 +49,11 @@ type Props = WithRouterProps & {
   maxTitleLength?: number;
 
   /**
+   * Reset these URL params when we fire actions (custom routing only)
+   */
+  resetParamsOnChange?: string[];
+
+  /**
    * A project will be forced from parent component (selection is disabled, and if user
    * does not have multi-project support enabled, it will not try to auto select a project).
    *
@@ -77,6 +82,7 @@ function ProjectPageFilter({
   router,
   specificProjectSlugs,
   maxTitleLength = 30,
+  resetParamsOnChange = [],
   ...otherProps
 }: Props) {
   const [currentSelectedProjects, setCurrentSelectedProjects] = useState<number[] | null>(
@@ -105,7 +111,7 @@ function ProjectPageFilter({
   const handleApplyChange = (newProjects: number[]) => {
     updateProjects(newProjects, router, {
       save: true,
-      resetParams: [],
+      resetParams: resetParamsOnChange,
       environments: [], // Clear environments when switching projects
     });
   };

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -82,7 +82,7 @@ class Monitors extends AsyncView<Props, State> {
           </HeaderTitle>
         </PageHeader>
         <Filters>
-          <ProjectPageFilter />
+          <ProjectPageFilter resetParamsOnChange={['cursor']} />
           <SearchBar
             query={decodeScalar(qs.parse(location.search)?.query, '')}
             placeholder={t('Search for monitors.')}

--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -20,9 +20,9 @@ function ReplaysFilters({organization, handleSearchQuery, query}: Props) {
     <FilterContainer>
       <SearchContainer>
         <PageFilterBar condensed>
-          <ProjectPageFilter />
-          <EnvironmentPageFilter />
-          <DatePageFilter alignDropdown="left" />
+          <ProjectPageFilter resetParamsOnChange={['cursor']} />
+          <EnvironmentPageFilter resetParamsOnChange={['cursor']} />
+          <DatePageFilter alignDropdown="left" resetParamsOnChange={['cursor']} />
         </PageFilterBar>
         <SearchBar
           organization={organization}


### PR DESCRIPTION
This was missing in the switch over to page filters and only existed in the old style GSH which isn't being used anymore. 

This usage of the prop basically tells the page filters to reset `cursor` anytime their selection is changed.