### PR TITLE
fix(ui): Add module to issue owners examples

### DIFF
--- a/static/app/views/settings/project/projectOwnership/editRulesModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/editRulesModal.tsx
@@ -27,7 +27,9 @@ class EditOwnershipRulesModal extends Component<Props, State> {
         <Block>
           {t('Examples')}
           <CodeBlock>
-            path:src/example/pipeline/* person@sentry.io #infrastructure
+            path:src/example/pipeline/* person@sentry.io #infra
+            {'\n'}
+            module:com.module.name.example #sdks
             {'\n'}
             url:http://example.com/settings/* #product
             {'\n'}

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -74,6 +74,7 @@ class ProjectOwnership extends AsyncView<Props, State> {
   getPlaceholder() {
     return `#example usage
 path:src/example/pipeline/* person@sentry.io #infra
+module:com.module.name.example #sdks
 url:http://example.com/settings/* #product
 tags.sku_class:enterprise #enterprise`;
   }

--- a/static/app/views/settings/project/projectOwnership/ownerInput.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownerInput.tsx
@@ -171,6 +171,7 @@ class OwnerInput extends Component<Props, State> {
             placeholder={
               '#example usage\n' +
               'path:src/example/pipeline/* person@sentry.io #infra\n' +
+              'module:com.module.name.example #sdks\n' +
               'url:http://example.com/settings/* #product\n' +
               'tags.sku_class:enterprise #enterprise'
             }

--- a/static/app/views/settings/project/projectOwnership/ruleBuilder.tsx
+++ b/static/app/views/settings/project/projectOwnership/ruleBuilder.tsx
@@ -28,6 +28,8 @@ function getMatchPlaceholder(type: string): string {
   switch (type) {
     case 'path':
       return 'src/example/*';
+    case 'module':
+      return 'com.module.name.example';
     case 'url':
       return 'https://example.com/settings/*';
     case 'tag':
@@ -151,6 +153,7 @@ class RuleBuilder extends Component<Props, State> {
             onChange={this.handleTypeChange}
             options={[
               {value: 'path', label: t('Path')},
+              {value: 'module', label: t('Module')},
               {value: 'tag', label: t('Tag')},
               {value: 'url', label: t('URL')},
             ]}


### PR DESCRIPTION
This adds module as an example to the issue owners. Module is supported in the Docs: [Issue Ownership](https://docs.sentry.io/product/issues/issue-owners/#ownership-rules) and in the BE: [sentry/grammar.py](https://github.com/getsentry/sentry/blob/34e9dc0e5a65fa606d679aabf5e10af03b2cb0d2/src/sentry/ownership/grammar.py#L127) but wasn't visible in the FE examples and dropdown. Added for parity

Jira: [WOR-1903](https://getsentry.atlassian.net/browse/WOR-1903)

After:
![Screen Shot 2022-06-09 at 4 07 33 PM](https://user-images.githubusercontent.com/15015880/172959851-f4f1a4af-aa1f-42ac-93a6-6024c9d97801.png)

Before:
![Screen Shot 2022-06-09 at 4 07 24 PM](https://user-images.githubusercontent.com/15015880/172959871-a546b978-49f7-4f77-9242-67300b5fdbd3.png)

