### PR TITLE
feat(discover): adds the deprecated decorator to eventsv2

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -55,7 +55,10 @@ API_TOKEN_REFERRER = "api.auth-token.events"
 class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
     """Deprecated in favour of OrganizationEventsEndpoint"""
 
-    @deprecated(datetime.fromisoformat("2022-07-21T00:00:00+00:00:00"), suggested_api="events")
+    @deprecated(
+        datetime.fromisoformat("2022-07-21T00:00:00+00:00:00"),
+        suggested_api="api/0/organizations/{organization_slug}/events/",
+    )
     def get(self, request: Request, organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 import sentry_sdk
 from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
@@ -8,6 +9,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import InvalidParams
 from sentry.apidocs import constants as api_constants
@@ -53,6 +55,7 @@ API_TOKEN_REFERRER = "api.auth-token.events"
 class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
     """Deprecated in favour of OrganizationEventsEndpoint"""
 
+    @deprecated(datetime.fromisoformat("2022-07-21T00:00:00+00:00:00"), suggested_api="events")
     def get(self, request: Request, organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)


### PR DESCRIPTION
Adds the deprecated decorator to eventsv2, using the default brownout of **Once a day at noon UTC for 1 minute**.

2 open questions:
- Waiting for an answer on what timezone the deprecation should officially start at, but the exact time might not matter that much since the default brownout always occurs on UTC 12pm.
- Using `events` as the suggested api. Is this enough detail? 