### PR TITLE
chore(dashboard): Add guide to backend for Release widget guide

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -22,6 +22,7 @@ GUIDES = {
     "release_stages": 23,
     "new_page_filters": 24,
     "new_page_filters_pin": 25,
+    "releases_widget": 26,
 }
 
 # demo mode has different guides


### PR DESCRIPTION
Frontend PR follows: https://github.com/getsentry/sentry/pull/35893

