### PR TITLE
ref(icon-update): remove unused fill and update categories

### DIFF
--- a/docs-ui/stories/assets/icons/data.tsx
+++ b/docs-ui/stories/assets/icons/data.tsx
@@ -168,7 +168,11 @@ export const icons: IconData[] = [
   {id: 'sync', groups: ['action'], keywords: ['swap']},
   {id: 'menu', groups: ['action'], keywords: ['navigate']},
   {id: 'list', groups: ['action'], keywords: ['item']},
-  {id: 'dashboard', groups: ['action'], keywords: ['overview', 'group', 'organize']},
+  {
+    id: 'dashboard',
+    groups: ['product'],
+    keywords: ['overview', 'group', 'organize', 'widgets'],
+  },
   {
     id: 'upgrade',
     groups: ['action'],
@@ -181,7 +185,7 @@ export const icons: IconData[] = [
   },
   {
     id: 'return',
-    groups: ['action'],
+    groups: ['device'],
     keywords: ['enter'],
   },
   {
@@ -235,7 +239,7 @@ export const icons: IconData[] = [
   },
   {
     id: 'stats',
-    groups: ['product', 'chart'],
+    groups: ['product'],
     keywords: ['bar', 'graph'],
   },
   {
@@ -265,7 +269,7 @@ export const icons: IconData[] = [
   },
   {
     id: 'print',
-    groups: ['action', 'device'],
+    groups: ['device'],
     keywords: [],
   },
   {
@@ -305,29 +309,28 @@ export const icons: IconData[] = [
   },
   {
     id: 'stack',
-    groups: ['action'],
+    groups: ['chart'],
     keywords: ['group', 'combine', 'view'],
   },
   {
     id: 'span',
-    groups: ['device'],
+    groups: ['chart'],
     keywords: ['performance', 'transaction'],
   },
   {
     id: 'link',
-    groups: ['action', 'device'],
+    groups: ['action'],
     keywords: ['hyperlink', 'anchor'],
   },
   {
     id: 'attachment',
-    groups: ['device'],
+    groups: ['action'],
     keywords: ['include', 'clip'],
   },
   {
     id: 'location',
     groups: ['action'],
     keywords: ['pin', 'position', 'map'],
-    additionalProps: ['isSolid'],
   },
   {
     id: 'edit',
@@ -422,11 +425,6 @@ export const icons: IconData[] = [
     keywords: ['person', 'portrait'],
   },
   {
-    id: 'group',
-    groups: ['action'],
-    keywords: ['person', 'people'],
-  },
-  {
     id: 'chat',
     groups: ['action', 'action'],
     keywords: ['message', 'bubble'],
@@ -507,7 +505,6 @@ export const icons: IconData[] = [
     id: 'lightning',
     groups: ['product'],
     keywords: ['feature', 'new', 'fresh'],
-    additionalProps: ['isSolid'],
   },
   {
     id: 'business',
@@ -630,11 +627,6 @@ export const icons: IconData[] = [
     keywords: [''],
   },
   {
-    id: 'dashboard',
-    groups: ['product'],
-    keywords: ['widgets'],
-  },
-  {
     id: 'globe',
     groups: ['action'],
     keywords: ['international', 'global'],
@@ -642,16 +634,16 @@ export const icons: IconData[] = [
   {
     id: 'group',
     groups: ['action'],
-    keywords: ['users'],
+    keywords: ['users', 'person', 'people'],
   },
   {
     id: 'input',
-    groups: ['action'],
+    groups: ['device'],
     keywords: ['text'],
   },
   {
     id: 'number',
-    groups: ['action'],
+    groups: ['chart'],
     keywords: ['value'],
   },
   {

--- a/static/app/icons/iconLightning.tsx
+++ b/static/app/icons/iconLightning.tsx
@@ -1,27 +1,14 @@
-import {forwardRef, Fragment} from 'react';
+import {forwardRef} from 'react';
 
 import SvgIcon, {SVGIconProps} from './svgIcon';
 
-interface Props extends SVGIconProps {
-  isSolid?: boolean;
-}
-
-const IconLightning = forwardRef<SVGSVGElement, Props>(
-  ({isSolid = false, ...props}, ref) => {
-    return (
-      <SvgIcon {...props} ref={ref}>
-        {isSolid ? (
-          <Fragment>
-            <path d="M3.81,16a1.21,1.21,0,0,1-.74-.26,1.19,1.19,0,0,1-.33-1.45L4.79,10,2.32,8.39a1,1,0,0,1-.07-1.58L10.67.26a1.19,1.19,0,0,1,1.8,1.46L10.41,6,12.9,7.64a1,1,0,0,1,.44.78,1,1,0,0,1-.38.8L4.54,15.74A1.15,1.15,0,0,1,3.81,16Z" />
-            <path d="M12.08,8.9Z" />
-          </Fragment>
-        ) : (
-          <path d="M3.81,16a1.21,1.21,0,0,1-.74-.26,1.19,1.19,0,0,1-.33-1.45L4.79,10,2.32,8.39a1,1,0,0,1-.07-1.58L10.67.26a1.19,1.19,0,0,1,1.8,1.46L10.41,6,12.9,7.64a1,1,0,0,1,.44.78,1,1,0,0,1-.38.8L4.54,15.74A1.15,1.15,0,0,1,3.81,16ZM3.76,7.53l2.4,1.56a.77.77,0,0,1,.27,1L4.65,13.76l6.81-5.27L9,6.91a.75.75,0,0,1-.26-1l1.78-3.71ZM12.08,8.9Zm-.95-8h0Z" />
-        )}
-      </SvgIcon>
-    );
-  }
-);
+const IconLightning = forwardRef<SVGSVGElement, SVGIconProps>((props, ref) => {
+  return (
+    <SvgIcon {...props} ref={ref}>
+      <path d="M3.81,16a1.21,1.21,0,0,1-.74-.26,1.19,1.19,0,0,1-.33-1.45L4.79,10,2.32,8.39a1,1,0,0,1-.07-1.58L10.67.26a1.19,1.19,0,0,1,1.8,1.46L10.41,6,12.9,7.64a1,1,0,0,1,.44.78,1,1,0,0,1-.38.8L4.54,15.74A1.15,1.15,0,0,1,3.81,16ZM3.76,7.53l2.4,1.56a.77.77,0,0,1,.27,1L4.65,13.76l6.81-5.27L9,6.91a.75.75,0,0,1-.26-1l1.78-3.71ZM12.08,8.9Zm-.95-8h0Z" />
+    </SvgIcon>
+  );
+});
 
 IconLightning.displayName = 'IconLightning';
 

--- a/static/app/icons/iconLocation.tsx
+++ b/static/app/icons/iconLocation.tsx
@@ -1,27 +1,15 @@
-import {forwardRef, Fragment} from 'react';
+import {forwardRef} from 'react';
 
 import SvgIcon, {SVGIconProps} from './svgIcon';
 
-interface Props extends SVGIconProps {
-  isSolid?: boolean;
-}
-
-const IconLocation = forwardRef<SVGSVGElement, Props>(
-  ({isSolid = false, ...props}, ref) => {
-    return (
-      <SvgIcon {...props} ref={ref}>
-        {isSolid ? (
-          <path d="M8,16a.74.74,0,0,1-.45-.15c-4-3-6.09-6.16-6.09-9.29A6.55,6.55,0,0,1,8,0a6.54,6.54,0,0,1,6.54,6.54c0,3.14-2,6.26-6.09,9.29A.74.74,0,0,1,8,16ZM8,4.05a2,2,0,1,0,2,2A2,2,0,0,0,8,4.05Z" />
-        ) : (
-          <Fragment>
-            <path d="M8,16a.74.74,0,0,1-.45-.15c-4-3-6.09-6.16-6.09-9.29A6.55,6.55,0,0,1,8,0a6.54,6.54,0,0,1,6.54,6.54c0,3.14-2,6.26-6.09,9.29A.74.74,0,0,1,8,16ZM8,1.51a5,5,0,0,0-5,5c0,2.53,1.69,5.13,5,7.74,3.34-2.61,5-5.21,5-7.74a5,5,0,0,0-5-5Z" />
-            <path d="M8,8.85a2.78,2.78,0,1,1,2.77-2.77A2.78,2.78,0,0,1,8,8.85Zm0-4A1.28,1.28,0,1,0,9.27,6.08,1.27,1.27,0,0,0,8,4.8Z" />
-          </Fragment>
-        )}
-      </SvgIcon>
-    );
-  }
-);
+const IconLocation = forwardRef<SVGSVGElement, SVGIconProps>((props, ref) => {
+  return (
+    <SvgIcon {...props} ref={ref}>
+      <path d="M8,16a.74.74,0,0,1-.45-.15c-4-3-6.09-6.16-6.09-9.29A6.55,6.55,0,0,1,8,0a6.54,6.54,0,0,1,6.54,6.54c0,3.14-2,6.26-6.09,9.29A.74.74,0,0,1,8,16ZM8,1.51a5,5,0,0,0-5,5c0,2.53,1.69,5.13,5,7.74,3.34-2.61,5-5.21,5-7.74a5,5,0,0,0-5-5Z" />
+      <path d="M8,8.85a2.78,2.78,0,1,1,2.77-2.77A2.78,2.78,0,0,1,8,8.85Zm0-4A1.28,1.28,0,1,0,9.27,6.08,1.27,1.27,0,0,0,8,4.8Z" />
+    </SvgIcon>
+  );
+});
 
 IconLocation.displayName = 'IconLocation';
 


### PR DESCRIPTION
- Removed duplicates in storybook docs
- Removed filled location and filled lightning
- Moved icons to categories to match Figma

![Screen Shot 2022-06-13 at 12 15 40 PM](https://user-images.githubusercontent.com/4830259/173427942-4aa7546e-0c3b-40c4-b48c-9af2f1872691.png)

