### PR TITLE
ref(perf): Remove perf wrapper from transactions table

### DIFF
--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -19,7 +19,6 @@ import {
   fieldAlignment,
   getAggregateAlias,
 } from 'sentry/utils/discover/fields';
-import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import CellAction, {Actions} from 'sentry/views/eventsV2/table/cellAction';
 import {TableColumn} from 'sentry/views/eventsV2/table/types';
 import {GridCell, GridCellNumber} from 'sentry/views/performance/styles';
@@ -207,19 +206,17 @@ class TransactionsTable extends PureComponent<Props> {
     const loader = <LoadingIndicator style={{margin: '70px auto'}} />;
 
     return (
-      <VisuallyCompleteWithData id="TransactionsTable" hasData={hasResults}>
-        <PanelTable
-          data-test-id="transactions-table"
-          isEmpty={!hasResults}
-          emptyMessage={t('No transactions found')}
-          headers={this.renderHeader()}
-          isLoading={isLoading}
-          disablePadding
-          loader={loader}
-        >
-          {this.renderResults()}
-        </PanelTable>
-      </VisuallyCompleteWithData>
+      <PanelTable
+        data-test-id="transactions-table"
+        isEmpty={!hasResults}
+        emptyMessage={t('No transactions found')}
+        headers={this.renderHeader()}
+        isLoading={isLoading}
+        disablePadding
+        loader={loader}
+      >
+        {this.renderResults()}
+      </PanelTable>
     );
   }
 }


### PR DESCRIPTION
### Summary
We're seeing a decline in ingested transactions only on specific pages (discover/perf), this removes the wrapper around the transaction table as it appears on those pages, we'll see if it improves the ingestion of txns for those pages again.

