### PR TITLE
ref(ui): Remove `boundaryGap:true` from charts

### DIFF
--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -23,8 +23,6 @@ import {ChartType, RenderDescriptor} from './types';
 
 const discoverxAxis = XAxis({
   theme,
-  // @ts-expect-error Not sure whats wrong with boundryGap type
-  boundaryGap: true,
   splitNumber: 3,
   isGroupedByDate: true,
   axisLabel: {fontSize: 11, fontFamily: DEFAULT_FONT_FAMILY},

--- a/static/app/components/charts/percentageAreaChart.tsx
+++ b/static/app/components/charts/percentageAreaChart.tsx
@@ -95,7 +95,6 @@ export default class PercentageAreaChart extends Component<Props> {
             ].join('');
           },
         }}
-        xAxis={{boundaryGap: true}}
         yAxis={{
           min: 0,
           max: 100,

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -436,7 +436,6 @@ export class UsageChart extends Component<Props, State> {
                 show: true,
                 type: 'category',
                 name: 'Date',
-                boundaryGap: true,
                 data: xAxisData,
                 axisTick: {
                   interval: xAxisTickInterval,

--- a/static/app/views/projectsDashboard/chart.tsx
+++ b/static/app/views/projectsDashboard/chart.tsx
@@ -106,7 +106,6 @@ const Chart = ({firstEvent, stats, transactionStats}: Props) => {
     },
     xAxes: Array.from(new Array(series.length)).map((_i, index) => ({
       gridIndex: index,
-      boundaryGap: true,
       axisLine: {
         show: false,
       },


### PR DESCRIPTION
This is an invalid value:

```
Boolean type for boundaryGap is only allowed for ordinal axis. Please use string in percentage instead, e.g., "20%". Currently, boundaryGap is set to be 0.
```
