### PR TITLE
feat(ci): Adjust mapping of workflow changes to executing them

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -42,8 +42,10 @@ backend_dependencies: &backend_dependencies
   - 'requirements-*.txt'
 
 backend_build_changes: &backend_build_changes
+  # If you change this line make sure that workflows using this action (e.g. acceptance, api_docs)
+  # *and* file-filters would be updated as well
   - '.github/actions/setup-sentry/action.yml'
-  - '.github/workflows/!(frontend)'
+  - '.github/workflows/backend.yml'
   - '.pre-commit-config.yaml'
   - 'Makefile'
   - 'pyproject.toml'
@@ -62,6 +64,9 @@ backend: &backend
 acceptance: &acceptance
   - *backend
   - *frontend
+  # This is verbose because backend_build_changes includes it, however,
+  - '.github/actions/setup-sentry/action.yml'
+  - '.github/workflows/acceptance.yml'
 
 plugins: &plugins
   - *backend

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -326,8 +326,9 @@ jobs:
       - name: Diff snapshots
         id: visual-snapshots-diff
         uses: getsentry/action-visual-snapshot@main
+        # Run this step only if there are acceptance related code changes
         # Forks are handled in visual-diff.yml
-        if: github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
+        if: needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           gcs-bucket: 'sentry-visual-snapshots'


### PR DESCRIPTION
Up until now, almost any Github workflow changes would make all backend and acceptance jobs to execute.

With this change, changes to a specific workflow will *only* make that workflow execute rather than most of them.

This reduces CI usage and reduces the chance of some non-related workflow failing and requiring a re-run.