### PR TITLE
ref(projectconfig): Only recompute cached configs

### DIFF
--- a/src/sentry/relay/projectconfig_cache/base.py
+++ b/src/sentry/relay/projectconfig_cache/base.py
@@ -15,3 +15,6 @@ class ProjectConfigCache(Service):
 
     def get(self, public_key):
         raise NotImplementedError()
+
+    def exists(self, public_key):
+        raise NotImplementedError()

--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -45,3 +45,6 @@ class RedisProjectConfigCache(ProjectConfigCache):
         if rv is not None:
             return json.loads(rv)
         return None
+
+    def exists(self, public_key):
+        self.cluster.exists(public_key)

--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -47,4 +47,4 @@ class RedisProjectConfigCache(ProjectConfigCache):
         return None
 
     def exists(self, public_key):
-        self.cluster.exists(public_key)
+        self.cluster.exists(self.__get_redis_key(public_key))


### PR DESCRIPTION
When invalidating a project all configs are recomputed, this change
only recomputes the configs which are already cached and adds a metric
to track the effectiveness.
