### PR TITLE
ref: replace usage of LooseVersion in sdk_updates

### DIFF
--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -1,8 +1,8 @@
 import logging
-from distutils.version import LooseVersion
 
 from django.conf import settings
 from django.core.cache import cache
+from packaging.version import Version
 
 from sentry.tasks.release_registry import SDK_INDEX_CACHE_KEY
 from sentry.utils.safe import get_path
@@ -101,7 +101,7 @@ class UpdateSDKSuggestion(Suggestion):
             new_sdk_version = ".".join(v for v in new_sdk_version.split(".")[:2])
 
         try:
-            has_newer_version = LooseVersion(old_state.sdk_version) < LooseVersion(new_sdk_version)
+            has_newer_version = Version(old_state.sdk_version) < Version(new_sdk_version)
         except Exception:
             has_newer_version = False
 
@@ -385,15 +385,13 @@ def _get_suggested_updates_step(setup_state, index_state, ignore_patch_version):
             continue
 
         try:
-            if LooseVersion(support_info["sdk_version_added"]) > LooseVersion(
-                setup_state.sdk_version
-            ):
+            if Version(support_info["sdk_version_added"]) > Version(setup_state.sdk_version):
                 continue
         except Exception:
             continue
 
         try:
-            if LooseVersion(support_info["module_version_min"]) > LooseVersion(
+            if Version(support_info["module_version_min"]) > Version(
                 setup_state.modules[support_info["module_name"]]
             ):
                 # TODO(markus): Maybe we want to suggest people to upgrade their module?


### PR DESCRIPTION
latest setuptools produces some failures here when constructing `LooseVersion`:

```console
$ pip install --upgrade setuptools
$ pytest $(git grep -l sdk_up -- tests | grep py$)
/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/django/utils/version.py:98: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  loose_version = LooseVersion(version)
====================================== test session starts =======================================
platform darwin -- Python 3.8.13, pytest-6.1.0, py-1.11.0, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: rerunfailures-9.1.1, cov-2.11.1, sentry-0.1.9, django-4.4.0
collected 46 items                                                                               

tests/sentry/api/endpoints/test_organization_sdk_updates.py ....FF                         [ 13%]
tests/sentry/api/serializers/test_event.py ...............FF                               [ 50%]
tests/sentry/test_sdk_updates.py .F..FFFF.FF.FFF....F.FF                                   [100%]

============================================ FAILURES ============================================
_______________________________ OrganizationSdkUpdates.test_simple _______________________________
tests/sentry/api/endpoints/test_organization_sdk_updates.py:45: in test_simple
    assert len(update_suggestions) == 1
E   AssertionError: assert 0 == 1
E    +  where 0 = len([])
__________________________ OrganizationSdkUpdates.test_unknown_version ___________________________
tests/sentry/api/endpoints/test_organization_sdk_updates.py:192: in test_unknown_version
    (warning,) = warninfo
E   ValueError: too many values to unpack (expected 1)
_______________________ EventSerializerSdkUpdatesTest.test_update_on_major _______________________
tests/sentry/api/serializers/test_event.py:314: in test_update_on_major
    assert result["sdkUpdates"] == [
E   AssertionError: assert [] == [{'enables': ...': None, ...}]
E     Right contains one more item: {'enables': [], 'newSdkVersion': '2.0.0', 'sdkName': 'example.sdk', 'sdkUrl': None, ...}
E     Use -v to get the full diff
_______________________ EventSerializerSdkUpdatesTest.test_update_on_minor _______________________
tests/sentry/api/serializers/test_event.py:343: in test_update_on_minor
    assert result["sdkUpdates"] == [
E   AssertionError: assert [] == [{'enables': ...': None, ...}]
E     Right contains one more item: {'enables': [], 'newSdkVersion': '1.1.0', 'sdkName': 'example.sdk', 'sdkUrl': None, ...}
E     Use -v to get the full diff
________________________________________ test_too_old_sdk ________________________________________
tests/sentry/test_sdk_updates.py:21: in test_too_old_sdk
    assert list(get_suggested_updates(setup, PYTHON_INDEX_STATE)) == [
E   AssertionError: assert [] == [{'enables': ...': None, ...}]
E     Right contains one more item: {'enables': [{'enables': [], 'integrationName': 'django', 'integrationUrl': 'https://docs.sentry.io/platforms/python/django/', 'type': 'enableIntegration'}], 'newSdkVersion': '0.9.1', 'sdkName': 'sentry.python', 'sdkUrl': None, ...}
E     Use -v to get the full diff
_________________________________ test_enable_django_integration _________________________________
tests/sentry/test_sdk_updates.py:59: in test_enable_django_integration
    assert list(get_suggested_updates(setup, PYTHON_INDEX_STATE)) == [
E   AssertionError: assert [] == [{'enables': ...Integration'}]
E     Right contains one more item: {'enables': [], 'integrationName': 'django', 'integrationUrl': 'https://docs.sentry.io/platforms/python/django/', 'type': 'enableIntegration'}
E     Use -v to get the full diff
________________________________________ test_update_sdk _________________________________________
tests/sentry/test_sdk_updates.py:73: in test_update_sdk
    assert list(get_suggested_updates(setup, PYTHON_INDEX_STATE)) == [
E   AssertionError: assert [] == [{'enables': ...': None, ...}]
E     Right contains one more item: {'enables': [], 'newSdkVersion': '0.9.1', 'sdkName': 'sentry.python', 'sdkUrl': None, ...}
E     Use -v to get the full diff
__________________________________ test_enable_two_integrations __________________________________
tests/sentry/test_sdk_updates.py:92: in test_enable_two_integrations
    assert list(get_suggested_updates(setup, PYTHON_INDEX_STATE)) == [
E   AssertionError: assert [] == [{'enables': ...': None, ...}]
E     Right contains one more item: {'enables': [{'enables': [], 'integrationName': 'django', 'integrationUrl': 'https://docs.sentry.io/platforms/python/d...thon/flask/', 'type': 'enableIntegration'}], 'newSdkVersion': '0.9.1', 'sdkName': 'sentry.python', 'sdkUrl': None, ...}
E     Use -v to get the full diff
_________________________ test_add_aspnetcore_sdk[sentry.dotnet.serilog] _________________________
tests/sentry/test_sdk_updates.py:145: in test_add_aspnetcore_sdk
    assert suggestions == [
E   AssertionError: assert [] == [{'enables': ... 'changeSdk'}]
E     Right contains one more item: {'enables': [], 'newSdkName': 'sentry.dotnet.aspnetcore', 'sdkUrl': None, 'type': 'changeSdk'}
E     Use -v to get the full diff
_________________________ test_add_aspnetcore_sdk[sentry.dotnet.foobar] __________________________
tests/sentry/test_sdk_updates.py:145: in test_add_aspnetcore_sdk
    assert suggestions == [
E   AssertionError: assert [] == [{'enables': ... 'changeSdk'}]
E     Right contains one more item: {'enables': [], 'newSdkName': 'sentry.dotnet.aspnetcore', 'sdkUrl': None, 'type': 'changeSdk'}
E     Use -v to get the full diff
_____________________________ test_add_aspnetcore_sdk[sentry.dotnet] _____________________________
tests/sentry/test_sdk_updates.py:145: in test_add_aspnetcore_sdk
    assert suggestions == [
E   AssertionError: assert [] == [{'enables': ... 'changeSdk'}]
E     Right contains one more item: {'enables': [], 'newSdkName': 'sentry.dotnet.aspnetcore', 'sdkUrl': None, 'type': 'changeSdk'}
E     Use -v to get the full diff
_________________________ test_add_serilog_sdk[sentry.dotnet.aspnetcore] _________________________
tests/sentry/test_sdk_updates.py:167: in test_add_serilog_sdk
    assert suggestions == [
E   AssertionError: assert [] == [{'enables': ... 'changeSdk'}]
E     Right contains one more item: {'enables': [], 'newSdkName': 'sentry.dotnet.serilog', 'sdkUrl': None, 'type': 'changeSdk'}
E     Use -v to get the full diff
___________________________ test_add_serilog_sdk[sentry.dotnet.foobar] ___________________________
tests/sentry/test_sdk_updates.py:167: in test_add_serilog_sdk
    assert suggestions == [
E   AssertionError: assert [] == [{'enables': ... 'changeSdk'}]
E     Right contains one more item: {'enables': [], 'newSdkName': 'sentry.dotnet.serilog', 'sdkUrl': None, 'type': 'changeSdk'}
E     Use -v to get the full diff
______________________________ test_add_serilog_sdk[sentry.dotnet] _______________________________
tests/sentry/test_sdk_updates.py:167: in test_add_serilog_sdk
    assert suggestions == [
E   AssertionError: assert [] == [{'enables': ... 'changeSdk'}]
E     Right contains one more item: {'enables': [], 'newSdkName': 'sentry.dotnet.serilog', 'sdkUrl': None, 'type': 'changeSdk'}
E     Use -v to get the full diff
______________________ test_more_specific_dotnet_sdk[sentry.dotnet.serilog] ______________________
tests/sentry/test_sdk_updates.py:212: in test_more_specific_dotnet_sdk
    assert suggestions == [
E   AssertionError: assert [] == [{'enables': ... 'changeSdk'}]
E     Right contains one more item: {'enables': [], 'newSdkName': 'sentry.dotnet.aspnetcore', 'sdkUrl': None, 'type': 'changeSdk'}
E     Use -v to get the full diff
______________________ test_more_specific_dotnet_sdk[sentry.dotnet.foobar] _______________________
tests/sentry/test_sdk_updates.py:212: in test_more_specific_dotnet_sdk
    assert suggestions == [
E   AssertionError: assert [] == [{'enables': ... 'changeSdk'}]
E     Right contains one more item: {'enables': [], 'newSdkName': 'sentry.dotnet.aspnetcore', 'sdkUrl': None, 'type': 'changeSdk'}
E     Use -v to get the full diff
__________________________ test_more_specific_dotnet_sdk[sentry.dotnet] __________________________
tests/sentry/test_sdk_updates.py:212: in test_more_specific_dotnet_sdk
    assert suggestions == [
E   AssertionError: assert [] == [{'enables': ... 'changeSdk'}]
E     Right contains one more item: {'enables': [], 'newSdkName': 'sentry.dotnet.aspnetcore', 'sdkUrl': None, 'type': 'changeSdk'}
E     Use -v to get the full diff
==================================== short test summary info =====================================
FAILED tests/sentry/api/endpoints/test_organization_sdk_updates.py::OrganizationSdkUpdates::test_simple
FAILED tests/sentry/api/endpoints/test_organization_sdk_updates.py::OrganizationSdkUpdates::test_unknown_version
FAILED tests/sentry/api/serializers/test_event.py::EventSerializerSdkUpdatesTest::test_update_on_major
FAILED tests/sentry/api/serializers/test_event.py::EventSerializerSdkUpdatesTest::test_update_on_minor
FAILED tests/sentry/test_sdk_updates.py::test_too_old_sdk - AssertionError: assert [] == [{'ena...
FAILED tests/sentry/test_sdk_updates.py::test_enable_django_integration - AssertionError: asser...
FAILED tests/sentry/test_sdk_updates.py::test_update_sdk - AssertionError: assert [] == [{'enab...
FAILED tests/sentry/test_sdk_updates.py::test_enable_two_integrations - AssertionError: assert ...
FAILED tests/sentry/test_sdk_updates.py::test_add_aspnetcore_sdk[sentry.dotnet.serilog] - Asser...
FAILED tests/sentry/test_sdk_updates.py::test_add_aspnetcore_sdk[sentry.dotnet.foobar] - Assert...
FAILED tests/sentry/test_sdk_updates.py::test_add_aspnetcore_sdk[sentry.dotnet] - AssertionErro...
FAILED tests/sentry/test_sdk_updates.py::test_add_serilog_sdk[sentry.dotnet.aspnetcore] - Asser...
FAILED tests/sentry/test_sdk_updates.py::test_add_serilog_sdk[sentry.dotnet.foobar] - Assertion...
FAILED tests/sentry/test_sdk_updates.py::test_add_serilog_sdk[sentry.dotnet] - AssertionError: ...
FAILED tests/sentry/test_sdk_updates.py::test_more_specific_dotnet_sdk[sentry.dotnet.serilog]
FAILED tests/sentry/test_sdk_updates.py::test_more_specific_dotnet_sdk[sentry.dotnet.foobar] - ...
FAILED tests/sentry/test_sdk_updates.py::test_more_specific_dotnet_sdk[sentry.dotnet] - Asserti...
================================= 17 failed, 29 passed in 10.17s =================================
%4|1655818421.745|TERMINATE|rdkafka#producer-1| [thrd:app]: Producer terminating with 1 message (183 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
```

after fixing:

```console
$ pytest $(git grep -l sdk_up -- tests | grep py$)
/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/django/utils/version.py:98: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  loose_version = LooseVersion(version)
====================================== test session starts =======================================
platform darwin -- Python 3.8.13, pytest-6.1.0, py-1.11.0, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: rerunfailures-9.1.1, cov-2.11.1, sentry-0.1.9, django-4.4.0
collected 46 items                                                                               

tests/sentry/api/endpoints/test_organization_sdk_updates.py ......                         [ 13%]
tests/sentry/api/serializers/test_event.py .................                               [ 50%]
tests/sentry/test_sdk_updates.py .......................                                   [100%]

====================================== 46 passed in 10.31s =======================================
%4|1655818444.954|TERMINATE|rdkafka#producer-1| [thrd:app]: Producer terminating with 1 message (183 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
```