### PR TITLE
fix(mep): Choose primary dataset when theres no having/orderby

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1940,7 +1940,16 @@ class MetricsQueryBuilder(QueryBuilder):
 
         # Pick one arbitrarily, there's no orderby on functions
         if primary is None:
-            primary = "distribution" if having_entity is None else having_entity
+            if having_entity is not None:
+                primary = having_entity
+            elif len(self.distributions) > 0:
+                primary = "distribution"
+            elif len(self.counters) > 0:
+                primary = "counter"
+            elif len(self.sets) > 0:
+                primary = "set"
+            else:
+                raise IncompatibleMetricsQuery("Need at least one function")
 
         query_framework[primary].having = self.having
 

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1555,6 +1555,24 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         assert data["failure_rate"] == 0.5
         assert data["failure_count"] == 3
 
+    def test_run_function_without_having_or_groupby(self):
+        self.store_metric(
+            1,
+            metric="user",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.start + datetime.timedelta(minutes=5),
+        )
+        query = MetricsQueryBuilder(
+            self.params,
+            "",
+            selected_columns=[
+                "transaction",
+                "count_unique(user)",
+            ],
+        )
+        primary, result = query._create_query_framework()
+        assert primary == "set"
+
     def test_run_query_with_multiple_groupby_orderby_null_values_in_second_entity(self):
         """Since the null value is on count_unique(user) we will still get baz_transaction since we query distributions
         first which will have it, and then just not find a unique count in the second"""


### PR DESCRIPTION
- This fixes a bug with get_snql_query where we werent getting the
  correct primary dataset, since we chose distribution instead of the
  first dataset with some functions
