### PR TITLE
chore(django-3.2): Upgrade django-pg-zero-downtime-migrations

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -10,7 +10,7 @@ croniter==0.3.37
 datadog==0.29.3
 django-crispy-forms==1.14.0
 django-picklefield==2.1.0
-django-pg-zero-downtime-migrations==0.10
+django-pg-zero-downtime-migrations==0.11
 Django==2.2.28
 djangorestframework==3.12.4
 drf-spectacular==0.22.1


### PR DESCRIPTION
Version 0.11 adds support for django 3.2 and has no breaking changes
