### PR TITLE
feat(alerts): Show alert threshold unit in alert list rows

### DIFF
--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -24,7 +24,9 @@ import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Actor, Project} from 'sentry/types';
 import type {Color} from 'sentry/utils/theme';
+import {getThresholdUnits} from 'sentry/views/alerts/rules/metric/constants';
 import {
+  AlertRuleComparisonType,
   AlertRuleThresholdType,
   AlertRuleTriggerType,
 } from 'sentry/views/alerts/rules/metric/types';
@@ -156,6 +158,12 @@ function RuleListRow({
               ? trigger?.alertThreshold?.toLocaleString()
               : resolvedTrigger?.toLocaleString()
           }`}
+          {getThresholdUnits(
+            rule.aggregate,
+            rule.comparisonDelta
+              ? AlertRuleComparisonType.CHANGE
+              : AlertRuleComparisonType.COUNT
+          )}
         </TriggerText>
       </FlexCenter>
     );

--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -3,6 +3,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {AggregationKey, LooseFieldKey} from 'sentry/utils/discover/fields';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {
+  AlertRuleComparisonType,
   AlertRuleThresholdType,
   AlertRuleTriggerType,
   Dataset,
@@ -211,4 +212,27 @@ export function createRuleFromWizardTemplate(
     aggregate,
     dataset,
   };
+}
+
+export function getThresholdUnits(
+  aggregate: string,
+  comparisonType: AlertRuleComparisonType
+): string {
+  // cls is a number not a measurement of time
+  if (
+    isSessionAggregate(aggregate) ||
+    comparisonType === AlertRuleComparisonType.CHANGE
+  ) {
+    return '%';
+  }
+
+  if (aggregate.includes('measurements.cls')) {
+    return '';
+  }
+
+  if (aggregate.includes('duration') || aggregate.includes('measurements')) {
+    return 'ms';
+  }
+
+  return '';
 }

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -157,9 +157,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       thresholdType: rule.thresholdType,
       thresholdPeriod: rule.thresholdPeriod ?? 1,
       comparisonDelta: rule.comparisonDelta ?? undefined,
-      comparisonType: !rule.comparisonDelta
-        ? AlertRuleComparisonType.COUNT
-        : AlertRuleComparisonType.CHANGE,
+      comparisonType: rule.comparisonDelta
+        ? AlertRuleComparisonType.CHANGE
+        : AlertRuleComparisonType.COUNT,
       project: this.props.project,
       owner: rule.owner,
     };

--- a/static/app/views/alerts/rules/metric/triggers/form.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/form.tsx
@@ -11,6 +11,7 @@ import space from 'sentry/styles/space';
 import {Config, Organization, Project} from 'sentry/types';
 import withApi from 'sentry/utils/withApi';
 import withConfig from 'sentry/utils/withConfig';
+import {getThresholdUnits} from 'sentry/views/alerts/rules/metric/constants';
 import ThresholdControl from 'sentry/views/alerts/rules/metric/triggers/thresholdControl';
 
 import {isSessionAggregate} from '../../../utils';
@@ -156,26 +157,6 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
     onResolveThresholdChange(trigger.alertThreshold);
   };
 
-  getThresholdUnits(aggregate: string, comparisonType: AlertRuleComparisonType) {
-    // cls is a number not a measurement of time
-    if (aggregate.includes('measurements.cls')) {
-      return '';
-    }
-
-    if (aggregate.includes('duration') || aggregate.includes('measurements')) {
-      return 'ms';
-    }
-
-    if (
-      isSessionAggregate(aggregate) ||
-      comparisonType === AlertRuleComparisonType.CHANGE
-    ) {
-      return '%';
-    }
-
-    return '';
-  }
-
   getCriticalThresholdPlaceholder(
     aggregate: string,
     comparisonType: AlertRuleComparisonType
@@ -246,7 +227,7 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
       actions: [],
     };
 
-    const thresholdUnits = this.getThresholdUnits(aggregate, comparisonType);
+    const thresholdUnits = getThresholdUnits(aggregate, comparisonType);
 
     return (
       <Fragment>


### PR DESCRIPTION
This adds a unit string to the threshold string, in the status column in the alert list rows. The unit is `'ms'` for measurements that are a factor of time, and `'%'` for Percent change alerts.

Jira: [WOR-1927](https://getsentry.atlassian.net/browse/WOR-1927)

After:
![Screen Shot 2022-06-09 at 1 15 47 PM](https://user-images.githubusercontent.com/15015880/172936771-f8c7e261-4bd5-404a-8136-be766322739f.png)

Before:
![Screen Shot 2022-06-09 at 1 15 51 PM](https://user-images.githubusercontent.com/15015880/172936799-6b1eb684-e3cc-46a1-b223-f63c11651b61.png)
