### PR TITLE
ref: freeze time for project_key_stats test to fix flake

### DIFF
--- a/tests/sentry/api/endpoints/test_project_key_stats.py
+++ b/tests/sentry/api/endpoints/test_project_key_stats.py
@@ -1,3 +1,5 @@
+import freezegun
+
 from sentry.constants import DataCategory
 from sentry.models import ProjectKey
 from sentry.testutils import APITestCase
@@ -6,6 +8,7 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.outcomes import Outcome
 
 
+@freezegun.freeze_time("2022-01-01 03:30:00")
 class ProjectKeyStatsTest(OutcomesSnubaTest, SnubaTestCase, APITestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
when time was frozen to `00:30`:

```console
$ pytest tests/sentry/api/endpoints/test_project_key_stats.py
====================================== test session starts =======================================
platform darwin -- Python 3.8.13, pytest-6.1.0, py-1.11.0, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: rerunfailures-9.1.1, cov-2.11.1, sentry-0.1.9, django-4.4.0
collected 4 items                                                                                

tests/sentry/api/endpoints/test_project_key_stats.py .F.F                                  [100%]

============================================ FAILURES ============================================
____________________________ ProjectKeyStatsTest.test_ignore_discard _____________________________
tests/sentry/api/endpoints/test_project_key_stats.py:118: in test_ignore_discard
    result = [bucket for bucket in response.data if bucket["total"] > 0][0]
E   IndexError: list index out of range
________________________________ ProjectKeyStatsTest.test_simple _________________________________
tests/sentry/api/endpoints/test_project_key_stats.py:81: in test_simple
    result = [bucket for bucket in response.data if bucket["total"] > 0][0]
E   IndexError: list index out of range
==================================== short test summary info =====================================
FAILED tests/sentry/api/endpoints/test_project_key_stats.py::ProjectKeyStatsTest::test_ignore_discard
FAILED tests/sentry/api/endpoints/test_project_key_stats.py::ProjectKeyStatsTest::test_simple
================================== 2 failed, 2 passed in 5.19s ===================================
```