### PR TITLE
Fix(replays): console.error not rendering properly

### DIFF
--- a/static/app/components/events/meta/annotatedText/index.tsx
+++ b/static/app/components/events/meta/annotatedText/index.tsx
@@ -86,7 +86,7 @@ const AnnotatedText = ({value, meta, className, ...props}: Props) => {
   };
 
   return (
-    <span className={className} {...props}>
+    <span role="text" className={className} {...props}>
       {renderValue()}
       {meta?.err && renderErrors(meta.err)}
     </span>

--- a/static/app/types/breadcrumbs.tsx
+++ b/static/app/types/breadcrumbs.tsx
@@ -10,6 +10,7 @@ export enum BreadcrumbLevelType {
   INFO = 'info',
   DEBUG = 'debug',
   UNDEFINED = 'undefined',
+  LOG = 'log',
 }
 
 export enum BreadcrumbType {

--- a/static/app/views/replays/detail/console/consoleMessage.tsx
+++ b/static/app/views/replays/detail/console/consoleMessage.tsx
@@ -73,7 +73,7 @@ function MessageFormatter({breadcrumb}: MessageFormatterProps) {
 
     logMessage = [formattedMessage, ...restArgs].join(' ').trim();
   } else {
-    // Make sure there are not objects to print in order to not get a "[Object object]"
+    // Make sure there are no objects to print in order to not get a "[Object object]"
     const argValues: (string | number | boolean)[] = [];
 
     for (const arg of breadcrumb.data?.arguments) {

--- a/tests/js/spec/views/replays/detail/console/messageFormatter.spec.tsx
+++ b/tests/js/spec/views/replays/detail/console/messageFormatter.spec.tsx
@@ -62,12 +62,12 @@ const breadcrumbs: BreadcrumbTypeDefault[] = [
     type: BreadcrumbType.DEBUG,
     category: 'console',
     data: {
-      arguments: [['test', 'test']],
+      arguments: ['test', ['foo', 'bar']],
       logger: 'console',
     },
     level: BreadcrumbLevelType.LOG,
-    message: 'test,test',
-    timestamp: '2022-06-23T13:33:15.768Z',
+    message: 'test foo,bar',
+    timestamp: '2022-06-23T17:09:31.158Z',
   },
 ];
 
@@ -99,6 +99,6 @@ describe('MessageFormatter', () => {
   it('Should print arrays correctly', () => {
     render(<MessageFormatter breadcrumb={breadcrumbs[4]} />);
 
-    expect(screen.getByRole('text')).toHaveTextContent('["test","test"]');
+    expect(screen.getByRole('text')).toHaveTextContent('test ["foo","bar"]');
   });
 });

--- a/tests/js/spec/views/replays/detail/console/messageFormatter.spec.tsx
+++ b/tests/js/spec/views/replays/detail/console/messageFormatter.spec.tsx
@@ -45,6 +45,16 @@ const breadcrumbs: BreadcrumbTypeDefault[] = [
     type: BreadcrumbType.DEBUG,
     category: 'console',
     data: {
+      arguments: [{}],
+      logger: 'console',
+    },
+    level: BreadcrumbLevelType.ERROR,
+    timestamp: '2022-06-22T20:00:39.958Z',
+  },
+  {
+    type: BreadcrumbType.DEBUG,
+    category: 'console',
+    data: {
       arguments: [
         '%c prev state',
         'color: #9E9E9E; font-weight: bold',
@@ -90,14 +100,20 @@ describe('MessageFormatter', () => {
     expect(screen.getByRole('text')).toHaveTextContent('Error: this is my error message');
   });
 
-  it('Should ignore the "%c" placheholder and print the console message correctly', () => {
+  it('Should print empty object in case there is no message prop', () => {
     render(<MessageFormatter breadcrumb={breadcrumbs[3]} />);
+
+    expect(screen.getByRole('text')).toHaveTextContent('{}');
+  });
+
+  it('Should ignore the "%c" placheholder and print the console message correctly', () => {
+    render(<MessageFormatter breadcrumb={breadcrumbs[4]} />);
 
     expect(screen.getByRole('text')).toHaveTextContent('prev state {"cart":[]}');
   });
 
   it('Should print arrays correctly', () => {
-    render(<MessageFormatter breadcrumb={breadcrumbs[4]} />);
+    render(<MessageFormatter breadcrumb={breadcrumbs[5]} />);
 
     expect(screen.getByRole('text')).toHaveTextContent('test ["foo","bar"]');
   });

--- a/tests/js/spec/views/replays/detail/console/messageFormatter.spec.tsx
+++ b/tests/js/spec/views/replays/detail/console/messageFormatter.spec.tsx
@@ -1,0 +1,87 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {
+  BreadcrumbLevelType,
+  BreadcrumbType,
+  BreadcrumbTypeDefault,
+} from 'sentry/types/breadcrumbs';
+import {MessageFormatter} from 'sentry/views/replays/detail/console/consoleMessage';
+
+const breadcrumbs: BreadcrumbTypeDefault[] = [
+  {
+    type: BreadcrumbType.DEBUG,
+    category: 'console',
+    data: {
+      arguments: ['This is a %s', 'test'],
+      logger: 'console',
+    },
+    level: BreadcrumbLevelType.LOG,
+    message: 'This is a %s test',
+    timestamp: '2022-06-22T20:00:39.959Z',
+  },
+  {
+    type: BreadcrumbType.DEBUG,
+    category: 'console',
+    data: {
+      arguments: ['test', 1, false, {}],
+      logger: 'console',
+    },
+    level: BreadcrumbLevelType.LOG,
+    message: 'test 1 false [object Object]',
+    timestamp: '2022-06-22T16:49:11.198Z',
+  },
+  {
+    type: BreadcrumbType.DEBUG,
+    category: 'console',
+    data: {
+      arguments: [{}],
+      logger: 'console',
+    },
+    level: BreadcrumbLevelType.ERROR,
+    message: 'Error: this is my error message',
+    timestamp: '2022-06-22T20:00:39.958Z',
+  },
+  {
+    type: BreadcrumbType.DEBUG,
+    category: 'console',
+    data: {
+      arguments: [
+        '%c prev state',
+        'color: #9E9E9E; font-weight: bold',
+        {
+          cart: [],
+        },
+      ],
+      logger: 'console',
+    },
+    level: BreadcrumbLevelType.LOG,
+    message: '%c prev state color: #9E9E9E; font-weight: bold [object Object]',
+    timestamp: '2022-06-09T00:50:25.273Z',
+  },
+];
+
+describe('MessageFormatter', () => {
+  it('Should print console message with placeholders correctly', () => {
+    render(<MessageFormatter breadcrumb={breadcrumbs[0]} />);
+
+    expect(screen.getByRole('text')).toHaveTextContent('This is a test');
+  });
+
+  it('Should print console message with objects correctly', () => {
+    render(<MessageFormatter breadcrumb={breadcrumbs[1]} />);
+
+    expect(screen.getByRole('text')).toHaveTextContent('test 1 false {}');
+  });
+
+  it('Should print console message correctly when it is an Error object', () => {
+    render(<MessageFormatter breadcrumb={breadcrumbs[2]} />);
+
+    expect(screen.getByRole('text')).toHaveTextContent('Error: this is my error message');
+  });
+
+  it('Should ignore the "%c" placheholder and print the console message correctly', () => {
+    render(<MessageFormatter breadcrumb={breadcrumbs[3]} />);
+
+    expect(screen.getByRole('text')).toHaveTextContent('prev state {"cart":[]}');
+  });
+});

--- a/tests/js/spec/views/replays/detail/console/messageFormatter.spec.tsx
+++ b/tests/js/spec/views/replays/detail/console/messageFormatter.spec.tsx
@@ -58,6 +58,17 @@ const breadcrumbs: BreadcrumbTypeDefault[] = [
     message: '%c prev state color: #9E9E9E; font-weight: bold [object Object]',
     timestamp: '2022-06-09T00:50:25.273Z',
   },
+  {
+    type: BreadcrumbType.DEBUG,
+    category: 'console',
+    data: {
+      arguments: [['test', 'test']],
+      logger: 'console',
+    },
+    level: BreadcrumbLevelType.LOG,
+    message: 'test,test',
+    timestamp: '2022-06-23T13:33:15.768Z',
+  },
 ];
 
 describe('MessageFormatter', () => {
@@ -83,5 +94,11 @@ describe('MessageFormatter', () => {
     render(<MessageFormatter breadcrumb={breadcrumbs[3]} />);
 
     expect(screen.getByRole('text')).toHaveTextContent('prev state {"cart":[]}');
+  });
+
+  it('Should print arrays correctly', () => {
+    render(<MessageFormatter breadcrumb={breadcrumbs[4]} />);
+
+    expect(screen.getByRole('text')).toHaveTextContent('["test","test"]');
   });
 });


### PR DESCRIPTION
<!-- Describe your PR here. -->
Now renders the messsage and ignore data.arguments when there are no placeholders in message or objects to print. Closes #35701 

Before: 
![image](https://user-images.githubusercontent.com/39612839/174911147-078e5f50-f8ad-4c03-be92-f7adc87967ca.png)

After:
![image](https://user-images.githubusercontent.com/39612839/174911219-4a52ef30-73b6-4ecd-97c8-2fd3b0409cc0.png)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
