### PR TITLE
ref: exclude a file from FOSSA to reduce output noise

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -5,3 +5,9 @@ project:
   # in duplicate projects.
 
   id: sentry
+
+# ignore a noisy warning produced by this file, it's a schema not a package.json
+targets:
+  exclude:
+    - type: projectjson
+      path: api-docs/components/schemas


### PR DESCRIPTION
should remove this from the output:

```
Error:  ----------
  An issue occurred
  >>> Relevant errors
    Error
      Error parsing file: /home/runner/work/sentry/sentry/api-docs/components/schemas/project.json.
          Error in $: key "dependencies" not found
      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com/hc/en-us, with a copy of:
        /home/runner/work/sentry/sentry/api-docs/components/schemas/project.json
      Traceback:
        - Parsing JSON file '/home/runner/work/sentry/sentry/api-docs/components/schemas/project.json'
        - Project Analysis: ProjectJsonProjectType
```

now produces:

```
[ INFO] Skipping projectjson project at "/home/runner/work/sentry/sentry/api-docs/components/schemas/": no filters matched
```