### PR TITLE
fix(ci): Prevent meeting acceptance required checks by mistake

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -309,7 +309,7 @@ jobs:
         if: needs.files-changed.outputs.backend == 'true'
 
   visual-diff:
-    if: needs.files-changed.outputs.acceptance == 'true'
+    if: ${{ always() }}
     # This guarantees that we will only schedule Visual Snapshots if all
     # workflows that generate artifacts succeed
     needs: [acceptance, frontend, chartcuterie]
@@ -336,6 +336,7 @@ jobs:
   # Since Visual Snapshot is a required check we need to pretend to have run
   fake-visual-snapshot:
     name: Visual Snapshot
+    needs: [files-changed]
     # Opposite condition to "triggers visual snapshot" required check
     if: needs.files-changed.outputs.acceptance != 'true'
     runs-on: ubuntu-20.04


### PR DESCRIPTION
The current two requirements for acceptance tests are that "triggers visual snapshot" and "Visual Snapshot" checks to pass.

In [this PR](https://github.com/getsentry/sentry/actions/runs/2454926271), we hit a bug that allowed the requirements to be met and the code to be auto-merged regardless of the FE tests failure.

The "triggers visual snapshot" got skipped because there was an acceptance job that timed out.

The fake "Visual Snapshot" has been running consistently for everyone because we were checking for the output from a needed job *yet* we actually did not declare the relationship. Unfortunately, Github's syntax doesn't see any problem with it. This fixes it.

Before:
<img width="572" alt="image" src="https://user-images.githubusercontent.com/44410/172641513-6c5ad54b-be0d-4bee-bcea-40f0e63ce4ba.png">

After (see fake Visual Snapshot requiring files changed):
<img width="734" alt="image" src="https://user-images.githubusercontent.com/44410/172642339-841d9045-1942-4fac-a926-1615fe273247.png">

