### PR TITLE
feat(workflow): Add button to duplicate alerts from the rule details page

### DIFF
--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -18,7 +18,7 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
 import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {IconEdit} from 'sentry/icons';
+import {IconCopy, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {DateString, Member, Organization, Project} from 'sentry/types';
@@ -255,7 +255,7 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
           </Layout.HeaderContent>
           <Layout.HeaderActions>
             <ButtonBar gap={1}>
-              <Button title={t('Duplicate')} to={duplicateLink}>
+              <Button icon={<IconCopy />} to={duplicateLink}>
                 {t('Duplicate')}
               </Button>
               <Button

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -207,6 +207,16 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
       );
     }
 
+    const duplicateLink = {
+      pathname: `/organizations/${orgId}/alerts/new/issue/`,
+      query: {
+        project: project.slug,
+        duplicateRuleId: rule.id,
+        createFromDuplicate: true,
+        referrer: 'issue_rule_details',
+      },
+    };
+
     return (
       <PageFiltersContainer
         skipInitializeUrlParams
@@ -245,11 +255,8 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
           </Layout.HeaderContent>
           <Layout.HeaderActions>
             <ButtonBar gap={1}>
-              <Button
-                title={t('Send us feedback via email')}
-                href="mailto:alerting-feedback@sentry.io?subject=Issue Alert Details Feedback"
-              >
-                {t('Give Feedback')}
+              <Button title={t('Duplicate')} to={duplicateLink}>
+                {t('Duplicate')}
               </Button>
               <Button
                 icon={<IconEdit />}

--- a/static/app/views/alerts/rules/metric/details/header.tsx
+++ b/static/app/views/alerts/rules/metric/details/header.tsx
@@ -6,7 +6,7 @@ import Breadcrumbs from 'sentry/components/breadcrumbs';
 import Button from 'sentry/components/button';
 import IdBadge from 'sentry/components/idBadge';
 import PageHeading from 'sentry/components/pageHeading';
-import {IconEdit} from 'sentry/icons';
+import {IconCopy, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
@@ -50,7 +50,7 @@ function DetailsHeader({hasMetricRuleDetailsError, rule, params, project}: Props
           ]}
         />
         <Controls>
-          <Button title={t('Duplicate')} to={duplicateLink}>
+          <Button icon={<IconCopy />} to={duplicateLink}>
             {t('Duplicate')}
           </Button>
           <Button icon={<IconEdit />} to={settingsLink}>

--- a/static/app/views/alerts/rules/metric/details/header.tsx
+++ b/static/app/views/alerts/rules/metric/details/header.tsx
@@ -30,6 +30,16 @@ function DetailsHeader({hasMetricRuleDetailsError, rule, params, project}: Props
       isIssueAlert(rule) ? 'rules' : 'metric-rules'
     }/${project?.slug ?? rule?.projects?.[0]}/${rule.id}/`;
 
+  const duplicateLink = {
+    pathname: `/organizations/${params.orgId}/alerts/new/metric/`,
+    query: {
+      project: project?.slug,
+      duplicateRuleId: rule?.id,
+      createFromDuplicate: true,
+      referrer: 'metric_rule_details',
+    },
+  };
+
   return (
     <Header>
       <BreadCrumbBar>
@@ -40,6 +50,9 @@ function DetailsHeader({hasMetricRuleDetailsError, rule, params, project}: Props
           ]}
         />
         <Controls>
+          <Button title={t('Duplicate')} to={duplicateLink}>
+            {t('Duplicate')}
+          </Button>
           <Button icon={<IconEdit />} to={settingsLink}>
             {t('Edit Rule')}
           </Button>


### PR DESCRIPTION
Add a button to duplicate a metric or issue alert from the rule details page.

This replaces the 'Give Feedback' button for Issue Alerts. 

Fixes WOR-1940