### PR TITLE
ref(datePageFilter): Use <Datetime /> in button label

### DIFF
--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -1,7 +1,9 @@
+import {Fragment} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {updateDateTime} from 'sentry/actionCreators/pageFilters';
+import Datetime from 'sentry/components/dateTime';
 import PageFilterDropdownButton from 'sentry/components/organizations/pageFilters/pageFilterDropdownButton';
 import PageFilterPinIndicator from 'sentry/components/organizations/pageFilters/pageFilterPinIndicator';
 import TimeRangeSelector, {
@@ -49,15 +51,17 @@ function DatePageFilter({router, resetParamsOnChange, ...props}: Props) {
       const startTimeFormatted = getFormattedDate(start, 'HH:mm:ss', {local: true});
       const endTimeFormatted = getFormattedDate(end, 'HH:mm:ss', {local: true});
 
-      const shouldShowTimes =
-        startTimeFormatted !== DEFAULT_DAY_START_TIME ||
-        endTimeFormatted !== DEFAULT_DAY_END_TIME;
-      const format = shouldShowTimes ? 'MMM D, h:mma' : 'MMM D';
+      const showDateOnly =
+        startTimeFormatted === DEFAULT_DAY_START_TIME &&
+        endTimeFormatted === DEFAULT_DAY_END_TIME;
 
-      const startString = getFormattedDate(start, format, {local: true});
-      const endString = getFormattedDate(end, format, {local: true});
-
-      label = `${startString} - ${endString}`;
+      label = (
+        <Fragment>
+          <Datetime date={start} dateOnly={showDateOnly} />
+          {' – '}
+          <Datetime date={end} dateOnly={showDateOnly} />
+        </Fragment>
+      );
     } else {
       label = period?.toUpperCase();
     }


### PR DESCRIPTION
`DatePageFilter`'s button label doesn't respect the user's clock preference: it will always show time based on a 12hr clock even if the user prefers the 24h version. So, when parsing the time range, instead of using a custom time formatting string, we can just use the `<Datetime />` component, which respects the user's clock preference.

Before, when clock preference is set to 24h:
<img width="291" alt="Screen Shot 2022-06-16 at 4 03 52 PM" src="https://user-images.githubusercontent.com/44172267/174192278-5ef2d7e4-85d1-46d4-a91b-831dcae2af98.png">

After, when clock preference is set to 24h:
<img width="261" alt="Screen Shot 2022-06-16 at 4 04 11 PM" src="https://user-images.githubusercontent.com/44172267/174192315-0b849c3d-dc17-4bd8-8b9f-bc61e78547f2.png">

