### PR TITLE
feat(issue-alerts): adds experiment for default alert rule action

### DIFF
--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -25,6 +25,12 @@ export const experimentList = [
     parameter: 'exposed',
     assignments: [0, 1],
   },
+  {
+    key: 'DefaultIssueAlertActionExperiment',
+    type: ExperimentType.Organization,
+    parameter: 'exposed',
+    assignments: [0, 1],
+  },
 ] as const;
 
 export const experimentConfig = experimentList.reduce(

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -82,6 +82,11 @@ type FirstPartyIntegrationAdditionalCTAProps = {
 
 type GuideUpdateCallback = (nextGuide: Guide | null, opts: {dismissed?: boolean}) => void;
 
+type DefaultAlertRuleActionHook = (
+  callback: (showDefaultAction: boolean) => void,
+  organization: Organization
+) => void;
+
 type CodeOwnersCTAProps = {
   organization: Organization;
   project: Project;
@@ -214,6 +219,7 @@ export type SettingsHooks = {
  * and perform some sort of callback logic
  */
 type CallbackHooks = {
+  'callback:default-action-alert-rule': DefaultAlertRuleActionHook;
   'callback:on-guide-update': GuideUpdateCallback;
 };
 

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -165,12 +165,13 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   componentDidMount() {
     const {params, organization, experimentAssignment, logExperiment} = this.props;
     if (!params.ruleId) {
-      // let hook decide when we want to select a default alert ruel
+      // let hook decide when we want to select a default alert rule
       HookStore.get('callback:default-action-alert-rule').forEach(cb => {
-        cb(showDefaultAction => {
+        cb((showDefaultAction: boolean) => {
           if (showDefaultAction) {
             const user = ConfigStore.get('user');
             const {rule} = this.state;
+            // always log the experiment if we meet the basic requirements decided by the hook
             logExperiment();
             if (experimentAssignment) {
               // this will add a default alert rule action


### PR DESCRIPTION
This PR adds an experiment to show a default alert rule action for issue alerts for orgs with 5 or fewer members. The default action is just sending a notification to the user who is making the alert. This experiment is going to be coupled with another change which will change the default notification settings to have Slack enabled by default. The goal is to see if having a default action will lead to better engagement, especially with Slack since users may not even realize such an alert rule action actually will go to their Slack if they have it set up. If this experiment goes well, we could potentially add a default value action for larger orgs as well.

I am adding a new `callback:default-action-alert-rule` to allow getsentry to decide whether an organization meets the requirements of testing out the default action for. This is because the subscription object has the number of members while the organization object does not.

<img width="1049" alt="Screen Shot 2022-06-20 at 1 32 44 PM" src="https://user-images.githubusercontent.com/8533851/174653543-f5702f7c-7eb0-489c-844e-eb2973e4a5d5.png">


