### PR TITLE
fix(team-roles): Padding matters

### DIFF
--- a/static/app/components/panels/panelHeader.tsx
+++ b/static/app/components/panels/panelHeader.tsx
@@ -22,7 +22,7 @@ type Props = {
 
 const getPadding = ({disablePadding, hasButtons}: Props) => css`
   padding: ${hasButtons ? space(1) : space(2)} ${disablePadding ? 0 : space(2)};
-  padding-right: ${hasButtons ? space(1) : null};
+  padding-right: ${hasButtons ? space(2) : null};
 `;
 
 const PanelHeader = styled('div')<Props>`

--- a/static/app/components/panels/panelHeader.tsx
+++ b/static/app/components/panels/panelHeader.tsx
@@ -22,7 +22,6 @@ type Props = {
 
 const getPadding = ({disablePadding, hasButtons}: Props) => css`
   padding: ${hasButtons ? space(1) : space(2)} ${disablePadding ? 0 : space(2)};
-  padding-right: ${hasButtons ? space(2) : null};
 `;
 
 const PanelHeader = styled('div')<Props>`


### PR DESCRIPTION
Adjust padding to the right of the action button on PanelHeader.

### Before
<img width="620" alt="Screen Shot 2022-06-07 at 10 16 00 PM" src="https://user-images.githubusercontent.com/1748388/172537271-80240e7c-e407-48a2-aa9f-8049fcebbc09.png">


### After
<img width="619" alt="Screen Shot 2022-06-07 at 10 15 46 PM" src="https://user-images.githubusercontent.com/1748388/172537283-2f86e89b-9b80-40a4-9a1d-1b2c0987254b.png">
