### PR TITLE
perf(api): Load events without stacktrace for the group events endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -88,7 +88,9 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         snuba_filter.conditions.append(["event.type", "!=", "transaction"])
 
         data_fn = partial(
-            eventstore.get_unfetched_events, referrer="api.group-events", filter=snuba_filter
+            eventstore.get_events if full else eventstore.get_unfetched_events,
+            referrer="api.group-events",
+            filter=snuba_filter,
         )
         serializer = EventSerializer() if full else SimpleEventSerializer()
         return self.paginate(

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -87,7 +87,9 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         snuba_filter.conditions.append(["event.type", "!=", "transaction"])
 
-        data_fn = partial(eventstore.get_events, referrer="api.group-events", filter=snuba_filter)
+        data_fn = partial(
+            eventstore.get_unfetched_events, referrer="api.group-events", filter=snuba_filter
+        )
         serializer = EventSerializer() if full else SimpleEventSerializer()
         return self.paginate(
             request=request,


### PR DESCRIPTION
Get unfetched events for the group events endpoint to improve performance.

The unfetched events do not have node data loaded, but contain all the information necessary to populate SimpleEventSerializer. This should improve the performance of Issue events search at the `/api/0/issues|groups/{issue_id}/events/` endpoint.

Fixes WOR-1866
