### PR TITLE
fix(breadcrumb): Fix overflowEllipsis interpolation

### DIFF
--- a/static/app/components/breadcrumbs.tsx
+++ b/static/app/components/breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {LocationDescriptor} from 'history';
 
@@ -136,8 +137,8 @@ const Breadcrumbs = ({crumbs, linkLastItem = false, ...props}: Props) => {
   );
 };
 
-const getBreadcrumbListItemStyles = (p: {theme: Theme}) => `
-  ${p.theme.overflowEllipsis};
+const getBreadcrumbListItemStyles = (p: {theme: Theme}) => css`
+  ${p.theme.overflowEllipsis}
   color: ${p.theme.gray300};
   width: auto;
 


### PR DESCRIPTION
Fix an `emotion` interpolation error that leads to the `overflowEllipsis` not working in `Breadcrumbs`. This happens because the new `overflowEllipsis` in theme (https://github.com/getsentry/sentry/pull/33924) is an `emotion` `css` object, not a string like before. This issue doesn't seem to affect any other component.

**Before:**
<img width="386" alt="Screen Shot 2022-06-13 at 3 55 08 PM" src="https://user-images.githubusercontent.com/44172267/173460960-014e9483-ced3-4cac-b996-d7d9882793e8.png">

**After:**
<img width="386" alt="Screen Shot 2022-06-13 at 3 54 25 PM" src="https://user-images.githubusercontent.com/44172267/173460972-0889ad05-bc6e-4580-a6f8-f919aa480e29.png">

