### PR TITLE
chore(dashboards): Change organization type to `Organization`

### DIFF
--- a/static/app/views/dashboardsV2/datasetConfig/base.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/base.tsx
@@ -1,6 +1,6 @@
 import trimStart from 'lodash/trimStart';
 
-import {OrganizationSummary, PageFilters, SelectValue, TagCollection} from 'sentry/types';
+import {Organization, PageFilters, SelectValue, TagCollection} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 import {MetaType} from 'sentry/utils/discover/eventView';
@@ -17,7 +17,7 @@ import {IssuesConfig} from './issues';
 import {ReleasesConfig} from './releases';
 
 export type ContextualProps = {
-  organization?: OrganizationSummary;
+  organization?: Organization;
   pageFilters?: PageFilters;
 };
 

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -12,7 +12,7 @@ import {t} from 'sentry/locale';
 import {
   EventsStats,
   MultiSeriesEventsStats,
-  OrganizationSummary,
+  Organization,
   PageFilters,
 } from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
@@ -120,7 +120,7 @@ type Props = {
       'loading' | 'timeseriesResults' | 'tableResults' | 'errorMessage' | 'pageLinks'
     >
   ) => React.ReactNode;
-  organization: OrganizationSummary;
+  organization: Organization;
   selection: PageFilters;
   widget: Widget;
   cursor?: string;


### PR DESCRIPTION
Use `Organization` instead of `OrganizationSummary` in
Contextual Props because a lot of downstream components
from the config use Organization.