### PR TITLE
fix(profiling): Remove data we don't need anymore on the profile

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -142,7 +142,6 @@ def _symbolicate(profile: MutableMapping[str, Any], project: Project) -> Mutable
                     frame.pop("context_line", None)
                     frame.pop("post_context", None)
 
-                original["original_frames"] = original["frames"]
                 original["frames"] = symbolicated["frames"]
             break
         except RetrySymbolication as e:


### PR DESCRIPTION
This drops data that was saved on the profile for debugging reasons. It's taking too much space and not needed anymore.