### PR TITLE
feat(issues): add project as a built in issue tag

### DIFF
--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -47,6 +47,7 @@ const BUILTIN_TAGS = [
   'stack.module',
   'stack.function',
   'stack.stack_level',
+  'project',
 ].reduce<TagCollection>((acc, tag) => {
   acc[tag] = {key: tag, name: tag};
   return acc;


### PR DESCRIPTION
Would there be any problem if we added `project` as a built in tag?
We've had feedback that users want to use the `project` filter in the dashboard widget issue search bar but it sometimes doesn't appear if the call to the `/tags/` endpoint doesn't respond quick enough.