### PR TITLE
ref(sampling): Add constraints to custom tag key and value - [TET-95]

### DIFF
--- a/static/app/views/settings/project/sampling/modal/tagKeyAutocomplete.tsx
+++ b/static/app/views/settings/project/sampling/modal/tagKeyAutocomplete.tsx
@@ -52,6 +52,13 @@ function TagKeyAutocomplete({tags, onChange, value, disabledOptions}: Props) {
         onChange={onChange}
         value={value}
         formatCreateLabel={formatCreateTagLabel}
+        isValidNewOption={newOption => {
+          // Tag keys cannot be empty and must have a maximum length of 32 characters
+          // https://github.com/getsentry/relay/blob/d8223d8d03ed4764063855eb3480f22684163d92/relay-general/src/store/normalize.rs#L220-L240
+          // In addition to that, it must be composed of numbers and/or letters and the only special characters allowed are "-", "_", "." and ":"
+          // https://github.com/getsentry/relay/blob/d8223d8d03ed4764063855eb3480f22684163d92/relay-general/src/protocol/tags.rs#L7
+          return /^([a-zA-Z0-9_\\:\\.\\-]+)$/.test(newOption) && newOption.length <= 32;
+        }}
       />
     </Wrapper>
   );

--- a/static/app/views/settings/project/sampling/modal/tagValueAutocomplete.tsx
+++ b/static/app/views/settings/project/sampling/modal/tagValueAutocomplete.tsx
@@ -126,7 +126,7 @@ function TagValueAutocomplete({
         // https://github.com/getsentry/relay/blob/d8223d8d03ed4764063855eb3480f22684163d92/relay-general/src/store/normalize.rs#L230-L236
         // In addition to that, it cannot contain a line-feed (newline) character
         // https://github.com/getsentry/relay/blob/d8223d8d03ed4764063855eb3480f22684163d92/relay-general/src/protocol/tags.rs#L8
-        return !newOption.includes('\n') && newOption.length <= 200;
+        return !/\\n/.test(newOption) && newOption.length <= 200;
       }}
       placeholder={getMatchFieldPlaceholder(category)}
       inline={false}

--- a/static/app/views/settings/project/sampling/modal/tagValueAutocomplete.tsx
+++ b/static/app/views/settings/project/sampling/modal/tagValueAutocomplete.tsx
@@ -121,6 +121,13 @@ function TagValueAutocomplete({
         ),
       }}
       formatCreateLabel={formatCreateTagLabel}
+      isValidNewOption={newOption => {
+        // Tag values cannot be empty and must have a maximum length of 200 characters
+        // https://github.com/getsentry/relay/blob/d8223d8d03ed4764063855eb3480f22684163d92/relay-general/src/store/normalize.rs#L230-L236
+        // In addition to that, it cannot contain a line-feed (newline) character
+        // https://github.com/getsentry/relay/blob/d8223d8d03ed4764063855eb3480f22684163d92/relay-general/src/protocol/tags.rs#L8
+        return !newOption.includes('\n') && newOption.length <= 200;
+      }}
       placeholder={getMatchFieldPlaceholder(category)}
       inline={false}
       multiple


### PR DESCRIPTION
**What this PR does:**

- Replicates Relay's constraint logic on tag keys in the field "tag" in the sampling form. Tag keys cannot be empty, shall be of a maximum of 32 long, and shall only contain the special characters ":", ".", "_" or "-".
-  Replicates Relay's constraint logic on tag values in the field "tag values" in the sampling form. Tag values cannot be empty, shall be of a maximum of 200 long, and shall not contain "\n" (line breaks)

**Before:**

https://user-images.githubusercontent.com/29228205/174595076-e7b1ab0f-8aea-4afe-858d-f600813865e8.mov


**After:**

https://user-images.githubusercontent.com/29228205/174598976-3d5003a6-7bd8-47e9-8d1f-80df96eae507.mov
