### PR TITLE
ref(icons): add existing icons to storybook

### DIFF
--- a/docs-ui/stories/assets/icons/data.tsx
+++ b/docs-ui/stories/assets/icons/data.tsx
@@ -69,6 +69,7 @@ export const iconProps: IconProps = {
       ['line', 'Line'],
       ['circle', 'Circle'],
       ['bar', 'Bar'],
+      ['area', 'Area'],
     ],
     default: 'line',
     enumerate: true,
@@ -622,5 +623,40 @@ export const icons: IconData[] = [
     id: 'expand',
     groups: ['action'],
     keywords: ['open'],
+  },
+  {
+    id: 'asana',
+    groups: ['logo'],
+    keywords: [''],
+  },
+  {
+    id: 'dashboard',
+    groups: ['product'],
+    keywords: ['widgets'],
+  },
+  {
+    id: 'globe',
+    groups: ['action'],
+    keywords: ['international', 'global'],
+  },
+  {
+    id: 'group',
+    groups: ['action'],
+    keywords: ['users'],
+  },
+  {
+    id: 'input',
+    groups: ['action'],
+    keywords: ['text'],
+  },
+  {
+    id: 'number',
+    groups: ['action'],
+    keywords: ['value'],
+  },
+  {
+    id: 'vercel',
+    groups: ['logo'],
+    keywords: [''],
   },
 ];


### PR DESCRIPTION
Showing the existing icons in storybook:
- Graph Area
- Asana
- Dashboard
- Globe
- Group
- Input
- Number
- Vercel

![Screen Shot 2022-06-10 at 10 45 55 AM](https://user-images.githubusercontent.com/4830259/173122527-607454c3-e750-486d-9369-962fd3618b54.png)
![Screen Shot 2022-06-10 at 10 46 04 AM](https://user-images.githubusercontent.com/4830259/173122540-4f5e2bfd-55e7-4ab9-8e38-abcf39a95852.png)