### PR TITLE
fix(dev): Do not export SENTRY_DSN in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -59,7 +59,8 @@ report_to_sentry() {
         curl -sL https://sentry.io/get-cli/ | bash
     fi
     # Report to sentry-dev-env project
-    sentry-cli send-event -m "$error_message" --logfile "$_SENTRY_LOG_FILE" --level $log_level
+    SENTRY_DSN="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503" \
+        sentry-cli send-event -m "$error_message" --logfile "$_SENTRY_LOG_FILE" --level $log_level
     rm "$_SENTRY_LOG_FILE"
 }
 
@@ -142,8 +143,6 @@ fi
 if [ -n "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
     debug "No development environment errors will be reported (since you've defined SENTRY_DEVENV_NO_REPORT)."
 else
-    # This is necessary for the bash-hook in lib.sh to work
-    export SENTRY_DSN="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503"
     # Since direnv traps the EXIT signal we place the temp file under /tmp for the odd time
     # the script will use the EXIT path
     _SENTRY_LOG_FILE=$(mktemp /tmp/sentry.envrc.$$.out || mktemp /tmp/sentry.envrc.XXXXXXXX.out)

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -16,13 +16,8 @@ if sys.version_info.major < 3:
 try:
     import sentry_sdk
 
-    if os.environ.get("SENTRY_DSN"):
-        sentry_sdk.init(dsn=os.environ["SENTRY_DSN"])
-    else:
-        sys.stdout.write(
-            "WARNING: Errors in this file will not be reported to Sentry since SENTRY_DSN is not set.\n"
-            "Use this command to report the issue: make direnv-help\n\n"
-        )
+    if not os.environ.get("SENTRY_DEVENV_NO_REPORT"):
+        sentry_sdk.init(dsn="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503")
 except ModuleNotFoundError:
     sys.stdout.write(
         "WARNING: Sentry SDK not installed, thus, errors will not be reported. Run: make install-py-dev\n"

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is an interface to any of the methods of lib.sh
 # Call this script as "do.sh method_from_lib" to execute any function from that library
-set -eu
+set -e
 HERE="$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
     pwd -P

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is an interface to any of the methods of lib.sh
 # Call this script as "do.sh method_from_lib" to execute any function from that library
-set -e
+set -eu
 HERE="$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
     pwd -P

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -28,10 +28,13 @@ configure-sentry-cli() {
     # We can remove this after it's fixed
     # https://github.com/getsentry/sentry-cli/pull/1059
     export SENTRY_CLI_NO_EXIT_TRAP=${SENTRY_CLI_NO_EXIT_TRAP-0}
-    if [ -n "${SENTRY_DSN+x}" ] && [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
+    if [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
         if ! require sentry-cli; then
             curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.0.4 bash
         fi
+        # This exported variable does not persist outside of the calling script, thus, not affecting other
+        # parts of the system
+        export SENTRY_DSN="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503"
         eval "$(sentry-cli bash-hook)"
     fi
 }


### PR DESCRIPTION
We started exporting SENTRY_DSN back in #32524 in order to fix errors in lib.sh not being reported.

Having this variable exported can cause a lot of errors from a developers' development to show up as dev env errors.

Exporting inside of lib.sh does not persist in the developers' environment.