### PR TITLE
ref(search): Rename quick actions to shortcuts

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -472,13 +472,13 @@ class SmartSearchBar extends Component<Props, State> {
     }
   };
 
-  runShortcut = (action: Shortcut) => {
+  runShortcut = (shortcut: Shortcut) => {
     const {query} = this.state;
     const token = this.cursorToken ?? undefined;
 
     const filterTokens = this.filterTokens;
 
-    const {shortcutType, canRunShortcut} = action;
+    const {shortcutType, canRunShortcut} = shortcut;
 
     if (!canRunShortcut || canRunShortcut(token, this.filterTokens.length)) {
       switch (shortcutType) {
@@ -1515,10 +1515,10 @@ class SmartSearchBar extends Component<Props, State> {
     const cursor = this.cursorPosition;
 
     const visibleShortcuts = shortcuts.filter(
-      action =>
-        action.hotkeys &&
-        (!action.canRunShortcut ||
-          action.canRunShortcut(this.cursorToken, this.filterTokens.length))
+      shortcut =>
+        shortcut.hotkeys &&
+        (!shortcut.canRunShortcut ||
+          shortcut.canRunShortcut(this.cursorToken, this.filterTokens.length))
     );
 
     return (

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -46,15 +46,15 @@ import withOrganization from 'sentry/utils/withOrganization';
 import {ActionButton} from './actions';
 import SearchDropdown from './searchDropdown';
 import SearchHotkeysListener from './searchHotkeysListener';
-import {ItemType, QuickAction, QuickActionType, SearchGroup, SearchItem} from './types';
+import {ItemType, SearchGroup, SearchItem, Shortcut, ShortcutType} from './types';
 import {
   addSpace,
   createSearchGroups,
   filterSearchGroupsByIndex,
   generateOperatorEntryMap,
   getValidOps,
-  quickActions,
   removeSpace,
+  shortcuts,
 } from './utils';
 
 const DROPDOWN_BLUR_DURATION = 200;
@@ -472,17 +472,17 @@ class SmartSearchBar extends Component<Props, State> {
     }
   };
 
-  runQuickAction = (action: QuickAction) => {
+  runShortcut = (action: Shortcut) => {
     const {query} = this.state;
     const token = this.cursorToken ?? undefined;
 
     const filterTokens = this.filterTokens;
 
-    const {actionType, canRunAction} = action;
+    const {shortcutType, canRunShortcut} = action;
 
-    if (!canRunAction || canRunAction(token, this.filterTokens.length)) {
-      switch (actionType) {
-        case QuickActionType.Delete: {
+    if (!canRunShortcut || canRunShortcut(token, this.filterTokens.length)) {
+      switch (shortcutType) {
+        case ShortcutType.Delete: {
           if (token && filterTokens.length > 0) {
             const index = filterTokens.findIndex(tok => tok === token) ?? -1;
 
@@ -507,7 +507,7 @@ class SmartSearchBar extends Component<Props, State> {
 
           break;
         }
-        case QuickActionType.Negate: {
+        case ShortcutType.Negate: {
           if (token && token.type === Token.Filter) {
             if (token.negated) {
               if (
@@ -548,12 +548,12 @@ class SmartSearchBar extends Component<Props, State> {
           }
           break;
         }
-        case QuickActionType.Next: {
+        case ShortcutType.Next: {
           this.moveToNextToken(token, filterTokens);
 
           break;
         }
-        case QuickActionType.Previous: {
+        case ShortcutType.Previous: {
           this.moveToNextToken(token, filterTokens.reverse());
 
           break;
@@ -1514,13 +1514,23 @@ class SmartSearchBar extends Component<Props, State> {
 
     const cursor = this.cursorPosition;
 
+    const visibleShortcuts = shortcuts.filter(
+      action =>
+        action.hotkeys &&
+        (!action.canRunShortcut ||
+          action.canRunShortcut(this.cursorToken, this.filterTokens.length))
+    );
+
     return (
       <Container
         ref={this.containerRef}
         className={className}
         inputHasFocus={inputHasFocus}
       >
-        <SearchHotkeysListener runQuickAction={this.runQuickAction} />
+        <SearchHotkeysListener
+          visibleShortcuts={visibleShortcuts}
+          runShortcut={this.runShortcut}
+        />
         <SearchLabel htmlFor="smart-search-input" aria-label={t('Search events')}>
           <IconSearch />
           {inlineLabel}
@@ -1574,13 +1584,8 @@ class SmartSearchBar extends Component<Props, State> {
             onClick={this.onAutoComplete}
             loading={loading}
             searchSubstring={searchTerm}
-            runQuickAction={this.runQuickAction}
-            visibleActions={quickActions.filter(
-              action =>
-                action.hotkeys &&
-                (!action.canRunAction ||
-                  action.canRunAction(this.cursorToken, this.filterTokens.length))
-            )}
+            runShortcut={this.runShortcut}
+            visibleShortcuts={visibleShortcuts}
             maxMenuHeight={maxMenuHeight}
           />
         )}

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -480,7 +480,7 @@ class SmartSearchBar extends Component<Props, State> {
 
     const {shortcutType, canRunShortcut} = shortcut;
 
-    if (!canRunShortcut || canRunShortcut(token, this.filterTokens.length)) {
+    if (canRunShortcut(token, this.filterTokens.length)) {
       switch (shortcutType) {
         case ShortcutType.Delete: {
           if (token && filterTokens.length > 0) {
@@ -1517,8 +1517,7 @@ class SmartSearchBar extends Component<Props, State> {
     const visibleShortcuts = shortcuts.filter(
       shortcut =>
         shortcut.hotkeys &&
-        (!shortcut.canRunShortcut ||
-          shortcut.canRunShortcut(this.cursorToken, this.filterTokens.length))
+        shortcut.canRunShortcut(this.cursorToken, this.filterTokens.length)
     );
 
     return (

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -18,7 +18,7 @@ type Props = {
   searchSubstring: string;
   className?: string;
   maxMenuHeight?: number;
-  runShortcut?: (action: Shortcut) => void;
+  runShortcut?: (shortcut: Shortcut) => void;
   visibleShortcuts?: Shortcut[];
 };
 

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -9,7 +9,7 @@ import space from 'sentry/styles/space';
 import Button from '../button';
 import HotkeysLabel from '../hotkeysLabel';
 
-import {ItemType, QuickAction, SearchGroup, SearchItem} from './types';
+import {ItemType, SearchGroup, SearchItem, Shortcut} from './types';
 
 type Props = {
   items: SearchGroup[];
@@ -18,8 +18,8 @@ type Props = {
   searchSubstring: string;
   className?: string;
   maxMenuHeight?: number;
-  runQuickAction?: (action: QuickAction) => void;
-  visibleActions?: QuickAction[];
+  runShortcut?: (action: Shortcut) => void;
+  visibleShortcuts?: Shortcut[];
 };
 
 class SearchDropdown extends PureComponent<Props> {
@@ -82,7 +82,7 @@ class SearchDropdown extends PureComponent<Props> {
   );
 
   render() {
-    const {className, loading, items, runQuickAction, visibleActions, maxMenuHeight} =
+    const {className, loading, items, runShortcut, visibleShortcuts, maxMenuHeight} =
       this.props;
     return (
       <StyledSearchDropdown className={className}>
@@ -109,23 +109,23 @@ class SearchDropdown extends PureComponent<Props> {
           </SearchItemsList>
         )}
         <DropdownFooter>
-          <ActionsRow>
-            {runQuickAction &&
-              visibleActions?.map(action => {
+          <ShortcutsRow>
+            {runShortcut &&
+              visibleShortcuts?.map(shortcut => {
                 return (
-                  <ActionButtonContainer
-                    key={action.text}
-                    onClick={() => runQuickAction(action)}
+                  <ShortcutButtonContainer
+                    key={shortcut.text}
+                    onClick={() => runShortcut(shortcut)}
                   >
                     <HotkeyGlyphWrapper>
-                      <HotkeysLabel value={action.hotkeys?.display ?? []} />
+                      <HotkeysLabel value={shortcut.hotkeys?.display ?? []} />
                     </HotkeyGlyphWrapper>
-                    <IconWrapper>{action.icon}</IconWrapper>
-                    <HotkeyTitle>{action.text}</HotkeyTitle>
-                  </ActionButtonContainer>
+                    <IconWrapper>{shortcut.icon}</IconWrapper>
+                    <HotkeyTitle>{shortcut.text}</HotkeyTitle>
+                  </ShortcutButtonContainer>
                 );
               })}
-          </ActionsRow>
+          </ShortcutsRow>
           <Button
             size="xsmall"
             href="https://docs.sentry.io/product/sentry-basics/search/"
@@ -262,13 +262,13 @@ const DropdownFooter = styled(`div`)`
   gap: ${space(1)};
 `;
 
-const ActionsRow = styled('div')`
+const ShortcutsRow = styled('div')`
   flex-direction: row;
   display: flex;
   align-items: center;
 `;
 
-const ActionButtonContainer = styled('div')`
+const ShortcutButtonContainer = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/static/app/components/smartSearchBar/searchHotkeysListener.tsx
+++ b/static/app/components/smartSearchBar/searchHotkeysListener.tsx
@@ -1,24 +1,25 @@
 import {useHotkeys} from 'sentry/utils/useHotkeys';
 
-import {QuickAction} from './types';
-import {quickActions} from './utils';
+import {Shortcut} from './types';
 
 const SearchHotkeysListener = ({
-  runQuickAction,
+  visibleShortcuts,
+  runShortcut,
 }: {
-  runQuickAction: (action: QuickAction) => void;
+  runShortcut: (action: Shortcut) => void;
+  visibleShortcuts: Shortcut[];
 }) => {
   useHotkeys(
-    quickActions
-      .filter(action => typeof action.hotkeys !== 'undefined')
-      .map(action => ({
-        match: action.hotkeys?.actual ?? [],
+    visibleShortcuts
+      .filter(shortcut => typeof shortcut.hotkeys !== 'undefined')
+      .map(shortcut => ({
+        match: shortcut.hotkeys?.actual ?? [],
         callback: e => {
           e.preventDefault();
-          runQuickAction(action);
+          runShortcut(shortcut);
         },
       })),
-    [runQuickAction]
+    [visibleShortcuts]
   );
 
   return null;

--- a/static/app/components/smartSearchBar/searchHotkeysListener.tsx
+++ b/static/app/components/smartSearchBar/searchHotkeysListener.tsx
@@ -6,7 +6,7 @@ const SearchHotkeysListener = ({
   visibleShortcuts,
   runShortcut,
 }: {
-  runShortcut: (action: Shortcut) => void;
+  runShortcut: (shortcut: Shortcut) => void;
   visibleShortcuts: Shortcut[];
 }) => {
   useHotkeys(

--- a/static/app/components/smartSearchBar/types.tsx
+++ b/static/app/components/smartSearchBar/types.tsx
@@ -42,18 +42,18 @@ export type Tag = {
   values: string[];
 };
 
-export enum QuickActionType {
+export enum ShortcutType {
   Delete = 'delete',
   Negate = 'negate',
   Next = 'next',
   Previous = 'previous',
 }
 
-export type QuickAction = {
-  actionType: QuickActionType;
+export type Shortcut = {
   icon: React.ReactNode;
+  shortcutType: ShortcutType;
   text: string;
-  canRunAction?: (
+  canRunShortcut?: (
     token: TokenResult<any> | null | undefined,
     filterTokenCount: number
   ) => boolean;

--- a/static/app/components/smartSearchBar/types.tsx
+++ b/static/app/components/smartSearchBar/types.tsx
@@ -50,13 +50,13 @@ export enum ShortcutType {
 }
 
 export type Shortcut = {
-  icon: React.ReactNode;
-  shortcutType: ShortcutType;
-  text: string;
-  canRunShortcut?: (
+  canRunShortcut: (
     token: TokenResult<any> | null | undefined,
     filterTokenCount: number
   ) => boolean;
+  icon: React.ReactNode;
+  shortcutType: ShortcutType;
+  text: string;
   hotkeys?: {
     actual: string[] | string;
     display: string[] | string;

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -19,7 +19,7 @@ import {t} from 'sentry/locale';
 
 import HotkeysLabel from '../hotkeysLabel';
 
-import {ItemType, QuickAction, QuickActionType, SearchGroup, SearchItem} from './types';
+import {ItemType, SearchGroup, SearchItem, Shortcut, ShortcutType} from './types';
 
 export function addSpace(query = '') {
   if (query.length !== 0 && query[query.length - 1] !== ' ') {
@@ -261,65 +261,66 @@ export function getValidOps(
   return [...validOps];
 }
 
-export const quickActions: QuickAction[] = [
+export const shortcuts: Shortcut[] = [
   {
     text: 'Delete',
-    actionType: QuickActionType.Delete,
+    shortcutType: ShortcutType.Delete,
     hotkeys: {
       actual: 'option+backspace',
       display: 'option+backspace',
     },
     icon: <IconDelete size="xs" color="gray300" />,
-    canRunAction: tok => {
+    canRunShortcut: tok => {
       return tok?.type === Token.Filter;
     },
   },
   {
     text: 'Negate',
-    actionType: QuickActionType.Negate,
+    shortcutType: ShortcutType.Negate,
     hotkeys: {
-      actual: ['option+1', 'cmd+1'],
+      actual: ['option+1'],
       display: 'option+!',
     },
     icon: <IconExclamation size="xs" color="gray300" />,
-    canRunAction: tok => {
+    canRunShortcut: tok => {
       return tok?.type === Token.Filter;
     },
   },
   {
     text: 'Previous',
-    actionType: QuickActionType.Previous,
+    shortcutType: ShortcutType.Previous,
     hotkeys: {
       actual: ['option+left'],
       display: 'option+left',
     },
     icon: <IconArrow direction="left" size="xs" color="gray300" />,
-    canRunAction: (tok, count) => {
+    canRunShortcut: (tok, count) => {
       return count > 1 || (count > 0 && tok?.type !== Token.Filter);
     },
   },
   {
     text: 'Next',
-    actionType: QuickActionType.Next,
+    shortcutType: ShortcutType.Next,
     hotkeys: {
       actual: ['option+right'],
       display: 'option+right',
     },
     icon: <IconArrow direction="right" size="xs" color="gray300" />,
-    canRunAction: (tok, count) => {
+    canRunShortcut: (tok, count) => {
       return count > 1 || (count > 0 && tok?.type !== Token.Filter);
     },
   },
 ];
 
 export function getQuickActionsSearchGroup(
-  runTokenActionOnCursorToken: (action: QuickAction) => void,
+  runTokenActionOnCursorToken: (action: Shortcut) => void,
   filterTokenCount: number,
   activeToken?: TokenResult<any>
 ): {searchGroup: SearchGroup; searchItems: SearchItem[]} | undefined {
-  const searchItems = quickActions
+  const searchItems = shortcuts
     .filter(
-      action => !action.canRunAction || action.canRunAction(activeToken, filterTokenCount)
+      action =>
+        !action.canRunShortcut || action.canRunShortcut(activeToken, filterTokenCount)
     )
     .map(action => ({
       title: action.text,

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -17,8 +17,6 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 
-import HotkeysLabel from '../hotkeysLabel';
-
 import {ItemType, SearchGroup, SearchItem, Shortcut, ShortcutType} from './types';
 
 export function addSpace(query = '') {
@@ -311,32 +309,3 @@ export const shortcuts: Shortcut[] = [
     },
   },
 ];
-
-export function getQuickActionsSearchGroup(
-  runTokenActionOnCursorToken: (action: Shortcut) => void,
-  filterTokenCount: number,
-  activeToken?: TokenResult<any>
-): {searchGroup: SearchGroup; searchItems: SearchItem[]} | undefined {
-  const searchItems = shortcuts
-    .filter(
-      action =>
-        !action.canRunShortcut || action.canRunShortcut(activeToken, filterTokenCount)
-    )
-    .map(action => ({
-      title: action.text,
-      callback: () => runTokenActionOnCursorToken(action),
-      documentation: action.hotkeys && <HotkeysLabel value={action.hotkeys.display} />,
-    }));
-
-  return searchItems.length > 0 && filterTokenCount > 0
-    ? {
-        searchGroup: {
-          title: t('Quick Actions'),
-          type: 'header',
-          icon: <IconStar size="xs" />,
-          children: searchItems,
-        },
-        searchItems,
-      }
-    : undefined;
-}

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -2,8 +2,8 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {Client} from 'sentry/api';
 import {SmartSearchBar} from 'sentry/components/smartSearchBar';
-import {QuickActionType} from 'sentry/components/smartSearchBar/types';
-import {quickActions} from 'sentry/components/smartSearchBar/utils';
+import {ShortcutType} from 'sentry/components/smartSearchBar/types';
+import {shortcuts} from 'sentry/components/smartSearchBar/utils';
 import TagStore from 'sentry/stores/tagStore';
 
 describe('SmartSearchBar', function () {
@@ -892,13 +892,11 @@ describe('SmartSearchBar', function () {
 
       await tick();
 
-      const deleteAction = quickActions.find(
-        a => a.actionType === QuickActionType.Delete
-      );
+      const deleteAction = shortcuts.find(a => a.shortcutType === ShortcutType.Delete);
 
       expect(deleteAction).toBeDefined();
       if (deleteAction) {
-        searchBar.runQuickAction(deleteAction);
+        searchBar.runShortcut(deleteAction);
 
         await tick();
 
@@ -920,13 +918,11 @@ describe('SmartSearchBar', function () {
 
       await tick();
 
-      const deleteAction = quickActions.find(
-        a => a.actionType === QuickActionType.Delete
-      );
+      const deleteAction = shortcuts.find(a => a.shortcutType === ShortcutType.Delete);
 
       expect(deleteAction).toBeDefined();
       if (deleteAction) {
-        searchBar.runQuickAction(deleteAction);
+        searchBar.runShortcut(deleteAction);
 
         await tick();
 
@@ -948,13 +944,11 @@ describe('SmartSearchBar', function () {
 
       await tick();
 
-      const deleteAction = quickActions.find(
-        a => a.actionType === QuickActionType.Negate
-      );
+      const deleteAction = shortcuts.find(a => a.shortcutType === ShortcutType.Negate);
 
       expect(deleteAction).toBeDefined();
       if (deleteAction) {
-        searchBar.runQuickAction(deleteAction);
+        searchBar.runShortcut(deleteAction);
 
         await tick();
 
@@ -978,13 +972,11 @@ describe('SmartSearchBar', function () {
 
       await tick();
 
-      const deleteAction = quickActions.find(
-        a => a.actionType === QuickActionType.Negate
-      );
+      const deleteAction = shortcuts.find(a => a.shortcutType === ShortcutType.Negate);
 
       expect(deleteAction).toBeDefined();
       if (deleteAction) {
-        searchBar.runQuickAction(deleteAction);
+        searchBar.runShortcut(deleteAction);
 
         await tick();
 


### PR DESCRIPTION
There's another feature in the smart search bar called actions already, renaming the "Quick Actions" to shortcuts makes it clear they're different features.