### PR TITLE
ref(menuListItem): Add dividers when details prop is defined

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 
 /**
  * Menu item priority. Currently there's only one option other than default,
@@ -100,7 +101,7 @@ function BaseMenuListItem({
             {leadingItems}
           </LeadingItems>
         )}
-        <ContentWrap isFocused={isFocused} showDivider={showDivider}>
+        <ContentWrap isFocused={isFocused} showDivider={defined(details) || showDivider}>
           <LabelWrap>
             <Label aria-hidden="true" {...labelProps}>
               {label}


### PR DESCRIPTION
Always show line dividers in `MenuListItem` when there is `details` text present. This is a new rule in our design system.

**Before:** dividers are optional (only visible when the `showDividers` prop is true)
<img width="350" alt="Screen Shot 2022-06-06 at 4 23 42 PM" src="https://user-images.githubusercontent.com/44172267/172265172-f2145fbc-37cf-4794-9ed8-864928480002.png">

**After:** if the `details` prop is defined, dividers will always be visible (even when `showDividers` is `false` or `undefined`):
<img width="343" alt="Screen Shot 2022-06-06 at 4 23 16 PM" src="https://user-images.githubusercontent.com/44172267/172265136-df7a8afa-f871-4295-96c0-21ed3c00f76a.png">

