### PR TITLE
fix: Fix permission_denied() got an unexpected keyword argument 'code'

### DIFF
--- a/src/sentry/api/endpoints/project_processingissues.py
+++ b/src/sentry/api/endpoints/project_processingissues.py
@@ -58,7 +58,7 @@ class ProjectProcessingIssuesFixEndpoint(ProjectEndpoint):
         resp["Content-Type"] = "text/plain"
         return resp
 
-    def permission_denied(self, request: Request, message=None):
+    def permission_denied(self, request: Request, **kwargs):
         resp = render_to_response("sentry/reprocessing-script.sh", {"token": None})
         resp["Content-Type"] = "text/plain"
         return resp


### PR DESCRIPTION
Addresses https://sentry.io/organizations/sentry/issues/3351302080/?project=1 where `permission_denied()` may receive unexpected keyword arguments.

Fixes SENTRY-VB4