### PR TITLE
fix(projectconfig): Apply correct time limits to tasks

### DIFF
--- a/src/sentry/relay/projectconfig_debounce_cache/redis.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/redis.py
@@ -1,4 +1,5 @@
 from sentry.relay.projectconfig_debounce_cache.base import ProjectConfigDebounceCache
+from sentry.utils import metrics
 from sentry.utils.redis import get_dynamic_cluster_from_options, validate_dynamic_cluster
 
 REDIS_CACHE_TIMEOUT = 3600  # 1 hr
@@ -43,8 +44,11 @@ class RedisProjectConfigDebounceCache(ProjectConfigDebounceCache):
         key = self._get_redis_key(public_key, project_id, organization_id)
         client = self._get_redis_client(key)
         client.setex(key, REDIS_CACHE_TIMEOUT, 1)
+        metrics.incr("relay.projectconfig_debounce_cache.debounce", sample_rate=1)
 
     def mark_task_done(self, *, public_key, project_id, organization_id):
         key = self._get_redis_key(public_key, project_id, organization_id)
         client = self._get_redis_client(key)
-        return client.delete(key)
+        ret = client.delete(key)
+        metrics.incr("relay.projectconfig_debounce_cache.task_done", sample_rate=1)
+        return ret

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -9,9 +9,6 @@ from sentry.utils.sdk import set_current_event_project
 
 logger = logging.getLogger(__name__)
 
-TASK_SOFT_LIMIT = 25
-TASK_HARD_LIMIT = 30  # Extra 5 seconds to remove the debounce key
-
 
 # Some projects have in the order of 150k ProjectKey entries.  We should compute these in
 # batches, but for now we just have a large timeout and don't compute at all for
@@ -20,8 +17,8 @@ TASK_HARD_LIMIT = 30  # Extra 5 seconds to remove the debounce key
     name="sentry.tasks.relay.build_project_config",
     queue="relay_config",
     acks_late=True,
-    soft_time_limit=25 * 60,  # 25mins
-    time_limit=25 * 60 + 5,
+    soft_time_limit=5,
+    time_limit=10,  # Extra 5 seconds to remove the debounce key
 )
 def build_project_config(public_key=None, **kwargs):
     """Build a project config and put it in the Redis cache.
@@ -169,8 +166,8 @@ def compute_projectkey_config(key):
     name="sentry.tasks.relay.invalidate_project_config",
     queue="relay_config",
     acks_late=True,
-    soft_time_limit=TASK_SOFT_LIMIT,
-    time_limit=TASK_HARD_LIMIT,
+    soft_time_limit=25 * 60,  # 25mins
+    time_limit=25 * 60 + 5,
 )
 def invalidate_project_config(
     organization_id=None, project_id=None, public_key=None, trigger="invalidated", **kwargs


### PR DESCRIPTION
The time limits did get mixed up somehow.  This also thightens the
time limit of the build task a lot, because this only ever can build a
single config that should be relatively short.  Having it this short
means it's 1/6th of the time limit in relay so relay can trigger a new
task in a new request and maybe that'll work beter.

Finally this adds metrics around the debouncing keys to check if they
match up correctly.