### PR TITLE
feat(mep): Use snql to create metric alerts

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -993,6 +993,8 @@ SENTRY_FEATURES = {
     "organizations:issue-search-use-cdc-secondary": False,
     # Enable metrics feature on the backend
     "organizations:metrics": False,
+    # Use SNQL to create metric alerts, and perform other snuba queries related to metric alerts
+    "organizations:metric-alert-snql": True,
     # Enable metric alert charts in email/slack
     "organizations:metric-alert-chartcuterie": False,
     # Enable the new widget builder experience on Dashboards

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -87,6 +87,7 @@ default_manager.add("organizations:issue-search-use-cdc-primary", OrganizationFe
 default_manager.add("organizations:issue-search-use-cdc-secondary", OrganizationFeature, True)
 default_manager.add("organizations:large-debug-files", OrganizationFeature)
 default_manager.add("organizations:metric-alert-threshold-period", OrganizationFeature, True)
+default_manager.add("organizations:metric-alert-snql", OrganizationFeature, True)
 default_manager.add("organizations:metrics", OrganizationFeature, True)
 default_manager.add("organizations:metric-alert-chartcuterie", OrganizationFeature, True)
 default_manager.add("organizations:new-widget-builder-experience", OrganizationFeature, True)

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -185,7 +185,10 @@ def _create_in_snuba(subscription: QuerySubscription) -> str:
     )
     # TODO: Once metrics work with `QueryBuilder` then use `build_snql_query` by default for all
     # datasets
-    if features.has("organizations:metric-alert-snql") and dataset != QueryDatasets.METRICS:
+    if (
+        features.has("organizations:metric-alert-snql", subscription.project.organization)
+        and dataset != QueryDatasets.METRICS
+    ):
         snql_query = build_snql_query(
             entity_subscription,
             snuba_query.query,

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -47,6 +47,7 @@ class OrganizationSerializerTest(TestCase):
             "integrations-ticket-rules",
             "invite-members",
             "invite-members-rate-limits",
+            "metric-alert-snql",
             "minute-resolution-sessions",
             "open-membership",
             "relay",

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -129,9 +129,8 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
         )
         with patch.object(_snuba_pool, "urlopen", side_effect=_snuba_pool.urlopen) as urlopen:
             create_subscription_in_snuba(sub.id)
-            assert ["group_id", "IN", [group_id]] in json.loads(urlopen.call_args[1]["body"])[
-                "conditions"
-            ]
+            request_body = json.loads(urlopen.call_args[1]["body"])
+            assert f"group_id = {group_id}" in request_body["query"]
         sub = QuerySubscription.objects.get(id=sub.id)
         assert sub.status == QuerySubscription.Status.ACTIVE.value
         assert sub.subscription_id is not None
@@ -156,7 +155,7 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
 
             create_subscription_in_snuba(sub.id)
             request_body = json.loads(pool.urlopen.call_args[1]["body"])
-            assert ["type", "=", "error"] in request_body["conditions"]
+            assert "type = 'error'" in request_body["query"]
 
     @responses.activate
     def test_granularity_on_metrics_crash_rate_alerts(self):


### PR DESCRIPTION
This switches `_create_in_snuba` to create metric alerts using `build_snql_query` instead of
`build_snuba_filter`. I've put this behind a switch so that it's easy to revert if we notice
problems.

We can't switch `METRICS` alerts over yet because `QueryBuilder` doesn't support generating queries
for alerts.

The payload we pass to snuba is a lot smaller with these changes as well. Most of the values we pass
are no longer needed and were just there as part of a transitionary period on the snuba api.


