### PR TITLE
ref(tests) Try disabling internal error collection

### DIFF
--- a/src/sentry/utils/pytest/relay.py
+++ b/src/sentry/utils/pytest/relay.py
@@ -43,6 +43,8 @@ def _remove_container_if_exists(docker_client, container_name):
             container.remove()
         except Exception:
             pass  # could not remove the container nothing to do about it
+    finally:
+        docker_client.close()
 
 
 @pytest.fixture(scope="session")
@@ -100,6 +102,8 @@ def relay_server_setup(live_server, tmpdir_factory):
     docker_client = get_docker_client()
     container_name = _relay_server_container_name()
     _remove_container_if_exists(docker_client, container_name)
+    docker_client.close()
+
     options = {
         "image": RELAY_TEST_IMAGE,
         "ports": {"%s/tcp" % relay_port: relay_port},
@@ -117,6 +121,7 @@ def relay_server_setup(live_server, tmpdir_factory):
 
     # cleanup
     shutil.rmtree(config_path)
+    docker_client = get_docker_client()
     _remove_container_if_exists(docker_client, container_name)
 
 

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -117,6 +117,12 @@ def pytest_configure(config):
     settings.DEBUG_VIEWS = True
     settings.SERVE_UPLOADED_FILES = True
 
+    # Disable internal error collection during tests.
+    settings.SENTRY_PROJECT = None
+    settings.SENTRY_PROJECT_KEY = None
+
+    settings.SENTRY_ENCRYPTION_SCHEMES = ()
+
     settings.CACHES = {
         "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
         "nodedata": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 import sentry_sdk
+from django.test.utils import override_settings
 from sentry_sdk import Hub, push_scope
 
 from sentry import eventstore
@@ -16,6 +17,7 @@ from sentry.utils.sdk import bind_organization_context, configure_sdk
 def post_event_with_sdk(settings, relay_server, wait_for_ingest_consumer):
     adjust_settings_for_relay_tests(settings)
     settings.SENTRY_ENDPOINT = relay_server["url"]
+    settings.SENTRY_PROJECT = 1
 
     configure_sdk()
 
@@ -33,9 +35,9 @@ def post_event_with_sdk(settings, relay_server, wait_for_ingest_consumer):
     return inner
 
 
+@override_settings(SENTRY_PROJECT=1)
 @pytest.mark.django_db
 def test_simple(settings, post_event_with_sdk):
-    settings.SENTRY_PROJECT = 1
     event = post_event_with_sdk({"message": "internal client test"})
 
     assert event
@@ -43,6 +45,7 @@ def test_simple(settings, post_event_with_sdk):
     assert event.data["logentry"]["formatted"] == "internal client test"
 
 
+@override_settings(SENTRY_PROJECT=1)
 @pytest.mark.django_db
 def test_recursion_breaker(settings, post_event_with_sdk):
     # If this test terminates at all then we avoided recursion.
@@ -60,9 +63,8 @@ def test_recursion_breaker(settings, post_event_with_sdk):
 
 
 @pytest.mark.django_db
+@override_settings(SENTRY_PROJECT=1)
 def test_encoding(settings, post_event_with_sdk):
-    settings.SENTRY_PROJECT = 1
-
     class NotJSONSerializable:
         pass
 
@@ -75,9 +77,9 @@ def test_encoding(settings, post_event_with_sdk):
     assert "NotJSONSerializable" in event.data["extra"]["request"]
 
 
+@override_settings(SENTRY_PROJECT=1)
 @pytest.mark.django_db
-def test_bind_organization_context(settings, default_organization):
-    settings.SENTRY_PROJECT = 1
+def test_bind_organization_context(default_organization):
 
     configure_sdk()
 
@@ -91,10 +93,9 @@ def test_bind_organization_context(settings, default_organization):
     }
 
 
+@override_settings(SENTRY_PROJECT=1)
 @pytest.mark.django_db
 def test_bind_organization_context_with_callback(settings, default_organization):
-    settings.SENTRY_PROJECT = 1
-
     configure_sdk()
 
     def add_context(scope, organization, **kwargs):
@@ -106,10 +107,9 @@ def test_bind_organization_context_with_callback(settings, default_organization)
     assert Hub.current.scope._tags["organization.test"] == "1"
 
 
+@override_settings(SENTRY_PROJECT=1)
 @pytest.mark.django_db
 def test_bind_organization_context_with_callback_error(settings, default_organization):
-    settings.SENTRY_PROJECT = 1
-
     configure_sdk()
 
     def add_context(scope, organization, **kwargs):

--- a/tests/sentry/receivers/test_core.py
+++ b/tests/sentry/receivers/test_core.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from django.conf import settings
+from django.test.utils import override_settings
 
 from sentry.models import Organization, Project, ProjectKey, Team, User
 from sentry.receivers.core import DEFAULT_SENTRY_PROJECT_ID, create_default_projects
@@ -7,6 +8,7 @@ from sentry.testutils import TestCase
 
 
 class CreateDefaultProjectsTest(TestCase):
+    @override_settings(SENTRY_PROJECT=1)
     def test_simple(self):
         user, _ = User.objects.get_or_create(is_superuser=True, defaults={"username": "test"})
         Organization.objects.all().delete()
@@ -29,6 +31,7 @@ class CreateDefaultProjectsTest(TestCase):
         # ensure that we don't hit an error here
         create_default_projects(config)
 
+    @override_settings(SENTRY_PROJECT=1)
     def test_without_user(self):
         User.objects.filter(is_superuser=True).delete()
         Team.objects.filter(slug="sentry").delete()


### PR DESCRIPTION
I've noticed that when tests have problems our test output gets cluttered with timeouts from the python SDK trying to submit errors back to a host that doesn't exist or isn't responding.

My hope is that by disabling the internal project key we can skip all of that and have faster, less noisy tests.