### PR TITLE
fix(settings): Refresh projects when joining a team

### DIFF
--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -2,6 +2,7 @@ import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {fetchOrganizationDetails} from 'sentry/actionCreators/organizations';
 import {joinTeam, leaveTeam} from 'sentry/actionCreators/teams';
 import TeamActions from 'sentry/actions/teamActions';
 import {Client} from 'sentry/api';
@@ -33,6 +34,14 @@ class AllTeamsRow extends Component<Props, State> {
     error: false,
   };
 
+  reloadProjects() {
+    const {organization} = this.props;
+    // After a change in teams has happened, refresh the project store
+    fetchOrganizationDetails(organization.slug, {
+      loadProjects: true,
+    });
+  }
+
   handleRequestAccess = () => {
     const {team} = this.props;
 
@@ -57,10 +66,10 @@ class AllTeamsRow extends Component<Props, State> {
     }
   };
 
-  handleJoinTeam = () => {
+  handleJoinTeam = async () => {
     const {team} = this.props;
 
-    this.joinTeam({
+    await this.joinTeam({
       successMessage: tct('You have joined [team]', {
         team: `#${team.slug}`,
       }),
@@ -68,6 +77,7 @@ class AllTeamsRow extends Component<Props, State> {
         team: `#${team.slug}`,
       }),
     });
+    this.reloadProjects();
   };
 
   joinTeam = ({
@@ -136,6 +146,9 @@ class AllTeamsRow extends Component<Props, State> {
               team: `#${team.slug}`,
             })
           );
+
+          // Reload ProjectsStore
+          this.reloadProjects();
         },
         error: () => {
           this.setState({

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -77,6 +77,7 @@ class AllTeamsRow extends Component<Props, State> {
         team: `#${team.slug}`,
       }),
     });
+
     this.reloadProjects();
   };
 

--- a/tests/js/spec/views/settings/organizationTeams.spec.jsx
+++ b/tests/js/spec/views/settings/organizationTeams.spec.jsx
@@ -68,6 +68,29 @@ describe('OrganizationTeams', function () {
       // Should also link to details
       expect(wrapper.find('Link')).not.toHaveLength(0);
     });
+
+    it('reloads projects after joining a team', async function () {
+      const team = TestStubs.Team({hasAccess: true, isMember: false});
+      const getOrgMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        body: TestStubs.Organization(),
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/members/me/teams/${team.slug}/`,
+        method: 'POST',
+        body: {...team, isMember: true},
+      });
+
+      const mockTeams = [team];
+      act(() => void TeamStore.loadInitialData(mockTeams, false, null));
+      const wrapper = createWrapper({
+        access: new Set([]),
+      });
+      act(() => void wrapper.find('button[aria-label="Join Team"]').simulate('click'));
+      await act(() => tick());
+
+      expect(getOrgMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Closed Membership', function () {


### PR DESCRIPTION
reload project store when joining or leaving a team as the user's projects will have changed.

fixes https://getsentry.atlassian.net/browse/WOR-1861