### PR TITLE
test(acceptance): Fix flake in issue comment acceptance test

### DIFF
--- a/fixtures/page_objects/issue_details.py
+++ b/fixtures/page_objects/issue_details.py
@@ -12,6 +12,10 @@ class IssueDetailsPage(BasePage):
         self.browser.get(f"/organizations/{org}/issues/{groupid}/")
         self.wait_until_loaded()
 
+    def visit_issue_activity(self, org, groupid):
+        self.browser.get(f"/organizations/{org}/issues/{groupid}/activity/")
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
+
     def visit_issue_in_environment(self, org, groupid, environment):
         self.browser.get(f"/organizations/{org}/issues/{groupid}/?environment={environment}")
         self.browser.wait_until(".group-detail")

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -71,8 +71,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
 
     def test_create_comment(self):
         event = self.create_sample_event(platform="python")
-        self.page.visit_issue(self.org.slug, event.group.id)
-        self.page.go_to_subtab("Activity")
+        self.page.visit_issue_activity(self.org.slug, event.group.id)
 
         form = self.page.find_comment_form()
         form.find_element_by_tag_name("textarea").send_keys("this looks bad")


### PR DESCRIPTION
Skip loading the event details and go directly to the group activity page, this fixes the flake because there's a race condition happening by visiting the event details page making additional requests and updating the group and the comment updating the group.

In practice this could happen in production, but most people cannot click and submit a comment this fast.
