### PR TITLE
fix(ci): Skip running visual snapshots if there are no BE or FE changes

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -326,8 +326,9 @@ jobs:
       - name: Diff snapshots
         id: visual-snapshots-diff
         uses: getsentry/action-visual-snapshot@main
+        # Run this step only if there are acceptance related code changes
         # Forks are handled in visual-diff.yml
-        if: github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
+        if: needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           gcs-bucket: 'sentry-visual-snapshots'


### PR DESCRIPTION
Regression introduced in https://github.com/getsentry/sentry/pull/35466

I've noticed in [this PR](https://github.com/getsentry/sentry/pull/35472) where I have no FE or BE changes (see screenshot below).]

I now understand why I had this change previously:
```diff
  visual-diff:
-    if: needs.files-changed.outputs.acceptance == 'true'
+    if: ${{ always() }}
```

Screenshot showing that executing the Visual Snapshot steps fails:
<img width="706" alt="image" src="https://user-images.githubusercontent.com/44410/172650950-31170e74-bb24-4188-92f0-3971dad396d3.png">
