### PR TITLE
ref(theme): Lighten purple100

### DIFF
--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -34,7 +34,7 @@ export const lightColors = {
   purple400: '#584AC0',
   purple300: '#6C5FC7',
   purple200: 'rgba(108, 95, 199, 0.5)',
-  purple100: 'rgba(108, 95, 199, 0.1)',
+  purple100: 'rgba(108, 95, 199, 0.08)',
 
   blue400: '#2562D4',
   blue300: '#3C74DD',


### PR DESCRIPTION
Make `purple100` lighter, from 10% opacity to 8% opacity, so it works better as a background color.

<img width="673" alt="image" src="https://user-images.githubusercontent.com/44172267/172450132-eb921b7e-b0dc-443c-9285-50b6a6431528.png">
