### PR TITLE
ref: allow explicit relative imports `from .json`

### DIFF
--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -42,6 +42,7 @@ from json import loads, load
 from simplejson import JSONDecoder, JSONDecodeError, _default_encoder
 import sentry.utils.json as good_json
 from sentry.utils.json import JSONDecoder, JSONDecodeError
+from .json import Validator
 
 
 def bad_code():

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -21,7 +21,7 @@ class SentryVisitor(ast.NodeVisitor):
         self.errors: list[tuple[int, int, str]] = []
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        if node.module and node.module.split(".")[0] in S003_modules:
+        if node.module and not node.level and node.module.split(".")[0] in S003_modules:
             self.errors.append((node.lineno, node.col_offset, S003_msg))
 
         self.generic_visit(node)


### PR DESCRIPTION
slight oversight in the `from` import checker -- `level` indicates how many explicit-relative dots the import has