### PR TITLE
fix(api): Add query filter to project commits endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_commits.py
+++ b/src/sentry/api/endpoints/project_commits.py
@@ -38,7 +38,7 @@ class ProjectCommitsEndpoint(ProjectEndpoint):
         return self.paginate(
             request=request,
             queryset=queryset,
-            order_by=("-id", "-date_added"),
+            order_by=("key", "-date_added") if query else "-date_added",
             on_results=lambda x: serialize(x, request.user),
             paginator_cls=OffsetPaginator,
         )

--- a/src/sentry/api/endpoints/project_commits.py
+++ b/src/sentry/api/endpoints/project_commits.py
@@ -22,12 +22,18 @@ class ProjectCommitsEndpoint(ProjectEndpoint):
                                           commit belongs to.
         :pparam string project_slug: the slug of the project to list the
                                      commits of.
+        :qparam string query: this parameter can be used to create a
+                              "starts with" filter for the commit key.
         """
+        query = request.GET.get("query")
 
         queryset = Commit.objects.filter(
             organization_id=project.organization_id,
             releasecommit__release__releaseproject__project_id=project.id,
         ).distinct("id")
+
+        if query:
+            queryset = queryset.filter(key__icontains=query)
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/project_commits.py
+++ b/src/sentry/api/endpoints/project_commits.py
@@ -30,7 +30,7 @@ class ProjectCommitsEndpoint(ProjectEndpoint):
         queryset = Commit.objects.filter(
             organization_id=project.organization_id,
             releasecommit__release__releaseproject__project_id=project.id,
-        ).distinct("id")
+        )
 
         if query:
             queryset = queryset.filter(key__istartswith=query)

--- a/src/sentry/api/endpoints/project_commits.py
+++ b/src/sentry/api/endpoints/project_commits.py
@@ -33,7 +33,7 @@ class ProjectCommitsEndpoint(ProjectEndpoint):
         ).distinct("id")
 
         if query:
-            queryset = queryset.filter(key__icontains=query)
+            queryset = queryset.filter(key__istartswith=query)
 
         return self.paginate(
             request=request,

--- a/tests/sentry/api/endpoints/test_project_commits.py
+++ b/tests/sentry/api/endpoints/test_project_commits.py
@@ -1,3 +1,5 @@
+from django.urls import reverse
+
 from sentry.models import Commit, Release, ReleaseCommit, ReleaseProject, Repository
 from sentry.testutils import APITestCase
 
@@ -49,3 +51,26 @@ class ProjectCommitListTest(APITestCase):
 
         response = self.get_success_response(project.organization.slug, project.slug)
         assert len(response.data) == 1
+
+    def test_query_filter(self):
+        project = self.create_project(name="komal")
+        version = "1.1"
+        repo = Repository.objects.create(organization_id=project.organization_id, name=project.name)
+        release = Release.objects.create(organization_id=project.organization_id, version=version)
+        self.create_commit(repo=repo, project=project, key="foobar", release=release)
+        ReleaseProject.objects.create(project=project, release=release)
+
+        self.login_as(user=self.user)
+
+        url = reverse(
+            "sentry-api-0-project-commits",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+
+        response = self.client.get(url + "?query=foobar", format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+
+        response = self.client.get(url + "?query=random", format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0

--- a/tests/sentry/api/endpoints/test_project_commits.py
+++ b/tests/sentry/api/endpoints/test_project_commits.py
@@ -74,3 +74,15 @@ class ProjectCommitListTest(APITestCase):
         response = self.client.get(url + "?query=random", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
+
+        response = self.client.get(url + "?query=foob", format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+
+        response = self.client.get(url + "?query=f", format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+
+        response = self.client.get(url + "?query=ooba", format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0


### PR DESCRIPTION
Changes made:
- `project_commits.py`: added query filter which will be used to display relevant commits based on input on the frontend
- `test_project_commits.py`: added a test with a query that matches the commit key and one that doesn't

Fixes `WOR-1934`