### PR TITLE
ref(alerts): Change placeholder text to include user

### DIFF
--- a/src/sentry/integrations/msteams/actions/notification.py
+++ b/src/sentry/integrations/msteams/actions/notification.py
@@ -24,7 +24,7 @@ class MsTeamsNotifyServiceAction(IntegrationEventAction):
                 "type": "choice",
                 "choices": [(i.id, i.name) for i in self.get_integrations()],
             },
-            "channel": {"type": "string", "placeholder": "i.e. General"},
+            "channel": {"type": "string", "placeholder": "i.e. General, Jane Schmidt"},
         }
 
     def after(self, event, state):

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -32,7 +32,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 "type": "choice",
                 "choices": [(i.id, i.name) for i in self.get_integrations()],
             },
-            "channel": {"type": "string", "placeholder": "i.e #critical"},
+            "channel": {"type": "string", "placeholder": "i.e #critical, Jane Schmidt"},
             "channel_id": {"type": "string", "placeholder": "i.e. CA2FRA079 or UA1J9RTE1"},
             "tags": {"type": "string", "placeholder": "i.e environment,user,my_tag"},
         }


### PR DESCRIPTION
You can type in a Slack and MSTeams user name to alert them instead of a channel, but the placeholder text doesn't make that very obvious. Update the placeholder to include a user name. 

Addresses https://github.com/getsentry/sentry/issues/35539