### PR TITLE
fix(projectconfig): Count real deleted projects only

### DIFF
--- a/tests/sentry/relay/test_projectconfig_cache.py
+++ b/tests/sentry/relay/test_projectconfig_cache.py
@@ -1,0 +1,16 @@
+from unittest import mock
+
+from sentry.relay.projectconfig_cache import redis
+
+
+def test_delete_count(monkeypatch):
+    cache = redis.RedisProjectConfigCache()
+    incr_mock = mock.Mock()
+    monkeypatch.setattr(redis.metrics, "incr", incr_mock)
+    cache.set_many({"a": 1})
+
+    cache.delete_many(["a", "b"])
+
+    assert incr_mock.call_args == mock.call(
+        "relay.projectconfig_cache.write", amount=1, tags={"action": "delete"}
+    )


### PR DESCRIPTION
This only counts projects which are actually deleted for the metric,
instead of all those that have been requested to be deleted.
Currently this metric shows a deleting many more projects than are
set, which isn't possible.