### PR TITLE
ref(search): Rename negate shortcut to include/exclude and show as option+1 hotkey

### DIFF
--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -129,7 +129,11 @@ class SearchDropdown extends PureComponent<Props> {
                     onClick={() => runShortcut(shortcut)}
                   >
                     <HotkeyGlyphWrapper>
-                      <HotkeysLabel value={shortcut.hotkeys?.display ?? []} />
+                      <HotkeysLabel
+                        value={
+                          shortcut.hotkeys?.display ?? shortcut.hotkeys?.actual ?? []
+                        }
+                      />
                     </HotkeyGlyphWrapper>
                     <IconWrapper>{shortcut.icon}</IconWrapper>
                     <HotkeyTitle>{shortcut.text}</HotkeyTitle>

--- a/static/app/components/smartSearchBar/types.tsx
+++ b/static/app/components/smartSearchBar/types.tsx
@@ -59,6 +59,6 @@ export type Shortcut = {
   text: string;
   hotkeys?: {
     actual: string[] | string;
-    display: string[] | string;
+    display?: string[] | string;
   };
 };

--- a/static/app/components/smartSearchBar/types.tsx
+++ b/static/app/components/smartSearchBar/types.tsx
@@ -1,4 +1,4 @@
-import {TokenResult} from '../searchSyntax/parser';
+import {Token, TokenResult} from '../searchSyntax/parser';
 
 export enum ItemType {
   DEFAULT = 'default',
@@ -51,7 +51,7 @@ export enum ShortcutType {
 
 export type Shortcut = {
   canRunShortcut: (
-    token: TokenResult<any> | null | undefined,
+    token: TokenResult<Token> | null | undefined,
     filterTokenCount: number
   ) => boolean;
   icon: React.ReactNode;

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -276,14 +276,27 @@ export const shortcuts: Shortcut[] = [
     text: 'Exclude',
     shortcutType: ShortcutType.Negate,
     hotkeys: {
-      actual: ['option+1'],
-      display: 'option+!',
+      actual: 'option+1',
+      display: 'option+1',
     },
     icon: <IconExclamation size="xs" color="gray300" />,
     canRunShortcut: tok => {
-      return tok?.type === Token.Filter;
+      return !!(tok && tok.text[0] !== '!' && tok.type === Token.Filter);
     },
   },
+  {
+    text: 'Include',
+    shortcutType: ShortcutType.Negate,
+    hotkeys: {
+      actual: 'option+1',
+      display: 'option+1',
+    },
+    icon: <IconExclamation size="xs" color="gray300" />,
+    canRunShortcut: tok => {
+      return !!(tok && tok.text[0] === '!' && tok.type === Token.Filter);
+    },
+  },
+
   {
     text: 'Previous',
     shortcutType: ShortcutType.Previous,

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -279,9 +279,7 @@ export const shortcuts: Shortcut[] = [
     },
     icon: <IconExclamation size="xs" color="gray300" />,
     canRunShortcut: token => {
-      return (
-        token?.type === Token.Filter && !(token as TokenResult<Token.Filter>).negated
-      );
+      return token?.type === Token.Filter && !token.negated;
     },
   },
   {
@@ -292,7 +290,7 @@ export const shortcuts: Shortcut[] = [
     },
     icon: <IconExclamation size="xs" color="gray300" />,
     canRunShortcut: token => {
-      return token?.type === Token.Filter && (token as TokenResult<Token.Filter>).negated;
+      return token?.type === Token.Filter && token.negated;
     },
   },
 

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -265,11 +265,10 @@ export const shortcuts: Shortcut[] = [
     shortcutType: ShortcutType.Delete,
     hotkeys: {
       actual: 'option+backspace',
-      display: 'option+backspace',
     },
     icon: <IconDelete size="xs" color="gray300" />,
-    canRunShortcut: tok => {
-      return tok?.type === Token.Filter;
+    canRunShortcut: token => {
+      return token?.type === Token.Filter;
     },
   },
   {
@@ -277,11 +276,12 @@ export const shortcuts: Shortcut[] = [
     shortcutType: ShortcutType.Negate,
     hotkeys: {
       actual: 'option+1',
-      display: 'option+1',
     },
     icon: <IconExclamation size="xs" color="gray300" />,
-    canRunShortcut: tok => {
-      return !!(tok && tok.text[0] !== '!' && tok.type === Token.Filter);
+    canRunShortcut: token => {
+      return (
+        token?.type === Token.Filter && !(token as TokenResult<Token.Filter>).negated
+      );
     },
   },
   {
@@ -289,11 +289,10 @@ export const shortcuts: Shortcut[] = [
     shortcutType: ShortcutType.Negate,
     hotkeys: {
       actual: 'option+1',
-      display: 'option+1',
     },
     icon: <IconExclamation size="xs" color="gray300" />,
-    canRunShortcut: tok => {
-      return !!(tok && tok.text[0] === '!' && tok.type === Token.Filter);
+    canRunShortcut: token => {
+      return token?.type === Token.Filter && (token as TokenResult<Token.Filter>).negated;
     },
   },
 
@@ -301,24 +300,22 @@ export const shortcuts: Shortcut[] = [
     text: 'Previous',
     shortcutType: ShortcutType.Previous,
     hotkeys: {
-      actual: ['option+left'],
-      display: 'option+left',
+      actual: 'option+left',
     },
     icon: <IconArrow direction="left" size="xs" color="gray300" />,
-    canRunShortcut: (tok, count) => {
-      return count > 1 || (count > 0 && tok?.type !== Token.Filter);
+    canRunShortcut: (token, count) => {
+      return count > 1 || (count > 0 && token?.type !== Token.Filter);
     },
   },
   {
     text: 'Next',
     shortcutType: ShortcutType.Next,
     hotkeys: {
-      actual: ['option+right'],
-      display: 'option+right',
+      actual: 'option+right',
     },
     icon: <IconArrow direction="right" size="xs" color="gray300" />,
-    canRunShortcut: (tok, count) => {
-      return count > 1 || (count > 0 && tok?.type !== Token.Filter);
+    canRunShortcut: (token, count) => {
+      return count > 1 || (count > 0 && token?.type !== Token.Filter);
     },
   },
 ];

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -935,7 +935,7 @@ describe('SmartSearchBar', function () {
       }
     });
 
-    it('negate token', async () => {
+    it('exclude token', async () => {
       const props = {
         query: 'is:unresolved sdk.name:sentry-cocoa has:key',
         organization,
@@ -949,11 +949,11 @@ describe('SmartSearchBar', function () {
 
       await tick();
 
-      const deleteAction = shortcuts.find(a => a.shortcutType === ShortcutType.Negate);
+      const excludeAction = shortcuts.find(shortcut => shortcut.text === 'Exclude');
 
-      expect(deleteAction).toBeDefined();
-      if (deleteAction) {
-        searchBar.runShortcut(deleteAction);
+      expect(excludeAction).toBeDefined();
+      if (excludeAction) {
+        searchBar.runShortcut(excludeAction);
 
         await tick();
 
@@ -963,7 +963,7 @@ describe('SmartSearchBar', function () {
       }
     });
 
-    it('un-negate token', async () => {
+    it('include token', async () => {
       const props = {
         query: 'is:unresolved !sdk.name:sentry-cocoa has:key',
         organization,
@@ -977,11 +977,11 @@ describe('SmartSearchBar', function () {
 
       await tick();
 
-      const deleteAction = shortcuts.find(a => a.shortcutType === ShortcutType.Negate);
+      const includeAction = shortcuts.find(shortcut => shortcut.text === 'Include');
 
-      expect(deleteAction).toBeDefined();
-      if (deleteAction) {
-        searchBar.runShortcut(deleteAction);
+      expect(includeAction).toBeDefined();
+      if (includeAction) {
+        searchBar.runShortcut(includeAction);
 
         await tick();
 


### PR DESCRIPTION
Rename Negate search shortcut to include/exclude and also change the hotkey label to `option+1` instead of `option+1`

Before:
<img width="112" alt="Screen Shot 2022-06-15 at 5 19 47 PM" src="https://user-images.githubusercontent.com/30991498/173963263-1ac0124b-6eec-445a-a31d-4031505ded11.png">

After:
<img width="103" alt="Screen Shot 2022-06-15 at 5 20 21 PM" src="https://user-images.githubusercontent.com/30991498/173963290-61d75c69-f490-4aeb-ae3e-975609855eed.png">
<img width="104" alt="Screen Shot 2022-06-15 at 5 20 18 PM" src="https://user-images.githubusercontent.com/30991498/173963294-bd4d03e1-c509-4b42-8734-e4c9cd6d1b31.png">

