### PR TITLE
feat(dashboard): Introduce supported display types to config

### DIFF
--- a/static/app/views/dashboardsV2/datasetConfig/base.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/base.tsx
@@ -4,7 +4,7 @@ import {TableData} from 'sentry/utils/discover/discoverQuery';
 import {MetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 
-import {WidgetQuery, WidgetType} from '../types';
+import {DisplayType, WidgetQuery, WidgetType} from '../types';
 
 import {ErrorsAndTransactionsConfig} from './errorsAndTransactions';
 import {IssuesConfig} from './issues';
@@ -25,6 +25,7 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
    * Transforms table API results into format that is used by
    * table and big number components.
    */
+  supportedDisplayTypes: DisplayType[];
   transformTable: (
     data: TableResponse,
     widgetQuery: WidgetQuery,

--- a/static/app/views/dashboardsV2/datasetConfig/base.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/base.tsx
@@ -22,10 +22,13 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
    */
   defaultWidgetQuery: WidgetQuery;
   /**
+   * List of supported display types for dataset.
+   */
+  supportedDisplayTypes: DisplayType[];
+  /**
    * Transforms table API results into format that is used by
    * table and big number components.
    */
-  supportedDisplayTypes: DisplayType[];
   transformTable: (
     data: TableResponse,
     widgetQuery: WidgetQuery,

--- a/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
@@ -18,7 +18,7 @@ import {
 import {getShortEventId} from 'sentry/utils/events';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
-import {WidgetQuery} from '../types';
+import {DisplayType, WidgetQuery} from '../types';
 import {
   flattenMultiSeriesDataWithGrouping,
   transformSeries,
@@ -44,6 +44,15 @@ export const ErrorsAndTransactionsConfig: DatasetConfig<
 > = {
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   getCustomFieldRenderer: getCustomEventsFieldRenderer,
+  supportedDisplayTypes: [
+    DisplayType.AREA,
+    DisplayType.BAR,
+    DisplayType.BIG_NUMBER,
+    DisplayType.LINE,
+    DisplayType.TABLE,
+    DisplayType.TOP_N,
+    DisplayType.WORLD_MAP,
+  ],
   transformSeries: transformEventsResponseToSeries,
   transformTable: transformEventsResponseToTable,
 };

--- a/static/app/views/dashboardsV2/datasetConfig/issues.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/issues.tsx
@@ -6,7 +6,7 @@ import {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {queryToObj} from 'sentry/utils/stream';
 import {DISCOVER_EXCLUSION_FIELDS, IssueSortOptions} from 'sentry/views/issueList/utils';
 
-import {WidgetQuery} from '../types';
+import {DisplayType, WidgetQuery} from '../types';
 import {ISSUE_FIELD_TO_HEADER_MAP} from '../widgetBuilder/issueWidget/fields';
 
 import {ContextualProps, DatasetConfig} from './base';
@@ -25,6 +25,7 @@ export const IssuesConfig: DatasetConfig<never, Group[]> = {
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   getCustomFieldRenderer: getIssueFieldRenderer,
   fieldHeaderMap: ISSUE_FIELD_TO_HEADER_MAP,
+  supportedDisplayTypes: [DisplayType.TABLE],
   transformTable: transformIssuesResponseToTable,
 };
 

--- a/static/app/views/dashboardsV2/datasetConfig/releases.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/releases.tsx
@@ -7,7 +7,7 @@ import {defined} from 'sentry/utils';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 
-import {WidgetQuery} from '../types';
+import {DisplayType, WidgetQuery} from '../types';
 import {DERIVED_STATUS_METRICS_PATTERN} from '../widgetBuilder/releaseWidget/fields';
 import {
   derivedMetricsToField,
@@ -38,6 +38,14 @@ export const ReleasesConfig: DatasetConfig<
 > = {
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   getCustomFieldRenderer: (field, meta) => getFieldRenderer(field, meta, false),
+  supportedDisplayTypes: [
+    DisplayType.AREA,
+    DisplayType.BAR,
+    DisplayType.BIG_NUMBER,
+    DisplayType.LINE,
+    DisplayType.TABLE,
+    DisplayType.TOP_N,
+  ],
   transformSeries: transformSessionsResponseToSeries,
   transformTable: transformSessionsResponseToTable,
 };

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -452,18 +452,6 @@ function WidgetBuilder({
       }
 
       if (!prevState.userHasModified) {
-        // If the Widget is an issue widget
-        // TODO: Remove this block?
-        if (
-          newDisplayType === DisplayType.TABLE &&
-          widgetToBeUpdated?.widgetType === WidgetType.ISSUE
-        ) {
-          set(newState, 'queries', widgetToBeUpdated.queries);
-          set(newState, 'dataSet', DataSet.ISSUES);
-          setDataSetConfig(getDatasetConfig(WidgetType.ISSUE));
-          return {...newState, errors: undefined};
-        }
-
         // Default widget provided by Add to Dashboard from Discover
         if (defaultWidgetQuery && defaultTableColumns) {
           // If switching to Table visualization, use saved query fields for Y-Axis if user has not made query changes
@@ -496,12 +484,6 @@ function WidgetBuilder({
             });
           }
         }
-      }
-
-      // TODO: Remove this block?
-      if (prevState.dataSet === DataSet.ISSUES) {
-        set(newState, 'dataSet', DataSet.EVENTS);
-        setDataSetConfig(getDatasetConfig(WidgetType.DISCOVER));
       }
 
       set(newState, 'queries', normalized);


### PR DESCRIPTION
Use supported display types to clean up display type
on change handler allowing us to remove if/else
conditions around datasets from 
`updateFieldsAccordingToDisplayType`