### PR TITLE
ref(projectconfig): Add missing metric tag

### DIFF
--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -234,7 +234,7 @@ def schedule_build_project_config(public_key=None, trigger="build"):
 
     metrics.incr(
         "relay.projectconfig_cache.scheduled",
-        tags={"update_reason": trigger},
+        tags={"update_reason": trigger, "task": "build"},
     )
     build_project_config.delay(public_key=public_key, trigger=trigger)
 


### PR DESCRIPTION
This metric is emitted by both build and invalidation task, the
invalidation one already has this tag.

