### PR TITLE
fix(perf): Do not set query.user_modified in the backend

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -85,9 +85,6 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
         sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
 
-        query_modified_by_user = request.GET.get("user_modified")
-        if query_modified_by_user in ["true", "false"]:
-            sentry_sdk.set_tag("query.user_modified", query_modified_by_user)
         referrer = (
             referrer if referrer in ALLOWED_EVENTS_REFERRERS else "api.organization-events-v2"
         )
@@ -240,10 +237,6 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             referrer = API_TOKEN_REFERRER
         elif referrer not in ALLOWED_EVENTS_REFERRERS:
             referrer = "api.organization-events"
-
-        query_modified_by_user = request.GET.get("user_modified")
-        if query_modified_by_user in ["true", "false"]:
-            sentry_sdk.set_tag("query.user_modified", query_modified_by_user)
 
         def data_fn(offset, limit):
             query_details = {

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -156,10 +156,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
             allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
 
-            query_modified_by_user = request.GET.get("user_modified")
-            if query_modified_by_user in ["true", "false"]:
-                sentry_sdk.set_tag("query.user_modified", query_modified_by_user)
-
         def get_event_stats(
             query_columns: Sequence[str],
             query: str,


### PR DESCRIPTION
This PR removes setting a `query.user_modified` tag in the backend when `user_modified` param was sent. This was done because we longer track that in the client.
