### PR TITLE
feat(api): Create endpoint to retrieve a list of commits for a project

### DIFF
--- a/src/sentry/api/endpoints/project_commits.py
+++ b/src/sentry/api/endpoints/project_commits.py
@@ -1,0 +1,42 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.models import ReleaseCommit
+from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
+
+
+class ProjectCommitsEndpoint(ProjectEndpoint):
+    permission_classes = (ProjectReleasePermission,)
+    rate_limits = RateLimitConfig(
+        group="CLI", limit_overrides={"GET": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}
+    )
+
+    def get(self, request: Request, project) -> Response:
+        """
+        List a Project's Commits
+        `````````````````````````
+
+        Retrieve a list of commits for a given project.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          commit belongs to.
+        :pparam string project_slug: the slug of the project to list the
+                                     commits of.
+        """
+
+        try:
+            queryset = ReleaseCommit.objects.filter(
+                organization_id=project.organization_id, project_id=project.id
+            )
+        except ReleaseCommit.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by="order",
+            on_results=lambda x: serialize([rc.commit for rc in x], request.user),
+        )

--- a/src/sentry/api/endpoints/project_commits.py
+++ b/src/sentry/api/endpoints/project_commits.py
@@ -2,9 +2,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.models import ReleaseCommit
+from sentry.models import Commit
 
 
 class ProjectCommitsEndpoint(ProjectEndpoint):
@@ -24,16 +23,13 @@ class ProjectCommitsEndpoint(ProjectEndpoint):
                                      commits of.
         """
 
-        try:
-            queryset = ReleaseCommit.objects.filter(
-                organization_id=project.organization_id, project_id=project.id
-            )
-        except ReleaseCommit.DoesNotExist:
-            raise ResourceDoesNotExist
+        queryset = Commit.objects.filter(
+            organization_id=project.organization_id, releasecommit__project_id=project.id
+        ).distinct("id")
 
         return self.paginate(
             request=request,
             queryset=queryset,
-            order_by="order",
-            on_results=lambda x: serialize([rc.commit for rc in x], request.user),
+            order_by="id",
+            on_results=lambda x: serialize(x, request.user),
         )

--- a/src/sentry/api/endpoints/project_commits.py
+++ b/src/sentry/api/endpoints/project_commits.py
@@ -5,14 +5,11 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models import ReleaseCommit
-from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
 
 
 class ProjectCommitsEndpoint(ProjectEndpoint):
+    private = True
     permission_classes = (ProjectReleasePermission,)
-    rate_limits = RateLimitConfig(
-        group="CLI", limit_overrides={"GET": SENTRY_RATELIMITER_GROUP_DEFAULTS["default"]}
-    )
 
     def get(self, request: Request, project) -> Response:
         """

--- a/src/sentry/api/endpoints/project_commits.py
+++ b/src/sentry/api/endpoints/project_commits.py
@@ -2,6 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import Commit
 
@@ -24,12 +25,14 @@ class ProjectCommitsEndpoint(ProjectEndpoint):
         """
 
         queryset = Commit.objects.filter(
-            organization_id=project.organization_id, releasecommit__project_id=project.id
+            organization_id=project.organization_id,
+            releasecommit__release__releaseproject__project_id=project.id,
         ).distinct("id")
 
         return self.paginate(
             request=request,
             queryset=queryset,
-            order_by="id",
+            order_by=("-id", "-date_added"),
             on_results=lambda x: serialize(x, request.user),
+            paginator_cls=OffsetPaginator,
         )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -354,6 +354,7 @@ from .endpoints.project_app_store_connect_credentials import (
     AppStoreConnectStatusEndpoint,
     AppStoreConnectUpdateCredentialsEndpoint,
 )
+from .endpoints.project_commits import ProjectCommitsEndpoint
 from .endpoints.project_create_sample import ProjectCreateSampleEndpoint
 from .endpoints.project_create_sample_transaction import ProjectCreateSampleTransactionEndpoint
 from .endpoints.project_details import ProjectDetailsEndpoint
@@ -1942,6 +1943,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/$",
                     ProjectReleasesEndpoint.as_view(),
                     name="sentry-api-0-project-releases",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/commits/$",
+                    ProjectCommitsEndpoint.as_view(),
+                    name="sentry-api-0-project-commits",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/token/$",

--- a/tests/sentry/api/endpoints/test_project_commits.py
+++ b/tests/sentry/api/endpoints/test_project_commits.py
@@ -10,12 +10,40 @@ class ProjectCommitListTest(APITestCase):
         version = "1.1"
         repo = Repository.objects.create(organization_id=project.organization_id, name=project.name)
         release = Release.objects.create(organization_id=project.organization_id, version=version)
+        commit = self.create_commit(repo=repo, project=project, key="a" * 40, release=release)
+
+        url = reverse(
+            "sentry-api-0-project-commits",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data[0]["id"] == commit.key
+
+    def test_duplicate_commits(self):
+        project = self.create_project(name="komal")
+        repo = Repository.objects.create(organization_id=project.organization_id, name=project.name)
+        release = Release.objects.create(organization_id=project.organization_id, version="1.1")
+        release2 = Release.objects.create(organization_id=project.organization_id, version="1.2")
+
         commit = Commit.objects.create(
             organization_id=project.organization_id, repository_id=repo.id, key="a" * 40
         )
+
         ReleaseCommit.objects.create(
             organization_id=project.organization_id,
             release=release,
+            commit=commit,
+            order=0,
+            project_id=project.id,
+        )
+
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            release=release2,
             commit=commit,
             order=0,
             project_id=project.id,
@@ -30,4 +58,4 @@ class ProjectCommitListTest(APITestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert response.data[0]["id"] == commit.key
+        assert len(response.data) == 1

--- a/tests/sentry/api/endpoints/test_project_commits.py
+++ b/tests/sentry/api/endpoints/test_project_commits.py
@@ -1,0 +1,33 @@
+from django.urls import reverse
+
+from sentry.models import Commit, Release, ReleaseCommit, Repository
+from sentry.testutils import APITestCase
+
+
+class ProjectCommitListTest(APITestCase):
+    def test_simple(self):
+        project = self.create_project(name="komal")
+        version = "1.1"
+        repo = Repository.objects.create(organization_id=project.organization_id, name=project.name)
+        release = Release.objects.create(organization_id=project.organization_id, version=version)
+        commit = Commit.objects.create(
+            organization_id=project.organization_id, repository_id=repo.id, key="a" * 40
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            release=release,
+            commit=commit,
+            order=0,
+            project_id=project.id,
+        )
+
+        url = reverse(
+            "sentry-api-0-project-commits",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data[0]["id"] == commit.key


### PR DESCRIPTION
Created an endpoint to retrieve a list of released commits for a specific project.

Changes made:
- `project_commits.py`: Created `ProjectCommitsEndpoint` in which I query on the `ReleaseCommit` table using the  `organization_id` and `project_id`
- `test_project_commits.py`: A simple test case that creates a project with a released commit, and asserts on the response status code 
