### PR TITLE
fix(performance): fixed performance landing page sort not working for some columns

### DIFF
--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -24,8 +24,8 @@ import DiscoverQuery, {
 } from 'sentry/utils/discover/discoverQuery';
 import EventView, {
   EventData,
-  EventsMetaType,
   isFieldSortable,
+  MetaType,
 } from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {fieldAlignment, getAggregateAlias} from 'sentry/utils/discover/fields';
@@ -287,10 +287,10 @@ class _Table extends Component<Props, State> {
 
     const align = fieldAlignment(column.name, column.type, tableMeta);
     const field = {field: column.name, width: column.width};
-    const aggregateAliasTableMeta: EventsMetaType['fields'] = {};
+    const aggregateAliasTableMeta: MetaType = {};
     if (tableMeta) {
       Object.keys(tableMeta).forEach(key => {
-        aggregateAliasTableMeta![getAggregateAlias(key)] = tableMeta[key];
+        aggregateAliasTableMeta[getAggregateAlias(key)] = tableMeta[key];
       });
     }
 

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -22,7 +22,11 @@ import DiscoverQuery, {
   TableData,
   TableDataRow,
 } from 'sentry/utils/discover/discoverQuery';
-import EventView, {EventData, isFieldSortable} from 'sentry/utils/discover/eventView';
+import EventView, {
+  EventData,
+  EventsMetaType,
+  isFieldSortable,
+} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {fieldAlignment, getAggregateAlias} from 'sentry/utils/discover/fields';
 import {MEPConsumer} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -283,13 +287,19 @@ class _Table extends Component<Props, State> {
 
     const align = fieldAlignment(column.name, column.type, tableMeta);
     const field = {field: column.name, width: column.width};
+    const aggregateAliasTableMeta: EventsMetaType['fields'] = {};
+    if (tableMeta) {
+      Object.keys(tableMeta).forEach(key => {
+        aggregateAliasTableMeta![getAggregateAlias(key)] = tableMeta[key];
+      });
+    }
 
     function generateSortLink(): LocationDescriptorObject | undefined {
       if (!tableMeta) {
         return undefined;
       }
 
-      const nextEventView = eventView.sortOnField(field, tableMeta);
+      const nextEventView = eventView.sortOnField(field, aggregateAliasTableMeta);
       const queryStringObject = nextEventView.generateQueryStringObject();
 
       return {
@@ -297,8 +307,8 @@ class _Table extends Component<Props, State> {
         query: {...location.query, sort: queryStringObject.sort},
       };
     }
-    const currentSort = eventView.sortForField(field, tableMeta);
-    const canSort = isFieldSortable(field, tableMeta);
+    const currentSort = eventView.sortForField(field, aggregateAliasTableMeta);
+    const canSort = isFieldSortable(field, aggregateAliasTableMeta);
 
     const currentSortKind = currentSort ? currentSort.kind : undefined;
     const currentSortField = currentSort ? currentSort.field : undefined;


### PR DESCRIPTION
Fixes a bug where some columns in the performance landing page table are unable to sort (tpm in the overall view). Eventview still uses aggregate aliases so we need to convert the table meta before parsing sorts