### PR TITLE
fix(eventstore): Silently handle events beyond retention

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -260,4 +260,4 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 format="json",
             )
 
-        assert response.status_code == 400, response.content
+        assert response.status_code == 404, response.content


### PR DESCRIPTION
When an event is looked up beyond retention it can currently return an exception when the event was still found but beyond the retention window. This makes this code path inconsistent with an error that was already so far beyond retention that it was deleted.

This fixes a bunch of 500 internal server errors in the UI and API when you try to look up a really old event. This now also means that the `sentry-api-0-organization-event-details` endpoint consistently returns 404 where previously it sometimes returned 400 for some out of retention events.

Fixes SENTRY-S0G