### PR TITLE
ref(grouping): Add read docs button

### DIFF
--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -5,6 +5,8 @@ import {Location} from 'history';
 import debounce from 'lodash/debounce';
 
 import {Client} from 'sentry/api';
+import Button from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import {FeatureFeedback} from 'sentry/components/featureFeedback';
 import RangeSlider from 'sentry/components/forms/controls/rangeSlider';
 import Slider from 'sentry/components/forms/controls/rangeSlider/slider';
@@ -50,6 +52,9 @@ export const groupingFeedbackTypes = [
   t('Too specific grouping'),
   t('Other grouping issue'),
 ];
+
+export const GROUPING_BREAKDOWN__DOC_LINK =
+  'https://docs.sentry.io/product/data-management-settings/event-grouping/grouping-breakdown/';
 
 function Grouping({api, groupId, location, organization, router, projSlug}: Props) {
   const {cursor, level} = location.query;
@@ -204,10 +209,15 @@ function Grouping({api, groupId, location, organization, router, projSlug}: Prop
         <Layout.Body>
           <Layout.Main fullWidth>
             <ErrorWrapper>
-              <FeatureFeedback
-                featureName="grouping"
-                feedbackTypes={groupingFeedbackTypes}
-              />
+              <ButtonBar gap={1}>
+                <Button href={GROUPING_BREAKDOWN__DOC_LINK} external>
+                  {t('Read Docs')}
+                </Button>
+                <FeatureFeedback
+                  featureName="grouping"
+                  feedbackTypes={groupingFeedbackTypes}
+                />
+              </ButtonBar>
               <StyledErrorMessage
                 onRetry={fetchGroupingLevels}
                 groupId={groupId}
@@ -255,10 +265,15 @@ function Grouping({api, groupId, location, organization, router, projSlug}: Prop
                 />
                 {t('More issues')}
               </SliderWrapper>
-              <FeatureFeedback
-                featureName="grouping"
-                feedbackTypes={groupingFeedbackTypes}
-              />
+              <StyledButtonBar gap={1}>
+                <Button href={GROUPING_BREAKDOWN__DOC_LINK} external>
+                  {t('Read Docs')}
+                </Button>
+                <FeatureFeedback
+                  featureName="grouping"
+                  feedbackTypes={groupingFeedbackTypes}
+                />
+              </StyledButtonBar>
             </Actions>
             <Content isReloading={isGroupingLevelDetailsLoading}>
               <StyledPanelTable headers={['', t('Events')]}>
@@ -327,9 +342,16 @@ const Body = styled('div')`
 
 const Actions = styled('div')`
   display: grid;
-  grid-template-columns: 1fr max-content;
   align-items: center;
   gap: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: 1fr max-content;
+  }
+`;
+
+const StyledButtonBar = styled(ButtonBar)`
+  justify-content: flex-start;
 `;
 
 const StyledErrorMessage = styled(ErrorMessage)`

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -53,7 +53,7 @@ export const groupingFeedbackTypes = [
   t('Other grouping issue'),
 ];
 
-export const GROUPING_BREAKDOWN__DOC_LINK =
+const GROUPING_BREAKDOWN__DOC_LINK =
   'https://docs.sentry.io/product/data-management-settings/event-grouping/grouping-breakdown/';
 
 function Grouping({api, groupId, location, organization, router, projSlug}: Props) {

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -343,10 +343,11 @@ const Body = styled('div')`
 const Actions = styled('div')`
   display: grid;
   align-items: center;
-  gap: ${space(2)};
+  gap: ${space(3)};
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: 1fr max-content;
+    gap: ${space(2)};
   }
 `;
 

--- a/static/app/views/settings/components/dataScrubbing/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.tsx
@@ -182,7 +182,7 @@ class DataScrubbing<T extends ProjectId = undefined> extends Component<Props<T>,
           />
           <PanelAction>
             <Button href={ADVANCED_DATASCRUBBING_LINK} target="_blank">
-              {t('Read the docs')}
+              {t('Read Docs')}
             </Button>
             <Button
               disabled={disabled}

--- a/tests/js/spec/views/settings/components/dataScrubbing/dataScrubbing.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/dataScrubbing.spec.tsx
@@ -89,7 +89,7 @@ describe('Data Scrubbing', () => {
       // PanelAction
       const actionButtons = wrapper.find('PanelAction').find('Button');
       expect(actionButtons).toHaveLength(2);
-      expect(actionButtons.at(0).text()).toEqual('Read the docs');
+      expect(actionButtons.at(0).text()).toEqual('Read Docs');
       expect(actionButtons.at(1).text()).toEqual('Add Rule');
       expect(actionButtons.at(1).prop('disabled')).toEqual(false);
     });
@@ -151,7 +151,7 @@ describe('Data Scrubbing', () => {
       // PanelAction
       const actionButtons = wrapper.find('PanelAction').find('Button');
       expect(actionButtons).toHaveLength(2);
-      expect(actionButtons.at(0).text()).toEqual('Read the docs');
+      expect(actionButtons.at(0).text()).toEqual('Read Docs');
       expect(actionButtons.at(1).text()).toEqual('Add Rule');
       expect(actionButtons.at(1).prop('disabled')).toEqual(false);
     });


### PR DESCRIPTION
**What this PR does:**

- Replace "Read the docs" with "Read Docs" on the data scrubbing settings to be consistent with the button in grouping
- Add a "Read Docs" to the Grouping Breakdown UI

**Before:**

![image](https://user-images.githubusercontent.com/29228205/173330619-7dcaa40c-560a-4495-87b0-ce1613fc61c9.png)

**After:**

![image](https://user-images.githubusercontent.com/29228205/173330644-555c4737-1354-408b-94aa-31f8de78f812.png)


![image](https://user-images.githubusercontent.com/29228205/173331030-e6dcc43a-ccb4-4ee3-b1b1-6bf4dddace74.png)
