### PR TITLE
feat(perf): Add selected project platforms to analytics events for Performance page views

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -111,7 +111,9 @@ export type PerformanceEventParameters = {
     from_vital: string;
     to_vital: string;
   };
-  'performance_views.vital_detail.view': {};
+  'performance_views.vital_detail.view': {
+    project_platforms: string;
+  };
 };
 
 export type PerformanceEventKey = keyof PerformanceEventParameters;

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -51,7 +51,9 @@ export type PerformanceEventParameters = {
     to_widget?: string;
   };
   'performance_views.overview.cellaction': {action?: string};
-  'performance_views.overview.navigate.summary': {};
+  'performance_views.overview.navigate.summary': {
+    project_platforms: string;
+  };
   'performance_views.overview.search': {};
   'performance_views.overview.view': {
     project_platforms: string;

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -54,6 +54,7 @@ export type PerformanceEventParameters = {
   'performance_views.overview.navigate.summary': {};
   'performance_views.overview.search': {};
   'performance_views.overview.view': {
+    selected_projects: string;
     show_onboarding: boolean;
   };
   'performance_views.span_summary.change_chart': {

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -62,7 +62,9 @@ export type PerformanceEventParameters = {
   'performance_views.span_summary.change_chart': {
     change_to_display: string;
   };
-  'performance_views.span_summary.view': {};
+  'performance_views.span_summary.view': {
+    project_platforms: string;
+  };
   'performance_views.spans.change_op': {
     operation_name?: string;
   };

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -54,7 +54,7 @@ export type PerformanceEventParameters = {
   'performance_views.overview.navigate.summary': {};
   'performance_views.overview.search': {};
   'performance_views.overview.view': {
-    selected_projects: string;
+    project_platforms: string;
     show_onboarding: boolean;
   };
   'performance_views.span_summary.change_chart': {

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -94,7 +94,7 @@ function PerformanceContent({selection, location, demoMode}: Props) {
       trackAdvancedAnalyticsEvent('performance_views.overview.view', {
         organization,
         show_onboarding: onboardingProject !== undefined,
-        selected_projects: selectedProjects,
+        project_platforms: selectedProjects,
       });
 
       loadOrganizationTags(api, organization.slug, selection);
@@ -165,7 +165,13 @@ function PerformanceContent({selection, location, demoMode}: Props) {
               eventView={eventView}
               setError={setError}
               handleSearch={handleSearch}
-              handleTrendsClick={() => handleTrendsClick({location, organization})}
+              handleTrendsClick={() =>
+                handleTrendsClick({
+                  location,
+                  organization,
+                  projectPlatforms: getSelectedProjectPlatforms(location, projects),
+                })
+              }
               onboardingProject={onboardingProject}
               organization={organization}
               location={location}

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -21,7 +21,11 @@ import withPageFilters from 'sentry/utils/withPageFilters';
 
 import {DEFAULT_STATS_PERIOD, generatePerformanceEventView} from './data';
 import {PerformanceLanding} from './landing';
-import {addRoutePerformanceContext, handleTrendsClick} from './utils';
+import {
+  addRoutePerformanceContext,
+  getSelectedProjectPlatforms,
+  handleTrendsClick,
+} from './utils';
 
 type Props = {
   location: Location;
@@ -85,10 +89,14 @@ function PerformanceContent({selection, location, demoMode}: Props) {
 
   useEffect(() => {
     if (!mounted.current) {
+      const selectedProjects = getSelectedProjectPlatforms(location, projects);
+
       trackAdvancedAnalyticsEvent('performance_views.overview.view', {
         organization,
         show_onboarding: onboardingProject !== undefined,
+        selected_projects: selectedProjects,
       });
+
       loadOrganizationTags(api, organization.slug, selection);
       addRoutePerformanceContext(selection);
       mounted.current = true;
@@ -105,6 +113,8 @@ function PerformanceContent({selection, location, demoMode}: Props) {
     api,
     organization,
     onboardingProject,
+    location,
+    projects,
   ]);
 
   function setError(newError?: string) {

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -6,9 +6,14 @@ import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
 import TrendsDiscoverQuery from 'sentry/utils/performance/trends/trendsDiscoverQuery';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import useProjects from 'sentry/utils/useProjects';
 import withProjects from 'sentry/utils/withProjects';
 import {CompareDurations} from 'sentry/views/performance/trends/changedTransactions';
-import {handleTrendsClick, trendsTargetRoute} from 'sentry/views/performance/utils';
+import {
+  getSelectedProjectPlatforms,
+  handleTrendsClick,
+  trendsTargetRoute,
+} from 'sentry/views/performance/utils';
 
 import {Chart} from '../../../trends/chart';
 import {TrendChangeType, TrendFunctionField} from '../../../trends/types';
@@ -32,6 +37,8 @@ type DataType = {
 const fields = [{field: 'transaction'}, {field: 'project'}];
 
 export function TrendsWidget(props: PerformanceWidgetProps) {
+  const {projects} = useProjects();
+
   const {
     eventView: _eventView,
     ContainerActions,
@@ -78,6 +85,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
       ),
       transform: transformTrendsDiscover,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [props.chartSetting, trendChangeType]
   );
 
@@ -94,7 +102,13 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
           <Fragment>
             <div>
               <Button
-                onClick={() => handleTrendsClick({location, organization})}
+                onClick={() =>
+                  handleTrendsClick({
+                    location,
+                    organization,
+                    projectPlatforms: getSelectedProjectPlatforms(location, projects),
+                  })
+                }
                 size="small"
                 data-test-id="view-all-button"
               >

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -39,6 +39,7 @@ import {
   transactionSummaryRouteWithQuery,
 } from './transactionSummary/utils';
 import {COLUMN_TITLES} from './data';
+import {getSelectedProjectPlatforms} from './utils';
 
 export function getProjectID(
   eventData: EventData,
@@ -355,9 +356,10 @@ class _Table extends Component<Props, State> {
   };
 
   handleSummaryClick = () => {
-    const {organization} = this.props;
+    const {organization, location, projects} = this.props;
     trackAdvancedAnalyticsEvent('performance_views.overview.navigate.summary', {
       organization,
+      project_platforms: getSelectedProjectPlatforms(location, projects),
     });
   };
 

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -31,6 +31,7 @@ import {appendTagCondition, decodeScalar} from 'sentry/utils/queryString';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 
 import {transactionSummaryRouteWithQuery} from '../transactionSummary/utils';
+import {getSelectedProjectPlatforms} from '../utils';
 
 import EventMetas from './eventMetas';
 import FinishSetupAlert from './finishSetupAlert';
@@ -41,6 +42,7 @@ type Props = Pick<
 > & {
   eventSlug: string;
   organization: Organization;
+  projects: Project[];
 };
 
 type State = {
@@ -119,7 +121,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
   }
 
   renderContent(event: Event) {
-    const {organization, location, eventSlug, route, router} = this.props;
+    const {organization, location, eventSlug, route, router, projects} = this.props;
 
     // metrics
     trackAnalyticsEvent({
@@ -127,6 +129,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
       eventName: 'Performance: Opened Event Details',
       event_type: event.type,
       organization_id: parseInt(organization.id, 10),
+      project_platforms: getSelectedProjectPlatforms(location, projects),
     });
 
     const {isSidebarVisible} = this.state;
@@ -192,7 +195,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                   )}
                   <Layout.Main fullWidth={!isSidebarVisible}>
                     <Projects orgId={organization.slug} slugs={[this.projectId]}>
-                      {({projects}) => (
+                      {({projects: _projects}) => (
                         <SpanEntryContext.Provider
                           value={{
                             getViewChildTransactionTarget: childTransactionProps => {
@@ -209,7 +212,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                             <BorderlessEventEntries
                               organization={organization}
                               event={event}
-                              project={projects[0] as Project}
+                              project={_projects[0] as Project}
                               showExampleCommit={false}
                               showTagSummary={false}
                               location={location}

--- a/static/app/views/performance/transactionDetails/index.tsx
+++ b/static/app/views/performance/transactionDetails/index.tsx
@@ -6,6 +6,7 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
+import useProjects from 'sentry/utils/useProjects';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import EventDetailsContent from './content';
@@ -15,6 +16,8 @@ type Props = RouteComponentProps<{eventSlug: string}, {}> & {
 };
 
 function EventDetails(props: Props) {
+  const {projects} = useProjects();
+
   const getEventSlug = (): string => {
     const {eventSlug} = props.params;
     return typeof eventSlug === 'string' ? eventSlug.trim() : '';
@@ -40,6 +43,7 @@ function EventDetails(props: Props) {
             eventSlug={eventSlug}
             router={router}
             route={route}
+            projects={projects}
           />
         </NoProjectMessage>
       </StyledPageContent>

--- a/static/app/views/performance/transactionDetails/index.tsx
+++ b/static/app/views/performance/transactionDetails/index.tsx
@@ -1,4 +1,3 @@
-import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -15,39 +14,37 @@ type Props = RouteComponentProps<{eventSlug: string}, {}> & {
   organization: Organization;
 };
 
-class EventDetails extends Component<Props> {
-  getEventSlug = (): string => {
-    const {eventSlug} = this.props.params;
+function EventDetails(props: Props) {
+  const getEventSlug = (): string => {
+    const {eventSlug} = props.params;
     return typeof eventSlug === 'string' ? eventSlug.trim() : '';
   };
 
-  render() {
-    const {organization, location, params, router, route} = this.props;
-    const documentTitle = t('Performance Details');
-    const eventSlug = this.getEventSlug();
-    const projectSlug = eventSlug.split(':')[0];
+  const {organization, location, params, router, route} = props;
+  const documentTitle = t('Performance Details');
+  const eventSlug = getEventSlug();
+  const projectSlug = eventSlug.split(':')[0];
 
-    return (
-      <SentryDocumentTitle
-        title={documentTitle}
-        orgSlug={organization.slug}
-        projectSlug={projectSlug}
-      >
-        <StyledPageContent>
-          <NoProjectMessage organization={organization}>
-            <EventDetailsContent
-              organization={organization}
-              location={location}
-              params={params}
-              eventSlug={eventSlug}
-              router={router}
-              route={route}
-            />
-          </NoProjectMessage>
-        </StyledPageContent>
-      </SentryDocumentTitle>
-    );
-  }
+  return (
+    <SentryDocumentTitle
+      title={documentTitle}
+      orgSlug={organization.slug}
+      projectSlug={projectSlug}
+    >
+      <StyledPageContent>
+        <NoProjectMessage organization={organization}>
+          <EventDetailsContent
+            organization={organization}
+            location={location}
+            params={params}
+            eventSlug={eventSlug}
+            router={router}
+            route={route}
+          />
+        </NoProjectMessage>
+      </StyledPageContent>
+    </SentryDocumentTitle>
+  );
 }
 
 export default withOrganization(EventDetails);

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -21,6 +21,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 
 import {getCurrentLandingDisplay, LandingDisplayField} from '../landing/utils';
+import {getSelectedProjectPlatforms} from '../utils';
 
 import {anomaliesRouteWithQuery} from './transactionAnomalies/utils';
 import {eventsRouteWithQuery} from './transactionEvents/utils';
@@ -95,9 +96,12 @@ class TransactionHeader extends Component<Props> {
       return;
     }
 
+    const {location, projects} = this.props;
+
     trackAnalyticsEvent({
       ...analyticKeys,
       organization_id: this.props.organization.id,
+      project_platforms: getSelectedProjectPlatforms(location, projects),
     });
   };
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -20,6 +20,7 @@ import SuspectSpansQuery, {
 import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
+import {getSelectedProjectPlatforms} from 'sentry/views/performance/utils';
 
 import Tab from '../../tabs';
 import {SpanSortOthers} from '../types';
@@ -46,10 +47,13 @@ export default function SpanDetailsContentWrapper(props: Props) {
   const maxExclusiveTime = decodeScalar(location.query[ZoomKeys.MAX]);
 
   useEffect(() => {
-    trackAdvancedAnalyticsEvent('performance_views.span_summary.view', {
-      organization,
-    });
-  }, [organization]);
+    if (project) {
+      trackAdvancedAnalyticsEvent('performance_views.span_summary.view', {
+        organization,
+        project_platforms: getSelectedProjectPlatforms(location, [project]),
+      });
+    }
+  }, [organization, project, location]);
 
   return (
     <Fragment>

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -144,15 +144,18 @@ export function getTransactionSearchQuery(location: Location, query: string = ''
 export function handleTrendsClick({
   location,
   organization,
+  projectPlatforms,
 }: {
   location: Location;
   organization: Organization;
+  projectPlatforms: string;
 }) {
   trackAnalyticsEvent({
     eventKey: 'performance_views.change_view',
     eventName: 'Performance Views: Change View',
     organization_id: parseInt(organization.id, 10),
     view_name: 'TRENDS',
+    project_platforms: projectPlatforms,
   });
 
   const target = trendsTargetRoute({location, organization});

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -265,3 +265,20 @@ export function getTransactionName(location: Location): string | undefined {
 export function getPerformanceDuration(milliseconds: number) {
   return getDuration(milliseconds / 1000, milliseconds > 1000 ? 2 : 0, true);
 }
+
+export function getSelectedProjectPlatforms(location: Location, projects: Project[]) {
+  const projectQuery = location.query.project;
+  const selectedProjectIdSet = Array.isArray(projectQuery)
+    ? new Set(projectQuery)
+    : new Set([projectQuery]);
+
+  const selectedProjectPlatforms = projects.reduce((acc: string[], project) => {
+    if (selectedProjectIdSet.has(project.id)) {
+      acc.push(project.platform ?? 'undefined');
+    }
+
+    return acc;
+  }, []);
+
+  return selectedProjectPlatforms.join(', ');
+}

--- a/static/app/views/performance/vitalDetail/index.tsx
+++ b/static/app/views/performance/vitalDetail/index.tsx
@@ -22,7 +22,11 @@ import withPageFilters from 'sentry/utils/withPageFilters';
 import withProjects from 'sentry/utils/withProjects';
 
 import {generatePerformanceVitalDetailView} from '../data';
-import {addRoutePerformanceContext, getTransactionName} from '../utils';
+import {
+  addRoutePerformanceContext,
+  getSelectedProjectPlatforms,
+  getTransactionName,
+} from '../utils';
 
 import VitalDetailContent from './vitalDetailContent';
 
@@ -51,12 +55,13 @@ class VitalDetail extends Component<Props, State> {
   }
 
   componentDidMount() {
-    const {api, organization, selection} = this.props;
+    const {api, organization, selection, location, projects} = this.props;
     loadOrganizationTags(api, organization.slug, selection);
     addRoutePerformanceContext(selection);
 
     trackAdvancedAnalyticsEvent('performance_views.vital_detail.view', {
       organization,
+      project_platforms: getSelectedProjectPlatforms(location, projects),
     });
   }
 

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -41,6 +41,7 @@ import {
   TransactionFilterOptions,
   transactionSummaryRouteWithQuery,
 } from '../transactionSummary/utils';
+import {getSelectedProjectPlatforms} from '../utils';
 
 import {
   getVitalDetailTableMehStatusFunction,
@@ -322,11 +323,12 @@ class Table extends Component<Props, State> {
   };
 
   handleSummaryClick = () => {
-    const {organization} = this.props;
+    const {organization, projects, location} = this.props;
     trackAnalyticsEvent({
       eventKey: 'performance_views.overview.navigate.summary',
       eventName: 'Performance Views: Overview view summary',
       organization_id: parseInt(organization.id, 10),
+      project_platforms: getSelectedProjectPlatforms(location, projects),
     });
   };
 


### PR DESCRIPTION
This PR passes a string containing the selected project platform(s) for each relevant pageview event within Performance. This data could be useful, since it would allow us to see different workflows within Performance depending on the type of project selected.

Adds this data to the following events:

- Landing Page view
- Trends Page view
- Transaction Summary Page view
- Transaction Summary Tab Views
- Span Summary Page View
- Event Details Page View
- Vital Detail Page View

### Reload PR
https://github.com/getsentry/reload/pull/272