### PR TITLE
ref: use html.escape directly

### DIFF
--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -1,3 +1,4 @@
+from html import escape
 from pprint import saferepr
 
 from django import forms
@@ -28,7 +29,6 @@ from sentry.models import (
     Team,
     User,
 )
-from sentry.utils.html import escape
 
 csrf_protect_m = method_decorator(csrf_protect)
 sensitive_post_parameters_m = method_decorator(sensitive_post_parameters())

--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -1,5 +1,6 @@
 import logging
 from collections import OrderedDict
+from html import escape
 from typing import Any, Dict, List, Optional, Union
 
 from django.conf import settings
@@ -7,7 +8,6 @@ from django.utils.translation import ugettext as _
 
 from sentry.utils.canonical import get_canonical_name
 from sentry.utils.decorators import classproperty
-from sentry.utils.html import escape
 from sentry.utils.imports import import_string
 from sentry.utils.json import prune_empty_keys
 from sentry.utils.safe import get_path, safe_execute

--- a/src/sentry/mediators/external_issues/creator.py
+++ b/src/sentry/mediators/external_issues/creator.py
@@ -1,6 +1,7 @@
+from html import escape
+
 from sentry.mediators import Mediator, Param
 from sentry.models import PlatformExternalIssue
-from sentry.utils.html import escape
 
 
 class Creator(Mediator):

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+from html import escape
 from typing import Any, Mapping
 
 from sentry_relay import parse_release
 
 from sentry.models import Activity
-from sentry.utils.html import escape
 from sentry.utils.http import absolute_uri
 
 from .base import GroupActivityNotification

--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from html import escape
 from typing import Any, Mapping
 
-from sentry.utils.html import escape
 from sentry.utils.http import absolute_uri
 
 from .base import GroupActivityNotification

--- a/src/sentry/utils/html.py
+++ b/src/sentry/utils/html.py
@@ -1,1 +1,0 @@
-from html import escape  # noqa

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -4,8 +4,6 @@ from functools import partial
 
 
 class SentryVisitor(ast.NodeVisitor):
-    NODE_WINDOW_SIZE = 4
-
     def __init__(self):
         self.errors = []
 
@@ -21,36 +19,13 @@ class SentryVisitor(ast.NodeVisitor):
             if alias.name.split(".", 1)[0] in S003.modules:
                 self.errors.append(S003(node.lineno, node.col_offset))
 
-    def visit_Call(self, node):
-        if isinstance(node.func, ast.Attribute):
-            for bug in (S004,):
-                if node.func.attr in bug.methods:
-                    call_path = ".".join(self.compose_call_path(node.func.value))
-                    if call_path in bug.invalid_paths:
-                        self.errors.append(bug(node.lineno, node.col_offset))
-                    break
-        self.generic_visit(node)
-
     def visit_Attribute(self, node):
         if node.attr in S001.methods:
             self.errors.append(S001(node.lineno, node.col_offset, vars=(node.attr,)))
 
     def visit_Name(self, node):
         if node.id == "print":
-            self.check_print(node)
-
-    def visit_Print(self, node):
-        self.check_print(node)
-
-    def check_print(self, node):
-        self.errors.append(S002(lineno=node.lineno, col=node.col_offset))
-
-    def compose_call_path(self, node):
-        if isinstance(node, ast.Attribute):
-            yield from self.compose_call_path(node.value)
-            yield node.attr
-        elif isinstance(node, ast.Name):
-            yield node.id
+            self.errors.append(S002(lineno=node.lineno, col=node.col_offset))
 
 
 class SentryCheck:
@@ -100,10 +75,3 @@ S003.names = {
     "JSONDecodeError",
     "_default_encoder",
 }
-
-S004 = Error(
-    message="S004: ``cgi.escape`` and ``html.escape`` should not be used. Use "
-    "sentry.utils.html.escape instead."
-)
-S004.methods = {"escape"}
-S004.invalid_paths = {"cgi", "html"}


### PR DESCRIPTION
sentry.utils.html.escape was just html.escape all along

there's no `cgi.escape` any more as well