### PR TITLE
feat(alerts): Update relatedTransactions table to use events

### DIFF
--- a/static/app/views/alerts/rules/metric/details/relatedTransactions.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedTransactions.tsx
@@ -68,7 +68,7 @@ class Table extends Component<TableProps, TableState> {
     const tableMeta = tableData.meta;
 
     const field = String(column.key);
-    const fieldRenderer = getFieldRenderer(field, tableMeta);
+    const fieldRenderer = getFieldRenderer(field, tableMeta, false);
     const rendered = fieldRenderer(dataRow, {organization, location});
 
     if (field === 'transaction') {
@@ -149,6 +149,7 @@ class Table extends Component<TableProps, TableState> {
           eventView={sortedEventView}
           orgSlug={organization.slug}
           location={location}
+          useEvents
         >
           {({isLoading, tableData}) => (
             <GridEditable


### PR DESCRIPTION
Updates `relatedTransactions` table to use the new `events` instead of `eventsv2`