### PR TITLE
fix(notifications): Add issue title in notification titles (API-2627)

### DIFF
--- a/fixtures/emails/note.txt
+++ b/fixtures/emails/note.txt
@@ -1,6 +1,6 @@
 # New Comment
 
-New comment by foo@example.com:
+New comment by foo@example.com on PROJECT-1:
 
 sincerely gobbler epic immensely katydid beloved stunning falcon mainly actively bedbug correctly sincere primate falcon guiding game notably hardly goose smiling gobbler
 

--- a/src/sentry/notifications/notifications/activity/assigned.py
+++ b/src/sentry/notifications/notifications/activity/assigned.py
@@ -61,18 +61,6 @@ class AssignedActivityNotification(GroupActivityNotification):
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} assigned {an issue} to {assignee}", {"assignee": self.get_assignee()}, {}
 
-    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
-        assignee = self.get_assignee()
-
-        if not self.activity.user:
-            return f"Issue automatically assigned to {assignee}"
-
-        author = self.activity.user.get_display_name()
-        if assignee == "themselves":
-            author, assignee = assignee, author
-
-        return f"Issue assigned to {assignee} by {author}"
-
     def get_participants_with_group_subscription_reason(
         self,
     ) -> Mapping[ExternalProviders, Mapping[Team | User, int]]:

--- a/src/sentry/notifications/notifications/activity/note.py
+++ b/src/sentry/notifications/notifications/activity/note.py
@@ -19,7 +19,7 @@ class NoteActivityNotification(GroupActivityNotification):
     @property
     def title(self) -> str:
         author = self.activity.user.get_display_name()
-        return f"New comment by {author}"
+        return f"New comment by {author} on {self.activity.group.qualified_short_id}"
 
     def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         return self.title

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -2,40 +2,23 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from sentry_relay import parse_release
-
 from sentry.models import Activity
-from sentry.utils.html import escape
-from sentry.utils.http import absolute_uri
 
-from .base import GroupActivityNotification
+from .versioned_notification import VersionedGroupActivityNotification
 
 
-class RegressionActivityNotification(GroupActivityNotification):
+class RegressionActivityNotification(VersionedGroupActivityNotification):
     metrics_key = "regression_activity"
     title = "Regression"
 
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity)
-        self.version = self.activity.data.get("version", "")
-        self.version_parsed = parse_release(self.version)["description"]
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
-        message, params, html_params = "{author} marked {an issue} as a regression", {}, {}
-
-        if self.version:
-            version_url = absolute_uri(
-                f"/organizations/{self.organization.slug}/releases/{self.version_parsed}/"
-            )
-
-            message += " in {version}"
-            params["version"] = self.version_parsed
-            html_params["version"] = f'<a href="{version_url}">{escape(self.version_parsed)}</a>'
+        message, params, html_params = (
+            "{author} marked {an issue} as a regression",
+            self.get_params(),
+            self.get_html_params(),
+        )
 
         return message, params, html_params
-
-    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
-        text = "Issue marked as regression"
-        if self.version:
-            text += f" in release {self.version_parsed}"
-        return text

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -21,4 +21,7 @@ class RegressionActivityNotification(VersionedGroupActivityNotification):
             self.get_html_params(),
         )
 
+        if "version" in params:
+            message += " in {version}"
+
         return message, params, html_params

--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -21,7 +21,7 @@ class ResolvedInReleaseActivityNotification(VersionedGroupActivityNotification):
             self.get_html_params(),
         )
 
-        if "version" not in params:
-            params["version"] = "an upcoming release"
+        if not params:
+            params = {"version": "an upcoming release"}
 
         return message, params, html_params

--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -21,6 +21,7 @@ class ResolvedInReleaseActivityNotification(VersionedGroupActivityNotification):
             self.get_html_params(),
         )
 
-        params["version"] = params.get("version", "an upcoming release")
+        if "version" not in params:
+            params["version"] = "an upcoming release"
 
         return message, params, html_params

--- a/src/sentry/notifications/notifications/activity/unassigned.py
+++ b/src/sentry/notifications/notifications/activity/unassigned.py
@@ -11,11 +11,3 @@ class UnassignedActivityNotification(GroupActivityNotification):
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} unassigned {an issue}", {}, {}
-
-    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
-        user = self.activity.user
-        if user:
-            author = user.name or user.email
-        else:
-            author = "Sentry"
-        return f"Issue unassigned by {author}"

--- a/src/sentry/notifications/notifications/activity/versioned_notification.py
+++ b/src/sentry/notifications/notifications/activity/versioned_notification.py
@@ -1,0 +1,39 @@
+import abc
+from typing import Mapping
+
+from sentry_relay import parse_release
+
+from sentry.models.activity import Activity
+from sentry.utils.html import escape
+from sentry.utils.http import absolute_uri
+
+from .base import GroupActivityNotification
+
+
+class VersionedGroupActivityNotification(GroupActivityNotification, abc.ABC):
+    """Notifications which have version or release as part of their title and description"""
+
+    def __init__(self, activity: Activity) -> None:
+        super().__init__(activity)
+
+        self.version = self.activity.data.get("version", "")
+
+        if self.version:
+            self.version_parsed = parse_release(self.version)["description"]
+            self.version_url = absolute_uri(
+                f"/organizations/{self.organization.slug}/releases/{self.version_parsed}/"
+            )
+        else:
+            self.version_parsed = "an upcoming release"
+
+    def get_params(self) -> Mapping[str, str]:
+        return {"version": self.version_parsed}
+
+    def get_html_params(self) -> Mapping[str, str]:
+        html_params = {}
+        if self.version:
+            html_params[
+                "version"
+            ] = f'<a href="{self.version_url}">{escape(self.version_parsed)}</a>'
+
+        return html_params

--- a/src/sentry/notifications/notifications/activity/versioned_notification.py
+++ b/src/sentry/notifications/notifications/activity/versioned_notification.py
@@ -25,17 +25,13 @@ class VersionedGroupActivityNotification(GroupActivityNotification, abc.ABC):
             )
 
     def get_params(self) -> Mapping[str, str]:
-        params = {}
         if self.version:
             return {"version": self.version_parsed}
 
-        return params
+        return {}
 
     def get_html_params(self) -> Mapping[str, str]:
-        html_params = {}
         if self.version:
-            html_params[
-                "version"
-            ] = f'<a href="{self.version_url}">{escape(self.version_parsed)}</a>'
+            return {"version": f'<a href="{self.version_url}">{escape(self.version_parsed)}</a>'}
 
-        return html_params
+        return {}

--- a/src/sentry/notifications/notifications/activity/versioned_notification.py
+++ b/src/sentry/notifications/notifications/activity/versioned_notification.py
@@ -23,11 +23,13 @@ class VersionedGroupActivityNotification(GroupActivityNotification, abc.ABC):
             self.version_url = absolute_uri(
                 f"/organizations/{self.organization.slug}/releases/{self.version_parsed}/"
             )
-        else:
-            self.version_parsed = "an upcoming release"
 
     def get_params(self) -> Mapping[str, str]:
-        return {"version": self.version_parsed}
+        params = {}
+        if self.version:
+            return {"version": self.version_parsed}
+
+        return params
 
     def get_html_params(self) -> Mapping[str, str]:
         html_params = {}

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1700,6 +1700,9 @@ class SlackActivityNotificationTest(ActivityTestCase):
         self.name = self.user.get_display_name()
         self.short_id = self.group.qualified_short_id
 
+    def get_issue_url(self):
+        return f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
+
 
 @apply_feature_flag_on_cls("organizations:metrics")
 @pytest.mark.usefixtures("reset_snuba")

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -138,7 +138,13 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest):
         with self.tasks():
             notification.send()
         attachment, text = get_attachment()
-        assert text == f"Issue assigned to {self.name} by themselves"
+
+        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
+
+        assert (
+            text
+            == f"{self.name} assigned <{test_issue_url}|{self.group.qualified_short_id}> to themselves"
+        )
         assert attachment["title"] == self.group.title
         assert (
             attachment["footer"]
@@ -154,7 +160,10 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest):
                 data={"assignee": self.user.id},
             )
         )
+
+        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
+
         assert (
             notification.get_notification_title()
-            == f"Issue automatically assigned to {self.user.get_display_name()}"
+            == f"Sentry assigned <{test_issue_url}|{self.group.qualified_short_id}> to {self.user.get_display_name()}"
         )

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -139,11 +139,9 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest):
             notification.send()
         attachment, text = get_attachment()
 
-        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
-
         assert (
             text
-            == f"{self.name} assigned <{test_issue_url}|{self.group.qualified_short_id}> to themselves"
+            == f"{self.name} assigned <{self.get_issue_url()}|{self.group.qualified_short_id}> to themselves"
         )
         assert attachment["title"] == self.group.title
         assert (
@@ -161,9 +159,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest):
             )
         )
 
-        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
-
         assert (
             notification.get_notification_title()
-            == f"Sentry assigned <{test_issue_url}|{self.group.qualified_short_id}> to {self.user.get_display_name()}"
+            == f"Sentry assigned <{self.get_issue_url()}|{self.group.qualified_short_id}> to {self.user.get_display_name()}"
         )

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -30,7 +30,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest):
 
         attachment, text = get_attachment()
 
-        assert text == f"New comment by {self.name}"
+        assert text == f"New comment by {self.name} on {self.group.qualified_short_id}"
         assert attachment["title"] == f"{self.group.title}"
         assert (
             attachment["title_link"]

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -29,7 +29,13 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest):
             notification.send()
 
         attachment, text = get_attachment()
-        assert text == "Issue marked as regression"
+
+        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
+
+        assert (
+            text
+            == f"{self.user.username} marked <{test_issue_url}|{self.group.qualified_short_id}> as a regression"
+        )
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user|Notification Settings>"

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -31,11 +31,9 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest):
 
         attachment, text = get_attachment()
 
-        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
-
         assert (
             text
-            == f"{self.user.username} marked <{test_issue_url}|{self.group.qualified_short_id}> as a regression"
+            == f"{self.user.username} marked <{self.get_issue_url()}|{self.group.qualified_short_id}> as a regression"
         )
         assert (
             attachment["footer"]
@@ -63,11 +61,10 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest):
         attachment, text = get_attachment()
 
         version_parsed = parse_release(notification.activity.data["version"])["description"]
-        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
 
         assert (
             text
-            == f"{self.user.username} marked <{test_issue_url}|{self.group.qualified_short_id}> as a regression in {version_parsed}"
+            == f"{self.user.username} marked <{self.get_issue_url()}|{self.group.qualified_short_id}> as a regression in {version_parsed}"
         )
         assert (
             attachment["footer"]

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -42,3 +42,34 @@ class SlackResolvedInReleaseNotificationTest(SlackActivityNotificationTest):
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user|Notification Settings>"
         )
+
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_resolved_in_release_without_version(self, mock_func):
+        """
+        Test that a Slack message is sent with the expected payload when an issue is resolved in a release
+        """
+        notification = ResolvedInReleaseActivityNotification(
+            Activity(
+                project=self.project,
+                group=self.group,
+                user=self.user,
+                type=ActivityType.SET_RESOLVED_IN_RELEASE,
+                data={},
+            )
+        )
+        with self.tasks():
+            notification.send()
+
+        attachment, text = get_attachment()
+
+        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
+
+        assert (
+            text
+            == f"{self.user.username} marked <{test_issue_url}|{self.group.qualified_short_id}> as resolved in an upcoming release"
+        )
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user|Notification Settings>"
+        )

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -32,11 +32,9 @@ class SlackResolvedInReleaseNotificationTest(SlackActivityNotificationTest):
         attachment, text = get_attachment()
         version_parsed = parse_release(notification.activity.data["version"])["description"]
 
-        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
-
         assert (
             text
-            == f"{self.user.username} marked <{test_issue_url}|{self.group.qualified_short_id}> as resolved in {version_parsed}"
+            == f"{self.user.username} marked <{self.get_issue_url()}|{self.group.qualified_short_id}> as resolved in {version_parsed}"
         )
         assert (
             attachment["footer"]
@@ -63,11 +61,9 @@ class SlackResolvedInReleaseNotificationTest(SlackActivityNotificationTest):
 
         attachment, text = get_attachment()
 
-        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
-
         assert (
             text
-            == f"{self.user.username} marked <{test_issue_url}|{self.group.qualified_short_id}> as resolved in an upcoming release"
+            == f"{self.user.username} marked <{self.get_issue_url()}|{self.group.qualified_short_id}> as resolved in an upcoming release"
         )
         assert (
             attachment["footer"]

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -29,7 +29,10 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest):
             notification.send()
 
         attachment, text = get_attachment()
-        assert text == f"Issue unassigned by {self.name}"
+
+        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
+
+        assert text == f"{self.name} unassigned <{test_issue_url}|{self.group.qualified_short_id}>"
         assert attachment["title"] == self.group.title
         assert (
             attachment["footer"]

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -30,9 +30,10 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest):
 
         attachment, text = get_attachment()
 
-        test_issue_url = f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification"
-
-        assert text == f"{self.name} unassigned <{test_issue_url}|{self.group.qualified_short_id}>"
+        assert (
+            text
+            == f"{self.name} unassigned <{self.get_issue_url()}|{self.group.qualified_short_id}>"
+        )
         assert attachment["title"] == self.group.title
         assert (
             attachment["footer"]

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -22,6 +22,8 @@ class AssignedNotificationAPITest(APITestCase):
 
         self.login_as(self.user)
 
+        self.test_issue_url_template = "http://testserver/organizations/{org_slug}/issues/{issue_id}/?referrer=activity_notification"
+
     @responses.activate
     def test_sends_assignment_notification(self):
         """
@@ -58,7 +60,15 @@ class AssignedNotificationAPITest(APITestCase):
 
         attachment, text = get_attachment()
 
-        assert text == f"Issue assigned to {self.user.get_display_name()} by themselves"
+        test_issue_url = self.test_issue_url_template.format(
+            org_slug=self.organization.slug,
+            issue_id=self.group.id,
+        )
+
+        assert (
+            text
+            == f"{self.user.get_display_name()} assigned <{test_issue_url}|{self.group.qualified_short_id}> to themselves"
+        )
         assert attachment["title"] == self.group.title
         assert self.project.slug in attachment["footer"]
 
@@ -89,8 +99,14 @@ class AssignedNotificationAPITest(APITestCase):
 
         attachment, text = get_attachment()
 
+        test_issue_url = self.test_issue_url_template.format(
+            org_slug=self.organization.slug,
+            issue_id=self.group.id,
+        )
+
         assert (
-            text == f"Issue assigned to the {self.team.name} team by {self.user.get_display_name()}"
+            text
+            == f"{self.user.get_display_name()} assigned <{test_issue_url}|{self.group.qualified_short_id}> to the {self.team.name} team"
         )
         assert attachment["title"] == self.group.title
         assert self.project.slug in attachment["footer"]


### PR DESCRIPTION
Currently most notifications except issue resolutions do not include the
issue title in the notification titles. This change introduces issue
titles in the notification titles.
