### PR TITLE
ref: require protobuf<4 for now to prevent descriptor crashes

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -104,4 +104,4 @@ selenium==3.141.0  # When upgrading, remove hack from lib.sh (see https://github
 sqlparse==0.2.4
 
 # work around old protobuf descriptors broken with protobuf 4.x
-protobuf==3.20.1
+protobuf==3.19.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -102,3 +102,6 @@ phabricator==0.7.0
 # sentry.utils.pytest and sentry.testutils are moved to tests/
 selenium==3.141.0  # When upgrading, remove hack from lib.sh (see https://github.com/getsentry/sentry/pull/29887 for details)
 sqlparse==0.2.4
+
+# work around old protobuf descriptors broken with protobuf 4.x
+protobuf==3.20.1


### PR DESCRIPTION
workaround for discovery error:

```
E   TypeError: Descriptors cannot not be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.20.x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
E   
E   More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```