### PR TITLE
feat(perf): Add analytics events for vital detail and trace view

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -78,7 +78,6 @@ export type PerformanceEventParameters = {
   'performance_views.transaction_summary.status_breakdown_click': {
     status: string;
   };
-  'performance_views.transaction_summary.view': {};
   'performance_views.trends.change_duration': {
     value: string;
     widget_type: string;
@@ -136,8 +135,6 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Transaction Summary chart display changed',
   'performance_views.transaction_summary.status_breakdown_click':
     'Performance Views: Transaction Summary status breakdown option clicked',
-  'performance_views.transaction_summary.view':
-    'Performance Views: Transaction Summary overview viewed',
   'performance_views.all_events.open_in_discover':
     'Performance Views: All Events page open in Discover button clicked',
   'performance_views.tags.change_tag':

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -78,6 +78,7 @@ export type PerformanceEventParameters = {
   'performance_views.transaction_summary.status_breakdown_click': {
     status: string;
   };
+  'performance_views.transaction_summary.view': {};
   'performance_views.trends.change_duration': {
     value: string;
     widget_type: string;
@@ -135,6 +136,8 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Transaction Summary chart display changed',
   'performance_views.transaction_summary.status_breakdown_click':
     'Performance Views: Transaction Summary status breakdown option clicked',
+  'performance_views.transaction_summary.view':
+    'Performance Views: Transaction Summary overview viewed',
   'performance_views.all_events.open_in_discover':
     'Performance Views: All Events page open in Discover button clicked',
   'performance_views.tags.change_tag':

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -84,6 +84,10 @@ export type PerformanceEventParameters = {
     direction: string;
     widget_type: string;
   };
+  'performance_views.vital_detail.switch_vital': {
+    from_vital: string;
+    to_vital: string;
+  };
   'performance_views.vital_detail.view': {};
 };
 
@@ -115,6 +119,8 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.overview.view': 'Performance Views: Transaction overview view',
   'performance_views.overview.search': 'Performance Views: Transaction overview search',
   'performance_views.vital_detail.view': 'Performance Views: Vital Detail viewed',
+  'performance_views.vital_detail.switch_vital':
+    'Performance Views: Vital Detail vital type switched',
   'performance_views.trace_view.view': 'Performance Views: Trace View viewed',
   'performance_views.transaction_summary.change_chart_display':
     'Performance Views: Transaction Summary chart display changed',

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -65,6 +65,7 @@ export type PerformanceEventParameters = {
   'performance_views.tour.advance': PerformanceTourParams;
   'performance_views.tour.close': PerformanceTourParams;
   'performance_views.tour.start': {};
+  'performance_views.trace_view.open_in_discover': {};
   'performance_views.trace_view.view': {};
   'performance_views.transaction_summary.change_chart_display': {
     from_chart: string;
@@ -122,6 +123,8 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.vital_detail.switch_vital':
     'Performance Views: Vital Detail vital type switched',
   'performance_views.trace_view.view': 'Performance Views: Trace View viewed',
+  'performance_views.trace_view.open_in_discover':
+    'Performance Views: Trace View open in Discover button clicked',
   'performance_views.transaction_summary.change_chart_display':
     'Performance Views: Transaction Summary chart display changed',
   'performance_views.transaction_summary.status_breakdown_click':

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -66,6 +66,10 @@ export type PerformanceEventParameters = {
   'performance_views.tour.close': PerformanceTourParams;
   'performance_views.tour.start': {};
   'performance_views.trace_view.open_in_discover': {};
+  'performance_views.trace_view.open_transaction_details': {
+    operation: string;
+    transaction: string;
+  };
   'performance_views.trace_view.view': {};
   'performance_views.transaction_summary.change_chart_display': {
     from_chart: string;
@@ -125,6 +129,8 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.trace_view.view': 'Performance Views: Trace View viewed',
   'performance_views.trace_view.open_in_discover':
     'Performance Views: Trace View open in Discover button clicked',
+  'performance_views.trace_view.open_transaction_details':
+    'Performance Views: Trace View transaction details opened',
   'performance_views.transaction_summary.change_chart_display':
     'Performance Views: Transaction Summary chart display changed',
   'performance_views.transaction_summary.status_breakdown_click':

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -13,6 +13,7 @@ import TimeSince from 'sentry/components/timeSince';
 import {t, tct, tn} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {getDuration} from 'sentry/utils/formatters';
@@ -333,6 +334,14 @@ class TraceDetailsContent extends Component<Props, State> {
             <ButtonBar gap={1}>
               <DiscoverButton
                 to={traceEventView.getResultsViewUrlTarget(organization.slug)}
+                onClick={() => {
+                  trackAdvancedAnalyticsEvent(
+                    'performance_views.trace_view.open_in_discover',
+                    {
+                      organization,
+                    }
+                  );
+                }}
               >
                 {t('Open in Discover')}
               </DiscoverButton>

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -21,6 +21,7 @@ import {IconAnchor} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {TraceFullDetailed} from 'sentry/utils/performance/quickTrace/types';
@@ -39,6 +40,16 @@ type Props = {
 };
 
 class TransactionDetail extends Component<Props> {
+  componentDidMount() {
+    const {organization, transaction} = this.props;
+
+    trackAdvancedAnalyticsEvent('performance_views.trace_view.open_transaction_details', {
+      organization,
+      operation: transaction['transaction.op'],
+      transaction: transaction.transaction,
+    });
+  }
+
   renderTransactionErrors() {
     const {organization, transaction} = this.props;
     const {errors} = transaction;

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -6,7 +6,6 @@ import {loadOrganizationTags} from 'sentry/actionCreators/tags';
 import {t} from 'sentry/locale';
 import {Organization, PageFilters, Project} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
-import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {
@@ -55,12 +54,6 @@ function TransactionOverview(props: Props) {
   const api = useApi();
 
   const {location, selection, organization, projects} = props;
-
-  useEffect(() => {
-    trackAdvancedAnalyticsEvent('performance_views.transaction_summary.view', {
-      organization,
-    });
-  }, [organization]);
 
   useEffect(
     () => {

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -6,6 +6,7 @@ import {loadOrganizationTags} from 'sentry/actionCreators/tags';
 import {t} from 'sentry/locale';
 import {Organization, PageFilters, Project} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {
@@ -54,6 +55,12 @@ function TransactionOverview(props: Props) {
   const api = useApi();
 
   const {location, selection, organization, projects} = props;
+
+  useEffect(() => {
+    trackAdvancedAnalyticsEvent('performance_views.transaction_summary.view', {
+      organization,
+    });
+  }, [organization]);
 
   useEffect(
     () => {

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -26,6 +26,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {generateQueryWithTag} from 'sentry/utils';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
 import {WebVital} from 'sentry/utils/discover/fields';
@@ -137,7 +138,7 @@ class VitalDetailContent extends Component<Props, State> {
   }
 
   renderVitalSwitcher() {
-    const {vitalName, location} = this.props;
+    const {vitalName, location, organization} = this.props;
 
     const position = FRONTEND_VITALS.indexOf(vitalName);
 
@@ -158,6 +159,12 @@ class VitalDetailContent extends Component<Props, State> {
                 vitalName: newVitalName,
                 cursor: undefined,
               },
+            });
+
+            trackAdvancedAnalyticsEvent('performance_views.vital_detail.switch_vital', {
+              organization,
+              from_vital: vitalAbbreviations[vitalName] ?? 'undefined',
+              to_vital: vitalAbbreviations[newVitalName] ?? 'undefined',
             });
           },
         };


### PR DESCRIPTION
Adds instrumentation for the following events:

### Vital Detail Page
- Switch the vital type from the dropdown

### Trace View
- Open in Discover
- Transaction clicked


### Reload PR
https://github.com/getsentry/reload/pull/271
