### PR TITLE
ref: fix exception AttributeError in social_auth.exceptions

### DIFF
--- a/src/social_auth/exceptions.py
+++ b/src/social_auth/exceptions.py
@@ -7,7 +7,7 @@ class SocialAuthBaseException(ValueError):
 
 class BackendError(SocialAuthBaseException):
     def __str__(self):
-        return ugettext("Backend error: %s" % self.message)
+        return ugettext("Backend error: %s") % super().__str__()
 
 
 class WrongBackend(BackendError):
@@ -39,7 +39,7 @@ class AuthFailed(AuthException):
     """Auth process failed for some reason."""
 
     def __str__(self):
-        if self.message == "access_denied":
+        if self.args == ("access_denied",):
             return ugettext("Authentication process was cancelled")
         else:
             return ugettext("Authentication failed: %s") % super().__str__()


### PR DESCRIPTION
previously stringifying either of these exceptions would crash:

```pycon
>>> from social_auth.exceptions import BackendError, AuthFailed
>>> str(BackendError('error!'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/asottile/workspace/sentry/src/social_auth/exceptions.py", line 10, in __str__
    return ugettext("Backend error: %s" % self.message)
AttributeError: 'BackendError' object has no attribute 'message'
>>> str(AuthFailed('access_denied'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/asottile/workspace/sentry/src/social_auth/exceptions.py", line 42, in __str__
    if self.message == "access_denied":
AttributeError: 'AuthFailed' object has no attribute 'message'
```

the typechecker catches these fortunately, and I couldn't find an appropriate place for a test