### PR TITLE
chore(dashboard): Add a guide anchor for Release Widgets

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -22,6 +22,7 @@ GUIDES = {
     "release_stages": 23,
     "new_page_filters": 24,
     "new_page_filters_pin": 25,
+    "releases_widget": 26,
 }
 
 # demo mode has different guides

--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -22,7 +22,6 @@ GUIDES = {
     "release_stages": 23,
     "new_page_filters": 24,
     "new_page_filters_pin": 25,
-    "releases_widget": 26,
 }
 
 # demo mode has different guides

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -214,12 +214,13 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
     {
       guide: 'releases_widget',
       requiredTargets: ['releases_widget'],
+      dateThreshold: new Date('2022-06-22'),
       steps: [
         {
           title: t('Releases are here!'),
           target: 'releases_widget',
           description: t(
-            'Want to know how you latest release is doing? Monitor release health and crash rates in Dashboards.'
+            'Want to know how your latest release is doing? Monitor release health and crash rates in Dashboards.'
           ),
           nextText: t('Sounds Good'),
         },

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -219,7 +219,7 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
           title: t('Releases are here!'),
           target: 'releases_widget',
           description: t(
-            'Want to know how that latest release is doing? Monitor release health and track crash rates in Dashboards.'
+            'Want to know how you latest release is doing? Monitor release health and crash rates in Dashboards.'
           ),
           nextText: t('Sounds Good'),
         },

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -211,6 +211,20 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
         },
       ],
     },
+    {
+      guide: 'releases_widget',
+      requiredTargets: ['releases_widget'],
+      steps: [
+        {
+          title: t('Releases are here!'),
+          target: 'releases_widget',
+          description: t(
+            'Want to know how that latest release is doing? Monitor release health and track crash rates in Dashboards.'
+          ),
+          nextText: t('Sounds Good'),
+        },
+      ],
+    },
   ];
 }
 

--- a/static/app/views/dashboardsV2/controls.tsx
+++ b/static/app/views/dashboardsV2/controls.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import Confirm from 'sentry/components/confirm';
@@ -141,23 +142,28 @@ function Controls({
                 })}
                 disabled={!!!widgetLimitReached}
               >
-                <Button
-                  data-test-id="add-widget-library"
-                  priority="primary"
-                  disabled={widgetLimitReached}
-                  icon={<IconAdd isCircled />}
-                  onClick={() => {
-                    trackAdvancedAnalyticsEvent(
-                      'dashboards_views.widget_library.opened',
-                      {
-                        organization,
-                      }
-                    );
-                    onAddWidget();
-                  }}
+                <GuideAnchor
+                  disabled={!!!organization.features.includes('dashboards-releases')}
+                  target="releases_widget"
                 >
-                  {t('Add Widget')}
-                </Button>
+                  <Button
+                    data-test-id="add-widget-library"
+                    priority="primary"
+                    disabled={widgetLimitReached}
+                    icon={<IconAdd isCircled />}
+                    onClick={() => {
+                      trackAdvancedAnalyticsEvent(
+                        'dashboards_views.widget_library.opened',
+                        {
+                          organization,
+                        }
+                      );
+                      onAddWidget();
+                    }}
+                  >
+                    {t('Add Widget')}
+                  </Button>
+                </GuideAnchor>
               </Tooltip>
             ) : null}
           </Fragment>


### PR DESCRIPTION
Release widget adoption is low so adding guide anchors.

Follow up to https://github.com/getsentry/sentry/pull/35894

![Screen Shot 2022-06-22 at 10 58 46 AM](https://user-images.githubusercontent.com/63818634/175065919-88d3f322-a911-4bf0-a66d-e678d6789423.png)

