### PR TITLE
feat(discover): Add count_web_vitals field to Query Builder

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -130,6 +130,49 @@ const CONDITIONS_ARGUMENTS: SelectValue<string>[] = [
   },
 ];
 
+const WEB_VITALS_QUALITY: SelectValue<string>[] = [
+  {
+    label: 'good',
+    value: 'good',
+  },
+  {
+    label: 'meh',
+    value: 'meh',
+  },
+  {
+    label: 'poor',
+    value: 'poor',
+  },
+  {
+    label: 'any',
+    value: 'any',
+  },
+];
+
+export enum WebVital {
+  FP = 'measurements.fp',
+  FCP = 'measurements.fcp',
+  LCP = 'measurements.lcp',
+  FID = 'measurements.fid',
+  CLS = 'measurements.cls',
+  TTFB = 'measurements.ttfb',
+  RequestTime = 'measurements.ttfb.requesttime',
+}
+
+export enum MobileVital {
+  AppStartCold = 'measurements.app_start_cold',
+  AppStartWarm = 'measurements.app_start_warm',
+  FramesTotal = 'measurements.frames_total',
+  FramesSlow = 'measurements.frames_slow',
+  FramesFrozen = 'measurements.frames_frozen',
+  FramesSlowRate = 'measurements.frames_slow_rate',
+  FramesFrozenRate = 'measurements.frames_frozen_rate',
+  StallCount = 'measurements.stall_count',
+  StallTotalTime = 'measurements.stall_total_time',
+  StallLongestTime = 'measurements.stall_longest_time',
+  StallPercentage = 'measurements.stall_percentage',
+}
+
 // Refer to src/sentry/search/events/fields.py
 // Try to keep functions logically sorted, ie. all the count functions are grouped together
 export const AGGREGATIONS = {
@@ -208,6 +251,33 @@ export const AGGREGATIONS = {
       },
     ],
     documentation: t('conditional number of events'),
+    outputType: 'number',
+    isSortable: true,
+    multiPlotType: 'area',
+  },
+  count_web_vitals: {
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: validateAllowedColumns([
+          WebVital.LCP,
+          WebVital.FP,
+          WebVital.FCP,
+          WebVital.FID,
+          WebVital.CLS,
+        ]),
+        defaultValue: WebVital.LCP,
+        required: true,
+      },
+      {
+        kind: 'dropdown',
+        options: WEB_VITALS_QUALITY,
+        dataType: 'string',
+        defaultValue: WEB_VITALS_QUALITY[0].value,
+        required: true,
+      },
+    ],
+    documentation: t('web vitals threshold counts'),
     outputType: 'number',
     isSortable: true,
     multiPlotType: 'area',
@@ -692,30 +762,6 @@ export function formatTagKey(key: string): string {
 
 // Allows for a less strict field key definition in cases we are returning custom strings as fields
 export type LooseFieldKey = FieldKey | string | '';
-
-export enum WebVital {
-  FP = 'measurements.fp',
-  FCP = 'measurements.fcp',
-  LCP = 'measurements.lcp',
-  FID = 'measurements.fid',
-  CLS = 'measurements.cls',
-  TTFB = 'measurements.ttfb',
-  RequestTime = 'measurements.ttfb.requesttime',
-}
-
-export enum MobileVital {
-  AppStartCold = 'measurements.app_start_cold',
-  AppStartWarm = 'measurements.app_start_warm',
-  FramesTotal = 'measurements.frames_total',
-  FramesSlow = 'measurements.frames_slow',
-  FramesFrozen = 'measurements.frames_frozen',
-  FramesSlowRate = 'measurements.frames_slow_rate',
-  FramesFrozenRate = 'measurements.frames_frozen_rate',
-  StallCount = 'measurements.stall_count',
-  StallTotalTime = 'measurements.stall_total_time',
-  StallLongestTime = 'measurements.stall_longest_time',
-  StallPercentage = 'measurements.stall_percentage',
-}
 
 export type MeasurementType = 'duration' | 'number' | 'integer' | 'percentage';
 

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -277,7 +277,7 @@ export const AGGREGATIONS = {
         required: true,
       },
     ],
-    documentation: t('web vitals threshold counts'),
+    documentation: t('events matching vital thresholds'),
     outputType: 'number',
     isSortable: true,
     multiPlotType: 'area',


### PR DESCRIPTION
This PR adds a new function field to Discover's query builder: `count_web_vitals()`

![image](https://user-images.githubusercontent.com/16740047/174673260-36c5b7ea-accb-4148-a513-14eff8c3df65.png)
