### PR TITLE
fix(profiling): Ensure table header is single line

### DIFF
--- a/static/app/components/profiling/functionsTable.tsx
+++ b/static/app/components/profiling/functionsTable.tsx
@@ -20,6 +20,7 @@ import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {getShortEventId} from 'sentry/utils/events';
 import {formatPercentage} from 'sentry/utils/formatters';
 import {generateFlamegraphRouteWithQuery} from 'sentry/utils/profiling/routes';
+import {renderTableHead} from 'sentry/utils/profiling/tableRenderer';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -100,12 +101,29 @@ function FunctionsTable(props: FunctionsTableProps) {
         data={functions}
         columnOrder={COLUMN_ORDER.map(key => COLUMNS[key])}
         columnSortBy={[]}
-        grid={{renderBodyCell: renderFunctionsTableCell}}
+        grid={{
+          renderHeadCell: renderTableHead(RIGHT_ALIGNED_COLUMNS),
+          renderBodyCell: renderFunctionsTableCell,
+        }}
         location={location}
       />
     </Fragment>
   );
 }
+
+const RIGHT_ALIGNED_COLUMNS = new Set<TableColumnKey>([
+  'p50Duration',
+  'p75Duration',
+  'p90Duration',
+  'p95Duration',
+  'p99Duration',
+  'mainThreadPercent',
+  'p50Frequency',
+  'p75Frequency',
+  'p90Frequency',
+  'p95Frequency',
+  'p99Frequency',
+]);
 
 function renderFunctionsTableCell(
   column: TableColumn,

--- a/static/app/components/profiling/profileTransactionsTable.tsx
+++ b/static/app/components/profiling/profileTransactionsTable.tsx
@@ -6,7 +6,6 @@ import GridEditable, {
   COL_WIDTH_UNDEFINED,
   GridColumnOrder,
 } from 'sentry/components/gridEditable';
-import SortLink from 'sentry/components/gridEditable/sortLink';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
 import PerformanceDuration from 'sentry/components/performanceDuration';
@@ -15,6 +14,7 @@ import {ProfileTransaction} from 'sentry/types/profiling/core';
 import {defined} from 'sentry/utils';
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {generateProfileSummaryRouteWithQuery} from 'sentry/utils/profiling/routes';
+import {renderTableHead} from 'sentry/utils/profiling/tableRenderer';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -68,7 +68,7 @@ function ProfileTransactionsTable(props: ProfileTransactionsTableProps) {
       columnOrder={COLUMN_ORDER.map(key => COLUMNS[key])}
       columnSortBy={[]}
       grid={{
-        renderHeadCell: renderTableHead,
+        renderHeadCell: renderTableHead(RIGHT_ALIGNED_COLUMNS),
         renderBodyCell: renderTableBody,
       }}
       location={location}
@@ -76,7 +76,7 @@ function ProfileTransactionsTable(props: ProfileTransactionsTableProps) {
   );
 }
 
-const RightAlignedColumns = new Set<TableColumnKey>([
+const RIGHT_ALIGNED_COLUMNS = new Set<TableColumnKey>([
   'count',
   'p50',
   'p75',
@@ -84,18 +84,6 @@ const RightAlignedColumns = new Set<TableColumnKey>([
   'p95',
   'p99',
 ]);
-
-function renderTableHead(column: TableColumn, _columnIndex: number) {
-  return (
-    <SortLink
-      align={RightAlignedColumns.has(column.key) ? 'right' : 'left'}
-      title={column.name}
-      direction={undefined}
-      canSort={false}
-      generateSortLink={() => undefined}
-    />
-  );
-}
 
 function renderTableBody(
   column: TableColumn,

--- a/static/app/components/profiling/profilesTable.tsx
+++ b/static/app/components/profiling/profilesTable.tsx
@@ -19,6 +19,7 @@ import {
   generateFlamegraphSummaryRoute,
   generateProfileSummaryRouteWithQuery,
 } from 'sentry/utils/profiling/routes';
+import {renderTableHead} from 'sentry/utils/profiling/tableRenderer';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -47,12 +48,17 @@ function ProfilesTable(props: ProfilesTableProps) {
         data={props.traces}
         columnOrder={(props.columnOrder ?? DEFAULT_COLUMN_ORDER).map(key => COLUMNS[key])}
         columnSortBy={[]}
-        grid={{renderBodyCell: renderProfilesTableCell}}
+        grid={{
+          renderHeadCell: renderTableHead(RIGHT_ALIGNED_COLUMNS),
+          renderBodyCell: renderProfilesTableCell,
+        }}
         location={location}
       />
     </Fragment>
   );
 }
+
+const RIGHT_ALIGNED_COLUMNS = new Set<TableColumnKey>(['trace_duration_ms']);
 
 function renderProfilesTableCell(
   column: TableColumn,

--- a/static/app/types/profiling/core.tsx
+++ b/static/app/types/profiling/core.tsx
@@ -80,5 +80,4 @@ export type ProfileTransaction = {
   name: string;
   profiles_count: number;
   project_id: string;
-  versions: string[];
 };

--- a/static/app/utils/profiling/tableRenderer.tsx
+++ b/static/app/utils/profiling/tableRenderer.tsx
@@ -1,0 +1,16 @@
+import {GridColumnOrder} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
+
+export function renderTableHead<K>(rightAlignedColumns: Set<K>) {
+  return (column: GridColumnOrder<K>, _columnIndex: number) => {
+    return (
+      <SortLink
+        align={rightAlignedColumns.has(column.key) ? 'right' : 'left'}
+        title={column.name}
+        direction={undefined}
+        canSort={false}
+        generateSortLink={() => undefined}
+      />
+    );
+  };
+}

--- a/static/app/views/profiling/utils.tsx
+++ b/static/app/views/profiling/utils.tsx
@@ -1,5 +1,7 @@
 import {Location} from 'history';
 
+import {GridColumnOrder} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
 import {t} from 'sentry/locale';
 import {SelectValue} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -32,4 +34,18 @@ export function getColorEncodingFromLocation(location: Location): ColorEncoding 
   }
 
   return 'transaction_name';
+}
+
+export function renderTableHeader<K>(rightAlignedColumns: Set<K>) {
+  return (column: GridColumnOrder<K>, _columnIndex: number) => {
+    return (
+      <SortLink
+        align={rightAlignedColumns.has(column.key) ? 'right' : 'left'}
+        title={column.name}
+        direction={undefined}
+        canSort={false}
+        generateSortLink={() => undefined}
+      />
+    );
+  };
 }


### PR DESCRIPTION
The table headers can break onto multiple lines on narrow view ports. This
ensures that it is always rendered on a single line. This also right aligns some
columns for better formatting.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/173379898-6a45ecee-d628-403c-b0ec-393e8ff33236.png)

## After

![image](https://user-images.githubusercontent.com/10239353/173379795-49d81448-2c21-4772-bae8-5c0c259f6d5f.png)
