### PR TITLE
ref(selectOption): Remove selectComponents.Option wrapper

### DIFF
--- a/static/app/components/forms/selectOption.tsx
+++ b/static/app/components/forms/selectOption.tsx
@@ -9,8 +9,20 @@ import {defined} from 'sentry/utils';
 
 type Props = React.ComponentProps<typeof selectComponents.Option>;
 
+// We still have some tests that find select options by the display name "Option".
+MenuListItem.displayName = 'Option';
+
 function SelectOption(props: Props) {
-  const {label, data, selectProps, isMulti, isSelected, isFocused, isDisabled} = props;
+  const {
+    label,
+    data,
+    selectProps,
+    isMulti,
+    isSelected,
+    isFocused,
+    isDisabled,
+    innerProps,
+  } = props;
   const {showDividers} = selectProps;
   const {
     value,
@@ -28,34 +40,35 @@ function SelectOption(props: Props) {
   const itemPriority = priority ?? (isSelected && !isMultiple ? 'primary' : 'default');
 
   return (
-    <selectComponents.Option className="select-option" {...props}>
-      <Tooltip skipWrapper title={tooltip} {...tooltipOptions}>
-        <MenuListItem
-          {...itemProps}
-          as="div"
-          label={label}
-          isDisabled={isDisabled}
-          isFocused={isFocused}
-          showDivider={showDividers}
-          priority={itemPriority}
-          innerWrapProps={{'data-test-id': value}}
-          labelProps={{as: typeof label === 'string' ? 'p' : 'div'}}
-          leadingItems={
-            <Fragment>
-              <CheckWrap isMultiple={isMultiple} isSelected={isSelected}>
-                {isSelected && (
-                  <IconCheckmark
-                    size={isMultiple ? 'xs' : 'sm'}
-                    color={isMultiple ? 'white' : undefined}
-                  />
-                )}
-              </CheckWrap>
-              {data.leadingItems}
-            </Fragment>
-          }
-        />
-      </Tooltip>
-    </selectComponents.Option>
+    <Tooltip skipWrapper title={tooltip} {...tooltipOptions}>
+      <MenuListItem
+        {...itemProps}
+        {...innerProps}
+        as="div"
+        className="option"
+        value={value}
+        label={label}
+        isDisabled={isDisabled}
+        isFocused={isFocused}
+        showDivider={showDividers}
+        priority={itemPriority}
+        innerWrapProps={{'data-test-id': value}}
+        labelProps={{as: typeof label === 'string' ? 'p' : 'div'}}
+        leadingItems={
+          <Fragment>
+            <CheckWrap isMultiple={isMultiple} isSelected={isSelected}>
+              {isSelected && (
+                <IconCheckmark
+                  size={isMultiple ? 'xs' : 'sm'}
+                  color={isMultiple ? 'white' : undefined}
+                />
+              )}
+            </CheckWrap>
+            {data.leadingItems}
+          </Fragment>
+        }
+      />
+    </Tooltip>
   );
 }
 

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -347,7 +347,7 @@ describe('Results', function () {
       wrapper.update();
 
       // Click one of the options.
-      wrapper.find('SelectOption').first().simulate('click');
+      wrapper.find('Option').first().simulate('click');
       await tick();
       wrapper.update();
 
@@ -393,7 +393,7 @@ describe('Results', function () {
       wrapper.update();
 
       // Click the 'default' option.
-      wrapper.find('SelectOption').first().simulate('click');
+      wrapper.find('Option').first().simulate('click');
       await tick();
       wrapper.update();
 
@@ -438,7 +438,7 @@ describe('Results', function () {
 
       // Make sure the top5 option isn't present
       const options = wrapper
-        .find('SelectOption [data-test-id]')
+        .find('Option [data-test-id]')
         .map(item => item.prop('data-test-id'));
       expect(options).not.toContain('top5');
       expect(options).not.toContain('dailytop5');
@@ -1023,7 +1023,7 @@ describe('Results', function () {
       wrapper.update();
 
       // Click one of the options.
-      wrapper.find('SelectOption').first().simulate('click');
+      wrapper.find('Option').first().simulate('click');
       await tick();
       wrapper.update();
 
@@ -1069,7 +1069,7 @@ describe('Results', function () {
       wrapper.update();
 
       // Click the 'default' option.
-      wrapper.find('SelectOption').first().simulate('click');
+      wrapper.find('Option').first().simulate('click');
       await tick();
       wrapper.update();
 
@@ -1114,7 +1114,7 @@ describe('Results', function () {
 
       // Make sure the top5 option isn't present
       const options = wrapper
-        .find('SelectOption [data-test-id]')
+        .find('Option [data-test-id]')
         .map(item => item.prop('data-test-id'));
       expect(options).not.toContain('top5');
       expect(options).not.toContain('dailytop5');

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -498,7 +498,7 @@ describe('IssueListActions', function () {
         await tick();
         wrapper.update();
       });
-      wrapper.find('SelectOption').at(3).simulate('click');
+      wrapper.find('Option').at(3).simulate('click');
 
       expect(onSortChange).toHaveBeenCalledWith('freq');
     });

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -511,7 +511,7 @@ describe('IssueList', function () {
         wrapper.update();
       });
 
-      wrapper.find('SelectOption').last().simulate('click');
+      wrapper.find('Option').last().simulate('click');
 
       expect(browserHistory.push).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -697,7 +697,7 @@ describe('IssueList', function () {
         wrapper.update();
       });
 
-      wrapper.find('SelectOption').first().simulate('click');
+      wrapper.find('Option').first().simulate('click');
 
       await tick();
 
@@ -755,7 +755,7 @@ describe('IssueList', function () {
         wrapper.update();
       });
 
-      wrapper.find('SelectOption').last().simulate('click');
+      wrapper.find('Option').last().simulate('click');
 
       expect(browserHistory.push).toHaveBeenLastCalledWith(
         expect.objectContaining({


### PR DESCRIPTION
In `SelectOption.tsx`, we wrap `selectComponents.Option` around our custom menu item component (`MenuListItem`). This is unnecessary (`MenuListItem` does everything that [`selectComponents.Option`](https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/components/Option.tsx) does and more). We can safely remove `selectComponents.Option` without loss of functionality.