### PR TITLE
fix(jira): reorder exceptions for jira plugin

### DIFF
--- a/src/sentry_plugins/jira/plugin.py
+++ b/src/sentry_plugins/jira/plugin.py
@@ -140,15 +140,15 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
         client = self.get_jira_client(group.project)
         try:
             meta = client.get_create_meta_for_project(jira_project_key)
-        except ApiError as e:
-            raise PluginError(
-                f"JIRA responded with an error. We received a status code of {e.code}"
-            )
         except ApiUnauthorized:
             raise PluginError(
                 "JIRA returned: Unauthorized. "
                 "Please check your username, password, "
                 "instance and project in your configuration settings."
+            )
+        except ApiError as e:
+            raise PluginError(
+                f"JIRA responded with an error. We received a status code of {e.code}"
             )
 
         if not meta:


### PR DESCRIPTION
Re-orders the _except_ clauses here. The `ApiUnauthorized` exception is a sub-class of `ApiError`; with the original order, the specific `ApiUnauthorized` exception clause was unreachable.

https://github.com/getsentry/sentry/blob/e415bd311ba456f91840c490835cbaf8eb10fdb7/src/sentry/shared_integrations/exceptions/__init__.py#L52-L53