### PR TITLE
fix(replay): Fix replay background so transparent pages have a white bg by default

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -136,7 +136,6 @@ const PositionedBuffering = styled(BufferingOverlay)`
 // Base styles, to make the Replayer instance work
 const PlayerRoot = styled(BasePlayerRoot)`
   .replayer-wrapper {
-    background: white;
     user-select: none;
   }
   .replayer-wrapper > .replayer-mouse-tail {
@@ -147,6 +146,7 @@ const PlayerRoot = styled(BasePlayerRoot)`
   /* Override default user-agent styles */
   .replayer-wrapper > iframe {
     border: none;
+    background: white;
   }
 `;
 


### PR DESCRIPTION
**Before:**
If the webpage has a transparent background, then you could see transparency in the replay:

<img width="784" alt="Screen Shot 2022-06-16 at 3 45 26 PM" src="https://user-images.githubusercontent.com/187460/174190788-7106ddb8-0b10-4ddb-9fcf-47715c6d17bc.png">

**After:**
The browser will default to showing a white background behind the page, so the player window should as well. 
The bug is that previously we had that white background on the wrong dom element.

<img width="519" alt="Screen Shot 2022-06-16 at 3 45 36 PM" src="https://user-images.githubusercontent.com/187460/174190793-2d15d26b-66e8-4e34-ac81-344ac1ed3fc0.png">
