### PR TITLE
ref(projectconfig): Cleanup deprecated task and cache methods

### DIFF
--- a/src/sentry/relay/projectconfig_debounce_cache/__init__.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/__init__.py
@@ -24,5 +24,4 @@ invalidation = LazyServiceWrapper(
 )
 
 if TYPE_CHECKING:
-    check_is_debounced = backend.check_is_debounced
     mark_task_done = backend.mark_task_done

--- a/src/sentry/relay/projectconfig_debounce_cache/base.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/base.py
@@ -17,21 +17,10 @@ class ProjectConfigDebounceCache(Service):
     multiple instances of this debounce cache with different keys.
     """
 
-    __all__ = ("check_is_debounced", "is_debounced", "debounce", "mark_task_done")
+    __all__ = ("is_debounced", "debounce", "mark_task_done")
 
     def __init__(self, **options):
         pass
-
-    def check_is_debounced(self, *, public_key, project_id, organization_id):
-        """
-        Check if the given project/organization should be debounced, and
-        debounces when it isn't.
-
-        It's fine to erroneously return false, it's not fine to erroneously
-        return true.
-        """
-
-        return False
 
     def is_debounced(self, *, public_key, project_id, organization_id):
         """Checks if the given project/organization should be debounced."""
@@ -44,7 +33,7 @@ class ProjectConfigDebounceCache(Service):
 
     def mark_task_done(self, *, public_key, project_id, organization_id):
         """
-        Mark a task done such that `check_is_debounced` starts emitting False
+        Mark a task done such that `is_debounced` starts emitting False
         for the given parameters.
 
         Returns 1 if the task was removed, 0 if it wasn't.

--- a/src/sentry/relay/projectconfig_debounce_cache/redis.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/redis.py
@@ -32,14 +32,6 @@ class RedisProjectConfigDebounceCache(ProjectConfigDebounceCache):
         else:
             return self.cluster.get_local_client_for_key(routing_key)
 
-    def check_is_debounced(self, *, public_key, project_id, organization_id):
-        if self.is_debounced(
-            public_key=public_key, project_id=project_id, organization_id=organization_id
-        ):
-            return True
-        self.debounce(public_key=public_key, project_id=project_id, organization_id=organization_id)
-        return False
-
     def is_debounced(self, *, public_key, project_id, organization_id):
         key = self._get_redis_key(public_key, project_id, organization_id)
         client = self._get_redis_client(key)

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -1,7 +1,6 @@
 import logging
 
 import sentry_sdk
-from django.conf import settings
 
 from sentry.relay import projectconfig_cache, projectconfig_debounce_cache
 from sentry.tasks.base import instrumented_task
@@ -12,158 +11,6 @@ logger = logging.getLogger(__name__)
 
 TASK_SOFT_LIMIT = 25
 TASK_HARD_LIMIT = 30  # Extra 5 seconds to remove the debounce key
-
-
-# DEPRECATED TASK, use build_project_config or invalidate_config_cache instead.
-@instrumented_task(
-    name="sentry.tasks.relay.update_config_cache",
-    queue="relay_config",
-    acks_late=True,
-    soft_time_limit=TASK_SOFT_LIMIT,
-    time_limit=TASK_HARD_LIMIT,
-)
-def update_config_cache(
-    generate, organization_id=None, project_id=None, public_key=None, update_reason=None
-):
-    """
-    Update the Redis cache for the Relay projectconfig. This task is invoked
-    whenever a project/org option has been saved or smart quotas potentially
-    caused a change in projectconfig.
-
-    Either organization_id or project_id has to be provided.
-
-    :param organization_id: The organization for which to invalidate configs.
-    :param project_id: The project for which to invalidate configs.
-    :param generate: If `True`, caches will be eagerly regenerated, not only
-        invalidated.
-    :param update_reason: A string to set as tag in sentry.
-    """
-    from sentry.models import Project, ProjectKey, ProjectKeyStatus
-    from sentry.relay import projectconfig_cache
-    from sentry.relay.config import get_project_config
-
-    if project_id:
-        set_current_event_project(project_id)
-
-    if organization_id:
-        # Cannot use bind_organization_context here because we do not have a
-        # model and don't want to fetch one
-        sentry_sdk.set_tag("organization_id", organization_id)
-
-    if public_key:
-        sentry_sdk.set_tag("public_key", public_key)
-
-    sentry_sdk.set_tag("update_reason", update_reason)
-    sentry_sdk.set_tag("generate", generate)
-
-    try:
-        if organization_id:
-            projects = list(Project.objects.filter(organization_id=organization_id))
-            keys = list(ProjectKey.objects.filter(project__in=projects))
-        elif project_id:
-            projects = [Project.objects.get(id=project_id)]
-            keys = list(ProjectKey.objects.filter(project__in=projects))
-        elif public_key:
-            try:
-                keys = [ProjectKey.objects.get(public_key=public_key)]
-            except ProjectKey.DoesNotExist:
-                # In this particular case, where a project key got deleted and
-                # triggered an update, we know that key doesn't exist and we want to
-                # avoid creating more tasks for it.
-                #
-                # In other similar cases, like an org being deleted, we potentially
-                # cannot find any keys anymore, so we don't know which cache keys
-                # to delete.
-                projectconfig_cache.delete_many([public_key])
-                return
-        else:
-            assert False
-
-        if generate:
-            config_cache = {}
-            for key in keys:
-                if key.status != ProjectKeyStatus.ACTIVE:
-                    project_config = {"disabled": True}
-                else:
-                    project_config = get_project_config(
-                        key.project, project_keys=[key], full_config=True
-                    ).to_dict()
-                config_cache[key.public_key] = project_config
-
-            projectconfig_cache.set_many(config_cache)
-        else:
-            cache_keys_to_delete = []
-            for key in keys:
-                cache_keys_to_delete.append(key.public_key)
-
-            projectconfig_cache.delete_many(cache_keys_to_delete)
-
-    finally:
-        # Delete the key in this `finally` block to make sure the debouncing key
-        # is always deleted. Deleting the key at the end of the task also makes
-        # debouncing more effective.
-        projectconfig_debounce_cache.mark_task_done(
-            organization_id=organization_id, project_id=project_id, public_key=public_key
-        )
-
-
-# DEPRECATED SCHEDULER, use schedule_build_project_config or schedule_invalidate_project_config instead.
-def schedule_update_config_cache(
-    generate, project_id=None, organization_id=None, public_key=None, update_reason=None
-):
-    """
-    Schedule the `update_config_cache` with debouncing applied.
-
-    See documentation of `update_config_cache` for documentation of parameters.
-    """
-
-    if (
-        settings.SENTRY_RELAY_PROJECTCONFIG_CACHE
-        == "sentry.relay.projectconfig_cache.base.ProjectConfigCache"
-    ):
-        # This cache backend is a noop, don't bother creating a noop celery
-        # task.
-        metrics.incr(
-            "relay.projectconfig_cache.skipped",
-            tags={"reason": "noop_backend", "update_reason": update_reason},
-        )
-        return
-
-    validate_args(organization_id, project_id, public_key)
-
-    if projectconfig_debounce_cache.is_debounced(
-        public_key=public_key, project_id=project_id, organization_id=organization_id
-    ):
-        metrics.incr(
-            "relay.projectconfig_cache.skipped",
-            tags={"reason": "debounce", "update_reason": update_reason},
-        )
-        # If this task is already in the queue, do not schedule another task.
-        return
-
-    # XXX(markus): We could schedule this task a couple seconds into the
-    # future, this would make debouncing more effective. If we want to do this
-    # we might want to use the sleep queue.
-    metrics.incr(
-        "relay.projectconfig_cache.scheduled",
-        tags={"generate": generate, "update_reason": update_reason},
-    )
-    update_config_cache.delay(
-        generate=generate,
-        project_id=project_id,
-        organization_id=organization_id,
-        public_key=public_key,
-        update_reason=update_reason,
-    )
-
-    # Checking if the project is debounced and debouncing it are two separate
-    # actions that aren't atomic. If the process marks a project as debounced
-    # and dies before scheduling it, the cache will be stale for the whole TTL.
-    # To avoid that, make sure we first schedule the task, and only then mark
-    # the project as debounced.
-    projectconfig_debounce_cache.debounce(
-        public_key=public_key, project_id=project_id, organization_id=organization_id
-    )
 
 
 # Some projects have in the order of 150k ProjectKey entries.  We should compute these in
@@ -187,14 +34,11 @@ def build_project_config(public_key=None, **kwargs):
 
     Do not invoke this task directly, instead use :func:`schedule_build_project_config`.
     """
-
     try:
-        validate_args(public_key=public_key)
+        from sentry.models import ProjectKey
 
         sentry_sdk.set_tag("public_key", public_key)
         sentry_sdk.set_context("kwargs", kwargs)
-
-        from sentry.models import ProjectKey
 
         try:
             key = ProjectKey.objects.get(public_key=public_key)
@@ -216,14 +60,11 @@ def build_project_config(public_key=None, **kwargs):
         )
 
 
-def schedule_build_project_config(public_key=None):
+def schedule_build_project_config(public_key):
     """Schedule the `build_project_config` with debouncing applied.
 
     See documentation of `build_project_config` for documentation of parameters.
     """
-
-    validate_args(public_key=public_key)
-
     if projectconfig_debounce_cache.is_debounced(
         public_key=public_key, project_id=None, organization_id=None
     ):
@@ -336,8 +177,8 @@ def invalidate_project_config(
 ):
     """Task which re-computes an invalidated project config.
 
-    This task can be scheduled regardless of whether the :func:`update_config_cache` task is
-    scheduled as well.  It is designed to make sure a new project config is computed if
+    This task can be scheduled regardless of whether the :func:`build_project_config` task
+    is scheduled as well.  It is designed to make sure a new project config is computed if
     scheduled on an invalidation trigger.  Use :func:`schedule_invalidation_task` to
     schedule this task as that will take care of the queueing semantics.
 
@@ -347,7 +188,7 @@ def invalidate_project_config(
     already existed.
 
     The current implementation has some limitations:
-    - The task does not synchronise with the :func:`update_config_cache`.
+    - The task does not synchronise with the :func:`build_project_config`.
     - The task does not synchronise with more recent invocations of itself.
 
     Both these mean that an outdated version of the project config could still end up in the

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -100,8 +100,6 @@ SAMPLED_TASKS = {
     "sentry.tasks.reprocessing2.handle_remaining_events": settings.SENTRY_REPROCESSING_APM_SAMPLING,
     "sentry.tasks.reprocessing2.reprocess_group": settings.SENTRY_REPROCESSING_APM_SAMPLING,
     "sentry.tasks.reprocessing2.finish_reprocessing": settings.SENTRY_REPROCESSING_APM_SAMPLING,
-    # `update_config_cache` is deprecated, leave this sampling until it's removed
-    "sentry.tasks.relay.update_config_cache": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
     "sentry.tasks.relay.build_project_config": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
     "sentry.tasks.relay.invalidate_project_config": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
     "sentry.tasks.reports.prepare_organization_report": 0.1,

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -7,7 +7,7 @@ from sentry_relay.auth import generate_key_pair
 
 from sentry.models.relay import Relay
 from sentry.relay.config import ProjectConfig
-from sentry.tasks.relay import update_config_cache
+from sentry.tasks.relay import build_project_config
 from sentry.utils import json
 
 
@@ -163,7 +163,7 @@ def test_enqueue_task_if_config_not_cached_not_queued(
     assert schedule_mock.call_count == 1
 
 
-@patch("sentry.tasks.relay.update_config_cache.delay")
+@patch("sentry.tasks.relay.build_project_config.delay")
 @pytest.mark.django_db
 def test_debounce_task_if_proj_config_not_cached_already_enqueued(
     task_mock,
@@ -184,10 +184,7 @@ def test_task_writes_config_into_cache(
     default_projectkey,
     project_config_get_mock,
 ):
-    update_config_cache(
-        generate=True,
-        organization_id=None,
-        project_id=None,
+    build_project_config(
         public_key=default_projectkey.public_key,
         update_reason="test",
     )

--- a/tests/sentry/relay/test_projectconfig_debounce_cache.py
+++ b/tests/sentry/relay/test_projectconfig_debounce_cache.py
@@ -10,7 +10,8 @@ def test_key_lifecycle():
         "organization_id": None,
     }
 
-    assert not cache.check_is_debounced(**kwargs)
+    assert not cache.is_debounced(**kwargs)
+    cache.debounced(**kwargs)
 
     assert cache.is_debounced(**kwargs)
 

--- a/tests/sentry/relay/test_projectconfig_debounce_cache.py
+++ b/tests/sentry/relay/test_projectconfig_debounce_cache.py
@@ -11,7 +11,7 @@ def test_key_lifecycle():
     }
 
     assert not cache.is_debounced(**kwargs)
-    cache.debounced(**kwargs)
+    cache.debounce(**kwargs)
 
     assert cache.is_debounced(**kwargs)
 

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -32,7 +32,7 @@ def _cache_keys_for_org(org):
 @pytest.fixture
 def emulate_transactions(burst_task_runner, django_capture_on_commit_callbacks):
     # This contraption helps in testing the usage of `transaction.on_commit` in
-    # schedule_update_config_cache. Normally tests involving transactions would
+    # schedule_build_project_config. Normally tests involving transactions would
     # require us to use the transactional testcase (or
     # `pytest.mark.django_db(transaction=True)`), but that incurs a 2x slowdown
     # in test speed and we're trying to keep our testcases fast.
@@ -44,7 +44,7 @@ def emulate_transactions(burst_task_runner, django_capture_on_commit_callbacks):
 
                 # Assert there are no relay-related jobs in the queue yet, as we should have
                 # some on_commit callbacks instead. If we don't, then the model
-                # hook has scheduled the update_config_cache task prematurely.
+                # hook has scheduled the build_project_config task prematurely.
                 #
                 # Remove any other jobs from the queue that may have been triggered via model hooks
                 assert not any("relay" in task.__name__ for task, _, _ in burst.queue)
@@ -94,10 +94,6 @@ def debounce_cache(monkeypatch):
     monkeypatch.setattr(
         "sentry.relay.projectconfig_debounce_cache.mark_task_done",
         debounce_cache.mark_task_done,
-    )
-    monkeypatch.setattr(
-        "sentry.relay.projectconfig_debounce_cache.check_is_debounced",
-        debounce_cache.check_is_debounced,
     )
     monkeypatch.setattr(
         "sentry.relay.projectconfig_debounce_cache.debounce",
@@ -301,10 +297,6 @@ class TestInvalidationTask:
         monkeypatch.setattr(
             "sentry.relay.projectconfig_debounce_cache.invalidation.mark_task_done",
             debounce_cache.mark_task_done,
-        )
-        monkeypatch.setattr(
-            "sentry.relay.projectconfig_debounce_cache.invalidation.check_is_debounced",
-            debounce_cache.check_is_debounced,
         )
         monkeypatch.setattr(
             "sentry.relay.projectconfig_debounce_cache.invalidation.debounce",


### PR DESCRIPTION
This removes the deprecated task now that it is no longer being
scheduled anywhere.

It also deletes an unused method in the debounce cache.

INGEST-1381
INGEST-1234

This is kind of important because it removes the double-using of the same debounce cache by two tasks.  However I could not find a way this would have gone wrong in reality since the way these were still being triggered meant both tasks were using non-conflicting debounce keys anyway.  But better not to share the same keys eh.