### PR TITLE
test(acceptance): Wait for bookmark before fetching from api

### DIFF
--- a/fixtures/page_objects/issue_details.py
+++ b/fixtures/page_objects/issue_details.py
@@ -60,6 +60,8 @@ class IssueDetailsPage(BasePage):
         self.browser.wait_until('[data-test-id="bookmark"]')
         button = self.browser.element('[data-test-id="bookmark"]')
         button.click()
+        self.browser.click('button[aria-label="More Actions"]')
+        self.browser.wait_until('[data-test-id="unbookmark"]')
 
     def assign_to(self, user):
         assignee = self.browser.find_element_by_css_selector(".assigned-to")

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -349,6 +349,7 @@ class Actions extends Component<Props, State> {
 
     const orgFeatures = new Set(organization.features);
 
+    const bookmarkKey = isBookmarked ? 'unbookmark' : 'bookmark';
     const bookmarkTitle = isBookmarked ? t('Remove bookmark') : t('Bookmark');
     const hasRelease = !!project.features?.includes('releases');
 
@@ -430,7 +431,7 @@ class Actions extends Component<Props, State> {
               }}
               items={[
                 {
-                  key: 'bookmark',
+                  key: bookmarkKey,
                   label: bookmarkTitle,
                   hidden: false,
                   onAction: this.onToggleBookmark,


### PR DESCRIPTION
Wait for unbookmark to appear before fetching the issue from the api. I think the flake was caused by fetching before the issue had updated.
