### PR TITLE
ref(addDashboardWidgetModal): Use SelectControl's tooltip prop

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -1,6 +1,5 @@
 import {Component, Fragment} from 'react';
 import {browserHistory} from 'react-router';
-import {OptionProps} from 'react-select';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
@@ -66,9 +65,6 @@ import {
 import WidgetCard from 'sentry/views/dashboardsV2/widgetCard';
 import {WidgetTemplate} from 'sentry/views/dashboardsV2/widgetLibrary/data';
 import {generateFieldOptions} from 'sentry/views/eventsV2/utils';
-
-import Option from '../forms/selectOption';
-import Tooltip from '../tooltip';
 
 import {TAB, TabsButtonBar} from './dashboardWidgetLibraryModal/tabsButtonBar';
 
@@ -568,6 +564,12 @@ class AddDashboardWidgetModal extends Component<Props, State> {
         label: d.title,
         value: d.id,
         isDisabled: d.widgetDisplay.length >= MAX_WIDGETS,
+        tooltip:
+          d.widgetDisplay.length >= MAX_WIDGETS &&
+          tct('Max widgets ([maxWidgets]) per dashboard reached.', {
+            maxWidgets: MAX_WIDGETS,
+          }),
+        tooltipOptions: {position: 'right'},
       };
     });
     return (
@@ -594,20 +596,6 @@ class AddDashboardWidgetModal extends Component<Props, State> {
             ]}
             onChange={(option: SelectValue<string>) => this.handleDashboardChange(option)}
             disabled={loading}
-            components={{
-              Option: ({label, data, ...optionProps}: OptionProps<any>) => (
-                <Tooltip
-                  disabled={!!!data.isDisabled}
-                  title={tct('Max widgets ([maxWidgets]) per dashboard reached.', {
-                    maxWidgets: MAX_WIDGETS,
-                  })}
-                  containerDisplayMode="block"
-                  position="right"
-                >
-                  <Option label={label} data={data} {...(optionProps as any)} />
-                </Tooltip>
-              ),
-            }}
           />
         </Field>
       </Fragment>

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
 import {InjectedRouter} from 'react-router';
-import {OptionProps} from 'react-select';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Query} from 'history';
@@ -15,8 +14,6 @@ import {ModalRenderProps} from 'sentry/actionCreators/modal';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import SelectControl from 'sentry/components/forms/selectControl';
-import SelectOption from 'sentry/components/forms/selectOption';
-import Tooltip from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {DateString, Organization, PageFilters, SelectValue} from 'sentry/types';
@@ -146,6 +143,12 @@ function AddToDashboardModal({
                   label: title,
                   value: id,
                   isDisabled: widgetDisplay.length >= MAX_WIDGETS,
+                  tooltip:
+                    widgetDisplay.length >= MAX_WIDGETS &&
+                    tct('Max widgets ([maxWidgets]) per dashboard reached.', {
+                      maxWidgets: MAX_WIDGETS,
+                    }),
+                  tooltipOptions: {position: 'right'},
                 })),
               ]
             }
@@ -154,20 +157,6 @@ function AddToDashboardModal({
                 return;
               }
               setSelectedDashboardId(option.value);
-            }}
-            components={{
-              Option: ({label, data, ...optionProps}: OptionProps<any>) => (
-                <Tooltip
-                  disabled={!!!data.isDisabled}
-                  title={tct('Max widgets ([maxWidgets]) per dashboard reached.', {
-                    maxWidgets: MAX_WIDGETS,
-                  })}
-                  containerDisplayMode="block"
-                  position="right"
-                >
-                  <SelectOption label={label} data={data} {...(optionProps as any)} />
-                </Tooltip>
-              ),
             }}
           />
         </SelectControlWrapper>

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -222,9 +222,9 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     openMenu(wrapper, {name: 'dashboard', control: true});
 
     const input = wrapper.find('SelectControl[name="dashboard"]');
-    expect(input.find('Option Option')).toHaveLength(2);
-    expect(input.find('Option Option').at(0).props().isDisabled).toBe(false);
-    expect(input.find('Option Option').at(1).props().isDisabled).toBe(true);
+    expect(input.find('Option')).toHaveLength(2);
+    expect(input.find('Option').at(0).props().isDisabled).toBe(false);
+    expect(input.find('Option').at(1).props().isDisabled).toBe(true);
 
     wrapper.unmount();
   });


### PR DESCRIPTION
In `AddDashboardWidgetModal`, we alter the dashboard selector's `Option` component (via the`components` prop), wrapping it with `<Tooltip />`. This is now unnecessary – `SelectControl` supports adding tooltips to select options via the `tooltip` and `tooltipOptions` prop.

The UI and behavior hasn't changed:
<img width="566" alt="Screen Shot 2022-06-10 at 10 14 00 AM" src="https://user-images.githubusercontent.com/44172267/173117735-15f47634-a30c-4f2a-9ec9-7f2f0def5f43.png">
<img width="817" alt="Screen Shot 2022-06-10 at 10 14 37 AM" src="https://user-images.githubusercontent.com/44172267/173117826-b7c0dd09-7303-4c52-aab3-3886bbfbef7f.png">

