### PR TITLE
fix(workflow): Added conditional check to cover issue regression

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -67,7 +67,7 @@ from sentry.models import (
     Organization,
     Project,
     ProjectKey,
-    PullRequestCommit,
+    PullRequest,
     Release,
     ReleaseCommit,
     ReleaseEnvironment,
@@ -148,10 +148,15 @@ def has_pending_commit_resolution(group):
         return False
     else:
         # check if this commit is a part of a PR
-        if PullRequestCommit.objects.filter(commit__id=recent_group_link.linked_id).exists():
-            # check if any commits in the PR have been released
+        pr_ids = list(
+            PullRequest.objects.filter(
+                pullrequestcommit__commit=recent_group_link.linked_id
+            ).values_list("id", flat=True)
+        )
+        if pr_ids:
+            # assume that this commit has been released if any commits in this PR have been released
             if ReleaseCommit.objects.filter(
-                commit__pullrequest_commit__commit_id=recent_group_link.linked_id
+                commit__pullrequestcommit__pull_request__in=pr_ids
             ).exists():
                 return False
         return True

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -148,17 +148,14 @@ def has_pending_commit_resolution(group):
         return False
     else:
         # check if this commit is a part of a PR
-        pr_ids = list(
-            PullRequest.objects.filter(
-                pullrequestcommit__commit=latest_issue_commit_resolution.linked_id
-            ).values_list("id", flat=True)
-        )
-        if pr_ids:
-            # assume that this commit has been released if any commits in this PR have been released
-            if ReleaseCommit.objects.filter(
-                commit__pullrequestcommit__pull_request__in=pr_ids
-            ).exists():
-                return False
+        pr_ids = PullRequest.objects.filter(
+            pullrequestcommit__commit=latest_issue_commit_resolution.linked_id
+        ).values_list("id", flat=True)
+        # assume that this commit has been released if any commits in this PR have been released
+        if ReleaseCommit.objects.filter(
+            commit__pullrequestcommit__pull_request__in=pr_ids
+        ).exists():
+            return False
         return True
 
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -131,7 +131,7 @@ def has_pending_commit_resolution(group):
     """
     Checks that the most recent commit that fixes a group has had a chance to release
     """
-    recent_group_link = (
+    latest_issue_commit_resolution = (
         GroupLink.objects.filter(
             group_id=group.id,
             linked_type=GroupLink.LinkedType.commit,
@@ -140,17 +140,17 @@ def has_pending_commit_resolution(group):
         .order_by("-datetime")
         .first()
     )
-    if recent_group_link is None:
+    if latest_issue_commit_resolution is None:
         return False
 
     # commit has been released and is not in pending commit state
-    if ReleaseCommit.objects.filter(commit__id=recent_group_link.linked_id).exists():
+    if ReleaseCommit.objects.filter(commit__id=latest_issue_commit_resolution.linked_id).exists():
         return False
     else:
         # check if this commit is a part of a PR
         pr_ids = list(
             PullRequest.objects.filter(
-                pullrequestcommit__commit=recent_group_link.linked_id
+                pullrequestcommit__commit=latest_issue_commit_resolution.linked_id
             ).values_list("id", flat=True)
         )
         if pr_ids:

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -733,9 +733,7 @@ class EventManagerTest(TestCase):
         unreleased_pr_commit = PullRequestCommit.objects.create(
             pull_request_id=pr.id, commit_id=unreleased_commit.id
         )
-        assert PullRequestCommit.objects.filter(
-            pull_request_id=pr.id, commit_id=unreleased_pr_commit.id
-        ).exists()
+        assert PullRequestCommit.objects.filter(commit__id=unreleased_pr_commit.commit.id).exists()
 
         ReleaseCommit.objects.create(
             organization_id=group.project.organization_id,

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -571,8 +571,7 @@ class EventManagerTest(TestCase):
 
         group = event.group
         assert group.first_release.version == "1.0"
-        pending = has_pending_commit_resolution(group)
-        assert pending is False
+        assert not has_pending_commit_resolution(group)
 
         # Add a commit with no associated release
         repo = self.create_repo(project=group.project)
@@ -587,8 +586,7 @@ class EventManagerTest(TestCase):
             relationship=GroupLink.Relationship.resolves,
         )
 
-        pending = has_pending_commit_resolution(group)
-        assert pending
+        assert has_pending_commit_resolution(group)
 
     def test_multiple_pending_commit_resolution(self):
         project_id = 1


### PR DESCRIPTION
Fixes `WOR-871` - Issues marked as resolved in commit don’t regress if the commit never gets released. 

Added a conditional check to `has_pending_commit_resolution` to check if the unreleased commit is part of a PR that has released commits.

Changes made:
- `event_manager.py`: Added logic to ensure that issues resolved in commits that were not released regress by checking if the commit was part of a PR, and assuming that commit is released if any commits in the PR have been released
- `test_event_manager.py`: Created two tests: `test_has_pending_commit_resolution_issue_regression` which tests the case where the commit that resolved the issue is part of a PR, but all commits within the PR are unreleased, and `test_has_pending_commit_resolution_issue_regression_released_commits` which tests the case where the PR has multiple commits that are both released and unreleased 