### PR TITLE
fix(ci): Visual Snapshots are not being triggered

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -309,10 +309,10 @@ jobs:
         if: needs.files-changed.outputs.backend == 'true'
 
   visual-diff:
-    if: ${{ always() }}
+    if: always()
     # This guarantees that we will only schedule Visual Snapshots if all
     # workflows that generate artifacts succeed
-    needs: [acceptance, frontend, chartcuterie]
+    needs: [acceptance, frontend, chartcuterie, files-changed]
     name: triggers visual snapshot
     runs-on: ubuntu-20.04
     timeout-minutes: 20


### PR DESCRIPTION
We added the `needs.files-changed.outputs.acceptance == 'true'` but we did not add `files-changed` as a dependency.

Regression introduced in #35474.

Test confirming effectiveness of this PR:

- We see the real "Visual Snapshot" actually run

<img width="734" alt="image" src="https://user-images.githubusercontent.com/44410/172707516-0c78038a-e2d0-488e-b509-76cbb08c65d7.png">
