### PR TITLE
feat(search): Redesign the search dropdown ui items

### DIFF
--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -7,7 +7,7 @@ import omit from 'lodash/omit';
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
 import {NEGATION_OPERATOR, SEARCH_WILDCARD} from 'sentry/constants';
-import {Organization, SavedSearchType, TagCollection} from 'sentry/types';
+import {Organization, SavedSearchType, Tag, TagCollection} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {
   Field,
@@ -118,7 +118,7 @@ function SearchBar(props: SearchBarProps) {
         )
       : {};
 
-    const field = Object.fromEntries(
+    const fieldTags = Object.fromEntries(
       Object.keys(FIELD_TAGS).map(key => [
         key,
         {
@@ -138,9 +138,11 @@ function SearchBar(props: SearchBarProps) {
       ])
     );
 
-    const fieldTags = organization.features.includes('performance-view')
-      ? Object.assign({}, measurementsWithKind, field, functionTags)
-      : omit(field, TRACING_FIELDS);
+    const combinedTags: Record<string, Tag> = organization.features.includes(
+      'performance-view'
+    )
+      ? Object.assign({}, measurementsWithKind, fieldTags, functionTags)
+      : omit(fieldTags, TRACING_FIELDS);
 
     const semverTags = Object.fromEntries(
       Object.keys(SEMVER_TAGS).map(key => [
@@ -152,16 +154,32 @@ function SearchBar(props: SearchBarProps) {
       ])
     );
 
-    const combined = assign({}, tags, fieldTags, semverTags);
-    combined.has = {
+    const tagsWithKind = Object.fromEntries(
+      Object.keys(tags).map(key => [
+        key,
+        {
+          ...tags[key],
+          kind: FieldValueKind.TAG,
+        },
+      ])
+    );
+
+    assign(combinedTags, tagsWithKind, fieldTags, semverTags);
+
+    const sortedTagKeys = Object.keys(combinedTags);
+    sortedTagKeys.sort((a, b) => {
+      return a.toLowerCase().localeCompare(b.toLowerCase());
+    });
+
+    combinedTags.has = {
       key: 'has',
       name: 'Has property',
-      values: Object.keys(combined),
+      values: sortedTagKeys,
       predefined: true,
       kind: FieldValueKind.FIELD,
     };
 
-    return omit(combined, omitTags ?? []);
+    return omit(combinedTags, omitTags ?? []);
   };
 
   return (

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1165,6 +1165,7 @@ class SmartSearchBar extends Component<Props, State> {
   };
 
   showDefaultSearches = async () => {
+    const {query} = this.state;
     const [defaultSearchItems, defaultRecentItems] = this.props.defaultSearchItems!;
 
     // Always clear searchTerm on showing default state.

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -43,6 +43,7 @@ import {callIfFunction} from 'sentry/utils/callIfFunction';
 import getDynamicComponent from 'sentry/utils/getDynamicComponent';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
+import {FieldValueKind} from 'sentry/views/eventsV2/table/types';
 
 import {ActionButton} from './actions';
 import SearchDropdown from './searchDropdown';
@@ -912,7 +913,7 @@ class SmartSearchBar extends Component<Props, State> {
   /**
    * Returns array of possible key values that substring match `query`
    */
-  getTagKeys(query: string): [SearchItem[], ItemType] {
+  getTagGroups(query: string): [SearchItem[], ItemType] {
     const {prepareQuery, supportedTagType, getFieldDoc} = this.props;
 
     const supportedTags = this.props.supportedTags ?? {};
@@ -932,16 +933,51 @@ class SmartSearchBar extends Component<Props, State> {
       tagKeys = tagKeys.filter(key => key !== 'environment:');
     }
 
-    return [
-      tagKeys
-        .map(value => ({
-          value,
-          desc: value,
-          documentation: getFieldDoc?.(value.slice(0, -1)) ?? '',
-        }))
-        .sort((a, b) => a.value.localeCompare(b.value)),
-      supportedTagType ?? ItemType.TAG_KEY,
-    ];
+    const accountedForSections = new Set<string>();
+
+    const tagGroups = tagKeys
+      .sort((a, b) => a.localeCompare(b))
+      .flatMap((key, _, arr) => {
+        const sections = key.split('.');
+        const kind = supportedTags[key.slice(0, -1)]?.kind;
+
+        if (
+          sections.length > 1 &&
+          kind !== FieldValueKind.FUNCTION &&
+          arr.filter(k => k.startsWith(sections[0])).length > 1
+        ) {
+          const [title, ...rest] = sections;
+
+          const item: SearchItem = {
+            value: key ?? '',
+            desc: `.${rest.join('.')}`,
+            documentation: getFieldDoc?.(key.slice(0, -1)) || '-',
+            kind,
+            isGrouped: arr.filter(k => k.startsWith(`${sections[0]}.`)).length > 1,
+            isChild: true,
+            title,
+          };
+
+          if (!accountedForSections.has(title)) {
+            accountedForSections.add(title);
+
+            item.isChild = false;
+          }
+
+          return [item];
+        }
+
+        return [
+          {
+            value: key,
+            desc: key,
+            documentation: getFieldDoc?.(key.slice(0, -1)) || '-',
+            kind,
+          },
+        ];
+      });
+
+    return [tagGroups, supportedTagType ?? ItemType.TAG_KEY];
   }
 
   /**
@@ -1124,7 +1160,7 @@ class SmartSearchBar extends Component<Props, State> {
   };
 
   async generateTagAutocompleteGroup(tagName: string): Promise<AutocompleteGroup> {
-    const [tagKeys, tagType] = this.getTagKeys(tagName);
+    const [tagKeys, tagType] = this.getTagGroups(tagName);
     const recentSearches = await this.getRecentSearches();
 
     return {
@@ -1214,7 +1250,7 @@ class SmartSearchBar extends Component<Props, State> {
       // does not get updated)
       this.setState({searchTerm: query});
 
-      const [tagKeys, tagType] = this.getTagKeys('');
+      const [tagKeys, tagType] = this.getTagGroups('');
       const recentSearches = await this.getRecentSearches();
 
       if (this.state.query === query) {
@@ -1340,7 +1376,8 @@ class SmartSearchBar extends Component<Props, State> {
       tagName,
       type,
       maxSearchItems,
-      queryCharsLeft
+      queryCharsLeft,
+      true
     );
 
     this.setState(searchGroups);
@@ -1365,7 +1402,8 @@ class SmartSearchBar extends Component<Props, State> {
           tagName,
           type,
           maxSearchItems,
-          queryCharsLeft
+          queryCharsLeft,
+          false
         )
       )
       .reduce(

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -52,10 +52,10 @@ import {
   addSpace,
   createSearchGroups,
   generateOperatorEntryMap,
+  getSearchGroupWithItemMarkedActive,
   getTagItemsFromKeys,
   getValidOps,
   removeSpace,
-  setSearchGroupItemActive,
   shortcuts,
 } from './utils';
 
@@ -679,7 +679,7 @@ class SmartSearchBar extends Component<Props, State> {
       evt.preventDefault();
 
       const {flatSearchItems, activeSearchItem} = this.state;
-      const searchGroups = [...this.state.searchGroups];
+      let searchGroups = [...this.state.searchGroups];
 
       const currIndex = isSelectingDropdownItems ? activeSearchItem : 0;
       const totalItems = flatSearchItems.length;
@@ -694,11 +694,11 @@ class SmartSearchBar extends Component<Props, State> {
 
       // Clear previous selection
       const prevItem = flatSearchItems[currIndex];
-      setSearchGroupItemActive(searchGroups, prevItem, false);
+      searchGroups = getSearchGroupWithItemMarkedActive(searchGroups, prevItem, false);
 
       // Set new selection
       const activeItem = flatSearchItems[nextActiveSearchItem];
-      setSearchGroupItemActive(searchGroups, activeItem, true);
+      searchGroups = getSearchGroupWithItemMarkedActive(searchGroups, activeItem, true);
 
       this.setState({searchGroups, activeSearchItem: nextActiveSearchItem});
     }
@@ -777,17 +777,22 @@ class SmartSearchBar extends Component<Props, State> {
       return;
     }
 
-    const {searchGroups, flatSearchItems, activeSearchItem} = this.state;
+    const {flatSearchItems, activeSearchItem} = this.state;
     const isSelectingDropdownItems = this.state.activeSearchItem > -1;
 
+    let searchGroups = [...this.state.searchGroups];
     if (isSelectingDropdownItems) {
-      setSearchGroupItemActive(searchGroups, flatSearchItems[activeSearchItem], false);
+      searchGroups = getSearchGroupWithItemMarkedActive(
+        searchGroups,
+        flatSearchItems[activeSearchItem],
+        false
+      );
     }
 
     this.setState({
       activeSearchItem: -1,
       showDropdown: false,
-      searchGroups: [...this.state.searchGroups],
+      searchGroups,
     });
   };
 

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -5,9 +5,11 @@ import color from 'color';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
+import {FieldValueKind} from 'sentry/views/eventsV2/table/types';
 
 import Button from '../button';
 import HotkeysLabel from '../hotkeysLabel';
+import Tag from '../tag';
 
 import {ItemType, SearchGroup, SearchItem, Shortcut} from './types';
 
@@ -78,21 +80,67 @@ class SearchDropdown extends PureComponent<Props> {
     </SearchDropdownGroup>
   );
 
-  renderItem = (item: SearchItem) => (
-    <SearchListItem
-      key={item.value || item.desc || item.title}
-      className={item.active ? 'active' : undefined}
-      data-test-id="search-autocomplete-item"
-      onClick={item.callback ?? this.props.onClick.bind(this, item.value, item)}
-      ref={element => item.active && element?.scrollIntoView?.({block: 'nearest'})}
-    >
-      <SearchItemTitleWrapper>
-        {item.title && `${item.title}${item.desc ? ' · ' : ''}`}
-        <Description>{this.renderDescription(item)}</Description>
+  renderItem = (item: SearchItem) => {
+    const description = this.renderDescription(item);
+    const hideTitle = item.isGrouped && item.isChild;
+
+    return (
+      <SearchListItem
+        key={item.value || item.desc || item.title}
+        className={`${item.isChild ? 'group-child' : ''} ${item.active ? 'active' : ''}`}
+        data-test-id="search-autocomplete-item"
+        onClick={item.callback ?? this.props.onClick.bind(this, item.value, item)}
+        ref={element => item.active && element?.scrollIntoView?.({block: 'nearest'})}
+        isGrouped={item.isGrouped}
+        isChild={item.isChild}
+      >
+        <SearchItemTitleWrapper>
+          {
+            <TitleWrapper hide={hideTitle} aria-hidden={hideTitle}>
+              {item.title}
+            </TitleWrapper>
+          }
+          {description && (
+            <ItemDescription hasTitle={!!item.title}>{description}</ItemDescription>
+          )}
+        </SearchItemTitleWrapper>
         <Documentation>{item.documentation}</Documentation>
-      </SearchItemTitleWrapper>
-    </SearchListItem>
-  );
+        <TagWrapper>
+          {item.kind && !item.isChild && this.renderKind(item.kind)}
+        </TagWrapper>
+      </SearchListItem>
+    );
+  };
+
+  renderKind(kind: FieldValueKind) {
+    let text, tagType;
+    switch (kind) {
+      case FieldValueKind.FUNCTION:
+        text = 'f(x)';
+        tagType = 'success';
+        break;
+      case FieldValueKind.MEASUREMENT:
+        text = 'field';
+        tagType = 'highlight';
+        break;
+      case FieldValueKind.BREAKDOWN:
+        text = 'field';
+        tagType = 'highlight';
+        break;
+      case FieldValueKind.TAG:
+        text = kind;
+        tagType = 'warning';
+        break;
+      case FieldValueKind.NUMERIC_METRICS:
+        text = 'f(x)';
+        tagType = 'success';
+        break;
+      case FieldValueKind.FIELD:
+      default:
+        text = kind;
+    }
+    return <Tag type={tagType}>{text}</Tag>;
+  }
 
   render() {
     const {className, loading, items, runShortcut, visibleShortcuts, maxMenuHeight} =
@@ -185,8 +233,8 @@ const Info = styled('div')`
 `;
 
 const ListItem = styled('li')`
-  &:not(:last-child) {
-    border-bottom: 1px solid ${p => p.theme.innerBorder};
+  &:not(:first-child):not(.group-child) {
+    border-top: 1px solid ${p => p.theme.innerBorder};
   }
 `;
 
@@ -227,16 +275,23 @@ const SearchItemsList = styled('ul')<{maxMenuHeight?: number}>`
   }}
 `;
 
-const SearchListItem = styled(ListItem)`
+const SearchListItem = styled(ListItem)<{isChild?: boolean; isGrouped?: boolean}>`
   scroll-margin: 40px 0;
   font-size: ${p => p.theme.fontSizeLarge};
-  padding: ${space(1)} ${space(2)};
+  padding: 4px ${space(2)};
+
+  min-height: ${p => (p.isGrouped ? '30px' : '36px')};
   cursor: pointer;
 
   &:hover,
   &.active {
     background: ${p => p.theme.hover};
   }
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
 `;
 
 const SearchItemTitleWrapper = styled('div')`
@@ -245,19 +300,43 @@ const SearchItemTitleWrapper = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   margin: 0;
   line-height: ${p => p.theme.text.lineHeightHeading};
+
+  display: flex;
+  flex-grow: 1;
+  flex-shrink: none;
+
+  max-width: 280px;
+
   ${p => p.theme.overflowEllipsis};
 `;
 
-const Description = styled('span')`
-  font-size: ${p => p.theme.fontSizeSmall};
-  font-family: ${p => p.theme.text.familyMono};
+const ItemDescription = styled('span')<{hasTitle?: boolean}>`
+  color: ${p => (p.hasTitle ? p.theme.blue400 : p.theme.textColor)};
+`;
+
+const TitleWrapper = styled('span')<{hide?: boolean}>`
+  opacity: ${p => (p.hide ? 0 : 1)};
+`;
+
+const TagWrapper = styled('span')`
+  width: 5%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
 `;
 
 const Documentation = styled('span')`
-  font-size: ${p => p.theme.fontSizeSmall};
-  font-family: ${p => p.theme.text.familyMono};
-  float: right;
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-family: ${p => p.theme.text.family};
   color: ${p => p.theme.gray300};
+  display: flex;
+  flex: 2;
+  padding: 0 ${space(1)};
+
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    display: none;
+  }
 `;
 
 const DropdownFooter = styled(`div`)`

--- a/static/app/components/smartSearchBar/types.tsx
+++ b/static/app/components/smartSearchBar/types.tsx
@@ -1,3 +1,5 @@
+import {FieldValueKind} from 'sentry/views/eventsV2/table/types';
+
 import {Token, TokenResult} from '../searchSyntax/parser';
 
 export enum ItemType {
@@ -30,6 +32,9 @@ export type SearchItem = {
   desc?: string;
   documentation?: React.ReactNode;
   ignoreMaxSearchItems?: boolean;
+  isChild?: boolean;
+  isGrouped?: boolean;
+  kind?: FieldValueKind;
   title?: string;
   type?: ItemType;
   value?: string;

--- a/static/app/components/smartSearchBar/types.tsx
+++ b/static/app/components/smartSearchBar/types.tsx
@@ -28,16 +28,20 @@ export type SearchItem = {
    * Call a callback instead of setting a value in the search query
    */
   callback?: () => void;
-  children?: React.ReactNode[];
+  /**
+   * Child search items, we only support 1 level of nesting though.
+   */
+  children?: SearchItem[];
   desc?: string;
   documentation?: React.ReactNode;
   ignoreMaxSearchItems?: boolean;
-  isChild?: boolean;
-  isGrouped?: boolean;
   kind?: FieldValueKind;
   title?: string;
   type?: ItemType;
-  value?: string;
+  /**
+   * A value of null means that this item is not selectable in the search dropdown
+   */
+  value?: string | null;
 };
 
 export type Tag = {

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -109,7 +109,8 @@ export function createSearchGroups(
   tagName: string,
   type: ItemType,
   maxSearchItems: number | undefined,
-  queryCharsLeft?: number
+  queryCharsLeft?: number,
+  isDefaultState?: boolean
 ) {
   const activeSearchItem = 0;
 
@@ -153,6 +154,15 @@ export function createSearchGroups(
   if (searchGroup.children && !!searchGroup.children.length) {
     searchGroup.children[activeSearchItem] = {
       ...searchGroup.children[activeSearchItem],
+    };
+  }
+
+  if (isDefaultState) {
+    // Recent searches first in default state.
+    return {
+      searchGroups: [...(recentSearchGroup ? [recentSearchGroup] : []), searchGroup],
+      flatSearchItems: [...(recentSearchItems ? recentSearchItems : []), ...searchItems],
+      activeSearchItem: -1,
     };
   }
 

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -106,17 +106,12 @@ function getIconForTypeAndTag(type: ItemType, tagName: string) {
   }
 }
 
-export function createSearchGroups(
+const filterSearchItems = (
   searchItems: SearchItem[],
-  recentSearchItems: SearchItem[] | undefined,
-  tagName: string,
-  type: ItemType,
-  maxSearchItems: number | undefined,
-  queryCharsLeft?: number,
-  isDefaultState?: boolean
-) {
-  const activeSearchItem = 0;
-
+  recentSearchItems?: SearchItem[],
+  maxSearchItems?: number,
+  queryCharsLeft?: number
+) => {
   if (maxSearchItems && maxSearchItems > 0) {
     searchItems = searchItems.filter(
       (value: SearchItem, index: number) =>
@@ -157,20 +152,36 @@ export function createSearchGroups(
     }
   }
 
+  return {searchItems, recentSearchItems};
+};
+
+export function createSearchGroups(
+  searchItems: SearchItem[],
+  recentSearchItems: SearchItem[] | undefined,
+  tagName: string,
+  type: ItemType,
+  maxSearchItems?: number,
+  queryCharsLeft?: number,
+  isDefaultState?: boolean
+) {
+  const activeSearchItem = 0;
+  const {searchItems: filteredSearchItems, recentSearchItems: filteredRecentSearchItems} =
+    filterSearchItems(searchItems, recentSearchItems, maxSearchItems, queryCharsLeft);
+
   const searchGroup: SearchGroup = {
     title: getTitleForType(type),
     type: type === ItemType.INVALID_TAG ? type : 'header',
     icon: getIconForTypeAndTag(type, tagName),
-    children: [...searchItems],
+    children: [...filteredSearchItems],
   };
 
   const recentSearchGroup: SearchGroup | undefined =
-    recentSearchItems && recentSearchItems.length > 0
+    filteredRecentSearchItems && filteredRecentSearchItems.length > 0
       ? {
           title: t('Recent Searches'),
           type: 'header',
           icon: <IconClock size="xs" />,
-          children: [...recentSearchItems],
+          children: [...filteredRecentSearchItems],
         }
       : undefined;
 
@@ -180,7 +191,7 @@ export function createSearchGroups(
     };
   }
 
-  const flatSearchItems = searchItems.flatMap(item => {
+  const flatSearchItems = filteredSearchItems.flatMap(item => {
     if (item.children) {
       if (!item.value) {
         return [...item.children];

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -421,35 +421,41 @@ export const getTagItemsFromKeys = (
 };
 
 /**
- * Sets an item as active within a search group array.
- * Comparison using the value of the item, assuming each item has a unique value.
+ * Sets an item as active within a search group array and returns new search groups without mutating.
+ * the item is compared via value, so this function assumes that each value is unique.
  */
-export const setSearchGroupItemActive = (
+export const getSearchGroupWithItemMarkedActive = (
   searchGroups: SearchGroup[],
   currentItem: SearchItem,
   active: boolean
 ) => {
-  searchGroups.find(group => {
-    return group.children?.find(item => {
+  return searchGroups.map(group => ({
+    ...group,
+    children: group.children?.map(item => {
       if (item.value === currentItem.value) {
-        item.active = active;
-
-        return true;
+        return {
+          ...item,
+          active,
+        };
       }
 
       if (item.children && item.children.length > 0) {
-        return item.children.find(child => {
-          if (child.value === currentItem.value) {
-            child.active = active;
+        return {
+          ...item,
+          children: item.children.map(child => {
+            if (child.value === currentItem.value) {
+              return {
+                ...child,
+                active,
+              };
+            }
 
-            return true;
-          }
-
-          return false;
-        });
+            return child;
+          }),
+        };
       }
 
-      return false;
-    });
-  });
+      return item;
+    }),
+  }));
 };

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -1,4 +1,5 @@
 import type {PlatformKey} from 'sentry/data/platformCategories';
+import {FieldValueKind} from 'sentry/views/eventsV2/table/types';
 
 import type {Actor, TimeseriesValue} from './core';
 import type {Event, EventMetadata, EventOrGroupType, Level} from './event';
@@ -63,7 +64,11 @@ export type EventAttachment = Omit<IssueAttachment, 'event_id'>;
 export type Tag = {
   key: string;
   name: string;
+
+  documentation?: string;
   isInput?: boolean;
+
+  kind?: FieldValueKind;
   /**
    * How many values should be suggested in autocomplete.
    * Overrides SmartSearchBar's `maxSearchItems` prop.

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -65,7 +65,6 @@ export type Tag = {
   key: string;
   name: string;
 
-  documentation?: string;
   isInput?: boolean;
 
   kind?: FieldValueKind;

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
@@ -4,7 +4,10 @@ import SearchBar, {SearchBarProps} from 'sentry/components/events/searchBar';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {Organization, PageFilters, SavedSearchType} from 'sentry/types';
 import {WidgetQuery} from 'sentry/views/dashboardsV2/types';
-import {MAX_MENU_HEIGHT} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
+import {
+  MAX_MENU_HEIGHT,
+  MAX_SEARCH_ITEMS,
+} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
 
 interface Props {
   onBlur: SearchBarProps['onBlur'];
@@ -34,6 +37,7 @@ export function EventsSearchBar({
       onBlur={onBlur}
       useFormWrapper={false}
       maxQueryLength={MAX_QUERY_LENGTH}
+      maxSearchItems={MAX_SEARCH_ITEMS}
       maxMenuHeight={MAX_MENU_HEIGHT}
       savedSearchType={SavedSearchType.EVENT}
     />

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
@@ -9,7 +9,10 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import useApi from 'sentry/utils/useApi';
 import withIssueTags from 'sentry/utils/withIssueTags';
 import {WidgetQuery} from 'sentry/views/dashboardsV2/types';
-import {MAX_MENU_HEIGHT} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
+import {
+  MAX_MENU_HEIGHT,
+  MAX_SEARCH_ITEMS,
+} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
 import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 
 interface Props {
@@ -56,6 +59,7 @@ function IssuesSearchBarContainer({
           placeholder={t('Search for issues, status, assigned, and more')}
           tagValueLoader={tagValueLoader}
           onSidebarToggle={() => undefined}
+          maxSearchItems={MAX_SEARCH_ITEMS}
           savedSearchType={SavedSearchType.ISSUE}
           dropdownClassName={css`
             max-height: ${MAX_MENU_HEIGHT}px;

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -10,7 +10,10 @@ import {t} from 'sentry/locale';
 import {Organization, PageFilters, SavedSearchType, Tag, TagValue} from 'sentry/types';
 import useApi from 'sentry/utils/useApi';
 import {WidgetQuery} from 'sentry/views/dashboardsV2/types';
-import {MAX_MENU_HEIGHT} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
+import {
+  MAX_MENU_HEIGHT,
+  MAX_SEARCH_ITEMS,
+} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
 
 import {SESSION_STATUSES, SESSIONS_FILTER_TAGS} from '../../releaseWidget/fields';
 
@@ -89,6 +92,7 @@ export function ReleaseSearchBar({
           onSearch={onSearch}
           onBlur={onBlur}
           maxQueryLength={MAX_QUERY_LENGTH}
+          maxSearchItems={MAX_SEARCH_ITEMS}
           searchSource="widget_builder"
           query={widgetQuery.conditions}
           savedSearchType={SavedSearchType.SESSION}

--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -313,6 +313,9 @@ export function getMetricFields(queries: WidgetQuery[]) {
   }, [] as string[]);
 }
 
+// Used to limit the number of results of the "filter your results" fields dropdown
+export const MAX_SEARCH_ITEMS = 5;
+
 // Used to set the max height of the smartSearchBar menu
 export const MAX_MENU_HEIGHT = 250;
 

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -122,7 +122,6 @@ class IssueListSearchBar extends Component<Props, State> {
       <SmartSearchBar
         searchSource="main_search"
         hasRecentSearches
-        maxSearchItems={5}
         savedSearchType={SavedSearchType.ISSUE}
         onGetTagValues={this.getTagValues}
         actionBarItems={[
@@ -131,6 +130,7 @@ class IssueListSearchBar extends Component<Props, State> {
           makeSearchBuilderAction({onSidebarToggle}),
         ]}
         {...props}
+        maxMenuHeight={500}
         supportedTags={this.state.supportedTags}
         getFieldDoc={getFieldDoc}
       />

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
 
-import {fetchRecentSearches} from 'sentry/actionCreators/savedSearches';
 import {Client} from 'sentry/api';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
 import {
@@ -83,28 +82,8 @@ class IssueListSearchBar extends Component<Props, State> {
   componentDidMount() {
     // Ideally, we would fetch on demand (e.g. when input gets focus)
     // but `<SmartSearchBar>` is a bit complicated and this is the easiest route
-    this.fetchData();
     this.getSupportedTags();
   }
-
-  fetchData = async () => {
-    this.props.api.clear();
-    const resp = await this.getRecentSearches();
-
-    this.setState({
-      defaultSearchItems: [
-        SEARCH_ITEMS,
-        resp
-          ? resp.map(query => ({
-              desc: query,
-              value: query,
-              type: ItemType.RECENT_SEARCH,
-            }))
-          : [],
-      ],
-      recentSearches: resp,
-    });
-  };
 
   getSupportedTags = () => {
     const {supportedTags} = this.props;
@@ -134,21 +113,6 @@ class IssueListSearchBar extends Component<Props, State> {
     return values.map(({value}) => value);
   };
 
-  getRecentSearches = async (): Promise<string[]> => {
-    const {api, organization} = this.props;
-    const recent = await fetchRecentSearches(
-      api,
-      organization.slug,
-      SavedSearchType.ISSUE
-    );
-    return recent?.map(({query}) => query) ?? [];
-  };
-
-  handleSavedRecentSearch = () => {
-    // Reset recent searches
-    this.fetchData();
-  };
-
   render() {
     const {tagValueLoader: _, savedSearch, sort, onSidebarToggle, ...props} = this.props;
 
@@ -158,16 +122,14 @@ class IssueListSearchBar extends Component<Props, State> {
       <SmartSearchBar
         searchSource="main_search"
         hasRecentSearches
+        maxSearchItems={5}
         savedSearchType={SavedSearchType.ISSUE}
         onGetTagValues={this.getTagValues}
-        // defaultSearchItems={this.state.defaultSearchItems}
-        onSavedRecentSearch={this.handleSavedRecentSearch}
         actionBarItems={[
           makePinSearchAction({sort, pinnedSearch}),
           makeSaveSearchAction({sort}),
           makeSearchBuilderAction({onSidebarToggle}),
         ]}
-        maxMenuHeight={500}
         {...props}
         supportedTags={this.state.supportedTags}
         getFieldDoc={getFieldDoc}

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -11,8 +11,11 @@ import {
 import {ItemType, SearchItem} from 'sentry/components/smartSearchBar/types';
 import {t} from 'sentry/locale';
 import {Organization, SavedSearch, SavedSearchType, Tag} from 'sentry/types';
+import {getFieldDoc} from 'sentry/utils/discover/fields';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
+
+import {FieldValueKind} from '../eventsV2/table/types';
 
 import {TagValueLoader} from './types';
 
@@ -54,6 +57,7 @@ type Props = React.ComponentProps<typeof SmartSearchBar> & {
   onSidebarToggle: (e: React.MouseEvent) => void;
   organization: Organization;
   sort: string;
+  supportedTags: {[key: string]: Tag};
   tagValueLoader: TagValueLoader;
   /**
    * Used to define the max height of the menu in px.
@@ -66,18 +70,21 @@ type Props = React.ComponentProps<typeof SmartSearchBar> & {
 type State = {
   defaultSearchItems: [SearchItem[], SearchItem[]];
   recentSearches: string[];
+  supportedTags: {[key: string]: Tag};
 };
 
 class IssueListSearchBar extends Component<Props, State> {
   state: State = {
     defaultSearchItems: [SEARCH_ITEMS, []],
     recentSearches: [],
+    supportedTags: {},
   };
 
   componentDidMount() {
     // Ideally, we would fetch on demand (e.g. when input gets focus)
     // but `<SmartSearchBar>` is a bit complicated and this is the easiest route
     this.fetchData();
+    this.getSupportedTags();
   }
 
   fetchData = async () => {
@@ -96,6 +103,24 @@ class IssueListSearchBar extends Component<Props, State> {
           : [],
       ],
       recentSearches: resp,
+    });
+  };
+
+  getSupportedTags = () => {
+    const {supportedTags} = this.props;
+
+    const newTags = Object.fromEntries(
+      Object.keys(supportedTags).map(key => [
+        key,
+        {
+          ...supportedTags[key],
+          kind: supportedTags[key].predefined ? FieldValueKind.TAG : FieldValueKind.FIELD,
+        },
+      ])
+    );
+
+    this.setState({
+      supportedTags: newTags,
     });
   };
 
@@ -135,7 +160,7 @@ class IssueListSearchBar extends Component<Props, State> {
         hasRecentSearches
         savedSearchType={SavedSearchType.ISSUE}
         onGetTagValues={this.getTagValues}
-        defaultSearchItems={this.state.defaultSearchItems}
+        // defaultSearchItems={this.state.defaultSearchItems}
         onSavedRecentSearch={this.handleSavedRecentSearch}
         actionBarItems={[
           makePinSearchAction({sort, pinnedSearch}),
@@ -144,6 +169,8 @@ class IssueListSearchBar extends Component<Props, State> {
         ]}
         maxMenuHeight={500}
         {...props}
+        supportedTags={this.state.supportedTags}
+        getFieldDoc={getFieldDoc}
       />
     );
   }

--- a/tests/js/spec/components/dashboards/issueWidgetQueriesForm.spec.tsx
+++ b/tests/js/spec/components/dashboards/issueWidgetQueriesForm.spec.tsx
@@ -118,12 +118,12 @@ describe('IssueWidgetQueriesForm', function () {
 
   it('fetches tag values when when focused on a lhs tag condition', async function () {
     const {tagsMock} = renderComponent(organization, routerContext);
-
+    //
     userEvent.type(screen.getAllByText('assigned:')[1], 'event.type:');
     await tick();
     expect(tagsMock).toHaveBeenCalled();
     expect(screen.getByText('default')).toBeInTheDocument();
-    expect(screen.getByText('error')).toBeInTheDocument();
+    expect(screen.getAllByText('error')[0]).toBeInTheDocument();
   });
 
   it('only calls onChange once when selecting a value from the autocomplete dropdown', async function () {
@@ -132,8 +132,8 @@ describe('IssueWidgetQueriesForm', function () {
     userEvent.click(screen.getAllByText('assigned:')[1]);
     await tick();
     expect(screen.getByText('Recent Searches')).toBeInTheDocument();
-    expect(screen.getByText(':#visibility level:error')).toBeInTheDocument();
-    userEvent.click(screen.getByText(':#visibility level:error'));
+    expect(screen.getByText('#visibility')).toBeInTheDocument();
+    userEvent.click(screen.getByText('#visibility'));
     await tick();
     expect(onChangeHandler).toHaveBeenCalledTimes(1);
   });

--- a/tests/js/spec/components/dashboards/issueWidgetQueriesForm.spec.tsx
+++ b/tests/js/spec/components/dashboards/issueWidgetQueriesForm.spec.tsx
@@ -118,7 +118,6 @@ describe('IssueWidgetQueriesForm', function () {
 
   it('fetches tag values when when focused on a lhs tag condition', async function () {
     const {tagsMock} = renderComponent(organization, routerContext);
-    //
     userEvent.type(screen.getAllByText('assigned:')[1], 'event.type:');
     await tick();
     expect(tagsMock).toHaveBeenCalled();

--- a/tests/js/spec/components/dashboards/widgetQueriesForm.spec.tsx
+++ b/tests/js/spec/components/dashboards/widgetQueriesForm.spec.tsx
@@ -103,7 +103,7 @@ describe('WidgetQueriesForm', function () {
     render(<TestComponent />);
     userEvent.click(screen.getByRole('textbox', {name: 'Search events'}));
     expect(await screen.findByText('Recent Searches')).toBeInTheDocument();
-    userEvent.click(screen.getByText(':transaction'));
+    userEvent.click(screen.getByText('transaction'));
     expect(screen.getByText('event.type:transaction')).toBeInTheDocument();
     expect(onChangeHandler).toHaveBeenCalledTimes(1);
   });

--- a/tests/js/spec/components/events/searchBar.spec.jsx
+++ b/tests/js/spec/components/events/searchBar.spec.jsx
@@ -107,7 +107,9 @@ describe('Events > SearchBar', function () {
     expect(wrapper.find('SearchDropdown FirstWordWrapper').first().text()).toEqual(
       'release'
     );
-    expect(wrapper.find('SearchDropdown RestOfWords').first().text()).toEqual('.build');
+    expect(wrapper.find('SearchDropdown RestOfWordsContainer').first().text()).toEqual(
+      '.build'
+    );
   });
 
   it('autocomplete has suggestions correctly', async function () {

--- a/tests/js/spec/components/events/searchBar.spec.jsx
+++ b/tests/js/spec/components/events/searchBar.spec.jsx
@@ -88,8 +88,8 @@ describe('Events > SearchBar', function () {
     wrapper.update();
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('fcp');
-    expect(wrapper.find('SearchDropdown Description').first().text()).toEqual(
-      'measurements.fcp:'
+    expect(wrapper.find('SearchDropdown SearchItemTitleWrapper').first().text()).toEqual(
+      'measurements.fcp'
     );
   });
 
@@ -104,12 +104,13 @@ describe('Events > SearchBar', function () {
     wrapper.update();
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('release.');
-    expect(wrapper.find('SearchDropdown Description').first().text()).toEqual(
-      'release.build:'
+    expect(wrapper.find('SearchDropdown FirstWordWrapper').first().text()).toEqual(
+      'release'
     );
+    expect(wrapper.find('SearchDropdown RestOfWords').first().text()).toEqual('.build');
   });
 
-  it('autocompletes has suggestions correctly', async function () {
+  it('autocomplete has suggestions correctly', async function () {
     const wrapper = mountWithTheme(<SearchBar {...props} />, options);
     await tick();
     setQuery(wrapper, 'has:');
@@ -118,9 +119,16 @@ describe('Events > SearchBar', function () {
     wrapper.update();
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('');
-    expect(wrapper.find('SearchDropdown Description').at(2).text()).toEqual('gpu');
+    expect(wrapper.find('SearchDropdown Value').contains('gpu')).toBe(true);
 
-    selectNthAutocompleteItem(wrapper, 2);
+    const itemIndex = wrapper
+      .find('SearchListItem[data-test-id="search-autocomplete-item"]')
+      .map(node => node)
+      .findIndex(node => node.text() === 'gpu');
+
+    expect(itemIndex).not.toBe(-1);
+
+    selectNthAutocompleteItem(wrapper, itemIndex);
     wrapper.update();
     // the trailing space is important here as without it, autocomplete suggestions will
     // try to complete `has:gpu` thinking the token has not ended yet
@@ -143,9 +151,7 @@ describe('Events > SearchBar', function () {
     wrapper.update();
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('');
-    expect(wrapper.find('SearchDropdown Description').at(2).text()).toEqual(
-      '"Nvidia 1080ti"'
-    );
+    expect(wrapper.find('SearchDropdown Value').at(2).text()).toEqual('"Nvidia 1080ti"');
 
     selectNthAutocompleteItem(wrapper, 2);
     wrapper.update();
@@ -174,9 +180,7 @@ describe('Events > SearchBar', function () {
     );
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('');
-    expect(wrapper.find('SearchDropdown Description').at(2).text()).toEqual(
-      '"Nvidia 1080ti"'
-    );
+    expect(wrapper.find('SearchDropdown Value').contains('"Nvidia 1080ti"')).toBe(true);
     selectNthAutocompleteItem(wrapper, 2);
 
     wrapper.find('textarea').simulate('keydown', {key: 'Enter'});
@@ -195,7 +199,7 @@ describe('Events > SearchBar', function () {
     wrapper.update();
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('g');
-    expect(wrapper.find('SearchDropdown Description')).toEqual({});
+    expect(wrapper.find('SearchDropdown SearchItemTitleWrapper')).toEqual({});
     expect(
       wrapper.find('SearchListItem[data-test-id="search-autocomplete-item"]')
     ).toHaveLength(1);
@@ -212,7 +216,7 @@ describe('Events > SearchBar', function () {
     wrapper.update();
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('g');
-    expect(wrapper.find('SearchDropdown Description')).toEqual({});
+    expect(wrapper.find('SearchDropdown SearchItemTitleWrapper')).toEqual({});
     expect(
       wrapper.find('SearchListItem[data-test-id="search-autocomplete-item"]')
     ).toHaveLength(0);
@@ -251,14 +255,14 @@ describe('Events > SearchBar', function () {
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('Description strong').text()).toBe('gpu');
+    expect(wrapper.find('SearchItemTitleWrapper strong').text()).toBe('gpu');
 
     // Should have nothing highlighted
     setQuery(wrapper, '');
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('Description strong')).toHaveLength(0);
+    expect(wrapper.find('SearchItemTitleWrapper strong')).toHaveLength(0);
   });
 
   it('ignores negation ("!") at the beginning of search term', async function () {
@@ -275,7 +279,7 @@ describe('Events > SearchBar', function () {
     ).toHaveLength(1);
     expect(
       wrapper.find('SearchListItem[data-test-id="search-autocomplete-item"]').text()
-    ).toBe('gpu:');
+    ).toMatch(/^gpu/);
   });
 
   it('ignores wildcard ("*") at the beginning of tag value query', async function () {

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -784,6 +784,77 @@ describe('SmartSearchBar', function () {
 
       expect(searchBar.state.searchGroups).toHaveLength(0);
     });
+
+    it('correctly groups nested keys', async function () {
+      const props = {
+        query: 'nest',
+        organization,
+        location,
+        supportedTags: {
+          nested: {
+            key: 'nested',
+            name: 'nested',
+          },
+          'nested.child': {
+            key: 'nested.child',
+            name: 'nested.child',
+          },
+        },
+      };
+      jest.useRealTimers();
+      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = wrapper.instance();
+      // Cursor is at end of line
+      mockCursorPosition(searchBar, 4);
+      searchBar.updateAutoCompleteItems();
+      await tick();
+      wrapper.update();
+
+      expect(searchBar.state.searchGroups).toHaveLength(1);
+      expect(searchBar.state.searchGroups[0].children).toHaveLength(1);
+      expect(searchBar.state.searchGroups[0].children[0].title).toBe('nested');
+      expect(searchBar.state.searchGroups[0].children[0].children).toHaveLength(1);
+      expect(searchBar.state.searchGroups[0].children[0].children[0].title).toBe(
+        'nested.child'
+      );
+    });
+
+    it('correctly groups nested keys without a parent', async function () {
+      const props = {
+        query: 'nest',
+        organization,
+        location,
+        supportedTags: {
+          'nested.child1': {
+            key: 'nested.child1',
+            name: 'nested.child1',
+          },
+          'nested.child2': {
+            key: 'nested.child2',
+            name: 'nested.child2',
+          },
+        },
+      };
+      jest.useRealTimers();
+      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = wrapper.instance();
+      // Cursor is at end of line
+      mockCursorPosition(searchBar, 4);
+      searchBar.updateAutoCompleteItems();
+      await tick();
+      wrapper.update();
+
+      expect(searchBar.state.searchGroups).toHaveLength(1);
+      expect(searchBar.state.searchGroups[0].children).toHaveLength(1);
+      expect(searchBar.state.searchGroups[0].children[0].title).toBe('nested');
+      expect(searchBar.state.searchGroups[0].children[0].children).toHaveLength(2);
+      expect(searchBar.state.searchGroups[0].children[0].children[0].title).toBe(
+        'nested.child1'
+      );
+      expect(searchBar.state.searchGroups[0].children[0].children[1].title).toBe(
+        'nested.child2'
+      );
+    });
   });
 
   describe('onAutoComplete()', function () {

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -1089,7 +1089,7 @@ describe('SmartSearchBar', function () {
       await tick();
 
       expect(searchBarInst.state.searchGroups).toHaveLength(1);
-      expect(searchBarInst.state.searchGroups[0].title).toEqual('Tags');
+      expect(searchBarInst.state.searchGroups[0].title).toEqual('Keys');
       expect(searchBarInst.state.searchGroups[0].type).toEqual('invalid-tag');
       expect(searchBar.text()).toContain("The field invalid isn't supported here");
     });

--- a/tests/js/spec/components/smartSearchBar/utils.spec.tsx
+++ b/tests/js/spec/components/smartSearchBar/utils.spec.tsx
@@ -2,8 +2,10 @@ import {
   addSpace,
   getLastTermIndex,
   getQueryTerms,
+  getTagItemsFromKeys,
   removeSpace,
 } from 'sentry/components/smartSearchBar/utils';
+import {FieldValueKind} from 'sentry/views/eventsV2/table/types';
 
 describe('addSpace()', function () {
   it('should add a space when there is no trailing space', function () {
@@ -56,5 +58,176 @@ describe('getLastTermIndex()', function () {
 
     query = 'tagname:foo anothertag:bar'; // 'f' (index 9)
     expect(getLastTermIndex(query, 9)).toEqual(11);
+  });
+});
+
+describe('getTagItemsFromKeys()', function () {
+  it('gets items from tags', () => {
+    const supportedTags = {
+      browser: {
+        kind: FieldValueKind.FIELD,
+        key: 'browser',
+        name: 'Browser',
+        predefined: true,
+        desc: '',
+        values: [],
+      },
+      device: {
+        kind: FieldValueKind.FIELD,
+        key: 'device',
+        name: 'Device',
+        predefined: true,
+        desc: '',
+        values: [],
+      },
+      has: {
+        kind: FieldValueKind.TAG,
+        key: 'has',
+        name: 'Has',
+        predefined: true,
+        desc: '',
+        values: [],
+      },
+    };
+    const tagKeys = Object.keys(supportedTags);
+
+    const items = getTagItemsFromKeys(tagKeys, supportedTags);
+
+    expect(items).toMatchObject([
+      {
+        title: 'browser',
+        value: 'browser:',
+        kind: FieldValueKind.FIELD,
+        documentation: '-',
+      },
+      {
+        title: 'device',
+        value: 'device:',
+        kind: FieldValueKind.FIELD,
+        documentation: '-',
+      },
+      {
+        title: 'has',
+        value: 'has:',
+        kind: FieldValueKind.TAG,
+        documentation: '-',
+      },
+    ]);
+  });
+
+  it('groups tags', () => {
+    const supportedTags = {
+      'device.arch': {
+        kind: FieldValueKind.FIELD,
+        key: 'device.arch',
+        name: 'Device Arch',
+        predefined: true,
+        desc: '',
+        values: [],
+      },
+      'device.family': {
+        kind: FieldValueKind.FIELD,
+        key: 'device.family',
+        name: 'Device Family',
+        predefined: true,
+        desc: '',
+        values: [],
+      },
+      has: {
+        kind: FieldValueKind.TAG,
+        key: 'has',
+        name: 'Has',
+        predefined: true,
+        desc: '',
+        values: [],
+      },
+    };
+    const tagKeys = Object.keys(supportedTags);
+
+    const items = getTagItemsFromKeys(tagKeys, supportedTags);
+
+    expect(items).toMatchObject([
+      {
+        title: 'device',
+        value: null,
+        kind: FieldValueKind.FIELD,
+        documentation: '-',
+        children: [
+          {
+            title: 'device.arch',
+            value: 'device.arch:',
+            kind: FieldValueKind.FIELD,
+            documentation: '-',
+          },
+          {
+            title: 'device.family',
+            value: 'device.family:',
+            kind: FieldValueKind.FIELD,
+            documentation: '-',
+          },
+        ],
+      },
+      {
+        title: 'has',
+        value: 'has:',
+        kind: FieldValueKind.TAG,
+        documentation: '-',
+      },
+    ]);
+  });
+
+  it('groups tags with single word parent', () => {
+    const supportedTags = {
+      device: {
+        kind: FieldValueKind.FIELD,
+        key: 'device',
+        name: 'Device',
+        predefined: true,
+        desc: '',
+        values: [],
+      },
+      'device.family': {
+        kind: FieldValueKind.FIELD,
+        key: 'device.family',
+        name: 'Device Family',
+        predefined: true,
+        desc: '',
+        values: [],
+      },
+      has: {
+        kind: FieldValueKind.TAG,
+        key: 'has',
+        name: 'Has',
+        predefined: true,
+        desc: '',
+        values: [],
+      },
+    };
+    const tagKeys = Object.keys(supportedTags);
+
+    const items = getTagItemsFromKeys(tagKeys, supportedTags);
+
+    expect(items).toMatchObject([
+      {
+        title: 'device',
+        value: 'device:',
+        kind: FieldValueKind.FIELD,
+        documentation: '-',
+        children: [
+          {
+            title: 'device.family',
+            value: 'device.family:',
+            kind: FieldValueKind.FIELD,
+            documentation: '-',
+          },
+        ],
+      },
+      {
+        title: 'has',
+        value: 'has:',
+        kind: FieldValueKind.TAG,
+        documentation: '-',
+      },
+    ]);
   });
 });

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2852,9 +2852,9 @@ describe('WidgetBuilder', function () {
             'Search for release version, session status, and more'
           )
         );
-        expect(await screen.findByText('environment:')).toBeInTheDocument();
-        expect(screen.getByText('project:')).toBeInTheDocument();
-        expect(screen.getByText('release:')).toBeInTheDocument();
+        expect(await screen.findByText('environment')).toBeInTheDocument();
+        expect(screen.getByText('project')).toBeInTheDocument();
+        expect(screen.getByText('release')).toBeInTheDocument();
       });
 
       it('adds a function when the only column chosen in a table is a tag', async function () {

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2843,7 +2843,7 @@ describe('WidgetBuilder', function () {
         );
 
         await waitFor(() => {
-          expect(screen.getByText('No items found')).toBeInTheDocument();
+          expect(screen.getByText("isn't supported here.")).toBeInTheDocument();
         });
 
         userEvent.click(screen.getByText('Releases (sessions, crash rates)'));

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -249,7 +249,9 @@ describe('IssueList', function () {
       // Update stores with saved searches
       await tick();
       await tick();
+
       wrapper.update();
+      wrapper.find('SmartSearchBar textarea').simulate('click');
 
       // auxillary requests being made
       expect(recentSearchesRequest).toHaveBeenCalledTimes(1);

--- a/tests/js/spec/views/projectDetail/projectFilters.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectFilters.spec.jsx
@@ -39,9 +39,9 @@ describe('ProjectDetail > ProjectFilters', () => {
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('[data-test-id="search-autocomplete-item"]').at(0).text()).toBe(
-      'release:'
-    );
+    expect(
+      wrapper.find('[data-test-id="search-autocomplete-item"]').at(0).text()
+    ).toMatch(/^release/);
 
     wrapper.find('SmartSearchBar textarea').simulate('focus');
     wrapper

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -561,7 +561,7 @@ describe('ReleasesList', () => {
     fireEvent.submit(smartSearchBar);
 
     const autocompleteItems = await screen.findAllByTestId('search-autocomplete-item');
-    expect(autocompleteItems.at(0)).toHaveTextContent('release:');
+    expect(autocompleteItems.at(0)).toHaveTextContent('release');
 
     userEvent.clear(smartSearchBar);
     fireEvent.change(smartSearchBar, {target: {value: 'release.version:'}});


### PR DESCRIPTION
Update the search dropdown UI to be way more informative including descriptions and field types. Also renders recent searches as pretty filter tokens. This will be followed up by a PR containing rich descriptions for each of the field keys.

## New Dropdown Redesign

### Old:
![Screen Shot 2022-06-21 at 11 38 49 AM](https://user-images.githubusercontent.com/30991498/174873954-fb85a84a-81cf-4804-8018-888812addb66.png)

### New:
<img width="1004" alt="Screen Shot 2022-06-28 at 1 09 02 PM" src="https://user-images.githubusercontent.com/30991498/176280880-657651ac-e141-48fc-a786-7d0a0f33c3f8.png">



## Issues Default State:
Suggestion to have the Issues Tab's default search state be the list of all possible tags instead:

### Old:
![Screen Shot 2022-06-21 at 11 38 37 AM](https://user-images.githubusercontent.com/30991498/174873926-2e002708-ea13-40b4-adfb-225bdf2d79d6.png)


### New:
<img width="751" alt="Screen Shot 2022-06-28 at 1 10 22 PM" src="https://user-images.githubusercontent.com/30991498/176280937-ef718b6d-5775-4fb3-9482-b28d34c68671.png">



## Remaining TODO:

- [x] Finish Field kinds on Discover tab
- [x] Ensure this works on every tab that search is used