### PR TITLE
feat(celery): Remove (hopefully unused) thread id hack

### DIFF
--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -12,50 +12,6 @@ else:
 
 from celery.worker.request import Request
 
-DB_SHARED_THREAD = """\
-DatabaseWrapper objects created in a thread can only \
-be used in that same thread.  The object with alias '%s' \
-was created in thread id %s and this is thread id %s.\
-"""
-
-
-def patch_thread_ident():
-    # monkey patch django.
-    # This patch make sure that we use real threads to get the ident which
-    # is going to happen if we are using gevent or eventlet.
-    # -- patch taken from gunicorn
-    if getattr(patch_thread_ident, "called", False):
-        return
-    try:
-        from django.db.backends import BaseDatabaseWrapper, DatabaseError
-
-        if "validate_thread_sharing" in BaseDatabaseWrapper.__dict__:
-            import _thread as thread
-
-            _get_ident = thread.get_ident
-
-            __old__init__ = BaseDatabaseWrapper.__init__
-
-            def _init(self, *args, **kwargs):
-                __old__init__(self, *args, **kwargs)
-                self._thread_ident = _get_ident()
-
-            def _validate_thread_sharing(self):
-                if not self.allow_thread_sharing and self._thread_ident != _get_ident():
-                    raise DatabaseError(
-                        DB_SHARED_THREAD % (self.alias, self._thread_ident, _get_ident())
-                    )
-
-            BaseDatabaseWrapper.__init__ = _init
-            BaseDatabaseWrapper.validate_thread_sharing = _validate_thread_sharing
-
-        patch_thread_ident.called = True
-    except ImportError:
-        pass
-
-
-patch_thread_ident()
-
 
 class SentryTask(Task):
     Request = "sentry.celery:SentryRequest"


### PR DESCRIPTION
I stumbled across this code when working on preventing bad uses of pickle in celery and from what I can tell we do not need this since we use neither gevent nor greenlet. In fact if we were, much more would be broken.