### PR TITLE
Use a forked version of an action dep

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -68,7 +68,7 @@ jobs:
           cp tests/apidocs/openapi-derefed.json sentry-api-schema
 
       - name: Git Commit & Push
-        uses: stefanzweifel/git-auto-commit-action@5804e42f86b1891093b151b6c4e78e759c746c4d
+        uses: getsentry/git-auto-commit-action
         if: steps.changes.outputs.api_docs == 'true'
         with:
           repository: sentry-api-schema


### PR DESCRIPTION
Last I heard our security/compliance policy is to use only forked versions of GHA deps.

I did fork ftr https://github.com/getsentry/git-auto-commit-action