### PR TITLE
ref(virtualizedtree): compute startindex and avoid wasteful iterations

### DIFF
--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -712,9 +712,6 @@ export function useVirtualizedTree<T extends TreeLike>(
     return {height, maxHeight: height, overflow: 'hidden'};
   }, [tree.flattened.length, props.rowHeight]);
 
-  // It is important that this is not executed from a map function because
-  // we are assigning the refs to each individual item. If we do that,
-  // we lose access to the refs and cannot call focus or scrollIntoView on them
   const renderRow = props.renderRow;
   const renderedItems: React.ReactNode[] = useMemo(() => {
     const renderered: React.ReactNode[] = [];

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -138,6 +138,67 @@ function updateGhostRow({
   ref.current.style.transform = `translateY(${rowHeight * tabIndexKey - scrollTop}px)`;
   ref.current.style.opacity = '1';
 }
+function findVisibleItems<T extends TreeLike>({
+  items,
+  overscroll,
+  rowHeight,
+  scrollHeight,
+  scrollTop,
+}: {
+  items: VirtualizedTreeNode<T>[];
+  overscroll: NonNullable<UseVirtualizedListProps<T>['overscroll']>;
+  rowHeight: UseVirtualizedListProps<T>['rowHeight'];
+  scrollHeight: VirtualizedState<T>['scrollHeight'];
+  scrollTop: VirtualizedState<T>['scrollTop'];
+}) {
+  // This is overscroll height for single direction, when computing the total,
+  // we need to multiply this by 2 because we overscroll in both directions.
+  const OVERSCROLL_HEIGHT = overscroll * rowHeight;
+
+  const visibleItems: VisibleItem<T>[] = [];
+
+  // Clamp viewport to scrollHeight bounds [0, length * rowHeight] because some browsers may fire
+  // scrollTop with negative values when the user scrolls up past the top of the list (overscroll behavior)
+  const viewport = {
+    top: Math.max(scrollTop - OVERSCROLL_HEIGHT, 0),
+    bottom: Math.min(
+      scrollTop + scrollHeight + OVERSCROLL_HEIGHT,
+      items.length * rowHeight
+    ),
+  };
+
+  // Points to the position inside the visible array
+  let visibleItemIndex = 0;
+  // Points to the currently iterated item
+  let indexPointer = 0;
+
+  // Max number of visible items in our list
+  const MAX_VISIBLE_ITEMS = Math.ceil((scrollHeight + OVERSCROLL_HEIGHT * 2) / rowHeight);
+  const ALL_ITEMS = items.length;
+
+  // While number of visible items is less than max visible items, and we haven't reached the end of the list
+  while (visibleItemIndex < MAX_VISIBLE_ITEMS && indexPointer < ALL_ITEMS) {
+    const elementTop = indexPointer * rowHeight;
+    const elementBottom = elementTop + rowHeight;
+
+    // An element is inside a viewport if the top of the element is below the top of the viewport
+    // and the bottom of the element is above the bottom of the viewport
+    if (elementTop >= viewport.top && elementBottom <= viewport.bottom) {
+      visibleItems[visibleItemIndex] = {
+        key: indexPointer,
+        ref: null,
+        styles: {position: 'absolute', top: elementTop},
+        item: items[indexPointer],
+      };
+
+      visibleItemIndex++;
+    }
+    indexPointer++;
+  }
+
+  return visibleItems;
+}
+
 interface VisibleItem<T> {
   item: VirtualizedTreeNode<T>;
   key: number;
@@ -251,56 +312,15 @@ export function useVirtualizedTree<T extends TreeLike>(
     setTree(newTree);
   }, [props.roots, props.skipFunction]);
 
-  const {rowHeight, renderRow} = props;
   const items = useMemo(() => {
-    // This is overscroll height for single direction, when computing the total,
-    // we need to multiply this by 2 because we overscroll in both directions.
-    const OVERSCROLL_HEIGHT = state.overscroll * rowHeight;
-
-    const visibleItems: VisibleItem<T>[] = [];
-
-    // Clamp viewport to scrollHeight bounds [0, length * rowHeight] because some browsers may fire
-    // scrollTop with negative values when the user scrolls up past the top of the list (overscroll behavior)
-    const viewport = {
-      top: Math.max(state.scrollTop - OVERSCROLL_HEIGHT, 0),
-      bottom: Math.min(
-        state.scrollTop + state.scrollHeight + OVERSCROLL_HEIGHT,
-        tree.flattened.length * rowHeight
-      ),
-    };
-
-    // Points to the position inside the visible array
-    let visibleItemIndex = 0;
-    // Points to the currently iterated item
-    let indexPointer = 0;
-
-    // Max number of visible items in our list
-    const MAX_VISIBLE_ITEMS = Math.ceil(
-      (state.scrollHeight + OVERSCROLL_HEIGHT * 2) / rowHeight
-    );
-    const ALL_ITEMS = tree.flattened.length;
-
-    // While number of visible items is less than max visible items, and we haven't reached the end of the list
-    while (visibleItemIndex < MAX_VISIBLE_ITEMS && indexPointer < ALL_ITEMS) {
-      const elementTop = indexPointer * rowHeight;
-      const elementBottom = elementTop + rowHeight;
-
-      // An element is inside a viewport if the top of the element is below the top of the viewport
-      // and the bottom of the element is above the bottom of the viewport
-      if (elementTop >= viewport.top && elementBottom <= viewport.bottom) {
-        visibleItems[visibleItemIndex] = {
-          key: indexPointer,
-          ref: null,
-          styles: {position: 'absolute', top: elementTop},
-          item: tree.flattened[indexPointer],
-        };
-
-        visibleItemIndex++;
-      }
-      indexPointer++;
-    }
-    return visibleItems;
-  }, [tree, state.overscroll, state.scrollHeight, state.scrollTop, rowHeight]);
+    return findVisibleItems<T>({
+      items: tree.flattened,
+      scrollHeight: state.scrollHeight,
+      scrollTop: state.scrollTop,
+      overscroll: state.overscroll,
+      rowHeight: props.rowHeight,
+    });
+  }, [tree, state.overscroll, state.scrollHeight, state.scrollTop, props.rowHeight]);
 
   const latestItemsRef = useRef(items);
   latestItemsRef.current = items;
@@ -668,6 +688,10 @@ export function useVirtualizedTree<T extends TreeLike>(
     return {height, maxHeight: height, overflow: 'hidden'};
   }, [tree.flattened.length, props.rowHeight]);
 
+  // It is important that this is not executed from a map function because
+  // we are assigning the refs to each individual item. If we do that,
+  // we lose access to the refs and cannot call focus or scrollIntoView on them
+  const renderRow = props.renderRow;
   const renderedItems: React.ReactNode[] = useMemo(() => {
     const renderered: React.ReactNode[] = [];
 


### PR DESCRIPTION
Since we can rely on order of elements, there is no need to start searching for a first visible item by always starting from 0 and we can just compute the start