### PR TITLE
feat(buffers): Move buffer.incr to a celery task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -599,6 +599,7 @@ CELERY_QUEUES = [
     Queue("assemble", routing_key="assemble"),
     Queue("auth", routing_key="auth"),
     Queue("buffers.process_pending", routing_key="buffers.process_pending"),
+    Queue("buffers.incr", routing_key="buffers.incr"),
     Queue("cleanup", routing_key="cleanup"),
     Queue("code_owners", routing_key="code_owners"),
     Queue("commits", routing_key="commits"),

--- a/src/sentry/models/grouprelease.py
+++ b/src/sentry/models/grouprelease.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 from django.db import IntegrityError, models, transaction
 from django.utils import timezone
 
-from sentry import buffer
 from sentry.db.models import BoundedBigIntegerField, BoundedPositiveIntegerField, Model, sane_repr
+from sentry.tasks.process_buffer import buffer_incr
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 
@@ -68,7 +68,7 @@ class GroupRelease(Model):
             created = False
 
         if not created and instance.last_seen < datetime - timedelta(seconds=60):
-            buffer.incr(
+            buffer_incr(
                 model=cls,
                 columns={},
                 filters={"id": instance.id},

--- a/src/sentry/reprocessing.py
+++ b/src/sentry/reprocessing.py
@@ -41,15 +41,15 @@ def get_reprocessing_revision(project, cached=True):
 
 def bump_reprocessing_revision(project, use_buffer=False):
     """Bumps the reprocessing revision."""
-    from sentry import buffer
     from sentry.models import ProjectOption
+    from sentry.tasks.process_buffer import buffer_incr
 
     rev = uuid.uuid4().hex
     if use_buffer:
-        buffer.incr(
+        buffer_incr(
             ProjectOption,
             columns={},
-            filters={"project": project, "key": REPROCESSING_OPTION},
+            filters={"project_id": project.id, "key": REPROCESSING_OPTION},
             signal_only=True,
         )
     else:

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -1,5 +1,7 @@
 import logging
 
+from django.apps import apps
+
 from sentry.tasks.base import instrumented_task
 from sentry.utils.locking import UnableToAcquireLock
 
@@ -38,3 +40,27 @@ def process_incr(**kwargs):
     from sentry import buffer
 
     buffer.process(**kwargs)
+
+
+def buffer_incr(model, *args, **kwargs):
+    """
+    Call `buffer.incr` task, resolving the model name first.
+
+    `model_name` must be in form `app_label.model_name` e.g. `sentry.group`.
+    """
+    buffer_incr_task.delay(
+        app_label=model._meta.app_label, model_name=model._meta.model_name, args=args, kwargs=kwargs
+    )
+
+
+@instrumented_task(
+    name="sentry.tasks.process_buffer.buffer_incr_task",
+    queue="buffers.incr",
+)
+def buffer_incr_task(app_label, model_name, args, kwargs):
+    """
+    Call `buffer.incr`, resolving the model first.
+    """
+    from sentry import buffer
+
+    buffer.incr(apps.get_model(app_label=app_label, model_name=model_name), *args, **kwargs)

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -8,6 +8,7 @@ from sentry import eventstore, eventstream, nodestore
 from sentry.eventstore.models import Event
 from sentry.reprocessing2 import buffered_delete_old_primary_hash
 from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.process_buffer import buffer_incr
 from sentry.utils import metrics
 from sentry.utils.query import celery_run_batch_query
 
@@ -155,7 +156,6 @@ def handle_remaining_events(
     See doc comment in sentry.reprocessing2.
     """
 
-    from sentry import buffer
     from sentry.models.group import Group
     from sentry.reprocessing2 import EVENT_MODELS_TO_MIGRATE, pop_batched_events_from_redis
 
@@ -196,7 +196,7 @@ def handle_remaining_events(
             to_timestamp=to_timestamp,
         )
 
-        buffer.incr(Group, {"times_seen": len(event_ids)}, {"id": new_group_id})
+        buffer_incr(Group, {"times_seen": len(event_ids)}, {"id": new_group_id})
     else:
         raise ValueError(f"Invalid value for remaining_events: {remaining_events}")
 


### PR DESCRIPTION
Moving direct calls to `buffer.incr` to a celery task will allow us to:

- Move calls to buffer from the hot path of the ingestion pipeline.
- Reduce the number of connections to the underlying Redis backend. Instead of all postprocess and save workers it will be just a separate smaller pool of workers.
- Gives us the ability to pause writing to buffer service by pausing the workers, simplifying maintenance work e.g. migration to different Redis backend.

Note: Before deploying this PR the queue definition must be merged & deployed in a separate PR.