### PR TITLE
fix(profiling): Use frames from Symbolicator directly and preserve originals

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -114,26 +114,8 @@ def _symbolicate(profile: MutableMapping[str, Any], project: Project) -> Mutable
     while True:
         try:
             response = symbolicator.process_payload(stacktraces=stacktraces, modules=modules)
-
-            # make sure we're getting the same number of stacktraces back
-            assert len(profile["sampled_profile"]["samples"]) == len(response["stacktraces"])
-
-            for i, (original, symbolicated) in enumerate(
-                zip(profile["sampled_profile"]["samples"], response["stacktraces"])
-            ):
-                # make sure we're getting the same number of frames back
-                assert len(original["frames"]) == len(symbolicated["frames"])
-
-                for symbolicated_frame in symbolicated["frames"]:
-                    original_frame = original["frames"][symbolicated_frame["original_index"]]
-
-                    # preserve original values
-                    new_frame = {}
-                    for k, v in original_frame.items():
-                        new_frame[f"_{k}"] = v
-
-                    new_frame.update(symbolicated_frame)
-                    original["frames"][symbolicated_frame["original_index"]] = new_frame
+            profile["sampled_profile"]["original_samples"] = profile["sampled_profile"]["samples"]
+            profile["sampled_profile"]["samples"] = response["stacktraces"]
             break
         except RetrySymbolication as e:
             if (

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -114,8 +114,14 @@ def _symbolicate(profile: MutableMapping[str, Any], project: Project) -> Mutable
     while True:
         try:
             response = symbolicator.process_payload(stacktraces=stacktraces, modules=modules)
-            profile["sampled_profile"]["original_samples"] = profile["sampled_profile"]["samples"]
-            profile["sampled_profile"]["samples"] = response["stacktraces"]
+
+            assert len(profile["sampled_profile"]["samples"]) == len(response["stacktraces"])
+
+            for original, symbolicated in zip(
+                profile["sampled_profile"]["samples"], response["stacktraces"]
+            ):
+                original["original_frames"] = original["frames"]
+                original["frames"] = symbolicated["frames"]
             break
         except RetrySymbolication as e:
             if (


### PR DESCRIPTION
This new logic for merging frames from Symbolicator with the existing samples was not taking into account inlining and was just wrong. Since the goal was to preserve the original samples, we're going to instead copy them into a different key on the profile and just use what's coming back from Symbolicator.