### PR TITLE
feat(search): Move quick actions into a footer

### DIFF
--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -1,5 +1,4 @@
 import {useEffect} from 'react';
-import {ClassNames} from '@emotion/react';
 import assign from 'lodash/assign';
 import flatten from 'lodash/flatten';
 import memoize from 'lodash/memoize';
@@ -60,6 +59,7 @@ function SearchBar(props: SearchBarProps) {
   useEffect(() => {
     // Clear memoized data on mount to make tests more consistent.
     getEventFieldValues.cache.clear?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectIds]);
 
   // Returns array of tag values that substring match `query`; invokes `callback`
@@ -132,28 +132,21 @@ function SearchBar(props: SearchBarProps) {
   return (
     <Measurements>
       {({measurements}) => (
-        <ClassNames>
-          {({css}) => (
-            <SmartSearchBar
-              hasRecentSearches
-              savedSearchType={SavedSearchType.EVENT}
-              onGetTagValues={getEventFieldValues}
-              supportedTags={getTagList(measurements)}
-              prepareQuery={query => {
-                // Prepare query string (e.g. strip special characters like negation operator)
-                return query.replace(SEARCH_SPECIAL_CHARS_REGEXP, '');
-              }}
-              maxSearchItems={maxSearchItems}
-              excludeEnvironment
-              dropdownClassName={css`
-                max-height: ${maxMenuHeight ?? 300}px;
-                overflow-y: auto;
-              `}
-              getFieldDoc={getFieldDoc}
-              {...props}
-            />
-          )}
-        </ClassNames>
+        <SmartSearchBar
+          hasRecentSearches
+          savedSearchType={SavedSearchType.EVENT}
+          onGetTagValues={getEventFieldValues}
+          supportedTags={getTagList(measurements)}
+          prepareQuery={query => {
+            // Prepare query string (e.g. strip special characters like negation operator)
+            return query.replace(SEARCH_SPECIAL_CHARS_REGEXP, '');
+          }}
+          maxSearchItems={maxSearchItems}
+          excludeEnvironment
+          maxMenuHeight={maxMenuHeight ?? 300}
+          getFieldDoc={getFieldDoc}
+          {...props}
+        />
       )}
     </Measurements>
   );

--- a/static/app/components/hotkeysLabel.tsx
+++ b/static/app/components/hotkeysLabel.tsx
@@ -95,6 +95,6 @@ const HotkeysContainer = styled('div')`
   align-items: center;
 
   > * {
-    margin-right: ${space(1)};
+    margin-right: ${space(0.5)};
   }
 `;

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -53,6 +53,7 @@ import {
   filterSearchGroupsByIndex,
   generateOperatorEntryMap,
   getValidOps,
+  quickActions,
   removeSpace,
 } from './utils';
 
@@ -1574,8 +1575,12 @@ class SmartSearchBar extends Component<Props, State> {
             loading={loading}
             searchSubstring={searchTerm}
             runQuickAction={this.runQuickAction}
-            cursorToken={this.cursorToken}
-            filterTokenCount={this.filterTokens.length}
+            visibleActions={quickActions.filter(
+              action =>
+                action.hotkeys &&
+                (!action.canRunAction ||
+                  action.canRunAction(this.cursorToken, this.filterTokens.length))
+            )}
             maxMenuHeight={maxMenuHeight}
           />
         )}

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -52,7 +52,6 @@ import {
   createSearchGroups,
   filterSearchGroupsByIndex,
   generateOperatorEntryMap,
-  getQuickActionsSearchGroup,
   getValidOps,
   removeSpace,
 } from './utils';
@@ -172,6 +171,10 @@ type Props = WithRouterProps & {
    * Allows additional content to be played before the search bar and icon
    */
   inlineLabel?: React.ReactNode;
+  /**
+   * Maximum height for the search dropdown menu
+   */
+  maxMenuHeight?: number;
   /**
    * Used to enforce length on the query
    */
@@ -1279,19 +1282,6 @@ class SmartSearchBar extends Component<Props, State> {
       queryCharsLeft
     );
 
-    const quickActionsSearchResults = getQuickActionsSearchGroup(
-      this.runQuickAction,
-      this.filterTokens.length,
-      this.cursorToken ?? undefined
-    );
-    if (quickActionsSearchResults) {
-      searchGroups.searchGroups.push(quickActionsSearchResults.searchGroup);
-      searchGroups.flatSearchItems = [
-        ...searchGroups.flatSearchItems,
-        ...quickActionsSearchResults.searchItems,
-      ];
-    }
-
     this.setState(searchGroups);
   }
 
@@ -1305,12 +1295,6 @@ class SmartSearchBar extends Component<Props, State> {
     const {query} = this.state;
     const queryCharsLeft =
       maxQueryLength && query ? maxQueryLength - query.length : undefined;
-
-    const quickActionsSearchResults = getQuickActionsSearchGroup(
-      this.runQuickAction,
-      this.filterTokens.length,
-      this.cursorToken ?? undefined
-    );
 
     const searchGroups = groups
       .map(({searchItems, recentSearchItems, tagName, type}) =>
@@ -1335,14 +1319,6 @@ class SmartSearchBar extends Component<Props, State> {
           activeSearchItem: -1,
         }
       );
-
-    if (quickActionsSearchResults) {
-      searchGroups.searchGroups.push(quickActionsSearchResults.searchGroup);
-      searchGroups.flatSearchItems = [
-        ...searchGroups.flatSearchItems,
-        ...quickActionsSearchResults.searchItems,
-      ];
-    }
 
     this.setState(searchGroups);
   };
@@ -1482,6 +1458,7 @@ class SmartSearchBar extends Component<Props, State> {
       useFormWrapper,
       inlineLabel,
       maxQueryLength,
+      maxMenuHeight,
     } = this.props;
 
     const {
@@ -1596,6 +1573,10 @@ class SmartSearchBar extends Component<Props, State> {
             onClick={this.onAutoComplete}
             loading={loading}
             searchSubstring={searchTerm}
+            runQuickAction={this.runQuickAction}
+            cursorToken={this.cursorToken}
+            filterTokenCount={this.filterTokens.length}
+            maxMenuHeight={maxMenuHeight}
           />
         )}
       </Container>

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -266,14 +266,15 @@ const Documentation = styled('span')`
 
 const DropdownFooter = styled(`div`)`
   width: 100%;
-  height: 45px;
+  min-height: 45px;
   background-color: ${p => p.theme.backgroundSecondary};
   border-top: 1px solid ${p => p.theme.innerBorder};
   flex-direction: row;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0px ${space(1)};
+  padding: ${space(1)};
+  flex-wrap: wrap;
 `;
 
 const ActionsRow = styled('div')`

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -218,7 +218,7 @@ const SearchItemsList = styled('ul')<{maxMenuHeight?: number}>`
   list-style: none;
   margin-bottom: 0;
   ${p => {
-    if (typeof p.maxMenuHeight !== 'undefined') {
+    if (p.maxMenuHeight !== undefined) {
       return `
         max-height: ${p.maxMenuHeight}px;
         overflow-y: scroll;

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -8,21 +8,18 @@ import space from 'sentry/styles/space';
 
 import Button from '../button';
 import HotkeysLabel from '../hotkeysLabel';
-import {TokenResult} from '../searchSyntax/parser';
 
 import {ItemType, QuickAction, SearchGroup, SearchItem} from './types';
-import {quickActions} from './utils';
 
 type Props = {
-  filterTokenCount: number;
   items: SearchGroup[];
   loading: boolean;
   onClick: (value: string, item: SearchItem) => void;
   runQuickAction: (action: QuickAction) => void;
   searchSubstring: string;
   className?: string;
-  cursorToken?: TokenResult<any> | null;
   maxMenuHeight?: number;
+  visibleActions?: QuickAction[];
 };
 
 class SearchDropdown extends PureComponent<Props> {
@@ -85,15 +82,8 @@ class SearchDropdown extends PureComponent<Props> {
   );
 
   render() {
-    const {
-      className,
-      loading,
-      items,
-      runQuickAction,
-      cursorToken,
-      filterTokenCount,
-      maxMenuHeight,
-    } = this.props;
+    const {className, loading, items, runQuickAction, visibleActions, maxMenuHeight} =
+      this.props;
     return (
       <StyledSearchDropdown className={className}>
         {loading ? (
@@ -121,26 +111,19 @@ class SearchDropdown extends PureComponent<Props> {
         <DropdownFooter>
           <ActionsRow>
             {runQuickAction &&
-              quickActions
-                .filter(
-                  action =>
-                    action.hotkeys &&
-                    (!action.canRunAction ||
-                      action.canRunAction(cursorToken, filterTokenCount))
-                )
-                .map(action => {
-                  return (
-                    <ActionButtonContainer
-                      key={action.text}
-                      onClick={() => runQuickAction(action)}
-                    >
-                      <HotkeyGlyphWrapper>
-                        <HotkeysLabel value={action.hotkeys?.display ?? []} />
-                      </HotkeyGlyphWrapper>
-                      <HotkeyTitle>{action.text}</HotkeyTitle>
-                    </ActionButtonContainer>
-                  );
-                })}
+              visibleActions?.map(action => {
+                return (
+                  <ActionButtonContainer
+                    key={action.text}
+                    onClick={() => runQuickAction(action)}
+                  >
+                    <HotkeyGlyphWrapper>
+                      <HotkeysLabel value={action.hotkeys?.display ?? []} />
+                    </HotkeyGlyphWrapper>
+                    <HotkeyTitle>{action.text}</HotkeyTitle>
+                  </ActionButtonContainer>
+                );
+              })}
           </ActionsRow>
           <Button
             size="xsmall"

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -15,10 +15,10 @@ type Props = {
   items: SearchGroup[];
   loading: boolean;
   onClick: (value: string, item: SearchItem) => void;
-  runQuickAction: (action: QuickAction) => void;
   searchSubstring: string;
   className?: string;
   maxMenuHeight?: number;
+  runQuickAction?: (action: QuickAction) => void;
   visibleActions?: QuickAction[];
 };
 

--- a/static/app/components/smartSearchBar/types.tsx
+++ b/static/app/components/smartSearchBar/types.tsx
@@ -53,7 +53,7 @@ export type QuickAction = {
   actionType: QuickActionType;
   text: string;
   canRunAction?: (
-    token: TokenResult<any> | undefined,
+    token: TokenResult<any> | null | undefined,
     filterTokenCount: number
   ) => boolean;
   hotkeys?: {

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -276,25 +276,25 @@ export const quickActions: QuickAction[] = [
     },
   },
   {
-    text: 'Previous Token',
+    text: 'Previous',
     actionType: QuickActionType.Previous,
     hotkeys: {
       actual: ['option+left'],
       display: 'option+left',
     },
     canRunAction: (tok, count) => {
-      return count > 1 || tok?.type !== Token.Filter;
+      return count > 1 || (count > 0 && tok?.type !== Token.Filter);
     },
   },
   {
-    text: 'Next Token',
+    text: 'Next',
     actionType: QuickActionType.Next,
     hotkeys: {
       actual: ['option+right'],
       display: 'option+right',
     },
     canRunAction: (tok, count) => {
-      return count > 1 || tok?.type !== Token.Filter;
+      return count > 1 || (count > 0 && tok?.type !== Token.Filter);
     },
   },
 ];

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -569,8 +569,8 @@ describe('SmartSearchBar', function () {
       await tick();
       wrapper.update();
       expect(searchBar.state.searchTerm).toEqual('fu');
-      // 2 items because of headers ("Tags", "Quick Actions")
-      expect(searchBar.state.searchGroups).toHaveLength(2);
+      // 2 items because of headers ("Tags")
+      expect(searchBar.state.searchGroups).toHaveLength(1);
       expect(searchBar.state.activeSearchItem).toEqual(-1);
     });
 
@@ -657,8 +657,8 @@ describe('SmartSearchBar', function () {
       searchBar.updateAutoCompleteItems();
       await tick();
       wrapper.update();
-      // three search groups because of operator suggestions
-      expect(searchBar.state.searchGroups).toHaveLength(3);
+      // two search groups because of operator suggestions
+      expect(searchBar.state.searchGroups).toHaveLength(2);
       expect(searchBar.state.activeSearchItem).toEqual(-1);
     });
 
@@ -677,15 +677,15 @@ describe('SmartSearchBar', function () {
       searchBar.updateAutoCompleteItems();
       await tick();
       wrapper.update();
-      // three search groups tags, values and quick actions
-      expect(searchBar.state.searchGroups).toHaveLength(3);
+      // two search groups tags and values
+      expect(searchBar.state.searchGroups).toHaveLength(2);
       expect(searchBar.state.activeSearchItem).toEqual(-1);
       mockCursorPosition(searchBar, 1);
       searchBar.updateAutoCompleteItems();
       await tick();
       wrapper.update();
-      // two search group because showing tags and quick actions now
-      expect(searchBar.state.searchGroups).toHaveLength(2);
+      // one search group because showing tags
+      expect(searchBar.state.searchGroups).toHaveLength(1);
       expect(searchBar.state.activeSearchItem).toEqual(-1);
     });
 
@@ -878,24 +878,6 @@ describe('SmartSearchBar', function () {
   });
 
   describe('quick actions', () => {
-    it('displays correct quick actions', async () => {
-      const props = {
-        query: 'is:unresolved sdk.name:sentry-cocoa has:key',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
-      searchBar.updateAutoCompleteItems();
-
-      mockCursorPosition(searchBar, 17);
-
-      await tick();
-      expect(searchBar.state.searchGroups).toHaveLength(2);
-      expect(searchBar.state.searchGroups[1].title).toEqual('Quick Actions');
-      expect(searchBar.state.searchGroups[1].children).toHaveLength(4);
-    });
-
     it('delete first token', async () => {
       const props = {
         query: 'is:unresolved sdk.name:sentry-cocoa has:key',


### PR DESCRIPTION
Moves the quick actions that are to be implemented in #35156 to a footer

<img width="1074" alt="Screen Shot 2022-06-09 at 1 41 02 PM" src="https://user-images.githubusercontent.com/30991498/172940536-9b033cbb-ec89-4e47-8b23-e5282dd24504.png">


<img width="1076" alt="Screen Shot 2022-06-09 at 1 40 57 PM" src="https://user-images.githubusercontent.com/30991498/172940513-8fa59037-412d-4187-9b1f-b6bca4f4e598.png">

https://user-images.githubusercontent.com/30991498/172940517-fb2229e0-5c58-47ff-9225-98594fd686b3.mov


