### PR TITLE
feat(ui): Manually mark an issue as resolved in a commit via the UI

### DIFF
--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -46,14 +46,10 @@ class ResolveActions extends Component<Props> {
   static defaultProps = defaultProps;
 
   handleCommitResolution(statusDetails: ResolutionStatusDetails) {
-    const {organization, onUpdate} = this.props;
+    const {onUpdate} = this.props;
     onUpdate({
       status: ResolutionStatus.RESOLVED,
       statusDetails,
-    });
-    trackAdvancedAnalyticsEvent('resolve_issue', {
-      organization,
-      release: 'anotherExisting',
     });
   }
 

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -6,6 +6,7 @@ import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {openConfirmModal} from 'sentry/components/confirm';
 import CustomResolutionModal from 'sentry/components/customResolutionModal';
+import CustomResolutionModalCommits from 'sentry/components/customResolutionModalCommits';
 import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
 import Tooltip from 'sentry/components/tooltip';
 import {IconCheckmark, IconChevron} from 'sentry/icons';
@@ -163,6 +164,11 @@ class ResolveActions extends Component<Props> {
         label: t('Another existing release\u2026'),
         onAction: () => this.openCustomReleaseModal(),
       },
+      {
+        key: 'a-commit',
+        label: t('A commit\u2026'),
+        onAction: () => this.openCustomCommitModal(),
+      },
     ];
 
     const isDisabled = !projectSlug ? disabled : disableDropdown;
@@ -189,6 +195,21 @@ class ResolveActions extends Component<Props> {
         isDisabled={isDisabled}
       />
     );
+  }
+
+  openCustomCommitModal() {
+    const {orgSlug, projectSlug} = this.props;
+
+    openModal(deps => (
+      <CustomResolutionModalCommits
+        {...deps}
+        onSelected={(statusDetails: ResolutionStatusDetails) =>
+          this.handleAnotherExistingReleaseResolution(statusDetails)
+        }
+        orgSlug={orgSlug}
+        projectSlug={projectSlug}
+      />
+    ));
   }
 
   openCustomReleaseModal() {

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -5,8 +5,8 @@ import {openModal} from 'sentry/actionCreators/modal';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {openConfirmModal} from 'sentry/components/confirm';
+import CustomCommitsResolutionModal from 'sentry/components/customCommitsResolutionModal';
 import CustomResolutionModal from 'sentry/components/customResolutionModal';
-import CustomResolutionModalCommits from 'sentry/components/customResolutionModalCommits';
 import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
 import Tooltip from 'sentry/components/tooltip';
 import {IconCheckmark, IconChevron} from 'sentry/icons';
@@ -44,6 +44,18 @@ type Props = {
 
 class ResolveActions extends Component<Props> {
   static defaultProps = defaultProps;
+
+  handleCommitResolution(statusDetails: ResolutionStatusDetails) {
+    const {organization, onUpdate} = this.props;
+    onUpdate({
+      status: ResolutionStatus.RESOLVED,
+      statusDetails,
+    });
+    trackAdvancedAnalyticsEvent('resolve_issue', {
+      organization,
+      release: 'anotherExisting',
+    });
+  }
 
   handleAnotherExistingReleaseResolution(statusDetails: ResolutionStatusDetails) {
     const {organization, onUpdate} = this.props;
@@ -201,10 +213,10 @@ class ResolveActions extends Component<Props> {
     const {orgSlug, projectSlug} = this.props;
 
     openModal(deps => (
-      <CustomResolutionModalCommits
+      <CustomCommitsResolutionModal
         {...deps}
         onSelected={(statusDetails: ResolutionStatusDetails) =>
-          this.handleAnotherExistingReleaseResolution(statusDetails)
+          this.handleCommitResolution(statusDetails)
         }
         orgSlug={orgSlug}
         projectSlug={projectSlug}

--- a/static/app/components/customCommitsResolutionModal.tsx
+++ b/static/app/components/customCommitsResolutionModal.tsx
@@ -13,7 +13,6 @@ type Props = ModalRenderProps & {
   onSelected: ({inCommit: string}) => void;
   orgSlug: string;
   projectSlug?: string;
-  version?: string;
 };
 
 type State = {

--- a/static/app/components/customCommitsResolutionModal.tsx
+++ b/static/app/components/customCommitsResolutionModal.tsx
@@ -17,21 +17,30 @@ type Props = ModalRenderProps & {
 };
 
 type State = {
-  commit: Commit | null;
+  commit: Commit | undefined;
+  commits: Commit[] | undefined;
 };
 
 class CustomCommitsResolutionModal extends Component<Props, State> {
   state: State = {
-    commit: null,
+    commit: undefined,
+    commits: undefined,
   };
 
-  onChange = (value: Commit) => {
-    this.setState({commit: value}); // TODO(ts): Add select value type as generic to select controls
+  onChange = (value: string | number | boolean) => {
+    const commits = this.state.commits;
+    if (commits === undefined) {
+      return;
+    }
+    this.setState({
+      commit: commits.find(result => result.id === value),
+    });
   };
 
-  onAsyncFieldResults = (results: Commit[]) =>
-    results.map(commit => ({
-      value: commit,
+  onAsyncFieldResults = (results: Commit[]) => {
+    this.setState({commits: results});
+    return results.map(commit => ({
+      value: commit.id,
       label: <Version version={commit.id} anchor={false} />,
       details: (
         <span>
@@ -40,6 +49,7 @@ class CustomCommitsResolutionModal extends Component<Props, State> {
       ),
       commit,
     }));
+  };
 
   render() {
     const {orgSlug, projectSlug, closeModal, onSelected, Header, Body, Footer} =

--- a/static/app/components/customCommitsResolutionModal.tsx
+++ b/static/app/components/customCommitsResolutionModal.tsx
@@ -24,27 +24,22 @@ function CustomCommitsResolutionModal({
   Body,
   Footer,
 }: Props) {
-  const [state, setState] = useState<{
-    commit: Commit | undefined;
-    commits: Commit[] | undefined;
-  }>({
-    commit: undefined,
+  const [commit, setCommit] = useState<{commit: Commit | undefined}>({commit: undefined});
+  const [commits, setCommits] = useState<{commits: Commit[] | undefined}>({
     commits: undefined,
   });
 
   const onChange = (value: string | number | boolean) => {
-    if (state.commits === undefined) {
+    if (commits === undefined) {
       return;
     }
-    setState({
-      ...state,
-      commit: state.commits.find(result => result.id === value),
+    setCommit({
+      commit: commits.commits?.find(result => result.id === value),
     });
   };
 
   const onAsyncFieldResults = (results: Commit[]) => {
-    setState({
-      ...state,
+    setCommits({
       commits: results,
     });
     return results.map(c => ({
@@ -65,8 +60,8 @@ function CustomCommitsResolutionModal({
     e.preventDefault();
     onSelected({
       inCommit: {
-        commit: state.commit?.id,
-        repository: state.commit?.repository?.name,
+        commit: commit.commit?.id,
+        repository: commit.commit?.repository?.name,
       },
     });
     closeModal();

--- a/static/app/components/customResolutionModalCommits.tsx
+++ b/static/app/components/customResolutionModalCommits.tsx
@@ -1,0 +1,102 @@
+import {Component} from 'react';
+import {components as selectComponents} from 'react-select';
+
+import {ModalRenderProps} from 'sentry/actionCreators/modal';
+import Button from 'sentry/components/button';
+import {SelectAsyncField} from 'sentry/components/deprecatedforms';
+import TimeSince from 'sentry/components/timeSince';
+import Version from 'sentry/components/version';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {Release} from 'sentry/types';
+
+type Props = ModalRenderProps & {
+  onSelected: ({inRelease: string}) => void;
+  orgSlug: string;
+  projectSlug?: string;
+  version?: string;
+};
+
+type State = {
+  version: string;
+};
+
+function CommitOption({
+  data,
+  ...props
+}: React.ComponentProps<typeof selectComponents.Option>) {
+  const release = data.release as Release;
+  return (
+    <selectComponents.Option data={data} {...props}>
+      <strong>
+        <Version version={release.version} anchor={false} />
+      </strong>
+      <br />
+      <small>
+        {t('Created')} <TimeSince date={release.dateCreated} />
+      </small>
+    </selectComponents.Option>
+  );
+}
+
+class CustomResolutionModalCommits extends Component<Props, State> {
+  state: State = {
+    version: '',
+  };
+
+  onChange = (value: string | number | boolean) => {
+    this.setState({version: value as string}); // TODO(ts): Add select value type as generic to select controls
+  };
+
+  onAsyncFieldResults = (results: Release[]) =>
+    results.map(release => ({
+      value: release.version,
+      label: release.version,
+      release,
+    }));
+
+  render() {
+    const {orgSlug, projectSlug, closeModal, onSelected, Header, Body, Footer} =
+      this.props;
+    const url = projectSlug
+      ? `/projects/${orgSlug}/${projectSlug}/releases/`
+      : `/organizations/${orgSlug}/releases/`;
+
+    const onSubmit = (e: React.FormEvent) => {
+      e.preventDefault();
+      onSelected({inRelease: this.state.version});
+      closeModal();
+    };
+
+    return (
+      <form onSubmit={onSubmit}>
+        <Header>{t('Resolved In')}</Header>
+        <Body>
+          <SelectAsyncField
+            label={t('Commit')}
+            id="commit"
+            name="commit"
+            onChange={this.onChange}
+            placeholder={t('e.g. 1.0.4')}
+            url={url}
+            onResults={this.onAsyncFieldResults}
+            onQuery={query => ({query})}
+            components={{
+              Option: CommitOption,
+            }}
+          />
+        </Body>
+        <Footer>
+          <Button type="button" css={{marginRight: space(1.5)}} onClick={closeModal}>
+            {t('Cancel')}
+          </Button>
+          <Button type="submit" priority="primary">
+            {t('Save Changes')}
+          </Button>
+        </Footer>
+      </form>
+    );
+  }
+}
+
+export default CustomResolutionModalCommits;

--- a/tests/js/spec/components/customCommitsResolutionModal.spec.jsx
+++ b/tests/js/spec/components/customCommitsResolutionModal.spec.jsx
@@ -1,4 +1,5 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {act} from 'sentry-test/reactTestingLibrary';
 import {selectByValue} from 'sentry-test/select-new';
 
 import CustomCommitsResolutionModal from 'sentry/components/customCommitsResolutionModal';
@@ -27,7 +28,7 @@ describe('CustomCommitsResolutionModal', function () {
     );
 
     expect(commitsMock).toHaveBeenCalled();
-    await tick();
+    await act(tick);
     wrapper.update();
 
     expect(wrapper.find('Select').prop('options')).toEqual([
@@ -40,6 +41,7 @@ describe('CustomCommitsResolutionModal', function () {
     selectByValue(wrapper, 'f7f395d14b2fe29a4e253bf1d3094d61e6ad4434', {
       selector: 'SelectAsyncControl[name="commit"]',
     });
+    await act(tick);
 
     wrapper.find('form').simulate('submit');
     expect(onSelected).toHaveBeenCalledWith({

--- a/tests/js/spec/components/customCommitsResolutionModal.spec.jsx
+++ b/tests/js/spec/components/customCommitsResolutionModal.spec.jsx
@@ -1,0 +1,52 @@
+import {mountWithTheme} from 'sentry-test/enzyme';
+import {selectByValue} from 'sentry-test/select-new';
+
+import CustomCommitsResolutionModal from 'sentry/components/customCommitsResolutionModal';
+
+describe('CustomCommitsResolutionModal', function () {
+  let commitsMock;
+  beforeEach(function () {
+    commitsMock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/commits/',
+      body: [TestStubs.Commit()],
+    });
+  });
+
+  it('can select a commit', async function () {
+    const onSelected = jest.fn();
+    const wrapper = mountWithTheme(
+      <CustomCommitsResolutionModal
+        Header={p => p.children}
+        Body={p => p.children}
+        Footer={p => p.children}
+        orgSlug="org-slug"
+        projectSlug="project-slug"
+        onSelected={onSelected}
+        closeModal={jest.fn()}
+      />
+    );
+
+    expect(commitsMock).toHaveBeenCalled();
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('Select').prop('options')).toEqual([
+      expect.objectContaining({
+        value: 'f7f395d14b2fe29a4e253bf1d3094d61e6ad4434',
+        label: expect.anything(),
+      }),
+    ]);
+
+    selectByValue(wrapper, 'f7f395d14b2fe29a4e253bf1d3094d61e6ad4434', {
+      selector: 'SelectAsyncControl[name="commit"]',
+    });
+
+    wrapper.find('form').simulate('submit');
+    expect(onSelected).toHaveBeenCalledWith({
+      inCommit: {
+        commit: 'f7f395d14b2fe29a4e253bf1d3094d61e6ad4434',
+        repository: 'example/repo-name',
+      },
+    });
+  });
+});


### PR DESCRIPTION
Added a fourth option to the `Resolved in` dropdown to manually resolve an issue with a specific commit.

Before:
<img width="783" alt="Screen Shot 2022-06-20 at 2 00 28 PM" src="https://user-images.githubusercontent.com/52506101/174677110-ff1b67c3-67f2-4274-bba6-fdb759465f1b.png">

After:
<img width="792" alt="Screen Shot 2022-06-20 at 1 58 59 PM" src="https://user-images.githubusercontent.com/52506101/174676970-ef3b136b-0182-4315-8d45-7c416bc195e3.png">
<img width="639" alt="Screen Shot 2022-06-20 at 1 59 15 PM" src="https://user-images.githubusercontent.com/52506101/174677002-437f3f4a-7b8e-498b-8bfe-136eac532c38.png">