### PR TITLE
fix(widget-builder): Orderby reset when sorting by equation

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -145,7 +145,8 @@ export function normalizeQueries({
         // Raw Equation from Top N only applies to timeseries
         (isTabularChart && isEquation(rawOrderBy)) ||
         // Not contained as tag, field, or function
-        (!isEquationAlias(rawOrderBy) &&
+        (!isEquation(rawOrderBy) &&
+          !isEquationAlias(rawOrderBy) &&
           ![...query.columns, ...query.aggregates].includes(rawOrderBy)) ||
         // Equation alias and not contained
         (isEquationAlias(rawOrderBy) &&

--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 import trimStart from 'lodash/trimStart';
 
@@ -7,7 +8,9 @@ import {Organization, TagCollection} from 'sentry/types';
 import {
   aggregateFunctionOutputType,
   aggregateOutputType,
+  getEquationAliasIndex,
   isEquation,
+  isEquationAlias,
   isLegalYAxisType,
   stripDerivedMetricsPrefix,
 } from 'sentry/utils/discover/fields';
@@ -24,7 +27,7 @@ import {FieldValueKind} from 'sentry/views/eventsV2/table/types';
 import {generateFieldOptions} from 'sentry/views/eventsV2/utils';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
-import {FlatValidationError, ValidationError} from '../utils';
+import {FlatValidationError, getNumEquations, ValidationError} from '../utils';
 
 // Used in the widget builder to limit the number of lines plotted in the chart
 export const DEFAULT_RESULTS_LIMIT = 5;
@@ -96,6 +99,7 @@ export function normalizeQueries({
 }): Widget['queries'] {
   const isTimeseriesChart = getIsTimeseriesChart(displayType);
   const isTabularChart = [DisplayType.TABLE, DisplayType.TOP_N].includes(displayType);
+  queries = cloneDeep(queries);
 
   if (
     [DisplayType.TABLE, DisplayType.WORLD_MAP, DisplayType.BIG_NUMBER].includes(
@@ -135,16 +139,18 @@ export function normalizeQueries({
         widgetType === WidgetType.RELEASE
           ? stripDerivedMetricsPrefix(queries[0].orderby)
           : queries[0].orderby;
+      const rawOrderBy = trimStart(queryOrderBy, '-');
 
-      // Ignore the orderby if it is a raw equation and we're switching to a table
-      // or Top-N chart, a custom equation should be reset since it only applies when
-      // grouping in timeseries charts
       const resetOrderBy =
-        isTabularChart &&
-        (isEquation(trimStart(queryOrderBy, '-')) ||
-          ![...query.columns, ...query.aggregates].includes(
-            trimStart(queryOrderBy, '-')
-          ));
+        // Raw Equation from Top N only applies to timeseries
+        (isTabularChart && isEquation(rawOrderBy)) ||
+        // Not contained as tag, field, or function
+        (!isEquationAlias(rawOrderBy) &&
+          ![...query.columns, ...query.aggregates].includes(rawOrderBy)) ||
+        // Equation alias and not contained
+        (isEquationAlias(rawOrderBy) &&
+          getEquationAliasIndex(rawOrderBy) >
+            getNumEquations([...query.columns, ...query.aggregates]) - 1);
       const orderBy =
         (!resetOrderBy && trimStart(queryOrderBy, '-')) ||
         (widgetType === WidgetType.ISSUE

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2000,6 +2000,50 @@ describe('WidgetBuilder', function () {
         expect(screen.getAllByText('count()')).toHaveLength(2);
         await selectEvent.select(screen.getAllByText('count()')[1], 'count() * 100');
       });
+
+      it.only('does not reset the orderby when ordered by an equation in table', async function () {
+        const widget: Widget = {
+          id: '1',
+          title: 'Errors over time',
+          interval: '5m',
+          displayType: DisplayType.TABLE,
+          queries: [
+            {
+              name: '',
+              conditions: '',
+              fields: [
+                'count()',
+                'count_unique(id)',
+                'equation|count() + count_unique(id)',
+              ],
+              aggregates: [
+                'count()',
+                'count_unique(id)',
+                'equation|count() + count_unique(id)',
+              ],
+              columns: [],
+              orderby: '-equation[0]',
+            },
+          ],
+        };
+
+        const dashboard: DashboardDetails = {
+          id: '1',
+          title: 'Dashboard',
+          createdBy: undefined,
+          dateCreated: '2020-01-01T00:00:00.000Z',
+          widgets: [widget],
+        };
+
+        renderTestComponent({
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        expect(await screen.findAllByText('count() + count_unique(id)')).toHaveLength(2);
+      });
     });
 
     describe('Widget creation coming from other verticals', function () {

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2001,7 +2001,7 @@ describe('WidgetBuilder', function () {
         await selectEvent.select(screen.getAllByText('count()')[1], 'count() * 100');
       });
 
-      it.only('does not reset the orderby when ordered by an equation in table', async function () {
+      it('does not reset the orderby when ordered by an equation in table', async function () {
         const widget: Widget = {
           id: '1',
           title: 'Errors over time',
@@ -2042,7 +2042,10 @@ describe('WidgetBuilder', function () {
           },
         });
 
-        expect(await screen.findAllByText('count() + count_unique(id)')).toHaveLength(2);
+        await screen.findByText('Sort by a column');
+
+        // 1 in the column selector, 1 in the sort by field
+        expect(screen.getAllByText('count() + count_unique(id)')).toHaveLength(2);
       });
     });
 


### PR DESCRIPTION
The orderby was being reset when sorting by an equation selected as a column in a table. This is because we still use the equation alias form when sorting on equations in y-axes or columns.

I've updated the logic because we should only be resetting the orderby in these conditions:
* Displaying a table and there's a raw equation ordering (raw equations are only allowed for top N timeseries charts)
* If the ordering is not an equation alias, then it's a tag, field, or function and should reset if it's not in columns or aggregates
* If it is an equation alias, the best we can do is check if the index corresponds with the max number of equations