### PR TITLE
fix(search): Fix moving to previous token not working without trailing space

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -448,22 +448,15 @@ class SmartSearchBar extends Component<Props, State> {
     token: TokenResult<any> | undefined,
     filterTokens: TokenResult<Token.Filter>[]
   ) => {
-    let offset = this.state.query.length;
-
     if (this.searchInput.current && filterTokens.length > 0) {
       this.searchInput.current.focus();
 
+      let offset = filterTokens[0].location.end.offset;
       if (token) {
         const tokenIndex = filterTokens.findIndex(tok => tok === token);
-        if (typeof tokenIndex !== 'undefined') {
-          if (tokenIndex + 1 < filterTokens.length) {
-            offset = filterTokens[tokenIndex + 1].location.end.offset;
-          }
+        if (tokenIndex !== -1 && tokenIndex + 1 < filterTokens.length) {
+          offset = filterTokens[tokenIndex + 1].location.end.offset;
         }
-      }
-
-      if (this.cursorPosition === this.state.query.length) {
-        offset = filterTokens[0].location.end.offset;
       }
 
       this.searchInput.current.selectionStart = offset;


### PR DESCRIPTION
Fix a bug when there was no trailing space in the search query moving to the previous token was not working.

Also no longer moves the cursor to select the trailing space from comments that the behavior felt weird.