### PR TITLE
ref(sampling): Add 'all' desc for single rules without conditions - [TET-125]

### DIFF
--- a/static/app/views/settings/project/sampling/rules/rule/index.tsx
+++ b/static/app/views/settings/project/sampling/rules/rule/index.tsx
@@ -89,13 +89,15 @@ export function Rule({
       </Column>
       <Column>
         <Conditions>
-          {rule.condition.inner.map((condition, index) => (
-            <Fragment key={index}>
-              <ConditionName>{getInnerNameLabel(condition.name)}</ConditionName>
-              <ConditionEqualOperator>{'='}</ConditionEqualOperator>
-              <ConditionValue value={condition.value} />
-            </Fragment>
-          ))}
+          {hideGrabButton && !rule.condition.inner.length
+            ? t('All')
+            : rule.condition.inner.map((condition, index) => (
+                <Fragment key={index}>
+                  <ConditionName>{getInnerNameLabel(condition.name)}</ConditionName>
+                  <ConditionEqualOperator>{'='}</ConditionEqualOperator>
+                  <ConditionValue value={condition.value} />
+                </Fragment>
+              ))}
         </Conditions>
       </Column>
       <RightColumn>

--- a/tests/js/spec/views/settings/projectSampling/index.spec.tsx
+++ b/tests/js/spec/views/settings/projectSampling/index.spec.tsx
@@ -115,6 +115,38 @@ describe('Sampling', function () {
     expect(router.push).toHaveBeenCalledWith(`${SamplingRuleType.TRANSACTION}/`);
   });
 
+  it('renders single rule without conditions', function () {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      method: 'GET',
+      body: TestStubs.Project({
+        dynamicSampling: {
+          rules: [
+            {
+              sampleRate: 0.2,
+              type: 'trace',
+              condition: {
+                op: 'and',
+                inner: [],
+              },
+              id: 40,
+            },
+          ],
+          next_id: 41,
+        },
+      }),
+    });
+
+    renderComponent({
+      withModal: false,
+      ruleType: SamplingRuleType.TRACE,
+    });
+
+    // Tab content
+    expect(screen.getAllByTestId('sampling-rule').length).toBe(1);
+    expect(screen.getByTestId('sampling-rule')).toHaveTextContent('All');
+  });
+
   it('renders individual transactions tab', function () {
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/',


### PR DESCRIPTION
Add the description "All" to a single sampling on the list without conditions.


https://user-images.githubusercontent.com/29228205/173359709-15b36e57-5a72-4b1b-abc7-3e5df0916c40.mov



