### PR TITLE
test(spans): Fix flakey spans test

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -528,10 +528,6 @@ class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndp
         }
 
     def test_sort_default(self):
-        # TODO: remove this and the @pytest.skip once the config
-        # is no longer necessary as this can add ~10s to the test
-        self.update_snuba_config_ensure({"write_span_columns_projects": f"[{self.project.id}]"})
-
         event = self.create_event()
 
         with self.feature(self.FEATURES):

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -1555,8 +1555,6 @@ class OrganizationEventsSpansExamplesEndpointTest(OrganizationEventsSpansEndpoin
             for x in ["d", "e", "f"]
         ]
 
-        # create two events
-        self.create_event(spans=spans)
         event = self.create_event(spans=spans)
 
         with self.feature(self.FEATURES):
@@ -1631,8 +1629,6 @@ class OrganizationEventsSpansExamplesEndpointTest(OrganizationEventsSpansEndpoin
             for x in ["d", "e", "f"]
         ]
 
-        # create two events
-        self.create_event(spans=spans)
         event = self.create_event(spans=spans)
 
         with self.feature(self.FEATURES):
@@ -1707,8 +1703,6 @@ class OrganizationEventsSpansExamplesEndpointTest(OrganizationEventsSpansEndpoin
             for x in ["d", "e", "f"]
         ]
 
-        # create two events
-        self.create_event(spans=spans)
         event = self.create_event(spans=spans)
 
         with self.feature(self.FEATURES):


### PR DESCRIPTION
This PR updates 3 `OrganizationEventsSpansExamplesEndpointTest`'s tests that have been quite flakey. There are two events that get created for each test but the assertions are made with an assumption that the endpoint would only return the second event which wasn't always true. The update makes sure that there is only one event that gets created so the assertion can be made on the consistent result.

Fixes SENTRY-TESTS-3CB