### PR TITLE
fix: only set SENTRY_USE_RELAY to True for devserver iff --ingest is passed

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -226,7 +226,8 @@ and run `sentry devservices up kafka zookeeper`.
             }
         )
 
-    settings.SENTRY_USE_RELAY = ingest
+    if ingest:
+        settings.SENTRY_USE_RELAY = True
 
     os.environ["SENTRY_USE_RELAY"] = "1" if settings.SENTRY_USE_RELAY else ""
 


### PR DESCRIPTION
regressed in https://github.com/getsentry/sentry/pull/35500