### PR TITLE
ref: fix DummyNewsletter optout_email

### DIFF
--- a/src/sentry/newsletter/dummy.py
+++ b/src/sentry/newsletter/dummy.py
@@ -67,7 +67,6 @@ class DummyNewsletter(Newsletter):
 
     def __init__(self, enabled=False):
         self._subscriptions = defaultdict(dict)
-        self._optout = set()
         self._enabled = enabled
 
     def enable(self):
@@ -78,7 +77,6 @@ class DummyNewsletter(Newsletter):
 
     def clear(self):
         self._subscriptions = defaultdict(dict)
-        self._optout = set()
 
     def is_enabled(self):
         return self._enabled
@@ -108,4 +106,8 @@ class DummyNewsletter(Newsletter):
         return self._subscriptions[user]
 
     def optout_email(self, email, **kwargs):
-        self._optout.add(email)
+        unsubscribe_date = timezone.now()
+        for by_list in self._subscriptions.values():
+            for subscription in by_list.values():
+                if subscription.email == email:
+                    subscription.update(subscribed=False, unsubscribe_date=unsubscribe_date)

--- a/tests/sentry/newsletter/test_dummy.py
+++ b/tests/sentry/newsletter/test_dummy.py
@@ -13,7 +13,8 @@ class DummyNewsletterTest(TestCase):
     def assert_subscriptions(self, user, count):
         subscriptions = self.newsletter.get_subscriptions(user)
         assert subscriptions.get("subscriptions") is not None
-        assert len(subscriptions["subscriptions"]) == count
+        subscribed = [sub for sub in subscriptions["subscriptions"] if sub.subscribed]
+        assert len(subscribed) == count
 
     def test_update_subscription(self):
         user = self.create_user("subscriber@example.com")
@@ -28,3 +29,12 @@ class DummyNewsletterTest(TestCase):
         self.assert_subscriptions(user, 0)
         self.newsletter.create_or_update_subscriptions(user)
         self.assert_subscriptions(user, 1)
+
+    def test_optout_email(self):
+        user = self.create_user("subscriber@example.com")
+
+        self.newsletter.create_or_update_subscriptions(user)
+        self.assert_subscriptions(user, 1)
+
+        self.newsletter.optout_email("subscriber@example.com")
+        self.assert_subscriptions(user, 0)


### PR DESCRIPTION
this wasn't actually doing anything (adding to a "private" set that no one was reading)

I changed it to act more like the real emailer implementations in getsentry

this fixes a test in `getsentry` which currently isn't running due to being misnamed -- part of https://getsentry.atlassian.net/browse/DEVINFRA-43