### PR TITLE
feat(stats): Updates the team misery table to use events endpoint

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -50,7 +50,8 @@ function TeamMisery({
   error,
 }: TeamMiseryProps) {
   const miseryRenderer =
-    periodTableData?.meta && getFieldRenderer('user_misery', periodTableData.meta);
+    periodTableData?.meta &&
+    getFieldRenderer('user_misery()', periodTableData.meta, false);
 
   // Calculate trend, so we can sort based on it
   const sortedTableData = (periodTableData?.data ?? [])
@@ -60,7 +61,8 @@ function TeamMisery({
       );
 
       const trend = weekRow
-        ? ((dataRow.user_misery as number) - (weekRow.user_misery as number)) * 100
+        ? ((dataRow['user_misery()'] as number) - (weekRow['user_misery()'] as number)) *
+          100
         : null;
 
       return {
@@ -242,12 +244,14 @@ function TeamMiseryWrapper({
       eventView={periodEventView}
       orgSlug={organization.slug}
       location={location}
+      useEvents
     >
       {({isLoading, tableData: periodTableData, error}) => (
         <DiscoverQuery
           eventView={weekEventView}
           orgSlug={organization.slug}
           location={location}
+          useEvents
         >
           {({isLoading: isWeekLoading, tableData: weekTableData, error: weekError}) => (
             <TeamMisery

--- a/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
@@ -13,12 +13,14 @@ describe('TeamMisery', () => {
   it('should render misery from projects and expand hidden items', async () => {
     const project = TestStubs.Project();
     const meta = {
-      transaction: 'string',
-      project: 'string',
-      tpm: 'number',
-      count_unique_user: 'number',
-      count_miserable_user: 'number',
-      user_misery: 'number',
+      fields: {
+        transaction: 'string',
+        project: 'string',
+        tpm: 'number',
+        'count_unique(user)': 'number',
+        'count_miserable(user)': 'number',
+        'user_misery()': 'number',
+      },
     };
     const extraData = {
       project: project.slug,
@@ -30,23 +32,23 @@ describe('TeamMisery', () => {
     const noChangeItems = 10;
     const noChange = range(0, noChangeItems).map(x => ({
       transaction: `/apple/${x}`,
-      user_misery: 0.1,
+      'user_misery()': 0.1,
       ...extraData,
     }));
 
     const weekMisery = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/eventsv2/`,
+      url: `/organizations/org-slug/events/`,
       body: {
         meta,
         data: [
           {
             transaction: '/apple/cart',
-            user_misery: 0.5,
+            'user_misery()': 0.5,
             ...extraData,
           },
           {
             transaction: '/apple/checkout',
-            user_misery: 0.1,
+            'user_misery()': 0.1,
             ...extraData,
           },
           ...noChange,
@@ -55,18 +57,18 @@ describe('TeamMisery', () => {
       match: [MockApiClient.matchQuery({statsPeriod: '7d'})],
     });
     const periodMisery = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/eventsv2/`,
+      url: `/organizations/org-slug/events/`,
       body: {
         meta,
         data: [
           {
             transaction: '/apple/cart',
-            user_misery: 0.25,
+            'user_misery()': 0.25,
             ...extraData,
           },
           {
             transaction: '/apple/checkout',
-            user_misery: 0.2,
+            'user_misery()': 0.2,
             ...extraData,
           },
           ...noChange,
@@ -118,7 +120,7 @@ describe('TeamMisery', () => {
 
   it('should render empty state on error', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/eventsv2/`,
+      url: `/organizations/org-slug/events/`,
       statusCode: 500,
       body: {},
     });


### PR DESCRIPTION
Updates the `teamMisery` table in Stats to use the new `events` endpoint instead of `eventsv2`