### PR TITLE
Allow models to be available read-only by server mode

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -1,4 +1,6 @@
-from typing import Any, Callable, Mapping, Tuple, Type, cast
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Mapping, Tuple, Type, cast
 
 from django.db import models
 from django.db.models import signals
@@ -134,31 +136,50 @@ signals.class_prepared.connect(__model_class_prepared)
 
 
 class ServerModeDataError(Exception):
-    pass
+    @classmethod
+    def create_override(cls, message: str) -> Callable[..., Any]:
+        def override(*args: Any, **kwargs: Any) -> Any:
+            raise cls(message)
+
+        return override
 
 
-def available_on(mode: ServerComponentMode) -> Callable[[type], type]:
+def _disallow_access(model_class: Type[BaseModel], allow_read: bool) -> None:
+    """Modify a model class to raise an error if reading or writing is attempted."""
+
+    model_class.objects = (
+        model_class.objects.create_read_only_copy()
+        if allow_read
+        else model_class.objects.create_disabled_copy()
+    )
+
+    # On the model (not manager) class itself, monkey-patch any methods that are
+    # tagged with the `alters_data` meta-attribute.
+    for model_attr_name in dir(model_class):
+        model_attr = getattr(model_class, model_attr_name)
+        if callable(model_attr) and getattr(model_attr, "alters_data", False):
+            override = ServerModeDataError.create_override(
+                f"{model_class.__name__}.{model_attr_name} is unavailable in this server mode"
+            )
+            setattr(model_class, model_attr_name, override)
+
+
+def available_on(
+    mode: ServerComponentMode,
+    read_only: ServerComponentMode | Iterable[ServerComponentMode] = (),
+) -> Callable[[type], type]:
     """Decorate a model class that should be active only in one mode."""
-    from . import BaseQuerySet
+
+    read_only = [read_only] if isinstance(read_only, ServerComponentMode) else read_only
 
     def decorator(decorated_class: Type[BaseModel]) -> Type[BaseModel]:
-        def queryset_override(obj) -> BaseQuerySet:
-            raise ServerModeDataError(
-                f"{decorated_class.__name__} is available only in the {mode.value} server mode"
-            )
-
         if not issubclass(decorated_class, BaseModel):
             raise ValueError("`@available_on` must decorate a Model class")
         assert isinstance(decorated_class.objects, BaseManager)
 
         if not mode.is_active():
-            manager_class = type(decorated_class.objects)
-            manager_class_with_override = type(
-                manager_class.__name__,
-                (manager_class,),
-                {"get_queryset": queryset_override},
-            )
-            decorated_class.objects = manager_class_with_override()
+            allow_read = any(m.is_active() for m in read_only)
+            _disallow_access(decorated_class, allow_read)
 
         return decorated_class
 

--- a/tests/sentry/models/test_base.py
+++ b/tests/sentry/models/test_base.py
@@ -62,15 +62,15 @@ class AvailableOnTest(TestCase):
             self.ControlModel.objects.get(id=1)
         with raises(ServerModeDataError):
             self.ControlModel.objects.create()
-        with self.assertRaises(ServerModeDataError):
+        with raises(ServerModeDataError):
             self.ControlModel.objects.filter(id=1).delete()
 
     def test_available_for_read_only(self):
         assert list(self.ReadOnlyModel.objects.all()) == []
-        with self.assertRaises(self.ReadOnlyModel.DoesNotExist):
+        with raises(self.ReadOnlyModel.DoesNotExist):
             self.ReadOnlyModel.objects.get(id=1)
 
-        with self.assertRaises(ServerModeDataError):
+        with raises(ServerModeDataError):
             self.ReadOnlyModel.objects.create()
-        with self.assertRaises(ServerModeDataError):
+        with raises(ServerModeDataError):
             self.ReadOnlyModel.objects.filter(id=1).delete()

--- a/tests/sentry/models/test_base.py
+++ b/tests/sentry/models/test_base.py
@@ -1,7 +1,7 @@
 from django.test import override_settings
 
-from sentry.db.models import Model, available_on
-from sentry.db.models.base import ServerModeDataError
+from sentry.db.models import available_on
+from sentry.db.models.base import BaseModel, ServerModeDataError
 from sentry.servermode import ServerComponentMode
 from sentry.testutils import TestCase
 
@@ -10,17 +10,21 @@ class AvailableOnTest(TestCase):
     with override_settings(SERVER_COMPONENT_MODE=ServerComponentMode.CUSTOMER):
 
         @available_on(ServerComponentMode.CONTROL)
-        class ControlModel(Model):
+        class ControlModel(BaseModel):
             __include_in_export__ = False
 
         @available_on(ServerComponentMode.CUSTOMER)
-        class CustomerModel(Model):
+        class CustomerModel(BaseModel):
+            __include_in_export__ = False
+
+        @available_on(ServerComponentMode.CONTROL, read_only=ServerComponentMode.CUSTOMER)
+        class ReadOnlyModel(BaseModel):
             __include_in_export__ = False
 
     with override_settings(SERVER_COMPONENT_MODE=ServerComponentMode.MONOLITH):
 
         @available_on(ServerComponentMode.MONOLITH)
-        class ModelOnMonolith(Model):
+        class ModelOnMonolith(BaseModel):
             __include_in_export__ = False
 
     def test_available_on_monolith_mode(self):
@@ -31,6 +35,8 @@ class AvailableOnTest(TestCase):
         self.ModelOnMonolith.objects.create()
         assert self.ModelOnMonolith.objects.count() == 1
 
+        self.ModelOnMonolith.objects.filter(id=1).delete()
+
     def test_available_on_same_mode(self):
         assert list(self.CustomerModel.objects.all()) == []
         with self.assertRaises(self.CustomerModel.DoesNotExist):
@@ -39,6 +45,8 @@ class AvailableOnTest(TestCase):
         self.CustomerModel.objects.create()
         assert self.CustomerModel.objects.count() == 1
 
+        self.CustomerModel.objects.filter(id=1).delete()
+
     def test_unavailable_on_other_mode(self):
         with self.assertRaises(ServerModeDataError):
             list(self.ControlModel.objects.all())
@@ -46,3 +54,15 @@ class AvailableOnTest(TestCase):
             self.ControlModel.objects.get(id=1)
         with self.assertRaises(ServerModeDataError):
             self.ControlModel.objects.create()
+        with self.assertRaises(ServerModeDataError):
+            self.ControlModel.objects.filter(id=1).delete()
+
+    def test_available_for_read_only(self):
+        assert list(self.ReadOnlyModel.objects.all()) == []
+        with self.assertRaises(self.ReadOnlyModel.DoesNotExist):
+            self.ReadOnlyModel.objects.get(id=1)
+
+        with self.assertRaises(ServerModeDataError):
+            self.ReadOnlyModel.objects.create()
+        with self.assertRaises(ServerModeDataError):
+            self.ReadOnlyModel.objects.filter(id=1).delete()


### PR DESCRIPTION
Follows #34981.

Add a read-only mode for the `available_on` decorator. Requires more in-depth modification of the affected model's manager object.