### PR TITLE
fix(search-ui): Don't show recent searches if there are none

### DIFF
--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -129,12 +129,15 @@ export function createSearchGroups(
     children: [...searchItems],
   };
 
-  const recentSearchGroup: SearchGroup | undefined = recentSearchItems && {
-    title: t('Recent Searches'),
-    type: 'header',
-    icon: <IconClock size="xs" />,
-    children: [...recentSearchItems],
-  };
+  const recentSearchGroup: SearchGroup | undefined =
+    recentSearchItems && recentSearchItems.length > 0
+      ? {
+          title: t('Recent Searches'),
+          type: 'header',
+          icon: <IconClock size="xs" />,
+          children: [...recentSearchItems],
+        }
+      : undefined;
 
   if (searchGroup.children && !!searchGroup.children.length) {
     searchGroup.children[activeSearchItem] = {

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2356,7 +2356,7 @@ describe('WidgetBuilder', function () {
 
         userEvent.paste(
           await screen.findByPlaceholderText('Search for events, users, tags, and more'),
-          'is:',
+          'bookmarks',
           {
             clipboardData: {getData: () => ''},
           } as unknown as React.ClipboardEvent<HTMLTextAreaElement>


### PR DESCRIPTION
Don't show the recent searches search group in the search bar if there are no recent searches. just takes up space

Old:
![Screen Shot 2022-06-07 at 2 22 37 PM](https://user-images.githubusercontent.com/30991498/172485080-3132ea02-15b0-4274-8f2c-1711553c2567.png)


New:
![Screen Shot 2022-06-07 at 2 21 52 PM](https://user-images.githubusercontent.com/30991498/172484980-ad1bcd8a-b3d0-4e26-8402-2cb8a435e775.png)

