### PR TITLE
fix(util): Use a much simpler hotkeys implementation

### DIFF
--- a/static/app/utils/useHotkeys.tsx
+++ b/static/app/utils/useHotkeys.tsx
@@ -22,6 +22,8 @@ const isKeyPressed = (key: string, evt: KeyboardEvent): boolean => {
  * Pass in the hotkey combinations under match and the corresponding callback function to be called.
  * Separate key names with +. For example, 'command+alt+shift+x'
  * Alternate matchings as an array: ['command+alt+backspace', 'ctrl+alt+delete']
+ *
+ * Note: you can only use one non-modifier (keys other than shift, ctrl, alt, command) key at a time.
  */
 export function useHotkeys(
   hotkeys: {callback: (e: KeyboardEvent) => void; match: string[] | string}[],

--- a/tests/js/spec/utils/useHotkeys.spec.jsx
+++ b/tests/js/spec/utils/useHotkeys.spec.jsx
@@ -1,0 +1,145 @@
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import {getKeyCode} from 'sentry/utils/getKeyCode';
+import {useHotkeys} from 'sentry/utils/useHotkeys';
+
+describe('useHotkeys', function () {
+  let events = {};
+
+  beforeEach(() => {
+    // Empty our events before each test case
+    events = {};
+
+    // Define the addEventListener method with a Jest mock function
+    document.addEventListener = jest.fn((event, callback) => {
+      events[event] = callback;
+    });
+
+    document.removeEventListener = jest.fn(event => {
+      delete events[event];
+    });
+  });
+
+  it('simple match', function () {
+    let didGetCalled = false;
+
+    expect(events.keydown).toBeUndefined();
+
+    reactHooks.renderHook(() =>
+      useHotkeys([
+        {
+          match: 'ctrl+s',
+          callback: () => {
+            didGetCalled = true;
+          },
+        },
+      ])
+    );
+
+    expect(events.keydown).toBeDefined();
+    expect(didGetCalled).toEqual(false);
+
+    events.keydown({keyCode: getKeyCode('s'), ctrlKey: true});
+
+    expect(didGetCalled).toEqual(true);
+  });
+
+  it('multi match', function () {
+    let didGetCalled = false;
+
+    expect(events.keydown).toBeUndefined();
+
+    reactHooks.renderHook(() =>
+      useHotkeys([
+        {
+          match: ['ctrl+s', 'cmd+m'],
+          callback: () => {
+            didGetCalled = true;
+          },
+        },
+      ])
+    );
+
+    expect(events.keydown).toBeDefined();
+    expect(didGetCalled).toEqual(false);
+
+    events.keydown({keyCode: getKeyCode('s'), ctrlKey: true});
+
+    expect(didGetCalled).toEqual(true);
+
+    didGetCalled = false;
+
+    events.keydown({keyCode: getKeyCode('m'), metaKey: true});
+
+    expect(didGetCalled).toEqual(true);
+  });
+
+  it('complex match', function () {
+    let didGetCalled = false;
+
+    expect(events.keydown).toBeUndefined();
+
+    reactHooks.renderHook(() =>
+      useHotkeys([
+        {
+          match: ['cmd+control+option+shift+x'],
+          callback: () => {
+            didGetCalled = true;
+          },
+        },
+      ])
+    );
+
+    expect(events.keydown).toBeDefined();
+    expect(didGetCalled).toEqual(false);
+
+    events.keydown({
+      keyCode: getKeyCode('x'),
+      altKey: true,
+      metaKey: true,
+      shiftKey: true,
+      ctrlKey: true,
+    });
+
+    expect(didGetCalled).toEqual(true);
+  });
+
+  it('rerender', function () {
+    let didGetCalled = false;
+
+    expect(events.keydown).toBeUndefined();
+
+    const {rerender} = reactHooks.renderHook(
+      p =>
+        useHotkeys([
+          {
+            match: p.match,
+            callback: () => {
+              didGetCalled = true;
+            },
+          },
+        ]),
+      {
+        initialProps: {
+          match: 'ctrl+s',
+        },
+      }
+    );
+
+    expect(events.keydown).toBeDefined();
+    expect(didGetCalled).toEqual(false);
+
+    events.keydown({keyCode: getKeyCode('s'), ctrlKey: true});
+
+    expect(didGetCalled).toEqual(true);
+    didGetCalled = false;
+
+    rerender({match: 'cmd+m'});
+
+    events.keydown({keyCode: getKeyCode('s'), ctrlKey: true});
+    expect(didGetCalled).toEqual(false);
+
+    events.keydown({keyCode: getKeyCode('m'), metaKey: true});
+    expect(didGetCalled).toEqual(true);
+  });
+});


### PR DESCRIPTION
A much simpler hotkeys implementation that doesn't have the bugs introduced in the previous iteration of #35276 and #35454 where we kept a state of what keys are pressed on keydown and remove them in keyup.

Benefit of this implementation is we don't need to do the hack with metaKey anymore, which means you can perform the key combo as slow as you want or spam it as many times as you want.

Limitation of this new implementation compared to the last is you can have multiple modifier keys (shift, cmd, ctrl, alt) but no more than one other key.