### PR TITLE
feat(ui): add react forwardRef to FormField

### DIFF
--- a/static/app/components/forms/fieldFromConfig.tsx
+++ b/static/app/components/forms/fieldFromConfig.tsx
@@ -66,7 +66,7 @@ function FieldFromConfig(props: FieldFromConfigProps): React.ReactElement | null
       if (componentProps.multiline) {
         return <TextareaField {...(componentProps as TextareaFieldProps)} />;
       }
-      return <TextField {...componentProps} />;
+      return <TextField {...(componentProps as InputFieldProps)} />;
     case 'number':
       return <NumberField {...componentProps} />;
     case 'textarea':

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -138,9 +138,7 @@ interface BaseProps {
 export interface FormFieldProps
   extends BaseProps,
     ObservableProps,
-    Omit<FieldProps, keyof ResolvedObservableProps | 'children'> {
-  formFieldForwardRef?: React.Ref<FormField>;
-}
+    Omit<FieldProps, keyof ResolvedObservableProps | 'children'> {}
 
 /**
  * ResolvedProps do NOT include props which may be given functions that are

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -138,7 +138,9 @@ interface BaseProps {
 export interface FormFieldProps
   extends BaseProps,
     ObservableProps,
-    Omit<FieldProps, keyof ResolvedObservableProps | 'children'> {}
+    Omit<FieldProps, keyof ResolvedObservableProps | 'children'> {
+  formFieldForwardRef?: React.Ref<FormField>;
+}
 
 /**
  * ResolvedProps do NOT include props which may be given functions that are

--- a/static/app/components/forms/inputField.tsx
+++ b/static/app/components/forms/inputField.tsx
@@ -1,4 +1,4 @@
-import {forwardRef} from 'react';
+import {forwardRef, LegacyRef} from 'react';
 
 import Input, {InputProps} from 'sentry/components/forms/controls/input';
 import FormField, {FormFieldProps} from 'sentry/components/forms/formField';
@@ -46,19 +46,18 @@ function defaultField({
   );
 }
 
-const InputField = forwardRef<FormField, InputFieldProps>(
-  (props: InputFieldProps, ref) => {
-    return (
-      <FormField className={props.className} formFieldForwardRef={ref} {...props}>
-        {formFieldProps => {
-          const {children: _children, ...otherFieldProps} = formFieldProps;
-          return props.field
-            ? props.field(otherFieldProps)
-            : defaultField(otherFieldProps);
-        }}
-      </FormField>
-    );
-  }
-);
+const InputField = forwardRef(function InputField(
+  props: InputFieldProps,
+  ref: LegacyRef<FormField>
+) {
+  return (
+    <FormField className={props.className} ref={ref} {...props}>
+      {formFieldProps => {
+        const {children: _children, ...otherFieldProps} = formFieldProps;
+        return props.field ? props.field(otherFieldProps) : defaultField(otherFieldProps);
+      }}
+    </FormField>
+  );
+});
 
 export default InputField;

--- a/static/app/components/forms/inputField.tsx
+++ b/static/app/components/forms/inputField.tsx
@@ -1,3 +1,5 @@
+import {forwardRef} from 'react';
+
 import Input, {InputProps} from 'sentry/components/forms/controls/input';
 import FormField, {FormFieldProps} from 'sentry/components/forms/formField';
 
@@ -44,15 +46,19 @@ function defaultField({
   );
 }
 
-function InputField(props: InputFieldProps) {
-  return (
-    <FormField className={props.className} {...props}>
-      {formFieldProps => {
-        const {children: _children, ...otherFieldProps} = formFieldProps;
-        return props.field ? props.field(otherFieldProps) : defaultField(otherFieldProps);
-      }}
-    </FormField>
-  );
-}
+const InputField = forwardRef<FormField, InputFieldProps>(
+  (props: InputFieldProps, ref) => {
+    return (
+      <FormField className={props.className} formFieldForwardRef={ref} {...props}>
+        {formFieldProps => {
+          const {children: _children, ...otherFieldProps} = formFieldProps;
+          return props.field
+            ? props.field(otherFieldProps)
+            : defaultField(otherFieldProps);
+        }}
+      </FormField>
+    );
+  }
+);
 
 export default InputField;

--- a/static/app/components/forms/textField.tsx
+++ b/static/app/components/forms/textField.tsx
@@ -1,6 +1,11 @@
+import {forwardRef} from 'react';
+
+import FormField from 'sentry/components/forms/formField';
 import InputField, {InputFieldProps} from 'sentry/components/forms/inputField';
 
 export interface TextFieldProps extends Omit<InputFieldProps, 'type'> {}
-export default function TextField(props) {
-  return <InputField {...props} type="text" />;
-}
+const TextField = forwardRef<FormField, InputFieldProps>((props, ref) => {
+  return <InputField formFieldForwardRef={ref} {...props} type="text" />;
+});
+
+export default TextField;


### PR DESCRIPTION
Accept react forward refs into form field functional components. This is necessary for downstream use in getsentry.