### PR TITLE
fix(replays): fix single line console messages alignment

### DIFF
--- a/static/app/views/replays/detail/console/consoleMessage.tsx
+++ b/static/app/views/replays/detail/console/consoleMessage.tsx
@@ -124,8 +124,7 @@ const Common = styled('div')<{isLast: boolean; level: string}>`
 `;
 
 const ConsoleTimestamp = styled(Common)<{isLast: boolean; level: string}>`
-  padding: ${space(1)};
-  border-left: 1px solid ${p => p.theme.innerBorder};
+  padding: ${space(0.25)} ${space(1)};
   cursor: pointer;
 `;
 


### PR DESCRIPTION
### Description

- Single line console messages are not centered

Fixes: #35084 

### Screenshots

![image](https://user-images.githubusercontent.com/14813235/172683272-0ab37acf-c600-442a-ab17-76b5f7c43071.png)



### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
