### PR TITLE
feat(mep): Use snql to validate query in metric alerts api

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -7,8 +7,10 @@ from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 from rest_framework import serializers
+from snuba_sdk import Column, Condition, Function, Limit, Op
 from snuba_sdk.legacy import json_to_snql
 
+from sentry import features
 from sentry.api.fields.actor import ActorField
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.serializers.rest_framework.environment import EnvironmentField
@@ -28,7 +30,7 @@ from sentry.incidents.models import AlertRule, AlertRuleThresholdType, AlertRule
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import get_entity_subscription_for_dataset
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
-from sentry.snuba.tasks import build_snuba_filter
+from sentry.snuba.tasks import build_query_builder, build_snuba_filter
 from sentry.utils import json
 from sentry.utils.snuba import raw_snql_query
 
@@ -168,27 +170,128 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         both alert and resolve 'after' the warning trigger (whether that means
         > or < the value depends on threshold type).
         """
+        self._validate_query(data)
+
+        triggers = data.get("triggers", [])
+        if not triggers:
+            raise serializers.ValidationError("Must include at least one trigger")
+        if len(triggers) > 2:
+            raise serializers.ValidationError(
+                "Must send 1 or 2 triggers - A critical trigger, and an optional warning trigger"
+            )
+
+        event_types = data.get("event_types")
+
+        valid_event_types = DATASET_VALID_EVENT_TYPES.get(data["dataset"], set())
+        if event_types and set(event_types) - valid_event_types:
+            raise serializers.ValidationError(
+                "Invalid event types for this dataset. Valid event types are %s"
+                % sorted(et.name.lower() for et in valid_event_types)
+            )
+
+        for i, (trigger, expected_label) in enumerate(
+            zip(triggers, (CRITICAL_TRIGGER_LABEL, WARNING_TRIGGER_LABEL))
+        ):
+            if trigger.get("label", None) != expected_label:
+                raise serializers.ValidationError(
+                    f'Trigger {i + 1} must be labeled "{expected_label}"'
+                )
+        threshold_type = data["threshold_type"]
+        self._translate_thresholds(threshold_type, data.get("comparison_delta"), triggers, data)
+
+        critical = triggers[0]
+
+        self._validate_trigger_thresholds(threshold_type, critical, data.get("resolve_threshold"))
+
+        if len(triggers) == 2:
+            warning = triggers[1]
+            self._validate_trigger_thresholds(
+                threshold_type, warning, data.get("resolve_threshold")
+            )
+            self._validate_critical_warning_triggers(threshold_type, critical, warning)
+
+        return data
+
+    def _validate_query(self, data):
         data.setdefault("dataset", QueryDatasets.EVENTS)
-        project_id = data.get("projects")
-        if not project_id:
+        dataset = QueryDatasets(data["dataset"])
+        projects = data.get("projects")
+        if not projects:
             # We just need a valid project id from the org so that we can verify
             # the query. We don't use the returned data anywhere, so it doesn't
             # matter which.
-            project_id = list(self.context["organization"].project_set.all()[:1])
+            projects = list(self.context["organization"].project_set.all()[:1])
 
         try:
             entity_subscription = get_entity_subscription_for_dataset(
-                dataset=QueryDatasets(data["dataset"]),
+                dataset=dataset,
                 aggregate=data["aggregate"],
                 time_window=int(timedelta(minutes=data["time_window"]).total_seconds()),
                 extra_fields={
-                    "org_id": project_id[0].organization_id,
+                    "org_id": projects[0].organization_id,
                     "event_types": data.get("event_types"),
                 },
             )
         except UnsupportedQuerySubscription as e:
             raise serializers.ValidationError(f"{e}")
 
+        if (
+            features.has(
+                "organizations:metric-alert-snql",
+                self.context.get("organization"),
+                actor=self.context.get("user"),
+            )
+            and dataset != QueryDatasets.METRICS
+        ):
+            self._validate_snql_query(data, entity_subscription, projects)
+        else:
+            self._validate_snuba_filter(data, entity_subscription, projects)
+
+    def _validate_snql_query(self, data, entity_subscription, projects):
+        end = timezone.now()
+        start = end - timedelta(minutes=10)
+        try:
+            query_builder = build_query_builder(
+                entity_subscription,
+                data["query"],
+                [p.id for p in projects],
+                data.get("environment"),
+                params={
+                    "organization_id": projects[0].organization_id,
+                    "project_id": [p.id for p in projects],
+                    "start": start,
+                    "end": end,
+                },
+            )
+        except (InvalidSearchQuery, ValueError) as e:
+            raise serializers.ValidationError(f"Invalid Query or Metric: {e}")
+
+        if not isinstance(query_builder.columns[0], Function):
+            raise serializers.ValidationError(
+                "Invalid Metric: Please pass a valid function for aggregation"
+            )
+
+        dataset = Dataset(data["dataset"].value)
+        self._validate_time_window(dataset, data.get("time_window"))
+
+        time_col = entity_subscription.time_col
+        query_builder.add_conditions(
+            [
+                Condition(Column(time_col), Op.GTE, start),
+                Condition(Column(time_col), Op.LT, end),
+            ]
+        )
+        query_builder.limit = Limit(1)
+
+        try:
+            query_builder.run_query(referrer="alertruleserializer.test_query")
+        except Exception:
+            logger.exception("Error while validating snuba alert rule query")
+            raise serializers.ValidationError(
+                "Invalid Query or Metric: An error occurred while attempting " "to run the query"
+            )
+
+    def _validate_snuba_filter(self, data, entity_subscription, project_id):
         try:
             snuba_filter = build_snuba_filter(
                 entity_subscription,
@@ -248,46 +351,6 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                     "Invalid Query or Metric: An error occurred while attempting "
                     "to run the query"
                 )
-
-        triggers = data.get("triggers", [])
-        if not triggers:
-            raise serializers.ValidationError("Must include at least one trigger")
-        if len(triggers) > 2:
-            raise serializers.ValidationError(
-                "Must send 1 or 2 triggers - A critical trigger, and an optional warning trigger"
-            )
-
-        event_types = data.get("event_types")
-
-        valid_event_types = DATASET_VALID_EVENT_TYPES.get(data["dataset"], set())
-        if event_types and set(event_types) - valid_event_types:
-            raise serializers.ValidationError(
-                "Invalid event types for this dataset. Valid event types are %s"
-                % sorted(et.name.lower() for et in valid_event_types)
-            )
-
-        for i, (trigger, expected_label) in enumerate(
-            zip(triggers, (CRITICAL_TRIGGER_LABEL, WARNING_TRIGGER_LABEL))
-        ):
-            if trigger.get("label", None) != expected_label:
-                raise serializers.ValidationError(
-                    f'Trigger {i + 1} must be labeled "{expected_label}"'
-                )
-        threshold_type = data["threshold_type"]
-        self._translate_thresholds(threshold_type, data.get("comparison_delta"), triggers, data)
-
-        critical = triggers[0]
-
-        self._validate_trigger_thresholds(threshold_type, critical, data.get("resolve_threshold"))
-
-        if len(triggers) == 2:
-            warning = triggers[1]
-            self._validate_trigger_thresholds(
-                threshold_type, warning, data.get("resolve_threshold")
-            )
-            self._validate_critical_warning_triggers(threshold_type, critical, warning)
-
-        return data
 
     def _translate_thresholds(self, threshold_type, comparison_delta, triggers, data):
         """

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -198,10 +198,12 @@ class TestAlertRuleSerializer(TestCase):
         assert alert_rule.snuba_query.aggregate == "count()"
 
     def test_query_project(self):
-        self.run_fail_validation_test(
-            {"query": f"project:{self.project.slug}"},
-            {"query": ["Project is an invalid search term"]},
-        )
+        # `project:` works using `QueryBuilder` so this test can go away once we're using it
+        with self.feature({"organizations:metric-alert-snql": False}):
+            self.run_fail_validation_test(
+                {"query": f"project:{self.project.slug}"},
+                {"query": ["Project is an invalid search term"]},
+            )
 
     def test_decimal(self):
         params = self.valid_transaction_params.copy()

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -74,7 +74,9 @@ class EntitySubscriptionTestCase(TestCase):
             ],
             ["identity", "sessions", "_total_count"],
         ]
-        snql_query = entity_subscription.build_snql_query("", [self.project.id], None)
+        snql_query = entity_subscription.build_query_builder(
+            "", [self.project.id], None
+        ).get_snql_query()
         snql_query.query.select.sort(key=lambda q: q.function)
         assert snql_query.query.select == [
             Function(
@@ -214,7 +216,9 @@ class EntitySubscriptionTestCase(TestCase):
         assert snuba_filter.aggregations == [
             ["quantile(0.95)", "duration", "percentile_transaction_duration__95"]
         ]
-        snql_query = entity_subscription.build_snql_query("", [self.project.id], None)
+        snql_query = entity_subscription.build_query_builder(
+            "", [self.project.id], None
+        ).get_snql_query()
         assert snql_query.query.select == [
             Function(
                 "quantile(0.95)",
@@ -243,7 +247,9 @@ class EntitySubscriptionTestCase(TestCase):
         ]
         assert snuba_filter.aggregations == [["uniq", "tags[sentry:user]", "count_unique_user"]]
 
-        snql_query = entity_subscription.build_snql_query("release:latest", [self.project.id], None)
+        snql_query = entity_subscription.build_query_builder(
+            "release:latest", [self.project.id], None
+        ).get_snql_query()
         assert snql_query.query.select == [
             Function(
                 function="uniq",

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -20,7 +20,7 @@ from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.tasks import (
     SUBSCRIPTION_STATUS_MAX_AGE,
-    build_snql_query,
+    build_query_builder,
     build_snuba_filter,
     create_subscription_in_snuba,
     delete_subscription_from_snuba,
@@ -681,7 +681,7 @@ class BuildSnqlQueryTest(TestCase):
             time_window=time_window,
             extra_fields=entity_extra_fields,
         )
-        snql_query = build_snql_query(
+        snql_query = build_query_builder(
             entity_subscription,
             query,
             (self.project.id,),
@@ -690,7 +690,7 @@ class BuildSnqlQueryTest(TestCase):
                 "organization_id": self.organization.id,
                 "project_id": [self.project.id],
             },
-        )
+        ).get_snql_query()
         select = [self.string_aggregate_to_snql(dataset, aggregate)]
         if dataset == QueryDatasets.SESSIONS:
             col_name = "sessions" if "sessions" in aggregate else "users"


### PR DESCRIPTION
This switches `AlertRuleSerializer` to use snql when validating queries for metric alerts. Same
constraints apply from https://github.com/getsentry/sentry/pull/35611.

This also refactors the `EntitySubscription` classes to have `build_query_builder` instead of
`build_snql_query`. They're the same as before, but now return `QueryBuilder` instead of the query,
which gives us extra flexibility.