### PR TITLE
fix(dashboards): Fix broken world map render

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -251,13 +251,13 @@ export const processTableResults = (tableResults?: TableDataWithTitle[]) => {
 
   const tableResult = tableResults[0];
 
-  const {data, meta} = tableResult;
+  const {data} = tableResult;
 
-  if (!data || !data.length || !meta) {
+  if (!data || !data.length) {
     return DEFAULT_GEO_DATA;
   }
 
-  const preAggregate = Object.keys(meta).find(column => {
+  const preAggregate = Object.keys(data[0]).find(column => {
     return column !== 'geo.country_code';
   });
 


### PR DESCRIPTION
World map was broken because the meta on the response
is returned in a different format than the events endpoint
and we were relying on [this](https://github.com/getsentry/sentry/blob/master/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx#L164) to add the meta to all table data and using that meta
downstream to transform world map results. Updated
to just use the data for now. Tests to follow, want to
get this in prod ASAP