### PR TITLE
ref(dashboards): Use select's `trailingItems` prop in QueryField

### DIFF
--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -429,7 +429,7 @@ class QueryField extends Component<Props> {
           : descriptor.options;
 
         aggregateParameters.forEach(opt => {
-          opt.trailingItems = this.renderTag(opt.value.kind, opt.label as string);
+          opt.trailingItems = this.renderTag(opt.value.kind, String(opt.label));
         });
 
         return (

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -588,7 +588,7 @@ class QueryField extends Component<Props> {
       : Object.values(fieldOptions);
 
     allFieldOptions.forEach(opt => {
-      opt.trailingItems = this.renderTag(opt.value.kind, opt.label as string);
+      opt.trailingItems = this.renderTag(opt.value.kind, String(opt.label));
     });
 
     const selectProps: ControlProps<FieldValueOption> = {

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -1,5 +1,5 @@
 import {Component, createRef} from 'react';
-import {components, OptionProps, SingleValueProps} from 'react-select';
+import {components, SingleValueProps} from 'react-select';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -109,18 +109,6 @@ type OptionType = {
 
 class QueryField extends Component<Props> {
   FieldSelectComponents = {
-    Option: ({label, data, ...props}: OptionProps<OptionType>) => {
-      return (
-        <components.Option label={label} data={data} {...props}>
-          <InnerWrap isFocused={props.isFocused}>
-            <OptionLabelWrapper data-test-id="label">
-              {label}
-              {data.value && this.renderTag(data.value.kind, label)}
-            </OptionLabelWrapper>
-          </InnerWrap>
-        </components.Option>
-      );
-    },
     SingleValue: ({data, ...props}: SingleValueProps<OptionType>) => {
       return (
         <components.SingleValue data={data} {...props}>
@@ -138,15 +126,6 @@ class QueryField extends Component<Props> {
         justifyContent: 'space-between',
         alignItems: 'center',
         width: 'calc(100% - 10px)',
-      };
-      return {...provided, ...custom};
-    },
-    option(provided: React.CSSProperties) {
-      const custom = {
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        width: '100%',
       };
       return {...provided, ...custom};
     },
@@ -449,6 +428,10 @@ class QueryField extends Component<Props> {
           ? descriptor.options.filter(filterAggregateParameters)
           : descriptor.options;
 
+        aggregateParameters.forEach(opt => {
+          opt.trailingItems = this.renderTag(opt.value.kind, opt.label as string);
+        });
+
         return (
           <SelectControl
             key="select"
@@ -603,6 +586,10 @@ class QueryField extends Component<Props> {
     const allFieldOptions = filterPrimaryOptions
       ? Object.values(fieldOptions).filter(filterPrimaryOptions)
       : Object.values(fieldOptions);
+
+    allFieldOptions.forEach(opt => {
+      opt.trailingItems = this.renderTag(opt.value.kind, opt.label as string);
+    });
 
     const selectProps: ControlProps<FieldValueOption> = {
       name: 'field',
@@ -815,22 +802,6 @@ const ArithmeticError = styled(Tooltip)`
   color: ${p => p.theme.red300};
   animation: ${() => pulse(1.15)} 1s ease infinite;
   display: flex;
-`;
-
-const InnerWrap = styled('div')<{isFocused: boolean}>`
-  display: flex;
-  padding: 0 ${space(1)};
-  border-radius: ${p => p.theme.borderRadius};
-  box-sizing: border-box;
-  width: 100%;
-  ${p => p.isFocused && `background: ${p.theme.hover};`}
-`;
-
-const OptionLabelWrapper = styled('span')`
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
-  padding: ${space(1)} 0;
 `;
 
 export {QueryField};

--- a/tests/js/spec/views/alerts/metricRules/metricField.spec.jsx
+++ b/tests/js/spec/views/alerts/metricRules/metricField.spec.jsx
@@ -56,7 +56,20 @@ describe('MetricField', function () {
     openSelectMenu('(Required)');
 
     // 10 error aggregate configs
-    expect(screen.getAllByTestId('label')).toHaveLength(10);
+    [
+      'avg(…)',
+      'percentile(…)',
+      'p50(…)',
+      'p75(…)',
+      'p95(…)',
+      'p99(…)',
+      'p100(…)',
+      'failure_rate()',
+      'apdex(…)',
+      'count()',
+    ].forEach(label => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
     userEvent.click(screen.getByText('avg(…)'));
     expect(model.fields.get('metric')).toBe('avg(transaction.duration)');
 


### PR DESCRIPTION
We can use the `trailingItems` prop to display tags in the right side of each option, instead of customizing the `Option` component.

**Before:**
<img width="766" alt="Screen Shot 2022-06-10 at 2 16 08 PM" src="https://user-images.githubusercontent.com/44172267/173152348-02fb1836-d830-4d7c-b253-022f9c9b4c1d.png">

**After:**
<img width="766" alt="Screen Shot 2022-06-10 at 2 15 35 PM" src="https://user-images.githubusercontent.com/44172267/173152280-9aea98e6-5607-419a-8889-c1dfaa7d957f.png">
