### PR TITLE
Fix missing org id for alert rules

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -299,6 +299,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 data.get("environment"),
                 params={
                     "project_id": [p.id for p in project_id],
+                    "organization_id": self.context["organization"].id,
                     "start": timezone.now() - timedelta(minutes=10),
                     "end": timezone.now(),
                 },


### PR DESCRIPTION
Follow up on #35796 

There are code paths where this could be triggered: https://github.com/getsentry/sentry/blob/1aad032188e73ec8c326f19501b71412de3bba8e/src/sentry/search/events/filter.py#L379-L380

DO NOT MERGE yet: There are other issues that are currently blocking the creation of alert rules.