### PR TITLE
fix(profiling): Add device classification back for tsc profiles

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -75,17 +75,17 @@ def _normalize(
     profile: MutableMapping[str, Any],
     organization: Organization,
 ) -> MutableMapping[str, Any]:
-    classification_options = dict()
+    if profile["platform"] in {"cocoa", "android"}:
+        classification_options = dict()
 
-    if profile["platform"] == "android":
-        classification_options.update(
-            {
-                "cpu_frequencies": profile["device_cpu_frequencies"],
-                "physical_memory_bytes": profile["device_physical_memory_bytes"],
-            }
-        )
+        if profile["platform"] == "android":
+            classification_options.update(
+                {
+                    "cpu_frequencies": profile["device_cpu_frequencies"],
+                    "physical_memory_bytes": profile["device_physical_memory_bytes"],
+                }
+            )
 
-    if profile["platform"] in ["cocoa", "android"]:
         classification_options.update(
             {
                 "model": profile["device_model"],
@@ -93,15 +93,19 @@ def _normalize(
                 "is_emulator": profile["device_is_emulator"],
             }
         )
-        profile.update({"device_classification": str(classify_device(**classification_options))})
 
-    if profile["platform"] == "rust":
+        profile.update({"device_classification": str(classify_device(**classification_options))})
+    else:
         profile.update(
             {
-                "device_classification": "",
-                "device_locale": "",
-                "device_manufacturer": "",
-                "device_model": "",
+                attr: ""
+                for attr in (
+                    "device_classification",
+                    "device_locale",
+                    "device_manufacturer",
+                    "device_model",
+                )
+                if attr not in profile
             }
         )
 


### PR DESCRIPTION
The recent addition of rust profiles stopped adding the required
device_classification field to tsc profiles. This fixes it so that non
ios/android profiles get empty values for the device specific attributes if not
specified.