### PR TITLE
feat(perf): Remove implicit filters for the transaction search experiment

### DIFF
--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -432,7 +432,7 @@ function generateGenericPerformanceEventView(
   const conditions = new MutableSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (shouldAddDefaultConditions(location) || withStaticFilters) {
+  if (shouldAddDefaultConditions(location) && !withStaticFilters) {
     conditions.setFilterValues('transaction.duration', ['<15m']);
   }
 
@@ -509,7 +509,7 @@ function generateBackendPerformanceEventView(
   const conditions = new MutableSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (shouldAddDefaultConditions(location) || withStaticFilters) {
+  if (shouldAddDefaultConditions(location) && !withStaticFilters) {
     conditions.setFilterValues('transaction.duration', ['<15m']);
   }
 
@@ -590,7 +590,7 @@ function generateMobilePerformanceEventView(
   const conditions = new MutableSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (shouldAddDefaultConditions(location) || withStaticFilters) {
+  if (shouldAddDefaultConditions(location) && !withStaticFilters) {
     conditions.setFilterValues('transaction.duration', ['<15m']);
   }
 
@@ -657,7 +657,7 @@ function generateFrontendPageloadPerformanceEventView(
   const conditions = new MutableSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (shouldAddDefaultConditions(location) || withStaticFilters) {
+  if (shouldAddDefaultConditions(location) && !withStaticFilters) {
     conditions.setFilterValues('transaction.duration', ['<15m']);
   }
 
@@ -725,7 +725,7 @@ function generateFrontendOtherPerformanceEventView(
   const conditions = new MutableSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (shouldAddDefaultConditions(location) || withStaticFilters) {
+  if (shouldAddDefaultConditions(location) && !withStaticFilters) {
     conditions.setFilterValues('transaction.duration', ['<15m']);
   }
 


### PR DESCRIPTION
`transaction.duration:<15m` is a default filter for the performance landing page. in the search bar experiment, it was converted to an implicit filter. This approach wasn't ideal because users couldn't remove it as it didn't show up in the search bar. In order to remove all hidden behavior, I've removed the implicit filter so all transaction data is displayed.