### PR TITLE
feat(custom-measurements): Add a parse_mri function

### DIFF
--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -19,7 +19,9 @@ metric that is queryable by the API.
 __all__ = ("SessionMRI", "TransactionMRI", "MRI_SCHEMA_REGEX", "MRI_EXPRESSION_REGEX")
 
 import re
+from dataclasses import dataclass
 from enum import Enum
+from typing import Optional
 
 from sentry.snuba.metrics.utils import OP_REGEX
 
@@ -29,8 +31,9 @@ ENTITY_TYPE_REGEX = r"(c|s|d|g|e)"
 # allowed the underscore character, optionally separated by a single dot
 MRI_NAME_REGEX = r"([a-z_]+(?:\.[a-z_]+)*)"
 # ToDo(ahmed): Add a better regex for unit portion for MRI
-MRI_SCHEMA_REGEX = rf"{ENTITY_TYPE_REGEX}:{NAMESPACE_REGEX}/{MRI_NAME_REGEX}@([\w.]*)"
-MRI_EXPRESSION_REGEX = re.compile(rf"^{OP_REGEX}\(({MRI_SCHEMA_REGEX})\)$")
+MRI_SCHEMA_REGEX_STRING = rf"(?P<entity>{ENTITY_TYPE_REGEX}):(?P<namespace>{NAMESPACE_REGEX})/(?P<name>{MRI_NAME_REGEX})@(?P<unit>[\w.]*)"
+MRI_SCHEMA_REGEX = re.compile(MRI_SCHEMA_REGEX_STRING)
+MRI_EXPRESSION_REGEX = re.compile(rf"^{OP_REGEX}\(({MRI_SCHEMA_REGEX_STRING})\)$")
 
 
 class SessionMRI(Enum):
@@ -101,3 +104,20 @@ class TransactionMRI(Enum):
     MISERABLE_USER = "e:transactions/user.miserable@none"
     ALL_USER = "e:transactions/user.all@none"
     USER_MISERY = "e:transactions/user_misery@ratio"
+
+
+@dataclass
+class ParsedMRI:
+    entity: str
+    namespace: str
+    name: str
+    unit: str
+
+
+def parse_mri(mri_string: str) -> Optional[ParsedMRI]:
+    """Parse a mri string to determine its entity, namespace, name and unit"""
+    match = MRI_SCHEMA_REGEX.match(mri_string)
+    if match is None:
+        return None
+
+    return ParsedMRI(**match.groupdict())

--- a/tests/sentry/snuba/metrics/test_naming_layer.py
+++ b/tests/sentry/snuba/metrics/test_naming_layer.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from sentry.snuba.metrics.naming_layer.mri import MRI_SCHEMA_REGEX
+from sentry.snuba.metrics.naming_layer.mri import MRI_SCHEMA_REGEX, ParsedMRI, parse_mri
 from sentry.snuba.metrics.naming_layer.public import PUBLIC_NAME_REGEX
 
 
@@ -62,7 +62,7 @@ def test_invalid_public_name_regex(name):
     ],
 )
 def test_valid_mri_schema_regex(name):
-    matches = re.compile(rf"^{MRI_SCHEMA_REGEX}$").match(name)
+    matches = MRI_SCHEMA_REGEX.match(name)
     assert matches
     assert matches[0] == name
 
@@ -82,4 +82,29 @@ def test_valid_mri_schema_regex(name):
     ],
 )
 def test_invalid_mri_schema_regex(name):
-    assert re.compile(rf"^{MRI_SCHEMA_REGEX}$").match(name) is None
+    assert MRI_SCHEMA_REGEX.match(name) is None
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        (
+            "d:transactions/measurements.stall_longest_time@millisecond",
+            ParsedMRI("d", "transactions", "measurements.stall_longest_time", "millisecond"),
+        ),
+        (
+            "d:transactions/breakdowns.span_ops.http@millisecond",
+            ParsedMRI("d", "transactions", "breakdowns.span_ops.http", "millisecond"),
+        ),
+        (
+            "c:transactions/measurements.db_calls@none",
+            ParsedMRI("c", "transactions", "measurements.db_calls", "none"),
+        ),
+        (
+            "s:sessions/error@none",
+            ParsedMRI("s", "sessions", "error", "none"),
+        ),
+    ],
+)
+def test_parse_mri(name, expected):
+    assert parse_mri(name) == expected


### PR DESCRIPTION
- This adds a function that given a MRI will parse out the pieces for use in other functions (like getting a custom measurement from the indexer and knowing which entity&unit corresponds with it)
- This changes MRI_SCHEMA_REGEX to have named regex groups, so that its really easy to pass to the ParsedMRI dataclass
  - Changed the existing variable to a string so the regex can be compiled ahead of time
- @ahmedetefy can MRIs contain casing inconsistencies? Should I `.lower()` the pieces? Or are they known consistent casing?