### PR TITLE
feat(team-roles) Changes to OrgMembers API response (BE)

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -258,6 +258,7 @@ class OnboardingTasksSerializer(Serializer):  # type: ignore
 
 class _DetailedOrganizationSerializerResponseOptional(OrganizationSerializerResponse, total=False):
     role: Any  # TODO replace with enum/literal
+    orgRole: str
 
 
 class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResponseOptional):
@@ -389,7 +390,8 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
 
         context["access"] = access.scopes
         if access.role is not None:
-            context["role"] = access.role
+            context["role"] = access.role  # Deprecated
+            context["orgRole"] = access.role
         context["pendingAccessRequests"] = OrganizationAccessRequest.objects.filter(
             team__organization=obj
         ).count()

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -67,8 +67,9 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             "email": obj.get_email(),
             "name": obj.user.get_display_name() if obj.user else obj.get_email(),
             "user": attrs["user"],
-            "role": obj.role,
-            "roleName": roles.get(obj.role).name,
+            "role": obj.role,  # Deprecated, use orgRole instead
+            "roleName": roles.get(obj.role).name,  # Deprecated
+            "orgRole": obj.role,
             "pending": obj.is_pending,
             "expired": obj.token_expired,
             "flags": {

--- a/src/sentry/api/serializers/models/organization_member/expand/roles.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/roles.py
@@ -57,11 +57,12 @@ class OrganizationMemberWithRolesSerializer(OrganizationMemberWithTeamsSerialize
         organization_role_list = [
             role for role in organization_roles.get_all() if not _is_retired_role_hidden(role, obj)
         ]
-        context["roles"] = serialize(
+        context["orgRoleList"] = serialize(
             organization_role_list,
             serializer=OrganizationRoleSerializer(),
             allowed_roles=self.allowed_roles,
         )
-        context["teamRoles"] = serialize(team_roles.get_all(), serializer=TeamRoleSerializer())
+        context["roles"] = context["orgRoleList"]  # deprecated
+        context["teamRoleList"] = serialize(team_roles.get_all(), serializer=TeamRoleSerializer())
 
         return context

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -59,8 +59,9 @@ class OrganizationMemberResponse(OrganizationMemberResponseOptional):
     email: str
     name: str
     user: UserSerializerResponse
-    role: str  # TODO: literal/enum
-    roleName: str  # TODO: literal/enum
+    role: str  # Deprecated: use orgRole
+    roleName: str  # Deprecated
+    orgRole: str
     pending: bool
     expired: str
     flags: _OrganizationMemberFlags
@@ -80,5 +81,6 @@ class OrganizationMemberWithProjectsResponse(OrganizationMemberResponse):
 class OrganizationMemberWithRolesResponse(OrganizationMemberWithTeamsResponse):
     invite_link: Optional[str]
     isOnlyOwner: bool
-    roles: List[RoleSerializerResponse]
-    teamRoles: List[RoleSerializerResponse]
+    roles: List[RoleSerializerResponse]  # Deprecated: use orgRoleList
+    orgRoleList: List[RoleSerializerResponse]
+    teamRoleList: List[RoleSerializerResponse]

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -60,6 +60,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         assert response.data["onboardingTasks"] == []
         assert response.data["id"] == str(self.organization.id)
         assert response.data["role"] == "owner"
+        assert response.data["orgRole"] == "owner"
         assert len(response.data["teams"]) == 0
         assert len(response.data["projects"]) == 0
 

--- a/tests/sentry/api/endpoints/test_organization_invite_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_details.py
@@ -109,6 +109,7 @@ class OrganizationInviteRequestUpdateTest(InviteRequestBase):
 
         assert resp.status_code == 200
         assert resp.data["role"] == "admin"
+        assert resp.data["orgRole"] == "admin"
         assert resp.data["inviteStatus"] == "requested_to_be_invited"
 
         assert OrganizationMember.objects.filter(id=self.invite_request.id, role="admin").exists()
@@ -135,6 +136,7 @@ class OrganizationInviteRequestUpdateTest(InviteRequestBase):
 
         assert resp.status_code == 200
         assert resp.data["role"] == "manager"
+        assert resp.data["orgRole"] == "manager"
         assert resp.data["inviteStatus"] == "requested_to_be_invited"
 
         assert OrganizationMemberTeam.objects.filter(
@@ -252,6 +254,7 @@ class OrganizationInviteRequestApproveTest(InviteRequestBase):
 
         assert resp.status_code == 200
         assert resp.data["role"] == "admin"
+        assert resp.data["orgRole"] == "admin"
         assert resp.data["inviteStatus"] == "approved"
 
         assert OrganizationMember.objects.filter(

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -32,6 +32,7 @@ class GetOrganizationMemberTest(OrganizationMemberTestBase):
         response = self.get_success_response(self.organization.slug, "me")
 
         assert response.data["role"] == "owner"
+        assert response.data["orgRole"] == "owner"
         assert response.data["user"]["id"] == str(self.user.id)
         assert response.data["email"] == self.user.email
 
@@ -44,6 +45,7 @@ class GetOrganizationMemberTest(OrganizationMemberTestBase):
 
         response = self.get_success_response(self.organization.slug, member.id)
         assert response.data["role"] == "member"
+        assert response.data["orgRole"] == "member"
         assert response.data["id"] == str(member.id)
 
     def test_get_by_garbage(self):
@@ -106,8 +108,9 @@ class GetOrganizationMemberTest(OrganizationMemberTestBase):
 
     def test_lists_organization_roles(self):
         response = self.get_success_response(self.organization.slug, "me")
+        assert response.data["roles"] == response.data["orgRoleList"]
 
-        role_ids = [role["id"] for role in response.data["roles"]]
+        role_ids = [role["id"] for role in response.data["orgRoleList"]]
         assert role_ids == ["member", "admin", "manager", "owner"]
 
     @with_feature("organizations:team-roles")
@@ -116,14 +119,15 @@ class GetOrganizationMemberTest(OrganizationMemberTestBase):
         Note: Admin will be hidden after team-roles EA.
         """
         response = self.get_success_response(self.organization.slug, "me")
+        assert response.data["roles"] == response.data["orgRoleList"]
 
-        role_ids = [role["id"] for role in response.data["roles"]]
+        role_ids = [role["id"] for role in response.data["orgRoleList"]]
         assert role_ids == ["member", "admin", "manager", "owner"]
 
     def test_lists_team_roles(self):
         response = self.get_success_response(self.organization.slug, "me")
 
-        role_ids = [role["id"] for role in response.data["teamRoles"]]
+        role_ids = [role["id"] for role in response.data["teamRoleList"]]
         assert role_ids == ["contributor", "admin"]
 
 


### PR DESCRIPTION
Using `role` was too ambiguous in the API response. Created `orgRole` and `teamRoles` to make it clearer.