### PR TITLE
ref: move apidocs test case to fixtures namespace

### DIFF
--- a/fixtures/apidocs_test_case.py
+++ b/fixtures/apidocs_test_case.py
@@ -15,7 +15,7 @@ class APIDocsTestCase(APITestCase):
 
     def create_schema(self):
         if not APIDocsTestCase.cached_schema:
-            path = os.path.join(os.path.dirname(__file__), "openapi-derefed.json")
+            path = os.path.join(os.path.dirname(__file__), "../tests/apidocs/openapi-derefed.json")
             with open(path) as json_file:
                 data = json.load(json_file)
                 data["servers"][0]["url"] = settings.SENTRY_OPTIONS["system.url-prefix"]

--- a/tests/apidocs/endpoints/events/test_group_events.py
+++ b/tests/apidocs/endpoints/events/test_group_events.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from tests.apidocs.util import APIDocsTestCase
 
 
 class ProjectGroupEventBase(APIDocsTestCase):

--- a/tests/apidocs/endpoints/events/test_group_hashes.py
+++ b/tests/apidocs/endpoints/events/test_group_hashes.py
@@ -1,6 +1,6 @@
 from django.test.client import RequestFactory
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectGroupHashesDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/events/test_group_issue_details.py
+++ b/tests/apidocs/endpoints/events/test_group_issue_details.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from tests.apidocs.util import APIDocsTestCase
 
 
 class ProjectGroupIssueDetailsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/events/test_group_tagkey_values.py
+++ b/tests/apidocs/endpoints/events/test_group_tagkey_values.py
@@ -1,6 +1,6 @@
 from django.test.client import RequestFactory
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class GroupTagKeyValuesDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/events/test_project_event_details.py
+++ b/tests/apidocs/endpoints/events/test_project_event_details.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectEventDetailsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/events/test_project_events.py
+++ b/tests/apidocs/endpoints/events/test_project_events.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectEventsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/events/test_project_issues.py
+++ b/tests/apidocs/endpoints/events/test_project_issues.py
@@ -1,6 +1,6 @@
 from django.test.client import RequestFactory
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectIssuesDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/events/test_project_tagkey_values.py
+++ b/tests/apidocs/endpoints/events/test_project_tagkey_values.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectTagKeyValuesDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issue_details.py
+++ b/tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issue_details.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models import SentryAppInstallation
-from tests.apidocs.util import APIDocsTestCase
 
 
 class SentryAppDetailsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issues.py
+++ b/tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issues.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models import SentryAppInstallation
-from tests.apidocs.util import APIDocsTestCase
 
 
 class SentryAppDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/integration_platform/test_sentry_app_installations.py
+++ b/tests/apidocs/endpoints/integration_platform/test_sentry_app_installations.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models import SentryAppInstallation
-from tests.apidocs.util import APIDocsTestCase
 
 
 class SentryAppInstallationDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/organizations/test_event_id_lookup.py
+++ b/tests/apidocs/endpoints/organizations/test_event_id_lookup.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class OrganizationEventIDLookupDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/organizations/test_org_details.py
+++ b/tests/apidocs/endpoints/organizations/test_org_details.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class OrganizationDetailsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/organizations/test_org_index.py
+++ b/tests/apidocs/endpoints/organizations/test_org_index.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class OrganizationIndexDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/organizations/test_org_projects.py
+++ b/tests/apidocs/endpoints/organizations/test_org_projects.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class OrganizationProjectsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/organizations/test_org_repos.py
+++ b/tests/apidocs/endpoints/organizations/test_org_repos.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class OrganizationReposDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/organizations/test_org_stats.py
+++ b/tests/apidocs/endpoints/organizations/test_org_stats.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class OrganizationStatsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/organizations/test_org_stats_v2.py
+++ b/tests/apidocs/endpoints/organizations/test_org_stats_v2.py
@@ -4,10 +4,10 @@ import pytz
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.constants import DataCategory
 from sentry.testutils.cases import OutcomesSnubaTest
 from sentry.utils.outcomes import Outcome
-from tests.apidocs.util import APIDocsTestCase
 
 
 class OrganizationStatsDocs(APIDocsTestCase, OutcomesSnubaTest):

--- a/tests/apidocs/endpoints/organizations/test_org_users.py
+++ b/tests/apidocs/endpoints/organizations/test_org_users.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class OrganizationUsersDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/organizations/test_repo_commits.py
+++ b/tests/apidocs/endpoints/organizations/test_repo_commits.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class OrganizationRepoCommitsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/organizations/test_shortid.py
+++ b/tests/apidocs/endpoints/organizations/test_shortid.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class OrganizationShortIDDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_details.py
+++ b/tests/apidocs/endpoints/projects/test_details.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectDetailsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_dsyms.py
+++ b/tests/apidocs/endpoints/projects/test_dsyms.py
@@ -5,7 +5,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectDsymsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_key_details.py
+++ b/tests/apidocs/endpoints/projects/test_key_details.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectKeyDetailsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_keys.py
+++ b/tests/apidocs/endpoints/projects/test_keys.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectKeysDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_project_index.py
+++ b/tests/apidocs/endpoints/projects/test_project_index.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectIndexDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_project_stats.py
+++ b/tests/apidocs/endpoints/projects/test_project_stats.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectStatsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_service_hook_details.py
+++ b/tests/apidocs/endpoints/projects/test_service_hook_details.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectServiceHookDetailsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_service_hooks.py
+++ b/tests/apidocs/endpoints/projects/test_service_hooks.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectServiceHooksDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_tag_values.py
+++ b/tests/apidocs/endpoints/projects/test_tag_values.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectTagValuesDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_user_feedback.py
+++ b/tests/apidocs/endpoints/projects/test_user_feedback.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.utils import timezone
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectUserFeedbackDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/projects/test_users.py
+++ b/tests/apidocs/endpoints/projects/test_users.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models import EventUser
-from tests.apidocs.util import APIDocsTestCase
 
 
 class ProjectUsersDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_deploys.py
+++ b/tests/apidocs/endpoints/releases/test_deploys.py
@@ -3,8 +3,8 @@ import datetime
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models import Deploy, Environment
-from tests.apidocs.util import APIDocsTestCase
 
 
 class ReleaseDeploysDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_organization_release_commit_files.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_commit_files.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models import Commit, CommitFileChange, ReleaseCommit
-from tests.apidocs.util import APIDocsTestCase
 
 
 class CommitFileChangeDocsTest(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_organization_release_commits.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_commits.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models import Commit, ReleaseCommit
-from tests.apidocs.util import APIDocsTestCase
 
 
 class ReleaseCommitsListDocsTest(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_organization_release_details.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_details.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class OrganizationReleaseDetailsDocsTest(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_organization_release_file_details.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_file_details.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ReleaseFileDetailsDocsTest(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_organization_release_files.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_files.py
@@ -2,7 +2,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ReleaseFilesListDocsTest(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_organization_releases.py
+++ b/tests/apidocs/endpoints/releases/test_organization_releases.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models import Release
-from tests.apidocs.util import APIDocsTestCase
 
 
 class OrganizationReleasesDocsTest(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_organization_sessions.py
+++ b/tests/apidocs/endpoints/releases/test_organization_sessions.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.testutils import SnubaTestCase
-from tests.apidocs.util import APIDocsTestCase
 
 
 class OrganizationSessionsDocsTest(APIDocsTestCase, SnubaTestCase):

--- a/tests/apidocs/endpoints/releases/test_project_issues_solved_in_release.py
+++ b/tests/apidocs/endpoints/releases/test_project_issues_solved_in_release.py
@@ -3,8 +3,8 @@ from uuid import uuid1
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models import Commit, GroupLink, GroupResolution, ReleaseCommit, Repository
-from tests.apidocs.util import APIDocsTestCase
 
 
 class ProjectIssuesResolvedInReleaseEndpointTest(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_project_release_commits.py
+++ b/tests/apidocs/endpoints/releases/test_project_release_commits.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models import Commit, ReleaseCommit
-from tests.apidocs.util import APIDocsTestCase
 
 
 class ProjectReleaseCommitsListDocsTest(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_project_release_file_details.py
+++ b/tests/apidocs/endpoints/releases/test_project_release_file_details.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectReleaseFileDetailsDocsTest(APIDocsTestCase):

--- a/tests/apidocs/endpoints/releases/test_project_release_files.py
+++ b/tests/apidocs/endpoints/releases/test_project_release_files.py
@@ -2,7 +2,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class ProjectReleaseFilesListDocsTest(APIDocsTestCase):

--- a/tests/apidocs/endpoints/scim/test_group_details.py
+++ b/tests/apidocs/endpoints/scim/test_group_details.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.testutils import SCIMTestCase
-from tests.apidocs.util import APIDocsTestCase
 
 
 class SCIMTeamDetailsDocs(APIDocsTestCase, SCIMTestCase):

--- a/tests/apidocs/endpoints/scim/test_group_index.py
+++ b/tests/apidocs/endpoints/scim/test_group_index.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.testutils import SCIMTestCase
-from tests.apidocs.util import APIDocsTestCase
 
 
 class SCIMTeamIndexDocs(APIDocsTestCase, SCIMTestCase):

--- a/tests/apidocs/endpoints/scim/test_member_details.py
+++ b/tests/apidocs/endpoints/scim/test_member_details.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.testutils import SCIMTestCase
-from tests.apidocs.util import APIDocsTestCase
 
 
 class SCIMMemberDetailsDocs(APIDocsTestCase, SCIMTestCase):

--- a/tests/apidocs/endpoints/scim/test_member_index.py
+++ b/tests/apidocs/endpoints/scim/test_member_index.py
@@ -1,8 +1,8 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.testutils import SCIMTestCase
-from tests.apidocs.util import APIDocsTestCase
 
 
 class SCIMMemberIndexDocs(APIDocsTestCase, SCIMTestCase):

--- a/tests/apidocs/endpoints/teams/test_by_slug.py
+++ b/tests/apidocs/endpoints/teams/test_by_slug.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class TeamsBySlugDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/teams/test_index.py
+++ b/tests/apidocs/endpoints/teams/test_index.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class TeamsIndexDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/teams/test_projects.py
+++ b/tests/apidocs/endpoints/teams/test_projects.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class TeamsProjectsDocs(APIDocsTestCase):

--- a/tests/apidocs/endpoints/teams/test_stats.py
+++ b/tests/apidocs/endpoints/teams/test_stats.py
@@ -1,7 +1,7 @@
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from tests.apidocs.util import APIDocsTestCase
+from fixtures.apidocs_test_case import APIDocsTestCase
 
 
 class TeamsStatsDocs(APIDocsTestCase):


### PR DESCRIPTION
I'm moving test code which isn't tests to `fixtures/` so I can enforce a naming convention for python test files

this is part of https://getsentry.atlassian.net/browse/DEVINFRA-43