### PR TITLE
ref: re-enable pyc files now that we're on python 3

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -113,9 +113,6 @@ show_commands_info() {
 
 commands_to_run=()
 
-# don't write *.pyc files; using stale python code occasionally causes subtle problems
-export PYTHONDONTWRITEBYTECODE=1
-
 # Always write stdout immediately. Very helpful for debugging
 export PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
[PEP 3147](https://peps.python.org/pep-3147/#case-3-pycache-foo-magic-pyc-with-no-source) changed how pyc files work such that a stale `.pyc` file won't be importable:

> It’s possible that the foo.py file somehow got removed, while leaving the cached pyc file still on the file system. If the `__pycache__/foo.<magic>.pyc` file exists, but the foo.py file used to create it does not, Python will raise an ImportError when asked to import foo. In other words, Python will not import a pyc file from the cache directory unless the source file exists.

this significantly speeds up local test execution -- here's a noop test best-of-20 before and after:

```console
$ best-of -n 20 -- pytest -qq tests/t.py
...
best of 20: 2.887s
```

```console
$ best-of -n 20 -- pytest -qq tests/t.py
...
best of 20: 1.348s
```