### PR TITLE
feat: Add support for il2cpp line mapping files

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -28,6 +28,7 @@ CHUNK_UPLOAD_ACCEPT = (
     "pdbs",  # PDB upload and debug id override
     "sources",  # Source artifact bundle upload
     "bcsymbolmaps",  # BCSymbolMaps and associated PLists/UuidMaps
+    "il2cpp",  # Il2cpp LineMappingJson files
 )
 
 

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -289,6 +289,7 @@ KNOWN_DIF_FORMATS: Dict[str, str] = {
     "application/x-sentry-bundle+zip": "sourcebundle",
     "application/x-bcsymbolmap": "bcsymbolmap",
     "application/x-debugid-map": "uuidmap",
+    "application/x-il2cpp-json": "il2cpp",
 }
 
 NATIVE_UNKNOWN_STRING = "<unknown>"

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -192,6 +192,8 @@ class ProjectDebugFile(Model):  # type: ignore
             return ".bcsymbolmap"
         if self.file_format == "uuidmap":
             return ".plist"
+        if self.file_format == "il2cpp":
+            return ".json"
 
         return ""
 
@@ -269,6 +271,7 @@ def create_dif_from_id(
         "sourcebundle",
         "bcsymbolmap",
         "uuidmap",
+        "il2cpp",
     ):
         object_name = meta.name
     elif meta.file_format == "breakpad":
@@ -514,7 +517,8 @@ def detect_dif_from_path(
         if debug_id is None:
             raise BadDif("Missing debug_id for il2cpp")
         try:
-            json.load(path)
+            with open(path, "rb") as fp:
+                json.load(fp)
         except json.JSONDecodeError as e:
             logger.debug("File failed to load as il2cpp: %s", path)
             raise BadDif("Invalid il2cpp: %s" % e)

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -1,7 +1,6 @@
 import enum
 import errno
 import hashlib
-import json
 import logging
 import os
 import os.path
@@ -45,6 +44,7 @@ from sentry.db.models import (
 )
 from sentry.models.file import File, clear_cached_files
 from sentry.reprocessing import bump_reprocessing_revision, resolve_processing_issue
+from sentry.utils import json
 from sentry.utils.zip import safe_extract_zip
 
 if TYPE_CHECKING:
@@ -415,7 +415,7 @@ class DifKind(enum.Enum):
     Object = enum.auto()
     BcSymbolMap = enum.auto()
     UuidMap = enum.auto()
-    LineMapping = enum.auto()
+    Il2Cpp = enum.auto()
     # TODO(flub): should we include proguard?  The tradeoff is that we'd be matching the
     # regex of it twice.  That cost is probably not too great to worry about.
 
@@ -431,8 +431,8 @@ def determine_dif_kind(path: str) -> DifKind:
             return DifKind.BcSymbolMap
         elif data.startswith(b"<?xml"):
             return DifKind.UuidMap
-        elif data.startswith(b"{"): # lol
-            return DifKind.LineMapping
+        elif data.startswith(b"{"):  # lol
+            return DifKind.Il2Cpp
         else:
             return DifKind.Object
 
@@ -510,20 +510,18 @@ def detect_dif_from_path(
             return [
                 DifMeta(file_format="uuidmap", arch="any", debug_id=debug_id, name=name, path=path)
             ]
-    elif dif_kind == DifKind.LineMapping:
+    elif dif_kind == DifKind.Il2Cpp:
         if debug_id is None:
-            raise BadDif("Missing debug_id for LineMapping")
+            raise BadDif("Missing debug_id for il2cpp")
         try:
             json.load(path)
         except json.JSONDecodeError as e:
-            logger.debug("File failed to load as LineMapping: %s", path)
-            raise BadDif("Invalid LineMapping: %s" % e)
+            logger.debug("File failed to load as il2cpp: %s", path)
+            raise BadDif("Invalid il2cpp: %s" % e)
         else:
-            logger.debug("File loaded as LineMapping: %s", path)
+            logger.debug("File loaded as il2cpp: %s", path)
             return [
-                DifMeta(
-                    file_format="linemapping", arch="any", debug_id=debug_id, name=name, path=path
-                )
+                DifMeta(file_format="il2cpp", arch="any", debug_id=debug_id, name=name, path=path)
             ]
     else:
         # native debug information files (MachO, ELF or Breakpad)

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -71,6 +71,7 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
               'wasm',
               'bcsymbolmap',
               'uuidmap',
+              'il2cpp',
             ],
           },
         },


### PR DESCRIPTION
The il2cpp line mapping json file is analogous to bcsymbolmaps, and make it possible to transform file/line records from C++ source lines to C# source files/lines.

They are being uploaded by sentry-cli (https://github.com/getsentry/sentry-cli/pull/1248) and later consumed by symbolicator (https://github.com/getsentry/symbolicator/pull/695) as a symcache transformer.