### PR TITLE
ref: fix linting of fixtures namespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,6 @@ exclude: >
         \.snap$|
         \.map$|
         \.map\.js$|
-        ^tests/sentry/lang/.*/fixtures/|
-        ^fixtures/|
         ^src/sentry/static/sentry/vendor/|
         ^tests/sentry/lang/javascript/example-project/|
         ^src/.*/locale/|
@@ -80,9 +78,10 @@ repos:
     - id: check-symlinks
     - id: end-of-file-fixer
       exclude_types: [svg]
+      exclude: ^fixtures/
     - id: trailing-whitespace
       exclude_types: [svg]
-      exclude: ^scripts/patches/
+      exclude: ^(fixtures/|scripts/patches/)
     - id: debug-statements
     - id: name-tests-test
       args: [--pytest-test-first]

--- a/fixtures/integrations/jira/stub_client.py
+++ b/fixtures/integrations/jira/stub_client.py
@@ -1,5 +1,5 @@
-from sentry.shared_integrations.exceptions import ApiError
 from fixtures.integrations import StubService
+from sentry.shared_integrations.exceptions import ApiError
 
 
 class StubJiraApiClient(StubService):

--- a/fixtures/integrations/mock_service.py
+++ b/fixtures/integrations/mock_service.py
@@ -1,11 +1,11 @@
-import json
 import os
 import shutil
 from collections import defaultdict
 
-from sentry.utils.numbers import base32_encode
 from fixtures.integrations import FIXTURE_DIRECTORY
 from fixtures.integrations.stub_service import StubService
+from sentry.utils import json
+from sentry.utils.numbers import base32_encode
 
 
 class MockService(StubService):

--- a/fixtures/integrations/stub_service.py
+++ b/fixtures/integrations/stub_service.py
@@ -1,8 +1,8 @@
 import os
 from copy import deepcopy
 
-from sentry.utils import json
 from fixtures.integrations import FIXTURE_DIRECTORY
+from sentry.utils import json
 
 
 class StubService:

--- a/fixtures/sudo_testutils.py
+++ b/fixtures/sudo_testutils.py
@@ -1,6 +1,5 @@
-from django.contrib.auth.models import AbstractBaseUser
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser, User
 from django.db import models
-from django.contrib.auth.models import AnonymousUser, User
 from django.test import RequestFactory, TestCase
 
 


### PR DESCRIPTION
oops, I accidentally turned off linting of this namespace when moving it from `tests/fixtures` -- this turns it back on and fixes the errors