### PR TITLE
ref: upgrade check-jsonschema so it does not reach network at runtime

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -43,5 +43,5 @@ jobs:
 
             "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
           skip-stale-pr-message: false
-          close-pr-label:
+          close-pr-label: ""
           close-pr-message: ""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,8 +63,8 @@ repos:
       additional_dependencies: [ "pyright@1.1.186" ]
       args: [ '--project', 'pyrightconfig-commithook.json' ]
 
--   repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.3.0
+-   repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.16.0
     hooks:
     - id: check-github-actions
     - id: check-github-workflows


### PR DESCRIPTION
the latest version of `check-jsonschema` vendors the github actions and workflows schemas rather than reaching out to the network to download them each time -- this should reduce flakiness of this check

I had to update one schema which had the value `close-pr-label: null` which is invalid according to the actions schema

```console
$ pre-commit run check-github-workflows --all-files
Validate GitHub Workflows................................................Passed
$ pre-commit run check-github-actions --all-files
Validate GitHub Actions..................................................Passed
```