### PR TITLE
fix(util): Fix hotkeys listener cmd not calling keyup when selection moves out of window

### DIFF
--- a/static/app/utils/useHotkeys.tsx
+++ b/static/app/utils/useHotkeys.tsx
@@ -2,12 +2,7 @@ import {useCallback, useEffect, useMemo, useRef} from 'react';
 
 import {getKeyCode} from './getKeyCode';
 
-const modifierKeys = [
-  getKeyCode('command'),
-  getKeyCode('shift'),
-  getKeyCode('alt'),
-  getKeyCode('ctrl'),
-];
+const modifierKeys = [getKeyCode('shift'), getKeyCode('alt'), getKeyCode('ctrl')];
 
 /**
  * Pass in the hotkey combinations under match and the corresponding callback function to be called.


### PR DESCRIPTION
Reproduce:
If you hold command or use an external hotkey that moves the focus out of the window, command does not call keyup. This allows hotkeys that start with command to run even when command isn't pressed.

Try: hold cmd, without releasing it, go to another window and release cmd.
When you come back to the sentry window, press shift + l and the dark mode toggle will be toggled even without needing command pressed.