### PR TITLE
fix(performance): Hide MEP dropdown when transaction search is enabled

### DIFF
--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -145,9 +145,11 @@ export function PerformanceLanding(props: Props) {
     pageFilters = <SearchContainerWithFilter>{pageFilters}</SearchContainerWithFilter>;
   }
 
-  const SearchFilterContainer = organization.features.includes('performance-use-metrics')
-    ? SearchContainerWithFilterAndMetrics
-    : SearchContainerWithFilter;
+  const SearchFilterContainer =
+    organization.features.includes('performance-use-metrics') &&
+    !organization.features.includes('performance-transaction-name-only-search')
+      ? SearchContainerWithFilterAndMetrics
+      : SearchContainerWithFilter;
 
   return (
     <StyledPageContent data-test-id="performance-landing-v3">
@@ -245,7 +247,7 @@ export function PerformanceLanding(props: Props) {
                   <Feature
                     features={['organizations:performance-transaction-name-only-search']}
                   >
-                    {({hasFeature}) => hasFeature && <MetricsEventsDropdown />}
+                    {({hasFeature}) => !hasFeature && <MetricsEventsDropdown />}
                   </Feature>
                 </SearchFilterContainer>
                 {initiallyLoaded ? (


### PR DESCRIPTION
This was an oversight from my last PR. MEP dropdown should be hidden for the transaction search since transaction search operation isn't possible with MEP.

