### PR TITLE
fix(ui) Fix autocomplete setState errors

### DIFF
--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -149,6 +149,10 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
     };
   }
 
+  componentDidMount() {
+    this._mounted = true;
+  }
+
   componentDidUpdate(_prevProps: Props<T>, prevState: State<T>) {
     // If we do NOT want to close on select, then we should not reset highlight state
     // when we select an item (when we select an item, `this.state.selectedItem` changes)
@@ -158,9 +162,12 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
   }
 
   componentWillUnmount() {
+    this._mounted = false;
     window.clearTimeout(this.blurTimeout);
     window.clearTimeout(this.cancelCloseTimeout);
   }
+
+  private _mounted: boolean = false;
 
   /**
    * Used to track keyboard navigation of items.
@@ -230,7 +237,6 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
   }
 
   /**
-   *
    * We need this delay because we want to close the menu when input
    * is blurred (i.e. clicking or via keyboard). However we have to handle the
    * case when we want to click on the dropdown and causes focus.
@@ -394,7 +400,7 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
 
     onClose?.(...args);
 
-    if (this.isControlled) {
+    if (this.isControlled || !this._mounted) {
       return;
     }
 

--- a/tests/js/spec/components/autoComplete.spec.jsx
+++ b/tests/js/spec/components/autoComplete.spec.jsx
@@ -139,6 +139,21 @@ describe('AutoComplete', function () {
       expect(mocks.onClose).toHaveBeenCalledTimes(1);
     });
 
+    it('handles component being unmounted and then blurred', function () {
+      input.simulate('focus');
+      input.simulate('blur');
+      expect(wrapper.state('isOpen')).toBe(true);
+      wrapper.unmount();
+
+      // This is a bit contrived but we inputs that fetch data async
+      // and then update state and the autocomplete has been removed
+      // from the DOM as the collapsible section of the page has
+      // been closed.
+      input.simulate('keyDown', {key: 'Escape'});
+      wrapper.update();
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    });
+
     it('can close dropdown menu when Escape is pressed', function () {
       input.simulate('focus');
       expect(wrapper.state('isOpen')).toBe(true);


### PR DESCRIPTION
Add mounted tracking to AutoComplete so that we can avoid 'setState() on unmounted component errors'. This scenario has come up in getsentry as we're using AutoComplete with google's address autocompletion services and we sometimes get results after a selection has been made and the autocomplete has been removed from the dom.


