### PR TITLE
feat(mep): Add `build_snql_query` method to replace `build_snuba_filter`

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -109,6 +109,8 @@ class QueryBuilder:
         turbo: bool = False,
         sample_rate: Optional[float] = None,
         equation_config: Optional[Dict[str, bool]] = None,
+        # This allows queries to be resolved without adding time constraints. Currently this is just
+        # used to allow metric alerts to be built and validated before creation in snuba.
         skip_time_conditions: bool = False,
     ):
         self.dataset = dataset

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -152,6 +152,8 @@ class QueryBuilder:
         self.limitby = self.resolve_limitby(limitby)
         self.array_join = None if array_join is None else [self.resolve_column(array_join)]
 
+        self.start: Optional[datetime] = None
+        self.end: Optional[datetime] = None
         self.resolve_query(
             query=query,
             use_aggregate_conditions=use_aggregate_conditions,
@@ -159,8 +161,6 @@ class QueryBuilder:
             equations=equations,
             orderby=orderby,
         )
-        self.start: Optional[datetime] = None
-        self.end: Optional[datetime] = None
 
     def resolve_time_conditions(self) -> None:
         if self.skip_time_conditions:

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -109,6 +109,7 @@ class QueryBuilder:
         turbo: bool = False,
         sample_rate: Optional[float] = None,
         equation_config: Optional[Dict[str, bool]] = None,
+        skip_time_conditions: bool = False,
     ):
         self.dataset = dataset
 
@@ -140,6 +141,7 @@ class QueryBuilder:
         self.offset = None if offset is None else Offset(offset)
         self.turbo = turbo
         self.sample_rate = sample_rate
+        self.skip_time_conditions = skip_time_conditions
 
         (
             self.field_alias_converter,
@@ -157,8 +159,12 @@ class QueryBuilder:
             equations=equations,
             orderby=orderby,
         )
+        self.start: Optional[datetime] = None
+        self.end: Optional[datetime] = None
 
     def resolve_time_conditions(self) -> None:
+        if self.skip_time_conditions:
+            return
         # start/end are required so that we can run a query in a reasonable amount of time
         if "start" not in self.params or "end" not in self.params:
             raise InvalidSearchQuery("Cannot query without a valid date range")
@@ -169,8 +175,8 @@ class QueryBuilder:
         ), "Both start and end params must be datetime objects"
 
         # Strip timezone, which are ignored and assumed UTC to match filtering
-        self.start: datetime = self.params["start"].replace(tzinfo=timezone.utc)
-        self.end: datetime = self.params["end"].replace(tzinfo=timezone.utc)
+        self.start = self.params["start"].replace(tzinfo=timezone.utc)
+        self.end = self.params["end"].replace(tzinfo=timezone.utc)
 
     def resolve_column_name(self, col: str) -> str:
         # TODO when utils/snuba.py becomes typed don't need this extra annotation
@@ -407,9 +413,11 @@ class QueryBuilder:
         conditions = []
 
         # Update start to be within retention
-        expired, self.start = outside_retention_with_modified_start(
-            self.start, self.end, Organization(self.params.get("organization_id"))
-        )
+        expired = False
+        if self.start and self.end:
+            expired, self.start = outside_retention_with_modified_start(
+                self.start, self.end, Organization(self.params.get("organization_id"))
+            )
 
         project_id: List[int] = self.params.get("project_id", [])  # type: ignore
         assert all(
@@ -420,8 +428,10 @@ class QueryBuilder:
                 "Invalid date range. Please try a more recent date range."
             )
 
-        conditions.append(Condition(self.column("timestamp"), Op.GTE, self.start))
-        conditions.append(Condition(self.column("timestamp"), Op.LT, self.end))
+        if self.start:
+            conditions.append(Condition(self.column("timestamp"), Op.GTE, self.start))
+        if self.end:
+            conditions.append(Condition(self.column("timestamp"), Op.LT, self.end))
 
         if "project_id" in self.params:
             conditions.append(
@@ -1630,6 +1640,8 @@ class MetricsQueryBuilder(QueryBuilder):
             and will fallback to hourly granularity
         - If the duration is over 30d we always use the daily granularities
         """
+        if self.end is None or self.start is None:
+            raise ValueError("skip_time_conditions must be False when calling this method")
         duration = (self.end - self.start).total_seconds()
 
         near_midnight: Callable[[datetime], bool] = lambda time: (

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -2,7 +2,21 @@ import re
 from abc import ABC, abstractmethod
 from copy import copy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, TypedDict, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypedDict,
+    Union,
+)
+
+from snuba_sdk import Request
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, CRASH_RATE_ALERT_SESSION_COUNT_ALIAS
 from sentry.eventstore import Filter
@@ -127,6 +141,15 @@ class BaseEntitySubscription(ABC, _EntitySubscription):
         """
         raise NotImplementedError
 
+    def build_snql_query(
+        self,
+        query: str,
+        project_ids: Sequence[int],
+        environment: Optional[Environment],
+        params: Optional[MutableMapping[str, Any]] = None,
+    ) -> Request:
+        pass
+
 
 class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
     def __init__(
@@ -159,6 +182,34 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
         if environment:
             snuba_filter.conditions.append(["environment", "=", environment.name])
         return snuba_filter
+
+    def build_snql_query(
+        self,
+        query: str,
+        project_ids: Sequence[int],
+        environment: Optional[Environment],
+        params: Optional[MutableMapping[str, Any]] = None,
+    ) -> Request:
+        from sentry.search.events.builder import QueryBuilder
+
+        if params is None:
+            params = {}
+
+        params["project_id"] = project_ids
+
+        query = apply_dataset_query_conditions(QueryDatasets(self.dataset), query, self.event_types)
+        if environment:
+            params["environment"] = environment.name
+
+        return QueryBuilder(
+            dataset=Dataset(self.dataset.value),
+            query=query,
+            selected_columns=[self.aggregate],
+            params=params,
+            offset=None,
+            limit=None,
+            skip_time_conditions=True,
+        ).get_snql_query()
 
     def get_entity_extra_params(self) -> Mapping[str, Any]:
         return {}
@@ -241,6 +292,15 @@ class SessionsEntitySubscription(BaseEntitySubscription):
                 "incidents.entity_subscription.sessions.aggregate_query_results.no_session_data"
             )
         return data
+
+    def build_snql_query(
+        self,
+        query: str,
+        project_ids: Sequence[int],
+        environment: Optional[Environment],
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Request:
+        raise NotImplementedError
 
 
 class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
@@ -370,6 +430,15 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
         col_name = alias if alias else CRASH_RATE_ALERT_AGGREGATE_ALIAS
         aggregated_results = [{col_name: crash_free_rate}]
         return aggregated_results
+
+    def build_snql_query(
+        self,
+        query: str,
+        project_ids: Sequence[int],
+        environment: Optional[Environment],
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Request:
+        raise NotImplementedError
 
 
 class MetricsCountersEntitySubscription(BaseMetricsEntitySubscription):

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -1,8 +1,10 @@
 import logging
 from datetime import timedelta
+from typing import Sequence
 
 import sentry_sdk
 from django.utils import timezone
+from snuba_sdk import Request
 from snuba_sdk.legacy import json_to_snql
 
 from sentry.eventstore import Filter
@@ -156,6 +158,16 @@ def build_snuba_filter(
     params: Optional[Mapping[str, Any]] = None,
 ) -> Filter:
     return entity_subscription.build_snuba_filter(query, environment, params)
+
+
+def build_snql_query(
+    entity_subscription: BaseEntitySubscription,
+    query: str,
+    project_ids: Sequence[int],
+    environment: Optional[Environment],
+    params: Optional[Mapping[str, Any]] = None,
+) -> Request:
+    return entity_subscription.build_snql_query(query, project_ids, environment, params)
 
 
 def _create_in_snuba(subscription: QuerySubscription) -> str:

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -7,17 +7,20 @@ import pytest
 import responses
 from django.utils import timezone
 from exam import patcher
+from snuba_sdk import And, Column, Condition, Entity, Function, Op, Or, Query
 
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.utils import resolve, resolve_many_weak, resolve_tag_key, resolve_weak
 from sentry.snuba.entity_subscription import (
     apply_dataset_query_conditions,
     get_entity_subscription_for_dataset,
+    map_aggregate_to_entity_key,
 )
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.tasks import (
     SUBSCRIPTION_STATUS_MAX_AGE,
+    build_snql_query,
     build_snuba_filter,
     create_subscription_in_snuba,
     delete_subscription_from_snuba,
@@ -593,6 +596,483 @@ class BuildSnubaFilterTest(TestCase):
             ],
         ]
         assert snuba_filter.aggregations == [["uniq", "tags[sentry:user]", "count_unique_user"]]
+
+
+class BuildSnqlQueryTest(TestCase):
+    aggregate_mappings = {
+        QueryDatasets.EVENTS: {
+            "count_unique(user)": Function(
+                function="uniq",
+                parameters=[Column(name="tags[sentry:user]")],
+                alias="count_unique_user",
+            ),
+        },
+        QueryDatasets.TRANSACTIONS: {
+            "count_unique(user)": Function(
+                function="uniq",
+                parameters=[Column(name="user")],
+                alias="count_unique_user",
+            ),
+            "percentile(transaction.duration,.95)": Function(
+                "quantile(0.95)",
+                parameters=[Column(name="duration")],
+                alias="percentile_transaction_duration__95",
+            ),
+            "p95()": Function("quantile(0.95)", parameters=[Column(name="duration")], alias="p95"),
+        },
+        "count()": Function("count", parameters=[], alias="count"),
+    }
+
+    def run_test(self, dataset, aggregate, query, expected_conditions, entity_extra_fields=None):
+        time_window = 3600
+        entity_subscription = get_entity_subscription_for_dataset(
+            dataset=dataset,
+            aggregate=aggregate,
+            time_window=time_window,
+            extra_fields=entity_extra_fields,
+        )
+        snql_query = build_snql_query(
+            entity_subscription,
+            query,
+            (self.project.id,),
+            environment=None,
+            params={
+                "organization_id": self.organization.id,
+                "project_id": [self.project.id],
+            },
+        )
+        assert snql_query.query == Query(
+            match=Entity(map_aggregate_to_entity_key(dataset, aggregate).value),
+            select=[self.string_aggregate_to_snql(dataset, aggregate)],
+            where=expected_conditions,
+            groupby=[],
+            having=[],
+            orderby=[],
+        )
+
+    def string_aggregate_to_snql(self, dataset, aggregate):
+        return self.aggregate_mappings[dataset].get(
+            aggregate, self.aggregate_mappings.get(aggregate, "")
+        )
+
+    def test_simple_events(self):
+        self.run_test(
+            QueryDatasets.EVENTS,
+            "count_unique(user)",
+            "",
+            [
+                Condition(Column(name="type"), Op.EQ, "error"),
+                Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
+            ],
+        )
+
+    def test_simple_transactions(self):
+        self.run_test(
+            QueryDatasets.TRANSACTIONS,
+            "count_unique(user)",
+            "",
+            [
+                Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
+            ],
+        )
+
+    def test_aliased_query_events(self):
+        self.create_release(self.project, version="something")
+        expected_conditions = [
+            And(
+                conditions=[
+                    Condition(Column(name="type"), Op.EQ, "error"),
+                    Condition(
+                        Function(
+                            function="ifNull",
+                            parameters=[Column(name="tags[sentry:release]"), ""],
+                        ),
+                        Op.IN,
+                        ["something"],
+                    ),
+                ]
+            ),
+            Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
+        ]
+        self.run_test(
+            QueryDatasets.EVENTS, "count_unique(user)", "release:latest", expected_conditions
+        )
+
+    def test_aliased_query_transactions(self):
+        self.create_release(self.project, version="something")
+        expected_conditions = [
+            Condition(Column("release"), Op.IN, ["something"]),
+            Condition(Column("project_id"), Op.IN, (self.project.id,)),
+        ]
+        self.run_test(
+            QueryDatasets.TRANSACTIONS,
+            "percentile(transaction.duration,.95)",
+            "release:latest",
+            expected_conditions,
+        )
+
+    def test_user_query(self):
+        expected_conditions = [
+            And(
+                conditions=[
+                    Condition(Column(name="type"), Op.EQ, "error"),
+                    Condition(
+                        Function(
+                            function="ifNull",
+                            parameters=[Column(name="tags[sentry:user]"), ""],
+                        ),
+                        Op.EQ,
+                        "anengineer@work.io",
+                    ),
+                ]
+            ),
+            Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
+        ]
+        self.run_test(
+            QueryDatasets.EVENTS, "count()", "user:anengineer@work.io", expected_conditions
+        )
+
+    def test_user_query_transactions(self):
+        expected_conditions = [
+            Condition(Column("user"), Op.EQ, "anengineer@work.io"),
+            Condition(Column("project_id"), Op.IN, (self.project.id,)),
+        ]
+        self.run_test(
+            QueryDatasets.TRANSACTIONS,
+            "p95()",
+            "user:anengineer@work.io",
+            expected_conditions,
+        )
+
+    def test_boolean_query(self):
+        self.create_release(self.project, version="something")
+        expected_conditions = [
+            And(
+                [
+                    Condition(Column(name="type"), Op.EQ, "error"),
+                    Or(
+                        [
+                            Condition(
+                                Function(
+                                    "ifNull", parameters=[Column(name="tags[sentry:release]"), ""]
+                                ),
+                                Op.IN,
+                                ["something"],
+                            ),
+                            Condition(
+                                Function(
+                                    "ifNull", parameters=[Column(name="tags[sentry:release]"), ""]
+                                ),
+                                Op.IN,
+                                ["123"],
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
+        ]
+        self.run_test(
+            QueryDatasets.EVENTS,
+            "count_unique(user)",
+            "release:latest OR release:123",
+            expected_conditions,
+        )
+
+    def test_event_types(self):
+        self.create_release(self.project, version="something")
+        expected_conditions = [
+            And(
+                [
+                    Or(
+                        [
+                            Condition(Column(name="type"), Op.EQ, "error"),
+                            Condition(Column(name="type"), Op.EQ, "default"),
+                        ]
+                    ),
+                    Or(
+                        [
+                            Condition(
+                                Function(
+                                    "ifNull", parameters=[Column(name="tags[sentry:release]"), ""]
+                                ),
+                                Op.IN,
+                                ["something"],
+                            ),
+                            Condition(
+                                Function(
+                                    "ifNull", parameters=[Column(name="tags[sentry:release]"), ""]
+                                ),
+                                Op.IN,
+                                ["123"],
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
+        ]
+        self.run_test(
+            QueryDatasets.EVENTS,
+            "count_unique(user)",
+            "release:latest OR release:123",
+            expected_conditions,
+            entity_extra_fields={
+                "event_types": [
+                    SnubaQueryEventType.EventType.ERROR,
+                    SnubaQueryEventType.EventType.DEFAULT,
+                ]
+            },
+        )
+
+    def test_issue_id_snql(self):
+        expected_conditions = [
+            And(
+                [
+                    Condition(Column(name="type"), Op.EQ, "error"),
+                    Condition(
+                        Column(name="group_id"),
+                        Op.IN,
+                        [self.group.id, 2],
+                    ),
+                ]
+            ),
+            Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
+        ]
+        self.run_test(
+            QueryDatasets.EVENTS,
+            "count_unique(user)",
+            f"issue.id:[{self.group.id}, 2]",
+            expected_conditions,
+        )
+
+    # TODO: Convert these tests once we implement `build_snql_query` for sessions and metrics
+    # def test_simple_sessions(self):
+    #     entity_subscription = get_entity_subscription_for_dataset(
+    #         dataset=QueryDatasets.SESSIONS,
+    #         time_window=3600,
+    #         aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+    #         extra_fields={"org_id": self.organization.id},
+    #     )
+    #     snuba_filter = build_snuba_filter(
+    #         entity_subscription,
+    #         query="",
+    #         environment=None,
+    #     )
+    #     assert snuba_filter
+    #     assert snuba_filter.aggregations == [
+    #         [
+    #             "if(greater(sessions,0),divide(sessions_crashed,sessions),null)",
+    #             None,
+    #             "_crash_rate_alert_aggregate",
+    #         ],
+    #         ["identity", "sessions", "_total_count"],
+    #     ]
+    #
+    # def test_simple_users(self):
+    #     entity_subscription = get_entity_subscription_for_dataset(
+    #         dataset=QueryDatasets.SESSIONS,
+    #         time_window=3600,
+    #         aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+    #         extra_fields={"org_id": self.organization.id},
+    #     )
+    #     snuba_filter = build_snuba_filter(
+    #         entity_subscription,
+    #         query="",
+    #         environment=None,
+    #     )
+    #     assert snuba_filter
+    #     assert snuba_filter.aggregations == [
+    #         [
+    #             "if(greater(users,0),divide(users_crashed,users),null)",
+    #             None,
+    #             "_crash_rate_alert_aggregate",
+    #         ],
+    #         ["identity", "users", "_total_count"],
+    #     ]
+    #
+    # def test_simple_sessions_for_metrics(self):
+    #     org_id = self.organization.id
+    #     for tag in [SessionMRI.SESSION.value, "session.status", "crashed", "init"]:
+    #         indexer.record(org_id, tag)
+    #     entity_subscription = get_entity_subscription_for_dataset(
+    #         dataset=QueryDatasets.METRICS,
+    #         time_window=3600,
+    #         aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+    #         extra_fields={"org_id": org_id},
+    #     )
+    #     snuba_filter = build_snuba_filter(
+    #         entity_subscription,
+    #         query="",
+    #         environment=None,
+    #     )
+    #     session_status = resolve_tag_key(org_id, "session.status")
+    #     session_status_tag_values = resolve_many_weak(org_id, ["crashed", "init"])
+    #     assert snuba_filter
+    #     assert snuba_filter.aggregations == [["sum(value)", None, "value"]]
+    #     assert snuba_filter.conditions == [
+    #         ["metric_id", "=", resolve(org_id, SessionMRI.SESSION.value)],
+    #         [session_status, "IN", session_status_tag_values],
+    #     ]
+    #     assert snuba_filter.groupby == [session_status]
+    #
+    # def test_simple_users_for_metrics(self):
+    #     org_id = self.organization.id
+    #     for tag in [SessionMRI.USER.value, "session.status", "crashed", "init"]:
+    #         indexer.record(org_id, tag)
+    #     entity_subscription = get_entity_subscription_for_dataset(
+    #         dataset=QueryDatasets.METRICS,
+    #         time_window=3600,
+    #         aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+    #         extra_fields={"org_id": org_id},
+    #     )
+    #     snuba_filter = build_snuba_filter(
+    #         entity_subscription,
+    #         query="",
+    #         environment=None,
+    #     )
+    #     session_status = resolve_tag_key(org_id, "session.status")
+    #     session_status_tag_values = resolve_many_weak(org_id, ["crashed", "init"])
+    #     assert snuba_filter
+    #     assert snuba_filter.aggregations == [["uniq(value)", None, "value"]]
+    #     assert snuba_filter.conditions == [
+    #         ["metric_id", "=", resolve(org_id, SessionMRI.USER.value)],
+    #         [session_status, "IN", session_status_tag_values],
+    #     ]
+    #     assert snuba_filter.groupby == [session_status]
+    #
+    # def test_query_and_environment_sessions(self):
+    #     entity_subscription = get_entity_subscription_for_dataset(
+    #         dataset=QueryDatasets.SESSIONS,
+    #         time_window=3600,
+    #         aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+    #         extra_fields={"org_id": self.organization.id},
+    #     )
+    #     env = self.create_environment(self.project, name="development")
+    #     snuba_filter = build_snuba_filter(
+    #         entity_subscription,
+    #         query="release:ahmed@12.2",
+    #         environment=env,
+    #     )
+    #     assert snuba_filter
+    #     assert snuba_filter.aggregations == [
+    #         [
+    #             "if(greater(sessions,0),divide(sessions_crashed,sessions),null)",
+    #             None,
+    #             "_crash_rate_alert_aggregate",
+    #         ],
+    #         ["identity", "sessions", "_total_count"],
+    #     ]
+    #     assert snuba_filter.conditions == [
+    #         ["release", "=", "ahmed@12.2"],
+    #         ["environment", "=", "development"],
+    #     ]
+    #
+    # def test_query_and_environment_sessions_metrics(self):
+    #     env = self.create_environment(self.project, name="development")
+    #     org_id = self.organization.id
+    #     for tag in [
+    #         SessionMRI.SESSION.value,
+    #         "session.status",
+    #         "environment",
+    #         "development",
+    #         "init",
+    #         "crashed",
+    #         "release",
+    #         "ahmed@12.2",
+    #     ]:
+    #         indexer.record(org_id, tag)
+    #     entity_subscription = get_entity_subscription_for_dataset(
+    #         dataset=QueryDatasets.METRICS,
+    #         time_window=3600,
+    #         aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+    #         extra_fields={"org_id": org_id},
+    #     )
+    #     snuba_filter = build_snuba_filter(
+    #         entity_subscription,
+    #         query="release:ahmed@12.2",
+    #         environment=env,
+    #     )
+    #     assert snuba_filter
+    #     assert snuba_filter.aggregations == [["sum(value)", None, "value"]]
+    #     assert snuba_filter.groupby == [resolve_tag_key(org_id, "session.status")]
+    #     assert snuba_filter.conditions == [
+    #         ["metric_id", "=", resolve(org_id, SessionMRI.SESSION.value)],
+    #         [
+    #             resolve_tag_key(org_id, "session.status"),
+    #             "IN",
+    #             resolve_many_weak(org_id, ["crashed", "init"]),
+    #         ],
+    #         [resolve_tag_key(org_id, "environment"), "=", resolve_weak(org_id, "development")],
+    #         [resolve_tag_key(org_id, "release"), "=", resolve_weak(org_id, "ahmed@12.2")],
+    #     ]
+    #
+    # def test_query_and_environment_users(self):
+    #     entity_subscription = get_entity_subscription_for_dataset(
+    #         dataset=QueryDatasets.SESSIONS,
+    #         aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+    #         extra_fields={"org_id": self.organization.id},
+    #         time_window=3600,
+    #     )
+    #     env = self.create_environment(self.project, name="development")
+    #     snuba_filter = build_snuba_filter(
+    #         entity_subscription,
+    #         query="release:ahmed@12.2",
+    #         environment=env,
+    #     )
+    #     assert snuba_filter
+    #     assert snuba_filter.aggregations == [
+    #         [
+    #             "if(greater(users,0),divide(users_crashed,users),null)",
+    #             None,
+    #             "_crash_rate_alert_aggregate",
+    #         ],
+    #         ["identity", "users", "_total_count"],
+    #     ]
+    #     assert snuba_filter.conditions == [
+    #         ["release", "=", "ahmed@12.2"],
+    #         ["environment", "=", "development"],
+    #     ]
+    #
+    # def test_query_and_environment_users_metrics(self):
+    #     env = self.create_environment(self.project, name="development")
+    #     org_id = self.organization.id
+    #     for tag in [
+    #         SessionMRI.USER.value,
+    #         "session.status",
+    #         "environment",
+    #         "development",
+    #         "init",
+    #         "crashed",
+    #         "release",
+    #         "ahmed@12.2",
+    #     ]:
+    #         indexer.record(org_id, tag)
+    #     entity_subscription = get_entity_subscription_for_dataset(
+    #         dataset=QueryDatasets.METRICS,
+    #         time_window=3600,
+    #         aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+    #         extra_fields={"org_id": org_id},
+    #     )
+    #     snuba_filter = build_snuba_filter(
+    #         entity_subscription,
+    #         query="release:ahmed@12.2",
+    #         environment=env,
+    #     )
+    #     assert snuba_filter
+    #     assert snuba_filter.aggregations == [["uniq(value)", None, "value"]]
+    #     assert snuba_filter.groupby == [resolve_tag_key(org_id, "session.status")]
+    #     assert snuba_filter.conditions == [
+    #         ["metric_id", "=", resolve(org_id, SessionMRI.USER.value)],
+    #         [
+    #             resolve_tag_key(org_id, "session.status"),
+    #             "IN",
+    #             resolve_many_weak(org_id, ["crashed", "init"]),
+    #         ],
+    #         [resolve_tag_key(org_id, "environment"), "=", resolve_weak(org_id, "development")],
+    #         [resolve_tag_key(org_id, "release"), "=", resolve_weak(org_id, "ahmed@12.2")],
+    #     ]
+    #
 
 
 class TestApplyDatasetQueryConditions(TestCase):


### PR DESCRIPTION
This adds in `build_snql_query`, which is intended to replace `build_snuba_filter` everywhere.
Initially, I'm just implementing this in the error and transaction entities. I'll follow up with
sessions and metrics in a later pr.

This function uses `QueryBuilder` to build the snql queries that we'll use to create alert rules.
Currently, `QueryBuilder` requires that all queries have a start/end passed since those are required
for all on demand queries that users make. Alert rules operate differently - we explicitly can't
pass a start/end, since these alerts operate on a time window, and snuba adds in the time component
every time these subscriptions run. To support this, I've added the ability to skip start/end checks
in `QueryBuilder`.

For testing, I just copied `BuildSnubaFilterTest` and converted it to check snql queries instead.
Since `build_snuba_filter` will go away soon I'm not concerned about duplication here. A bunch of
tests here are still commented out - these are all session/metric related. I'll fix those tests in
a follow up pr as well.
