### PR TITLE
ref: only override SENTRY_NEWSLETTER under test if it hasn't already been overridden

### DIFF
--- a/requirements-dev-only-frozen.txt
+++ b/requirements-dev-only-frozen.txt
@@ -12,7 +12,7 @@ distlib==0.3.4
 docker==3.7.0
 docker-pycreds==0.4.0
 exam==0.5.1
-filelock==3.7.0
+filelock==3.7.1
 flake8==4.0.1
 flake8-bugbear==22.4.25
 freezegun==1.1.0

--- a/src/sentry/utils/pytest/kafka.py
+++ b/src/sentry/utils/pytest/kafka.py
@@ -209,7 +209,7 @@ def wait_for_ingest_consumer(session_ingest_consumer, task_runner):
             _log.warning(
                 "Ingest consumer waiter timed-out after %d seconds", time.time() - start_wait
             )
-            return None  # timout without any success
+            return None  # timeout without any success
 
         return waiter
 

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -95,8 +95,10 @@ def pytest_configure(config):
     settings.SENTRY_TSDB = "sentry.tsdb.inmemory.InMemoryTSDB"
     settings.SENTRY_TSDB_OPTIONS = {}
 
-    settings.SENTRY_NEWSLETTER = "sentry.newsletter.dummy.DummyNewsletter"
-    settings.SENTRY_NEWSLETTER_OPTIONS = {}
+    # override it only if it's not the default
+    if settings.SENTRY_NEWSLETTER == "sentry.newsletter.base.Newsletter":
+        settings.SENTRY_NEWSLETTER = "sentry.newsletter.dummy.DummyNewsletter"
+        settings.SENTRY_NEWSLETTER_OPTIONS = {}
 
     settings.BROKER_BACKEND = "memory"
     settings.BROKER_URL = "memory://"


### PR DESCRIPTION
this fixes a (not running because misnamed) test in getsentry
