### PR TITLE
fix(page-filters): Date selector not respecting current start/end times

### DIFF
--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -259,7 +259,12 @@ class TimeRangeSelector extends PureComponent<Props, State> {
   };
 
   handleAbsoluteClick = () => {
-    const {relative, onChange, defaultPeriod, defaultAbsolute} = this.props;
+    const {relative, onChange, defaultPeriod, defaultAbsolute, start, end} = this.props;
+
+    // If we already have a start/end we don't have to set a default
+    if (start && end) {
+      return;
+    }
 
     // Set default range to equivalent of last relative period,
     // or use default stats period

--- a/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
@@ -311,4 +311,18 @@ describe('TimeRangeSelector', function () {
       end: new Date('2017-10-17T23:59:59.000Z'),
     });
   });
+
+  it('uses the current absolute date if provided', async function () {
+    wrapper = createWrapper({
+      start: new Date('2022-06-12T00:00:00.000Z'),
+      end: new Date('2022-06-14T00:00:00.000Z'),
+    });
+
+    await wrapper.find('HeaderItem').simulate('click');
+    await wrapper.find('AutoCompleteItem[data-test-id="absolute"]').simulate('click');
+
+    wrapper.find('AutoCompleteItem[data-test-id="absolute"]').simulate('click');
+    // On change should not be called because start/end did not change
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Fixes a bug where we would override the current absolute date selection with the default, even when a selection existed.

![image](https://user-images.githubusercontent.com/9372512/173684773-082d6ef8-f464-43cc-adb7-168cd84e99ba.png)