### PR TITLE
feat(team-roles): Add roleLists to DetailedOrganization (FE)

### DIFF
--- a/static/app/components/acl/role.tsx
+++ b/static/app/components/acl/role.tsx
@@ -21,11 +21,11 @@ function checkUserRole(user: User, organization: Organization, role: RoleProps['
     return true;
   }
 
-  if (!Array.isArray(organization.availableRoles)) {
+  if (!Array.isArray(organization.orgRoleList)) {
     return false;
   }
 
-  const roleIds = organization.availableRoles.map(r => r.id);
+  const roleIds = organization.orgRoleList.map(r => r.id);
 
   if (!roleIds.includes(role) || !roleIds.includes(organization.role ?? '')) {
     return false;

--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -50,7 +50,7 @@ const formGroups: JsonFormObject[] = [
         label: t('Default Role'),
         // seems weird to have choices in initial form data
         choices: ({initialData} = {}) =>
-          initialData?.availableRoles?.map((r: MemberRole) => [r.id, r.name]) ?? [],
+          initialData?.orgRoleList?.map((r: MemberRole) => [r.id, r.name]) ?? [],
         help: t('The default role new members will receive'),
         disabled: ({access}) => !access.has('org:admin'),
       },
@@ -81,7 +81,7 @@ const formGroups: JsonFormObject[] = [
         name: 'attachmentsRole',
         type: 'select',
         choices: ({initialData = {}}) =>
-          initialData?.availableRoles?.map((r: MemberRole) => [r.id, r.name]) ?? [],
+          initialData?.orgRoleList?.map((r: MemberRole) => [r.id, r.name]) ?? [],
         label: t('Attachments Access'),
         help: t(
           'Role required to download event attachments, such as native crash reports or log files.'
@@ -92,7 +92,7 @@ const formGroups: JsonFormObject[] = [
         name: 'debugFilesRole',
         type: 'select',
         choices: ({initialData = {}}) =>
-          initialData?.availableRoles?.map((r: MemberRole) => [r.id, r.name]) ?? [],
+          initialData?.orgRoleList?.map((r: MemberRole) => [r.id, r.name]) ?? [],
         label: t('Debug Files Access'),
         help: t(
           'Role required to download debug information files, proguard mappings and source maps.'

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -32,7 +32,7 @@ export type Organization = OrganizationSummary & {
   allowJoinRequests: boolean;
   allowSharedIssues: boolean;
   attachmentsRole: string;
-  availableRoles: {id: string; name: string}[];
+  availableRoles: {id: string; name: string}[]; // Deprecated, use orgRoleList
   dataScrubber: boolean;
   dataScrubberDefaults: boolean;
   debugFilesRole: string;
@@ -43,6 +43,7 @@ export type Organization = OrganizationSummary & {
   isDefault: boolean;
   onboardingTasks: OnboardingTaskStatus[];
   openMembership: boolean;
+  orgRoleList: OrgRole[];
   pendingAccessRequests: number;
   quota: {
     accountLimit: number | null;
@@ -56,6 +57,7 @@ export type Organization = OrganizationSummary & {
   scrubIPAddresses: boolean;
   sensitiveFields: string[];
   storeCrashReports: number;
+  teamRoleList: TeamRole[];
   trustedRelays: Relay[];
   orgRole?: string;
   /**
@@ -124,7 +126,7 @@ export type Member = {
 
   teamRoleList: TeamRole[]; // TODO: Move to global store
   teamRoles: {
-    role: TeamRole['id'];
+    role: string | null;
     teamSlug: string;
   }[];
   teams: string[]; // # Deprecated, use teamRoles

--- a/tests/js/spec/components/acl/role.spec.jsx
+++ b/tests/js/spec/components/acl/role.spec.jsx
@@ -8,22 +8,30 @@ import ConfigStore from 'sentry/stores/configStore';
 describe('Role', function () {
   const organization = TestStubs.Organization({
     role: 'admin',
-    availableRoles: [
+    orgRoleList: [
       {
         id: 'member',
         name: 'Member',
+        desc: '...',
+        minimumTeamRole: 'contributor',
       },
       {
         id: 'admin',
         name: 'Admin',
+        desc: '...',
+        minimumTeamRole: 'admin',
       },
       {
         id: 'manager',
         name: 'Manager',
+        desc: '...',
+        minimumTeamRole: 'admin',
       },
       {
         id: 'owner',
         name: 'Owner',
+        desc: '...',
+        minimumTeamRole: 'admin',
       },
     ],
   });
@@ -47,7 +55,7 @@ describe('Role', function () {
       });
     });
 
-    it('has an unsufficient role', function () {
+    it('has an insufficient role', function () {
       render(<Role role="manager">{childrenMock}</Role>, {
         context: routerContext,
       });
@@ -57,7 +65,7 @@ describe('Role', function () {
       });
     });
 
-    it('gives access to a superuser with unsufficient role', function () {
+    it('gives access to a superuser with insufficient role', function () {
       ConfigStore.config.user = {isSuperuser: true};
       Cookies.set = jest.fn();
 
@@ -109,9 +117,9 @@ describe('Role', function () {
       });
     });
 
-    it('handles no availableRoles', function () {
+    it('handles no organization.orgRoleList', function () {
       render(
-        <Role role="member" organization={{...organization, availableRoles: undefined}}>
+        <Role role="member" organization={{...organization, orgRoleList: undefined}}>
           {childrenMock}
         </Role>,
         {context: routerContext}
@@ -135,7 +143,7 @@ describe('Role', function () {
       expect(screen.getByText('The Child')).toBeInTheDocument();
     });
 
-    it('has an unsufficient role', function () {
+    it('has an insufficient role', function () {
       render(
         <Role role="owner">
           <div>The Child</div>

--- a/tests/js/spec/components/events/eventTagsAndScreenshot.spec.tsx
+++ b/tests/js/spec/components/events/eventTagsAndScreenshot.spec.tsx
@@ -115,10 +115,12 @@ describe('EventTagsAndScreenshot', function () {
     organization: {
       role: 'member',
       attachmentsRole: 'member',
-      availableRoles: [
+      orgRoleList: [
         {
           id: 'member',
           name: 'Member',
+          desc: '...',
+          minimumTeamRole: 'contributor',
         },
       ],
     },


### PR DESCRIPTION
The list of organization roles is being used in other place, especially seeing that someone else had added `availableRoles` to `DetailedOrganization`. 

Related to #35626, dependent on #35391