### PR TITLE
feat(stacktrace-linking): optionally pass in stackframe data to endpoint

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -138,11 +138,22 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     }
     const commitId = event.release?.lastCommit?.id;
     const platform = event.platform;
+    const sdkName = event.sdk?.name;
     return [
       [
         'match',
         `/projects/${organization.slug}/${project.slug}/stacktrace-link/`,
-        {query: {file: frame.filename, platform, commitId}},
+        {
+          query: {
+            file: frame.filename,
+            platform,
+            commitId,
+            ...(sdkName && {sdkName}),
+            ...(frame.absPath && {absPath: frame.absPath}),
+            ...(frame.module && {module: frame.module}),
+            ...(frame.package && {package: frame.package}),
+          },
+        },
       ],
     ];
   }


### PR DESCRIPTION
Related to this [PR](https://github.com/getsentry/sentry/pull/35433).

Stacktrace-linking normally only relies on the `file` param in the stackframe. To support other platforms (kotlin, react-native, flutter, and swift) that require extra context information, we need to provide the BE endpoint more data.

This change should be backwards compatible with what we currently have.