### PR TITLE
fix(tests): Attempt to fix unstable `GroupListTest.test_simple` test

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -1,4 +1,3 @@
-from sentry.models import GroupStatus
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -31,9 +30,18 @@ class GroupListTest(APITestCase, SnubaTestCase):
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
-        group_a = self.create_group(status=GroupStatus.UNRESOLVED)
-        self.create_group(status=GroupStatus.UNRESOLVED)
-        group_c = self.create_group(status=GroupStatus.UNRESOLVED)
+        group_a = self.store_event(
+            data={"timestamp": iso_format(before_now(seconds=1)), "fingerprint": ["group-a"]},
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={"timestamp": iso_format(before_now(seconds=2)), "fingerprint": ["group-b"]},
+            project_id=self.project.id,
+        )
+        group_c = self.store_event(
+            data={"timestamp": iso_format(before_now(seconds=3)), "fingerprint": ["group-c"]},
+            project_id=self.project.id,
+        ).group
         self.login_as(user=self.user)
         response = self.get_response(
             sort_by="date", limit=10, query="is:unresolved", groups=[group_a.id, group_c.id]


### PR DESCRIPTION
It seems like the order can randomly switch around here sometimes. Explicitly creating the groups
via events and specifying their age should make it deterministic.