### PR TITLE
feat(perf): Add analytics for Event Details interactions

### DIFF
--- a/static/app/components/events/interfaces/spans/filter.tsx
+++ b/static/app/components/events/interfaces/spans/filter.tsx
@@ -8,6 +8,8 @@ import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {IconFilter} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
 
@@ -39,6 +41,8 @@ function Filter({
   toggleOperationNameFilter,
   toggleAllOperationNameFilters,
 }: Props) {
+  const organization = useOrganization();
+
   if (operationNameCounts.size === 0) {
     return null;
   }
@@ -103,6 +107,14 @@ function Filter({
               onClick={event => {
                 event.stopPropagation();
                 toggleAllOperationNameFilters();
+
+                trackAdvancedAnalyticsEvent(
+                  'performance_views.event_details.filter_by_op',
+                  {
+                    organization,
+                    operation: 'ALL',
+                  }
+                );
               }}
             />
           </Header>
@@ -123,6 +135,14 @@ function Filter({
                     onClick={event => {
                       event.stopPropagation();
                       toggleOperationNameFilter(operationName);
+
+                      trackAdvancedAnalyticsEvent(
+                        'performance_views.event_details.filter_by_op',
+                        {
+                          organization,
+                          operation: operationName,
+                        }
+                      );
                     }}
                   />
                 </ListItem>

--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -139,7 +139,8 @@ class SpansInterface extends PureComponent<Props, State> {
                           onClick={scrollToSpan(
                             spanId,
                             scrollToHash,
-                            this.props.location
+                            this.props.location,
+                            this.props.organization
                           )}
                         >
                           {operation}

--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -14,6 +14,7 @@ import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {EventTransaction} from 'sentry/types/event';
 import {objectIsEmpty} from 'sentry/utils';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import * as QuickTraceContext from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import {TraceError} from 'sentry/utils/performance/quickTrace/types';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -55,7 +56,13 @@ class SpansInterface extends PureComponent<Props, State> {
 
   handleSpanFilter = (searchQuery: string) => {
     const {waterfallModel} = this.state;
+    const {organization} = this.props;
     waterfallModel.querySpanSearch(searchQuery);
+
+    trackAdvancedAnalyticsEvent('performance_views.event_details.search_query', {
+      organization,
+      query: searchQuery,
+    });
   };
 
   renderTraceErrorsAlert({

--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -61,7 +61,6 @@ class SpansInterface extends PureComponent<Props, State> {
 
     trackAdvancedAnalyticsEvent('performance_views.event_details.search_query', {
       organization,
-      query: searchQuery,
     });
   };
 

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -376,7 +376,12 @@ class SpanDetail extends Component<Props, State> {
                     <SpanIdTitle>Span ID</SpanIdTitle>
                   ) : (
                     <SpanIdTitle
-                      onClick={scrollToSpan(span.span_id, scrollToHash, location)}
+                      onClick={scrollToSpan(
+                        span.span_id,
+                        scrollToHash,
+                        location,
+                        organization
+                      )}
                     >
                       Span ID
                       <StyledIconAnchor />

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -90,7 +90,6 @@ class SpanDetail extends Component<Props, State> {
     trackAdvancedAnalyticsEvent('performance_views.event_details.open_span_details', {
       organization,
       operation: span.op ?? 'undefined',
-      description: span.description ?? 'undefined',
     });
   }
 

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -35,6 +35,7 @@ import {Organization} from 'sentry/types';
 import {EventTransaction} from 'sentry/types/event';
 import {assert} from 'sentry/types/utils';
 import {defined} from 'sentry/utils';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 import getDynamicText from 'sentry/utils/getDynamicText';
@@ -79,6 +80,19 @@ class SpanDetail extends Component<Props, State> {
   state: State = {
     errorsOpened: false,
   };
+
+  componentDidMount() {
+    const {span, organization} = this.props;
+    if ('type' in span) {
+      return;
+    }
+
+    trackAdvancedAnalyticsEvent('performance_views.event_details.open_span_details', {
+      organization,
+      operation: span.op ?? 'undefined',
+      description: span.description ?? 'undefined',
+    });
+  }
 
   renderTraversalButton(): React.ReactNode {
     if (!this.props.childTransactions) {

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -9,8 +9,10 @@ import {
   TOGGLE_BORDER_BOX,
   TOGGLE_BUTTON_MAX_WIDTH,
 } from 'sentry/components/performance/waterfall/treeConnector';
+import {Organization} from 'sentry/types';
 import {EntryType, EventTransaction} from 'sentry/types/event';
 import {assert} from 'sentry/types/utils';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {getPerformanceTransaction} from 'sentry/utils/performanceForSentry';
 
@@ -659,7 +661,8 @@ export function getMeasurementBounds(
 export function scrollToSpan(
   spanId: string,
   scrollToHash: (hash: string) => void,
-  location: Location
+  location: Location,
+  organization: Organization
 ) {
   return (e: React.MouseEvent<Element>) => {
     // do not use the default anchor behaviour
@@ -677,6 +680,11 @@ export function scrollToSpan(
     browserHistory.push({
       ...location,
       hash,
+    });
+
+    trackAdvancedAnalyticsEvent('performance_views.event_details.anchor_span', {
+      organization,
+      span_id: spanId,
     });
   };
 }

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -20,12 +20,9 @@ export type PerformanceEventParameters = {
 
   'performance_views.event_details.json_button_click': {};
   'performance_views.event_details.open_span_details': {
-    description: string;
     operation: string;
   };
-  'performance_views.event_details.search_query': {
-    query: string;
-  };
+  'performance_views.event_details.search_query': {};
   'performance_views.landingv2.transactions.sort': {
     direction?: string;
     field?: string;

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -17,6 +17,8 @@ export type PerformanceEventParameters = {
   'performance_views.event_details.filter_by_op': {
     operation: string;
   };
+
+  'performance_views.event_details.json_button_click': {};
   'performance_views.event_details.open_span_details': {
     description: string;
     operation: string;
@@ -133,4 +135,6 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Event Details span details opened',
   'performance_views.event_details.anchor_span':
     'Performance Views: Event Details span anchored',
+  'performance_views.event_details.json_button_click':
+    'Performance Views: Event Details JSON button clicked',
 };

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -14,6 +14,10 @@ export type PerformanceEventParameters = {
   'performance_views.event_details.filter_by_op': {
     operation: string;
   };
+  'performance_views.event_details.open_span_details': {
+    description: string;
+    operation: string;
+  };
   'performance_views.event_details.search_query': {
     query: string;
   };
@@ -120,4 +124,6 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Event Details page operation filter applied',
   'performance_views.event_details.search_query':
     'Performance Views: Event Details search query',
+  'performance_views.event_details.open_span_details':
+    'Performance Views: Event Details span details opened',
 };

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -59,6 +59,7 @@ export type PerformanceEventParameters = {
   'performance_views.span_summary.change_chart': {
     change_to_display: string;
   };
+  'performance_views.span_summary.view': {};
   'performance_views.spans.change_op': {
     operation_name?: string;
   };
@@ -109,6 +110,7 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Landing Page Transactions Table Page Changed',
   'performance_views.span_summary.change_chart':
     'Performance Views: Span Summary displayed chart changed',
+  'performance_views.span_summary.view': 'Performance Views: Span Summary page viewed',
   'performance_views.spans.change_op': 'Performance Views: Change span operation name',
   'performance_views.spans.change_sort': 'Performance Views: Change span sort column',
   'performance_views.overview.view': 'Performance Views: Transaction overview view',

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -11,6 +11,9 @@ type PerformanceTourParams = {
 
 export type PerformanceEventParameters = {
   'performance_views.create_sample_transaction': SampleTransactionParam;
+  'performance_views.event_details.anchor_span': {
+    span_id: string;
+  };
   'performance_views.event_details.filter_by_op': {
     operation: string;
   };
@@ -126,4 +129,6 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Event Details search query',
   'performance_views.event_details.open_span_details':
     'Performance Views: Event Details span details opened',
+  'performance_views.event_details.anchor_span':
+    'Performance Views: Event Details span anchored',
 };

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -14,6 +14,9 @@ export type PerformanceEventParameters = {
   'performance_views.event_details.filter_by_op': {
     operation: string;
   };
+  'performance_views.event_details.search_query': {
+    query: string;
+  };
   'performance_views.landingv2.transactions.sort': {
     direction?: string;
     field?: string;
@@ -115,4 +118,6 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Trends Widget Duration Changed',
   'performance_views.event_details.filter_by_op':
     'Performance Views: Event Details page operation filter applied',
+  'performance_views.event_details.search_query':
+    'Performance Views: Event Details search query',
 };

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -11,6 +11,9 @@ type PerformanceTourParams = {
 
 export type PerformanceEventParameters = {
   'performance_views.create_sample_transaction': SampleTransactionParam;
+  'performance_views.event_details.filter_by_op': {
+    operation: string;
+  };
   'performance_views.landingv2.transactions.sort': {
     direction?: string;
     field?: string;
@@ -110,4 +113,6 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Trends Widget Page Changed',
   'performance_views.trends.change_duration':
     'Performance Views: Trends Widget Duration Changed',
+  'performance_views.event_details.filter_by_op':
+    'Performance Views: Event Details page operation filter applied',
 };

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -24,6 +24,7 @@ import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {Event, EventTag} from 'sentry/types/event';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
 import {formatTagKey} from 'sentry/utils/discover/fields';
 import {eventDetailsRoute} from 'sentry/utils/discover/urls';
@@ -165,7 +166,19 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
               <Button onClick={this.toggleSidebar}>
                 {isSidebarVisible ? 'Hide Details' : 'Show Details'}
               </Button>
-              <Button icon={<IconOpen />} href={eventJsonUrl} external>
+              <Button
+                icon={<IconOpen />}
+                href={eventJsonUrl}
+                external
+                onClick={() =>
+                  trackAdvancedAnalyticsEvent(
+                    'performance_views.event_details.json_button_click',
+                    {
+                      organization,
+                    }
+                  )
+                }
+              >
                 {t('JSON')} (<FileSize bytes={event.size} />)
               </Button>
               {transactionSummaryTarget && (

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
 import styled from '@emotion/styled';
 import {setTag} from '@sentry/react';
 import {Location} from 'history';
@@ -8,6 +8,7 @@ import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import SpanExamplesQuery, {
@@ -43,6 +44,12 @@ export default function SpanDetailsContentWrapper(props: Props) {
   const {location, organization, eventView, project, transactionName, spanSlug} = props;
   const minExclusiveTime = decodeScalar(location.query[ZoomKeys.MIN]);
   const maxExclusiveTime = decodeScalar(location.query[ZoomKeys.MAX]);
+
+  useEffect(() => {
+    trackAdvancedAnalyticsEvent('performance_views.span_summary.view', {
+      organization,
+    });
+  }, [organization]);
 
   return (
     <Fragment>


### PR DESCRIPTION
Adds instrumentation for the following events on the Event Details page:

- Filter by operation dropdown
- Searchbar
- Click on a span to view its details
- Anchoring a span
- Click button to view JSON data of the event

Also adds an event for when a user views the Span Summary page, which I had forgotten to add earlier.

### Reload PR
https://github.com/getsentry/reload/pull/271