### PR TITLE
feat(replays): Use tabular-nums font variant for in Breadcrumbs and Timeline

### DIFF
--- a/static/app/components/replays/breadcrumbs/gridlines.tsx
+++ b/static/app/components/replays/breadcrumbs/gridlines.tsx
@@ -45,7 +45,7 @@ export function MajorGridlines({duration, minWidth = 50, width}: Props) {
 
   return (
     <Gridlines cols={cols} lineStyle="solid" remaining={remaining}>
-      {i => <small>{formatTime((i + 1) * timespan)}</small>}
+      {i => <Label>{formatTime((i + 1) * timespan)}</Label>}
     </Gridlines>
   );
 }
@@ -55,3 +55,7 @@ export function MinorGridlines({duration, minWidth = 20, width}: Props) {
 
   return <Gridlines cols={cols} lineStyle="dotted" remaining={remaining} />;
 }
+
+const Label = styled('small')`
+  font-variant-numeric: tabular-nums;
+`;

--- a/static/app/components/replays/playerRelativeTime.tsx
+++ b/static/app/components/replays/playerRelativeTime.tsx
@@ -17,7 +17,7 @@ const PlayerRelativeTime = ({relativeTime, timestamp}: Props) => {
 
   return (
     <Tooltip
-      title={<DateTime date={timestamp} />}
+      title={<DateTime date={timestamp} seconds />}
       disabled={!timestamp}
       skipWrapper
       disableForVisualTest
@@ -31,8 +31,8 @@ const PlayerRelativeTime = ({relativeTime, timestamp}: Props) => {
 
 const Value = styled('p')`
   color: ${p => p.theme.subText};
-  font-size: 0.7em;
-  font-family: ${p => p.theme.text.familyMono};
+  font-size: 0.9em;
+  font-variant-numeric: tabular-nums;
 `;
 
 export default PlayerRelativeTime;

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -33,7 +33,7 @@ export function showPlayerTime(timestamp: string, relativeTime: number): string 
 
 // TODO: move into 'sentry/utils/formatters'
 export function formatTime(ms: number): string {
-  if (ms <= 0) {
+  if (ms <= 0 || isNaN(ms)) {
     return '0:00';
   }
   const hour = Math.floor(ms / HOUR);

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -17,7 +17,6 @@ function padZero(num: number, len = 2): string {
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 const HOUR = 60 * MINUTE;
-const TIME_FORMAT = 'HH:mm:ss';
 
 /**
  * @param timestamp The timestamp that is our reference point. Can be anything that `moment` accepts such as `'2022-05-04T19:47:52.915000Z'` or `1651664872.915`
@@ -29,7 +28,7 @@ export function relativeTimeInMs(timestamp: moment.MomentInput, diffMs: number):
 }
 
 export function showPlayerTime(timestamp: string, relativeTime: number): string {
-  return moment.utc(relativeTimeInMs(timestamp, relativeTime)).format(TIME_FORMAT);
+  return formatTime(relativeTimeInMs(timestamp, relativeTime));
 }
 
 // TODO: move into 'sentry/utils/formatters'
@@ -43,9 +42,9 @@ export function formatTime(ms: number): string {
   ms = ms % MINUTE;
   const second = Math.floor(ms / SECOND);
   if (hour) {
-    return `${hour}:${padZero(minute)}:${padZero(second)}`;
+    return `${padZero(hour)}:${padZero(minute)}:${padZero(second)}`;
   }
-  return `${minute}:${padZero(second)}`;
+  return `${padZero(minute)}:${padZero(second)}`;
 }
 
 /**

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -82,7 +82,7 @@ const Title = styled('span')`
 const Description = styled('span')`
   ${p => p.theme.overflowEllipsis};
   font-size: 0.7rem;
-  font-family: ${p => p.theme.text.familyMono};
+  font-variant-numeric: tabular-nums;
 `;
 
 type CrumbItemProps = {

--- a/tests/js/spec/components/replays/utils.spec.tsx
+++ b/tests/js/spec/components/replays/utils.spec.tsx
@@ -33,9 +33,9 @@ function createCrumb({timestamp}: Pick<Crumb, 'timestamp'>): Crumb {
 
 describe('formatTime', () => {
   it.each([
-    ['seconds', 15 * 1000, '0:15'],
-    ['minutes', 2.5 * 60 * 1000, '2:30'],
-    ['hours', 75 * 60 * 1000, '1:15:00'],
+    ['seconds', 15 * 1000, '00:15'],
+    ['minutes', 2.5 * 60 * 1000, '02:30'],
+    ['hours', 75 * 60 * 1000, '01:15:00'],
   ])('should format a %s long duration into a string', (_desc, duration, expected) => {
     expect(formatTime(duration)).toEqual(expected);
   });
@@ -271,14 +271,12 @@ describe('flattenSpans', () => {
   describe('showPlayerTime', () => {
     it('returns time formatted for player', () => {
       expect(showPlayerTime('2022-05-11T23:04:27.576000Z', 1652309918.676)).toEqual(
-        '00:05:48'
+        '05:48'
       );
     });
 
-    it('returns invalid date if timestamp is malformed', () => {
-      expect(showPlayerTime('20223:04:27.576000Z', 1652309918.676)).toEqual(
-        'Invalid date'
-      );
+    it('returns 0:00 if timestamp is malformed', () => {
+      expect(showPlayerTime('20223:04:27.576000Z', 1652309918.676)).toEqual('0:00');
     });
   });
 


### PR DESCRIPTION
Notice
1. The `1` digit is wider with this font variation
2. We no longer format as `HH:mm:ss` unless the timestamp is an hour or longer
3. Formatting is consistent in the two places with a leading zero
4. Breadcrumb tooltips show seconds, this matches with timestamps in the Console

### In Breadcrumbs: 
| Before | After |
| --- | --- |
| <img width="339" alt="Screen Shot 2022-06-17 at 12 38 23 PM" src="https://user-images.githubusercontent.com/187460/174391377-d538055c-eb61-45ee-8c72-83dc7d5a6b45.png"> | <img width="351" alt="Screen Shot 2022-06-17 at 12 37 11 PM" src="https://user-images.githubusercontent.com/187460/174391393-482ebe99-c1ca-40c5-9b9a-f149b7bb8271.png">


### Timeline

|  |  |
| --- | --- |
| Before | <img width="1135" alt="Screen Shot 2022-06-17 at 12 38 28 PM" src="https://user-images.githubusercontent.com/187460/174391166-1a5fded4-e5b5-49e5-aa6e-f3ccdfef005d.png"> |
| After | <img width="1137" alt="Screen Shot 2022-06-17 at 12 37 16 PM" src="https://user-images.githubusercontent.com/187460/174391191-b5a7417a-a476-49e8-8324-bf2aff4c7a51.png"> |
