### PR TITLE
fix(alerts): Update environments on project change issue alert wizard

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -157,6 +157,14 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     window.clearTimeout(this.pollingTimeout);
   }
 
+  componentDidUpdate(_prevProps: Props, prevState: State) {
+    if (prevState.project.id === this.state.project.id) {
+      return;
+    }
+
+    this.fetchEnvironments();
+  }
+
   getTitle() {
     const {organization} = this.props;
     const {rule, project} = this.state;
@@ -289,6 +297,22 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       this.setState({loading: false});
     }
   };
+
+  fetchEnvironments() {
+    const {
+      params: {orgId},
+    } = this.props;
+    const {project} = this.state;
+
+    this.api
+      .requestPromise(`/projects/${orgId}/${project.slug}/environments/`, {
+        query: {
+          visibility: 'visible',
+        },
+      })
+      .then(response => this.setState({environments: response}))
+      .catch(_err => addErrorMessage(t('Unable to fetch environments')));
+  }
 
   fetchStatus() {
     // pollHandler calls itself until it gets either a success


### PR DESCRIPTION
When changing projects in metric alert wizard we fetch the environments, this brings the issue alert wizard to parity.

Jira: [WOR-1933](https://getsentry.atlassian.net/browse/WOR-1933)
