### PR TITLE
ref(js): Extract `renderLoading` in useApiRequests

### DIFF
--- a/static/app/utils/useApiRequests.tsx
+++ b/static/app/utils/useApiRequests.tsx
@@ -87,6 +87,10 @@ type MetricsState = {
   hasMeasured: boolean;
 };
 
+function renderLoading() {
+  return <LoadingIndicator />;
+}
+
 function useApiRequests({
   endpoints = [],
   reloadOnVisible = false,
@@ -309,10 +313,6 @@ function useApiRequests({
 
   function shouldRenderLoading() {
     return state.isLoading && (!shouldReload || !state.isReloading);
-  }
-
-  function renderLoading() {
-    return <LoadingIndicator />;
   }
 
   function renderError(error?: Error, disableLog = false): React.ReactElement {


### PR DESCRIPTION
This doesn't need to be redeclared for every usage