### PR TITLE
ref: only run FOSSA on PRs

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -1,8 +1,6 @@
 name: Enforce License Compliance
 
 on:
-  push:
-    branches: [master, main, release/*]
   pull_request:
     branches: [master, main]
 


### PR DESCRIPTION
it really only is helpful for gating pull requests, and often turns master red for flakes


request from @mitsuhiko 