### PR TITLE
feat(perf): Add performance onboarding checklist

### DIFF
--- a/static/app/components/onboardingWizard/sidebar.tsx
+++ b/static/app/components/onboardingWizard/sidebar.tsx
@@ -10,10 +10,10 @@ import {CommonSidebarProps} from 'sentry/components/sidebar/types';
 import Tooltip from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {OnboardingTask, OnboardingTaskKey, Organization, Project} from 'sentry/types';
+import {OnboardingTask, OnboardingTaskKey, Project} from 'sentry/types';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
-import withOrganization from 'sentry/utils/withOrganization';
+import useOrganization from 'sentry/utils/useOrganization';
 import withProjects from 'sentry/utils/withProjects';
 import {usePersistedOnboardingState} from 'sentry/views/onboarding/targetedOnboarding/utils';
 
@@ -24,7 +24,6 @@ import {findActiveTasks, findCompleteTasks, findUpcomingTasks, taskIsDone} from 
 
 type Props = Pick<CommonSidebarProps, 'orientation' | 'collapsed'> & {
   onClose: () => void;
-  organization: Organization;
   projects: Project[];
 };
 
@@ -67,14 +66,10 @@ const upcomingTasksHeading = (
 );
 const completedTasksHeading = <Heading key="complete">{t('Completed')}</Heading>;
 
-function OnboardingWizardSidebar({
-  organization,
-  collapsed,
-  orientation,
-  onClose,
-  projects,
-}: Props) {
+function OnboardingWizardSidebar({collapsed, orientation, onClose, projects}: Props) {
   const api = useApi();
+  const organization = useOrganization();
+
   const [onboardingState, setOnboardingState] = usePersistedOnboardingState();
 
   const markCompletionTimeout = useRef<number | undefined>();
@@ -269,4 +264,4 @@ const TopRight = styled('img')`
   width: 60%;
 `;
 
-export default withOrganization(withProjects(OnboardingWizardSidebar));
+export default withProjects(OnboardingWizardSidebar);

--- a/static/app/components/onboardingWizard/task.tsx
+++ b/static/app/components/onboardingWizard/task.tsx
@@ -1,5 +1,4 @@
 import {forwardRef} from 'react';
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 import moment from 'moment';
@@ -16,6 +15,7 @@ import space from 'sentry/styles/space';
 import {AvatarUser, OnboardingTask, OnboardingTaskKey, Organization} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import testableTransition from 'sentry/utils/testableTransition';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import SkipConfirm from './skipConfirm';
@@ -33,7 +33,7 @@ const recordAnalytics = (
     action,
   });
 
-type Props = WithRouterProps & {
+type Props = {
   forwardedRef: React.Ref<HTMLDivElement>;
   /**
    * Fired when a task is completed. This will typically happen if there is a
@@ -52,7 +52,10 @@ type Props = WithRouterProps & {
   task: OnboardingTask;
 };
 
-function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}: Props) {
+function Task(props: Props) {
+  const {task, onSkip, onMarkComplete, forwardedRef, organization} = props;
+  const routeContext = useRouteContext();
+  const {router} = routeContext;
   const handleSkip = () => {
     recordAnalytics(task, organization, 'skipped');
     onSkip(task.task);
@@ -67,7 +70,7 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
     }
 
     if (task.actionType === 'action') {
-      task.action();
+      task.action(routeContext);
     }
 
     if (task.actionType === 'app') {
@@ -285,7 +288,7 @@ TaskBlankAvatar.defaultProps = {
   transition,
 };
 
-const WrappedTask = withOrganization(withRouter(Task));
+const WrappedTask = withOrganization(Task);
 
 export default forwardRef<
   HTMLDivElement,

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
 
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';
+import {navigateTo} from 'sentry/actionCreators/navigation';
 import {Client} from 'sentry/api';
 import {taskIsDone} from 'sentry/components/onboardingWizard/utils';
+import {filterProjects} from 'sentry/components/performanceOnboarding/utils';
 import {sourceMaps} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
 import pulsingIndicatorStyles from 'sentry/styles/pulsingIndicator';
@@ -154,8 +156,44 @@ export function getOnboardingTasks({
       ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT],
-      actionType: 'external',
-      location: 'https://docs.sentry.io/product/performance/getting-started/',
+      actionType: 'action',
+      action: ({router}) => {
+        if (!organization.features?.includes('performance-onboarding-checklist')) {
+          window.open(
+            'https://docs.sentry.io/product/performance/getting-started/',
+            '_blank'
+          );
+          return;
+        }
+
+        // TODO: add analytics here for this specific action.
+
+        if (!projects) {
+          navigateTo(`/organizations/${organization.slug}/performance/`, router);
+          return;
+        }
+
+        const {projectsWithoutFirstTransactionEvent, projectsForOnboarding} =
+          filterProjects(projects);
+
+        if (projectsWithoutFirstTransactionEvent.length <= 0) {
+          navigateTo(`/organizations/${organization.slug}/performance/`, router);
+          return;
+        }
+
+        if (projectsForOnboarding.length) {
+          navigateTo(
+            `/organizations/${organization.slug}/performance/?project=${projectsForOnboarding[0].id}#performance-sidequest`,
+            router
+          );
+          return;
+        }
+
+        navigateTo(
+          `/organizations/${organization.slug}/performance/?project=${projectsWithoutFirstTransactionEvent[0].id}#performance-sidequest`,
+          router
+        );
+      },
       display: true,
       SupplementComponent: withApi(({api, task, onCompleteTask}: FirstEventWaiterProps) =>
         !!projects?.length && task.requisiteTasks.length === 0 && !task.completionSeen ? (

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -1,0 +1,352 @@
+import {Fragment, useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+
+import HighlightTopRightPattern from 'sentry-images/pattern/highlight-top-right.svg';
+
+import Button from 'sentry/components/button';
+import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
+import {MenuItemProps} from 'sentry/components/dropdownMenuItemV2';
+import IdBadge from 'sentry/components/idBadge';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import SidebarPanel from 'sentry/components/sidebar/sidebarPanel';
+import {CommonSidebarProps, SidebarPanelKey} from 'sentry/components/sidebar/types';
+import {withoutPerformanceSupport} from 'sentry/data/platformCategories';
+import platforms from 'sentry/data/platforms';
+import {t, tct} from 'sentry/locale';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import pulsingIndicatorStyles from 'sentry/styles/pulsingIndicator';
+import space from 'sentry/styles/space';
+import {Project} from 'sentry/types';
+import EventWaiter from 'sentry/utils/eventWaiter';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePrevious from 'sentry/utils/usePrevious';
+import useProjects from 'sentry/utils/useProjects';
+
+import OnBoardingStep from './step';
+import usePerformanceOnboardingDocs, {
+  generateOnboardingDocKeys,
+} from './usePerformanceOnboardingDocs';
+import {filterProjects} from './utils';
+
+function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
+  const {currentPanel, collapsed, hidePanel, orientation} = props;
+  const isActive = currentPanel === SidebarPanelKey.PerformanceOnboarding;
+  const organization = useOrganization();
+  const access = new Set(organization.access);
+  const hasProjectAccess = access.has('project:read');
+
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+
+  const [currentProject, setCurrentProject] = useState<Project | undefined>(undefined);
+
+  const {selection, isReady} = useLegacyStore(PageFiltersStore);
+
+  const {projectsWithoutFirstTransactionEvent, projectsForOnboarding} =
+    filterProjects(projects);
+
+  useEffect(() => {
+    if (
+      currentProject ||
+      projects.length === 0 ||
+      !isReady ||
+      !isActive ||
+      projectsWithoutFirstTransactionEvent.length <= 0
+    ) {
+      return;
+    }
+    // Establish current project
+
+    const projectMap: Record<string, Project> = projects.reduce((acc, project) => {
+      acc[project.id] = project;
+      return acc;
+    }, {});
+
+    if (selection.projects.length) {
+      const projectSelection = selection.projects.map(
+        projectId => projectMap[String(projectId)]
+      );
+
+      // Among the project selection, find a project that has performance onboarding docs support, and has not sent
+      // a first transaction event.
+      const maybeProject = projectSelection.find(project =>
+        projectsForOnboarding.includes(project)
+      );
+      if (maybeProject) {
+        setCurrentProject(maybeProject);
+        return;
+      }
+
+      // Among the project selection, find a project that has not sent a first transaction event
+      const maybeProjectFallback = projectSelection.find(project =>
+        projectsWithoutFirstTransactionEvent.includes(project)
+      );
+      if (maybeProjectFallback) {
+        setCurrentProject(maybeProjectFallback);
+        return;
+      }
+    }
+
+    // Among the projects, find a project that has performance onboarding docs support, and has not sent
+    // a first transaction event.
+    if (projectsForOnboarding.length) {
+      setCurrentProject(projectsForOnboarding[0]);
+      return;
+    }
+
+    // Otherwise, pick a first project that has not sent a first transaction event.
+    setCurrentProject(projectsWithoutFirstTransactionEvent[0]);
+  }, [
+    selection.projects,
+    projects,
+    isActive,
+    isReady,
+    projectsForOnboarding,
+    projectsWithoutFirstTransactionEvent,
+    currentProject,
+  ]);
+
+  if (
+    !isActive ||
+    !hasProjectAccess ||
+    currentProject === undefined ||
+    !projectsLoaded ||
+    !projects ||
+    projects.length <= 0 ||
+    projectsWithoutFirstTransactionEvent.length <= 0
+  ) {
+    return null;
+  }
+
+  const items: MenuItemProps[] = projectsWithoutFirstTransactionEvent.reduce(
+    (acc: MenuItemProps[], project) => {
+      const itemProps: MenuItemProps = {
+        key: project.id,
+        label: (
+          <StyledIdBadge project={project} avatarSize={16} hideOverflow disableLink />
+        ),
+        onAction: function switchProject() {
+          setCurrentProject(project);
+        },
+      };
+
+      if (currentProject.id === project.id) {
+        acc.unshift(itemProps);
+      } else {
+        acc.push(itemProps);
+      }
+
+      return acc;
+    },
+    []
+  );
+
+  return (
+    <TaskSidebarPanel
+      orientation={orientation}
+      collapsed={collapsed}
+      hidePanel={hidePanel}
+    >
+      <TopRightBackgroundImage src={HighlightTopRightPattern} />
+      <TaskList>
+        <Heading>{t('Boost Performance')}</Heading>
+        <div>
+          <DropdownMenuControlV2
+            items={items}
+            triggerLabel={
+              <StyledIdBadge
+                project={currentProject}
+                avatarSize={16}
+                hideOverflow
+                disableLink
+              />
+            }
+            triggerProps={{
+              'aria-label': currentProject.slug,
+              // borderless: true,
+            }}
+            placement="bottom left"
+          />
+        </div>
+        <OnboardingContent currentProject={currentProject} />
+      </TaskList>
+    </TaskSidebarPanel>
+  );
+}
+
+function OnboardingContent({currentProject}: {currentProject: Project}) {
+  const api = useApi();
+  const organization = useOrganization();
+  const previousProject = usePrevious(currentProject);
+  const [received, setReceived] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (previousProject.id !== currentProject.id) {
+      setReceived(false);
+    }
+  }, [previousProject.id, currentProject.id]);
+
+  const {docContents, isLoading, hasOnboardingContents} =
+    usePerformanceOnboardingDocs(currentProject);
+
+  const doesNotSupportPerformance = currentProject.platform
+    ? withoutPerformanceSupport.has(currentProject.platform)
+    : false;
+
+  if (doesNotSupportPerformance) {
+    return (
+      <Fragment>
+        <div>
+          {t(
+            'Fiddlesticks. Performance isn’t available for Elixir yet but we’re definitely still working on it. Stay tuned.'
+          )}
+        </div>
+        <div>
+          <Button size="small" href="https://docs.sentry.io/platforms/" external>
+            {t('Go to Sentry Documentation')}
+          </Button>
+        </div>
+      </Fragment>
+    );
+  }
+
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  const currentPlatform = currentProject.platform
+    ? platforms.find(p => p.id === currentProject.platform)
+    : undefined;
+  if (!currentPlatform || !hasOnboardingContents) {
+    return (
+      <Fragment>
+        <div>
+          {t(
+            'Fiddlesticks. This checklist isn’t available for this project yet, but for now, go to Sentry docs for installation details.'
+          )}
+        </div>
+        <div>
+          <Button
+            size="small"
+            href="https://docs.sentry.io/product/performance/getting-started/"
+            external
+          >
+            {t('Go to documentation')}
+          </Button>
+        </div>
+      </Fragment>
+    );
+  }
+
+  const docKeys = generateOnboardingDocKeys(currentPlatform.id);
+
+  return (
+    <Fragment>
+      <div>
+        {tct(
+          `Adding performance to your [platform] project is simple. Make sure you've got these basics down.`,
+          {platform: currentPlatform?.name || currentProject.slug}
+        )}
+      </div>
+      {docKeys.map((docKey, index) => {
+        let footer: React.ReactNode = null;
+
+        if (index === 2) {
+          footer = (
+            <EventWaiter
+              api={api}
+              organization={organization}
+              project={currentProject}
+              eventType="transaction"
+              onIssueReceived={() => {
+                setReceived(true);
+              }}
+            >
+              {() => (received ? <EventReceivedIndicator /> : <EventWaitingIndicator />)}
+            </EventWaiter>
+          );
+        }
+        return (
+          <div key={index}>
+            <OnBoardingStep
+              docKey={docKey}
+              project={currentProject}
+              docContent={docContents[docKey]}
+            />
+            {footer}
+          </div>
+        );
+      })}
+    </Fragment>
+  );
+}
+
+const TaskSidebarPanel = styled(SidebarPanel)`
+  width: 450px;
+`;
+
+const TopRightBackgroundImage = styled('img')`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 60%;
+  user-select: none;
+`;
+
+const TaskList = styled('div')`
+  display: grid;
+  grid-auto-flow: row;
+  grid-template-columns: 100%;
+  gap: ${space(1)};
+  margin: 50px ${space(4)} ${space(4)} ${space(4)};
+`;
+
+const Heading = styled('div')`
+  display: flex;
+  color: ${p => p.theme.purple300};
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  text-transform: uppercase;
+  font-weight: 600;
+  line-height: 1;
+  margin-top: ${space(3)};
+`;
+
+const StyledIdBadge = styled(IdBadge)`
+  overflow: hidden;
+  white-space: nowrap;
+  flex-shrink: 1;
+`;
+
+const PulsingIndicator = styled('div')`
+  ${pulsingIndicatorStyles};
+  margin-right: ${space(1)};
+`;
+
+const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
+  <div {...p}>
+    <PulsingIndicator />
+    {t(`Waiting for this project's first transaction event`)}
+  </div>
+))`
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.pink300};
+`;
+
+const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
+  <div {...p}>
+    {'🎉 '}
+    {t(`We've received this project's first transaction event!`)}
+  </div>
+))`
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.green300};
+`;
+
+export default PerformanceOnboardingSidebar;

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -163,7 +163,6 @@ function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
             }
             triggerProps={{
               'aria-label': currentProject.slug,
-              // borderless: true,
             }}
             placement="bottom left"
           />

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -150,21 +150,21 @@ function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
       <TopRightBackgroundImage src={HighlightTopRightPattern} />
       <TaskList>
         <Heading>{t('Boost Performance')}</Heading>
-          <DropdownMenuControlV2
-            items={items}
-            triggerLabel={
-              <StyledIdBadge
-                project={currentProject}
-                avatarSize={16}
-                hideOverflow
-                disableLink
-              />
-            }
-            triggerProps={{
-              'aria-label': currentProject.slug,
-            }}
-            placement="bottom left"
-          />
+        <DropdownMenuControlV2
+          items={items}
+          triggerLabel={
+            <StyledIdBadge
+              project={currentProject}
+              avatarSize={16}
+              hideOverflow
+              disableLink
+            />
+          }
+          triggerProps={{
+            'aria-label': currentProject.slug,
+          }}
+          placement="bottom left"
+        />
         <OnboardingContent currentProject={currentProject} />
       </TaskList>
     </TaskSidebarPanel>

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -198,7 +198,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
       <Fragment>
         <div>
           {t(
-            'Fiddlesticks. Performance isn’t available for Elixir yet but we’re definitely still working on it. Stay tuned.'
+            'Fiddlesticks. Performance isn’t available for this project yet but we’re definitely still working on it. Stay tuned.'
           )}
         </div>
         <div>

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -167,7 +167,6 @@ function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
             }}
             placement="bottom left"
           />
-        </div>
         <OnboardingContent currentProject={currentProject} />
       </TaskList>
     </TaskSidebarPanel>

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -34,8 +34,7 @@ function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
   const {currentPanel, collapsed, hidePanel, orientation} = props;
   const isActive = currentPanel === SidebarPanelKey.PerformanceOnboarding;
   const organization = useOrganization();
-  const access = new Set(organization.access);
-  const hasProjectAccess = access.has('project:read');
+  const hasProjectAccess = organization.access.includes('project:read');
 
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
 

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -208,7 +208,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
           )}
         </div>
         <div>
-          <Button size="small" href="https://docs.sentry.io/platforms/" external>
+          <Button size="sm" href="https://docs.sentry.io/platforms/" external>
             {t('Go to Sentry Documentation')}
           </Button>
         </div>
@@ -227,7 +227,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
         </div>
         <div>
           <Button
-            size="small"
+            size="sm"
             href="https://docs.sentry.io/product/performance/getting-started/"
             external
           >

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -244,7 +244,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     <Fragment>
       <div>
         {tct(
-          `Adding performance to your [platform] project is simple. Make sure you've got these basics down.`,
+          `Adding Performance to your [platform] project is simple. Make sure you've got these basics down.`,
           {platform: currentPlatform?.name || currentProject.slug}
         )}
       </div>

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -150,7 +150,6 @@ function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
       <TopRightBackgroundImage src={HighlightTopRightPattern} />
       <TaskList>
         <Heading>{t('Boost Performance')}</Heading>
-        <div>
           <DropdownMenuControlV2
             items={items}
             triggerLabel={

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -186,6 +186,10 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
   const {docContents, isLoading, hasOnboardingContents} =
     usePerformanceOnboardingDocs(currentProject);
 
+  const currentPlatform = currentProject.platform
+    ? platforms.find(p => p.id === currentProject.platform)
+    : undefined;
+
   const doesNotSupportPerformance = currentProject.platform
     ? withoutPerformanceSupport.has(currentProject.platform)
     : false;
@@ -194,8 +198,9 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     return (
       <Fragment>
         <div>
-          {t(
-            'Fiddlesticks. Performance isn’t available for this project yet but we’re definitely still working on it. Stay tuned.'
+          {tct(
+            'Fiddlesticks. Performance isn’t available for your [platform] project yet but we’re definitely still working on it. Stay tuned.',
+            {platform: currentPlatform?.name || currentProject.slug}
           )}
         </div>
         <div>
@@ -211,15 +216,13 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     return <LoadingIndicator />;
   }
 
-  const currentPlatform = currentProject.platform
-    ? platforms.find(p => p.id === currentProject.platform)
-    : undefined;
   if (!currentPlatform || !hasOnboardingContents) {
     return (
       <Fragment>
         <div>
-          {t(
-            'Fiddlesticks. This checklist isn’t available for this project yet, but for now, go to Sentry docs for installation details.'
+          {tct(
+            'Fiddlesticks. This checklist isn’t available for your [project] project yet, but for now, go to Sentry docs for installation details.',
+            {project: currentProject.slug}
           )}
         </div>
         <div>

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -186,6 +186,10 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
   const {docContents, isLoading, hasOnboardingContents} =
     usePerformanceOnboardingDocs(currentProject);
 
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
   const currentPlatform = currentProject.platform
     ? platforms.find(p => p.id === currentProject.platform)
     : undefined;
@@ -210,10 +214,6 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
         </div>
       </Fragment>
     );
-  }
-
-  if (isLoading) {
-    return <LoadingIndicator />;
   }
 
   if (!currentPlatform || !hasOnboardingContents) {

--- a/static/app/components/performanceOnboarding/step.tsx
+++ b/static/app/components/performanceOnboarding/step.tsx
@@ -1,0 +1,108 @@
+import 'prism-sentry/index.css';
+
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import CheckboxFancy from 'sentry/components/checkboxFancy/checkboxFancy';
+import space from 'sentry/styles/space';
+import {Project} from 'sentry/types';
+import localStorage from 'sentry/utils/localStorage';
+
+type Props = {
+  docContent: string | undefined;
+  docKey: string;
+  project: Project;
+};
+
+function OnBoardingStep(props: Props) {
+  const {docKey, project, docContent} = props;
+
+  const [increment, setIncrement] = useState<number>(0);
+
+  if (!docContent) {
+    return null;
+  }
+
+  const localStorageKey = `perf-onboarding-${project.id}-${docKey}`;
+
+  function isChecked() {
+    return localStorage.getItem(localStorageKey) === 'check';
+  }
+
+  return (
+    <Wrapper>
+      <TaskCheckBox>
+        <CheckboxFancy
+          size="22px"
+          isChecked={isChecked()}
+          onClick={event => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            if (isChecked()) {
+              localStorage.removeItem(localStorageKey);
+            } else {
+              localStorage.setItem(localStorageKey, 'check');
+            }
+            setIncrement(increment + 1);
+
+            return;
+          }}
+        />
+      </TaskCheckBox>
+      <DocumentationWrapper dangerouslySetInnerHTML={{__html: docContent}} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')`
+  position: relative;
+`;
+
+const TaskCheckBox = styled('div')`
+  float: left;
+  margin-right: ${space(1.5)};
+  height: 27px;
+  display: flex;
+  align-items: center;
+  z-index: 2;
+  position: relative;
+`;
+
+const DocumentationWrapper = styled('div')`
+  line-height: 1.5;
+
+  .gatsby-highlight {
+    margin-bottom: ${space(3)};
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .alert {
+    margin-bottom: ${space(3)};
+    border-radius: ${p => p.theme.borderRadius};
+  }
+
+  pre {
+    word-break: break-all;
+    white-space: pre-wrap;
+  }
+
+  blockquote {
+    padding: ${space(1)};
+    margin-left: 0;
+    background: ${p => p.theme.alert.info.backgroundLight};
+    border-left: 2px solid ${p => p.theme.alert.info.border};
+  }
+  blockquote > *:last-child {
+    margin-bottom: 0;
+  }
+
+  /* Ensures documentation content is placed behind the checkbox */
+  z-index: 1;
+  position: relative;
+`;
+
+export default OnBoardingStep;

--- a/static/app/components/performanceOnboarding/usePerformanceOnboardingDocs.tsx
+++ b/static/app/components/performanceOnboarding/usePerformanceOnboardingDocs.tsx
@@ -1,0 +1,141 @@
+import {useEffect, useState} from 'react';
+import * as Sentry from '@sentry/react';
+
+import {loadDocs} from 'sentry/actionCreators/projects';
+import {
+  PlatformKey,
+  withoutPerformanceSupport,
+  withPerformanceOnboarding,
+} from 'sentry/data/platformCategories';
+import platforms from 'sentry/data/platforms';
+import {Project} from 'sentry/types';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function generateOnboardingDocKeys(platform: PlatformKey): string[] {
+  return ['1-install', '2-configure', '3-verify'].map(
+    key => `${platform}-performance-onboarding-${key}`
+  );
+}
+
+const INITIAL_LOADING_DOCS = {};
+const INITIAL_DOC_CONTENTS = {};
+
+function usePerformanceOnboardingDocs(project: Project) {
+  const organization = useOrganization();
+  const api = useApi();
+
+  const [loadingDocs, setLoadingDocs] =
+    useState<Record<string, boolean>>(INITIAL_LOADING_DOCS);
+  const [docContents, setDocContents] =
+    useState<Record<string, string>>(INITIAL_DOC_CONTENTS);
+
+  const currentPlatform = project.platform
+    ? platforms.find(p => p.id === project.platform)
+    : undefined;
+
+  const hasPerformanceOnboarding = currentPlatform
+    ? withPerformanceOnboarding.has(currentPlatform.id)
+    : false;
+
+  const doesNotSupportPerformance = currentPlatform
+    ? withoutPerformanceSupport.has(currentPlatform.id)
+    : false;
+
+  useEffect(() => {
+    if (!currentPlatform || !hasPerformanceOnboarding || doesNotSupportPerformance) {
+      if (loadingDocs !== INITIAL_LOADING_DOCS) {
+        setLoadingDocs(INITIAL_LOADING_DOCS);
+      }
+      if (docContents !== INITIAL_DOC_CONTENTS) {
+        setDocContents(INITIAL_DOC_CONTENTS);
+      }
+      return;
+    }
+
+    const docKeys = generateOnboardingDocKeys(currentPlatform.id);
+
+    docKeys.forEach(docKey => {
+      if (docKey in loadingDocs) {
+        // If a documentation content is loading, we should not attempt to fetch it again.
+        // otherwise, if it's not loading, we should only fetch at most once.
+        // Any errors that occurred will be captured via Sentry.
+        return;
+      }
+
+      const setLoadingDoc = (loadingState: boolean) =>
+        setLoadingDocs(prevState => {
+          return {
+            ...prevState,
+            [docKey]: loadingState,
+          };
+        });
+
+      const setDocContent = (docContent: string | undefined) =>
+        setDocContents(prevState => {
+          if (docContent === undefined) {
+            const newState = {
+              ...prevState,
+            };
+            delete newState[docKey];
+            return newState;
+          }
+          return {
+            ...prevState,
+            [docKey]: docContent,
+          };
+        });
+
+      setLoadingDoc(true);
+
+      loadDocs(api, organization.slug, project.slug, docKey as any)
+        .then(({html}) => {
+          setDocContent(html as string);
+          setLoadingDoc(false);
+        })
+        .catch(error => {
+          Sentry.captureException(error);
+          setDocContent(undefined);
+          setLoadingDoc(false);
+        });
+    });
+  }, [
+    currentPlatform,
+    hasPerformanceOnboarding,
+    doesNotSupportPerformance,
+    api,
+    loadingDocs,
+    organization.slug,
+    project.slug,
+    docContents,
+  ]);
+
+  if (!currentPlatform || !hasPerformanceOnboarding || doesNotSupportPerformance) {
+    return {
+      isLoading: false,
+      hasOnboardingContents: false,
+      docContents: {},
+    };
+  }
+
+  const docKeys = generateOnboardingDocKeys(currentPlatform.id);
+
+  const isLoading = docKeys.some(key => {
+    if (key in loadingDocs) {
+      return !!loadingDocs[key];
+    }
+    return true;
+  });
+
+  const hasOnboardingContents = docKeys.every(
+    key => typeof docContents[key] === 'string'
+  );
+
+  return {
+    isLoading,
+    hasOnboardingContents,
+    docContents,
+  };
+}
+
+export default usePerformanceOnboardingDocs;

--- a/static/app/components/performanceOnboarding/utils.tsx
+++ b/static/app/components/performanceOnboarding/utils.tsx
@@ -1,0 +1,24 @@
+import {
+  withoutPerformanceSupport,
+  withPerformanceOnboarding,
+} from 'sentry/data/platformCategories';
+import {Project} from 'sentry/types';
+
+export function filterProjects(rawProjects: Project[]) {
+  // filter on projects that have not sent a first transaction event
+  const projectsWithoutFirstTransactionEvent = rawProjects.filter(
+    p =>
+      p.firstTransactionEvent === false &&
+      (!p.platform || !withoutPerformanceSupport.has(p.platform))
+  );
+
+  // additionally filter on projects that have performance onboarding checklist support
+  const projectsForOnboarding = projectsWithoutFirstTransactionEvent.filter(
+    p => p.platform && withPerformanceOnboarding.has(p.platform)
+  );
+
+  return {
+    projectsWithoutFirstTransactionEvent,
+    projectsForOnboarding,
+  };
+}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -7,6 +7,7 @@ import {hideSidebar, showSidebar} from 'sentry/actionCreators/preferences';
 import Feature from 'sentry/components/acl/feature';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import HookOrDefault from 'sentry/components/hookOrDefault';
+import PerformanceOnboardingSidebar from 'sentry/components/performanceOnboarding/sidebar';
 import {
   IconChevron,
   IconDashboard,
@@ -54,6 +55,10 @@ type Props = {
   organization?: Organization;
 };
 
+function activatePanel(panel: SidebarPanelKey) {
+  SidebarPanelStore.activatePanel(panel);
+}
+
 function togglePanel(panel: SidebarPanelKey) {
   SidebarPanelStore.togglePanel(panel);
 }
@@ -100,9 +105,14 @@ function Sidebar({location, organization}: Props) {
   // Trigger panels depending on the location hash
   useEffect(() => {
     if (location?.hash === '#welcome') {
-      togglePanel(SidebarPanelKey.OnboardingWizard);
+      activatePanel(SidebarPanelKey.OnboardingWizard);
+    } else if (
+      location?.hash === '#performance-sidequest' &&
+      organization?.features?.includes('performance-onboarding-checklist')
+    ) {
+      activatePanel(SidebarPanelKey.PerformanceOnboarding);
     }
-  }, [location?.hash]);
+  }, [location?.hash, organization]);
 
   const hasPanel = !!activePanel;
   const hasOrganization = !!organization;
@@ -340,6 +350,12 @@ function Sidebar({location, organization}: Props) {
 
       {hasOrganization && (
         <SidebarSectionGroup>
+          <PerformanceOnboardingSidebar
+            currentPanel={activePanel}
+            onShowPanel={() => togglePanel(SidebarPanelKey.PerformanceOnboarding)}
+            hidePanel={hidePanel}
+            {...sidebarItemProps}
+          />
           <SidebarSection noMargin noPadding>
             <OnboardingStatus
               org={organization}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -106,13 +106,8 @@ function Sidebar({location, organization}: Props) {
   useEffect(() => {
     if (location?.hash === '#welcome') {
       activatePanel(SidebarPanelKey.OnboardingWizard);
-    } else if (
-      location?.hash === '#performance-sidequest' &&
-      organization?.features?.includes('performance-onboarding-checklist')
-    ) {
-      activatePanel(SidebarPanelKey.PerformanceOnboarding);
     }
-  }, [location?.hash, organization]);
+  }, [location?.hash]);
 
   const hasPanel = !!activePanel;
   const hasOrganization = !!organization;

--- a/static/app/components/sidebar/types.tsx
+++ b/static/app/components/sidebar/types.tsx
@@ -4,6 +4,7 @@ export enum SidebarPanelKey {
   Broadcasts = 'broadcasts',
   OnboardingWizard = 'todos',
   ServiceIncidents = 'statusupdate',
+  PerformanceOnboarding = 'performance_onboarding',
 }
 
 export type CommonSidebarProps = {

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -181,6 +181,19 @@ export const performance: PlatformKey[] = [
   'node-connect',
 ];
 
+// List of platforms that have performance onboarding checklist content
+export const withPerformanceOnboarding: Set<PlatformKey> = new Set([
+  'javascript',
+  'javascript-react',
+]);
+
+// List of platforms that do not have performance support. We make use of this list in the product to not provide any Performance
+// views such as Performance onboarding checklist.
+export const withoutPerformanceSupport: Set<PlatformKey> = new Set([
+  'elixir',
+  'minidump',
+]);
+
 export const releaseHealth: PlatformKey[] = [
   // frontend
   'javascript',

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -1,3 +1,5 @@
+import {RouteContextInterface} from 'react-router';
+
 import {Organization, Project} from 'sentry/types';
 import {OnboardingState} from 'sentry/views/onboarding/targetedOnboarding/types';
 
@@ -78,7 +80,7 @@ export type OnboardingTaskDescriptor = {
       location: string;
     }
   | {
-      action: () => void;
+      action: (props: RouteContextInterface) => void;
       actionType: 'action';
     }
 );

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -21,10 +22,16 @@ import FeatureTourModal, {
   TourText,
 } from 'sentry/components/modals/featureTourModal';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
+import {filterProjects} from 'sentry/components/performanceOnboarding/utils';
+import {SidebarPanelKey} from 'sentry/components/sidebar/types';
+import {withPerformanceOnboarding} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
+import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {Organization, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import useApi from 'sentry/utils/useApi';
+import useProjects from 'sentry/utils/useProjects';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 const performanceSetupUrl =
   'https://docs.sentry.io/performance-monitoring/getting-started/';
@@ -93,6 +100,25 @@ type Props = {
 function Onboarding({organization, project}: Props) {
   const api = useApi();
 
+  const {projects} = useProjects();
+  const {location} = useRouteContext();
+
+  const {projectsForOnboarding} = filterProjects(projects);
+
+  const showOnboardingChecklist = organization.features?.includes(
+    'performance-onboarding-checklist'
+  );
+
+  useEffect(() => {
+    if (
+      showOnboardingChecklist &&
+      location.hash === '#performance-sidequest' &&
+      projectsForOnboarding.some(p => p.id === project.id)
+    ) {
+      SidebarPanelStore.activatePanel(SidebarPanelKey.PerformanceOnboarding);
+    }
+  }, [location.hash, projectsForOnboarding, project.id, showOnboardingChecklist]);
+
   function handleAdvance(step: number, duration: number) {
     trackAdvancedAnalyticsEvent('performance_views.tour.advance', {
       step,
@@ -109,6 +135,35 @@ function Onboarding({organization, project}: Props) {
     });
   }
 
+  const currentPlatform = project.platform;
+  const hasPerformanceOnboarding = currentPlatform
+    ? withPerformanceOnboarding.has(currentPlatform)
+    : false;
+
+  let setupButton = (
+    <Button
+      priority="primary"
+      href="https://docs.sentry.io/performance-monitoring/getting-started/"
+      external
+    >
+      {t('Start Setup')}
+    </Button>
+  );
+
+  if (hasPerformanceOnboarding && showOnboardingChecklist) {
+    setupButton = (
+      <Button
+        priority="primary"
+        onClick={event => {
+          event.preventDefault();
+          SidebarPanelStore.activatePanel(SidebarPanelKey.PerformanceOnboarding);
+        }}
+      >
+        {t('Start Checklist')}
+      </Button>
+    );
+  }
+
   return (
     <OnboardingPanel image={<PerfImage src={emptyStateImg} />}>
       <h3>{t('Pinpoint problems')}</h3>
@@ -118,13 +173,7 @@ function Onboarding({organization, project}: Props) {
         )}
       </p>
       <ButtonList gap={1}>
-        <Button
-          priority="primary"
-          href="https://docs.sentry.io/performance-monitoring/getting-started/"
-          external
-        >
-          {t('Start Setup')}
-        </Button>
+        {setupButton}
         <Button
           data-test-id="create-sample-transaction-btn"
           onClick={async () => {

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -156,6 +156,7 @@ function Onboarding({organization, project}: Props) {
         priority="primary"
         onClick={event => {
           event.preventDefault();
+          window.location.hash = 'performance-sidequest';
           SidebarPanelStore.activatePanel(SidebarPanelKey.PerformanceOnboarding);
         }}
       >

--- a/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
@@ -1,3 +1,6 @@
+import {withRouter, WithRouterProps} from 'react-router';
+
+import {navigateTo} from 'sentry/actionCreators/navigation';
 import Feature from 'sentry/components/acl/feature';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -11,9 +14,9 @@ const DOCS_URL = 'https://docs.sentry.io/performance-monitoring/getting-started/
 
 type Props = {
   organization: Organization;
-};
+} & WithRouterProps;
 
-function MissingPerformanceButtons({organization}: Props) {
+function MissingPerformanceButtons({organization, router}: Props) {
   function handleTourAdvance(step: number, duration: number) {
     trackAnalyticsEvent({
       eventKey: 'project_detail.performance_tour.advance',
@@ -41,7 +44,18 @@ function MissingPerformanceButtons({organization}: Props) {
       organization={organization}
     >
       <ButtonBar gap={1}>
-        <Button size="sm" priority="primary" external href={DOCS_URL}>
+        <Button
+          size="sm"
+          priority="primary"
+          onClick={event => {
+            event.preventDefault();
+            // TODO: add analytics here for this specific action.
+            navigateTo(
+              `/organizations/${organization.slug}/performance/?project=:project#performance-sidequest`,
+              router
+            );
+          }}
+        >
           {t('Start Setup')}
         </Button>
 
@@ -63,4 +77,4 @@ function MissingPerformanceButtons({organization}: Props) {
   );
 }
 
-export default MissingPerformanceButtons;
+export default withRouter(MissingPerformanceButtons);

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -6,6 +6,7 @@ import SidebarContainer from 'sentry/components/sidebar';
 import ConfigStore from 'sentry/stores/configStore';
 import {PersistedStoreProvider} from 'sentry/stores/persistedStore';
 import {OrganizationContext} from 'sentry/views/organizationContext';
+import {RouteContext} from 'sentry/views/routeContext';
 
 jest.mock('sentry/actionCreators/serviceIncidents');
 
@@ -18,11 +19,20 @@ describe('Sidebar', function () {
   const location = {...router.location, ...{pathname: '/test/'}};
 
   const getElement = props => (
-    <OrganizationContext.Provider value={organization}>
-      <PersistedStoreProvider>
-        <SidebarContainer organization={organization} location={location} {...props} />
-      </PersistedStoreProvider>
-    </OrganizationContext.Provider>
+    <RouteContext.Provider
+      value={{
+        location,
+        params: {},
+        router,
+        routes: [],
+      }}
+    >
+      <OrganizationContext.Provider value={organization}>
+        <PersistedStoreProvider>
+          <SidebarContainer organization={organization} location={location} {...props} />
+        </PersistedStoreProvider>
+      </OrganizationContext.Provider>
+    </RouteContext.Provider>
   );
 
   const renderSidebar = props => render(getElement(props));

--- a/tests/js/spec/components/sidebar/performanceOnboarding.spec.tsx
+++ b/tests/js/spec/components/sidebar/performanceOnboarding.spec.tsx
@@ -1,0 +1,285 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
+
+import {generateOnboardingDocKeys} from 'sentry/components/performanceOnboarding/usePerformanceOnboardingDocs';
+import SidebarContainer from 'sentry/components/sidebar';
+import {SidebarPanelKey} from 'sentry/components/sidebar/types';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {PersistedStoreProvider} from 'sentry/stores/persistedStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+import {RouteContext} from 'sentry/views/routeContext';
+
+jest.mock('sentry/actionCreators/serviceIncidents');
+
+describe('Sidebar > Performance Onboarding Checklist', function () {
+  const {organization, router} = initializeOrg({
+    router: {
+      location: {query: {}, search: ''},
+      push: jest.fn(),
+    },
+  } as any);
+  const broadcast = TestStubs.Broadcast();
+
+  const apiMocks: any = {};
+
+  const location = {...router.location, ...{pathname: '/test/'}};
+
+  const getElement = props => {
+    return (
+      <RouteContext.Provider
+        value={{
+          location,
+          params: {},
+          router,
+          routes: [],
+        }}
+      >
+        <OrganizationContext.Provider value={props.organization}>
+          <PersistedStoreProvider>
+            <SidebarContainer
+              organization={props.organization}
+              location={location}
+              {...props}
+            />
+          </PersistedStoreProvider>
+        </OrganizationContext.Provider>
+      </RouteContext.Provider>
+    );
+  };
+
+  const renderSidebar = props => render(getElement(props));
+
+  beforeEach(function () {
+    jest.resetAllMocks();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(
+      {
+        projects: [],
+        environments: [],
+        datetime: {start: null, end: null, period: '24h', utc: null},
+      },
+      new Set()
+    );
+    apiMocks.broadcasts = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/broadcasts/`,
+      body: [broadcast],
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.teardown();
+  });
+
+  it('displays boost performance card', async function () {
+    const {container} = renderSidebar({
+      organization: {
+        ...organization,
+        features: ['onboarding'],
+      },
+    });
+    await waitFor(() => container);
+
+    const quickStart = screen.getByText('Quick Start');
+
+    expect(quickStart).toBeInTheDocument();
+    userEvent.click(quickStart);
+
+    const sidebar = await screen.findByRole('dialog');
+    expect(sidebar).toBeInTheDocument();
+
+    expect(screen.getByText('Capture your first error')).toBeInTheDocument();
+    expect(screen.getByText('Level Up')).toBeInTheDocument();
+    expect(screen.getByText('Boost performance')).toBeInTheDocument();
+
+    userEvent.click(quickStart);
+    expect(screen.queryByText('Boost performance')).not.toBeInTheDocument();
+    await tick();
+  });
+
+  it('checklist feature disabled', async function () {
+    const {container} = renderSidebar({
+      organization: {
+        ...organization,
+        features: ['onboarding'],
+      },
+    });
+    await waitFor(() => container);
+    window.open = jest.fn().mockImplementation(() => true);
+
+    const quickStart = screen.getByText('Quick Start');
+
+    expect(quickStart).toBeInTheDocument();
+    userEvent.click(quickStart);
+
+    const sidebar = await screen.findByRole('dialog');
+    expect(sidebar).toBeInTheDocument();
+
+    expect(screen.getByText('Capture your first error')).toBeInTheDocument();
+    expect(screen.getByText('Level Up')).toBeInTheDocument();
+    expect(screen.getByText('Boost performance')).toBeInTheDocument();
+    const performanceCard = screen.getByTestId('setup_transactions');
+
+    userEvent.click(performanceCard);
+    expect(window.open).toHaveBeenCalledWith(
+      'https://docs.sentry.io/product/performance/getting-started/',
+      '_blank'
+    );
+    await tick();
+  });
+
+  it('checklist feature enabled > navigate to performance page > project with onboarding support', async function () {
+    ProjectsStore.loadInitialData([
+      TestStubs.Project({platform: 'javascript-react', firstTransactionEvent: false}),
+    ]);
+    const {container} = renderSidebar({
+      organization: {
+        ...organization,
+        features: ['onboarding', 'performance-onboarding-checklist'],
+      },
+    });
+    await waitFor(() => container);
+    window.open = jest.fn().mockImplementation(() => true);
+
+    const quickStart = screen.getByText('Quick Start');
+
+    expect(quickStart).toBeInTheDocument();
+    userEvent.click(quickStart);
+
+    const sidebar = await screen.findByRole('dialog');
+    expect(sidebar).toBeInTheDocument();
+
+    expect(screen.getByText('Capture your first error')).toBeInTheDocument();
+    expect(screen.getByText('Level Up')).toBeInTheDocument();
+    expect(screen.getByText('Boost performance')).toBeInTheDocument();
+    const performanceCard = screen.getByTestId('setup_transactions');
+
+    userEvent.click(performanceCard);
+    expect(window.open).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledWith(
+      '/organizations/org-slug/performance/?project=2#performance-sidequest'
+    );
+
+    await tick();
+  });
+
+  it('checklist feature enabled > navigate to performance page > project without onboarding support', async function () {
+    ProjectsStore.loadInitialData([
+      TestStubs.Project({platform: 'javascript-angular', firstTransactionEvent: false}),
+    ]);
+    const {container} = renderSidebar({
+      organization: {
+        ...organization,
+        features: ['onboarding', 'performance-onboarding-checklist'],
+      },
+    });
+    await waitFor(() => container);
+    window.open = jest.fn().mockImplementation(() => true);
+
+    const quickStart = screen.getByText('Quick Start');
+
+    expect(quickStart).toBeInTheDocument();
+    userEvent.click(quickStart);
+
+    const sidebar = await screen.findByRole('dialog');
+    expect(sidebar).toBeInTheDocument();
+
+    expect(screen.getByText('Capture your first error')).toBeInTheDocument();
+    expect(screen.getByText('Level Up')).toBeInTheDocument();
+    expect(screen.getByText('Boost performance')).toBeInTheDocument();
+    const performanceCard = screen.getByTestId('setup_transactions');
+
+    userEvent.click(performanceCard);
+    expect(window.open).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledWith(
+      '/organizations/org-slug/performance/?project=2#performance-sidequest'
+    );
+
+    await tick();
+  });
+
+  it('checklist feature enabled > navigate to performance page > project without performance support', async function () {
+    ProjectsStore.loadInitialData([
+      TestStubs.Project({platform: 'elixir', firstTransactionEvent: false}),
+    ]);
+    const {container} = renderSidebar({
+      organization: {
+        ...organization,
+        features: ['onboarding', 'performance-onboarding-checklist'],
+      },
+    });
+    await waitFor(() => container);
+    window.open = jest.fn().mockImplementation(() => true);
+
+    const quickStart = screen.getByText('Quick Start');
+
+    expect(quickStart).toBeInTheDocument();
+    userEvent.click(quickStart);
+
+    const sidebar = await screen.findByRole('dialog');
+    expect(sidebar).toBeInTheDocument();
+
+    expect(screen.getByText('Capture your first error')).toBeInTheDocument();
+    expect(screen.getByText('Level Up')).toBeInTheDocument();
+    expect(screen.getByText('Boost performance')).toBeInTheDocument();
+    const performanceCard = screen.getByTestId('setup_transactions');
+
+    userEvent.click(performanceCard);
+    expect(window.open).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledWith('/organizations/org-slug/performance/');
+
+    await tick();
+  });
+
+  it('displays checklist', async function () {
+    const project = TestStubs.Project({
+      platform: 'javascript-react',
+      firstTransactionEvent: false,
+    });
+    ProjectsStore.loadInitialData([project]);
+
+    const docApiMocks: any = {};
+    const docKeys = generateOnboardingDocKeys(project.platform);
+
+    docKeys.forEach(docKey => {
+      docApiMocks[docKey] = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/docs/${docKey}/`,
+        method: 'GET',
+        body: {html: `<h1>${docKey}</h1> content`},
+      });
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      method: 'GET',
+      body: {},
+    });
+
+    renderSidebar({
+      organization: {
+        ...organization,
+        features: ['onboarding', 'performance-onboarding-checklist'],
+      },
+    });
+
+    act(() => {
+      SidebarPanelStore.activatePanel(SidebarPanelKey.PerformanceOnboarding);
+    });
+
+    expect(
+      await screen.findByText(
+        textWithMarkupMatcher('Adding performance to your React project is simple.')
+      )
+    ).toBeInTheDocument();
+
+    for (const docKey of docKeys) {
+      expect(
+        await screen.findByText(textWithMarkupMatcher(`${docKey} content`))
+      ).toBeInTheDocument();
+    }
+    await tick();
+  });
+});

--- a/tests/js/spec/components/sidebar/performanceOnboarding.spec.tsx
+++ b/tests/js/spec/components/sidebar/performanceOnboarding.spec.tsx
@@ -263,7 +263,7 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
 
     expect(
       await screen.findByText(
-        textWithMarkupMatcher('Adding performance to your React project is simple.')
+        textWithMarkupMatcher('Adding Performance to your React project is simple.')
       )
     ).toBeInTheDocument();
 

--- a/tests/js/spec/components/sidebar/performanceOnboarding.spec.tsx
+++ b/tests/js/spec/components/sidebar/performanceOnboarding.spec.tsx
@@ -97,7 +97,6 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
 
     userEvent.click(quickStart);
     expect(screen.queryByText('Boost performance')).not.toBeInTheDocument();
-    await tick();
   });
 
   it('checklist feature disabled', async function () {
@@ -128,7 +127,6 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
       'https://docs.sentry.io/product/performance/getting-started/',
       '_blank'
     );
-    await tick();
   });
 
   it('checklist feature enabled > navigate to performance page > project with onboarding support', async function () {
@@ -162,8 +160,6 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
     expect(router.push).toHaveBeenCalledWith(
       '/organizations/org-slug/performance/?project=2#performance-sidequest'
     );
-
-    await tick();
   });
 
   it('checklist feature enabled > navigate to performance page > project without onboarding support', async function () {
@@ -197,8 +193,6 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
     expect(router.push).toHaveBeenCalledWith(
       '/organizations/org-slug/performance/?project=2#performance-sidequest'
     );
-
-    await tick();
   });
 
   it('checklist feature enabled > navigate to performance page > project without performance support', async function () {
@@ -230,8 +224,6 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
     userEvent.click(performanceCard);
     expect(window.open).not.toHaveBeenCalled();
     expect(router.push).toHaveBeenCalledWith('/organizations/org-slug/performance/');
-
-    await tick();
   });
 
   it('displays checklist', async function () {
@@ -280,6 +272,5 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
         await screen.findByText(textWithMarkupMatcher(`${docKey} content`))
       ).toBeInTheDocument();
     }
-    await tick();
   });
 });

--- a/tests/js/spec/components/sidebar/usePerformanceOnboardingDocs.spec.tsx
+++ b/tests/js/spec/components/sidebar/usePerformanceOnboardingDocs.spec.tsx
@@ -1,0 +1,161 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import usePerformanceOnboardingDocs, {
+  generateOnboardingDocKeys,
+} from 'sentry/components/performanceOnboarding/usePerformanceOnboardingDocs';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+describe('usePerformanceOnboardingDocs', function () {
+  it('fetches onboarding documentation steps', async function () {
+    const {organization} = initializeOrg({
+      router: {
+        location: {query: {}, search: ''},
+        push: jest.fn(),
+      },
+    } as any);
+    const wrapper = ({children}) => (
+      <OrganizationContext.Provider value={organization}>
+        {children}
+      </OrganizationContext.Provider>
+    );
+    const project = TestStubs.Project({
+      platform: 'javascript-react',
+      firstTransactionEvent: false,
+    });
+
+    const apiMocks: any = {};
+
+    const docKeys = generateOnboardingDocKeys(project.platform);
+
+    expect(docKeys).toEqual([
+      'javascript-react-performance-onboarding-1-install',
+      'javascript-react-performance-onboarding-2-configure',
+      'javascript-react-performance-onboarding-3-verify',
+    ]);
+
+    docKeys.forEach(docKey => {
+      apiMocks[docKey] = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/docs/${docKey}/`,
+        method: 'GET',
+        body: {html: `${docKey} content`},
+      });
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(
+      () => usePerformanceOnboardingDocs(project),
+      {
+        wrapper,
+      }
+    );
+    await waitForNextUpdate();
+    const {docContents, isLoading, hasOnboardingContents} = result.current;
+
+    expect(isLoading).toEqual(false);
+    const expectedDocContents = Object.keys(apiMocks).reduce((acc, key) => {
+      acc[key] = `${key} content`;
+      return acc;
+    }, {});
+    expect(docContents).toEqual(expectedDocContents);
+    expect(hasOnboardingContents).toEqual(true);
+    Object.values(apiMocks).forEach(mock => {
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+
+  it('project with no onboarding support', function () {
+    const {organization} = initializeOrg({
+      router: {
+        location: {query: {}, search: ''},
+        push: jest.fn(),
+      },
+    } as any);
+    const wrapper = ({children}) => (
+      <OrganizationContext.Provider value={organization}>
+        {children}
+      </OrganizationContext.Provider>
+    );
+    const project = TestStubs.Project({
+      platform: 'javascript-angular',
+      firstTransactionEvent: false,
+    });
+
+    const apiMocks: any = {};
+
+    const docKeys = generateOnboardingDocKeys(project.platform);
+
+    expect(docKeys).toEqual([
+      'javascript-angular-performance-onboarding-1-install',
+      'javascript-angular-performance-onboarding-2-configure',
+      'javascript-angular-performance-onboarding-3-verify',
+    ]);
+
+    docKeys.forEach(docKey => {
+      apiMocks[docKey] = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/docs/${docKey}/`,
+        method: 'GET',
+        body: {html: `${docKey} content`},
+      });
+    });
+
+    const {result} = reactHooks.renderHook(() => usePerformanceOnboardingDocs(project), {
+      wrapper,
+    });
+    const {docContents, isLoading, hasOnboardingContents} = result.current;
+
+    expect(isLoading).toEqual(false);
+    expect(docContents).toEqual({});
+    expect(hasOnboardingContents).toEqual(false);
+    Object.values(apiMocks).forEach(mock => {
+      expect(mock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('project with no performance support', function () {
+    const {organization} = initializeOrg({
+      router: {
+        location: {query: {}, search: ''},
+        push: jest.fn(),
+      },
+    } as any);
+    const wrapper = ({children}) => (
+      <OrganizationContext.Provider value={organization}>
+        {children}
+      </OrganizationContext.Provider>
+    );
+    const project = TestStubs.Project({
+      platform: 'elixir',
+      firstTransactionEvent: false,
+    });
+
+    const apiMocks: any = {};
+
+    const docKeys = generateOnboardingDocKeys(project.platform);
+
+    expect(docKeys).toEqual([
+      'elixir-performance-onboarding-1-install',
+      'elixir-performance-onboarding-2-configure',
+      'elixir-performance-onboarding-3-verify',
+    ]);
+
+    docKeys.forEach(docKey => {
+      apiMocks[docKey] = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/docs/${docKey}/`,
+        method: 'GET',
+        body: {html: `${docKey} content`},
+      });
+    });
+
+    const {result} = reactHooks.renderHook(() => usePerformanceOnboardingDocs(project), {
+      wrapper,
+    });
+    const {docContents, isLoading, hasOnboardingContents} = result.current;
+
+    expect(isLoading).toEqual(false);
+    expect(docContents).toEqual({});
+    expect(hasOnboardingContents).toEqual(false);
+    Object.values(apiMocks).forEach(mock => {
+      expect(mock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/js/spec/views/performance/content.spec.jsx
+++ b/tests/js/spec/views/performance/content.spec.jsx
@@ -12,16 +12,26 @@ import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhan
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import PerformanceContent from 'sentry/views/performance/content';
 import {DEFAULT_MAX_DURATION} from 'sentry/views/performance/trends/utils';
+import {RouteContext} from 'sentry/views/routeContext';
 
 const FEATURES = ['performance-view'];
 
-function WrappedComponent({organization, isMEPEnabled = false, location}) {
+function WrappedComponent({organization, isMEPEnabled = false, router}) {
   return (
-    <OrganizationContext.Provider value={organization}>
-      <MEPSettingProvider _isMEPEnabled={isMEPEnabled}>
-        <PerformanceContent organization={organization} location={location} />
-      </MEPSettingProvider>
-    </OrganizationContext.Provider>
+    <RouteContext.Provider
+      value={{
+        location,
+        params: {},
+        router,
+        routes: [],
+      }}
+    >
+      <OrganizationContext.Provider value={organization}>
+        <MEPSettingProvider _isMEPEnabled={isMEPEnabled}>
+          <PerformanceContent organization={organization} location={router.location} />
+        </MEPSettingProvider>
+      </OrganizationContext.Provider>
+    </RouteContext.Provider>
   );
 }
 
@@ -274,10 +284,7 @@ describe('Performance > Content', function () {
     const data = initializeData(projects, {});
 
     const wrapper = mountWithTheme(
-      <WrappedComponent
-        organization={data.organization}
-        location={data.router.location}
-      />,
+      <WrappedComponent organization={data.organization} router={data.router} />,
       data.routerContext
     );
 
@@ -308,10 +315,7 @@ describe('Performance > Content', function () {
     const data = initializeData(projects, {project: [1]});
 
     const wrapper = mountWithTheme(
-      <WrappedComponent
-        organization={data.organization}
-        location={data.router.location}
-      />,
+      <WrappedComponent organization={data.organization} router={data.router} />,
       data.routerContext
     );
 
@@ -336,10 +340,7 @@ describe('Performance > Content', function () {
     const data = initializeData(projects, {project: ['-1']});
 
     const wrapper = mountWithTheme(
-      <WrappedComponent
-        organization={data.organization}
-        location={data.router.location}
-      />,
+      <WrappedComponent organization={data.organization} router={data.router} />,
       data.routerContext
     );
 
@@ -357,10 +358,7 @@ describe('Performance > Content', function () {
     const data = initializeData(projects, {project: ['1'], query: 'sentry:yes'});
 
     const wrapper = mountWithTheme(
-      <WrappedComponent
-        organization={data.organization}
-        location={data.router.location}
-      />,
+      <WrappedComponent organization={data.organization} router={data.router} />,
       data.routerContext
     );
 
@@ -386,10 +384,7 @@ describe('Performance > Content', function () {
   it('Default period for trends does not call updateDateTime', async function () {
     const data = initializeTrendsData({query: 'tag:value'}, false);
     const wrapper = mountWithTheme(
-      <WrappedComponent
-        organization={data.organization}
-        location={data.router.location}
-      />,
+      <WrappedComponent organization={data.organization} router={data.router} />,
       data.routerContext
     );
 
@@ -409,10 +404,7 @@ describe('Performance > Content', function () {
     });
 
     const wrapper = mountWithTheme(
-      <WrappedComponent
-        organization={data.organization}
-        location={data.router.location}
-      />,
+      <WrappedComponent organization={data.organization} router={data.router} />,
       data.routerContext
     );
 
@@ -446,10 +438,7 @@ describe('Performance > Content', function () {
     const data = initializeData(projects, {view: undefined});
 
     const wrapper = mountWithTheme(
-      <WrappedComponent
-        organization={data.organization}
-        location={data.router.location}
-      />,
+      <WrappedComponent organization={data.organization} router={data.router} />,
       data.routerContext
     );
 
@@ -466,10 +455,7 @@ describe('Performance > Content', function () {
     const data = initializeTrendsData({view: undefined}, false);
 
     const wrapper = mountWithTheme(
-      <WrappedComponent
-        organization={data.organization}
-        location={data.router.location}
-      />,
+      <WrappedComponent organization={data.organization} router={data.router} />,
       data.routerContext
     );
 
@@ -486,10 +472,7 @@ describe('Performance > Content', function () {
     const data = initializeTrendsData({query: 'device.family:Mac'}, false);
 
     const wrapper = mountWithTheme(
-      <WrappedComponent
-        organization={data.organization}
-        location={data.router.location}
-      />,
+      <WrappedComponent organization={data.organization} router={data.router} />,
       data.routerContext
     );
 
@@ -520,10 +503,7 @@ describe('Performance > Content', function () {
     const data = initializeData(projects, {view: undefined});
 
     const wrapper = mountWithTheme(
-      <WrappedComponent
-        organization={data.organization}
-        location={data.router.location}
-      />,
+      <WrappedComponent organization={data.organization} router={data.router} />,
       data.routerContext
     );
 


### PR DESCRIPTION
This pull request adds the performance on-boarding checklist with sub-step documentation added in https://github.com/getsentry/sentry-docs/pull/4888. 

Prior to the checklist, the user would have to "leave" the product, and are left to their own devices to read the Sentry documentation website to set up Performance monitoring for their applications.

Instead, we provide those same set up documentation steps, in a brief manner, such that they can set up, and verify a transaction has been received for a project.

The feature is gated behind `performance-onboarding-checklist` feature. 

![Screen Shot 2022-06-06 at 6 30 53 PM](https://user-images.githubusercontent.com/139499/172476549-0e3071ac-575e-4e63-b331-8a954512a1cb.png)
