### PR TITLE
fix(replays): show right time on breadcrumbs

### DIFF
--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -29,7 +29,7 @@ export function relativeTimeInMs(timestamp: moment.MomentInput, diffMs: number):
 }
 
 export function showPlayerTime(timestamp: string, relativeTime: number): string {
-  return moment(relativeTimeInMs(timestamp, relativeTime)).format(TIME_FORMAT);
+  return moment.utc(relativeTimeInMs(timestamp, relativeTime)).format(TIME_FORMAT);
 }
 
 // TODO: move into 'sentry/utils/formatters'


### PR DESCRIPTION
### Description 

Due to the fact we are using different timezones, some users with timezones like EST (-5) are showing the wrong timestamp.

Fixes: #35114 

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/14813235/172877111-b68580ea-a52d-47d1-8d50-d72af26b83d7.png)

After:

![image](https://user-images.githubusercontent.com/14813235/172877226-8559a6eb-0dbd-4700-a69b-80a3aa4be133.png)


Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
