### PR TITLE
fix(alerts): Percentage change alert critical should be gt warning

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -356,6 +356,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     resolveThreshold = this.state.resolveThreshold,
     changedTriggerIndex?: number
   ) {
+    const {comparisonType} = this.state;
     const triggerErrors = new Map();
 
     const requiredFields = ['label', 'alertThreshold'];
@@ -401,7 +402,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const criticalThreshold = criticalTrigger.alertThreshold ?? 0;
 
     const hasError =
-      thresholdType === AlertRuleThresholdType.ABOVE
+      thresholdType === AlertRuleThresholdType.ABOVE ||
+      comparisonType === AlertRuleComparisonType.CHANGE
         ? warningThreshold > criticalThreshold
         : warningThreshold < criticalThreshold;
 
@@ -411,9 +413,10 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         triggerErrors.set(index, {
           ...otherErrors,
           alertThreshold:
-            thresholdType === AlertRuleThresholdType.BELOW
-              ? t('Warning threshold must be greater than critical alert')
-              : t('Warning threshold must be less than critical alert'),
+            thresholdType === AlertRuleThresholdType.ABOVE ||
+            comparisonType === AlertRuleComparisonType.CHANGE
+              ? t('Warning threshold must be less than critical threshold')
+              : t('Warning threshold must be greater than critical threshold'),
         });
       });
     }


### PR DESCRIPTION
This fixes a small bug on the FE where an error shows up in the alert wizards threshold selector, when you pick %-change alerts > less than and your critical threshold is > warning threshold. For static threshold alerts this is true but for %-change it should always validate critical > warning. eg. 5% change is warning, 10% change is critical, regardless of direction.

JIRA: [WOR-1950](https://getsentry.atlassian.net/browse/WOR-1950)