### PR TITLE
feat(multi-region): Introduce system.base-hostname and system.customer-base-hostname

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -25,6 +25,8 @@ register("system.secret-key", flags=FLAG_NOSTORE)
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
 register("system.url-prefix", ttl=60, grace=3600, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
 register("system.internal-url-prefix", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+register("system.base-hostname", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+register("system.customer-base-hostname", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register("system.root-api-key", flags=FLAG_PRIORITIZE_DISK)
 register("system.logging-format", default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -141,6 +141,8 @@ def pytest_configure(config):
             "redis.clusters": {"default": {"hosts": {0: {"db": 9}}}},
             "mail.backend": "django.core.mail.backends.locmem.EmailBackend",
             "system.url-prefix": "http://testserver",
+            "system.base-hostname": "testserver",
+            "system.customer-base-hostname": "{slug}.{region}.testserver",
             "system.secret-key": "a" * 52,
             "slack.client-id": "slack-client-id",
             "slack.client-secret": "slack-client-secret",


### PR DESCRIPTION
Split out from https://github.com/getsentry/sentry/pull/35169.

----

This PR introduces the Sentry options as part of the customer domain initiative:  `system.base-hostname` and `system.customer-base-hostname`. 

- We will be setting the values for these options from `getsentry`. 
- For self-hosted users, these options will remain unset for the time being.

The PR https://github.com/getsentry/getsentry/pull/7657 depends on this change. 