### PR TITLE
style(replays): adjusted the height for the url copy bar

### DIFF
--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -25,6 +25,7 @@ const UrlCopyInput = styled(TextCopyInput)`
     padding: 0 ${space(0.75)};
     font-size: ${p => p.theme.fontSizeMedium};
     border-bottom-left-radius: 0;
+    height: ${space(4)};
   }
   ${StyledInput}[disabled] {
     border: none;
@@ -34,6 +35,8 @@ const UrlCopyInput = styled(TextCopyInput)`
     border-top: none;
     border-right: none;
     border-bottom: none;
+    height: ${space(4)};
+    min-height: ${space(4)};
   }
 `;
 


### PR DESCRIPTION
Closes #35408

Made the height smaller on the url copy bar on the player.

<img width="958" alt="image" src="https://user-images.githubusercontent.com/7014871/172272137-78aa8f2c-2a33-4b16-840b-bd5bdf491f23.png">


<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
