### PR TITLE
feat(team-roles): Return teamRoles in OrganizationMemberWithTeamsSerializer (BE)

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/expand/teams.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/teams.py
@@ -20,8 +20,10 @@ class OrganizationMemberWithTeamsSerializer(OrganizationMemberSerializer):
                 attrs[item]["teams"] = teams.get(item.id, [])  # Deprecated
                 attrs[item]["teamRoles"] = teams_with_role.get(item.id, [])
             except KeyError:
-                attrs[item] = {"teams": teams}  # Deprecated
-                attrs[item] = {"teamRoles": teams_with_role}
+                attrs[item] = {
+                    "teams": teams,  # Deprecated
+                    "teamRoles": teams_with_role,
+                }
 
         return attrs
 

--- a/src/sentry/api/serializers/models/organization_member/expand/teams.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/teams.py
@@ -15,11 +15,13 @@ class OrganizationMemberWithTeamsSerializer(OrganizationMemberSerializer):
 
         team_ids_by_organization_member_id = get_team_slugs_by_organization_member_id(item_list)
         for item in item_list:
-            teams = team_ids_by_organization_member_id.get(item.id, [])
+            teams, teams_with_role = team_ids_by_organization_member_id.get(item.id, ([], []))
             try:
-                attrs[item]["teams"] = teams
+                attrs[item]["teams"] = teams  # Deprecated
+                attrs[item]["teamRoles"] = teams_with_role
             except KeyError:
-                attrs[item] = {"teams": teams}
+                attrs[item] = {"teams": teams}  # Deprecated
+                attrs[item] = {"teamRoles": teams_with_role}
 
         return attrs
 
@@ -27,5 +29,6 @@ class OrganizationMemberWithTeamsSerializer(OrganizationMemberSerializer):
         self, obj: OrganizationMember, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> OrganizationMemberWithTeamsResponse:
         d = cast(OrganizationMemberWithTeamsResponse, super().serialize(obj, attrs, user))
-        d["teams"] = attrs.get("teams", [])
+        d["teams"] = attrs.get("teams", [])  # Deprecated
+        d["teamRoles"] = attrs.get("teamRoles", [])
         return d

--- a/src/sentry/api/serializers/models/organization_member/expand/teams.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/teams.py
@@ -12,10 +12,9 @@ class OrganizationMemberWithTeamsSerializer(OrganizationMemberSerializer):
         self, item_list: Sequence[OrganizationMember], user: User, **kwargs: Any
     ) -> MutableMapping[OrganizationMember, MutableMapping[str, Any]]:
         attrs = super().get_attrs(item_list, user)
-
         teams, teams_with_role = get_teams_by_organization_member_id(item_list)
-        for item in item_list:
 
+        for item in item_list:
             try:
                 attrs[item]["teams"] = teams.get(item.id, [])  # Deprecated
                 attrs[item]["teamRoles"] = teams_with_role.get(item.id, [])

--- a/src/sentry/api/serializers/models/organization_member/expand/teams.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/teams.py
@@ -4,7 +4,7 @@ from sentry.models import OrganizationMember, User
 
 from ..base import OrganizationMemberSerializer
 from ..response import OrganizationMemberWithTeamsResponse
-from ..utils import get_team_slugs_by_organization_member_id
+from ..utils import get_teams_by_organization_member_id
 
 
 class OrganizationMemberWithTeamsSerializer(OrganizationMemberSerializer):
@@ -13,12 +13,12 @@ class OrganizationMemberWithTeamsSerializer(OrganizationMemberSerializer):
     ) -> MutableMapping[OrganizationMember, MutableMapping[str, Any]]:
         attrs = super().get_attrs(item_list, user)
 
-        team_ids_by_organization_member_id = get_team_slugs_by_organization_member_id(item_list)
+        teams, teams_with_role = get_teams_by_organization_member_id(item_list)
         for item in item_list:
-            teams, teams_with_role = team_ids_by_organization_member_id.get(item.id, ([], []))
+
             try:
-                attrs[item]["teams"] = teams  # Deprecated
-                attrs[item]["teamRoles"] = teams_with_role
+                attrs[item]["teams"] = teams.get(item.id, [])  # Deprecated
+                attrs[item]["teamRoles"] = teams_with_role.get(item.id, [])
             except KeyError:
                 attrs[item] = {"teams": teams}  # Deprecated
                 attrs[item] = {"teamRoles": teams_with_role}

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -36,6 +36,11 @@ _OrganizationMemberFlags = TypedDict(
 )
 
 
+class _TeamRole(TypedDict):
+    team: str
+    role: str
+
+
 class OrganizationMemberResponseOptional(TypedDict, total=False):
     externalUsers: List[ExternalActorResponse]
 
@@ -72,6 +77,7 @@ class OrganizationMemberResponse(OrganizationMemberResponseOptional):
 
 class OrganizationMemberWithTeamsResponse(OrganizationMemberResponse):
     teams: List[str]
+    teamRoles: List[_TeamRole]
 
 
 class OrganizationMemberWithProjectsResponse(OrganizationMemberResponse):

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -37,7 +37,7 @@ _OrganizationMemberFlags = TypedDict(
 
 
 class _TeamRole(TypedDict):
-    team: str
+    teamSlug: str
     role: str
 
 

--- a/src/sentry/api/serializers/models/organization_member/utils.py
+++ b/src/sentry/api/serializers/models/organization_member/utils.py
@@ -1,8 +1,13 @@
 from collections import defaultdict
-from typing import Any, Dict, List, Mapping, Sequence, Set, Tuple
+from typing import Any, Dict, List, Mapping, Sequence, Set, Tuple, TypeVar
 
 from sentry.api.serializers import serialize
 from sentry.models import OrganizationMember, OrganizationMemberTeam, Team, TeamStatus, User
+
+TeamData = TypeVar("TeamData")
+DictOfMembers = Dict[Any, List[TeamData]]
+MembersTeams = DictOfMembers[str]
+MembersTeamRoles = DictOfMembers[Dict[str, str]]
 
 
 def get_serialized_users_by_id(users_set: Set[User], user: User) -> Mapping[str, User]:
@@ -12,7 +17,7 @@ def get_serialized_users_by_id(users_set: Set[User], user: User) -> Mapping[str,
 
 def get_teams_by_organization_member_id(
     organization_members: Sequence[OrganizationMember],
-) -> Tuple[Dict[Any, List[str]], Dict[Any, List[Dict[Any, Any]]]]:
+) -> Tuple[MembersTeams, MembersTeamRoles]:
     """@returns a map of member id -> team_slug[]"""
     organization_member_tuples = list(
         OrganizationMemberTeam.objects.filter(

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -56,8 +56,16 @@ class OrganizationMemberWithTeamsSerializerTest(OrganizationMemberSerializerTest
             self.user_2,
             OrganizationMemberWithTeamsSerializer(),
         )
-        expected_teams = [{self.team.slug, self.team_2.slug}, {self.team.slug}]
-        assert [set(r["teams"]) for r in result] == expected_teams
+        expected_teams = [[self.team.slug, self.team_2.slug], [self.team.slug]]
+        expected_team_roles = [
+            [
+                {"teamSlug": self.team.slug, "role": None},
+                {"teamSlug": self.team_2.slug, "role": None},
+            ],
+            [{"teamSlug": self.team.slug, "role": None}],
+        ]
+        assert [r["teams"] for r in result] == expected_teams
+        assert [r["teamRoles"] for r in result] == expected_team_roles
 
 
 class OrganizationMemberSCIMSerializerTest(OrganizationMemberSerializerTest):


### PR DESCRIPTION
Currently, `OrganizationMemberWithTeamsSerializer` returns the list of team slugs. 

We've added the `role` property to `OrganizationMemberTeam` in #33385, so we need more information to be returned along with the team slugs.