### PR TITLE
fix: Do not run visual diff from forks without acceptance changes

### DIFF
--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -11,9 +11,27 @@ on:
       - completed
 
 jobs:
+  files-changed:
+    name: detect what files changed
+    runs-on: ubuntu-20.04
+    timeout-minutes: 3
+    # Map a step output to a job output
+    outputs:
+      acceptance: ${{ steps.changes.outputs.acceptance }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check for files changed
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
   visual-diff:
+    needs: files-changed
     # Only execute this check when a PR is opened from a fork rather than the upstream repo
-    if: github.event.workflow_run.head_repository.full_name != 'getsentry/sentry'
+    if: github.event.workflow_run.head_repository.full_name != 'getsentry/sentry' && needs.files-changed.outputs.acceptance == 'true'
     runs-on: ubuntu-20.04
     timeout-minutes: 20
 


### PR DESCRIPTION
In PR #35565 contributed a change that did not have acceptance related changes.

A [visual diff](https://github.com/getsentry/sentry/actions/runs/2537386363) executed because this is a PR from a fork. That triggered a visual diff run, however, there were no artifacts generated (as expected), thus, it failed to run successfully.