### PR TITLE
feat(api): Kill no longer used crossdomain.xml code

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -4,11 +4,8 @@ from django.views.generic.base import View as BaseView
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.models import Project
 from sentry.utils import json
-from sentry.utils.http import get_origins
 from sentry.web.client_config import get_client_config
-from sentry.web.helpers import render_to_response
 
 
 class ClientConfigView(BaseView):
@@ -19,20 +16,3 @@ class ClientConfigView(BaseView):
 @cache_control(max_age=3600, public=True)
 def robots_txt(request):
     return HttpResponse("User-agent: *\nDisallow: /\n", content_type="text/plain")
-
-
-@cache_control(max_age=60)
-def crossdomain_xml(request, project_id):
-    if not project_id.isdigit():
-        return HttpResponse(status=404)
-
-    try:
-        project = Project.objects.get_from_cache(id=project_id)
-    except Project.DoesNotExist:
-        return HttpResponse(status=404)
-
-    origin_list = get_origins(project)
-    response = render_to_response("sentry/crossdomain.xml", {"origin_list": origin_list})
-    response["Content-Type"] = "application/xml"
-
-    return response

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -89,11 +89,6 @@ if settings.DEBUG:
     ]
 
 urlpatterns += [
-    url(
-        r"^api/(?P<project_id>[\w_-]+)/crossdomain\.xml$",
-        api.crossdomain_xml,
-        name="sentry-api-crossdomain-xml",
-    ),
     # Frontend client config
     url(r"^api/client-config/?$", api.ClientConfigView.as_view(), name="sentry-api-client-config"),
     # We do not want to have webpack assets served under a versioned URL, as these assets have
@@ -612,8 +607,6 @@ urlpatterns += [
     # since this gets stored in session as the last viewed page.
     # See: https://github.com/getsentry/sentry/issues/2195
     url(r"favicon\.ico$", lambda r: HttpResponse(status=404)),
-    # crossdomain.xml
-    url(r"^crossdomain\.xml$", lambda r: HttpResponse(status=404)),
     # plugins
     # XXX(dcramer): preferably we'd be able to use 'integrations' as the URL
     # prefix here, but unfortunately sentry.io has that mapped to marketing


### PR DESCRIPTION
This removes the `crossdomain.xml` code from Sentry. It's doubtful that anyone still uses this after a 404 was introduced at an earlier point that shadowed it.

```
$ curl -i https://sentry.io/crossdomain.xml
HTTP/1.1 404 Not Found
Server: nginx
Date: Mon, 20 Jun 2022 18:21:36 GMT
```

Likewise relay has no clue about crossdomain.xml so it won't be possible to send an event in anyways at this point.