### PR TITLE
fix(superuser): fixed superuser session on dev env for non sso flow

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -108,7 +108,9 @@ class AuthIndexEndpoint(Endpoint):
         authenticated = None
 
         def _require_password_or_u2f_check():
-            if not is_self_hosted() and VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON:
+            if (
+                not is_self_hosted() and VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON
+            ) or DISABLE_SSO_CHECK_SU_FORM_FOR_LOCAL_DEV:
                 # Don't need to check password as its only for self-hosted users or if superuser form is turned off
                 return False
             if request.user.has_usable_password():

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -63,6 +63,10 @@ UNSET = object()
 
 ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV = getattr(settings, "ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV", False)
 
+DISABLE_SSO_CHECK_SU_FORM_FOR_LOCAL_DEV = getattr(
+    settings, "DISABLE_SSO_CHECK_SU_FORM_FOR_LOCAL_DEV", False
+)
+
 
 def is_active_superuser(request):
     if is_system_auth(getattr(request, "auth", None)):
@@ -146,7 +150,8 @@ class Superuser:
         # if we've bound superuser to an organization they must
         # have completed SSO to gain status
         if self.org_id and not has_completed_sso(self.request, self.org_id):
-            return False, "incomplete-sso"
+            if not DISABLE_SSO_CHECK_SU_FORM_FOR_LOCAL_DEV:
+                return False, "incomplete-sso"
         # if there's no IPs configured, we allow assume its the same as *
         if not allowed_ips:
             return True, None
@@ -172,7 +177,6 @@ class Superuser:
                 extra={"ip_address": request.META["REMOTE_ADDR"], "user_id": request.user.id},
             )
             return
-
         if not cookie_token:
             if data:
                 logger.warning(

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -177,6 +177,7 @@ class Superuser:
                 extra={"ip_address": request.META["REMOTE_ADDR"], "user_id": request.user.id},
             )
             return
+
         if not cookie_token:
             if data:
                 logger.warning(


### PR DESCRIPTION
On local dev, if the user doesn't have SSO enabled, the user is not able to get superuser through the superuser modal as it requires an SSO check. Used the `DISABLE_SSO_CHECK_SU_FORM_FOR_LOCAL_DEV` flag to disable some checks to allow this flow to work.