### PR TITLE
fix: implement __iter__ for ClosesDependentFiles

### DIFF
--- a/src/sentry/api/endpoints/project_release_file_details.py
+++ b/src/sentry/api/endpoints/project_release_file_details.py
@@ -51,6 +51,9 @@ class ClosesDependentFiles:
         for closable in self._closables:
             closable.close()
 
+    def __iter__(self):
+        return self._f
+
     def __getattr__(self, attr):
         return getattr(self._f, attr)
 

--- a/tests/sentry/api/endpoints/test_project_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_file_details.py
@@ -1,12 +1,22 @@
+import io
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from hashlib import sha1
 
 from django.urls import reverse
 
-from sentry.api.endpoints.project_release_file_details import INVALID_UPDATE_MESSAGE
+from sentry.api.endpoints.project_release_file_details import (
+    INVALID_UPDATE_MESSAGE,
+    ClosesDependentFiles,
+)
 from sentry.models import File, Release, ReleaseFile
 from sentry.models.distribution import Distribution
 from sentry.testutils import APITestCase
+
+
+def test_closes_depnedent_files_is_iterable():
+    # django (but not django.test) requires a file response to be iterable
+    f = ClosesDependentFiles(io.BytesIO(b"hello\nworld\n"))
+    assert list(f) == [b"hello\n", b"world\n"]
 
 
 class ReleaseFileDetailsTest(APITestCase):


### PR DESCRIPTION
a fix for https://sentry.io/organizations/sentry/issues/3332655630/?project=1

annoyingly the django test runner takes a different path when producing responses which avoids the problem (despite the original code being exercised) -- so I opted for a unit test of the specific behaviour

regressed in #35429