### PR TITLE
ref: fix test pollution in test_mediator.py

### DIFF
--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -32,10 +32,11 @@ class TestMediator(TestCase):
         self.mediator = MockMediator(user={"name": "Example"}, age=30, logger=self.logger)
 
     def test_must_implement_call(self):
-        del MockMediator.call
+        with patch.object(MockMediator, "call"):
+            del MockMediator.call
 
-        with self.assertRaises(NotImplementedError):
-            MockMediator.run(user={"name": "Example"})
+            with self.assertRaises(NotImplementedError):
+                MockMediator.run(user={"name": "Example"})
 
     def test_validate_params(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
found using https://github.com/asottile/detect-test-pollution

before:

```console
$ pytest -v tests/sentry/mediators/test_mediator.py::TestMediator::test_must_implement_call tests/sentry/mediators/test_mediator.py::TestMediator::test_log_start
============================================ test session starts ============================================
platform darwin -- Python 3.8.13, pytest-6.1.0, py-1.11.0, pluggy-0.13.1 -- /Users/asottile/workspace/sentry/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: rerunfailures-9.1.1, cov-2.11.1, django-3.10.0, sentry-0.1.9
collected 2 items                                                                                           

tests/sentry/mediators/test_mediator.py::TestMediator::test_must_implement_call PASSED                [ 50%]
tests/sentry/mediators/test_mediator.py::TestMediator::test_log_start FAILED                          [100%]

================================================= FAILURES ==================================================
________________________________________ TestMediator.test_log_start ________________________________________
tests/sentry/mediators/test_mediator.py:100: in test_log_start
    self.mediator.call()
src/sentry/mediators/mediator.py:168: in call
    raise NotImplementedError
E   NotImplementedError
----------------------------------------- Captured stderr teardown ------------------------------------------
Destroying test database for alias 'default'...
========================================== short test summary info ==========================================
FAILED tests/sentry/mediators/test_mediator.py::TestMediator::test_log_start - NotImplementedError
======================================== 1 failed, 1 passed in 4.05s ========================================
```

after:

```console
$ pytest -v tests/sentry/mediators/test_mediator.py::TestMediator::test_must_implement_call tests/sentry/mediators/test_mediator.py::TestMediator::test_log_start
============================================ test session starts ============================================
platform darwin -- Python 3.8.13, pytest-6.1.0, py-1.11.0, pluggy-0.13.1 -- /Users/asottile/workspace/sentry/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: rerunfailures-9.1.1, cov-2.11.1, django-3.10.0, sentry-0.1.9
collected 2 items                                                                                           

tests/sentry/mediators/test_mediator.py::TestMediator::test_must_implement_call PASSED                [ 50%]
tests/sentry/mediators/test_mediator.py::TestMediator::test_log_start PASSED                          [100%]

============================================= 2 passed in 4.02s =============================================
```