### PR TITLE
ref: replace self.assertRaises with pytest.raises

### DIFF
--- a/fixtures/schema_validation.py
+++ b/fixtures/schema_validation.py
@@ -1,9 +1,10 @@
+import pytest
 from jsonschema import ValidationError
 
 
 def invalid_schema(func):
     def inner(self, *args, **kwargs):
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             func(self)
 
     return inner
@@ -12,9 +13,9 @@ def invalid_schema(func):
 def invalid_schema_with_error_message(message):
     def decorator(func):
         def inner(self, *args, **kwargs):
-            with self.assertRaises(ValidationError) as cm:
+            with pytest.raises(ValidationError) as excinfo:
                 func(self)
-            assert cm.exception.message == message
+            assert excinfo.value.message == message
 
         return inner
 

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -122,10 +122,10 @@ class OrganizationPermissionTest(OrganizationPermissionBase):
             flags=OrganizationMember.flags["member-limit:restricted"],
         )
 
-        with pytest.raises(MemberDisabledOverLimit) as err:
+        with pytest.raises(MemberDisabledOverLimit) as excinfo:
             self.has_object_perm("GET", self.org, user=user)
 
-        assert err.exception.detail == {
+        assert excinfo.value.detail == {
             "detail": {
                 "code": "member-disabled-over-limit",
                 "message": "Organization over member limit",

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest import mock
 
+import pytest
 from django.db.models import F
 from django.test import RequestFactory
 from django.utils import timezone
@@ -101,14 +102,14 @@ class OrganizationPermissionTest(OrganizationPermissionBase):
         user = self.create_user()
         self.create_member(user=user, organization=self.org, role="member")
 
-        with self.assertRaises(TwoFactorRequired):
+        with pytest.raises(TwoFactorRequired):
             self.has_object_perm("GET", self.org, user=user)
 
     def test_org_requires_2fa_with_superuser_not_active(self):
         self.org_require_2fa()
         user = self.create_user(is_superuser=True)
         self.create_member(user=user, organization=self.org, role="member")
-        with self.assertRaises(SuperuserRequired):
+        with pytest.raises(SuperuserRequired):
             assert self.has_object_perm("GET", self.org, user=user)
 
     @mock.patch("sentry.api.utils.get_cached_organization_member")
@@ -121,7 +122,7 @@ class OrganizationPermissionTest(OrganizationPermissionBase):
             flags=OrganizationMember.flags["member-limit:restricted"],
         )
 
-        with self.assertRaises(MemberDisabledOverLimit) as err:
+        with pytest.raises(MemberDisabledOverLimit) as err:
             self.has_object_perm("GET", self.org, user=user)
 
         assert err.exception.detail == {
@@ -255,7 +256,7 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
         self.run_test([self.project_1, self.project_2])
 
     def test_ids_no_teams(self):
-        with self.assertRaises(PermissionDenied):
+        with pytest.raises(PermissionDenied):
             self.run_test([], project_ids=[self.project_1.id])
 
         self.run_test(
@@ -272,13 +273,13 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
 
         self.org.flags.allow_joinleave = False
         self.org.save()
-        with self.assertRaises(PermissionDenied):
+        with pytest.raises(PermissionDenied):
             self.run_test([self.project_1], user=self.member, project_ids=[self.project_1.id])
 
     def test_ids_teams(self):
         membership = self.create_team_membership(user=self.user, team=self.team_1)
         self.run_test([self.project_1], project_ids=[self.project_1.id])
-        with self.assertRaises(PermissionDenied):
+        with pytest.raises(PermissionDenied):
             self.run_test([], project_ids=[self.project_2.id])
         membership.delete()
         self.create_team_membership(user=self.user, team=self.team_3)
@@ -407,9 +408,9 @@ class GetEnvironmentsTest(BaseOrganizationEndpointTest):
         self.run_test([self.env_1, self.env_2], [self.env_1.name, self.env_2.name])
 
     def test_invalid_params(self):
-        with self.assertRaises(ResourceDoesNotExist):
+        with pytest.raises(ResourceDoesNotExist):
             self.run_test([], ["fake"])
-        with self.assertRaises(ResourceDoesNotExist):
+        with pytest.raises(ResourceDoesNotExist):
             self.run_test([self.env_1, self.env_2], ["fake", self.env_2.name])
 
 
@@ -464,7 +465,7 @@ class GetFilterParamsTest(BaseOrganizationEndpointTest):
 
     @freeze_time("2018-12-11 03:21:34")
     def test_no_params(self):
-        with self.assertRaises(NoProjects):
+        with pytest.raises(NoProjects):
             self.run_test([])
         self.run_test(
             expected_projects=[self.project_1, self.project_2],

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 
+import pytest
 from django.http import Http404
 
 from sentry.api.bases.sentryapps import (
@@ -30,7 +31,7 @@ class SentryAppPermissionTest(TestCase):
     def test_request_user_is_not_app_owner_fails(self):
         self.request.user = self.create_user()
 
-        with self.assertRaises(Http404):
+        with pytest.raises(Http404):
             self.permission.has_object_permission(self.request, None, self.sentry_app)
 
     def test_has_permission(self):
@@ -57,7 +58,7 @@ class SentryAppBaseEndpointTest(TestCase):
         assert kwargs["sentry_app"] == self.sentry_app
 
     def test_raises_when_sentry_app_not_found(self):
-        with self.assertRaises(Http404):
+        with pytest.raises(Http404):
             self.endpoint.convert_args(self.request, "notanapp")
 
 
@@ -88,7 +89,7 @@ class SentryAppInstallationPermissionTest(TestCase):
         assert self.permission.has_object_permission(self.request, None, self.installation)
 
     def test_request_user_not_in_organization(self):
-        with self.assertRaises(Http404):
+        with pytest.raises(Http404):
             self.permission.has_object_permission(self.request, None, self.installation)
 
 
@@ -112,7 +113,7 @@ class SentryAppInstallationBaseEndpointTest(TestCase):
         assert kwargs["installation"] == self.installation
 
     def test_raises_when_sentry_app_not_found(self):
-        with self.assertRaises(Http404):
+        with pytest.raises(Http404):
             self.endpoint.convert_args(self.request, "1234")
 
 

--- a/tests/sentry/api/endpoints/test_doc_integration_details.py
+++ b/tests/sentry/api/endpoints/test_doc_integration_details.py
@@ -1,3 +1,4 @@
+import pytest
 from rest_framework import status
 
 from sentry.api.serializers.base import serialize
@@ -257,7 +258,7 @@ class DeleteDocIntegrationDetailsTest(DocIntegrationDetailsTest):
         assert features.exists()
         assert self.doc_delete.avatar.exists()
         self.get_success_response(self.doc_delete.slug, status_code=status.HTTP_204_NO_CONTENT)
-        with self.assertRaises(DocIntegration.DoesNotExist):
+        with pytest.raises(DocIntegration.DoesNotExist):
             DocIntegration.objects.get(id=self.doc_delete.id)
         assert not features.exists()
         assert not self.doc_delete.avatar.exists()

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import pytest
 from django.http import QueryDict
 
 from sentry.api.helpers.group_index import (
@@ -27,8 +28,8 @@ class ValidateSearchFilterPermissionsTest(TestCase):
     @patch("sentry.analytics.record")
     def test_negative(self, mock_record):
         query = "!has:user"
-        with self.feature({"organizations:advanced-search": False}), self.assertRaisesRegex(
-            ValidationError, ".*negative search.*"
+        with self.feature({"organizations:advanced-search": False}), pytest.raises(
+            ValidationError, match=".*negative search.*"
         ):
             self.run_test(query)
 
@@ -36,8 +37,8 @@ class ValidateSearchFilterPermissionsTest(TestCase):
         self.assert_analytics_recorded(mock_record)
 
         query = "!something:123"
-        with self.feature({"organizations:advanced-search": False}), self.assertRaisesRegex(
-            ValidationError, ".*negative search.*"
+        with self.feature({"organizations:advanced-search": False}), pytest.raises(
+            ValidationError, match=".*negative search.*"
         ):
             self.run_test(query)
 
@@ -47,8 +48,8 @@ class ValidateSearchFilterPermissionsTest(TestCase):
     @patch("sentry.analytics.record")
     def test_wildcard(self, mock_record):
         query = "abc:hello*"
-        with self.feature({"organizations:advanced-search": False}), self.assertRaisesRegex(
-            ValidationError, ".*wildcard search.*"
+        with self.feature({"organizations:advanced-search": False}), pytest.raises(
+            ValidationError, match=".*wildcard search.*"
         ):
             self.run_test(query)
 
@@ -56,8 +57,8 @@ class ValidateSearchFilterPermissionsTest(TestCase):
         self.assert_analytics_recorded(mock_record)
 
         query = "raw * search"
-        with self.feature({"organizations:advanced-search": False}), self.assertRaisesRegex(
-            ValidationError, ".*wildcard search.*"
+        with self.feature({"organizations:advanced-search": False}), pytest.raises(
+            ValidationError, match=".*wildcard search.*"
         ):
             self.run_test(query)
 

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -41,35 +41,35 @@ class TestClientIdSecretAuthentication(TestCase):
         request = HttpRequest()
         request.json_body = None
 
-        with self.assertRaises(AuthenticationFailed):
+        with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_missing_client_id(self):
         request = HttpRequest()
         request.json_body = {"client_secret": self.api_app.client_secret}
 
-        with self.assertRaises(AuthenticationFailed):
+        with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_missing_client_secret(self):
         request = HttpRequest()
         request.json_body = {"client_id": self.api_app.client_id}
 
-        with self.assertRaises(AuthenticationFailed):
+        with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_incorrect_client_id(self):
         request = HttpRequest()
         request.json_body = {"client_id": "notit", "client_secret": self.api_app.client_secret}
 
-        with self.assertRaises(AuthenticationFailed):
+        with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_incorrect_client_secret(self):
         request = HttpRequest()
         request.json_body = {"client_id": self.api_app.client_id, "client_secret": "notit"}
 
-        with self.assertRaises(AuthenticationFailed):
+        with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -174,7 +174,7 @@ class ParseSearchQueryTest(SimpleTestCase):
             expect_error = True
 
         if expect_error:
-            with self.assertRaises(InvalidSearchQuery, msg=failure_help):
+            with pytest.raises(InvalidSearchQuery, msg=failure_help):
                 parse_search_query(query)
             return
 
@@ -353,7 +353,7 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
         ]
 
         # malformed key
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             parse_search_query('has:"hi there"')
 
     def test_not_has_tag(self):
@@ -403,8 +403,8 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
             parse_search_query("count_if(measurements.fcp, greater, 5s):3s")
 
     def test_is_query_unsupported(self):
-        with self.assertRaisesRegex(
-            InvalidSearchQuery, ".*queries are not supported in this search.*"
+        with pytest.raises(
+            InvalidSearchQuery, match=".*queries are not supported in this search.*"
         ):
             parse_search_query("is:unassigned")
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -174,7 +174,7 @@ class ParseSearchQueryTest(SimpleTestCase):
             expect_error = True
 
         if expect_error:
-            with pytest.raises(InvalidSearchQuery, msg=failure_help):
+            with pytest.raises(InvalidSearchQuery):
                 parse_search_query(query)
             return
 

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -87,10 +87,10 @@ class ParseSearchQueryTest(unittest.TestCase):
             ]
 
     def test_is_query_invalid(self):
-        with self.assertRaises(InvalidSearchQuery) as cm:
+        with pytest.raises(InvalidSearchQuery) as excinfo:
             parse_search_query("is:wrong")
 
-        assert str(cm.exception).startswith('Invalid value for "is" search, valid values are')
+        assert str(excinfo.value).startswith('Invalid value for "is" search, valid values are')
 
     def test_is_query_inbox(self):
         assert parse_search_query("is:for_review") == [

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest import TestCase as SimpleTestCase
 
+import pytest
 from django.utils import timezone
 
 from sentry.api.paginator import (
@@ -123,11 +124,11 @@ class OffsetPaginatorTest(TestCase):
         queryset = User.objects.all()
         paginator = OffsetPaginator(queryset)
         cursor = Cursor(10, -1)
-        with self.assertRaises(BadPaginationError):
+        with pytest.raises(BadPaginationError):
             paginator.get_result(cursor=cursor)
 
         cursor = Cursor(-10, 1)
-        with self.assertRaises(BadPaginationError):
+        with pytest.raises(BadPaginationError):
             paginator.get_result(cursor=cursor)
 
     def test_order_by_multiple(self):
@@ -171,7 +172,7 @@ class OffsetPaginatorTest(TestCase):
         assert len(result1) == 3, result1
 
         paginator = OffsetPaginator(queryset, max_offset=0)
-        with self.assertRaises(BadPaginationError):
+        with pytest.raises(BadPaginationError):
             paginator.get_result()
 
 
@@ -612,14 +613,14 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         assert list(result) == page1_results
 
     def test_order_by_invalid_key(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             rule_intermediary = CombinedQuerysetIntermediary(Rule.objects.all(), "dontexist")
             CombinedQuerysetPaginator(
                 intermediaries=[rule_intermediary],
             )
 
     def test_mix_date_and_not_date(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             rule_intermediary = CombinedQuerysetIntermediary(Rule.objects.all(), "date_added")
             rule_intermediary2 = CombinedQuerysetIntermediary(Rule.objects.all(), "label")
             CombinedQuerysetPaginator(

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -1,6 +1,7 @@
 import datetime
 import unittest
 
+import pytest
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -24,7 +25,7 @@ class GetDateRangeFromParamsTest(unittest.TestCase):
         start, end = get_date_range_from_params({"statsPeriod": "91d"})
         assert end - datetime.timedelta(days=91) == start
 
-        with self.assertRaises(InvalidParams):
+        with pytest.raises(InvalidParams):
             get_date_range_from_params({"statsPeriod": "9000000d"})
 
     def test_date_range(self):
@@ -33,7 +34,7 @@ class GetDateRangeFromParamsTest(unittest.TestCase):
         assert start == datetime.datetime(2018, 11, 1, tzinfo=timezone.utc)
         assert end == datetime.datetime(2018, 11, 7, tzinfo=timezone.utc)
 
-        with self.assertRaises(InvalidParams):
+        with pytest.raises(InvalidParams):
             get_date_range_from_params(
                 {"start": "2018-11-01T00:00:00", "end": "2018-11-01T00:00:00"}
             )
@@ -58,5 +59,5 @@ class GetDateRangeFromParamsTest(unittest.TestCase):
     @freeze_time("2018-12-11 03:21:34")
     def test_relative_date_range_incomplete(self):
 
-        with self.assertRaises(InvalidParams):
+        with pytest.raises(InvalidParams):
             start, end = get_date_range_from_params({"statsPeriodStart": "14d"})

--- a/tests/sentry/audit_log/test_manager.py
+++ b/tests/sentry/audit_log/test_manager.py
@@ -1,3 +1,4 @@
+import pytest
 from django.utils import timezone
 
 from sentry import audit_log
@@ -51,7 +52,7 @@ class AuditLogEventManagerTest(TestCase):
                 template="test member {email} is {role}",
             )
         )
-        with self.assertRaises(DuplicateAuditLogEvent):
+        with pytest.raises(DuplicateAuditLogEvent):
             test_manager.add(
                 AuditLogEvent(
                     event_id=500,
@@ -62,7 +63,7 @@ class AuditLogEventManagerTest(TestCase):
             )
         assert test_manager.get_event_id(name="TEST_LOG_ENTRY") == 500
 
-        with self.assertRaises(AuditLogEventNotRegistered):
+        with pytest.raises(AuditLogEventNotRegistered):
             test_manager.get_event_id(name="TEST_DUPLICATE")
 
     def test_duplicate_event_name(self):
@@ -76,7 +77,7 @@ class AuditLogEventManagerTest(TestCase):
                 template="test member {email} is {role}",
             )
         )
-        with self.assertRaises(DuplicateAuditLogEvent):
+        with pytest.raises(DuplicateAuditLogEvent):
             test_manager.add(
                 AuditLogEvent(
                     event_id=501,
@@ -88,7 +89,7 @@ class AuditLogEventManagerTest(TestCase):
         assert test_manager.get_event_id(name="TEST_LOG_ENTRY") == 500
         assert "test.duplicate" not in test_manager.get_api_names()
 
-        with self.assertRaises(AuditLogEventNotRegistered):
+        with pytest.raises(AuditLogEventNotRegistered):
             test_manager.get(501)
 
     def test_duplicate_api_name(self):
@@ -102,7 +103,7 @@ class AuditLogEventManagerTest(TestCase):
                 template="test member {email} is {role}",
             )
         )
-        with self.assertRaises(DuplicateAuditLogEvent):
+        with pytest.raises(DuplicateAuditLogEvent):
             test_manager.add(
                 AuditLogEvent(
                     event_id=501,
@@ -113,5 +114,5 @@ class AuditLogEventManagerTest(TestCase):
             )
         assert test_manager.get_event_id_from_api_name(api_name="test-log.entry") == 500
 
-        with self.assertRaises(AuditLogEventNotRegistered):
+        with pytest.raises(AuditLogEventNotRegistered):
             test_manager.get(501)

--- a/tests/sentry/auth/test_email.py
+++ b/tests/sentry/auth/test_email.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
 from sentry.models import OrganizationMember, UserEmail
 from sentry.testutils import TestCase
@@ -23,7 +25,7 @@ class EmailResolverTest(TestCase):
         for user in (self.user1, self.user2):
             UserEmail.objects.create(user=user, email="me@example.com")
 
-        with self.assertRaises(AmbiguousUserFromEmail) as context:
+        with pytest.raises(AmbiguousUserFromEmail) as context:
             resolve_email_to_user("me@example.com")
         assert set(context.exception.users) == {self.user1, self.user2}
         assert mock_metrics.incr.call_args.args == ("auth.email_resolution.no_resolution",)

--- a/tests/sentry/auth/test_email.py
+++ b/tests/sentry/auth/test_email.py
@@ -25,9 +25,9 @@ class EmailResolverTest(TestCase):
         for user in (self.user1, self.user2):
             UserEmail.objects.create(user=user, email="me@example.com")
 
-        with pytest.raises(AmbiguousUserFromEmail) as context:
+        with pytest.raises(AmbiguousUserFromEmail) as excinfo:
             resolve_email_to_user("me@example.com")
-        assert set(context.exception.users) == {self.user1, self.user2}
+        assert set(excinfo.value.users) == {self.user1, self.user2}
         assert mock_metrics.incr.call_args.args == ("auth.email_resolution.no_resolution",)
 
     @mock.patch("sentry.auth.email.metrics")

--- a/tests/sentry/auth/test_superuser.py
+++ b/tests/sentry/auth/test_superuser.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 from unittest.mock import Mock, patch
 
+import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
 from django.utils import timezone
@@ -197,7 +198,7 @@ class SuperuserTestCase(TestCase):
         with self.settings(
             SENTRY_SELF_HOSTED=False, VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON=True
         ):
-            with self.assertRaises(EmptySuperuserAccessForm):
+            with pytest.raises(EmptySuperuserAccessForm):
                 superuser.set_logged_in(request.user)
                 assert superuser.is_active is False
 
@@ -265,7 +266,7 @@ class SuperuserTestCase(TestCase):
         with self.settings(
             SENTRY_SELF_HOSTED=False, VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON=True
         ):
-            with self.assertRaises(SuperuserAccessFormInvalidJson):
+            with pytest.raises(SuperuserAccessFormInvalidJson):
                 superuser.set_logged_in(request.user)
                 assert superuser.is_active is False
 

--- a/tests/sentry/cache/test_redis.py
+++ b/tests/sentry/cache/test_redis.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.cache.redis import RedisCache, ValueTooLarge
 from sentry.testutils import TestCase
 
@@ -17,5 +19,5 @@ class RedisCacheTest(TestCase):
         result = self.backend.get("foo")
         assert result is None
 
-        with self.assertRaises(ValueTooLarge):
+        with pytest.raises(ValueTooLarge):
             self.backend.set("foo", "x" * (RedisCache.max_size + 1), 0)

--- a/tests/sentry/data_export/processors/test_discover.py
+++ b/tests/sentry/data_export/processors/test_discover.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.data_export.base import ExportError
 from sentry.data_export.processors.discover import DiscoverProcessor
 from sentry.testutils import SnubaTestCase, TestCase
@@ -28,7 +30,7 @@ class DiscoverProcessorTest(TestCase, SnubaTestCase):
             organization_id=self.org.id, query={"project": [self.project1.id, self.project2.id]}
         )
         assert sorted(p.id for p in projects) == sorted([self.project1.id, self.project2.id])
-        with self.assertRaises(ExportError):
+        with pytest.raises(ExportError):
             DiscoverProcessor.get_projects(organization_id=self.org.id, query={"project": [-1]})
 
     def test_handle_fields(self):

--- a/tests/sentry/data_export/processors/test_issues_by_tag.py
+++ b/tests/sentry/data_export/processors/test_issues_by_tag.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.data_export.base import ExportError
 from sentry.data_export.processors.issues_by_tag import IssuesByTagProcessor
 from sentry.models import EventUser, Group, Project
@@ -38,14 +40,14 @@ class IssuesByTagProcessorTest(TestCase, SnubaTestCase):
         project = IssuesByTagProcessor.get_project(project_id=self.project.id)
         assert isinstance(project, Project)
         assert project == self.project
-        with self.assertRaises(ExportError):
+        with pytest.raises(ExportError):
             IssuesByTagProcessor.get_project(project_id=-1)
 
     def test_get_group(self):
         group = IssuesByTagProcessor.get_group(group_id=self.group.id, project=self.project)
         assert isinstance(group, Group)
         assert group == self.group
-        with self.assertRaises(ExportError):
+        with pytest.raises(ExportError):
             IssuesByTagProcessor.get_group(group_id=-1, project=self.project)
 
     def test_get_header_fields(self):

--- a/tests/sentry/db/models/fields/bitfield/test_bitfield.py
+++ b/tests/sentry/db/models/fields/bitfield/test_bitfield.py
@@ -1,6 +1,7 @@
 import pickle
 import unittest
 
+import pytest
 from django import forms
 from django.db import connection, models
 from django.db.models import F
@@ -44,7 +45,7 @@ class BitHandlerTest(unittest.TestCase):
         self.assertEqual(int(bithandler.FLAG_2.number), 2)
         self.assertEqual(int(bithandler.FLAG_3.number), 3)
         # Negative test non-existant key.
-        self.assertRaises(AttributeError, lambda: bithandler.FLAG_4)
+        pytest.raises(AttributeError, lambda: bithandler.FLAG_4)
         # Test bool().
         self.assertEqual(bool(bithandler.FLAG_0), False)
         self.assertEqual(bool(bithandler.FLAG_1), False)
@@ -306,7 +307,7 @@ class BitFieldTest(TestCase):
         except ValueError:
             self.fail("It should work well with these flags")
 
-        self.assertRaises(ValueError, BitField, flags=flags[: (MAX_COUNT + 1)])
+        pytest.raises(ValueError, BitField, flags=flags[: (MAX_COUNT + 1)])
 
     def test_dictionary_init(self):
         flags = {
@@ -325,9 +326,9 @@ class BitFieldTest(TestCase):
             self.fail("It should work well with these flags")
 
         self.assertEqual(bf.flags, ["zero", "first", "second", "", "", "", "", "", "", "", "tenth"])
-        self.assertRaises(ValueError, BitField, flags={})
-        self.assertRaises(ValueError, BitField, flags={"wrongkey": "wrongkey"})
-        self.assertRaises(ValueError, BitField, flags={"1": "non_int_key"})
+        pytest.raises(ValueError, BitField, flags={})
+        pytest.raises(ValueError, BitField, flags={"wrongkey": "wrongkey"})
+        pytest.raises(ValueError, BitField, flags={"1": "non_int_key"})
 
     def test_defaults_as_key_names(self):
         class TestModel(models.Model):

--- a/tests/sentry/db/models/fields/test_bounded.py
+++ b/tests/sentry/db/models/fields/test_bounded.py
@@ -1,3 +1,4 @@
+import pytest
 from django.db import models
 
 from sentry.db.models import (
@@ -25,11 +26,11 @@ class DummyModel(Model):
 
 class ModelTest(TestCase):
     def test_large_int(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             DummyModel.objects.create(normint=int(9223372036854775807), foo="bar")
 
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             DummyModel.objects.create(bigint=int(9223372036854775808), foo="bar")
 
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             DummyModel.objects.create(posint=int(9223372036854775808), foo="bar")

--- a/tests/sentry/db/models/fields/test_jsonfield.py
+++ b/tests/sentry/db/models/fields/test_jsonfield.py
@@ -1,3 +1,4 @@
+import pytest
 from django import forms
 from django.db import models
 from django.utils.encoding import force_text
@@ -136,7 +137,7 @@ class JSONFieldTest(TestCase):
         # self.assertEqual(1, JSONFieldTestModel.objects.filter(json__contains={'baz':'bing', 'foo':'bar'}).count())
         self.assertEqual(2, JSONFieldTestModel.objects.filter(json__contains="foo").count())
         # This code needs to be implemented!
-        self.assertRaises(
+        pytest.raises(
             TypeError, lambda: JSONFieldTestModel.objects.filter(json__contains=["baz", "foo"])
         )
 
@@ -179,11 +180,11 @@ class JSONFieldTest(TestCase):
         obj = JSONFieldTestModel()
         obj.json = '{"foo": 2}'
         assert "foo" in obj.json
-        with self.assertRaises(forms.ValidationError):
+        with pytest.raises(forms.ValidationError):
             obj.json = '{"foo"}'
 
     def test_invalid_json_default(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             JSONField("test", default='{"foo"}')
 
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1604,7 +1604,7 @@ class EventManagerTest(TestCase):
         with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
             with self.feature("organizations:event-attachments"):
                 with self.tasks():
-                    with self.assertRaises(HashDiscarded):
+                    with pytest.raises(HashDiscarded):
                         event = manager.save(1, cache_key=cache_key)
 
         assert mock_track_outcome.call_count == 3

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 import responses
 from django.test import override_settings
 from exam import fixture
@@ -406,7 +407,7 @@ class TestAlertRuleSerializer(TestCase):
         )
         serializer = AlertRuleSerializer(context=self.context, data=base_params)
         assert serializer.is_valid()
-        with self.assertRaises(serializers.ValidationError):
+        with pytest.raises(serializers.ValidationError):
             serializer.save()
 
         # Make sure the rule was not created.
@@ -477,7 +478,7 @@ class TestAlertRuleSerializer(TestCase):
         serializer = AlertRuleSerializer(context=self.context, data=base_params)
         # error is raised during save
         assert serializer.is_valid()
-        with self.assertRaises(ChannelLookupTimeoutError) as err:
+        with pytest.raises(ChannelLookupTimeoutError) as err:
             serializer.save()
         assert (
             str(err.exception)
@@ -510,7 +511,7 @@ class TestAlertRuleSerializer(TestCase):
         serializer = AlertRuleSerializer(context=self.context, data=base_params)
         # error is raised during save
         assert serializer.is_valid()
-        with self.assertRaises(serializers.ValidationError) as err:
+        with pytest.raises(serializers.ValidationError) as err:
             serializer.save()
         assert err.exception.detail == {"nonFieldErrors": ["Team does not exist"]}
         mock_get_channel_id.assert_called_with(self.integration, "my-channel", 10)
@@ -647,9 +648,9 @@ class TestAlertRuleSerializer(TestCase):
         serializer.save()
         serializer = AlertRuleSerializer(context=self.context, data=self.valid_params)
         assert serializer.is_valid(), serializer.errors
-        with self.assertRaises(serializers.ValidationError) as cm:
+        with pytest.raises(serializers.ValidationError) as excinfo:
             serializer.save()
-        assert cm.exception.detail[0] == "You may not exceed 1 metric alerts per organization"
+        assert excinfo.value.detail[0] == "You may not exceed 1 metric alerts per organization"
 
 
 class TestAlertRuleTriggerSerializer(TestCase):
@@ -850,7 +851,7 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
         )
         serializer = AlertRuleTriggerActionSerializer(context=self.context, data=base_params)
         assert serializer.is_valid()
-        with self.assertRaises(serializers.ValidationError):
+        with pytest.raises(serializers.ValidationError):
             serializer.save()
 
     @responses.activate

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -478,10 +478,10 @@ class TestAlertRuleSerializer(TestCase):
         serializer = AlertRuleSerializer(context=self.context, data=base_params)
         # error is raised during save
         assert serializer.is_valid()
-        with pytest.raises(ChannelLookupTimeoutError) as err:
+        with pytest.raises(ChannelLookupTimeoutError) as excinfo:
             serializer.save()
         assert (
-            str(err.exception)
+            str(excinfo.value)
             == "Could not find channel my-channel. We have timed out trying to look for it."
         )
 
@@ -511,9 +511,9 @@ class TestAlertRuleSerializer(TestCase):
         serializer = AlertRuleSerializer(context=self.context, data=base_params)
         # error is raised during save
         assert serializer.is_valid()
-        with pytest.raises(serializers.ValidationError) as err:
+        with pytest.raises(serializers.ValidationError) as excinfo:
             serializer.save()
-        assert err.exception.detail == {"nonFieldErrors": ["Team does not exist"]}
+        assert excinfo.value.detail == {"nonFieldErrors": ["Team does not exist"]}
         mock_get_channel_id.assert_called_with(self.integration, "my-channel", 10)
 
     def test_event_types(self):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -461,7 +461,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.include_all_projects == include_all_projects
 
     def test_invalid_query(self):
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             create_alert_rule(
                 self.organization,
                 [self.project],
@@ -636,7 +636,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.snuba_query.query == ""
 
     def test_invalid_query(self):
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             update_alert_rule(self.alert_rule, query="has:")
 
     def test_delete_projects(self):
@@ -966,13 +966,13 @@ class CreateAlertRuleTriggerTest(TestCase):
     def test_excluded_projects_not_associated_with_rule(self):
         other_project = self.create_project(fire_project_created=True)
         alert_rule = self.create_alert_rule(projects=[self.project])
-        with self.assertRaises(ProjectsNotAssociatedWithAlertRuleError):
+        with pytest.raises(ProjectsNotAssociatedWithAlertRuleError):
             create_alert_rule_trigger(alert_rule, "hi", 100, excluded_projects=[other_project])
 
     def test_existing_label(self):
         name = "uh oh"
         create_alert_rule_trigger(self.alert_rule, name, 100)
-        with self.assertRaises(AlertRuleTriggerLabelAlreadyUsedError):
+        with pytest.raises(AlertRuleTriggerLabelAlreadyUsedError):
             create_alert_rule_trigger(self.alert_rule, name, 100)
 
 
@@ -994,7 +994,7 @@ class UpdateAlertRuleTriggerTest(TestCase):
         label = "uh oh"
         create_alert_rule_trigger(self.alert_rule, label, 1000)
         trigger = create_alert_rule_trigger(self.alert_rule, "something else", 1000)
-        with self.assertRaises(AlertRuleTriggerLabelAlreadyUsedError):
+        with pytest.raises(AlertRuleTriggerLabelAlreadyUsedError):
             update_alert_rule_trigger(trigger, label=label)
 
     def test_exclude_projects(self):
@@ -1026,7 +1026,7 @@ class UpdateAlertRuleTriggerTest(TestCase):
         alert_rule = self.create_alert_rule(projects=[self.project])
         trigger = create_alert_rule_trigger(alert_rule, "hi", 1000)
 
-        with self.assertRaises(ProjectsNotAssociatedWithAlertRuleError):
+        with pytest.raises(ProjectsNotAssociatedWithAlertRuleError):
             update_alert_rule_trigger(trigger, excluded_projects=[other_project])
 
 
@@ -1123,7 +1123,7 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
         type = AlertRuleTriggerAction.Type.SLACK
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
         channel_name = "#some_channel_that_doesnt_exist"
-        with self.assertRaises(InvalidTriggerActionError):
+        with pytest.raises(InvalidTriggerActionError):
             create_alert_rule_trigger_action(
                 self.trigger,
                 type,
@@ -1155,7 +1155,7 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
             content_type="application/json",
             body=json.dumps({"ok": "false", "error": "ratelimited"}),
         )
-        with self.assertRaises(ApiRateLimitedError):
+        with pytest.raises(ApiRateLimitedError):
             create_alert_rule_trigger_action(
                 self.trigger,
                 type,
@@ -1195,7 +1195,7 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
         channel_name = "some_channel"
 
-        with self.assertRaises(InvalidTriggerActionError):
+        with pytest.raises(InvalidTriggerActionError):
             create_alert_rule_trigger_action(
                 self.trigger,
                 type,
@@ -1253,7 +1253,7 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
         target_identifier = 1
 
-        with self.assertRaises(InvalidTriggerActionError):
+        with pytest.raises(InvalidTriggerActionError):
             create_alert_rule_trigger_action(
                 self.trigger,
                 type,
@@ -1329,7 +1329,7 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
         type = AlertRuleTriggerAction.Type.SLACK
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
         channel_name = "#some_channel_that_doesnt_exist"
-        with self.assertRaises(InvalidTriggerActionError):
+        with pytest.raises(InvalidTriggerActionError):
             update_alert_rule_trigger_action(
                 self.action,
                 type,
@@ -1361,7 +1361,7 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             content_type="application/json",
             body=json.dumps({"ok": "false", "error": "ratelimited"}),
         )
-        with self.assertRaises(ApiRateLimitedError):
+        with pytest.raises(ApiRateLimitedError):
             update_alert_rule_trigger_action(
                 self.action,
                 type,
@@ -1401,7 +1401,7 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
         channel_name = "some_channel"
 
-        with self.assertRaises(InvalidTriggerActionError):
+        with pytest.raises(InvalidTriggerActionError):
             update_alert_rule_trigger_action(
                 self.action,
                 type,
@@ -1460,7 +1460,7 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
         target_identifier = 1
 
-        with self.assertRaises(InvalidTriggerActionError):
+        with pytest.raises(InvalidTriggerActionError):
             update_alert_rule_trigger_action(
                 self.action,
                 type,
@@ -1483,7 +1483,7 @@ class DeleteAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
     def test(self):
         action_id = self.action.id
         delete_alert_rule_trigger_action(self.action)
-        with self.assertRaises(AlertRuleTriggerAction.DoesNotExist):
+        with pytest.raises(AlertRuleTriggerAction.DoesNotExist):
             AlertRuleTriggerAction.objects.get(id=action_id)
 
 

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
+import pytest
 from django.core.cache import cache
 from django.db import IntegrityError, transaction
 from django.utils import timezone
@@ -102,7 +103,7 @@ class IncidentClearSubscriptionCacheTest(TestCase):
         self.subscription.delete()
         # Add the subscription id back in so we don't use `None` in the lookup check.
         self.subscription.id = subscription_id
-        with self.assertRaises(AlertRule.DoesNotExist):
+        with pytest.raises(AlertRule.DoesNotExist):
             AlertRule.objects.get_for_subscription(self.subscription)
 
     def test_deleted_alert_rule(self):
@@ -112,7 +113,7 @@ class IncidentClearSubscriptionCacheTest(TestCase):
             == self.alert_rule
         )
         delete_alert_rule(self.alert_rule)
-        with self.assertRaises(AlertRule.DoesNotExist):
+        with pytest.raises(AlertRule.DoesNotExist):
             AlertRule.objects.get_for_subscription(self.subscription)
 
 

--- a/tests/sentry/integrations/aws_lambda/test_utils.py
+++ b/tests/sentry/integrations/aws_lambda/test_utils.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.core.cache import cache
 from django.test import override_settings
 
@@ -192,15 +193,15 @@ class GetOptionValueTest(TestCase):
         }
         mock_get.return_value = self.cache_value
         with override_settings(SENTRY_RELEASE_REGISTRY_BASEURL="http://localhost:5000"):
-            with self.assertRaisesRegex(IntegrationError, "Unsupported region us-gov-east-1"):
+            with pytest.raises(IntegrationError, match="Unsupported region us-gov-east-1"):
                 get_option_value(fn, OPTION_VERSION)
 
     @patch.object(cache, "get")
     def test_cache_miss(self, mock_get):
         mock_get.return_value = {}
         with override_settings(SENTRY_RELEASE_REGISTRY_BASEURL="http://localhost:5000"):
-            with self.assertRaisesRegex(
+            with pytest.raises(
                 IntegrationError,
-                "Could not find cache value with key aws-layer:node",
+                match="Could not find cache value with key aws-layer:node",
             ):
                 get_option_value(self.node_fn, OPTION_VERSION)

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1,6 +1,7 @@
 import base64
 from unittest import mock
 
+import pytest
 import responses
 
 from sentry.models import Integration, Repository
@@ -96,7 +97,7 @@ class GitHubAppsClientTest(TestCase):
 
         responses.add(method=responses.HEAD, url=url, status=404)
 
-        with self.assertRaises(ApiError):
+        with pytest.raises(ApiError):
             self.client.check_file(self.repo, path, version)
         assert responses.calls[1].response.status_code == 404
 

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -157,7 +157,7 @@ class GitlabRefreshAuthTest(GitLabTestCase):
             f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/src%2Ffile.py?ref={ref}",
             status=404,
         )
-        with self.assertRaises(ApiError):
+        with pytest.raises(ApiError):
             self.client.check_file(self.repo, path, ref)
         assert responses.calls[0].response.status_code == 404
 

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -1,5 +1,6 @@
 import copy
 
+import pytest
 import responses
 
 from fixtures.gitlab import GitLabTestCase
@@ -394,7 +395,7 @@ class GitlabIssuesTest(GitLabTestCase):
         external_issue = ExternalIssue.objects.create(
             organization_id=self.organization.id, integration_id=self.integration.id, key="#"
         )
-        with self.assertRaises(IntegrationError):
+        with pytest.raises(IntegrationError):
             self.installation.after_link_issue(external_issue, data=data)
 
     @responses.activate
@@ -408,5 +409,5 @@ class GitlabIssuesTest(GitLabTestCase):
         external_issue = ExternalIssue.objects.create(
             organization_id=self.organization.id, integration_id=self.integration.id, key="2#321"
         )
-        with self.assertRaises(IntegrationError):
+        with pytest.raises(IntegrationError):
             self.installation.after_link_issue(external_issue, data=data)

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -664,7 +664,7 @@ class JiraIntegrationTest(APITestCase):
             "sync_status_forward": {10100: {"on_resolve": "", "on_unresolve": "3"}},
         }
 
-        with self.assertRaises(IntegrationError):
+        with pytest.raises(IntegrationError):
             installation.update_organization_config(data)
 
         data = {

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -1,6 +1,8 @@
 from unittest import mock
 from urllib.parse import urlencode
 
+import pytest
+
 from sentry import options
 from sentry.integrations.slack.requests.action import SlackActionRequest
 from sentry.integrations.slack.requests.base import SlackRequest, SlackRequestError
@@ -59,31 +61,31 @@ class SlackRequestTest(TestCase):
     def test_validate_existence_of_data(self):
         type(self.request).DATA = mock.PropertyMock(side_effect=ValueError())
 
-        with self.assertRaises(SlackRequestError):
+        with pytest.raises(SlackRequestError):
             self.slack_request.validate()
 
     def test_returns_400_on_invalid_data(self):
         type(self.request).DATA = mock.PropertyMock(side_effect=ValueError())
 
-        with self.assertRaises(SlackRequestError) as e:
+        with pytest.raises(SlackRequestError) as e:
             self.slack_request.validate()
             assert e.status == 400
 
     def test_validates_token(self):
         self.request.data["token"] = "notthetoken"
 
-        with self.assertRaises(SlackRequestError):
+        with pytest.raises(SlackRequestError):
             self.slack_request.validate()
 
     def test_returns_401_on_invalid_token(self):
         self.request.data["token"] = "notthetoken"
 
-        with self.assertRaises(SlackRequestError) as e:
+        with pytest.raises(SlackRequestError) as e:
             self.slack_request.validate()
             assert e.status == 401
 
     def test_validates_existence_of_integration(self):
-        with self.assertRaises(SlackRequestError) as e:
+        with pytest.raises(SlackRequestError) as e:
             self.slack_request.validate()
             assert e.status == 403
 
@@ -134,13 +136,13 @@ class SlackEventRequestTest(TestCase):
     def test_validate_missing_event(self):
         self.request.data.pop("event")
 
-        with self.assertRaises(SlackRequestError):
+        with pytest.raises(SlackRequestError):
             self.slack_request.validate()
 
     def test_validate_missing_event_type(self):
         self.request.data["event"] = {}
 
-        with self.assertRaises(SlackRequestError):
+        with pytest.raises(SlackRequestError):
             self.slack_request.validate()
 
     def test_type(self):
@@ -155,7 +157,7 @@ class SlackEventRequestTest(TestCase):
         self.request.body = urlencode(self.request.data).encode("utf-8")
 
         self.request.META = set_signing_secret("bad_key", self.request.body)
-        with self.assertRaises(SlackRequestError) as e:
+        with pytest.raises(SlackRequestError) as e:
             self.slack_request.validate()
             assert e.status == 401
 
@@ -206,11 +208,11 @@ class SlackActionRequestTest(TestCase):
     def test_validates_existence_of_payload(self):
         self.request.data.pop("payload")
 
-        with self.assertRaises(SlackRequestError):
+        with pytest.raises(SlackRequestError):
             self.slack_request.validate()
 
     def test_validates_payload_json(self):
         self.request.data["payload"] = "notjson"
 
-        with self.assertRaises(SlackRequestError):
+        with pytest.raises(SlackRequestError):
             self.slack_request.validate()

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -1,5 +1,6 @@
 from urllib.parse import parse_qs
 
+import pytest
 import responses
 from rest_framework.serializers import ValidationError
 
@@ -342,7 +343,7 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         dsn = ProjectKey.get_default(project=Project.objects.get(id=project_id))
         dsn.update(id=dsn.id, status=ProjectKeyStatus.INACTIVE)
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             installation.update_organization_config(data)
 
     @responses.activate
@@ -366,7 +367,7 @@ class VercelIntegrationTest(IntegrationTestCase):
             % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
             json={},
         )
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             installation.update_organization_config(data)
 
     @responses.activate

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -326,7 +326,7 @@ class VstsIntegrationTest(VstsIntegrationTestCase):
 
         # test validation
         data = {"sync_status_forward": {1: {"on_resolve": "", "on_unresolve": "UnresolvedStatus1"}}}
-        with self.assertRaises(IntegrationError):
+        with pytest.raises(IntegrationError):
             integration.update_organization_config(data)
 
         data = {

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -924,7 +924,7 @@ class DiscoverSourcemapTest(unittest.TestCase):
         result = http.UrlResult(
             "http://example.com", {}, b"//# sourceMappingURL=/*lol*/", 200, None
         )
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             discover_sourcemap(result)
 
 

--- a/tests/sentry/mediators/external_issues/test_issue_link_creator.py
+++ b/tests/sentry/mediators/external_issues/test_issue_link_creator.py
@@ -1,3 +1,4 @@
+import pytest
 import responses
 
 from sentry.coreapi import APIUnauthorized
@@ -56,7 +57,7 @@ class TestIssueLinkCreator(TestCase):
         assert external_issue.display_name == "Projectname#issue-1"
 
     def test_invalid_action(self):
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             IssueLinkCreator.run(
                 install=self.install,
                 group=self.group,

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -1,3 +1,4 @@
+import pytest
 import responses
 
 from sentry.coreapi import APIError
@@ -90,7 +91,7 @@ class TestIssueLinkRequester(TestCase):
             status=200,
             content_type="application/json",
         )
-        with self.assertRaises(APIError):
+        with pytest.raises(APIError):
             IssueLinkRequester.run(
                 install=self.install,
                 project=self.project,
@@ -110,7 +111,7 @@ class TestIssueLinkRequester(TestCase):
             status=500,
         )
 
-        with self.assertRaises(APIError):
+        with pytest.raises(APIError):
             IssueLinkRequester.run(
                 install=self.install,
                 project=self.project,

--- a/tests/sentry/mediators/external_requests/test_select_requester.py
+++ b/tests/sentry/mediators/external_requests/test_select_requester.py
@@ -1,3 +1,4 @@
+import pytest
 import responses
 
 from sentry.coreapi import APIError
@@ -64,7 +65,7 @@ class TestSelectRequester(TestCase):
             content_type="application/json",
         )
 
-        with self.assertRaises(APIError):
+        with pytest.raises(APIError):
             SelectRequester.run(
                 install=self.install,
                 project=self.project,
@@ -82,7 +83,7 @@ class TestSelectRequester(TestCase):
             status=500,
         )
 
-        with self.assertRaises(APIError):
+        with pytest.raises(APIError):
             SelectRequester.run(
                 install=self.install,
                 project=self.project,

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 import responses
 from django.db import connection
 from requests.exceptions import RequestException
@@ -124,7 +125,7 @@ class TestDestroyer(TestCase):
         responses.add(responses.POST, "https://example.com/webhook")
         self.destroyer.call()
 
-        with self.assertRaises(SentryAppInstallation.DoesNotExist):
+        with pytest.raises(SentryAppInstallation.DoesNotExist):
             SentryAppInstallation.objects.get(pk=self.install.id)
 
         # The QuerySet will automatically NOT include deleted installs, so we

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -1,6 +1,8 @@
 from collections import namedtuple
 from unittest.mock import patch
 
+import pytest
+
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.sentry_app_installations import InstallationNotifier
 from sentry.testutils import TestCase
@@ -103,7 +105,7 @@ class TestInstallationNotifier(TestCase):
 
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     def test_invalid_installation_action(self, safe_urlopen):
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             InstallationNotifier.run(install=self.install, user=self.user, action="updated")
 
         assert not safe_urlopen.called

--- a/tests/sentry/mediators/sentry_apps/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_apps/test_destroyer.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 import responses
 from django.db import connection
 
@@ -62,7 +63,7 @@ class TestDestroyer(TestCase):
     def test_soft_deletes_sentry_app(self):
         self.destroyer.call()
 
-        with self.assertRaises(SentryApp.DoesNotExist):
+        with pytest.raises(SentryApp.DoesNotExist):
             SentryApp.objects.get(pk=self.sentry_app.id)
 
         # The QuerySet will automatically NOT include deleted installs, so we

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import pytest
 from django.utils import timezone
 
 from sentry.constants import SentryAppStatus
@@ -73,7 +74,7 @@ class TestUpdater(TestCase):
         updater = Updater(sentry_app=sentry_app, user=self.user)
         updater.scopes = ("project:read", "project:write")
 
-        with self.assertRaises(APIError):
+        with pytest.raises(APIError):
             updater.call()
 
     def test_update_webhook_published_app(self):
@@ -93,7 +94,7 @@ class TestUpdater(TestCase):
         )
         updater = Updater(sentry_app=sentry_app, user=self.user)
         updater.events = ("issue",)
-        with self.assertRaises(APIError):
+        with pytest.raises(APIError):
             updater.call()
 
     def test_doesnt_update_verify_install_if_internal(self):
@@ -101,7 +102,7 @@ class TestUpdater(TestCase):
         sentry_app = self.create_internal_integration(name="Internal", organization=self.org)
         updater = Updater(sentry_app=sentry_app, user=self.user)
         updater.verify_install = True
-        with self.assertRaises(APIError):
+        with pytest.raises(APIError):
             updater.call()
 
     def test_updates_service_hook_events(self):

--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -2,6 +2,8 @@ import logging
 import types
 from unittest.mock import PropertyMock, patch
 
+import pytest
+
 from sentry.mediators import Mediator, Param
 from sentry.models import User
 from sentry.testutils import TestCase
@@ -35,11 +37,11 @@ class TestMediator(TestCase):
         with patch.object(MockMediator, "call"):
             del MockMediator.call
 
-            with self.assertRaises(NotImplementedError):
+            with pytest.raises(NotImplementedError):
                 MockMediator.run(user={"name": "Example"})
 
     def test_validate_params(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             MockMediator.run(user=False)
 
     def test_param_access(self):
@@ -50,7 +52,7 @@ class TestMediator(TestCase):
         assert self.mediator.name == "Example"
 
     def test_missing_params(self):
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             MockMediator.run(name="Pete", age=30)
 
     def test_log(self):
@@ -131,7 +133,7 @@ class TestMediator(TestCase):
                 User.objects.create(username="beep")
                 raise RuntimeError()
 
-        with self.assertRaises(RuntimeError):
+        with pytest.raises(RuntimeError):
             TransactionMediator.run()
 
         assert not User.objects.filter(username="beep").exists()

--- a/tests/sentry/mediators/test_param.py
+++ b/tests/sentry/mediators/test_param.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.mediators import Param
 from sentry.models import User
 from sentry.testutils import TestCase
@@ -7,19 +9,19 @@ class TestParam(TestCase):
     def test_validate_type(self):
         name = Param((str,))
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             name.validate(None, "name", 1)
 
     def test_validate_required(self):
         name = Param((str,))
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             name.validate(None, "name", None)
 
     def test_validate_default_type(self):
         name = Param((str,), default=1)
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             name.validate(None, "name", None)
 
     def test_validate_user_defined_type(self):

--- a/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
+++ b/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+import pytest
+
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.token_exchange import GrantExchanger
 from sentry.models import ApiApplication, ApiGrant, SentryApp, SentryAppInstallation
@@ -37,35 +39,35 @@ class TestGrantExchanger(TestCase):
         other_install = self.create_sentry_app_installation(prevent_token_exchange=True)
         self.grant_exchanger.code = other_install.api_grant.code
 
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.grant_exchanger.call()
 
     def test_request_user_owns_api_grant(self):
         self.grant_exchanger.user = self.create_user()
 
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.grant_exchanger.call()
 
     def test_grant_must_be_active(self):
         self.install.api_grant.update(expires_at=(datetime.utcnow() - timedelta(hours=1)))
 
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.grant_exchanger.call()
 
     def test_grant_must_exist(self):
         self.grant_exchanger.code = "123"
 
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.grant_exchanger.call()
 
     @patch("sentry.models.ApiGrant.application", side_effect=ApiApplication.DoesNotExist)
     def test_application_must_exist(self, _):
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.grant_exchanger.call()
 
     @patch("sentry.models.ApiApplication.sentry_app", side_effect=SentryApp.DoesNotExist)
     def test_sentry_app_must_exist(self, _):
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.grant_exchanger.call()
 
     def test_deletes_grant_on_successful_exchange(self):

--- a/tests/sentry/mediators/token_exchange/test_refresher.py
+++ b/tests/sentry/mediators/token_exchange/test_refresher.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.token_exchange import Refresher
 from sentry.models import ApiApplication, ApiToken, SentryApp, SentryAppInstallation
@@ -46,22 +48,22 @@ class TestRefresher(TestCase):
             application=ApiApplication.objects.create(owner_id=self.create_user().id),
         ).refresh_token
 
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.refresher.call()
 
     @patch("sentry.models.ApiToken.objects.get", side_effect=ApiToken.DoesNotExist)
     def test_token_must_exist(self, _):
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.refresher.call()
 
     @patch("sentry.models.ApiApplication.objects.get", side_effect=ApiApplication.DoesNotExist)
     def test_api_application_must_exist(self, _):
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.refresher.call()
 
     @patch("sentry.models.ApiApplication.sentry_app", side_effect=SentryApp.DoesNotExist)
     def test_sentry_app_must_exist(self, _):
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.refresher.call()
 
     @patch("sentry.analytics.record")

--- a/tests/sentry/mediators/token_exchange/test_validator.py
+++ b/tests/sentry/mediators/token_exchange/test_validator.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.token_exchange import Validator
 from sentry.models import SentryApp
@@ -20,30 +22,30 @@ class TestValidator(TestCase):
     def test_request_must_be_made_by_sentry_app(self):
         self.validator.user = self.create_user()
 
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.validator.call()
 
     def test_request_user_must_own_sentry_app(self):
         self.validator.user = self.create_user(is_sentry_app=True)
 
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.validator.call()
 
     def test_installation_belongs_to_sentry_app_with_client_id(self):
         self.validator.install = self.create_sentry_app_installation()
 
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.validator.call()
 
     @patch("sentry.models.ApiApplication.sentry_app")
     def test_raises_when_sentry_app_cannot_be_found(self, sentry_app):
         sentry_app.side_effect = SentryApp.DoesNotExist()
 
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.validator.call()
 
     def test_raises_with_invalid_client_id(self):
         self.validator.client_id = "123"
 
-        with self.assertRaises(APIUnauthorized):
+        with pytest.raises(APIUnauthorized):
             self.validator.call()

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -2,6 +2,7 @@ import os
 from io import BytesIO
 from unittest.mock import patch
 
+import pytest
 from django.core.files.base import ContentFile
 from django.db import DatabaseError
 
@@ -46,7 +47,7 @@ class FileBlobTest(TestCase):
 
         with patch("sentry.models.file.super") as mock_super:
             mock_super.side_effect = DatabaseError("server closed connection")
-            with self.tasks(), self.assertRaises(DatabaseError):
+            with self.tasks(), pytest.raises(DatabaseError):
                 blob.delete()
         # Even those postgres failed we should stil queue
         # a task to delete the filestore object.
@@ -114,16 +115,16 @@ class FileTest(TestCase):
             fp.seek(1000)
             assert fp.tell() == 1000
 
-            with self.assertRaises(IOError):
+            with pytest.raises(IOError):
                 fp.seek(-1)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             fp.seek(0)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             fp.tell()
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             fp.read()
 
     def test_seek(self):
@@ -151,7 +152,7 @@ class FileTest(TestCase):
             assert fp.tell() == bytes.tell() == 16
             assert fp.read() == bytes.read() == b"qrstuvwxyz"
 
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 fp.seek(0, 666)
 
     def test_multi_chunk_prefetch(self):

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -167,13 +167,13 @@ class GroupTest(TestCase, SnubaTestCase):
 
         assert group2 == group
 
-        with self.assertRaises(Group.DoesNotExist):
+        with pytest.raises(Group.DoesNotExist):
             Group.objects.by_qualified_short_id(
                 group.organization.id, "server_name:my-server-with-dashes-0ac14dadda3b428cf"
             )
 
         group.update(status=GroupStatus.PENDING_DELETION)
-        with self.assertRaises(Group.DoesNotExist):
+        with pytest.raises(Group.DoesNotExist):
             Group.objects.by_qualified_short_id(group.organization.id, short_id)
 
     def test_qualified_share_id_bulk(self):
@@ -193,7 +193,7 @@ class GroupTest(TestCase, SnubaTestCase):
         )
 
         group.update(status=GroupStatus.PENDING_DELETION)
-        with self.assertRaises(Group.DoesNotExist):
+        with pytest.raises(Group.DoesNotExist):
             Group.objects.by_qualified_short_id_bulk(
                 group.organization.id, [group_short_id, group_2_short_id]
             )

--- a/tests/sentry/models/test_groupmeta.py
+++ b/tests/sentry/models/test_groupmeta.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.models import GroupMeta
 from sentry.testutils import TestCase
 
@@ -8,11 +10,11 @@ class GroupMetaManagerTest(TestCase):
         assert GroupMeta.objects.filter(group=self.group, key="foo", value="bar").exists()
 
     def test_get_value(self):
-        with self.assertRaises(GroupMeta.CacheNotPopulated):
+        with pytest.raises(GroupMeta.CacheNotPopulated):
             GroupMeta.objects.get_value(self.group, "foo")
 
         GroupMeta.objects.create(group=self.group, key="foo", value="bar")
-        with self.assertRaises(GroupMeta.CacheNotPopulated):
+        with pytest.raises(GroupMeta.CacheNotPopulated):
             GroupMeta.objects.get_value(self.group, "foo")
 
         GroupMeta.objects.populate_cache([self.group])
@@ -26,11 +28,11 @@ class GroupMetaManagerTest(TestCase):
         assert not GroupMeta.objects.filter(group=self.group, key="foo").exists()
 
     def test_get_value_bulk(self):
-        with self.assertRaises(GroupMeta.CacheNotPopulated):
+        with pytest.raises(GroupMeta.CacheNotPopulated):
             GroupMeta.objects.get_value_bulk([self.group], "foo")
 
         GroupMeta.objects.create(group=self.group, key="foo", value="bar")
-        with self.assertRaises(GroupMeta.CacheNotPopulated):
+        with pytest.raises(GroupMeta.CacheNotPopulated):
             GroupMeta.objects.get_value_bulk([self.group], "foo")
 
         GroupMeta.objects.populate_cache([self.group])

--- a/tests/sentry/models/test_projectkey.py
+++ b/tests/sentry/models/test_projectkey.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus
 from sentry.testutils import TestCase
 
@@ -45,10 +47,10 @@ class ProjectKeyTest(TestCase):
         assert self.model.from_dsn("http://abc@testserver/1") == key
         assert self.model.from_dsn("http://abc@o1.ingest.testserver/1") == key
 
-        with self.assertRaises(self.model.DoesNotExist):
+        with pytest.raises(self.model.DoesNotExist):
             self.model.from_dsn("http://xxx@testserver/1")
 
-        with self.assertRaises(self.model.DoesNotExist):
+        with pytest.raises(self.model.DoesNotExist):
             self.model.from_dsn("abc")
 
     def test_get_default(self):

--- a/tests/sentry/notifications/test_class_manager.py
+++ b/tests/sentry/notifications/test_class_manager.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.notifications.class_manager import (
     NotificationClassAlreadySetException,
     get,
@@ -18,5 +20,5 @@ class ClassManagerTest(TestCase):
 
     def test_duplicate_register(self):
         register()(AnotherDummyNotification)
-        with self.assertRaises(NotificationClassAlreadySetException):
+        with pytest.raises(NotificationClassAlreadySetException):
             register()(AnotherDummyNotification)

--- a/tests/sentry/notifications/utils/test_tasks.py
+++ b/tests/sentry/notifications/utils/test_tasks.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from sentry.notifications.class_manager import NotificationClassNotSetException, manager, register
 from sentry.notifications.utils.tasks import _send_notification, async_send_notification
 from sentry.testutils import TestCase
@@ -62,5 +64,5 @@ class NotificationTaskTests(TestCase):
         notification.return_value.send.assert_called_once_with()
 
     def test_invalid_notification(self):
-        with self.assertRaises(NotificationClassNotSetException):
+        with pytest.raises(NotificationClassNotSetException):
             async_send_notification(DummyNotification, self.organization, "some_value")

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 from django.conf import settings
 from django.core.cache.backends.locmem import LocMemCache
 from exam import around, fixture
@@ -56,27 +57,27 @@ class OptionsManagerTest(TestCase):
         assert self.manager.get("foo") == ""
 
     def test_register(self):
-        with self.assertRaises(UnknownOption):
+        with pytest.raises(UnknownOption):
             self.manager.get("does-not-exit")
 
-        with self.assertRaises(UnknownOption):
+        with pytest.raises(UnknownOption):
             self.manager.set("does-not-exist", "bar")
 
         self.manager.register("does-not-exist")
         self.manager.get("does-not-exist")  # Just shouldn't raise
         self.manager.unregister("does-not-exist")
 
-        with self.assertRaises(UnknownOption):
+        with pytest.raises(UnknownOption):
             self.manager.get("does-not-exist")
 
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             # This key should already exist, and we can't re-register
             self.manager.register("foo")
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.manager.register("wrong-type", default=1, type=String)
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.manager.register("none-type", default=None, type=type(None))
 
     def test_coerce(self):
@@ -87,10 +88,10 @@ class OptionsManagerTest(TestCase):
         self.manager.set("some-int", "0")
         assert self.manager.get("some-int") == 0
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.manager.set("some-int", "foo")
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.manager.set("some-int", "0", coerce=False)
 
     def test_legacy_key(self):
@@ -106,7 +107,7 @@ class OptionsManagerTest(TestCase):
 
     def test_types(self):
         self.manager.register("some-int", type=Int, default=0)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.manager.set("some-int", "foo")
         self.manager.set("some-int", 1)
         assert self.manager.get("some-int") == 1
@@ -135,14 +136,14 @@ class OptionsManagerTest(TestCase):
 
     def test_flag_immutable(self):
         self.manager.register("immutable", flags=FLAG_IMMUTABLE)
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.manager.set("immutable", "thing")
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.manager.delete("immutable")
 
     def test_flag_nostore(self):
         self.manager.register("nostore", flags=FLAG_NOSTORE)
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.manager.set("nostore", "thing")
 
         # Make sure that we don't touch either of the stores
@@ -155,21 +156,21 @@ class OptionsManagerTest(TestCase):
                     assert self.manager.get("nostore") == "foo"
                     self.store.flush_local_cache()
 
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.manager.delete("nostore")
 
     def test_validate(self):
-        with self.assertRaises(UnknownOption):
+        with pytest.raises(UnknownOption):
             self.manager.validate({"unknown": ""})
 
         self.manager.register("unknown")
         self.manager.register("storeonly", flags=FLAG_STOREONLY)
         self.manager.validate({"unknown": ""})
 
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.manager.validate({"storeonly": ""})
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.manager.validate({"unknown": True})
 
     def test_flag_storeonly(self):
@@ -184,7 +185,7 @@ class OptionsManagerTest(TestCase):
         assert self.manager.get("prioritize_disk") == ""
 
         with self.settings(SENTRY_OPTIONS={"prioritize_disk": "something-else!"}):
-            with self.assertRaises(AssertionError):
+            with pytest.raises(AssertionError):
                 assert self.manager.set("prioritize_disk", "foo")
             assert self.manager.get("prioritize_disk") == "something-else!"
 
@@ -206,7 +207,7 @@ class OptionsManagerTest(TestCase):
     def test_db_unavailable(self):
         with patch.object(Option.objects, "get_queryset", side_effect=RuntimeError()):
             # we can't update options if the db is unavailable
-            with self.assertRaises(RuntimeError):
+            with pytest.raises(RuntimeError):
                 self.manager.set("foo", "bar")
 
         self.manager.set("foo", "bar")
@@ -269,7 +270,7 @@ class OptionsManagerTest(TestCase):
                 self.store.flush_local_cache()
 
     def test_unregister(self):
-        with self.assertRaises(UnknownOption):
+        with pytest.raises(UnknownOption):
             self.manager.unregister("does-not-exist")
 
     def test_all(self):

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -53,7 +53,7 @@ class OptionsStoreTest(TestCase):
         store, key = self.store, self.key
         with patch.object(Option.objects, "get_queryset", side_effect=RuntimeError()):
             # we can't update options if the db is unavailable
-            with self.assertRaises(RuntimeError):
+            with pytest.raises(RuntimeError):
                 store.set(key, "bar")
 
         # Assert nothing was written to the local_cache

--- a/tests/sentry/plugins/bases/test_issue.py
+++ b/tests/sentry/plugins/bases/test_issue.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from sentry.models import User
 from sentry.plugins.bases.issue import IssueTrackingPlugin
 from sentry.testutils import TestCase
@@ -15,7 +17,7 @@ class GetAuthForUserTest(TestCase):
     def test_requires_auth_provider(self):
         user = self._get_mock_user()
         p = IssueTrackingPlugin()
-        self.assertRaises(AssertionError, p.get_auth_for_user, user)
+        pytest.raises(AssertionError, p.get_auth_for_user, user)
 
     def test_returns_none_on_missing_identity(self):
         user = self._get_mock_user()

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from sentry.models import GroupMeta, User
 from sentry.plugins.base import plugins
 from sentry.plugins.bases import IssueTrackingPlugin2
@@ -56,7 +58,7 @@ class GetAuthForUserTest(TestCase):
     def test_requires_auth_provider(self):
         user = self._get_mock_user()
         p = IssueTrackingPlugin2()
-        self.assertRaises(AssertionError, p.get_auth_for_user, user)
+        pytest.raises(AssertionError, p.get_auth_for_user, user)
 
     def test_returns_none_on_missing_identity(self):
         user = self._get_mock_user()

--- a/tests/sentry/plugins/interfaces/test_releasehook.py
+++ b/tests/sentry/plugins/interfaces/test_releasehook.py
@@ -1,3 +1,5 @@
+import pytest
+
 __all__ = ["ReleaseHook"]
 
 from sentry.exceptions import HookValidationError
@@ -23,33 +25,33 @@ class StartReleaseTest(TestCase):
         hook = ReleaseHook(project)
 
         version = ""
-        with self.assertRaises(HookValidationError):
+        with pytest.raises(HookValidationError):
             hook.start_release(version)
 
-        with self.assertRaises(HookValidationError):
+        with pytest.raises(HookValidationError):
             hook.finish_release(version)
 
-        with self.assertRaises(HookValidationError):
+        with pytest.raises(HookValidationError):
             hook.set_commits(version, [])
 
         version = "."
-        with self.assertRaises(HookValidationError):
+        with pytest.raises(HookValidationError):
             hook.start_release(version)
 
-        with self.assertRaises(HookValidationError):
+        with pytest.raises(HookValidationError):
             hook.finish_release(version)
 
-        with self.assertRaises(HookValidationError):
+        with pytest.raises(HookValidationError):
             hook.set_commits(version, [])
 
         version = ".."
-        with self.assertRaises(HookValidationError):
+        with pytest.raises(HookValidationError):
             hook.start_release(version)
 
-        with self.assertRaises(HookValidationError):
+        with pytest.raises(HookValidationError):
             hook.finish_release(version)
 
-        with self.assertRaises(HookValidationError):
+        with pytest.raises(HookValidationError):
             hook.set_commits(version, [])
 
     def test_update_release(self):

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 from exam import before
 from rest_framework import serializers
 
@@ -102,14 +103,14 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
 
         # Test no Sentry App Installation uuid
         rule = self.get_rule(data={"hasSchemaFormConfig": True})
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             rule.self_validate()
 
         # Test invalid Sentry App Installation uuid
         rule = self.get_rule(
             data={"hasSchemaFormConfig": True, "sentryAppInstallationUuid": "not_a_real_uuid"}
         )
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             rule.self_validate()
 
         # Test deleted Sentry App Installation uuid
@@ -120,7 +121,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
         rule = self.get_rule(
             data={"hasSchemaFormConfig": True, "sentryAppInstallationUuid": test_install.uuid}
         )
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             rule.self_validate()
 
         # Test Sentry Apps without alert rules configured in their schema
@@ -131,14 +132,14 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
         rule = self.get_rule(
             data={"hasSchemaFormConfig": True, "sentryAppInstallationUuid": test_install.uuid}
         )
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             rule.self_validate()
 
         # Test without providing settings in rule data
         rule = self.get_rule(
             data={"hasSchemaFormConfig": True, "sentryAppInstallationUuid": self.install.uuid}
         )
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             rule.self_validate()
 
         # Test without providing required field values
@@ -149,7 +150,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
                 "settings": [{"name": "title", "value": "Lamy"}],
             }
         )
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             rule.self_validate()
 
         # Test with additional fields not on the app's schema
@@ -164,7 +165,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
                 ],
             }
         )
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             rule.self_validate()
 
         # Test with invalid value on Select field
@@ -179,5 +180,5 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
                 ],
             }
         )
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             rule.self_validate()

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -217,9 +217,9 @@ class QueryBuilderTest(TestCase):
         project2 = self.create_project()
         # params is assumed to be validated at this point, so this query should be invalid
         self.params["project_id"] = [project2.id]
-        with self.assertRaisesRegex(
+        with pytest.raises(
             InvalidSearchQuery,
-            re.escape(
+            match=re.escape(
                 f"Invalid query. Project(s) {str(project1.slug)} do not exist or are not actively selected."
             ),
         ):
@@ -381,7 +381,7 @@ class QueryBuilderTest(TestCase):
         old_end = datetime.datetime(2015, 5, 19, 10, 15, 1, tzinfo=timezone.utc)
         old_params = {**self.params, "start": old_start, "end": old_end}
         with self.options({"system.event-retention-days": 10}):
-            with self.assertRaises(QueryOutsideRetentionError):
+            with pytest.raises(QueryOutsideRetentionError):
                 QueryBuilder(
                     Dataset.Discover,
                     old_params,
@@ -409,7 +409,7 @@ class QueryBuilderTest(TestCase):
         )
 
     def test_array_combinator_is_private(self):
-        with self.assertRaisesRegex(InvalidSearchQuery, "sum: no access to private function"):
+        with pytest.raises(InvalidSearchQuery, match="sum: no access to private function"):
             QueryBuilder(
                 Dataset.Discover,
                 self.params,
@@ -418,7 +418,7 @@ class QueryBuilderTest(TestCase):
             )
 
     def test_array_combinator_with_non_array_arg(self):
-        with self.assertRaisesRegex(InvalidSearchQuery, "stuff is not a valid array column"):
+        with pytest.raises(InvalidSearchQuery, match="stuff is not a valid array column"):
             QueryBuilder(
                 Dataset.Discover,
                 self.params,
@@ -580,7 +580,7 @@ class QueryBuilderTest(TestCase):
             use_aggregate_conditions=True,
         )
         # With count_unique only in a condition and no auto_aggregations this should raise a invalid search query
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             query.get_snql_query()
 
     def test_query_chained_or_tip(self):
@@ -816,7 +816,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         )
 
     def test_custom_percentile_throws_error(self):
-        with self.assertRaises(IncompatibleMetricsQuery):
+        with pytest.raises(IncompatibleMetricsQuery):
             MetricsQueryBuilder(
                 self.params,
                 "",
@@ -1017,9 +1017,9 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         )
 
     def test_missing_transaction_index(self):
-        with self.assertRaisesRegex(
+        with pytest.raises(
             InvalidSearchQuery,
-            re.escape("Tag value was not found"),
+            match=re.escape("Tag value was not found"),
         ):
             MetricsQueryBuilder(
                 self.params,
@@ -1028,9 +1028,9 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             )
 
     def test_missing_transaction_index_in_filter(self):
-        with self.assertRaisesRegex(
+        with pytest.raises(
             InvalidSearchQuery,
-            re.escape("Tag value was not found"),
+            match=re.escape("Tag value was not found"),
         ):
             MetricsQueryBuilder(
                 self.params,
@@ -1039,7 +1039,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             )
 
     def test_incorrect_parameter_for_metrics(self):
-        with self.assertRaises(IncompatibleMetricsQuery):
+        with pytest.raises(IncompatibleMetricsQuery):
             MetricsQueryBuilder(
                 self.params,
                 f"project:{self.project.slug}",
@@ -1068,7 +1068,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         query = MetricsQueryBuilder(self.params)
         assert query.limit.limit == 50
         # anything higher should throw an error
-        with self.assertRaises(IncompatibleMetricsQuery):
+        with pytest.raises(IncompatibleMetricsQuery):
             MetricsQueryBuilder(self.params, limit=10_000)
 
     def test_granularity(self):
@@ -1398,7 +1398,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         }
 
     def test_run_query_with_tag_orderby(self):
-        with self.assertRaises(IncompatibleMetricsQuery):
+        with pytest.raises(IncompatibleMetricsQuery):
             query = MetricsQueryBuilder(
                 self.params,
                 selected_columns=[
@@ -1614,7 +1614,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         }
 
     def test_multiple_entity_orderby_fails(self):
-        with self.assertRaises(IncompatibleMetricsQuery):
+        with pytest.raises(IncompatibleMetricsQuery):
             query = MetricsQueryBuilder(
                 self.params,
                 f"project:{self.project.slug}",
@@ -1629,7 +1629,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             query.run_query("test_query")
 
     def test_multiple_entity_query_fails(self):
-        with self.assertRaises(IncompatibleMetricsQuery):
+        with pytest.raises(IncompatibleMetricsQuery):
             query = MetricsQueryBuilder(
                 self.params,
                 "p95(transaction.duration):>5s AND count_unique(user):>0",
@@ -1644,7 +1644,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             query.run_query("test_query")
 
     def test_query_entity_does_not_match_orderby(self):
-        with self.assertRaises(IncompatibleMetricsQuery):
+        with pytest.raises(IncompatibleMetricsQuery):
             query = MetricsQueryBuilder(
                 self.params,
                 "count_unique(user):>0",
@@ -1771,7 +1771,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             "p75(user)",
             "count_web_vitals(user, poor)",
         ]:
-            with self.assertRaises(IncompatibleMetricsQuery):
+            with pytest.raises(IncompatibleMetricsQuery):
                 MetricsQueryBuilder(
                     self.params,
                     "",
@@ -1807,7 +1807,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
 
     def test_error_if_aggregates_disallowed(self):
         def run_query(query, use_aggregate_conditions):
-            with self.assertRaises(IncompatibleMetricsQuery):
+            with pytest.raises(IncompatibleMetricsQuery):
                 MetricsQueryBuilder(
                     self.params,
                     selected_columns=[
@@ -2011,9 +2011,9 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         )
 
     def test_missing_transaction_index(self):
-        with self.assertRaisesRegex(
+        with pytest.raises(
             InvalidSearchQuery,
-            re.escape("Tag value was not found"),
+            match=re.escape("Tag value was not found"),
         ):
             TimeseriesMetricQueryBuilder(
                 self.params,
@@ -2023,9 +2023,9 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             )
 
     def test_missing_transaction_index_in_filter(self):
-        with self.assertRaisesRegex(
+        with pytest.raises(
             InvalidSearchQuery,
-            re.escape("Tag value was not found"),
+            match=re.escape("Tag value was not found"),
         ):
             TimeseriesMetricQueryBuilder(
                 self.params,
@@ -2256,7 +2256,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
 
     def test_error_if_aggregates_disallowed(self):
         def run_query(query):
-            with self.assertRaises(IncompatibleMetricsQuery):
+            with pytest.raises(IncompatibleMetricsQuery):
                 TimeseriesMetricQueryBuilder(
                     self.params,
                     interval=900,
@@ -2283,7 +2283,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         )
 
     def test_invalid_semver_filter(self):
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             QueryBuilder(
                 Dataset.Discover,
                 self.params,

--- a/tests/sentry/search/events/test_fields.py
+++ b/tests/sentry/search/events/test_fields.py
@@ -1368,13 +1368,13 @@ class ResolveFieldListTest(unittest.TestCase):
         }
 
     def test_to_other_validation(self):
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             resolve_field_list(["to_other(release,a)"], eventstore.Filter())
 
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             resolve_field_list(['to_other(release,"a)'], eventstore.Filter())
 
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             resolve_field_list(['to_other(release,a")'], eventstore.Filter())
 
     def test_failure_count_function(self):
@@ -1559,7 +1559,7 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
 
     def test_invalid_count_if_fields(self):
-        with self.assertRaises(InvalidSearchQuery) as query_error:
+        with pytest.raises(InvalidSearchQuery) as query_error:
             resolve_field_list(
                 ["count_if(transaction.duration, equals, sentry)"], eventstore.Filter()
             )
@@ -1568,21 +1568,21 @@ class ResolveFieldListTest(unittest.TestCase):
             == "'sentry' is not a valid value to compare with transaction.duration"
         )
 
-        with self.assertRaises(InvalidSearchQuery) as query_error:
+        with pytest.raises(InvalidSearchQuery) as query_error:
             resolve_field_list(
                 ["count_if(transaction.duration, equals, 10wow)"], eventstore.Filter()
             )
         assert str(query_error.exception).startswith("wow is not a valid duration type")
 
-        with self.assertRaises(InvalidSearchQuery) as query_error:
+        with pytest.raises(InvalidSearchQuery) as query_error:
             resolve_field_list(["count_if(project, equals, sentry)"], eventstore.Filter())
         assert str(query_error.exception) == "project is not supported by count_if"
 
-        with self.assertRaises(InvalidSearchQuery) as query_error:
+        with pytest.raises(InvalidSearchQuery) as query_error:
             resolve_field_list(["count_if(stack.function, equals, test)"], eventstore.Filter())
         assert str(query_error.exception) == "stack.function is not supported by count_if"
 
-        with self.assertRaises(InvalidSearchQuery) as query_error:
+        with pytest.raises(InvalidSearchQuery) as query_error:
             resolve_field_list(
                 ["count_if(transaction.status, equals, fakestatus)"], eventstore.Filter()
             )

--- a/tests/sentry/search/events/test_fields.py
+++ b/tests/sentry/search/events/test_fields.py
@@ -1559,36 +1559,34 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
 
     def test_invalid_count_if_fields(self):
-        with pytest.raises(InvalidSearchQuery) as query_error:
+        with pytest.raises(InvalidSearchQuery) as excinfo:
             resolve_field_list(
                 ["count_if(transaction.duration, equals, sentry)"], eventstore.Filter()
             )
         assert (
-            str(query_error.exception)
+            str(excinfo.value)
             == "'sentry' is not a valid value to compare with transaction.duration"
         )
 
-        with pytest.raises(InvalidSearchQuery) as query_error:
+        with pytest.raises(InvalidSearchQuery) as excinfo:
             resolve_field_list(
                 ["count_if(transaction.duration, equals, 10wow)"], eventstore.Filter()
             )
-        assert str(query_error.exception).startswith("wow is not a valid duration type")
+        assert str(excinfo.value).startswith("wow is not a valid duration type")
 
-        with pytest.raises(InvalidSearchQuery) as query_error:
+        with pytest.raises(InvalidSearchQuery) as excinfo:
             resolve_field_list(["count_if(project, equals, sentry)"], eventstore.Filter())
-        assert str(query_error.exception) == "project is not supported by count_if"
+        assert str(excinfo.value) == "project is not supported by count_if"
 
-        with pytest.raises(InvalidSearchQuery) as query_error:
+        with pytest.raises(InvalidSearchQuery) as excinfo:
             resolve_field_list(["count_if(stack.function, equals, test)"], eventstore.Filter())
-        assert str(query_error.exception) == "stack.function is not supported by count_if"
+        assert str(excinfo.value) == "stack.function is not supported by count_if"
 
-        with pytest.raises(InvalidSearchQuery) as query_error:
+        with pytest.raises(InvalidSearchQuery) as excinfo:
             resolve_field_list(
                 ["count_if(transaction.status, equals, fakestatus)"], eventstore.Filter()
             )
-        assert (
-            str(query_error.exception) == "'fakestatus' is not a valid value for transaction.status"
-        )
+        assert str(excinfo.value) == "'fakestatus' is not a valid value for transaction.status"
 
 
 def resolve_snql_fieldlist(fields):

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -558,9 +558,9 @@ class ParseBooleanSearchQueryTest(TestCase):
         project1 = self.create_project()
         project2 = self.create_project()
         project3 = self.create_project()
-        with self.assertRaisesRegex(
+        with pytest.raises(
             InvalidSearchQuery,
-            re.escape(
+            match=re.escape(
                 f"Invalid query. Project(s) {str(project3.slug)} do not exist or are not actively selected."
             ),
         ):
@@ -615,23 +615,24 @@ class ParseBooleanSearchQueryTest(TestCase):
             assert test[2] == result.group_ids, test[0]
 
     def test_invalid_conditional_filters(self):
-        with self.assertRaisesRegex(
-            InvalidSearchQuery, "Condition is missing on the left side of 'OR' operator"
+        with pytest.raises(
+            InvalidSearchQuery, match="Condition is missing on the left side of 'OR' operator"
         ):
             get_filter("OR a:b")
 
-        with self.assertRaisesRegex(
-            InvalidSearchQuery, "Missing condition in between two condition operators: 'OR AND'"
+        with pytest.raises(
+            InvalidSearchQuery,
+            match="Missing condition in between two condition operators: 'OR AND'",
         ):
             get_filter("a:b Or And c:d")
 
-        with self.assertRaisesRegex(
-            InvalidSearchQuery, "Condition is missing on the right side of 'AND' operator"
+        with pytest.raises(
+            InvalidSearchQuery, match="Condition is missing on the right side of 'AND' operator"
         ):
             get_filter("a:b AND c:d AND")
 
-        with self.assertRaisesRegex(
-            InvalidSearchQuery, "Condition is missing on the left side of 'OR' operator"
+        with pytest.raises(
+            InvalidSearchQuery, match="Condition is missing on the left side of 'OR' operator"
         ):
             get_filter("(OR a:b) AND c:d")
 
@@ -824,7 +825,7 @@ class GetSnubaQueryArgsTest(TestCase):
         assert _filter.filter_keys == {}
 
     def test_wildcard_event_id(self):
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             get_filter("id:deadbeef*")
 
     def test_event_id_validation(self):
@@ -836,10 +837,10 @@ class GetSnubaQueryArgsTest(TestCase):
         results = get_filter(f"id:{event_id}")
         assert results.conditions == [["id", "=", event_id]]
 
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             get_filter("id:deadbeef")
 
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             get_filter(f"id:{'g' * 32}")
 
     def test_trace_id_validation(self):
@@ -851,10 +852,10 @@ class GetSnubaQueryArgsTest(TestCase):
         results = get_filter(f"trace:{trace_id}")
         assert results.conditions == [["trace", "=", trace_id]]
 
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             get_filter("trace:deadbeef")
 
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             get_filter(f"trace:{'g' * 32}")
 
     def test_negated_wildcard(self):
@@ -1351,13 +1352,13 @@ class GetSnubaQueryArgsTest(TestCase):
         ]
 
     def test_shorthand_overflow(self):
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             get_filter(f"transaction.duration:<{'9'*13}m")
 
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             get_filter(f"transaction.duration:<{'9'*11}h")
 
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             get_filter(f"transaction.duration:<{'9'*10}d")
 
     def test_semver(self):
@@ -1417,12 +1418,12 @@ class GetSnubaQueryArgsTest(TestCase):
         ]
         assert _filter.filter_keys == {}
 
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             _filter = get_filter(
                 f"!{RELEASE_STAGE_ALIAS}:invalid", {"organization_id": self.organization.id}
             )
 
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             _filter = get_filter(
                 f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.REPLACED}, {ReleaseStages.LOW_ADOPTION}]",
                 {"organization_id": self.organization.id},
@@ -1452,14 +1453,14 @@ class DiscoverFunctionTest(unittest.TestCase):
         self.fn_wo_optionals.validate_argument_count("fn_wo_optionals()", ["arg1", "arg2"])
 
     def test_no_optional_not_enough_arguments(self):
-        with self.assertRaisesRegex(
-            InvalidSearchQuery, r"fn_wo_optionals\(\): expected 2 argument\(s\)"
+        with pytest.raises(
+            InvalidSearchQuery, match=r"fn_wo_optionals\(\): expected 2 argument\(s\)"
         ):
             self.fn_wo_optionals.validate_argument_count("fn_wo_optionals()", ["arg1"])
 
     def test_no_optional_too_may_arguments(self):
-        with self.assertRaisesRegex(
-            InvalidSearchQuery, r"fn_wo_optionals\(\): expected 2 argument\(s\)"
+        with pytest.raises(
+            InvalidSearchQuery, match=r"fn_wo_optionals\(\): expected 2 argument\(s\)"
         ):
             self.fn_wo_optionals.validate_argument_count(
                 "fn_wo_optionals()", ["arg1", "arg2", "arg3"]
@@ -1471,27 +1472,27 @@ class DiscoverFunctionTest(unittest.TestCase):
         self.fn_w_optionals.validate_argument_count("fn_w_optionals()", ["arg1"])
 
     def test_optional_not_enough_arguments(self):
-        with self.assertRaisesRegex(
-            InvalidSearchQuery, r"fn_w_optionals\(\): expected at least 1 argument\(s\)"
+        with pytest.raises(
+            InvalidSearchQuery, match=r"fn_w_optionals\(\): expected at least 1 argument\(s\)"
         ):
             self.fn_w_optionals.validate_argument_count("fn_w_optionals()", [])
 
     def test_optional_too_many_arguments(self):
-        with self.assertRaisesRegex(
-            InvalidSearchQuery, r"fn_w_optionals\(\): expected at most 2 argument\(s\)"
+        with pytest.raises(
+            InvalidSearchQuery, match=r"fn_w_optionals\(\): expected at most 2 argument\(s\)"
         ):
             self.fn_w_optionals.validate_argument_count(
                 "fn_w_optionals()", ["arg1", "arg2", "arg3"]
             )
 
     def test_optional_args_have_default(self):
-        with self.assertRaisesRegex(
-            AssertionError, "test: optional argument at index 0 does not have default"
+        with pytest.raises(
+            AssertionError, match="test: optional argument at index 0 does not have default"
         ):
             DiscoverFunction("test", optional_args=[FunctionArg("arg1")])
 
     def test_defining_duplicate_args(self):
-        with self.assertRaisesRegex(AssertionError, "test: argument arg1 specified more than once"):
+        with pytest.raises(AssertionError, match="test: argument arg1 specified more than once"):
             DiscoverFunction(
                 "test",
                 required_args=[FunctionArg("arg1")],
@@ -1499,7 +1500,7 @@ class DiscoverFunctionTest(unittest.TestCase):
                 transform="",
             )
 
-        with self.assertRaisesRegex(AssertionError, "test: argument arg1 specified more than once"):
+        with pytest.raises(AssertionError, match="test: argument arg1 specified more than once"):
             DiscoverFunction(
                 "test",
                 required_args=[FunctionArg("arg1")],
@@ -1507,7 +1508,7 @@ class DiscoverFunctionTest(unittest.TestCase):
                 transform="",
             )
 
-        with self.assertRaisesRegex(AssertionError, "test: argument arg1 specified more than once"):
+        with pytest.raises(AssertionError, match="test: argument arg1 specified more than once"):
             DiscoverFunction(
                 "test",
                 optional_args=[with_default("default", FunctionArg("arg1"))],
@@ -2622,9 +2623,9 @@ class SnQLBooleanSearchQueryTest(TestCase):
         assert having == []
 
     def test_project_not_selected(self):
-        with self.assertRaisesRegex(
+        with pytest.raises(
             InvalidSearchQuery,
-            re.escape(
+            match=re.escape(
                 f"Invalid query. Project(s) {str(self.project3.slug)} do not exist or are not actively selected."
             ),
         ):

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -64,10 +64,10 @@ class TestParseDuration(TestCase):
         assert parse_duration(890, "w") == 890 * 7 * 24 * 60 * 60 * 1000
 
     def test_errors(self):
-        with self.assertRaises(InvalidQuery):
+        with pytest.raises(InvalidQuery):
             parse_duration("test", "ms")
 
-        with self.assertRaises(InvalidQuery):
+        with pytest.raises(InvalidQuery):
             parse_duration(123, "test")
 
     def test_large_durations(self):
@@ -79,19 +79,19 @@ class TestParseDuration(TestCase):
         assert parse_duration(999999999 * 24 * 60 * 60 * 1000, "ms") == max_duration
 
     def test_overflow_durations(self):
-        with self.assertRaises(InvalidQuery):
+        with pytest.raises(InvalidQuery):
             assert parse_duration(999999999 + 1, "d")
 
-        with self.assertRaises(InvalidQuery):
+        with pytest.raises(InvalidQuery):
             assert parse_duration((999999999 + 1) * 24, "h")
 
-        with self.assertRaises(InvalidQuery):
+        with pytest.raises(InvalidQuery):
             assert parse_duration((999999999 + 1) * 24 * 60 + 1, "m")
 
-        with self.assertRaises(InvalidQuery):
+        with pytest.raises(InvalidQuery):
             assert parse_duration((999999999 + 1) * 24 * 60 * 60 + 1, "s")
 
-        with self.assertRaises(InvalidQuery):
+        with pytest.raises(InvalidQuery):
             assert parse_duration((999999999 + 1) * 24 * 60 * 60 * 1000 + 1, "ms")
 
 

--- a/tests/sentry/snuba/test_discover_query.py
+++ b/tests/sentry/snuba/test_discover_query.py
@@ -3044,7 +3044,7 @@ class ArithmeticTest(SnubaTestCase, TestCase):
         assert result["equation[2]"] == 1500 + result["transaction.duration"]
 
     def test_invalid_field(self):
-        with self.assertRaises(ArithmeticValidationError):
+        with pytest.raises(ArithmeticValidationError):
             discover.query(
                 selected_columns=[
                     "spans.http",
@@ -3057,7 +3057,7 @@ class ArithmeticTest(SnubaTestCase, TestCase):
             )
 
     def test_invalid_function(self):
-        with self.assertRaises(ArithmeticValidationError):
+        with pytest.raises(ArithmeticValidationError):
             discover.query(
                 selected_columns=[
                     "p50(transaction.duration)",
@@ -3069,7 +3069,7 @@ class ArithmeticTest(SnubaTestCase, TestCase):
             )
 
     def test_unselected_field(self):
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             discover.query(
                 selected_columns=[
                     "spans.http",
@@ -3080,7 +3080,7 @@ class ArithmeticTest(SnubaTestCase, TestCase):
             )
 
     def test_unselected_function(self):
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             discover.query(
                 selected_columns=[
                     "p50(transaction.duration)",
@@ -3127,7 +3127,7 @@ class ArithmeticTest(SnubaTestCase, TestCase):
         assert [result["equation[0]"] for result in results["data"]] == [0.5, 0.2, 0.1]
 
     def test_orderby_nonexistent_equation(self):
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             discover.query(
                 selected_columns=[
                     "spans.http",
@@ -3139,7 +3139,7 @@ class ArithmeticTest(SnubaTestCase, TestCase):
             )
 
     def test_equation_without_field_or_function(self):
-        with self.assertRaises(InvalidSearchQuery):
+        with pytest.raises(InvalidSearchQuery):
             discover.query(
                 selected_columns=[
                     "spans.http",

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -1,3 +1,4 @@
+import pytest
 from snuba_sdk import And, Column, Condition, Function, Op
 
 from sentry.exceptions import InvalidQuerySubscription, UnsupportedQuerySubscription
@@ -32,7 +33,7 @@ class EntitySubscriptionTestCase(TestCase):
 
     def test_get_entity_subscriptions_for_sessions_dataset_non_supported_aggregate(self) -> None:
         aggregate = "count(sessions)"
-        with self.assertRaises(UnsupportedQuerySubscription):
+        with pytest.raises(UnsupportedQuerySubscription):
             get_entity_subscription_for_dataset(
                 dataset=QueryDatasets.SESSIONS,
                 aggregate=aggregate,
@@ -42,7 +43,7 @@ class EntitySubscriptionTestCase(TestCase):
 
     def test_get_entity_subscriptions_for_sessions_dataset_missing_organization(self) -> None:
         aggregate = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
-        with self.assertRaises(InvalidQuerySubscription):
+        with pytest.raises(InvalidQuerySubscription):
             get_entity_subscription_for_dataset(
                 dataset=QueryDatasets.SESSIONS, aggregate=aggregate, time_window=3600
             )
@@ -99,7 +100,7 @@ class EntitySubscriptionTestCase(TestCase):
 
     def test_get_entity_subscription_for_metrics_dataset_non_supported_aggregate(self) -> None:
         aggregate = "count(sessions)"
-        with self.assertRaises(UnsupportedQuerySubscription):
+        with pytest.raises(UnsupportedQuerySubscription):
             get_entity_subscription_for_dataset(
                 dataset=QueryDatasets.METRICS,
                 aggregate=aggregate,
@@ -109,7 +110,7 @@ class EntitySubscriptionTestCase(TestCase):
 
     def test_get_entity_subscription_for_metrics_dataset_missing_organization(self) -> None:
         aggregate = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
-        with self.assertRaises(InvalidQuerySubscription):
+        with pytest.raises(InvalidQuerySubscription):
             get_entity_subscription_for_dataset(
                 dataset=QueryDatasets.METRICS, aggregate=aggregate, time_window=3600
             )

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from datetime import timedelta
 from unittest import mock
 
+import pytest
 import pytz
 from dateutil.parser import parse as parse_date
 from django.conf import settings
@@ -129,7 +130,7 @@ class ParseMessageValueTest(BaseQuerySubscriptionTest, unittest.TestCase):
         self.consumer.parse_message_value(json.dumps(message))
 
     def run_invalid_schema_test(self, message):
-        with self.assertRaises(InvalidSchemaError):
+        with pytest.raises(InvalidSchemaError):
             self.run_test(message)
 
     def run_invalid_payload_test(self, remove_fields=None, update_fields=None):
@@ -153,9 +154,9 @@ class ParseMessageValueTest(BaseQuerySubscriptionTest, unittest.TestCase):
         self.run_invalid_payload_test(update_fields={"entity": -1})
 
     def test_invalid_version(self):
-        with self.assertRaises(InvalidMessageError) as cm:
+        with pytest.raises(InvalidMessageError) as excinfo:
             self.run_test({"version": 50, "payload": {}})
-        assert str(cm.exception) == "Version specified in wrapper has no schema"
+        assert str(excinfo.value) == "Version specified in wrapper has no schema"
 
     def test_valid(self):
         self.run_test({"version": 3, "payload": self.valid_payload})
@@ -195,6 +196,6 @@ class RegisterSubscriberTest(unittest.TestCase):
         other_callback = object()
         register_subscriber("hello")(callback)
         assert subscriber_registry["hello"] == callback
-        with self.assertRaises(Exception) as cm:
+        with pytest.raises(Exception) as excinfo:
             register_subscriber("hello")(other_callback)
-        assert str(cm.exception) == "Handler already registered for hello"
+        assert str(excinfo.value) == "Handler already registered for hello"

--- a/tests/sentry/sudo/test_forms.py
+++ b/tests/sentry/sudo/test_forms.py
@@ -1,3 +1,4 @@
+import pytest
 from django.forms import ValidationError
 from django.test import override_settings
 
@@ -29,7 +30,7 @@ class SudoFormTestCase(BaseTestCase):
         self.assertTrue(SudoForm(self.user, {"password": "stub"}).is_valid())
 
     def test_clean_password_invalid_password(self):
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             SudoForm(self.user, {"password": "lol"}).clean_password()
 
     def test_clean_password_valid_password(self):

--- a/tests/sentry/sudo/test_middleware.py
+++ b/tests/sentry/sudo/test_middleware.py
@@ -1,3 +1,4 @@
+import pytest
 from django.http import HttpResponse
 
 from fixtures.sudo_testutils import BaseTestCase
@@ -15,7 +16,7 @@ class SudoMiddlewareTestCase(BaseTestCase):
 
     def test_process_request_raises_without_session(self):
         del self.request.session
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.middleware.process_request(self.request)
 
     def test_process_request_adds_is_sudo(self):

--- a/tests/sentry/sudo/test_utils.py
+++ b/tests/sentry/sudo/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 from django.core.signing import BadSignature
 from django.utils.http import is_safe_url
 
@@ -16,7 +17,7 @@ class GrantSudoPrivilegesTestCase(BaseTestCase):
         self.assertEqual(request._sudo_max_age, max_age)
 
     def test_grant_token_not_logged_in(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             grant_sudo_privileges(self.request)
 
     def test_grant_token_default_max_age(self):

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -557,7 +557,7 @@ class TestWebhookRequests(TestCase):
     def test_saves_error_if_webhook_request_fails(self, safe_urlopen):
         data = {"issue": serialize(self.issue)}
 
-        with self.assertRaises(ClientError):
+        with pytest.raises(ClientError):
             send_webhooks(
                 installation=self.install, event="issue.assigned", data=data, actor=self.user
             )
@@ -578,7 +578,7 @@ class TestWebhookRequests(TestCase):
     def test_saves_error_if_webhook_request_with_html_content_fails(self, safe_urlopen):
         data = {"issue": serialize(self.issue)}
 
-        with self.assertRaises(ClientError):
+        with pytest.raises(ClientError):
             send_webhooks(
                 installation=self.install, event="issue.assigned", data=data, actor=self.user
             )
@@ -601,7 +601,7 @@ class TestWebhookRequests(TestCase):
     def test_saves_error_if_webhook_request_with_json_content_fails(self, safe_urlopen):
         data = {"issue": serialize(self.issue)}
 
-        with self.assertRaises(ClientError):
+        with pytest.raises(ClientError):
             send_webhooks(
                 installation=self.install, event="issue.assigned", data=data, actor=self.user
             )
@@ -636,7 +636,7 @@ class TestWebhookRequests(TestCase):
     def test_saves_error_for_request_timeout(self, safe_urlopen):
         data = {"issue": serialize(self.issue)}
         # we don't log errors for unpublished and internal apps
-        with self.assertRaises(Timeout):
+        with pytest.raises(Timeout):
             send_webhooks(
                 installation=self.install, event="issue.assigned", data=data, actor=self.user
             )
@@ -657,7 +657,7 @@ class TestWebhookRequests(TestCase):
     )
     def test_saves_error_event_id_if_in_header(self, safe_urlopen):
         data = {"issue": serialize(self.issue)}
-        with self.assertRaises(ClientError):
+        with pytest.raises(ClientError):
             send_webhooks(
                 installation=self.install, event="issue.assigned", data=data, actor=self.user
             )

--- a/tests/sentry/utils/locking/test_lock.py
+++ b/tests/sentry/utils/locking/test_lock.py
@@ -64,7 +64,7 @@ class LockTestCase(unittest.TestCase):
         with patch(
             "sentry.utils.locking.lock.time.monotonic", side_effect=lambda: MockTime.time
         ), patch("sentry.utils.locking.lock.time.sleep", side_effect=MockTime.incr) as mock_sleep:
-            with self.assertRaises(UnableToAcquireLock):
+            with pytest.raises(UnableToAcquireLock):
                 lock.blocking_acquire(initial_delay=0.1, timeout=1, exp_base=2)
 
             # 0.0, 0.05, 0.15, 0.35, 0.75

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from unittest.mock import Mock
 from uuid import uuid4
 
+import pytest
 from django.utils import timezone
 
 from sentry.models import Commit, CommitAuthor, CommitFileChange, GroupRelease, Release, Repository
@@ -837,7 +838,7 @@ class GetEventFileCommitters(CommitTestCase):
             group_id=event.group.id, project_id=self.project.id, release_id=self.release.id
         )
 
-        with self.assertRaises(Commit.DoesNotExist):
+        with pytest.raises(Commit.DoesNotExist):
             get_serialized_event_file_committers(self.project, event)
 
 

--- a/tests/sentry/utils/test_pickle_protocol.py
+++ b/tests/sentry/utils/test_pickle_protocol.py
@@ -1,6 +1,8 @@
 import pickle
 from pickle import PickleBuffer, PickleError
 
+import pytest
+
 from sentry.testutils import TestCase
 
 
@@ -18,7 +20,7 @@ class PickleProtocolTestCase(TestCase):
         data = b"iamsomedata"
 
         pickled_data = PickleBuffer(data)
-        with self.assertRaises(PickleError) as context:
+        with pytest.raises(PickleError) as context:
             result = pickle.dumps(pickled_data)
 
         assert "PickleBuffer can only pickled with protocol >= 5" == str(context.exception)

--- a/tests/sentry/utils/test_pickle_protocol.py
+++ b/tests/sentry/utils/test_pickle_protocol.py
@@ -20,10 +20,10 @@ class PickleProtocolTestCase(TestCase):
         data = b"iamsomedata"
 
         pickled_data = PickleBuffer(data)
-        with pytest.raises(PickleError) as context:
+        with pytest.raises(PickleError) as excinfo:
             result = pickle.dumps(pickled_data)
 
-        assert "PickleBuffer can only pickled with protocol >= 5" == str(context.exception)
+        assert "PickleBuffer can only pickled with protocol >= 5" == str(excinfo.value)
 
         result = pickle.dumps(pickled_data, protocol=5)
         assert result

--- a/tests/sentry/utils/test_session_store.py
+++ b/tests/sentry/utils/test_session_store.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+import pytest
 from django.test import Client, RequestFactory
 
 from sentry.utils.session_store import RedisSessionStore, redis_property
@@ -26,7 +27,7 @@ class RedisSessionStoreTestCase(TestCase):
         assert store2.is_valid()
         assert store2.some_value == "test_value"
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             self.store.missing_key
 
         self.store.clear()

--- a/tests/sentry/utils/test_settings.py
+++ b/tests/sentry/utils/test_settings.py
@@ -67,7 +67,7 @@ class DependencyTest(TestCase):
         import_string.side_effect = self.raise_import_error(package)
 
         with self.settings(**{key: setting_value}):
-            with self.assertRaises(ConfigurationError):
+            with pytest.raises(ConfigurationError):
                 validate_settings(settings)
 
     def test_validate_fails_on_postgres(self):

--- a/tests/sentry/utils/test_types.py
+++ b/tests/sentry/utils/test_types.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+import pytest
+
 from sentry.utils.types import Any, Bool, Dict, Float, Int, InvalidTypeError, Sequence, String
 
 
@@ -34,7 +36,7 @@ class OptionsTypesTest(TestCase):
         assert Bool.test(None) is False
         assert Bool(True) is True
         assert Bool.test("foo") is False
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             Bool("foo")
 
     def test_int(self):
@@ -42,9 +44,9 @@ class OptionsTypesTest(TestCase):
         assert Int("1") == 1
         assert Int("-1") == -1
         assert Int() == 0
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             Int("foo")
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             Int("1.1")
 
     def test_float(self):
@@ -53,14 +55,14 @@ class OptionsTypesTest(TestCase):
         assert Float("-1.1") == -1.1
         assert Float(1) == 1.0
         assert Float() == 0.0
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             Float("foo")
 
     def test_string(self):
         assert String("foo") == "foo"
         assert String("foo") == "foo"
         assert String() == ""
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             String(0)
 
     def test_dict(self):
@@ -69,13 +71,13 @@ class OptionsTypesTest(TestCase):
         assert Dict("{foo: bar}") == {"foo": "bar"}
 
         assert Dict() == {}
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             assert Dict("[]")
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             assert Dict([])
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             assert Dict("")
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             # malformed yaml/json (a plain scalar, "b: ar", cannot contain ": ")
             assert Dict("{foo: b: ar}")
 
@@ -85,12 +87,12 @@ class OptionsTypesTest(TestCase):
         assert Sequence((1, 2, 3)) == (1, 2, 3)
         assert Sequence([1, 2, 3]) == [1, 2, 3]
         assert Sequence("[1,2,3]") == (1, 2, 3)
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             Sequence("{}")
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             Sequence({})
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             Sequence("")
-        with self.assertRaises(InvalidTypeError):
+        with pytest.raises(InvalidTypeError):
             # malformed yaml/json
             Sequence("[1,")

--- a/tests/sentry_plugins/amazon_sqs/test_plugin.py
+++ b/tests/sentry_plugins/amazon_sqs/test_plugin.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 from botocore.client import ClientError
 from exam import fixture
 
@@ -61,7 +62,7 @@ class AmazonSQSPluginTest(PluginTestCase):
         mock_client.return_value.send_message.side_effect = ClientError(
             {"Error": {"Code": "Hello", "Message": "hello"}}, "SendMessage"
         )
-        with self.assertRaises(ClientError):
+        with pytest.raises(ClientError):
             self.run_test()
         assert len(logger.info.call_args_list) == 0
 

--- a/tests/sentry_plugins/asana/test_plugin.py
+++ b/tests/sentry_plugins/asana/test_plugin.py
@@ -1,3 +1,4 @@
+import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
@@ -53,7 +54,7 @@ class AsanaPluginTest(PluginTestCase):
         request = self.request.get("/")
         request.user = AnonymousUser()
         form_data = {"title": "Hello", "description": "Fix this."}
-        with self.assertRaises(PluginError):
+        with pytest.raises(PluginError):
             self.plugin.create_issue(request, group, form_data)
 
         request.user = self.user
@@ -86,7 +87,7 @@ class AsanaPluginTest(PluginTestCase):
         request = self.request.get("/")
         request.user = AnonymousUser()
         form_data = {"comment": "please fix this", "issue_id": "1"}
-        with self.assertRaises(PluginError):
+        with pytest.raises(PluginError):
             self.plugin.link_issue(request, group, form_data)
 
         request.user = self.user

--- a/tests/sentry_plugins/bitbucket/test_plugin.py
+++ b/tests/sentry_plugins/bitbucket/test_plugin.py
@@ -1,3 +1,4 @@
+import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
@@ -60,7 +61,7 @@ class BitbucketPluginTest(PluginTestCase):
             "issue_type": "bug",
             "priority": "trivial",
         }
-        with self.assertRaises(PluginError):
+        with pytest.raises(PluginError):
             self.plugin.create_issue(request, group, form_data)
 
         request.user = self.user
@@ -101,7 +102,7 @@ class BitbucketPluginTest(PluginTestCase):
         request = self.request.get("/")
         request.user = AnonymousUser()
         form_data = {"comment": "Hello", "issue_id": "1"}
-        with self.assertRaises(PluginError):
+        with pytest.raises(PluginError):
             self.plugin.link_issue(request, group, form_data)
 
         request.user = self.user

--- a/tests/sentry_plugins/github/test_plugin.py
+++ b/tests/sentry_plugins/github/test_plugin.py
@@ -1,3 +1,4 @@
+import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
@@ -53,7 +54,7 @@ class GitHubPluginTest(PluginTestCase):
         request = self.request.get("/")
         request.user = AnonymousUser()
         form_data = {"title": "Hello", "description": "Fix this."}
-        with self.assertRaises(PluginError):
+        with pytest.raises(PluginError):
             self.plugin.create_issue(request, group, form_data)
 
         request.user = self.user
@@ -87,7 +88,7 @@ class GitHubPluginTest(PluginTestCase):
         request = self.request.get("/")
         request.user = AnonymousUser()
         form_data = {"comment": "Hello", "issue_id": "1"}
-        with self.assertRaises(PluginError):
+        with pytest.raises(PluginError):
             self.plugin.link_issue(request, group, form_data)
 
         request.user = self.user

--- a/tests/sentry_plugins/heroku/test_plugin.py
+++ b/tests/sentry_plugins/heroku/test_plugin.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
+import pytest
 from django.utils import timezone
 
 from sentry.exceptions import HookValidationError
@@ -171,5 +172,5 @@ class HookHandleTest(TestCase):
 
         req = Mock()
         req.POST = {"head_long": "", "url": "http://example.com", "user": user.email}
-        with self.assertRaises(HookValidationError):
+        with pytest.raises(HookValidationError):
             hook.handle(req)

--- a/tests/sentry_plugins/splunk/test_plugin.py
+++ b/tests/sentry_plugins/splunk/test_plugin.py
@@ -1,3 +1,4 @@
+import pytest
 import responses
 from exam import fixture
 
@@ -71,7 +72,7 @@ class SplunkPluginTest(PluginTestCase):
             data={"message": "Hello world", "level": "warning"}, project_id=self.project.id
         )
         with self.options({"system.url-prefix": "http://example.com"}):
-            with self.assertRaises(ApiError):
+            with pytest.raises(ApiError):
                 self.plugin.post_process(event)
 
     def test_http_payload(self):

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -1,3 +1,4 @@
+import pytest
 from django.urls import NoReverseMatch, reverse
 
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
@@ -34,7 +35,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
         self.query_id_without_access = invalid.id
 
     def test_invalid_id(self):
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             reverse("sentry-api-0-discover-saved-query-detail", args=[self.org.slug, "not-an-id"])
 
     def test_get(self):

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import pytest
 from django.urls import NoReverseMatch, reverse
 
 from sentry.models import Group
@@ -176,7 +177,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 404, response.content
 
     def test_invalid_event_id(self):
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             reverse(
                 "sentry-api-0-organization-event-details",
                 kwargs={

--- a/tests/snuba/api/endpoints/test_organization_eventid.py
+++ b/tests/snuba/api/endpoints/test_organization_eventid.py
@@ -1,3 +1,4 @@
+import pytest
 from django.test import override_settings
 from django.urls import NoReverseMatch, reverse
 from freezegun import freeze_time
@@ -62,7 +63,7 @@ class EventIdLookupEndpointTest(APITestCase, SnubaTestCase):
             assert resp.status_code == 429
 
     def test_invalid_event_id(self):
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             reverse(
                 "sentry-api-0-event-id-lookup",
                 kwargs={

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from uuid import uuid4
 
+import pytest
 from django.urls import NoReverseMatch, reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
@@ -251,7 +252,7 @@ class OrganizationEventsTraceLightEndpointTest(OrganizationEventsTraceEndpointBa
         assert response.status_code == 404, response.content
 
         # Invalid trace id
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             self.url = reverse(
                 "sentry-api-0-organization-events-trace-light",
                 kwargs={
@@ -1181,7 +1182,7 @@ class OrganizationEventsTraceMetaEndpointTest(OrganizationEventsTraceEndpointBas
         assert data["errors"] == 0
 
         # Invalid trace id
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             self.url = reverse(
                 self.url_name,
                 kwargs={

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2092,7 +2092,7 @@ class CdcEventsSnubaSearchTest(TestCase, SnubaTestCase):
         self.run_test("is:unresolved", [self.group1, self.group2], None)
 
     def test_invalid(self):
-        with self.assertRaises(InvalidQueryForExecutor):
+        with pytest.raises(InvalidQueryForExecutor):
             self.make_query(search_filter_query="is:unresolved abc:123")
 
     def test_resolved_group(self):

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -59,3 +59,20 @@ def bad_code():
         "t.py:3:0: S003 Use ``from sentry.utils import json`` instead.",
         "t.py:4:0: S003 Use ``from sentry.utils import json`` instead.",
     ]
+
+
+def test_S004():
+    S004_py = """\
+import unittest
+from something import func
+
+
+class Test(unittest.TestCase):
+    def test(self):
+        with self.assertRaises(ValueError):
+            func()
+"""
+    errors = _run(S004_py)
+    assert errors == [
+        "t.py:7:13: S004 Use `pytest.raises` instead for better debuggability.",
+    ]

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -13,7 +13,10 @@ S001_methods = frozenset(("not_called", "called_once", "called_once_with"))
 S002_msg = "S002 print functions or statements are not allowed."
 
 S003_msg = "S003 Use ``from sentry.utils import json`` instead."
-S003_modules = {"json", "simplejson"}
+S003_modules = frozenset(("json", "simplejson"))
+
+S004_msg = "S004 Use `pytest.raises` instead for better debuggability."
+S004_methods = frozenset(("assertRaises", "assertRaisesRegex"))
 
 
 class SentryVisitor(ast.NodeVisitor):
@@ -36,6 +39,8 @@ class SentryVisitor(ast.NodeVisitor):
     def visit_Attribute(self, node: ast.Attribute) -> None:
         if node.attr in S001_methods:
             self.errors.append((node.lineno, node.col_offset, S001_fmt.format(node.attr)))
+        elif node.attr in S004_methods:
+            self.errors.append((node.lineno, node.col_offset, S004_msg))
 
         self.generic_visit(node)
 


### PR DESCRIPTION
unittest's assertRaises calls traceback.clear_frame which makes it difficult to debug tests (especially in --pdb [postmortem mode](https://youtu.be/s8Nx2frW4ps))

pytest.raises is otherwise a drop-in replacement which does not have this shortcoming

needs: https://github.com/getsentry/getsentry/pull/7651