### PR TITLE
fix(api): correctly assess api token scopes for project update endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -450,9 +450,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         :param int digestsMaxDelay:
         :auth: required
         """
-        has_project_write = (request.auth and request.auth.has_scope("project:write")) or (
-            request.access and request.access.has_scope("project:write")
-        )
+        has_project_write = request.access and request.access.has_scope("project:write")
 
         changed_proj_settings = {}
 

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -233,6 +233,27 @@ class ProjectUpdateTestTokenAuthenticated(APITestCase):
         self.project = self.create_project(platform="javascript")
         self.user = self.create_user("bar@example.com")
 
+    def test_member_can_read_project_details(self):
+        self.create_member(
+            user=self.user,
+            organization=self.project.organization,
+            teams=[self.project.teams.first()],
+            role="member",
+        )
+
+        token = ApiToken.objects.create(user=self.user, scope_list=["project:read"])
+        authorization = f"Bearer {token.token}"
+
+        url = reverse(
+            "sentry-api-0-project-details",
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+            },
+        )
+        response = self.client.get(url, format="json", HTTP_AUTHORIZATION=authorization)
+        assert response.status_code == 200, response.content
+
     def test_member_updates_denied_with_token(self):
         self.create_member(
             user=self.user,

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -2,6 +2,7 @@ from time import time
 from unittest import mock
 
 import pytest
+from django.urls import reverse
 
 from sentry import audit_log
 from sentry.api.endpoints.project_details import (
@@ -10,6 +11,7 @@ from sentry.api.endpoints.project_details import (
 )
 from sentry.constants import RESERVED_PROJECT_SLUGS
 from sentry.models import (
+    ApiToken,
     AuditLogEntry,
     DeletedProject,
     EnvironmentProject,
@@ -220,6 +222,104 @@ class ProjectDetailsTest(APITestCase):
         self.login_as(user=user)
 
         self.get_error_response(other_org.slug, "old_slug", status_code=403)
+
+
+class ProjectUpdateTestTokenAuthenticated(APITestCase):
+    endpoint = "sentry-api-0-project-details"
+    method = "put"
+
+    def setUp(self):
+        super().setUp()
+        self.org_slug = self.project.organization.slug
+        self.proj_slug = self.project.slug
+
+    def test_member_updates_denied_with_token(self):
+        project = self.create_project(platform="javascript")
+        user = self.create_user("bar@example.com")
+        self.create_member(
+            user=user,
+            organization=project.organization,
+            teams=[project.teams.first()],
+            role="member",
+        )
+
+        token = ApiToken.objects.create(user=user, scope_list=["project:write"])
+        authorization = f"Bearer {token.token}"
+
+        data = {"platform": "rust"}
+
+        url = reverse(
+            "sentry-api-0-project-details",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.put(url, format="json", HTTP_AUTHORIZATION=authorization, data=data)
+        assert response.status_code == 403, response.content
+
+    def test_admin_updates_allowed_with_correct_token_scope(self):
+        project = self.create_project(platform="javascript")
+        user = self.create_user("bar@example.com")
+        self.create_member(
+            user=user,
+            organization=project.organization,
+            teams=[project.teams.first()],
+            role="admin",
+        )
+
+        token = ApiToken.objects.create(user=user, scope_list=["project:write"])
+        authorization = f"Bearer {token.token}"
+
+        data = {"platform": "rust"}
+
+        url = reverse(
+            "sentry-api-0-project-details",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.put(url, format="json", HTTP_AUTHORIZATION=authorization, data=data)
+        assert response.status_code == 200, response.content
+
+    def test_admin_updates_denied_with_token(self):
+        project = self.create_project(platform="javascript")
+        user = self.create_user("bar@example.com")
+        self.create_member(
+            user=user,
+            organization=project.organization,
+            teams=[project.teams.first()],
+            role="admin",
+        )
+
+        token = ApiToken.objects.create(user=user, scope_list=["event:read"])
+        authorization = f"Bearer {token.token}"
+
+        data = {"platform": "rust"}
+
+        url = reverse(
+            "sentry-api-0-project-details",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.put(url, format="json", HTTP_AUTHORIZATION=authorization, data=data)
+        assert response.status_code == 403, response.content
+
+    def test_empty_token_scopes_denied(self):
+        project = self.create_project(platform="javascript")
+        user = self.create_user("bar@example.com")
+        self.create_member(
+            user=user,
+            organization=project.organization,
+            teams=[project.teams.first()],
+            role="member",
+        )
+
+        token = ApiToken.objects.create(user=user, scope_list=[""])
+        authorization = f"Bearer {token.token}"
+
+        data = {"platform": "rust"}
+
+        url = reverse(
+            "sentry-api-0-project-details",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.put(url, format="json", HTTP_AUTHORIZATION=authorization, data=data)
+        assert response.status_code == 403, response.content
 
 
 class ProjectUpdateTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -230,93 +230,97 @@ class ProjectUpdateTestTokenAuthenticated(APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.org_slug = self.project.organization.slug
-        self.proj_slug = self.project.slug
+        self.project = self.create_project(platform="javascript")
+        self.user = self.create_user("bar@example.com")
 
     def test_member_updates_denied_with_token(self):
-        project = self.create_project(platform="javascript")
-        user = self.create_user("bar@example.com")
         self.create_member(
-            user=user,
-            organization=project.organization,
-            teams=[project.teams.first()],
+            user=self.user,
+            organization=self.project.organization,
+            teams=[self.project.teams.first()],
             role="member",
         )
 
-        token = ApiToken.objects.create(user=user, scope_list=["project:write"])
+        token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
         authorization = f"Bearer {token.token}"
 
         data = {"platform": "rust"}
 
         url = reverse(
             "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+            },
         )
         response = self.client.put(url, format="json", HTTP_AUTHORIZATION=authorization, data=data)
         assert response.status_code == 403, response.content
 
     def test_admin_updates_allowed_with_correct_token_scope(self):
-        project = self.create_project(platform="javascript")
-        user = self.create_user("bar@example.com")
         self.create_member(
-            user=user,
-            organization=project.organization,
-            teams=[project.teams.first()],
+            user=self.user,
+            organization=self.project.organization,
+            teams=[self.project.teams.first()],
             role="admin",
         )
 
-        token = ApiToken.objects.create(user=user, scope_list=["project:write"])
+        token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
         authorization = f"Bearer {token.token}"
 
         data = {"platform": "rust"}
 
         url = reverse(
             "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+            },
         )
         response = self.client.put(url, format="json", HTTP_AUTHORIZATION=authorization, data=data)
         assert response.status_code == 200, response.content
 
     def test_admin_updates_denied_with_token(self):
-        project = self.create_project(platform="javascript")
-        user = self.create_user("bar@example.com")
         self.create_member(
-            user=user,
-            organization=project.organization,
-            teams=[project.teams.first()],
+            user=self.user,
+            organization=self.project.organization,
+            teams=[self.project.teams.first()],
             role="admin",
         )
 
-        token = ApiToken.objects.create(user=user, scope_list=["event:read"])
+        token = ApiToken.objects.create(user=self.user, scope_list=["event:read"])
         authorization = f"Bearer {token.token}"
 
         data = {"platform": "rust"}
 
         url = reverse(
             "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+            },
         )
         response = self.client.put(url, format="json", HTTP_AUTHORIZATION=authorization, data=data)
         assert response.status_code == 403, response.content
 
     def test_empty_token_scopes_denied(self):
-        project = self.create_project(platform="javascript")
-        user = self.create_user("bar@example.com")
         self.create_member(
-            user=user,
-            organization=project.organization,
-            teams=[project.teams.first()],
+            user=self.user,
+            organization=self.project.organization,
+            teams=[self.project.teams.first()],
             role="member",
         )
 
-        token = ApiToken.objects.create(user=user, scope_list=[""])
+        token = ApiToken.objects.create(user=self.user, scope_list=[""])
         authorization = f"Bearer {token.token}"
 
         data = {"platform": "rust"}
 
         url = reverse(
             "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+            },
         )
         response = self.client.put(url, format="json", HTTP_AUTHORIZATION=authorization, data=data)
         assert response.status_code == 403, response.content

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -308,7 +308,8 @@ class ProjectUpdateTestTokenAuthenticated(APITestCase):
             role="admin",
         )
 
-        token = ApiToken.objects.create(user=self.user, scope_list=["event:read"])
+        # even though the user has the 'admin' role, they've issued a token with only a project:read scope
+        token = ApiToken.objects.create(user=self.user, scope_list=["project:read"])
         authorization = f"Bearer {token.token}"
 
         data = {"platform": "rust"}


### PR DESCRIPTION
See https://github.com/getsentry/sentry/discussions/35424. 

Changes in this PR ensure we are correctly evaluating the assigned scopes of an API token.