### PR TITLE
fix(select): Focus on selected item on menu open

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "react-mentions": "4.4.2",
     "react-popper": "^2.3.0",
     "react-router": "3.2.0",
-    "react-select": "^3.0.8",
+    "react-select": "3.1.0",
     "react-select-event": "5.5.0",
     "react-sparklines": "1.7.0",
     "react-virtualized": "^9.22.3",

--- a/static/app/components/forms/compactSelect.tsx
+++ b/static/app/components/forms/compactSelect.tsx
@@ -294,14 +294,13 @@ function CompactSelect<OptionType extends GeneralSelectValue = GeneralSelectValu
             placeholder={placeholder}
             isSearchable={isSearchable}
             menuPlacement="bottom"
-            menuIsOpen
             isCompact
-            autoFocus
             controlShouldRenderValue={false}
             hideSelectedOptions={false}
             blurInputOnSelect={false}
             closeMenuOnSelect={false}
             closeMenuOnScroll={false}
+            openMenuOnFocus
           />
         </Overlay>
       </FocusScope>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7131,12 +7131,20 @@ dom-converter@^0.2.0:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.3.1, dom-helpers@^3.4.0:
+dom-helpers@^3.3.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
   dependencies:
     "@babel/runtime" "^7.1.2"
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-helpers@^5.1.3:
   version "5.2.0"
@@ -13019,10 +13027,10 @@ react-select-event@5.5.0:
   dependencies:
     "@testing-library/dom" ">=7"
 
-react-select@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#06ff764e29db843bcec439ef13e196865242e0c1"
-  integrity sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==
+react-select@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.0.tgz#ab098720b2e9fe275047c993f0d0caf5ded17c27"
+  integrity sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/cache" "^10.0.9"
@@ -13031,7 +13039,7 @@ react-select@^3.0.8:
     memoize-one "^5.0.0"
     prop-types "^15.6.0"
     react-input-autosize "^2.2.2"
-    react-transition-group "^2.2.1"
+    react-transition-group "^4.3.0"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
@@ -13095,15 +13103,15 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-transition-group@^2.2.1:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
+react-transition-group@^4.3.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
   dependencies:
-    dom-helpers "^3.4.0"
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react-virtualized@^9.22.3:
   version "9.22.3"


### PR DESCRIPTION
By default, when opening a select menu, `react-select` should focus on the selected item. However, in the current version that we use – `v3.0.8` – there is a bug preventing that from happening. This bug was fixed in `v3.1.0` ([release notes](https://github.com/JedWatson/react-select/releases/tag/react-select%403.1.0)). 

This PR upgrades react-select from `v3.0.8` to `v3.1.0`, and slightly tweaks `CompactSelect` to take advantage of this auto focus feature.

**Before:** select menu opens with the focus on either the first option or none of them
<img width="197" alt="Screen Shot 2022-06-07 at 12 41 06 PM" src="https://user-images.githubusercontent.com/44172267/172468238-bd58a84c-467e-46ba-9fbe-e8d2c2cff220.png">

**After:** select menu opens with the focus on the selected item
<img width="197" alt="Screen Shot 2022-06-07 at 12 40 53 PM" src="https://user-images.githubusercontent.com/44172267/172468194-a9dac75b-3a47-4c66-9e84-18b7d6f67a54.png">

