### PR TITLE
perf(api): Load events without stacktrace for the group events endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -87,7 +87,9 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         snuba_filter.conditions.append(["event.type", "!=", "transaction"])
 
-        data_fn = partial(eventstore.get_events, referrer="api.group-events", filter=snuba_filter)
+        data_fn = partial(
+            eventstore.get_unfetched_events, referrer="api.group-events", filter=snuba_filter
+        )
         serializer = EventSerializer() if full else SimpleEventSerializer()
         return self.paginate(
             request=request,

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -177,6 +177,9 @@ const Title = styled('div')<{hasGroupingTreeUI: boolean; size: Size}>`
     font-style: normal;
     font-weight: 300;
     color: ${p => p.theme.subText};
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
   ${p =>
     !p.hasGroupingTreeUI


### PR DESCRIPTION
Get unfetched events for the group events endpoint to improve performance.

The unfetched events do not have node data loaded, but contain all the information necessary to populate SimpleEventSerializer. This should improve the performance of Issue events search at the `/api/0/issues|g
roups/{issue_id}/events/` endpoint.

Fixes WOR-1866
