### PR TITLE
fix(replays): show right time on breadcrumbs

### DIFF
--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -25,9 +25,7 @@ const TIME_FORMAT = 'HH:mm:ss';
  * @returns Unix timestamp of the adjusted timestamp, in milliseconds
  */
 export function relativeTimeInMs(timestamp: moment.MomentInput, diffMs: number): number {
-  return moment(timestamp)
-    .diff(diffMs * 1000)
-    .valueOf();
+  return moment(timestamp).diff(moment.unix(diffMs)).valueOf();
 }
 
 export function showPlayerTime(timestamp: string, relativeTime: number): string {


### PR DESCRIPTION
### Description

- Relative time on breadcrumbs shows an incorrect time instead of a duration

Fixes: #35114 

### Screenshots

![image](https://user-images.githubusercontent.com/14813235/172479924-f7634ba3-e64f-4b12-8dcf-17c9c7034db8.png)


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
