### PR TITLE
ref(alerts): Remove moment from metric chart date parsing

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -105,8 +105,8 @@ function getRuleChangeSeries(
   }
 
   const seriesData = data[0].data;
-  const seriesStart = moment(seriesData[0].name).valueOf();
-  const ruleChanged = moment(dateModified).valueOf();
+  const seriesStart = new Date(seriesData[0].name).getTime();
+  const ruleChanged = new Date(dateModified).getTime();
 
   if (ruleChanged < seriesStart) {
     return [];


### PR DESCRIPTION
Moment is slower than the native date function for getting a unix time out of a date string. My suspicion is it could possibly be using more memory in charcuterie.

Either way its 3 loops deep parsing lots of dates, this should speed up the generation of chart options.