### PR TITLE
fix(metric_alerts): Prevent date fields from being used as filters in metric alerts

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1095,6 +1095,5 @@ def parse_search_query(
         )
 
     if config_overrides:
-        for param, value in config_overrides.items():
-            setattr(config, param, value)
+        config = SearchConfig.create_from(config, **config_overrides)
     return SearchVisitor(config, params=params, builder=builder).visit(tree)

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -112,6 +112,7 @@ class QueryBuilder:
         # This allows queries to be resolved without adding time constraints. Currently this is just
         # used to allow metric alerts to be built and validated before creation in snuba.
         skip_time_conditions: bool = False,
+        parser_config_overrides: Optional[Mapping[str, Any]] = None,
     ):
         self.dataset = dataset
 
@@ -144,6 +145,7 @@ class QueryBuilder:
         self.turbo = turbo
         self.sample_rate = sample_rate
         self.skip_time_conditions = skip_time_conditions
+        self.parser_config_overrides = parser_config_overrides
 
         (
             self.field_alias_converter,
@@ -907,7 +909,12 @@ class QueryBuilder:
             return []
 
         try:
-            parsed_terms = parse_search_query(query, params=self.params, builder=self)
+            parsed_terms = parse_search_query(
+                query,
+                params=self.params,
+                builder=self,
+                config_overrides=self.parser_config_overrides,
+            )
         except ParseError as e:
             raise InvalidSearchQuery(f"Parse error: {e.expr.name} (column {e.column():d})")
 

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -843,7 +843,7 @@ def convert_search_boolean_to_snuba_query(terms, params=None):
     return condition, having, projects_to_filter, group_ids
 
 
-def get_filter(query=None, params=None):
+def get_filter(query=None, params=None, parser_config_overrides=None):
     """
     Returns an eventstore filter given the search text provided by the user and
     URL params
@@ -852,7 +852,9 @@ def get_filter(query=None, params=None):
     parsed_terms = []
     if query is not None:
         try:
-            parsed_terms = parse_search_query(query, params=params)
+            parsed_terms = parse_search_query(
+                query, params=params, config_overrides=parser_config_overrides
+            )
         except ParseError as e:
             raise InvalidSearchQuery(f"Parse error: {e.expr.name} (column {e.column():d})")
 

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -59,6 +59,15 @@ ENTITY_TIME_COLUMNS: Mapping[EntityKey, str] = {
 CRASH_RATE_ALERT_AGGREGATE_RE = (
     r"^percentage\([ ]*(sessions_crashed|users_crashed)[ ]*\,[ ]*(sessions|users)[ ]*\)"
 )
+ALERT_BLOCKED_FIELDS = {
+    "start",
+    "end",
+    "last_seen()",
+    "time",
+    "timestamp",
+    "timestamp.to_hour",
+    "timestamp.to_day",
+}
 
 
 def apply_dataset_query_conditions(
@@ -174,7 +183,9 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
         resolve_func = resolve_column(Dataset(self.dataset.value))
 
         query = apply_dataset_query_conditions(QueryDatasets(self.dataset), query, self.event_types)
-        snuba_filter = get_filter(query, params=params)
+        snuba_filter = get_filter(
+            query, params=params, parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS}
+        )
         snuba_filter.update_with(
             resolve_field_list([self.aggregate], snuba_filter, auto_fields=False)
         )
@@ -213,6 +224,7 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
             offset=None,
             limit=None,
             skip_time_conditions=True,
+            parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
         )
 
     def get_entity_extra_params(self) -> Mapping[str, Any]:
@@ -270,7 +282,9 @@ class SessionsEntitySubscription(BaseEntitySubscription):
 
         aggregations += [f"identity({count_col_matched}) AS {CRASH_RATE_ALERT_SESSION_COUNT_ALIAS}"]
         functions_acl = ["identity"]
-        snuba_filter = get_filter(query, params=params)
+        snuba_filter = get_filter(
+            query, params=params, parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS}
+        )
         snuba_filter.update_with(
             resolve_field_list(
                 aggregations, snuba_filter, auto_fields=False, functions_acl=functions_acl
@@ -336,6 +350,7 @@ class SessionsEntitySubscription(BaseEntitySubscription):
             limit=None,
             functions_acl=["identity"],
             skip_time_conditions=True,
+            parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
         )
 
 
@@ -388,7 +403,9 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
         environment: Optional[Environment],
         params: Optional[Mapping[str, Any]] = None,
     ) -> Filter:
-        snuba_filter = get_filter(query, params=params)
+        snuba_filter = get_filter(
+            query, params=params, parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS}
+        )
         conditions = copy(snuba_filter.conditions)
         snuba_filter.update_with(
             {

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -1,7 +1,11 @@
 import pytest
 from snuba_sdk import And, Column, Condition, Function, Op
 
-from sentry.exceptions import InvalidQuerySubscription, UnsupportedQuerySubscription
+from sentry.exceptions import (
+    InvalidQuerySubscription,
+    InvalidSearchQuery,
+    UnsupportedQuerySubscription,
+)
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.utils import resolve, resolve_tag_key
 from sentry.snuba.dataset import EntityKey
@@ -47,6 +51,48 @@ class EntitySubscriptionTestCase(TestCase):
             get_entity_subscription_for_dataset(
                 dataset=QueryDatasets.SESSIONS, aggregate=aggregate, time_window=3600
             )
+
+    def test_build_snuba_filter_invalid_fields_raise_error(self) -> None:
+        entities = [
+            get_entity_subscription_for_dataset(
+                dataset=QueryDatasets.SESSIONS,
+                aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+                time_window=3600,
+                extra_fields={"org_id": self.organization.id},
+            ),
+            get_entity_subscription_for_dataset(
+                dataset=QueryDatasets.METRICS,
+                aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+                time_window=3600,
+                extra_fields={"org_id": self.organization.id},
+            ),
+            get_entity_subscription_for_dataset(
+                dataset=QueryDatasets.EVENTS,
+                aggregate="count_unique(user)",
+                time_window=3600,
+            ),
+        ]
+        for entity in entities:
+            with pytest.raises(InvalidSearchQuery, match="Invalid key for this search: timestamp"):
+                entity.build_snuba_filter("timestamp:-24h", [self.project.id], None)
+
+    def test_build_query_builder_invalid_fields_raise_error(self) -> None:
+        entities = [
+            get_entity_subscription_for_dataset(
+                dataset=QueryDatasets.SESSIONS,
+                aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+                time_window=3600,
+                extra_fields={"org_id": self.organization.id},
+            ),
+            get_entity_subscription_for_dataset(
+                dataset=QueryDatasets.EVENTS,
+                aggregate="count_unique(user)",
+                time_window=3600,
+            ),
+        ]
+        for entity in entities:
+            with pytest.raises(InvalidSearchQuery, match="Invalid key for this search: timestamp"):
+                entity.build_query_builder("timestamp:-24h", [self.project.id], None)
 
     def test_get_entity_subscriptions_for_sessions_dataset(self) -> None:
         aggregate = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"


### PR DESCRIPTION
Since metric alerts are relative alerts based on the current time and the timestamp, it doesn't make
sense to filter on dates within them. There were also cases where people would use relative syntax
like `-24h`, which would convert to 24 hours before the current time and then store that absolute
value in the query. Accepting these filters is confusing because it implies that the relative date
would be applied to the alert.

Not sure if overrides is the best way to do this, but it's simple enough to implement this way.

