### PR TITLE
feat(multi-region): Add SubdomainMiddleware

### DIFF
--- a/src/sentry/middleware/subdomain.py
+++ b/src/sentry/middleware/subdomain.py
@@ -25,7 +25,7 @@ class SubdomainMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: Request) -> Response:
-        setattr(request, "subdomain", None)
+        request.subdomain = None
 
         if not self.base_hostname:
             return self.get_response(request)
@@ -40,5 +40,5 @@ class SubdomainMiddleware:
         if len(subdomain) == 0:
             subdomain = None
 
-        setattr(request, "subdomain", subdomain)
+        request.subdomain = subdomain
         return self.get_response(request)

--- a/src/sentry/middleware/subdomain.py
+++ b/src/sentry/middleware/subdomain.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import options
+
+
+class SubdomainMiddleware:
+    """
+    Extracts any subdomain from request.get_host() relative to the `system.url-prefix` option, and attaches it to
+    the request object under request.subdomain.
+
+    If no subdomain is extracted, then request.subdomain is None.
+    """
+
+    def __init__(self, get_response: Callable[[Request], Response]):
+        self.base_hostname = options.get("system.base-hostname")
+
+        if self.base_hostname:
+            self.base_hostname = self.base_hostname.rstrip("/")
+
+        self.get_response = get_response
+
+    def __call__(self, request: Request) -> Response:
+        setattr(request, "subdomain", None)
+
+        if not self.base_hostname:
+            return self.get_response(request)
+
+        host = request.get_host().lower()
+
+        if not host.endswith(f".{self.base_hostname}"):
+            return self.get_response(request)
+
+        subdomain = host[: -len(self.base_hostname)].rstrip(".")
+
+        if len(subdomain) == 0:
+            subdomain = None
+
+        setattr(request, "subdomain", subdomain)
+        return self.get_response(request)

--- a/tests/sentry/middleware/test_subdomain.py
+++ b/tests/sentry/middleware/test_subdomain.py
@@ -1,0 +1,31 @@
+from django.test import RequestFactory
+
+from sentry.middleware.subdomain import SubdomainMiddleware
+from sentry.testutils import TestCase
+
+
+class SubdomainMiddlewareTest(TestCase):
+    def test_attaches_subdomain_attribute(self):
+
+        options = {
+            "system.base-hostname": "us.dev.getsentry.net:8000",
+        }
+
+        def request_with_host(host):
+            subdomain_middleware = SubdomainMiddleware(lambda request: request)
+            request = RequestFactory().get("/", HTTP_HOST=host)
+            return subdomain_middleware(request)
+
+        with self.options(options):
+            assert request_with_host("foobar").subdomain is None
+            assert request_with_host("dev.getsentry.net:8000").subdomain is None
+            assert request_with_host("us.dev.getsentry.net:8000").subdomain is None
+            assert request_with_host("foobar.us.dev.getsentry.net:8000").subdomain == "foobar"
+            assert request_with_host("foo.bar.us.dev.getsentry.net:8000").subdomain == "foo.bar"
+
+        with self.options({}):
+            assert request_with_host("foobar").subdomain is None
+            assert request_with_host("dev.getsentry.net:8000").subdomain is None
+            assert request_with_host("us.dev.getsentry.net:8000").subdomain is None
+            assert request_with_host("foobar.us.dev.getsentry.net:8000").subdomain is None
+            assert request_with_host("foo.bar.us.dev.getsentry.net:8000").subdomain is None


### PR DESCRIPTION
This is split out from https://github.com/getsentry/sentry/pull/35169.

Depends on https://github.com/getsentry/sentry/pull/35757

------

This introduces a Django middleware to infer any subdomain based on the `HTTP_HOST` metadata attached to the Django `request` object relative to the `system.base-hostname` Sentry option.

I've intentionally not attached this middleware just yet. That will come in a follow up PR.
