### PR TITLE
style(workflow): Fix text overflow styling for the issue stream

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -177,6 +177,9 @@ const Title = styled('div')<{hasGroupingTreeUI: boolean; size: Size}>`
     font-style: normal;
     font-weight: 300;
     color: ${p => p.theme.subText};
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
   ${p =>
     !p.hasGroupingTreeUI


### PR DESCRIPTION
Add styling to the issue stream to clip the text with ellipsis instead of wrapping across multiple lines. 

Before:
<img width="908" alt="Screen Shot 2022-06-10 at 5 13 15 PM" src="https://user-images.githubusercontent.com/16563948/173164830-8735f004-40d4-402b-8977-c6ee1c418a76.png">

After:
<img width="910" alt="Screen Shot 2022-06-10 at 5 12 57 PM" src="https://user-images.githubusercontent.com/16563948/173164840-3d6812b7-76f4-41f8-9b57-38089c6f774a.png">

Fixes WOR-1939