### PR TITLE
fix(perf): Remove all references to user modified query

### DIFF
--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -36,7 +36,6 @@ type Options = {
   start?: DateString;
   team?: Readonly<string | string[]>;
   topEvents?: number;
-  userModified?: string;
   withoutZerofill?: boolean;
   yAxis?: string | string[];
 };
@@ -86,7 +85,6 @@ export const doEventsRequest = (
     generatePathname,
     queryExtras,
     excludeOther,
-    userModified,
   }: Options
 ): Promise<EventsStats | MultiSeriesEventsStats> => {
   const pathname =
@@ -110,7 +108,6 @@ export const doEventsRequest = (
       withoutZerofill: withoutZerofill ? '1' : undefined,
       referrer: referrer ? referrer : 'api.organization-event-stats',
       excludeOther: excludeOther ? '1' : undefined,
-      user_modified: pathname.includes('events-stats') ? userModified : undefined,
     }).filter(([, value]) => typeof value !== 'undefined')
   );
 

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -37,7 +37,7 @@ import {
   getEquation,
   isEquation,
 } from 'sentry/utils/discover/fields';
-import {decodeList, decodeScalar} from 'sentry/utils/queryString';
+import {decodeList} from 'sentry/utils/queryString';
 import {Theme} from 'sentry/utils/theme';
 
 import EventsGeoRequest from './eventsGeoRequest';
@@ -667,7 +667,6 @@ class EventsChart extends React.Component<EventsChartProps> {
               partial
               // Cannot do interpolation when stacking series
               withoutZerofill={withoutZerofill && !this.isStacked()}
-              userModified={decodeScalar(router.location.query.userModified)}
             >
               {eventData => {
                 return chartImplementation({

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -194,10 +194,6 @@ type EventsRequestPartialProps = {
    */
   topEvents?: number;
   /**
-   * Tracks whether the query was modified by a user in the search bar
-   */
-  userModified?: string;
-  /**
    * Whether or not to zerofill results
    */
   withoutZerofill?: boolean;

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -12,8 +12,6 @@ import EventView, {
 import {PerformanceEventViewContext} from 'sentry/utils/performance/contexts/performanceEventViewContext';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
-import {decodeScalar} from '../queryString';
-
 export class QueryError {
   message: string;
   private originalError: any; // For debugging in case parseError picks a value that doesn't make sense.
@@ -172,7 +170,7 @@ class _GenericDiscoverQuery<T, P> extends Component<Props<T, P>, State<T>> {
   }
 
   getPayload(props: Props<T, P>) {
-    const {cursor, limit, noPagination, referrer, location} = props;
+    const {cursor, limit, noPagination, referrer} = props;
     const payload = this.props.getRequestPayload
       ? this.props.getRequestPayload(props)
       : props.eventView.getEventsAPIPayload(props.location);
@@ -188,13 +186,6 @@ class _GenericDiscoverQuery<T, P> extends Component<Props<T, P>, State<T>> {
     }
     if (referrer) {
       payload.referrer = referrer;
-    }
-
-    if (['events', 'eventsv2'].includes(props.route)) {
-      const queryUserModified = decodeScalar(location.query?.userModified);
-      if (queryUserModified !== undefined) {
-        payload.user_modified = queryUserModified;
-      }
     }
 
     Object.assign(payload, props.queryExtras ?? {});

--- a/static/app/views/eventsV2/index.tsx
+++ b/static/app/views/eventsV2/index.tsx
@@ -1,6 +1,3 @@
-import {useEffect, useRef} from 'react';
-import {browserHistory} from 'react-router';
-
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import {t} from 'sentry/locale';
@@ -10,30 +7,10 @@ import withOrganization from 'sentry/utils/withOrganization';
 
 type Props = {
   children: React.ReactChildren;
-  location: any;
   organization: Organization;
 };
 
-function DiscoverContainer({organization, children, location}: Props) {
-  const prevLocationPathname = useRef('');
-
-  useEffect(
-    // when new discover page loads, query is pristine
-    function () {
-      if (location.pathname !== prevLocationPathname.current) {
-        prevLocationPathname.current = location.pathname;
-        browserHistory.push({
-          pathname: location.pathname,
-          query: {
-            ...location.query,
-            userModified: undefined,
-          },
-        });
-      }
-    },
-    [location]
-  );
-
+function DiscoverContainer({organization, children}: Props) {
   function renderNoAccess() {
     return (
       <PageContent>

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -314,10 +314,7 @@ class Results extends Component<Props, State> {
 
     router.push({
       pathname: location.pathname,
-      query: {
-        ...searchQueryParams,
-        userModified: true,
-      },
+      query: searchQueryParams,
     });
   };
 

--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -16,7 +16,6 @@ import EventView, {
 import Measurements from 'sentry/utils/measurements/measurements';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {SPAN_OP_BREAKDOWN_FIELDS} from 'sentry/utils/performance/spanOperationBreakdowns/constants';
-import {decodeScalar} from 'sentry/utils/queryString';
 import withApi from 'sentry/utils/withApi';
 
 import TableView from './tableView';
@@ -104,11 +103,6 @@ class Table extends PureComponent<TableProps, TableState> {
     const apiPayload = eventView.getEventsAPIPayload(location) as LocationQuery &
       EventQuery & {user_modified?: string};
     apiPayload.referrer = 'api.discover.query-table';
-
-    const queryUserModified = decodeScalar(location.query.userModified);
-    if (queryUserModified !== undefined) {
-      apiPayload.user_modified = queryUserModified;
-    }
 
     setError('', 200);
 

--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -99,9 +99,8 @@ class Table extends PureComponent<TableProps, TableState> {
       : `/organizations/${organization.slug}/eventsv2/`;
     const tableFetchID = Symbol('tableFetchID');
 
-    // adding user_modified property. this property will be removed once search bar experiment is complete
     const apiPayload = eventView.getEventsAPIPayload(location) as LocationQuery &
-      EventQuery & {user_modified?: string};
+      EventQuery;
     apiPayload.referrer = 'api.discover.query-table';
 
     setError('', 200);

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -131,7 +131,6 @@ function PerformanceContent({selection, location, demoMode}: Props) {
         cursor: undefined,
         query: String(searchQuery).trim() || undefined,
         isDefaultQuery: false,
-        userModified: true,
       },
     });
   }

--- a/static/app/views/performance/index.tsx
+++ b/static/app/views/performance/index.tsx
@@ -12,7 +12,6 @@ type Props = {
 };
 
 function PerformanceContainer({organization, children}: Props) {
-
   function renderNoAccess() {
     return (
       <PageContent>

--- a/static/app/views/performance/index.tsx
+++ b/static/app/views/performance/index.tsx
@@ -1,7 +1,3 @@
-import {useEffect, useRef} from 'react';
-import {browserHistory} from 'react-router';
-import {Location} from 'history';
-
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import {t} from 'sentry/locale';
@@ -12,30 +8,10 @@ import withOrganization from 'sentry/utils/withOrganization';
 
 type Props = {
   children: React.ReactChildren;
-  location: Location;
   organization: Organization;
 };
 
-function PerformanceContainer({organization, children, location}: Props) {
-  const prevLocationPathname = useRef('');
-
-  useEffect(
-    function () {
-      // when new perf page loads, query is pristine
-      if (location.pathname !== prevLocationPathname.current) {
-        prevLocationPathname.current = location.pathname;
-        browserHistory.push({
-          pathname: location.pathname,
-          query: {
-            ...location.query,
-            userModified: undefined,
-          },
-          hash: location.hash,
-        });
-      }
-    },
-    [location]
-  );
+function PerformanceContainer({organization, children}: Props) {
 
   function renderNoAccess() {
     return (

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -13,7 +13,6 @@ import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
-import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withApi from 'sentry/utils/withApi';
 import _DurationChart from 'sentry/views/performance/charts/chart';
@@ -186,7 +185,6 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
               hideError
               onError={pageError.setPageError}
               queryExtras={getMEPParamsIfApplicable(mepSetting, props.chartSetting)}
-              userModified={decodeScalar(props.location.query.userModified)}
             />
           );
         },
@@ -194,12 +192,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      props.chartSetting,
-      selectedListIndex,
-      mepSetting.memoizationKey,
-      props.location.query.userModified,
-    ]
+    [props.chartSetting, selectedListIndex, mepSetting.memoizationKey]
   );
 
   const Queries = {

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -9,7 +9,6 @@ import {t} from 'sentry/locale';
 import {QueryBatchNode} from 'sentry/utils/performance/contexts/genericQueryBatcher';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
-import {decodeScalar} from 'sentry/utils/queryString';
 import withApi from 'sentry/utils/withApi';
 import _DurationChart from 'sentry/views/performance/charts/chart';
 
@@ -23,7 +22,7 @@ type DataType = {
 };
 
 export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
-  const {ContainerActions, location} = props;
+  const {ContainerActions} = props;
   const globalSelection = props.eventView.getPageFilters();
   const pageError = usePageError();
   const mepSetting = useMEPSettingContext();
@@ -60,14 +59,13 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
               hideError
               onError={pageError.setPageError}
               queryExtras={getMEPQueryParams(mepSetting)}
-              userModified={decodeScalar(location.query.userModified)}
             />
           )}
         </QueryBatchNode>
       ),
       transform: transformEventsRequestToArea,
     }),
-    [props.chartSetting, mepSetting.memoizationKey, location.query.userModified]
+    [props.chartSetting, mepSetting.memoizationKey]
   );
 
   const Queries = {

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -14,7 +14,7 @@ import {getAggregateAlias, WebVital} from 'sentry/utils/discover/fields';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {VitalData} from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
-import {decodeList, decodeScalar} from 'sentry/utils/queryString';
+import {decodeList} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withApi from 'sentry/utils/withApi';
 import {vitalDetailRouteWithQuery} from 'sentry/views/performance/vitalDetail/utils';
@@ -173,19 +173,13 @@ export function VitalWidget(props: PerformanceWidgetProps) {
               hideError
               onError={pageError.setPageError}
               queryExtras={getMEPQueryParams(mepSetting)}
-              userModified={decodeScalar(props.location.query.userModified)}
             />
           );
         },
         transform: transformEventsRequestToVitals,
       }),
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [
-        props.chartSetting,
-        selectedListIndex,
-        mepSetting.memoizationKey,
-        props.location.query.userModified,
-      ]
+      [props.chartSetting, selectedListIndex, mepSetting.memoizationKey]
     ),
   };
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -114,10 +114,7 @@ function Search(props: Props) {
 
     browserHistory.push({
       pathname: location.pathname,
-      query: {
-        ...searchQueryParams,
-        userModified: true,
-      },
+      query: searchQueryParams,
     });
   };
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -104,10 +104,7 @@ function SummaryContent({
 
     browserHistory.push({
       pathname: location.pathname,
-      query: {
-        ...searchQueryParams,
-        userModified: true,
-      },
+      query: searchQueryParams,
     });
   }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
@@ -12,7 +12,6 @@ import {t, tct} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import {getMEPQueryParams} from 'sentry/views/performance/landing/widgets/utils';
 
@@ -149,7 +148,6 @@ function DurationChart({
         withoutZerofill={withoutZerofill}
         referrer="api.performance.transaction-summary.duration-chart"
         queryExtras={getMEPQueryParams(mepContext)}
-        userModified={decodeScalar(location.query.userModified)}
       >
         {({results, errored, loading, reloading, timeframe: timeFrame}) => (
           <Content

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -11,7 +11,6 @@ import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
-import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 
 import {TrendFunctionField} from '../../../trends/types';
@@ -130,7 +129,6 @@ function TrendChart({
         partial
         withoutZerofill={withoutZerofill}
         referrer="api.performance.transaction-summary.trends-chart"
-        userModified={decodeScalar(location.query.userModified)}
       >
         {({errored, loading, reloading, timeseriesData, timeframe: timeFrame}) => (
           <Content

--- a/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
@@ -16,7 +16,6 @@ import {
   getMeasurementSlug,
   WebVital,
 } from 'sentry/utils/discover/fields';
-import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 
 import {ViewProps} from '../../../types';
@@ -141,7 +140,6 @@ function VitalsChart({
         partial
         withoutZerofill={withoutZerofill}
         referrer="api.performance.transaction-summary.vitals-chart"
-        userModified={decodeScalar(location.query.userModified)}
       >
         {({results, errored, loading, reloading, timeframe: timeFrame}) => (
           <Content

--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -78,10 +78,7 @@ function SpansContent(props: Props) {
 
       browserHistory.push({
         ...location,
-        query: {
-          ...searchQueryParams,
-          userModified: key === 'query',
-        },
+        query: searchQueryParams,
       });
     };
   }

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsControls.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsControls.tsx
@@ -36,7 +36,6 @@ export default function SpanDetailsControls({
         ...location.query,
         cursor: undefined,
         query: String(searchQuery).trim() || undefined,
-        userModified: true,
       },
     });
   };

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -18,7 +18,6 @@ import {Series} from 'sentry/types/echarts';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {WebVital} from 'sentry/utils/discover/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 
 import {replaceSeriesName, transformEventStatsSmoothed} from '../trends/utils';
@@ -111,7 +110,6 @@ function VitalChart({
               includePrevious={false}
               yAxis={[yAxis]}
               partial
-              userModified={decodeScalar(location.query.userModified)}
             >
               {({timeseriesData: results, errored, loading, reloading}) => {
                 if (errored) {

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -93,10 +93,7 @@ class VitalDetailContent extends Component<Props, State> {
 
     browserHistory.push({
       pathname: location.pathname,
-      query: {
-        ...searchQueryParams,
-        userModified: true,
-      },
+      query: searchQueryParams,
     });
   };
 

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -308,8 +308,6 @@ describe('Results', function () {
           ...generateFields(),
           query: 'geo:canada',
           statsPeriod: '14d',
-          // userModified added on new search for the search bar experiment
-          userModified: true,
         },
       });
       wrapper.unmount();
@@ -986,8 +984,6 @@ describe('Results', function () {
           ...generateFields(),
           query: 'geo:canada',
           statsPeriod: '14d',
-          // userModified added on new search for the search bar experiment
-          userModified: true,
         },
       });
       wrapper.unmount();

--- a/tests/js/spec/views/performance/transactionSummary.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.tsx
@@ -560,7 +560,6 @@ describe('Performance > TransactionSummary', function () {
           statsPeriod: '14d',
           query: 'user.email:uhoh*',
           transactionCursor: '1:0:0',
-          userModified: true,
         },
       });
     });
@@ -965,7 +964,6 @@ describe('Performance > TransactionSummary', function () {
           statsPeriod: '14d',
           query: 'user.email:uhoh*',
           transactionCursor: '1:0:0',
-          userModified: true,
         },
       });
     });

--- a/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
+++ b/tests/js/spec/views/performance/vitalDetail/index.spec.tsx
@@ -303,7 +303,6 @@ describe('Performance > VitalDetail', function () {
         project: 1,
         statsPeriod: '14d',
         query: 'user.email:uhoh*',
-        userModified: true,
       },
     });
   });


### PR DESCRIPTION
Top level reloading seemed to break LCP reporting since transactions end early. If necessary, we can add this back but the solution needs to be tweaked so the LCP logic doesn't break.
