### PR TITLE
feat(profiling): flamegraph textsearch highlight

### DIFF
--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -13,7 +13,6 @@ import {
   FlamegraphFrame,
   getFlamegraphFrameSearchId,
 } from 'sentry/utils/profiling/flamegraphFrame';
-import {Bounds} from 'sentry/utils/profiling/gl/utils';
 import {memoizeByReference} from 'sentry/utils/profiling/profile/utils';
 import {isRegExpString, parseRegExp} from 'sentry/utils/profiling/validators/regExp';
 
@@ -66,7 +65,7 @@ function frameSearch(
               acc.push([match.index, match.index + match[0].length]);
 
               return acc;
-            }, [] as [number, number][]),
+            }, [] as Fuse.RangeTuple[]),
           };
           matches += 1;
         }
@@ -98,7 +97,7 @@ function frameSearch(
       matchIndices: fuseFrameResult.matches!.reduce((acc, val) => {
         acc.push(...val.indices);
         return acc;
-      }, [] as Bounds[]),
+      }, [] as Fuse.RangeTuple[]),
     };
   }
 

--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -8,7 +8,10 @@ import {t} from 'sentry/locale';
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {useFlamegraphSearch} from 'sentry/utils/profiling/flamegraph/useFlamegraphSearch';
-import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {
+  FlamegraphFrame,
+  getFlamegraphFrameSearchId,
+} from 'sentry/utils/profiling/flamegraphFrame';
 import {memoizeByReference} from 'sentry/utils/profiling/profile/utils';
 import {isRegExpString, parseRegExp} from 'sentry/utils/profiling/validators/regExp';
 
@@ -46,13 +49,8 @@ function frameSearch(
         const frame = frames[i];
 
         if (new RegExp(lookup, flags ?? 'g').test(frame.frame.name.trim())) {
-          results[
-            `${
-              frame.frame.name +
-              (frame.frame.file ? frame.frame.file : '') +
-              String(frame.start)
-            }`
-          ] = frame;
+          const frameId = getFlamegraphFrameSearchId(frame);
+          results[frameId] = frame;
           matches += 1;
         }
       }

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -280,7 +280,7 @@ function FlamegraphZoomView({
       textRenderer.draw(
         flamegraphView.configView,
         flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace),
-        flamegraphSearch
+        flamegraphSearch.results
       );
     };
 

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -8,6 +8,7 @@ import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {DifferentialFlamegraph} from 'sentry/utils/profiling/differentialFlamegraph';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {useFlamegraphSearch} from 'sentry/utils/profiling/flamegraph/useFlamegraphSearch';
 import {
   useDispatchFlamegraphState,
   useFlamegraphState,
@@ -56,6 +57,7 @@ function FlamegraphZoomView({
   setFlamegraphOverlayCanvasRef,
 }: FlamegraphZoomViewProps): React.ReactElement {
   const flamegraphTheme = useFlamegraphTheme();
+  const [flamegraphSearch] = useFlamegraphSearch();
 
   const [lastInteraction, setLastInteraction] = useState<
     'pan' | 'click' | 'zoom' | 'scroll' | null
@@ -277,7 +279,8 @@ function FlamegraphZoomView({
     const drawText = () => {
       textRenderer.draw(
         flamegraphView.configView,
-        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
+        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace),
+        flamegraphSearch
       );
     };
 
@@ -314,6 +317,7 @@ function FlamegraphZoomView({
     flamegraphState.profiles.selectedNode,
     hoveredNode,
     selectedFrameRenderer,
+    flamegraphSearch,
   ]);
 
   useEffect(() => {

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphSearch.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphSearch.tsx
@@ -1,9 +1,15 @@
 import {FlamegraphFrame} from '../../flamegraphFrame';
+import {Bounds} from '../../gl/utils';
+
+export type FlamegraphSearchResult = {
+  frame: FlamegraphFrame;
+  matchIndices: Bounds[];
+};
 
 export type FlamegraphSearch = {
   index: number | null;
   query: string;
-  results: Record<string, FlamegraphFrame> | null;
+  results: Record<string, FlamegraphSearchResult> | null;
 };
 
 type ClearFlamegraphSearchAction = {

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphSearch.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphSearch.tsx
@@ -1,6 +1,6 @@
 import {FlamegraphFrame} from '../../flamegraphFrame';
 
-type FlamegraphSearch = {
+export type FlamegraphSearch = {
   index: number | null;
   query: string;
   results: Record<string, FlamegraphFrame> | null;

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphSearch.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphSearch.tsx
@@ -1,9 +1,10 @@
+import type Fuse from 'fuse.js';
+
 import {FlamegraphFrame} from '../../flamegraphFrame';
-import {Bounds} from '../../gl/utils';
 
 export type FlamegraphSearchResult = {
   frame: FlamegraphFrame;
-  matchIndices: Bounds[];
+  matchIndices: Fuse.RangeTuple[];
 };
 
 export type FlamegraphSearch = {

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -38,6 +38,7 @@ export interface FlamegraphTheme {
     FRAME_FALLBACK_COLOR: [number, number, number, number];
     GRID_FRAME_BACKGROUND_COLOR: string;
     GRID_LINE_COLOR: string;
+    HIGHLIGHTED_LABEL_COLOR: ColorChannels;
     HOVERED_FRAME_BORDER_COLOR: string;
     LABEL_FONT_COLOR: string;
     MINIMAP_POSITION_OVERLAY_BORDER_COLOR: string;
@@ -146,6 +147,7 @@ export const LightFlamegraphTheme: FlamegraphTheme = {
     GRID_FRAME_BACKGROUND_COLOR: 'rgba(255, 255, 255, 0.8)',
     SEARCH_RESULT_FRAME_COLOR: 'vec4(0.99, 0.70, 0.35, 1.0)',
     SELECTED_FRAME_BORDER_COLOR: '#005aff',
+    HIGHLIGHTED_LABEL_COLOR: [255, 255, 0],
     HOVERED_FRAME_BORDER_COLOR: 'rgba(0, 0, 0, 0.8)',
     CURSOR_CROSSHAIR: '#bbbbbb',
     SPAN_FRAME_BORDER: 'rgba(200, 200, 200, 1)',
@@ -204,6 +206,7 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
     GRID_FRAME_BACKGROUND_COLOR: 'rgba(0, 0, 0, 0.4)',
     SEARCH_RESULT_FRAME_COLOR: 'vec4(0.99, 0.70, 0.35, 0.7)',
     SELECTED_FRAME_BORDER_COLOR: '#3482ea',
+    HIGHLIGHTED_LABEL_COLOR: [255, 255, 0],
     HOVERED_FRAME_BORDER_COLOR: 'rgba(255, 255, 255, 0.8)',
     CURSOR_CROSSHAIR: '#828285',
     SPAN_FRAME_BORDER: '#57575b',

--- a/static/app/utils/profiling/flamegraphFrame.tsx
+++ b/static/app/utils/profiling/flamegraphFrame.tsx
@@ -15,7 +15,7 @@ export interface FlamegraphFrame {
 }
 
 export function getFlamegraphFrameSearchId(frame: FlamegraphFrame) {
-  return `${
+  return (
     frame.frame.name + (frame.frame.file ? frame.frame.file : '') + String(frame.start)
-  }`;
+  );
 }

--- a/static/app/utils/profiling/flamegraphFrame.tsx
+++ b/static/app/utils/profiling/flamegraphFrame.tsx
@@ -13,3 +13,9 @@ export interface FlamegraphFrame {
   processId?: number;
   threadId?: number;
 }
+
+export function getFlamegraphFrameSearchId(frame: FlamegraphFrame) {
+  return `${
+    frame.frame.name + (frame.frame.file ? frame.frame.file : '') + String(frame.start)
+  }`;
+}

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -559,16 +559,14 @@ function isBetween(num: number, low: number, high: number) {
   return num >= low && num <= high;
 }
 
-function computeHighlightedBounds(
-  bounds: number[],
-  trim: TrimTextCenter
-): [number, number] {
+type Bounds = [number, number];
+function computeHighlightedBounds(bounds: Bounds, trim: TrimTextCenter): Bounds {
   let next = bounds;
   const [boundStart, boundEnd] = next;
-  const {start, end, length} = trim;
+  const {start, end, length, text} = trim;
 
-  if (start === 0 && end === length && trim.text.length > 1) {
-    return next as [number, number];
+  if (start === 0 && end === length && text.length > 1) {
+    return next;
   }
   // check if matched word now falls within an ellipsis at the head or tail of the word
   // "display" in "...play"
@@ -594,7 +592,7 @@ function computeHighlightedBounds(
       return delta + 1;
     }
     return v;
-  }) as [number, number];
+  }) as Bounds;
 }
 
 export function matchHighlightedBounds(
@@ -608,7 +606,7 @@ export function matchHighlightedBounds(
       continue;
     }
     const bounds = [match.index, match[0].length + match.index];
-    const computedBounds = computeHighlightedBounds(bounds, trim);
+    const computedBounds = computeHighlightedBounds(bounds as Bounds, trim);
     const lastBound = boundaries[boundaries.length - 1];
     const isContinuous = lastBound && isBetween(computedBounds[0], ...lastBound);
     if (isContinuous) {

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -514,7 +514,7 @@ export function trimTextCenter(text: string, low: number): TrimTextCenter {
     return {
       text,
       start: 0,
-      end: text.length,
+      end: 0,
       length: 0,
     };
   }

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -1,6 +1,7 @@
 import {mat3, vec2} from 'gl-matrix';
 
 import {Flamegraph} from '../flamegraph';
+import {FlamegraphSearch} from '../flamegraph/flamegraphStateProvider/flamegraphSearch';
 import {FlamegraphTheme} from '../flamegraph/flamegraphTheme';
 import {FlamegraphFrame, getFlamegraphFrameSearchId} from '../flamegraphFrame';
 import {
@@ -391,7 +392,7 @@ class FlamegraphRenderer {
 
   draw(
     configViewToPhysicalSpace: mat3,
-    searchResults: Record<FlamegraphFrame['frame']['key'], FlamegraphFrame> | null = null
+    searchResults: FlamegraphSearch['results'] = null
   ): void {
     if (!this.gl) {
       throw new Error('Uninitialized WebGL context');

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -2,7 +2,7 @@ import {mat3, vec2} from 'gl-matrix';
 
 import {Flamegraph} from '../flamegraph';
 import {FlamegraphTheme} from '../flamegraph/flamegraphTheme';
-import {FlamegraphFrame} from '../flamegraphFrame';
+import {FlamegraphFrame, getFlamegraphFrameSearchId} from '../flamegraphFrame';
 import {
   createProgram,
   createShader,
@@ -444,18 +444,10 @@ class FlamegraphRenderer {
       for (let i = 0; i < length; i++) {
         frame = this.frames[i];
         const vertexOffset = i * VERTICES;
-
+        const frameId = getFlamegraphFrameSearchId(frame);
         this.gl.uniform1i(
           this.uniforms.u_is_search_result,
-          searchResults[
-            `${
-              frame.frame.name +
-              (frame.frame.file ? frame.frame.file : '') +
-              String(frame.start)
-            }`
-          ]
-            ? 1
-            : 0
+          searchResults[frameId] ? 1 : 0
         );
         this.gl.drawArrays(this.gl.TRIANGLES, vertexOffset, VERTICES);
       }

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -1,19 +1,21 @@
 import {mat3} from 'gl-matrix';
 
 import {Flamegraph} from '../flamegraph';
+import {FlamegraphSearch} from '../flamegraph/flamegraphStateProvider/flamegraphSearch';
 import {FlamegraphTheme} from '../flamegraph/flamegraphTheme';
-import {FlamegraphFrame} from '../flamegraphFrame';
+import {FlamegraphFrame, getFlamegraphFrameSearchId} from '../flamegraphFrame';
 import {
   ELLIPSIS,
   findRangeBinarySearch,
   getContext,
+  matchHighlightedBounds,
   Rect,
   resizeCanvasToDisplaySize,
   trimTextCenter,
 } from '../gl/utils';
 
 class TextRenderer {
-  textCache: Record<string, number> = {};
+  textCache: Record<string, TextMetrics> = {};
 
   canvas: HTMLCanvasElement;
   context: CanvasRenderingContext2D;
@@ -29,11 +31,11 @@ class TextRenderer {
     resizeCanvasToDisplaySize(canvas);
   }
 
-  measureAndCacheText(text: string): number {
+  measureAndCacheText(text: string): TextMetrics {
     if (this.textCache[text]) {
       return this.textCache[text];
     }
-    this.textCache[text] = this.context.measureText(text).width;
+    this.textCache[text] = this.context.measureText(text);
     return this.textCache[text];
   }
 
@@ -45,13 +47,17 @@ class TextRenderer {
       return;
     }
 
-    const newMeasuredSize = this.context.measureText(TEST_STRING).width;
+    const newMeasuredSize = this.context.measureText(TEST_STRING);
     if (newMeasuredSize !== this.textCache[TEST_STRING]) {
       this.textCache = {[TEST_STRING]: newMeasuredSize};
     }
   }
 
-  draw(configView: Rect, configViewToPhysicalSpace: mat3): void {
+  draw(
+    configView: Rect,
+    configViewToPhysicalSpace: mat3,
+    flamegraphSearch: FlamegraphSearch | null = null
+  ): void {
     this.maybeInvalidateCache();
 
     this.context.font = `${this.theme.SIZES.BAR_FONT_SIZE * window.devicePixelRatio}px ${
@@ -61,7 +67,7 @@ class TextRenderer {
     this.context.textBaseline = 'alphabetic';
     this.context.fillStyle = this.theme.COLORS.LABEL_FONT_COLOR;
 
-    const minWidth = this.measureAndCacheText(ELLIPSIS);
+    const minWidth = this.measureAndCacheText(ELLIPSIS).width;
 
     const SIDE_PADDING = 2 * this.theme.SIZES.BAR_PADDING * window.devicePixelRatio;
     const HALF_SIDE_PADDING = SIDE_PADDING / 2;
@@ -74,7 +80,6 @@ class TextRenderer {
     // 1. We can skip drawing the entire tree if the root frame is not visible
     // 2. We can skip drawing and
     const frames: FlamegraphFrame[] = [...this.flamegraph.roots];
-
     while (frames.length) {
       const frame = frames.pop()!;
 
@@ -126,18 +131,48 @@ class TextRenderer {
       // Offset x by 1x the padding
       const x = frameInPhysicalSpace[0] + HALF_SIDE_PADDING;
 
-      this.context.fillText(
-        trimTextCenter(
-          frame.frame.name,
-          findRangeBinarySearch(
-            {low: 0, high: paddedRectangleWidth},
-            n => this.measureAndCacheText(frame.frame.name.substring(0, n)),
-            paddedRectangleWidth
-          )[0]
-        ),
-        x,
-        y
+      const frameName = frame.frame.name;
+      const trim = trimTextCenter(
+        frameName,
+        findRangeBinarySearch(
+          {low: 0, high: paddedRectangleWidth},
+          n => this.measureAndCacheText(frame.frame.name.substring(0, n)).width,
+          paddedRectangleWidth
+        )[0]
       );
+
+      const {text: trimText} = trim;
+
+      if (flamegraphSearch) {
+        const searchResults = flamegraphSearch.results ?? {};
+        const searchQuery = flamegraphSearch.query;
+        const frameId = getFlamegraphFrameSearchId(frame);
+        const isFrameInSearchResults = searchResults[frameId];
+
+        if (isFrameInSearchResults && searchQuery) {
+          const re = new RegExp(searchQuery, 'ig');
+
+          for (const highlightedBounds of matchHighlightedBounds(frameName, re, trim)) {
+            const [startIndex, endIndex] = highlightedBounds;
+            const highlightTextSize = this.measureAndCacheText(
+              trimText.substring(startIndex, endIndex)
+            );
+            const frontMatter = trimText.slice(0, startIndex);
+            const startHighlightX = this.measureAndCacheText(frontMatter).width;
+            this.context.fillStyle = '#FFFF00';
+            this.context.fillRect(
+              startHighlightX + x,
+              y - highlightTextSize.fontBoundingBoxAscent,
+              highlightTextSize.width,
+              highlightTextSize.fontBoundingBoxAscent +
+                highlightTextSize.fontBoundingBoxDescent
+            );
+          }
+        }
+      }
+
+      this.context.fillStyle = '#000000';
+      this.context.fillText(trimText, x, y);
 
       for (let i = 0; i < frame.children.length; i++) {
         frames.push(frame.children[i]);

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -5,10 +5,10 @@ import {FlamegraphSearch} from '../flamegraph/flamegraphStateProvider/flamegraph
 import {FlamegraphTheme} from '../flamegraph/flamegraphTheme';
 import {FlamegraphFrame, getFlamegraphFrameSearchId} from '../flamegraphFrame';
 import {
+  computeHighlightedBounds,
   ELLIPSIS,
   findRangeBinarySearch,
   getContext,
-  matchHighlightedBounds,
   Rect,
   resizeCanvasToDisplaySize,
   trimTextCenter,
@@ -56,7 +56,7 @@ class TextRenderer {
   draw(
     configView: Rect,
     configViewToPhysicalSpace: mat3,
-    flamegraphSearch: FlamegraphSearch | null = null
+    flamegraphSearchResults: FlamegraphSearch['results'] | null = null
   ): void {
     this.maybeInvalidateCache();
 
@@ -143,16 +143,13 @@ class TextRenderer {
 
       const {text: trimText} = trim;
 
-      if (flamegraphSearch) {
-        const searchResults = flamegraphSearch.results ?? {};
-        const searchQuery = flamegraphSearch.query;
+      if (flamegraphSearchResults) {
         const frameId = getFlamegraphFrameSearchId(frame);
-        const isFrameInSearchResults = searchResults[frameId];
+        const frameSearchResult = flamegraphSearchResults[frameId];
 
-        if (isFrameInSearchResults && searchQuery) {
-          const re = new RegExp(searchQuery, 'ig');
-
-          for (const highlightedBounds of matchHighlightedBounds(frameName, re, trim)) {
+        if (frameSearchResult) {
+          for (const matchIndices of frameSearchResult.matchIndices) {
+            const highlightedBounds = computeHighlightedBounds(matchIndices, trim);
             const [startIndex, endIndex] = highlightedBounds;
             const highlightTextSize = this.measureAndCacheText(
               trimText.substring(startIndex, endIndex)

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -65,7 +65,6 @@ class TextRenderer {
     }`;
 
     this.context.textBaseline = 'alphabetic';
-    this.context.fillStyle = this.theme.COLORS.LABEL_FONT_COLOR;
 
     const minWidth = this.measureAndCacheText(ELLIPSIS).width;
 
@@ -147,10 +146,11 @@ class TextRenderer {
         const frameId = getFlamegraphFrameSearchId(frame);
         const frameSearchResult = flamegraphSearchResults[frameId];
 
-        if (frameSearchResult) {
+        if (frameSearchResult && frameSearchResult.matchIndices.length > 0) {
           const highlightFillStyle = `rgb(${this.theme.COLORS.HIGHLIGHTED_LABEL_COLOR.join(
             ', '
           )})`;
+          this.context.fillStyle = highlightFillStyle;
 
           for (const matchIndices of frameSearchResult.matchIndices) {
             const highlightedBounds = computeHighlightedBounds(matchIndices, trim);
@@ -163,7 +163,6 @@ class TextRenderer {
             );
             const frontMatter = trimText.slice(0, startIndex);
             const startHighlightX = this.measureAndCacheText(frontMatter).width;
-            this.context.fillStyle = highlightFillStyle;
             this.context.fillRect(
               startHighlightX + x,
               y - highlightTextSize.fontBoundingBoxAscent,

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -150,6 +150,9 @@ class TextRenderer {
         if (frameSearchResult) {
           for (const matchIndices of frameSearchResult.matchIndices) {
             const highlightedBounds = computeHighlightedBounds(matchIndices, trim);
+            if (!highlightedBounds) {
+              continue;
+            }
             const [startIndex, endIndex] = highlightedBounds;
             const highlightTextSize = this.measureAndCacheText(
               trimText.substring(startIndex, endIndex)
@@ -168,7 +171,7 @@ class TextRenderer {
         }
       }
 
-      this.context.fillStyle = '#000000';
+      this.context.fillStyle = this.theme.COLORS.LABEL_FONT_COLOR;
       this.context.fillText(trimText, x, y);
 
       for (let i = 0; i < frame.children.length; i++) {

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -148,6 +148,10 @@ class TextRenderer {
         const frameSearchResult = flamegraphSearchResults[frameId];
 
         if (frameSearchResult) {
+          const highlightFillStyle = `rgb(${this.theme.COLORS.HIGHLIGHTED_LABEL_COLOR.join(
+            ', '
+          )})`;
+
           for (const matchIndices of frameSearchResult.matchIndices) {
             const highlightedBounds = computeHighlightedBounds(matchIndices, trim);
             if (!highlightedBounds) {
@@ -159,7 +163,7 @@ class TextRenderer {
             );
             const frontMatter = trimText.slice(0, startIndex);
             const startHighlightX = this.measureAndCacheText(frontMatter).width;
-            this.context.fillStyle = '#FFFF00';
+            this.context.fillStyle = highlightFillStyle;
             this.context.fillRect(
               startHighlightX + x,
               y - highlightTextSize.fontBoundingBoxAscent,

--- a/tests/js/spec/utils/profiling/gl/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/gl/utils.spec.tsx
@@ -362,7 +362,7 @@ describe('findRangeBinarySearch', () => {
 describe('trimTextCenter', () => {
   it('trims nothing if low > length', () => {
     expect(trimTextCenter('abc', 4)).toMatchObject({
-      end: 3,
+      end: 0,
       length: 0,
       start: 0,
       text: 'abc',

--- a/tests/js/spec/utils/profiling/gl/utils.spec.tsx
+++ b/tests/js/spec/utils/profiling/gl/utils.spec.tsx
@@ -363,7 +363,7 @@ describe('trimTextCenter', () => {
   it('trims nothing if low > length', () => {
     expect(trimTextCenter('abc', 4)).toMatchObject({
       end: 3,
-      length: 3,
+      length: 0,
       start: 0,
       text: 'abc',
     });
@@ -446,6 +446,36 @@ describe('computeHighlightedBounds', () => {
         },
       },
       expected: [7, 8], // …
+    },
+    {
+      name: 'matched bounds fall before and after truncate',
+      text: '-[UIScrollView _smoothScrollDisplayLink:]',
+      args: {
+        bounds: [16, 28],
+        trim: {
+          // match bounds are shifted after truncate
+          text: '-[UIScrollView _sm…rollDisplayLink:]',
+          start: 18,
+          end: 24,
+          length: 6,
+        },
+      },
+      expected: [16, 23], // smoothScroll
+    },
+    {
+      name: 'matched bounds fall before  truncate',
+      text: '-[UIScrollView _smoothScrollDisplayLink:]',
+      args: {
+        bounds: [4, 14],
+        trim: {
+          // match bounds are shifted after truncate
+          text: '-[UIScrollView _sm…rollDisplayLink:]',
+          start: 18,
+          end: 24,
+          length: 6,
+        },
+      },
+      expected: [4, 14], // smoothScroll
     },
   ];
 

--- a/tests/js/spec/utils/profiling/renderers/flamegraphRenderer.spec.tsx
+++ b/tests/js/spec/utils/profiling/renderers/flamegraphRenderer.spec.tsx
@@ -6,12 +6,12 @@ import {
   makeFlamegraph,
 } from 'sentry-test/profiling/utils';
 
+import {FlamegraphSearch} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphSearch';
 import {
   LightFlamegraphTheme,
   LightFlamegraphTheme as theme,
 } from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
@@ -184,7 +184,7 @@ describe('flamegraphRenderer', () => {
 
       // @ts-ignore partial mock, we dont need the actual frame,
       // only f0 matched a search result
-      const results: Record<string, FlamegraphFrame> = {f00: 1};
+      const results: FlamegraphSearch['results'] = {f00: 1};
 
       const flamegraph = makeFlamegraph(
         {

--- a/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
+++ b/tests/js/spec/utils/profiling/renderers/textRenderer.spec.tsx
@@ -56,7 +56,9 @@ describe('TextRenderer', () => {
 
     expect(textRenderer.textCache.test).toBe(undefined);
     expect(textRenderer.textCache).toEqual({
-      'Who knows if this changed, font-display: swap wont tell me': 20,
+      'Who knows if this changed, font-display: swap wont tell me': {
+        width: 20,
+      },
     });
   });
   it('caches measure text', () => {
@@ -162,7 +164,7 @@ describe('TextRenderer', () => {
       trimTextCenter(
         longFrameName,
         Math.floor(longFrameName.length / 2) - Theme.SIZES.BAR_PADDING * 2
-      ),
+      ).text,
       Theme.SIZES.BAR_PADDING,
       Theme.SIZES.BAR_HEIGHT - Theme.SIZES.BAR_FONT_SIZE / 2 // center text vertically inside the rect
     );
@@ -216,7 +218,7 @@ describe('TextRenderer', () => {
       trimTextCenter(
         longFrameName,
         Math.floor(longFrameName.length / 2 / 2) - Theme.SIZES.BAR_PADDING * 2
-      ),
+      ).text,
       Math.floor(longFrameName.length / 2) + Theme.SIZES.BAR_PADDING,
       Theme.SIZES.BAR_HEIGHT - Theme.SIZES.BAR_FONT_SIZE / 2 // center text vertically inside the rect
     );


### PR DESCRIPTION
## Summary
Searching currently will only change the color of a frame's rect to orange. With this change we now highlight portions of the matched text in yellow.

## Demo
https://user-images.githubusercontent.com/7349258/174079831-2474d252-cffa-43d2-b8b6-e0422291fa7d.mov




