### PR TITLE
feat(sampling): Remove error message sampling from UI [TET-150]

### DIFF
--- a/static/app/types/sampling.tsx
+++ b/static/app/types/sampling.tsx
@@ -72,7 +72,6 @@ export enum SamplingInnerName {
   // Custom operators
   EVENT_IP_ADDRESSES = 'event.client_ip',
   EVENT_LEGACY_BROWSER = 'event.legacy_browser',
-  EVENT_ERROR_MESSAGES = 'event.error_messages',
   EVENT_CSP = 'event.csp',
   EVENT_CUSTOM_TAG = 'event.custom_tag', // used for the fresh new custom tag condition (gets replaced once you choose tag key)
 }
@@ -129,10 +128,7 @@ type SamplingConditionLogicalInnerEqBoolean = {
 };
 
 type SamplingConditionLogicalInnerCustom = {
-  name:
-    | SamplingInnerName.EVENT_CSP
-    | SamplingInnerName.EVENT_ERROR_MESSAGES
-    | SamplingInnerName.EVENT_IP_ADDRESSES;
+  name: SamplingInnerName.EVENT_CSP | SamplingInnerName.EVENT_IP_ADDRESSES;
   op: SamplingInnerOperator.CUSTOM;
   value: Array<string>;
 };

--- a/static/app/views/settings/project/sampling/modal/utils.tsx
+++ b/static/app/views/settings/project/sampling/modal/utils.tsx
@@ -70,8 +70,6 @@ export function getMatchFieldPlaceholder(category: SamplingInnerName | string) {
       return t('ex. 127.0.0.1 or 10.0.0.0/8 (Multiline)');
     case SamplingInnerName.EVENT_CSP:
       return t('ex. file://*, example.com (Multiline)');
-    case SamplingInnerName.EVENT_ERROR_MESSAGES:
-      return t('ex. TypeError* (Multiline)');
     case SamplingInnerName.TRACE_TRANSACTION:
     case SamplingInnerName.EVENT_TRANSACTION:
       return t('ex. page-load');
@@ -118,7 +116,6 @@ export function getNewCondition(condition: Condition): SamplingConditionLogicalI
 
   if (
     condition.category === SamplingInnerName.EVENT_IP_ADDRESSES ||
-    condition.category === SamplingInnerName.EVENT_ERROR_MESSAGES ||
     condition.category === SamplingInnerName.EVENT_CSP
   ) {
     return {
@@ -272,7 +269,6 @@ export const individualTransactionsConditions = [
   SamplingInnerName.EVENT_WEB_CRAWLERS,
   SamplingInnerName.EVENT_IP_ADDRESSES,
   SamplingInnerName.EVENT_CSP,
-  SamplingInnerName.EVENT_ERROR_MESSAGES,
   SamplingInnerName.EVENT_TRANSACTION,
   SamplingInnerName.EVENT_OS_NAME,
   SamplingInnerName.EVENT_OS_VERSION,

--- a/static/app/views/settings/project/sampling/utils.tsx
+++ b/static/app/views/settings/project/sampling/utils.tsx
@@ -65,8 +65,6 @@ export function getInnerNameLabel(name: SamplingInnerName | string) {
     case SamplingInnerName.EVENT_TRANSACTION:
     case SamplingInnerName.TRACE_TRANSACTION:
       return t('Transaction');
-    case SamplingInnerName.EVENT_ERROR_MESSAGES:
-      return t('Error Message');
     case SamplingInnerName.EVENT_CSP:
       return t('Content Security Policy');
     case SamplingInnerName.EVENT_IP_ADDRESSES:


### PR DESCRIPTION
Error message sampling works for errors only and since we are for now enabling DS for transactions only, we are removing it from the UI.