### PR TITLE
fix(proj-config): Add `fullConfig` as requirement for v3

### DIFF
--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -49,9 +49,6 @@ class RelayProjectConfigsEndpoint(Endpoint):
         version = request.GET.get("version") or "1"
         set_tag("relay_protocol_version", version)
 
-        no_cache = request.relay_request_data.get("noCache") or False
-        set_tag("relay_no_cache", no_cache)
-
         if self._should_use_v3(request):
             # Always compute the full config. It's invalid to send partial
             # configs to processing relays, and these validate the requests they
@@ -71,6 +68,9 @@ class RelayProjectConfigsEndpoint(Endpoint):
             return Response("Unsupported version, we only support versions 1 to 3.", 400)
 
     def _should_use_v3(self, request):
+        no_cache = request.relay_request_data.get("noCache") or False
+        set_tag("relay_no_cache", no_cache)
+
         if request.GET.get("version") != "3":
             return False
         if not request.relay_request_data.get("fullConfig"):
@@ -79,7 +79,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
             # should be low, so we handle them per request instead of
             # considering them v3.
             return False
-        if request.relay_request_data.get("noCache"):
+        if no_cache:
             return False
         if random.random() >= options.get("relay.project-config-v3-enable"):
             return False

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -68,6 +68,8 @@ class RelayProjectConfigsEndpoint(Endpoint):
             return Response("Unsupported version, we only support versions 1 to 3.", 400)
 
     def _should_use_v3(self, request):
+        version = request.GET.get("version")
+        set_tag("relay_endpoint_version", version)
         no_cache = request.relay_request_data.get("noCache") or False
         set_tag("relay_no_cache", no_cache)
         is_full_config = request.relay_request_data.get("fullConfig")
@@ -76,7 +78,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         use_v3 = True
         reject_reason = None
 
-        if request.GET.get("version") != "3":
+        if version != "3":
             use_v3 = False
             reject_reason = "version"
         elif not is_full_config:

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -100,7 +100,14 @@ class RelayProjectConfigsEndpoint(Endpoint):
 
         set_tag("relay_use_v3", use_v3)
         set_tag("relay_use_v3_rejected", reject_reason)
-        return use_v3, reject_reason
+        metrics.incr(
+            "api.endpoints.relay.project_configs._post",
+            tags={"version": version, "reason": reject_reason},
+            amount=1,
+            sample_rate=1,
+        )
+
+        return use_v3
 
     def _post_or_schedule_by_key(self, request: Request):
         public_keys = set(request.relay_request_data.get("publicKeys") or ())

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -101,7 +101,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         set_tag("relay_use_v3", use_v3)
         set_tag("relay_use_v3_rejected", reason)
         metrics.incr(
-            "api.endpoints.relay.project_configs._post",
+            "api.endpoints.relay.project_configs.post",
             tags={"version": version, "reason": reason},
             sample_rate=1,
         )

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -103,7 +103,6 @@ class RelayProjectConfigsEndpoint(Endpoint):
         metrics.incr(
             "api.endpoints.relay.project_configs._post",
             tags={"version": version, "reason": reject_reason},
-            amount=1,
             sample_rate=1,
         )
 

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -76,33 +76,33 @@ class RelayProjectConfigsEndpoint(Endpoint):
         set_tag("relay_full_config", is_full_config)
 
         use_v3 = True
-        reject_reason = None
+        reason = "accepted"
 
         if version != "3":
             use_v3 = False
-            reject_reason = "version"
+            reason = "version"
         elif not is_full_config:
             # The v3 implementation can't handle partial configs. Relay by
             # default request full configs and the amount of partial configs
             # should be low, so we handle them per request instead of
             # considering them v3.
             use_v3 = False
-            reject_reason = "fullConfig"
+            reason = "fullConfig"
         elif no_cache:
             use_v3 = False
-            reject_reason = "noCache"
+            reason = "noCache"
         elif random.random() >= options.get("relay.project-config-v3-enable"):
             set_tag("relay_v3_sampled", False)
             use_v3 = False
-            reject_reason = "sampling"
+            reason = "sampling"
         else:
             set_tag("relay_v3_sampled", True)
 
         set_tag("relay_use_v3", use_v3)
-        set_tag("relay_use_v3_rejected", reject_reason)
+        set_tag("relay_use_v3_rejected", reason)
         metrics.incr(
             "api.endpoints.relay.project_configs._post",
-            tags={"version": version, "reason": reject_reason},
+            tags={"version": version, "reason": reason},
             sample_rate=1,
         )
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -117,15 +117,21 @@ def test_return_full_config_if_in_cache(
 
 @pytest.mark.django_db
 def test_return_partial_config_if_in_cache(
-    call_endpoint, default_projectkey, projectconfig_cache_get_mock_config
+    monkeypatch,
+    call_endpoint,
+    default_projectkey,
+    default_project,
 ):
-    # Partial configs aren't supported, but the endpoint must always return full
-    # configs.
+    # Partial configs are handled as ``v2``, even if the param is ``v3``
+    monkeypatch.setattr(
+        "sentry.relay.config.get_project_config",
+        lambda *args, **kwargs: ProjectConfig(default_project, is_mock_config=True),
+    )
+
     result, status_code = call_endpoint(full_config=False)
     assert status_code < 400
     expected = {
         "configs": {default_projectkey.public_key: {"is_mock_config": True}},
-        "pending": [],
     }
     assert result == expected
 


### PR DESCRIPTION
The v3 implementation can't handle partial configs. Relay by default requests full configs and the amount of partial configs should be low, so we handle them per request instead of considering them for v3. For readability purposes, the requirements to use v3 have also been extracted into a function.