### PR TITLE
feat(team-roles): Add roleLists to DetailedOrganization (BE)

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 from rest_framework import serializers
 from sentry_relay.auth import PublicKey
@@ -12,7 +12,9 @@ from typing_extensions import TypedDict
 from sentry import features, roles
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models import UserSerializer
+from sentry.api.serializers.models.organization_member.response import RoleSerializerResponse
 from sentry.api.serializers.models.project import ProjectSerializerResponse
+from sentry.api.serializers.models.role import OrganizationRoleSerializer, TeamRoleSerializer
 from sentry.api.serializers.models.team import TeamSerializerResponse
 from sentry.app import quotas
 from sentry.auth.access import Access
@@ -265,7 +267,9 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     quota: Any
     isDefault: bool
     defaultRole: bool
-    availableRoles: list[Any]  # TODO replace with enum/literal
+    availableRoles: list[Any]  # TODO: deprecate, use orgRoleList
+    orgRoleList: List[RoleSerializerResponse]
+    teamRoleList: List[RoleSerializerResponse]
     openMembership: bool
     allowSharedIssues: bool
     enhancedPrivacy: bool
@@ -333,7 +337,13 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             {
                 "isDefault": obj.is_default,
                 "defaultRole": obj.default_role,
-                "availableRoles": [{"id": r.id, "name": r.name} for r in roles.get_all()],
+                "availableRoles": [
+                    {"id": r.id, "name": r.name} for r in roles.get_all()
+                ],  # Deprecated
+                "orgRoleList": serialize(roles.get_all(), serializer=OrganizationRoleSerializer()),
+                "teamRoleList": serialize(
+                    roles.team_roles.get_all(), serializer=TeamRoleSerializer()
+                ),
                 "openMembership": bool(obj.flags.allow_joinleave),
                 "require2FA": bool(obj.flags.require_2fa),
                 "requireEmailVerification": bool(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -12,9 +12,12 @@ from typing_extensions import TypedDict
 from sentry import features, roles
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models import UserSerializer
-from sentry.api.serializers.models.organization_member.response import RoleSerializerResponse
 from sentry.api.serializers.models.project import ProjectSerializerResponse
-from sentry.api.serializers.models.role import OrganizationRoleSerializer, TeamRoleSerializer
+from sentry.api.serializers.models.role import (
+    OrganizationRoleSerializer,
+    RoleSerializerResponse,
+    TeamRoleSerializer,
+)
 from sentry.api.serializers.models.team import TeamSerializerResponse
 from sentry.app import quotas
 from sentry.auth.access import Access

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -270,7 +270,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     quota: Any
     isDefault: bool
     defaultRole: bool
-    availableRoles: list[Any]  # TODO: deprecate, use orgRoleList
+    availableRoles: list[Any]  # TODO: deprecated, use orgRoleList
     orgRoleList: List[RoleSerializerResponse]
     teamRoleList: List[RoleSerializerResponse]
     openMembership: bool

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -89,6 +89,8 @@ class DetailedOrganizationSerializerTest(TestCase):
         assert result["role"] == "owner"
         assert result["access"] == settings.SENTRY_SCOPES
         assert result["relayPiiConfig"] is None
+        assert isinstance(result["orgRoleList"], list)
+        assert isinstance(result["teamRoleList"], list)
 
 
 class DetailedOrganizationSerializerWithProjectsAndTeamsTest(TestCase):


### PR DESCRIPTION
The list of organization roles is being used in other place, especially seeing that someone else had added `availableRoles` to `DetailedOrganization`. 