### PR TITLE
ref: actually test async/sync consumer

### DIFF
--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -111,6 +111,7 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
             group_id=random_group_id,
             consumer_types={ConsumerType.Events},
             auto_offset_reset="earliest",
+            executor=executor,
         )
 
     with task_runner():


### PR DESCRIPTION
this parametrize was added in e4b5f79bb292e7ffba2a7b9173a0145c8d687314 but unused