### PR TITLE
fix(django): Third attempt: Detect spawned celery tasks that can exhibit stale reads [INGEST-1348]

### DIFF
--- a/src/sentry/models/integrations/external_actor.py
+++ b/src/sentry/models/integrations/external_actor.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db import models
+from django.db import models, transaction
 from django.db.models.signals import post_delete, post_save
 
 from sentry.db.models import BoundedPositiveIntegerField, DefaultFieldsModel, FlexibleForeignKey
@@ -48,11 +48,18 @@ class ExternalActor(DefaultFieldsModel):
 
 
 def process_resource_change(instance, **kwargs):
+    from sentry.models import Organization, Project
     from sentry.tasks.codeowners import update_code_owners_schema
 
-    return update_code_owners_schema.apply_async(
-        kwargs={"organization": instance.organization, "integration": instance.integration}
-    )
+    def _spawn_task():
+        try:
+            update_code_owners_schema.apply_async(
+                kwargs={"organization": instance.organization, "integration": instance.integration}
+            )
+        except (Organization.DoesNotExist, Project.DoesNotExist):
+            pass
+
+    transaction.on_commit(_spawn_task)
 
 
 post_save.connect(

--- a/src/sentry/models/integrations/repository_project_path_config.py
+++ b/src/sentry/models/integrations/repository_project_path_config.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.db import models, transaction
 from django.db.models.signals import post_save
 
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey
@@ -23,11 +23,21 @@ class RepositoryProjectPathConfig(DefaultFieldsModel):
 
 
 def process_resource_change(instance, **kwargs):
+    from sentry.models import Organization, Project
     from sentry.tasks.codeowners import update_code_owners_schema
 
-    return update_code_owners_schema.apply_async(
-        kwargs={"organization": instance.project.organization, "projects": [instance.project]}
-    )
+    def _spawn_task():
+        try:
+            update_code_owners_schema.apply_async(
+                kwargs={
+                    "organization": instance.project.organization,
+                    "projects": [instance.project],
+                }
+            )
+        except (Project.DoesNotExist, Organization.DoesNotExist):
+            pass
+
+    transaction.on_commit(_spawn_task)
 
 
 post_save.connect(

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -102,14 +102,21 @@ class TeamManager(BaseManager):
         self.process_resource_change(instance, **kwargs)
 
     def process_resource_change(self, instance, **kwargs):
+        from sentry.models import Organization, Project
         from sentry.tasks.codeowners import update_code_owners_schema
 
-        update_code_owners_schema.apply_async(
-            kwargs={
-                "organization": instance.organization,
-                "projects": instance.get_projects(),
-            }
-        )
+        def _spawn_task():
+            try:
+                update_code_owners_schema.apply_async(
+                    kwargs={
+                        "organization": instance.organization,
+                        "projects": instance.get_projects(),
+                    }
+                )
+            except (Organization.DoesNotExist, Project.DoesNotExist):
+                pass
+
+        transaction.on_commit(_spawn_task)
 
 
 # TODO(dcramer): pull in enum library

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -36,7 +36,7 @@ def resolve_group_resolutions(instance, created, **kwargs):
     if not created:
         return
 
-    clear_expired_resolutions.delay(release_id=instance.id)
+    transaction.on_commit(lambda: clear_expired_resolutions.delay(release_id=instance.id))
 
 
 def remove_resolved_link(link):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -166,6 +166,10 @@ class BaseTestCase(Fixtures, Exam):
         """
         self.capture_on_commit_callbacks = django_capture_on_commit_callbacks
 
+    @pytest.fixture(autouse=True)
+    def expose_stale_database_reads(self, stale_database_reads):
+        self.stale_database_reads = stale_database_reads
+
     def feature(self, names):
         """
         >>> with self.feature({'feature:name': True})

--- a/src/sentry/utils/pytest/__init__.py
+++ b/src/sentry/utils/pytest/__init__.py
@@ -5,4 +5,5 @@ pytest_plugins = [
     "sentry.utils.pytest.unittest",
     "sentry.utils.pytest.kafka",
     "sentry.utils.pytest.relay",
+    "sentry.utils.pytest.stale_database_reads",
 ]

--- a/src/sentry/utils/pytest/stale_database_reads.py
+++ b/src/sentry/utils/pytest/stale_database_reads.py
@@ -1,0 +1,143 @@
+import dataclasses
+from threading import local
+from typing import Any, List, Tuple
+
+import pytest
+from celery.app.task import Task
+from django.db import transaction
+from django.db.models.signals import ModelSignal
+
+_SEP_LINE = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+
+@dataclasses.dataclass
+class StaleDatabaseReads:
+    model_signal_handlers: List[Tuple[Any, Any]]
+    transaction_blocks: List[Any]
+
+    def clear(self):
+        self.model_signal_handlers.clear()
+        self.transaction_blocks.clear()
+
+
+def _raise_reports(reports: StaleDatabaseReads):
+    if not reports.model_signal_handlers and not reports.transaction_blocks:
+        return
+
+    msg = f"""\
+{_SEP_LINE}
+We have detected that you are spawning a celery task in the following situations:
+"""
+
+    if reports.model_signal_handlers:
+        for signal_sender, task_self in reports.model_signal_handlers:
+            msg += f"  - A change to model {signal_sender} spawning a task {task_self.__name__}\n"
+
+        msg += """
+We found that such model signal handlers are often subtly broken in situations
+where the model is being updated inside of a transaction. In this case the
+spawned celery task can observe the old model state in production (where it
+runs on a different machine) but not in tests (where it doesn't).
+
+Typically the fix is to spawn the task using django.db.transaction.on_commit:
+
+    # Before
+    handle_model_changes.apply_async(...)
+    # After
+    transaction.on_commit(lambda: handle_model_changes.apply_async(...))
+"""
+
+    if reports.model_signal_handlers and reports.transaction_blocks:
+        msg += f"""
+{_SEP_LINE}
+Additionally we found:
+"""
+
+    if reports.transaction_blocks:
+        for task_self in reports.transaction_blocks:
+            msg += f"  - A task {task_self.__name__} being spawned inside of a transaction.atomic block\n"
+
+        msg += """
+Those tasks can also observe outdated database state, and are better spawned
+after the transaction has finished (using `django.db.transaction.on_commit` or
+literally moving the code around).
+        """
+
+    msg += """
+For an example of a real-world fix, see
+https://github.com/getsentry/sentry/pull/35523, and for the PR that introduced
+this fixture see https://github.com/getsentry/sentry/pull/35671
+
+If you think this doesn't apply to this test, use the
+`stale_database_reads` fixture like so at the end of the test:
+
+    class MyTestCase(TestCase):
+        def test_very_special(self):
+            self.stale_database_reads.clear()
+
+Or like this in pytest-based tests:
+
+    def test_very_special(stale_database_reads):
+        # Do something odd with models here
+
+        stale_database_reads.clear()
+{_SEP_LINE}"""
+
+    pytest.fail(msg)
+
+
+@pytest.fixture(autouse=True)
+def stale_database_reads(monkeypatch):
+    _state = local()
+
+    old_send = ModelSignal.send
+
+    def send(self, sender, **named):
+        _state.in_signal_sender = getattr(sender, "__name__", repr(sender))
+        try:
+            return old_send(self, sender, **named)
+        finally:
+            _state.in_signal_sender = False
+
+    monkeypatch.setattr(ModelSignal, "send", send)
+
+    old_on_commit = transaction.on_commit
+
+    def on_commit(*args, **kwargs):
+        _state.in_on_commit = True
+        try:
+            return old_on_commit(*args, **kwargs)
+        finally:
+            _state.in_on_commit = False
+
+    monkeypatch.setattr(transaction, "on_commit", on_commit)
+
+    old_atomic = transaction.atomic
+
+    def atomic(*args, **kwargs):
+        _state.in_atomic = True
+        try:
+            return old_atomic(*args, **kwargs)
+        finally:
+            _state.in_atomic = False
+
+    monkeypatch.setattr(transaction, "atomic", atomic)
+
+    old_apply_async = Task.apply_async
+
+    reports = StaleDatabaseReads(model_signal_handlers=[], transaction_blocks=[])
+
+    def apply_async(self, args=(), kwargs=(), countdown=None):
+        if getattr(_state, "in_signal_sender", None) and not getattr(_state, "in_on_commit", None):
+            reports.model_signal_handlers.append((_state.in_signal_sender, self))
+
+        elif getattr(_state, "in_atomic", None) and not getattr(_state, "in_on_commit", None):
+            reports.transaction_blocks.append(self)
+
+        return old_apply_async(self, args, kwargs, countdown)
+
+    monkeypatch.setattr(Task, "apply_async", apply_async)
+
+    yield reports
+
+    _raise_reports(reports)

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -32,8 +32,11 @@ from sentry.types.activity import ActivityType
 class ResolveGroupResolutionsTest(TestCase):
     @patch("sentry.tasks.clear_expired_resolutions.clear_expired_resolutions.delay")
     def test_simple(self, mock_delay):
-        release = Release.objects.create(version="a", organization_id=self.project.organization_id)
-        release.add_project(self.project)
+        with self.capture_on_commit_callbacks(execute=True):
+            release = Release.objects.create(
+                version="a", organization_id=self.project.organization_id
+            )
+            release.add_project(self.project)
 
         mock_delay.assert_called_once_with(release_id=release.id)
 

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -218,7 +218,7 @@ def test_invalidation_project_deleted(default_project, emulate_transactions, red
     project_id = default_project.id
 
     # Delete the project normally, this will delete it from the cache
-    with emulate_transactions(assert_num_callbacks=4):
+    with emulate_transactions(assert_num_callbacks=5):
         default_project.delete()
     assert redis_cache.get(project_key) is None
 


### PR DESCRIPTION
This reverts commit a35aa96.

Reattempts https://github.com/getsentry/sentry/pull/35783 which reattempts https://github.com/getsentry/sentry/pull/35671

there's a getsentry PR that needs to be green before we can merge: https://github.com/getsentry/getsentry/pull/7677

#sync-getsentry