### PR TITLE
feat(alerts): Consolidate metric alert discover queries

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -191,20 +191,14 @@ class MetricChart extends PureComponent<Props, State> {
     warningDuration: number
   ) {
     const {rule, orgId, project, timePeriod, query} = this.props;
-    const transactionFields = ['title', 'count()', 'count_unique(user)'];
-    const errorFields = ['issue', 'title', 'count()', 'count_unique(user)'];
 
-    const ctaOpts = {
+    const {buttonText, ...props} = makeDefaultCta({
       orgSlug: orgId,
       projects: [project],
       rule,
-      eventType: query,
-      start: timePeriod.start,
-      end: timePeriod.end,
-      fields: rule.dataset === 'transactions' ? transactionFields : errorFields,
-    };
-
-    const {buttonText, ...props} = makeDefaultCta(ctaOpts);
+      timePeriod,
+      query,
+    });
 
     const resolvedPercent =
       (100 * Math.max(totalDuration - criticalDuration - warningDuration, 0)) /

--- a/static/app/views/alerts/rules/metric/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedIssues.tsx
@@ -34,16 +34,13 @@ function RelatedIssues({rule, organization, projects, query, timePeriod}: Props)
       detail === RELATED_ISSUES_BOOLEAN_QUERY_ERROR &&
       !isSessionAggregate(rule.aggregate)
     ) {
-      const ctaOpts = {
+      const {buttonText, to} = makeDefaultCta({
         orgSlug: organization.slug,
         projects,
         rule,
-        eventType: query,
-        start: timePeriod.start,
-        end: timePeriod.end,
-      };
-
-      const {buttonText, to} = makeDefaultCta(ctaOpts);
+        query,
+        timePeriod,
+      });
       return <RelatedIssuesNotAvailable buttonTo={to} buttonText={buttonText} />;
     }
 

--- a/static/app/views/alerts/rules/metric/metricRulePresets.tsx
+++ b/static/app/views/alerts/rules/metric/metricRulePresets.tsx
@@ -1,8 +1,9 @@
 import type {LinkProps} from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
-import {Project} from 'sentry/types';
+import type {Project} from 'sentry/types';
 import {DisplayModes} from 'sentry/utils/discover/types';
-import {MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
+import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {getMetricRuleDiscoverUrl} from 'sentry/views/alerts/utils/getMetricRuleDiscoverUrl';
 
 interface PresetCta {
@@ -23,11 +24,9 @@ interface PresetCta {
 interface PresetCtaOpts {
   orgSlug: string;
   projects: Project[];
-  end?: string;
-  eventType?: string;
-  fields?: string[];
+  query?: string;
   rule?: MetricRule;
-  start?: string;
+  timePeriod?: TimePeriodType;
 }
 
 /**
@@ -37,10 +36,8 @@ export function makeDefaultCta({
   orgSlug,
   projects,
   rule,
-  eventType,
-  start,
-  end,
-  fields,
+  timePeriod,
+  query,
 }: PresetCtaOpts): PresetCta {
   if (!rule) {
     return {
@@ -58,13 +55,10 @@ export function makeDefaultCta({
     to: getMetricRuleDiscoverUrl({
       orgSlug,
       projects,
-      environment: rule.environment,
       rule,
-      eventType,
-      start,
-      end,
+      timePeriod,
+      query,
       extraQueryParams,
-      fields,
     }),
   };
 }

--- a/static/app/views/alerts/rules/metric/metricRulePresets.tsx
+++ b/static/app/views/alerts/rules/metric/metricRulePresets.tsx
@@ -15,18 +15,14 @@ interface PresetCta {
    * The location to direct to upon clicking the CTA.
    */
   to: LinkProps['to'];
-  /**
-   * The tooltip title for the CTA button, may be empty.
-   */
-  title?: string;
 }
 
 interface PresetCtaOpts {
   orgSlug: string;
   projects: Project[];
+  timePeriod: TimePeriodType;
   query?: string;
   rule?: MetricRule;
-  timePeriod?: TimePeriodType;
 }
 
 /**

--- a/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
+++ b/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
@@ -1,7 +1,7 @@
-import {NewQuery, Project} from 'sentry/types';
+import type {NewQuery, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
-import {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
+import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
 import {Dataset, MetricRule, TimePeriod} from 'sentry/views/alerts/rules/metric/types';
 import {DEFAULT_PROJECT_THRESHOLD} from 'sentry/views/performance/data';
 

--- a/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
+++ b/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
@@ -1,74 +1,88 @@
 import {NewQuery, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
-import {Dataset, MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
+import {Dataset, MetricRule, TimePeriod} from 'sentry/views/alerts/rules/metric/types';
+import {DEFAULT_PROJECT_THRESHOLD} from 'sentry/views/performance/data';
+
+interface MetricRuleDiscoverUrlOptions {
+  orgSlug: string;
+  projects: Project[];
+  extraQueryParams?: Partial<NewQuery>;
+  query?: string;
+  rule?: MetricRule;
+  timePeriod?: TimePeriodType;
+}
+
 /**
  * Gets the URL for a discover view of the rule with the following default
  * parameters:
  *
  * - Ordered by the rule aggregate, descending
  * - yAxis maps to the aggregate
- * - The following fields are displayed:
- *   - For Error dataset alert rules: [issue, count(), count_unique(user)]
- *   - For Transaction dataset alert rules: [transaction, count()]
  * - Start and end are the period's values selected in the chart header
  */
-export function getMetricRuleDiscoverUrl(opts: {
-  orgSlug: string;
-  projects: Project[];
-  end?: string;
-  environment?: string | null;
-  eventType?: string;
-  extraQueryParams?: Partial<NewQuery>;
-  fields?: string[];
-  rule?: MetricRule;
-  start?: string;
-}) {
-  const {
-    orgSlug,
-    projects,
-    rule,
-    eventType,
-    start,
-    end,
-    extraQueryParams,
-    fields,
-    environment,
-  } = opts;
-  const eventTypeTagFilter = eventType && rule?.query ? eventType : '';
-
-  if (!projects || !projects.length || !rule || (!start && !end)) {
+export function getMetricRuleDiscoverUrl({
+  orgSlug,
+  ...rest
+}: MetricRuleDiscoverUrlOptions) {
+  const discoverView = getMetricRuleDiscoverQuery(rest);
+  if (!discoverView || !rest.rule) {
     return '';
   }
 
-  const timeWindowString = `${rule.timeWindow}m`;
-
-  const discoverQuery: NewQuery = {
-    id: undefined,
-    name: (rule && rule.name) || '',
-    orderby: `-${getAggregateAlias(rule.aggregate)}`,
-    yAxis: rule.aggregate ? [rule.aggregate] : undefined,
-    query: (eventTypeTagFilter || rule?.query || eventType) ?? '',
-    projects: projects
-      .filter(({slug}) => rule.projects.includes(slug))
-      .map(({id}) => Number(id)),
-    environment: environment ? [environment] : undefined,
-    version: 2,
-    fields: fields
-      ? fields
-      : rule.dataset === Dataset.ERRORS
-      ? ['issue', 'count()', 'count_unique(user)']
-      : ['transaction', rule.aggregate],
-    start,
-    end,
-    ...extraQueryParams,
-  };
-
-  const discoverView = EventView.fromSavedQuery(discoverQuery);
   const {query, ...toObject} = discoverView.getResultsViewUrlTarget(orgSlug);
+  const timeWindowString = `${rest.rule.timeWindow}m`;
 
   return {
     query: {...query, interval: timeWindowString},
     ...toObject,
   };
+}
+
+export function getMetricRuleDiscoverQuery({
+  projects,
+  rule,
+  timePeriod,
+  query,
+  extraQueryParams,
+}: Omit<MetricRuleDiscoverUrlOptions, 'orgSlug'>) {
+  const missingDate = (!timePeriod?.start && !timePeriod?.end) || !timePeriod?.period;
+  if (!projects || !projects.length || !rule || missingDate) {
+    return '';
+  }
+
+  const aggregateAlias = getAggregateAlias(rule.aggregate);
+
+  const timePeriodFields = timePeriod.usingPeriod
+    ? {range: timePeriod.period === TimePeriod.SEVEN_DAYS ? '7d' : timePeriod.period}
+    : {start: timePeriod.start, end: timePeriod.end};
+
+  const fields =
+    rule.dataset === Dataset.ERRORS
+      ? ['issue', 'count()', 'count_unique(user)']
+      : [
+          'transaction',
+          'project',
+          `${rule.aggregate}`,
+          'count_unique(user)',
+          `user_misery(${DEFAULT_PROJECT_THRESHOLD})`,
+        ];
+
+  const eventQuery: NewQuery = {
+    id: undefined,
+    name: (rule && rule.name) || 'Transactions',
+    fields,
+    orderby: `-${aggregateAlias}`,
+    query: query ?? rule.query ?? '',
+    version: 2,
+    projects: projects
+      .filter(({slug}) => rule.projects.includes(slug))
+      .map(project => Number(project.id)),
+    environment: rule.environment ? [rule.environment] : undefined,
+    ...timePeriodFields,
+    ...extraQueryParams,
+  };
+
+  return EventView.fromSavedQuery(eventQuery);
 }

--- a/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
+++ b/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
@@ -8,10 +8,10 @@ import {DEFAULT_PROJECT_THRESHOLD} from 'sentry/views/performance/data';
 interface MetricRuleDiscoverUrlOptions {
   orgSlug: string;
   projects: Project[];
+  timePeriod: Omit<TimePeriodType, 'display' | 'label'>;
   extraQueryParams?: Partial<NewQuery>;
   query?: string;
   rule?: MetricRule;
-  timePeriod?: TimePeriodType;
 }
 
 /**
@@ -47,8 +47,7 @@ export function getMetricRuleDiscoverQuery({
   query,
   extraQueryParams,
 }: Omit<MetricRuleDiscoverUrlOptions, 'orgSlug'>) {
-  const missingDate = (!timePeriod?.start && !timePeriod?.end) || !timePeriod?.period;
-  if (!projects || !projects.length || !rule || missingDate) {
+  if (!projects || !projects.length || !rule) {
     return '';
   }
 

--- a/tests/js/spec/views/alerts/utils/getMetricRuleDiscoverUrl.spec.tsx
+++ b/tests/js/spec/views/alerts/utils/getMetricRuleDiscoverUrl.spec.tsx
@@ -1,0 +1,44 @@
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {getMetricRuleDiscoverQuery} from 'sentry/views/alerts/utils/getMetricRuleDiscoverUrl';
+
+describe('getMetricRuleDiscoverQuery', () => {
+  it('should use metric aggregate', () => {
+    const rule = TestStubs.MetricRule({
+      aggregate: 'failure_rate()',
+      dataset: Dataset.TRANSACTIONS,
+    });
+    const projects = [TestStubs.Project()];
+    const query = getMetricRuleDiscoverQuery({
+      rule,
+      projects,
+      timePeriod: {period: '7d', usingPeriod: true} as any,
+    });
+    expect(query.valueOf()).toEqual(
+      expect.objectContaining({
+        statsPeriod: '7d',
+        fields: [
+          {
+            field: 'transaction',
+            width: -1,
+          },
+          {
+            field: 'project',
+            width: -1,
+          },
+          {
+            field: 'failure_rate()',
+            width: -1,
+          },
+          {
+            field: 'count_unique(user)',
+            width: -1,
+          },
+          {
+            field: 'user_misery(300)',
+            width: -1,
+          },
+        ],
+      })
+    );
+  });
+});

--- a/tests/js/spec/views/alerts/utils/getMetricRuleDiscoverUrl.spec.tsx
+++ b/tests/js/spec/views/alerts/utils/getMetricRuleDiscoverUrl.spec.tsx
@@ -2,7 +2,7 @@ import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {getMetricRuleDiscoverQuery} from 'sentry/views/alerts/utils/getMetricRuleDiscoverUrl';
 
 describe('getMetricRuleDiscoverQuery', () => {
-  it('should use metric aggregate', () => {
+  it('should use metric aggregate in discover query', () => {
     const rule = TestStubs.MetricRule({
       aggregate: 'failure_rate()',
       dataset: Dataset.TRANSACTIONS,
@@ -11,7 +11,12 @@ describe('getMetricRuleDiscoverQuery', () => {
     const query = getMetricRuleDiscoverQuery({
       rule,
       projects,
-      timePeriod: {period: '7d', usingPeriod: true} as any,
+      timePeriod: {
+        period: '7d',
+        usingPeriod: true,
+        start: new Date().toISOString(),
+        end: new Date().toISOString(),
+      },
     });
     expect(query.valueOf()).toEqual(
       expect.objectContaining({


### PR DESCRIPTION
Combine metric alert "open in discover" button and the query made for related transactions. 

Fixes `failure_rate()` not  being selected when using "open in discover" button on failure rate alert.

fixes https://getsentry.atlassian.net/browse/WOR-1851
