### PR TITLE
fix(workflow): Increase TsChecker memory limit

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -357,6 +357,7 @@ const appConfig: Configuration = {
               configOverwrite: {
                 compilerOptions: {incremental: true},
               },
+              memoryLimit: 3072,
             },
             devServer: false,
           }),


### PR DESCRIPTION
I have been having memoryLimit issues on TsChecker

<img width="979" alt="image" src="https://user-images.githubusercontent.com/44422760/174881536-3636f7d3-9fbe-4f83-8f70-b1ae0e8442dc.png">

This PR bumps the memoryLimit from 2048 (default) to 3072, increasing memory by 50% which appears to resolve my issues in my local dev environment.