### PR TITLE
feat(search): Replace hotkeys labels with icons in search quick actions menu on mobile

### DIFF
--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -120,6 +120,7 @@ class SearchDropdown extends PureComponent<Props> {
                     <HotkeyGlyphWrapper>
                       <HotkeysLabel value={action.hotkeys?.display ?? []} />
                     </HotkeyGlyphWrapper>
+                    <IconWrapper>{action.icon}</IconWrapper>
                     <HotkeyTitle>{action.text}</HotkeyTitle>
                   </ActionButtonContainer>
                 );
@@ -258,6 +259,7 @@ const DropdownFooter = styled(`div`)`
   justify-content: space-between;
   padding: ${space(1)};
   flex-wrap: wrap;
+  gap: ${space(1)};
 `;
 
 const ActionsRow = styled('div')`
@@ -284,6 +286,21 @@ const ActionButtonContainer = styled('div')`
 const HotkeyGlyphWrapper = styled('span')`
   color: ${p => p.theme.gray300};
   margin-right: ${space(0.5)};
+
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    display: none;
+  }
+`;
+
+const IconWrapper = styled('span')`
+  display: none;
+
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    display: flex;
+    margin-right: ${space(0.5)};
+    align-items: center;
+    justify-content: center;
+  }
 `;
 
 const HotkeyTitle = styled(`span`)`

--- a/static/app/components/smartSearchBar/types.tsx
+++ b/static/app/components/smartSearchBar/types.tsx
@@ -51,6 +51,7 @@ export enum QuickActionType {
 
 export type QuickAction = {
   actionType: QuickActionType;
+  icon: React.ReactNode;
   text: string;
   canRunAction?: (
     token: TokenResult<any> | null | undefined,

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -5,7 +5,16 @@ import {
   Token,
   TokenResult,
 } from 'sentry/components/searchSyntax/parser';
-import {IconClock, IconStar, IconTag, IconToggle, IconUser} from 'sentry/icons';
+import {
+  IconArrow,
+  IconClock,
+  IconDelete,
+  IconExclamation,
+  IconStar,
+  IconTag,
+  IconToggle,
+  IconUser,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 import HotkeysLabel from '../hotkeysLabel';
@@ -260,6 +269,7 @@ export const quickActions: QuickAction[] = [
       actual: 'option+backspace',
       display: 'option+backspace',
     },
+    icon: <IconDelete size="xs" />,
     canRunAction: tok => {
       return tok?.type === Token.Filter;
     },
@@ -271,6 +281,7 @@ export const quickActions: QuickAction[] = [
       actual: ['option+1', 'cmd+1'],
       display: 'option+!',
     },
+    icon: <IconExclamation size="xs" />,
     canRunAction: tok => {
       return tok?.type === Token.Filter;
     },
@@ -282,6 +293,7 @@ export const quickActions: QuickAction[] = [
       actual: ['option+left'],
       display: 'option+left',
     },
+    icon: <IconArrow direction="left" size="xs" />,
     canRunAction: (tok, count) => {
       return count > 1 || (count > 0 && tok?.type !== Token.Filter);
     },
@@ -293,6 +305,7 @@ export const quickActions: QuickAction[] = [
       actual: ['option+right'],
       display: 'option+right',
     },
+    icon: <IconArrow direction="right" size="xs" />,
     canRunAction: (tok, count) => {
       return count > 1 || (count > 0 && tok?.type !== Token.Filter);
     },

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -269,7 +269,7 @@ export const quickActions: QuickAction[] = [
       actual: 'option+backspace',
       display: 'option+backspace',
     },
-    icon: <IconDelete size="xs" />,
+    icon: <IconDelete size="xs" color="gray300" />,
     canRunAction: tok => {
       return tok?.type === Token.Filter;
     },
@@ -281,7 +281,7 @@ export const quickActions: QuickAction[] = [
       actual: ['option+1', 'cmd+1'],
       display: 'option+!',
     },
-    icon: <IconExclamation size="xs" />,
+    icon: <IconExclamation size="xs" color="gray300" />,
     canRunAction: tok => {
       return tok?.type === Token.Filter;
     },
@@ -293,7 +293,7 @@ export const quickActions: QuickAction[] = [
       actual: ['option+left'],
       display: 'option+left',
     },
-    icon: <IconArrow direction="left" size="xs" />,
+    icon: <IconArrow direction="left" size="xs" color="gray300" />,
     canRunAction: (tok, count) => {
       return count > 1 || (count > 0 && tok?.type !== Token.Filter);
     },
@@ -305,7 +305,7 @@ export const quickActions: QuickAction[] = [
       actual: ['option+right'],
       display: 'option+right',
     },
-    icon: <IconArrow direction="right" size="xs" />,
+    icon: <IconArrow direction="right" size="xs" color="gray300" />,
     canRunAction: (tok, count) => {
       return count > 1 || (count > 0 && tok?.type !== Token.Filter);
     },


### PR DESCRIPTION
As the search quick actions still functions as buttons on mobile, and you can't use hotkeys on mobile, we replace the hotkey icons with normal icons instead so it makes sense when you tap them.

Old:
<img width="498" alt="Screen Shot 2022-06-15 at 12 13 57 PM" src="https://user-images.githubusercontent.com/30991498/173906737-4443eefb-0bcd-42aa-aea4-985dc32f9037.png">

New:
<img width="396" alt="Screen Shot 2022-06-15 at 12 17 58 PM" src="https://user-images.githubusercontent.com/30991498/173907147-def28c26-297c-4482-bb0e-834e43e733df.png">


