### PR TITLE
fix(page-filters): Persist locked filters dashboards

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -598,7 +598,6 @@ class DashboardDetail extends Component<Props, State> {
 
     return (
       <PageFiltersContainer
-        skipLoadLastUsed={organization.features.includes('global-views')}
         hideGlobalHeader
         defaultSelection={{
           datetime: {
@@ -686,7 +685,6 @@ class DashboardDetail extends Component<Props, State> {
     return (
       <SentryDocumentTitle title={dashboard.title} orgSlug={organization.slug}>
         <PageFiltersContainer
-          skipLoadLastUsed={organization.features.includes('global-views')}
           hideGlobalHeader
           defaultSelection={{
             datetime: {

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -1118,7 +1118,6 @@ function WidgetBuilder({
   return (
     <SentryDocumentTitle title={dashboard.title} orgSlug={orgSlug}>
       <PageFiltersContainer
-        skipLoadLastUsed={organization.features.includes('global-views')}
         defaultSelection={{
           datetime: {start: null, end: null, utc: false, period: DEFAULT_STATS_PERIOD},
         }}


### PR DESCRIPTION
Similar to the fix in https://github.com/getsentry/sentry/pull/35026, ensures that we use the locked filters when moving into dashboards.