### PR TITLE
feat(search): Better invalid field state

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1126,7 +1126,16 @@ class SmartSearchBar extends Component<Props, State> {
 
     if (!tag) {
       return {
-        searchItems: [],
+        searchItems: [
+          {
+            type: ItemType.INVALID_TAG,
+            desc: tagName,
+            callback: () =>
+              window.open(
+                'https://docs.sentry.io/product/sentry-basics/search/searchable-properties/'
+              ),
+          },
+        ],
         recentSearchItems: [],
         tagName,
         type: ItemType.INVALID_TAG,
@@ -1212,7 +1221,9 @@ class SmartSearchBar extends Component<Props, State> {
         // show operator group if at beginning of value
         if (cursor === node.location.start.offset) {
           const opGroup = generateOpAutocompleteGroup(getValidOps(cursorToken), tagName);
-          autocompleteGroups.unshift(opGroup);
+          if (valueGroup?.type !== ItemType.INVALID_TAG) {
+            autocompleteGroups.unshift(opGroup);
+          }
         }
         this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
         return;

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -78,23 +78,21 @@ class SearchDropdown extends PureComponent<Props> {
     </SearchDropdownGroup>
   );
 
-  renderItem = (item: SearchItem) => {
-    return (
-      <SearchListItem
-        key={item.value || item.desc || item.title}
-        className={item.active ? 'active' : undefined}
-        data-test-id="search-autocomplete-item"
-        onClick={item.callback ?? this.props.onClick.bind(this, item.value, item)}
-        ref={element => item.active && element?.scrollIntoView?.({block: 'nearest'})}
-      >
-        <SearchItemTitleWrapper>
-          {item.title && `${item.title}${item.desc ? ' · ' : ''}`}
-          <Description>{this.renderDescription(item)}</Description>
-          <Documentation>{item.documentation}</Documentation>
-        </SearchItemTitleWrapper>
-      </SearchListItem>
-    );
-  };
+  renderItem = (item: SearchItem) => (
+    <SearchListItem
+      key={item.value || item.desc || item.title}
+      className={item.active ? 'active' : undefined}
+      data-test-id="search-autocomplete-item"
+      onClick={item.callback ?? this.props.onClick.bind(this, item.value, item)}
+      ref={element => item.active && element?.scrollIntoView?.({block: 'nearest'})}
+    >
+      <SearchItemTitleWrapper>
+        {item.title && `${item.title}${item.desc ? ' · ' : ''}`}
+        <Description>{this.renderDescription(item)}</Description>
+        <Documentation>{item.documentation}</Documentation>
+      </SearchItemTitleWrapper>
+    </SearchListItem>
+  );
 
   render() {
     const {className, loading, items, runQuickAction, visibleActions, maxMenuHeight} =

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -34,7 +34,7 @@ class SearchDropdown extends PureComponent<Props> {
       if (item.type === ItemType.INVALID_TAG) {
         return (
           <Invalid>
- {tct(
+            {tct(
               "The field [field] isn't supported here. [highlight:See all searchable properties in the docs.]",
               {
                 field: <strong>{item.desc}</strong>,
@@ -89,7 +89,7 @@ class SearchDropdown extends PureComponent<Props> {
         ref={element => item.active && element?.scrollIntoView?.({block: 'nearest'})}
       >
         <SearchItemTitleWrapper>
-  {item.title && `${item.title}${item.desc ? ' · ' : ''}`}
+          {item.title && `${item.title}${item.desc ? ' · ' : ''}`}
           <Description>{this.renderDescription(item)}</Description>
           <Documentation>{item.documentation}</Documentation>
         </SearchItemTitleWrapper>

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -31,6 +31,15 @@ class SearchDropdown extends PureComponent<Props> {
   renderDescription = (item: SearchItem) => {
     const searchSubstring = this.props.searchSubstring;
     if (!searchSubstring) {
+      if (item.type === ItemType.INVALID_TAG) {
+        return (
+          <Invalid>
+            The field <strong>{item.desc}</strong> isn't supported here.{' '}
+            <Highlight>See all searchable properties in the docs.</Highlight>
+          </Invalid>
+        );
+      }
+
       return item.desc;
     }
 
@@ -65,21 +74,23 @@ class SearchDropdown extends PureComponent<Props> {
     </SearchDropdownGroup>
   );
 
-  renderItem = (item: SearchItem) => (
-    <SearchListItem
-      key={item.value || item.desc || item.title}
-      className={item.active ? 'active' : undefined}
-      data-test-id="search-autocomplete-item"
-      onClick={item.callback ?? this.props.onClick.bind(this, item.value, item)}
-      ref={element => item.active && element?.scrollIntoView?.({block: 'nearest'})}
-    >
-      <SearchItemTitleWrapper>
-        {item.title && item.title + (item.desc ? ' · ' : '')}
-        <Description>{this.renderDescription(item)}</Description>
-        <Documentation>{item.documentation}</Documentation>
-      </SearchItemTitleWrapper>
-    </SearchListItem>
-  );
+  renderItem = (item: SearchItem) => {
+    return (
+      <SearchListItem
+        key={item.value || item.desc || item.title}
+        className={item.active ? 'active' : undefined}
+        data-test-id="search-autocomplete-item"
+        onClick={item.callback ?? this.props.onClick.bind(this, item.value, item)}
+        ref={element => item.active && element?.scrollIntoView?.({block: 'nearest'})}
+      >
+        <SearchItemTitleWrapper>
+          {item.title && item.title + (item.desc ? ' · ' : '')}
+          <Description>{this.renderDescription(item)}</Description>
+          <Documentation>{item.documentation}</Documentation>
+        </SearchItemTitleWrapper>
+      </SearchListItem>
+    );
+  };
 
   render() {
     const {className, loading, items, runQuickAction, visibleActions, maxMenuHeight} =
@@ -94,15 +105,13 @@ class SearchDropdown extends PureComponent<Props> {
           <SearchItemsList maxMenuHeight={maxMenuHeight}>
             {items.map(item => {
               const isEmpty = item.children && !item.children.length;
-              const invalidTag = item.type === ItemType.INVALID_TAG;
 
               // Hide header if `item.children` is defined, an array, and is empty
               return (
                 <Fragment key={item.title}>
-                  {invalidTag && <Info>{t('Invalid tag')}</Info>}
                   {item.type === 'header' && this.renderHeaderItem(item)}
                   {item.children && item.children.map(this.renderItem)}
-                  {isEmpty && !invalidTag && <Info>{t('No items found')}</Info>}
+                  {isEmpty && <Info>{t('No items found')}</Info>}
                 </Fragment>
               );
             })}
@@ -288,4 +297,14 @@ const HotkeyGlyphWrapper = styled('span')`
 
 const HotkeyTitle = styled(`span`)`
   font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const Invalid = styled(`span`)`
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-family: ${p => p.theme.text.family};
+  color: ${p => p.theme.gray400};
+`;
+
+const Highlight = styled(`strong`)`
+  color: ${p => p.theme.linkColor};
 `;

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import color from 'color';
 
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 
 import Button from '../button';
@@ -34,13 +34,12 @@ class SearchDropdown extends PureComponent<Props> {
       if (item.type === ItemType.INVALID_TAG) {
         return (
           <Invalid>
-            {tct(
-              "The field [field] isn't supported here. [highlight:See all searchable properties in the docs.]",
-              {
-                field: <strong>{item.desc}</strong>,
-                highlight: <Highlight />,
-              }
-            )}
+            {tct("The field [field] isn't supported here. ", {
+              field: <strong>{item.desc}</strong>,
+            })}
+            {tct('[highlight:See all searchable properties in the docs.]', {
+              highlight: <Highlight />,
+            })}
           </Invalid>
         );
       }
@@ -308,6 +307,13 @@ const Invalid = styled(`span`)`
   font-size: ${p => p.theme.fontSizeSmall};
   font-family: ${p => p.theme.text.family};
   color: ${p => p.theme.gray400};
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+
+  span {
+    white-space: pre;
+  }
 `;
 
 const Highlight = styled(`strong`)`

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -34,8 +34,13 @@ class SearchDropdown extends PureComponent<Props> {
       if (item.type === ItemType.INVALID_TAG) {
         return (
           <Invalid>
-            The field <strong>{item.desc}</strong> isn't supported here.{' '}
-            <Highlight>See all searchable properties in the docs.</Highlight>
+ {tct(
+              "The field [field] isn't supported here. [highlight:See all searchable properties in the docs.]",
+              {
+                field: <strong>{item.desc}</strong>,
+                highlight: <Highlight />,
+              }
+            )}
           </Invalid>
         );
       }
@@ -84,7 +89,7 @@ class SearchDropdown extends PureComponent<Props> {
         ref={element => item.active && element?.scrollIntoView?.({block: 'nearest'})}
       >
         <SearchItemTitleWrapper>
-          {item.title && item.title + (item.desc ? ' · ' : '')}
+  {item.title && `${item.title}${item.desc ? ' · ' : ''}`}
           <Description>{this.renderDescription(item)}</Description>
           <Documentation>{item.documentation}</Documentation>
         </SearchItemTitleWrapper>

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -28,6 +28,11 @@ describe('SmartSearchBar', function () {
       key: 'firstRelease',
       name: 'firstRelease',
     };
+    supportedTags.is = {
+      key: 'is',
+      name: 'is',
+    };
+
     organization = TestStubs.Organization({id: '123'});
 
     location = {
@@ -992,6 +997,49 @@ describe('SmartSearchBar', function () {
           'is:unresolved sdk.name:sentry-cocoa has:key '
         );
       }
+    });
+  });
+
+  describe('Invalid field state', () => {
+    it('Shows invalid field state when invalid field is used', async () => {
+      const props = {
+        query: 'invalid:',
+        organization,
+        location,
+        supportedTags,
+      };
+      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBarInst = searchBar.instance();
+
+      mockCursorPosition(searchBarInst, 8);
+
+      searchBarInst.updateAutoCompleteItems();
+
+      await tick();
+
+      expect(searchBarInst.state.searchGroups).toHaveLength(1);
+      expect(searchBarInst.state.searchGroups[0].title).toEqual('Tags');
+      expect(searchBarInst.state.searchGroups[0].type).toEqual('invalid-tag');
+      expect(searchBar.text()).toContain("The field invalid isn't supported here");
+    });
+
+    it('Does not show invalid field state when valid field is used', async () => {
+      const props = {
+        query: 'is:',
+        organization,
+        location,
+        supportedTags,
+      };
+      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBarInst = searchBar.instance();
+
+      mockCursorPosition(searchBarInst, 3);
+
+      searchBarInst.updateAutoCompleteItems();
+
+      await tick();
+
+      expect(searchBar.text()).not.toContain("isn't supported here");
     });
   });
 });

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2792,8 +2792,9 @@ describe('WidgetBuilder', function () {
           'session.status:'
         );
 
-        await tick();
-        expect(await screen.findByText('No items found')).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByText('No items found')).toBeInTheDocument();
+        });
 
         userEvent.click(screen.getByText('Releases (sessions, crash rates)'));
         userEvent.click(

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2791,6 +2791,8 @@ describe('WidgetBuilder', function () {
           await screen.findByPlaceholderText('Search for events, users, tags, and more'),
           'session.status:'
         );
+
+        await tick();
         expect(await screen.findByText('No items found')).toBeInTheDocument();
 
         userEvent.click(screen.getByText('Releases (sessions, crash rates)'));


### PR DESCRIPTION
Nicer invalid field state with a link to the docs on all searchable properties.

Before:
![Screen Shot 2022-06-09 at 3 25 46 PM](https://user-images.githubusercontent.com/30991498/173704520-060f2d96-61d8-44bc-a177-c2efaca5b009.png)

After:
<img width="839" alt="Screen Shot 2022-06-10 at 1 02 01 PM" src="https://user-images.githubusercontent.com/30991498/173704530-827c7681-9ca1-4057-a1ff-bc306e5606d0.png">
<img width="1286" alt="Screen Shot 2022-06-10 at 1 01 51 PM" src="https://user-images.githubusercontent.com/30991498/173704535-a9465f1b-5614-4613-a43c-4779bcf5d396.png">
<img width="472" alt="Screen Shot 2022-06-15 at 11 04 41 AM" src="https://user-images.githubusercontent.com/30991498/173894944-de932ee4-00cf-4620-a26a-84e040e332f0.png">
<img width="893" alt="Screen Shot 2022-06-15 at 11 05 28 AM" src="https://user-images.githubusercontent.com/30991498/173895091-24091e52-e2ba-4e7d-add1-b93f459a2a07.png">

